### PR TITLE
renaming all usable Types and LibFuncs.

### DIFF
--- a/crates/sierra/src/extensions/core/function_call.rs
+++ b/crates/sierra/src/extensions/core/function_call.rs
@@ -5,9 +5,9 @@ use crate::program::{Function, GenericArg};
 
 /// LibFunc used to call user functions.
 #[derive(Default)]
-pub struct FunctionCallGeneric {}
-impl NamedLibFunc for FunctionCallGeneric {
-    type Concrete = FunctionCallConcrete;
+pub struct FunctionCallLibFunc {}
+impl NamedLibFunc for FunctionCallLibFunc {
+    type Concrete = FunctionCallConcreteLibFunc;
     const NAME: &'static str = "function_call";
     fn specialize(
         &self,
@@ -27,10 +27,10 @@ impl NamedLibFunc for FunctionCallGeneric {
     }
 }
 
-pub struct FunctionCallConcrete {
+pub struct FunctionCallConcreteLibFunc {
     pub function: Function,
 }
-impl NonBranchConcreteLibFunc for FunctionCallConcrete {
+impl NonBranchConcreteLibFunc for FunctionCallConcreteLibFunc {
     fn input_types(&self) -> Vec<ConcreteTypeId> {
         self.function.params.iter().map(|p| p.ty.clone()).collect()
     }

--- a/crates/sierra/src/extensions/core/mem.rs
+++ b/crates/sierra/src/extensions/core/mem.rs
@@ -9,28 +9,28 @@ use crate::program::GenericArg;
 
 /// Type for deferred actions.
 #[derive(Default)]
-pub struct DeferredGeneric {}
-impl NamedType for DeferredGeneric {
-    type Concrete = DeferredConcrete;
+pub struct DeferredType {}
+impl NamedType for DeferredType {
+    type Concrete = DeferredConcreteType;
     const NAME: &'static str = "Deferred";
     fn specialize(&self, args: &[GenericArg]) -> Result<Self::Concrete, SpecializationError> {
-        Ok(DeferredConcrete { ty: as_single_type(args)? })
+        Ok(DeferredConcreteType { ty: as_single_type(args)? })
     }
 }
-pub struct DeferredConcrete {
+pub struct DeferredConcreteType {
     pub ty: ConcreteTypeId,
 }
-impl ConcreteType for DeferredConcrete {}
+impl ConcreteType for DeferredConcreteType {}
 
 define_libfunc_hierarchy! {
-pub enum MemLibFunc {
-    StoreTemp(StoreTempGeneric),
-    AlignTemps(AlignTempsGeneric),
-    StoreLocal(StoreLocalGeneric),
-    AllocLocals(AllocLocalsGeneric),
-    Rename(RenameGeneric),
-    Move(MoveGeneric),
-}, MemConcrete
+    pub enum MemLibFunc {
+        StoreTemp(StoreTempLibFunc),
+        AlignTemps(AlignTempsLibFunc),
+        StoreLocal(StoreLocalLibFunc),
+        AllocLocals(AllocLocalsLibFunc),
+        Rename(RenameLibFunc),
+        Move(MoveLibFunc),
+    }, MemConcreteLibFunc
 }
 
 /// Helper for extracting the type from the template arguments.
@@ -43,23 +43,23 @@ fn as_single_type(args: &[GenericArg]) -> Result<ConcreteTypeId, SpecializationE
 
 /// LibFunc for storing a deferred value into temporary memory.
 #[derive(Default)]
-pub struct StoreTempGeneric {}
-impl NamedLibFunc for StoreTempGeneric {
-    type Concrete = StoreTempConcrete;
+pub struct StoreTempLibFunc {}
+impl NamedLibFunc for StoreTempLibFunc {
+    type Concrete = StoreTempConcreteLibFunc;
     const NAME: &'static str = "store_temp";
     fn specialize(
         &self,
         _context: SpecializationContext<'_>,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        Ok(StoreTempConcrete { ty: as_single_type(args)? })
+        Ok(StoreTempConcreteLibFunc { ty: as_single_type(args)? })
     }
 }
 
-pub struct StoreTempConcrete {
+pub struct StoreTempConcreteLibFunc {
     ty: ConcreteTypeId,
 }
-impl NonBranchConcreteLibFunc for StoreTempConcrete {
+impl NonBranchConcreteLibFunc for StoreTempConcreteLibFunc {
     fn input_types(&self) -> Vec<ConcreteTypeId> {
         vec![self.ty.clone()]
     }
@@ -70,23 +70,23 @@ impl NonBranchConcreteLibFunc for StoreTempConcrete {
 
 /// LibFunc for aligning the temporary buffer for flow control merge.
 #[derive(Default)]
-pub struct AlignTempsGeneric {}
-impl NamedLibFunc for AlignTempsGeneric {
-    type Concrete = AlignTempsConcrete;
+pub struct AlignTempsLibFunc {}
+impl NamedLibFunc for AlignTempsLibFunc {
+    type Concrete = AlignTempsConcreteLibFunc;
     const NAME: &'static str = "align_temps";
     fn specialize(
         &self,
         _context: SpecializationContext<'_>,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        Ok(AlignTempsConcrete { _ty: as_single_type(args)? })
+        Ok(AlignTempsConcreteLibFunc { _ty: as_single_type(args)? })
     }
 }
 
-pub struct AlignTempsConcrete {
+pub struct AlignTempsConcreteLibFunc {
     _ty: ConcreteTypeId,
 }
-impl NonBranchConcreteLibFunc for AlignTempsConcrete {
+impl NonBranchConcreteLibFunc for AlignTempsConcreteLibFunc {
     fn input_types(&self) -> Vec<ConcreteTypeId> {
         vec![]
     }
@@ -97,23 +97,23 @@ impl NonBranchConcreteLibFunc for AlignTempsConcrete {
 
 /// LibFunc for storing a deferred value into local memory.
 #[derive(Default)]
-pub struct StoreLocalGeneric {}
-impl NamedLibFunc for StoreLocalGeneric {
-    type Concrete = StoreLocalConcrete;
+pub struct StoreLocalLibFunc {}
+impl NamedLibFunc for StoreLocalLibFunc {
+    type Concrete = StoreLocalConcreteLibFunc;
     const NAME: &'static str = "store_local";
     fn specialize(
         &self,
         _context: SpecializationContext<'_>,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        Ok(StoreLocalConcrete { ty: as_single_type(args)? })
+        Ok(StoreLocalConcreteLibFunc { ty: as_single_type(args)? })
     }
 }
 
-pub struct StoreLocalConcrete {
+pub struct StoreLocalConcreteLibFunc {
     ty: ConcreteTypeId,
 }
-impl NonBranchConcreteLibFunc for StoreLocalConcrete {
+impl NonBranchConcreteLibFunc for StoreLocalConcreteLibFunc {
     fn input_types(&self) -> Vec<ConcreteTypeId> {
         vec![self.ty.clone()]
     }
@@ -124,20 +124,20 @@ impl NonBranchConcreteLibFunc for StoreLocalConcrete {
 
 /// LibFunc for allocating locals for later stores.
 #[derive(Default)]
-pub struct AllocLocalsGeneric {}
-impl NoGenericArgsGenericLibFunc for AllocLocalsGeneric {
-    type Concrete = AllocLocalsConcrete;
+pub struct AllocLocalsLibFunc {}
+impl NoGenericArgsGenericLibFunc for AllocLocalsLibFunc {
+    type Concrete = AllocLocalsConcreteLibFunc;
     const NAME: &'static str = "alloc_locals";
     fn specialize(
         &self,
         _context: SpecializationContext<'_>,
     ) -> Result<Self::Concrete, SpecializationError> {
-        Ok(AllocLocalsConcrete {})
+        Ok(AllocLocalsConcreteLibFunc {})
     }
 }
 
-pub struct AllocLocalsConcrete {}
-impl NonBranchConcreteLibFunc for AllocLocalsConcrete {
+pub struct AllocLocalsConcreteLibFunc {}
+impl NonBranchConcreteLibFunc for AllocLocalsConcreteLibFunc {
     fn input_types(&self) -> Vec<ConcreteTypeId> {
         vec![]
     }
@@ -148,23 +148,23 @@ impl NonBranchConcreteLibFunc for AllocLocalsConcrete {
 
 /// LibFunc for renaming an identifier - used to align identities for flow control merge.
 #[derive(Default)]
-pub struct RenameGeneric {}
-impl NamedLibFunc for RenameGeneric {
-    type Concrete = RenameConcrete;
+pub struct RenameLibFunc {}
+impl NamedLibFunc for RenameLibFunc {
+    type Concrete = RenameConcreteLibFunc;
     const NAME: &'static str = "rename";
     fn specialize(
         &self,
         _context: SpecializationContext<'_>,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        Ok(RenameConcrete { ty: as_single_type(args)? })
+        Ok(RenameConcreteLibFunc { ty: as_single_type(args)? })
     }
 }
 
-pub struct RenameConcrete {
+pub struct RenameConcreteLibFunc {
     ty: ConcreteTypeId,
 }
-impl NonBranchConcreteLibFunc for RenameConcrete {
+impl NonBranchConcreteLibFunc for RenameConcreteLibFunc {
     fn input_types(&self) -> Vec<ConcreteTypeId> {
         vec![self.ty.clone()]
     }
@@ -175,23 +175,23 @@ impl NonBranchConcreteLibFunc for RenameConcrete {
 
 /// LibFunc for making a type deferred for later store.
 #[derive(Default)]
-pub struct MoveGeneric {}
-impl NamedLibFunc for MoveGeneric {
-    type Concrete = MoveConcrete;
+pub struct MoveLibFunc {}
+impl NamedLibFunc for MoveLibFunc {
+    type Concrete = MoveConcreteLibFunc;
     const NAME: &'static str = "move";
     fn specialize(
         &self,
         _context: SpecializationContext<'_>,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        Ok(MoveConcrete { ty: as_single_type(args)? })
+        Ok(MoveConcreteLibFunc { ty: as_single_type(args)? })
     }
 }
 
-pub struct MoveConcrete {
+pub struct MoveConcreteLibFunc {
     ty: ConcreteTypeId,
 }
-impl NonBranchConcreteLibFunc for MoveConcrete {
+impl NonBranchConcreteLibFunc for MoveConcreteLibFunc {
     fn input_types(&self) -> Vec<ConcreteTypeId> {
         vec![self.ty.clone()]
     }

--- a/crates/sierra/src/extensions/core/mod.rs
+++ b/crates/sierra/src/extensions/core/mod.rs
@@ -1,8 +1,8 @@
-use self::function_call::FunctionCallGeneric;
-use self::gas::{GasBuiltinGeneric, GasLibFunc};
-use self::integer::{IntegerGenericType, IntegerLibFunc};
-use self::mem::{DeferredGeneric, MemLibFunc};
-use self::unconditional_jump::UnconditionalJumpGeneric;
+use self::function_call::FunctionCallLibFunc;
+use self::gas::{GasBuiltinType, GasLibFunc};
+use self::integer::{IntegerLibFunc, IntegerType};
+use self::mem::{DeferredType, MemLibFunc};
+use self::unconditional_jump::UnconditionalJumpLibFunc;
 use super::GenericLibFunc;
 use crate::{define_libfunc_hierarchy, define_type_hierarchy};
 
@@ -14,19 +14,18 @@ pub mod unconditional_jump;
 
 define_type_hierarchy! {
     pub enum CoreType {
-        GasBuiltin(GasBuiltinGeneric),
-        Integer(IntegerGenericType),
-        Deferred(DeferredGeneric),
+        GasBuiltin(GasBuiltinType),
+        Integer(IntegerType),
+        Deferred(DeferredType),
     }, CoreTypeConcrete
 }
 
-// TODO(orizi): Improve naming of this hierarchy. e.g. CoreConcrete should have LibFunc in its name.
 define_libfunc_hierarchy! {
     pub enum CoreLibFunc {
-        FunctionCall(FunctionCallGeneric),
+        FunctionCall(FunctionCallLibFunc),
         Gas(GasLibFunc),
         Integer(IntegerLibFunc),
         Mem(MemLibFunc),
-        UnconditionalJump(UnconditionalJumpGeneric),
-    }, CoreConcrete
+        UnconditionalJump(UnconditionalJumpLibFunc),
+    }, CoreConcreteLibFunc
 }

--- a/crates/sierra/src/extensions/core/unconditional_jump.rs
+++ b/crates/sierra/src/extensions/core/unconditional_jump.rs
@@ -3,20 +3,20 @@ use crate::extensions::{ConcreteLibFunc, NoGenericArgsGenericLibFunc, Specializa
 use crate::ids::ConcreteTypeId;
 
 #[derive(Default)]
-pub struct UnconditionalJumpGeneric {}
-impl NoGenericArgsGenericLibFunc for UnconditionalJumpGeneric {
-    type Concrete = UnconditionalJumpConcrete;
+pub struct UnconditionalJumpLibFunc {}
+impl NoGenericArgsGenericLibFunc for UnconditionalJumpLibFunc {
+    type Concrete = UnconditionalJumpConcreteLibFunc;
     const NAME: &'static str = "jump";
     fn specialize(
         &self,
         _context: SpecializationContext<'_>,
     ) -> Result<Self::Concrete, SpecializationError> {
-        Ok(UnconditionalJumpConcrete {})
+        Ok(UnconditionalJumpConcreteLibFunc {})
     }
 }
 
-pub struct UnconditionalJumpConcrete {}
-impl ConcreteLibFunc for UnconditionalJumpConcrete {
+pub struct UnconditionalJumpConcreteLibFunc {}
+impl ConcreteLibFunc for UnconditionalJumpConcreteLibFunc {
     fn input_types(&self) -> Vec<ConcreteTypeId> {
         vec![]
     }

--- a/crates/sierra/src/extensions/mod.rs
+++ b/crates/sierra/src/extensions/mod.rs
@@ -3,7 +3,7 @@ pub mod error;
 pub mod lib_func;
 pub mod types;
 
-pub use self::core::{CoreConcrete, CoreLibFunc, CoreType, CoreTypeConcrete};
+pub use self::core::{CoreConcreteLibFunc, CoreLibFunc, CoreType, CoreTypeConcrete};
 pub use self::error::{ExtensionError, SpecializationError};
 pub use self::lib_func::{
     ConcreteLibFunc, GenericLibFunc, GenericLibFuncEx, NamedLibFunc, NoGenericArgsGenericLibFunc,

--- a/crates/sierra/src/program_registry.rs
+++ b/crates/sierra/src/program_registry.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use crate::extensions::lib_func::{ConcreteTypeIdMap, FunctionMap, SpecializationContext};
 use crate::extensions::{
-    CoreConcrete, CoreLibFunc, CoreType, CoreTypeConcrete, ExtensionError, GenericLibFuncEx,
+    CoreConcreteLibFunc, CoreLibFunc, CoreType, CoreTypeConcrete, ExtensionError, GenericLibFuncEx,
     GenericTypeEx,
 };
 use crate::ids::{ConcreteLibFuncId, ConcreteTypeId, FunctionId, GenericTypeId};
@@ -39,7 +39,7 @@ pub enum ProgramRegistryError {
 }
 
 type TypeMap = HashMap<ConcreteTypeId, CoreTypeConcrete>;
-type LibFuncMap = HashMap<ConcreteLibFuncId, CoreConcrete>;
+type LibFuncMap = HashMap<ConcreteLibFuncId, CoreConcreteLibFunc>;
 
 /// Registry for the data of the compiler, for all program specific data.
 pub struct ProgramRegistry {
@@ -76,7 +76,7 @@ impl ProgramRegistry {
     pub fn get_libfunc<'a>(
         &'a self,
         id: &ConcreteLibFuncId,
-    ) -> Result<&'a CoreConcrete, ProgramRegistryError> {
+    ) -> Result<&'a CoreConcreteLibFunc, ProgramRegistryError> {
         self.concrete_libfuncs
             .get(id)
             .ok_or_else(|| ProgramRegistryError::MissingLibFunc(id.clone()))

--- a/crates/sierra/src/simulation/mod.rs
+++ b/crates/sierra/src/simulation/mod.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 
 use self::mem_cell::MemCell;
 use crate::edit_state::{put_results, take_args, EditStateError};
-use crate::extensions::core::function_call::FunctionCallConcrete;
-use crate::extensions::CoreConcrete;
+use crate::extensions::core::function_call::FunctionCallConcreteLibFunc;
+use crate::extensions::CoreConcreteLibFunc;
 use crate::ids::{FunctionId, VarId};
 use crate::program::{Program, Statement, StatementIdx};
 use crate::program_registry::{ProgramRegistry, ProgramRegistryError};
@@ -122,11 +122,12 @@ impl RunContext<'_> {
     /// Simulates the run of libfuncs - even complex ones.
     fn simulate_libfunc(
         &self,
-        libfunc: &CoreConcrete,
+        libfunc: &CoreConcreteLibFunc,
         inputs: Vec<Vec<MemCell>>,
         current_statement_id: StatementIdx,
     ) -> Result<(Vec<Vec<MemCell>>, usize), SimulationError> {
-        if let CoreConcrete::FunctionCall(FunctionCallConcrete { function }) = libfunc {
+        if let CoreConcreteLibFunc::FunctionCall(FunctionCallConcreteLibFunc { function }) = libfunc
+        {
             Ok((self.run_function(&function.id, inputs)?, 0))
         } else {
             core::simple_simulate(libfunc, inputs).map_err(|error| {

--- a/crates/sierra_to_casm/src/invocations.rs
+++ b/crates/sierra_to_casm/src/invocations.rs
@@ -1,8 +1,8 @@
 use casm::ap_change::ApChange;
 use casm::instructions::{AssertEqInstruction, Instruction, InstructionBody};
 use casm::operand::{DerefOperand, Register, ResOperand};
-use sierra::extensions::core::mem::MemConcrete;
-use sierra::extensions::{CoreConcrete, ExtensionError};
+use sierra::extensions::core::mem::MemConcreteLibFunc;
+use sierra::extensions::{CoreConcreteLibFunc, ExtensionError};
 
 use crate::references::ReferenceValue;
 
@@ -25,12 +25,12 @@ pub struct CompiledInvocation {
 }
 
 pub fn compile_invocation(
-    ext: &CoreConcrete,
+    ext: &CoreConcreteLibFunc,
     refs: &[ReferenceValue],
 ) -> Result<CompiledInvocation, ExtensionError> {
     match ext {
         // TODO(ilya, 10/10/2022): Handle type.
-        CoreConcrete::Mem(MemConcrete::StoreTemp(_)) => Ok(CompiledInvocation {
+        CoreConcreteLibFunc::Mem(MemConcreteLibFunc::StoreTemp(_)) => Ok(CompiledInvocation {
             instruction: vec![Instruction {
                 body: InstructionBody::AssertEq(AssertEqInstruction {
                     a: DerefOperand { register: Register::AP, offset: 0 },


### PR DESCRIPTION
* Generic are now of the form: <name>{LibFunc,Type}
* Concrete are now of the form: <name>Concrete{LibFunc,Type}

---

**Stack**:
- #121
- #120
- #115
- #113
- #112 ⬅
- #106


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/112)
<!-- Reviewable:end -->
