### PR TITLE
Use AsciiDoc syntax instead of Markdown wherever possible

### DIFF
--- a/docs/reference/src/SUMMARY.adoc
+++ b/docs/reference/src/SUMMARY.adoc
@@ -1,10 +1,10 @@
-# Summary
+= Summary
 
-## Introduction
+== Introduction
 
 link:notation.adoc[Notation]
 
-## Language Constructs
+== Language Constructs
 
 * link:lexical-structure.adoc[Lexical structure]
 ** link:keywords.adoc[Keywords]
@@ -84,7 +84,7 @@ link:notation.adoc[Notation]
 
 * Hints
 
-## Language Semantics
+== Language Semantics
 
 * Memory model
 
@@ -94,6 +94,6 @@ link:notation.adoc[Notation]
 
 * Runtime
 
-## Appendices
+== Appendices
 
 * link:Full Grammar

--- a/docs/reference/src/assignment-statement.adoc
+++ b/docs/reference/src/assignment-statement.adoc
@@ -1,8 +1,9 @@
-# Assignment statement
+= Assignment statement
 
-```bnf
+[source,bnf]
+----
 ASSIGN_STMT : IDENTIFIER "=" EXPR ";"
-```
+----
 
 An _assignment statement_ moves a value into the specified target.
 

--- a/docs/reference/src/block-expression.adoc
+++ b/docs/reference/src/block-expression.adoc
@@ -1,2 +1,2 @@
-# Block expression
+= Block expression
 TODO

--- a/docs/reference/src/comments.adoc
+++ b/docs/reference/src/comments.adoc
@@ -1,13 +1,15 @@
-# Comments
+= Comments
 
-```bnf
+[source,bnf]
+----
 LINE_COMMENT : "//"  ( ~EOL* )
-```
+----
 
 Comments follow general C++/Rust style of line (`//`) comments.
 
-## Example
+== Example
 
-```cairo
+[source,cairo]
+----
 // Comment.
-```
+----

--- a/docs/reference/src/expression-statement.adoc
+++ b/docs/reference/src/expression-statement.adoc
@@ -1,9 +1,10 @@
-# Expression statement
+= Expression statement
 
-```bnf
+[source,bnf]
+----
 EXPR_STMT : EXPR_WITHOUT_BLOCK ";"
           | EXPR_WITH_BLOCK ";"?
-```
+----
 
 An _expression statement_ evaluates an link:expressions.adoc[expression] and ignores its result.
 Its purpose is to trigger side effects of expression evaluation only.
@@ -18,7 +19,8 @@ This can cause an ambiguity between it being parsed as a standalone statement an
 another expression; in this case, it is parsed as a statement.
 
 // TODO(spapini): Use cairo syntax highlighting.
-```rust
+[source,rust]
+----
 v.pop();          // Ignore the element returned from pop
 if v.is_empty() {
     v.push(5);
@@ -26,12 +28,13 @@ if v.is_empty() {
     v.remove(0);
 }                 // Semicolon can be omitted.
 [1];              // Separate expression statement, not an indexing expression
-```
+----
 
 When the trailing semicolon is omitted, the result return type of the expression must be
 the link:unit-type.adoc[unit type].
 
-```rust
+[source,rust]
+----
 // bad: the block's type is i32, not ()
 // Error: expected `()` because of default return type
 // if true {
@@ -44,4 +47,4 @@ if true {
 } else {
   2
 };
-```
+----

--- a/docs/reference/src/expressions.adoc
+++ b/docs/reference/src/expressions.adoc
@@ -1,6 +1,7 @@
-# Expressions
+= Expressions
 
-```bnf
+[source,bnf]
+----
 EXPR : EXPR_WITHOUT_BLOCK | EXPR_WITH_BLOCK
 
 EXPR_WITHOUT_BLOCK
@@ -20,4 +21,4 @@ EXPR_WITH_BLOCK
     | IF_EXPR
     | MATCH_EXPR
     | FOR_EXPR
-```
+----

