### PR TITLE
Small cairo_spec fixes: made return type optional and made param-name an identifier instead of a direct terminal

### DIFF
--- a/crates/syntax/src/node/ast.rs
+++ b/crates/syntax/src/node/ast.rs
@@ -2226,8 +2226,8 @@ impl Param {
             width,
         }))
     }
-    pub fn identifier(&self, db: &dyn SyntaxGroup) -> Terminal {
-        Terminal::from_syntax_node(db, self.children[0].clone())
+    pub fn identifier(&self, db: &dyn SyntaxGroup) -> Identifier {
+        Identifier::from_syntax_node(db, self.children[0].clone())
     }
     pub fn type_clause(&self, db: &dyn SyntaxGroup) -> TypeClause {
         TypeClause::from_syntax_node(db, self.children[1].clone())
@@ -2237,7 +2237,7 @@ impl TypedSyntaxNode for Param {
     fn missing(db: &dyn SyntaxGroup) -> GreenId {
         db.intern_green(GreenNode::Internal(GreenNodeInternal {
             kind: SyntaxKind::Param,
-            children: vec![Terminal::missing(db), TypeClause::missing(db)],
+            children: vec![Identifier::missing(db), TypeClause::missing(db)],
             width: 0,
         }))
     }
@@ -2458,8 +2458,8 @@ impl FunctionSignature {
     pub fn rparen(&self, db: &dyn SyntaxGroup) -> Terminal {
         Terminal::from_syntax_node(db, self.children[4].clone())
     }
-    pub fn ret_ty(&self, db: &dyn SyntaxGroup) -> ReturnTypeClause {
-        ReturnTypeClause::from_syntax_node(db, self.children[5].clone())
+    pub fn ret_ty(&self, db: &dyn SyntaxGroup) -> OptionReturnTypeClause {
+        OptionReturnTypeClause::from_syntax_node(db, self.children[5].clone())
     }
 }
 impl TypedSyntaxNode for FunctionSignature {
@@ -2472,7 +2472,7 @@ impl TypedSyntaxNode for FunctionSignature {
                 Terminal::missing(db),
                 ParamList::missing(db),
                 Terminal::missing(db),
-                ReturnTypeClause::missing(db),
+                OptionReturnTypeClause::missing(db),
             ],
             width: 0,
         }))

--- a/crates/syntax_codegen/src/cairo_spec.rs
+++ b/crates/syntax_codegen/src/cairo_spec.rs
@@ -160,7 +160,7 @@ pub fn get_spec() -> Vec<Node> {
             .build(),
         // --- Parameters and Functions ---
         StructBuilder::new("Param")
-            .node("identifier", "Terminal")
+            .node("identifier", "Identifier")
             .node("type_clause", "TypeClause")
             .build(),
         separated_list_node("ParamList", "Param"),
@@ -181,7 +181,7 @@ pub fn get_spec() -> Vec<Node> {
             .node("lparen", "Terminal")
             .node("parameters", "ParamList")
             .node("rparen", "Terminal")
-            .node("ret_ty", "ReturnTypeClause")
+            .node("ret_ty", "OptionReturnTypeClause")
             .build(),
         // --- Items ---
         EnumBuilder::new("Item")


### PR DESCRIPTION
… an identifier instead of a direct terminal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/184)
<!-- Reviewable:end -->