--- a/docs/reference/src/identifiers.adoc
+++ b/docs/reference/src/identifiers.adoc
@@ -1,4 +1,4 @@
-# Identifiers
+= Identifiers
 
 :xid_continue: http://unicode.org/cldr/utility/list-unicodeset.jsp?a=%5B%3AXID_Continue%3A%5D&abb=on&g=&i=[XID_Continue]
 
@@ -8,13 +8,13 @@
 
 :UAX31: https://www.unicode.org/reports/tr31/tr31-33.html[Unicode Standard Annex #31]
 
-
-```bnf
+[source,bnf]
+----
 IDENTIFIER_OR_KEYWORD : XID_Start XID_Continue*
                       | "_" XID_Continue+
 
 IDENTIFIER : IDENTIFIER_OR_KEYWORD /* except strict or reserved keywords */
-```
+----
 
 //  When updating the version, update the UAX links, too.
 Identifiers follow the specification in {UAX31} for Unicode version
@@ -48,12 +48,12 @@ and {xid_continue} in the following situations:
 
 - Module names loaded from the filesystem.
 
-## Normalization
+== Normalization
 
 Identifiers are normalized using Normalization Form C (NFC) as defined
 in {UAX15}.
 Two identifiers are equal if their NFC forms are equal.
 
-## Case sensitivity
+== Case sensitivity
 
 Cairo is a _case-sensitive_ language which means that upper and lower case code points are distinct.

--- a/docs/reference/src/items.adoc
+++ b/docs/reference/src/items.adoc
@@ -1,2 +1,2 @@
-# Items
+= Items
 // TODO(spapini): Fill with content.

--- a/docs/reference/src/keywords.adoc
+++ b/docs/reference/src/keywords.adoc
@@ -1,4 +1,4 @@
-# Keywords
+= Keywords
 
 There are three keyword categories:
 
@@ -6,13 +6,13 @@ There are three keyword categories:
 - <<_reserved_keywords,reserved>>
 - <<_contextual_keywords,contextual>>
 
-## Strict keywords
+== Strict keywords
 
 These keywords can only be used in their correct contexts.
 They cannot be used as names of any items.
 
-
-```
+[source]
+----
 break
 const
 continue
@@ -33,16 +33,17 @@ trait
 true
 type
 use
-```
+----
 
-## Reserved keywords
+== Reserved keywords
 
 These keywords aren't used yet, but they are reserved for future use.
 They have the same restrictions as strict keywords.
 The reasoning behind this is to make current programs forward compatible with future versions of
 Cairo by forbidding them to use these keywords.
 
-```
+[source]
+----
 as
 assert
 do
@@ -65,9 +66,9 @@ where
 while
 with
 yield
-```
+----
 
-## Contextual keywords
+== Contextual keywords
 
 Some grammar productions may make use of new keywords not listed here.
 Such keywords have special meaning only in these certain contexts.

--- a/docs/reference/src/let-statement.adoc
+++ b/docs/reference/src/let-statement.adoc
@@ -1,8 +1,9 @@
-# Let statement
+= Let statement
 
-```bnf
+[source,bnf]
+----
 LET_STMT : "let" PATTERN (":" TYPE)? "=" EXPR ";"
-```
+----
 
 A _let statement_ introduces a new set of variables, given by an irrefutable pattern.
 The pattern is followed optionally by a type annotation and then by an initializer expression.

--- a/docs/reference/src/lexical-structure.adoc
+++ b/docs/reference/src/lexical-structure.adoc
@@ -1,4 +1,4 @@
-# Lexical structure
+= Lexical structure
 
 This chapter describes the lexical structure of Cairo.
 

--- a/docs/reference/src/literal-expressions.adoc
+++ b/docs/reference/src/literal-expressions.adoc
@@ -1,25 +1,28 @@
-# Literal expressions
+= Literal expressions
 
-```bnf
+[source,bnf]
+----
 LITERAL_EXPR : NUMERIC_LITERAL
              | BOOLEAN_LITERAL
-```
+----
 
 A _literal expression_ is an expression consisting of a single token, rather than a sequence of
 tokens, that immediately and directly denotes the value it evaluates to, rather than referring to it
 by name or some other evaluation rule.
 
-## Boolean literals
+== Boolean literals
 
-```bnf
+[source,bnf]
+----
 BOOLEAN_LITERAL : "true" | "false"
-```
+----
 
 The two values of the boolean type are written `true` and `false`.
 
-## Numeric literals
+== Numeric literals
 
-```bnf
+[source,bnf]
+----
 NUMERIC_LITERAL : ( DEC_LITERAL | HEX_LITERAL | BIN_LITERAL ) LITERAL_SUFFIX?
 
 DEC_LITERAL : [0-9] [0-9_]*
@@ -27,7 +30,7 @@ HEX_LITERAL : "0x" [a-fA-F0-9_]*
 BIN_LITERAL : "0b" [01_]*
 
 LITERAL_SUFFIX : XID_Start XID_Continue*
-```
+----
 
 A numeric literal can be written using three bases:
 
@@ -60,11 +63,11 @@ Examples of numeric literals of various forms:
 
 [cols="1,1,1",options="header"]
 |===
-| Literal                 | Value | Type  
+| Literal                 | Value | Type
 | `1234`                  | 1234  | `felt`
 | `1234f`                 | 1234  | `felt`
 | `1234_f`                | 1234  | `felt`
-| `1234i`                 | 1234  | `int` 
+| `1234i`                 | 1234  | `int`
 | `1234u`                 | 1234  | `uint`
 | `0x4D2`                 | 1234  | `felt`
 | `0x4_D2`                | 1234  | `felt`

--- a/docs/reference/src/naming-conventions.adoc
+++ b/docs/reference/src/naming-conventions.adoc
@@ -1,8 +1,8 @@
-# Naming conventions
+= Naming conventions
 
 This chapter covers standard naming conventions.
 
-## Casing
+== Casing
 
 In general, use `PascalCase` for names of types or traits and use `snake_case` otherwise.
 More precisely:
@@ -32,13 +32,14 @@ So, we have `btree_map` rather than `b_tree_map`, but `PI_2` rather than `PI2`.
 
 Language implementations can emit warnings when names do not follow these rules.
 
-## Underscore Prefix (e.g. `_foo`)
+== Underscore Prefix (e.g. `_foo`)
 
 The name of an unused variable must start with an _ (a common example is simply "_").
 
-```cairo
+[source,cairo]
+----
 let _unused = compute_something();
-```
+----
 
 Language implementations can emit warnings when a variable **not** starting with an underscore is
 only written-to but is never read. The same applies when a variable starting with an underscore is

--- a/docs/reference/src/negation-operators.adoc
+++ b/docs/reference/src/negation-operators.adoc
@@ -1,9 +1,10 @@
-# Negation operators
+= Negation operators
 
-```bnf
+[source,bnf]
+----
 NEGATION_OP_EXPR : "-" EXPR
                  | "!" EXPR
-```
+----
 
 The following table summarizes the behavior of negation operators and which traits are used to
 overload them for other types:
@@ -11,6 +12,6 @@ overload them for other types:
 [cols="1,2,2,2",options="header"]
 |===
 | Symbol | Operation   | Accepted types             | Overloading trait
-| `-`    | Negation    | `felt`, `int`, `i*` family | `std::ops::Neg`  
-| `!`    | Logical NOT | `bool`                     | `std::ops::Not`  
+| `-`    | Negation    | `felt`, `int`, `i*` family | `std::ops::Neg`
+| `!`    | Logical NOT | `bool`                     | `std::ops::Not`
 |===

--- a/docs/reference/src/notation.adoc
+++ b/docs/reference/src/notation.adoc
@@ -1,29 +1,29 @@
-# Notation
+= Notation
 
-## Grammar
+== Grammar
 
 The following notational convention is used in grammar snippets:
 
 [cols="1,1,2",options="header"]
 |===
-| Notation                | Example                       | Meaning                                                   
-| `CAPITAL_CASE`          | `IDENTIFIER`                  | A named nonterminal or lexer token                        
-| `"string"`              | `"if"`, `"+"`                 | The exact character(s)                                    
-| `` \`string` ``         | `` \`"` ``                    | Alternative syntax for exact character(s)                 
-| `snake_case`            | `let_stmt`, `item`            | A syntactical production                                  
-| `\x`                    | `\n`, `\r`, `\t`, `\0`        | The character represented by this escape                  
-| `x?`                    | `pub?`                        | An optional item                                          
-| `x*`                    | `item*`                       | 0 or more of `x`                                          
-| `x+`                    | `item+`                       | 1 or more of `x`                                          
-| `x{a}`                  | `[0-9a-fA-F]{2}`              | Exactly `a` repetitions of `x`                            
-| `x{a,b}`                | `[0-9a-fA-F]{1,6}`            | `a` to `b` repetitions of `x`                             
-| `&#124;`                | `felt &#124; int`             | Either one or another                                     
-| `[ ]`                   | `[bB]`                        | Any of the characters listed                              
-| `[ - ]`                 | `[a-z]`                       | Any of the characters in the range                        
-| `~[ ]`                  | `~[bB]`                       | Any characters, except those listed                       
-| `~"string"`             | `~"\n"`, `~"*/"`              | Any characters, except this sequence                      
+| Notation                | Example                       | Meaning
+| `CAPITAL_CASE`          | `IDENTIFIER`                  | A named nonterminal or lexer token
+| `"string"`              | `"if"`, `"+"`                 | The exact character(s)
+| `` \`string` ``         | `` \`"` ``                    | Alternative syntax for exact character(s)
+| `snake_case`            | `let_stmt`, `item`            | A syntactical production
+| `\x`                    | `\n`, `\r`, `\t`, `\0`        | The character represented by this escape
+| `x?`                    | `pub?`                        | An optional item
+| `x*`                    | `item*`                       | 0 or more of `x`
+| `x+`                    | `item+`                       | 1 or more of `x`
+| `x{a}`                  | `[0-9a-fA-F]{2}`              | Exactly `a` repetitions of `x`
+| `x{a,b}`                | `[0-9a-fA-F]{1,6}`            | `a` to `b` repetitions of `x`
+| `&#124;`                | `felt &#124; int`             | Either one or another
+| `[ ]`                   | `[bB]`                        | Any of the characters listed
+| `[ - ]`                 | `[a-z]`                       | Any of the characters in the range
+| `~[ ]`                  | `~[bB]`                       | Any characters, except those listed
+| `~"string"`             | `~"\n"`, `~"*/"`              | Any characters, except this sequence
 | `~CAPITAL_CASE`         | `~EOL*`                       | Any characters, except sequences
-                                                            matching the lexer token 
-| `( )`                   | `( "," parameter )?`          | Group items                                              
-| `/* text */`            | `ITEM /* except IMPL_ITEM */` | Human words supplementation                               
+                                                            matching the lexer token
+| `( )`                   | `( "," parameter )?`          | Group items
+| `/* text */`            | `ITEM /* except IMPL_ITEM */` | Human words supplementation
 |===

--- a/docs/reference/src/operator-expressions.adoc
+++ b/docs/reference/src/operator-expressions.adoc
@@ -1,10 +1,11 @@
-# Operator expressions
+= Operator expressions
 
-```bnf
+[source,bnf]
+----
 OPERATOR_EXPR : NEGATION_OP_EXPR
               | ARITHMETIC_OR_LOGICAL_OP_EXPR
               | EQUALITY_EXPR
               | COMPARISON_EXPR
               | BOOLEAN_EXPR
               | ERROR_PROPAGATION_EXPR
-```
+----

--- a/docs/reference/src/parentheses.adoc
+++ b/docs/reference/src/parentheses.adoc
@@ -1,15 +1,17 @@
-# Parenthesized expressions
+= Parenthesized expressions
 
-```bnf
+[source,bnf]
+----
 PARENTHESIZED_EXPR : "(" EXPR ")"
-```
+----
 
 Parentheses can be used to enforce a particular order of evaluation in expressions that contain
 multiple operators.
 
 An example of a parenthesized expression:
 
-```cairo
+[source,cairo]
+----
  2 + 2  * 2 // == 6
 (2 + 2) * 2 // == 8
-```
+----

--- a/docs/reference/src/prelude.adoc
+++ b/docs/reference/src/prelude.adoc
@@ -1,4 +1,4 @@
-# Prelude
+= Prelude
 
 A _prelude_ is a collection of items that are always available in every module in a program.
 

--- a/docs/reference/src/punctuation.adoc
+++ b/docs/reference/src/punctuation.adoc
@@ -1,4 +1,4 @@
-# Punctuation
+= Punctuation
 
 Punctuation symbol tokens are listed here for completeness.
 Their individual usages and meanings are defined in the linked pages.
@@ -6,10 +6,10 @@ Their individual usages and meanings are defined in the linked pages.
 [cols="1,1,1",options="header"]
 |===
 | Symbol | Name | Usage
-| TODO   | TODO | TODO 
+| TODO   | TODO | TODO
 |===
 
-## Brackets
+== Brackets
 
 Bracket punctuation is used in various parts of the grammar.
 An open bracket must always be paired with a close bracket.
@@ -17,8 +17,8 @@ The three types of brackets are:
 
 [cols="1,1,1",options="header"]
 |===
-| Bracket | Type           
-| `{` `}` | Curly braces   
+| Bracket | Type
+| `{` `}` | Curly braces
 | `[` `]` | Square brackets
-| `(` `)` | Round parentheses    
+| `(` `)` | Round parentheses
 |===

--- a/docs/reference/src/statements.adoc
+++ b/docs/reference/src/statements.adoc
@@ -1,12 +1,13 @@
-# Statements
+= Statements
 
-```bnf
+[source,bnf]
+----
 STMT : ";"
      | ASSIGN_STMT
      | ITEM_STMT
      | LET_STMT
      | EXPR_STMT
-```
+----
 
 Cairo is an expression-oriented language, where most syntax productions producing values or
 causing effects when evaluated are _expressions_.
@@ -17,7 +18,7 @@ There are not a lot of statements kinds, which role is limited to containing exp
 link:expression-statement.adoc[expression evaluation] and declaring link:items.adoc[items]
 and link:let-statement.adoc[variables] in [code blocks].
 
-## Semicolons
+== Semicolons
 
 Statements are _usually_ separated with a semicolon (`;`).
 Extraneous semicolons are ignored.

--- a/docs/reference/src/type-system.adoc
+++ b/docs/reference/src/type-system.adoc
@@ -1,3 +1,3 @@
-# Type system
+= Type system
 
 This chapter describes the type system of Cairo.

--- a/docs/reference/src/types.adoc
+++ b/docs/reference/src/types.adoc
@@ -1,7 +1,8 @@
-# Types
+= Types
 
-```bnf
+[source,bnf]
+----
 TYPE : TYPE_PATH
      | UNIT_TYPE
      | TUPLE_TYPE
-```
+----

--- a/docs/reference/src/unit-type.adoc
+++ b/docs/reference/src/unit-type.adoc
@@ -1,8 +1,9 @@
-# Unit type
+= Unit type
 
-```bnf
+[source,bnf]
+----
 UNIT_TYPE : "()"
-```
+----
 
 A _unit type_ is a type which has only one value (link:literal-expressions.adoc[unit literal], `()`).
 Its size is always zero, and it is guaranteed to be eliminated from output code in compilation time.

--- a/docs/reference/src/whitespace.adoc
+++ b/docs/reference/src/whitespace.adoc
@@ -1,8 +1,9 @@
-# Whitespace
+= Whitespace
 
-```bnf
+[source,bnf]
+----
 EOL : "\n" | "\r\n"
-```
+----
 
 Whitespace is any non-empty string containing only characters that have the https://www.unicode.org/reports/tr31/[`Pattern_White_Space`]
 Unicode property, namely:


### PR DESCRIPTION
![obraz](https://user-images.githubusercontent.com/3450050/186689238-3fc1308b-992e-4f8a-9573-0893658197e3.png)

This diff was generated automatically by IntelliJ 😄 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/137)
<!-- Reviewable:end -->
