### PR TITLE
Move function name to item ast

### DIFF
--- a/crates/defs/src/db.rs
+++ b/crates/defs/src/db.rs
@@ -67,8 +67,7 @@ fn module_items(
             syntax_file.items(syntax_group).elements(syntax_group).iter().map(|item| match item {
                 ast::Item::Module(_module) => todo!(),
                 ast::Item::Function(function) => {
-                    let name =
-                        function.signature(syntax_group).name(syntax_group).text(syntax_group);
+                    let name = function.name(syntax_group).text(syntax_group);
                     (
                         name.clone(),
                         ModuleItemId::FreeFunction(
@@ -77,10 +76,7 @@ fn module_items(
                     )
                 }
                 ast::Item::ExternFunction(extern_function) => {
-                    let name = extern_function
-                        .signature(syntax_group)
-                        .name(syntax_group)
-                        .text(syntax_group);
+                    let name = extern_function.name(syntax_group).text(syntax_group);
                     (
                         name.clone(),
                         ModuleItemId::ExternFunction(db.intern_extern_function(

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -159,13 +159,10 @@ impl<'a> Parser<'a> {
         )
     }
 
-    /// Assumes the current token is Function.
-    /// Expected pattern: fn<Identifier><ParenthesizedParamList><ReturnTypeClause>
+    /// Expected pattern: <ParenthesizedParamList><ReturnTypeClause>
     fn expect_function_signature(&mut self) -> GreenId {
         FunctionSignature::new_green(
             self.db,
-            self.take(),                             // function keyword
-            self.parse_token(TokenKind::Identifier), // name
             // TODO(yuval): support generics
             self.parse_token(TokenKind::LParen),      // (
             self.parse_param_list(TokenKind::RParen), // params
@@ -182,9 +179,11 @@ impl<'a> Parser<'a> {
             TokenKind::Function => {
                 ItemExternFunction::new_green(
                     self.db,
-                    externkw,                          // externkw
-                    self.expect_function_signature(),  // signature
-                    self.parse_token(TokenKind::Semi), // semi
+                    externkw,                                // externkw
+                    self.take(),                             // function keyword
+                    self.parse_token(TokenKind::Identifier), // name
+                    self.expect_function_signature(),        // signature
+                    self.parse_token(TokenKind::Semi),       // semi
                 )
             }
             _ => {
@@ -205,8 +204,10 @@ impl<'a> Parser<'a> {
     fn expect_function(&mut self) -> GreenId {
         ItemFunction::new_green(
             self.db,
-            self.expect_function_signature(), // signature
-            self.parse_block(),               // function body
+            self.take(),                             // function keyword
+            self.parse_token(TokenKind::Identifier), // name
+            self.expect_function_signature(),        // signature
+            self.parse_block(),                      // function body
         )
     }
 

--- a/crates/parser/test_data/expected_results/short_tree
+++ b/crates/parser/test_data/expected_results/short_tree
@@ -1,9 +1,9 @@
 └── root (kind: SyntaxFile)
     ├── items (kind: ItemList)
     │   └── child #0 (kind: ItemFunction)
+    │       ├── funckw (kind: Function): 'func'
+    │       ├── name (kind: Identifier): 'foo'
     │       ├── signature (kind: FunctionSignature)
-    │       │   ├── funckw (kind: Function): 'func'
-    │       │   ├── name (kind: Identifier): 'foo'
     │       │   ├── lparen (kind: LParen): '('
     │       │   ├── parameters (kind: ParamList)
     │       │   │   └── item #0 (kind: Param)

--- a/crates/parser/test_data/expected_results/short_tree_colored
+++ b/crates/parser/test_data/expected_results/short_tree_colored
@@ -1,9 +1,9 @@
 └── [36mroot[0m (kind: SyntaxFile)
     ├── [36mitems[0m (kind: ItemList)
     │   └── [36mchild #0[0m (kind: ItemFunction)
+    │       ├── [34mfunckw[0m (kind: Function): '[1;32mfunc[0m'
+    │       ├── [34mname[0m (kind: Identifier): '[1;32mfoo[0m'
     │       ├── [36msignature[0m (kind: FunctionSignature)
-    │       │   ├── [34mfunckw[0m (kind: Function): '[1;32mfunc[0m'
-    │       │   ├── [34mname[0m (kind: Identifier): '[1;32mfoo[0m'
     │       │   ├── [34mlparen[0m (kind: LParen): '[1;32m([0m'
     │       │   ├── [36mparameters[0m (kind: ParamList)
     │       │   │   └── [36mitem #0[0m (kind: Param)

--- a/crates/parser/test_data/expected_results/test1_tree
+++ b/crates/parser/test_data/expected_results/test1_tree
@@ -1,9 +1,9 @@
 └── root (kind: SyntaxFile)
     ├── items (kind: ItemList)
     │   ├── child #0 (kind: ItemFunction)
+    │   │   ├── funckw (kind: Function): 'func'
+    │   │   ├── name (kind: Identifier): 'foo'
     │   │   ├── signature (kind: FunctionSignature)
-    │   │   │   ├── funckw (kind: Function): 'func'
-    │   │   │   ├── name (kind: Identifier): 'foo'
     │   │   │   ├── lparen (kind: LParen): '('
     │   │   │   ├── parameters (kind: ParamList)
     │   │   │   │   ├── item #0 (kind: Param)
@@ -156,9 +156,9 @@
     │   │   └── semi (kind: Semi): ';'
     │   └── child #2 (kind: ItemExternFunction)
     │       ├── externkw (kind: Extern): 'extern'
+    │       ├── funckw (kind: Function): 'func'
+    │       ├── name (kind: Identifier): 'bar'
     │       ├── signature (kind: FunctionSignature)
-    │       │   ├── funckw (kind: Function): 'func'
-    │       │   ├── name (kind: Identifier): 'bar'
     │       │   ├── lparen (kind: LParen): '('
     │       │   ├── parameters (kind: ParamList)
     │       │   │   ├── item #0 (kind: Param)

--- a/crates/parser/test_data/expected_results/test1_tree_with_trivia
+++ b/crates/parser/test_data/expected_results/test1_tree_with_trivia
@@ -1,25 +1,25 @@
 └── root (kind: SyntaxFile)
     ├── items (kind: ItemList)
     │   ├── child #0 (kind: ItemFunction)
+    │   │   ├── funckw (kind: Terminal)
+    │   │   │   ├── leading_trivia (kind: Trivia)
+    │   │   │   │   └── child #0 (kind: TriviumSkippedTerminal)
+    │   │   │   │       ├── leading_trivia (kind: Trivia)
+    │   │   │   │       │   ├── child #0 (kind: SingleLineComment): '// Func foo'
+    │   │   │   │       │   ├── child #1 (kind: Newline).
+    │   │   │   │       │   ├── child #2 (kind: SingleLineComment): '// Second line'
+    │   │   │   │       │   └── child #3 (kind: Newline).
+    │   │   │   │       ├── token (kind: Semi): ';'
+    │   │   │   │       └── trailing_trivia (kind: Trivia)
+    │   │   │   │           └── child #0 (kind: Newline).
+    │   │   │   ├── token (kind: Function): 'func'
+    │   │   │   └── trailing_trivia (kind: Trivia)
+    │   │   │       └── child #0 (kind: Whitespace).
+    │   │   ├── name (kind: Terminal)
+    │   │   │   ├── leading_trivia (kind: Trivia) []
+    │   │   │   ├── token (kind: Identifier): 'foo'
+    │   │   │   └── trailing_trivia (kind: Trivia) []
     │   │   ├── signature (kind: FunctionSignature)
-    │   │   │   ├── funckw (kind: Terminal)
-    │   │   │   │   ├── leading_trivia (kind: Trivia)
-    │   │   │   │   │   └── child #0 (kind: TriviumSkippedTerminal)
-    │   │   │   │   │       ├── leading_trivia (kind: Trivia)
-    │   │   │   │   │       │   ├── child #0 (kind: SingleLineComment): '// Func foo'
-    │   │   │   │   │       │   ├── child #1 (kind: Newline).
-    │   │   │   │   │       │   ├── child #2 (kind: SingleLineComment): '// Second line'
-    │   │   │   │   │       │   └── child #3 (kind: Newline).
-    │   │   │   │   │       ├── token (kind: Semi): ';'
-    │   │   │   │   │       └── trailing_trivia (kind: Trivia)
-    │   │   │   │   │           └── child #0 (kind: Newline).
-    │   │   │   │   ├── token (kind: Function): 'func'
-    │   │   │   │   └── trailing_trivia (kind: Trivia)
-    │   │   │   │       └── child #0 (kind: Whitespace).
-    │   │   │   ├── name (kind: Terminal)
-    │   │   │   │   ├── leading_trivia (kind: Trivia) []
-    │   │   │   │   ├── token (kind: Identifier): 'foo'
-    │   │   │   │   └── trailing_trivia (kind: Trivia) []
     │   │   │   ├── lparen (kind: Terminal)
     │   │   │   │   ├── leading_trivia (kind: Trivia) []
     │   │   │   │   ├── token (kind: LParen): '('
@@ -473,16 +473,16 @@
     │       │   ├── token (kind: Extern): 'extern'
     │       │   └── trailing_trivia (kind: Trivia)
     │       │       └── child #0 (kind: Whitespace).
+    │       ├── funckw (kind: Terminal)
+    │       │   ├── leading_trivia (kind: Trivia) []
+    │       │   ├── token (kind: Function): 'func'
+    │       │   └── trailing_trivia (kind: Trivia)
+    │       │       └── child #0 (kind: Whitespace).
+    │       ├── name (kind: Terminal)
+    │       │   ├── leading_trivia (kind: Trivia) []
+    │       │   ├── token (kind: Identifier): 'bar'
+    │       │   └── trailing_trivia (kind: Trivia) []
     │       ├── signature (kind: FunctionSignature)
-    │       │   ├── funckw (kind: Terminal)
-    │       │   │   ├── leading_trivia (kind: Trivia) []
-    │       │   │   ├── token (kind: Function): 'func'
-    │       │   │   └── trailing_trivia (kind: Trivia)
-    │       │   │       └── child #0 (kind: Whitespace).
-    │       │   ├── name (kind: Terminal)
-    │       │   │   ├── leading_trivia (kind: Trivia) []
-    │       │   │   ├── token (kind: Identifier): 'bar'
-    │       │   │   └── trailing_trivia (kind: Trivia) []
     │       │   ├── lparen (kind: Terminal)
     │       │   │   ├── leading_trivia (kind: Trivia) []
     │       │   │   ├── token (kind: LParen): '('

--- a/crates/parser/test_data/expected_results/test2_tree
+++ b/crates/parser/test_data/expected_results/test2_tree
@@ -1,9 +1,9 @@
 └── root (kind: SyntaxFile)
     ├── items (kind: ItemList)
     │   ├── child #0 (kind: ItemFunction)
+    │   │   ├── funckw (kind: Function): 'func'
+    │   │   ├── name (kind: Identifier): 'foo'
     │   │   ├── signature (kind: FunctionSignature)
-    │   │   │   ├── funckw (kind: Function): 'func'
-    │   │   │   ├── name (kind: Identifier): 'foo'
     │   │   │   ├── lparen (kind: LParen): '('
     │   │   │   ├── parameters (kind: ParamList)
     │   │   │   │   └── item #0 (kind: Param)
@@ -144,9 +144,9 @@
     │   │   ├── name (kind: Identifier): 'my_mod'
     │   │   └── semi: Missing
     │   ├── child #2 (kind: ItemFunction)
+    │   │   ├── funckw (kind: Function): 'func'
+    │   │   ├── name (kind: Identifier): 'bar'
     │   │   ├── signature (kind: FunctionSignature)
-    │   │   │   ├── funckw (kind: Function): 'func'
-    │   │   │   ├── name (kind: Identifier): 'bar'
     │   │   │   ├── lparen (kind: LParen): '('
     │   │   │   ├── parameters (kind: ParamList)
     │   │   │   │   ├── item #0 (kind: Param)

--- a/crates/parser/test_data/expected_results/test2_tree_with_trivia
+++ b/crates/parser/test_data/expected_results/test2_tree_with_trivia
@@ -1,17 +1,17 @@
 └── root (kind: SyntaxFile)
     ├── items (kind: ItemList)
     │   ├── child #0 (kind: ItemFunction)
+    │   │   ├── funckw (kind: Terminal)
+    │   │   │   ├── leading_trivia (kind: Trivia) []
+    │   │   │   ├── token (kind: Function): 'func'
+    │   │   │   └── trailing_trivia (kind: Trivia)
+    │   │   │       └── child #0 (kind: Whitespace).
+    │   │   ├── name (kind: Terminal)
+    │   │   │   ├── leading_trivia (kind: Trivia) []
+    │   │   │   ├── token (kind: Identifier): 'foo'
+    │   │   │   └── trailing_trivia (kind: Trivia)
+    │   │   │       └── child #0 (kind: Whitespace).
     │   │   ├── signature (kind: FunctionSignature)
-    │   │   │   ├── funckw (kind: Terminal)
-    │   │   │   │   ├── leading_trivia (kind: Trivia) []
-    │   │   │   │   ├── token (kind: Function): 'func'
-    │   │   │   │   └── trailing_trivia (kind: Trivia)
-    │   │   │   │       └── child #0 (kind: Whitespace).
-    │   │   │   ├── name (kind: Terminal)
-    │   │   │   │   ├── leading_trivia (kind: Trivia) []
-    │   │   │   │   ├── token (kind: Identifier): 'foo'
-    │   │   │   │   └── trailing_trivia (kind: Trivia)
-    │   │   │   │       └── child #0 (kind: Whitespace).
     │   │   │   ├── lparen (kind: Terminal)
     │   │   │   │   ├── leading_trivia (kind: Trivia) []
     │   │   │   │   ├── token (kind: LParen): '('
@@ -392,23 +392,23 @@
     │   │   │   └── trailing_trivia (kind: Trivia) []
     │   │   └── semi: Missing
     │   ├── child #2 (kind: ItemFunction)
+    │   │   ├── funckw (kind: Terminal)
+    │   │   │   ├── leading_trivia (kind: Trivia)
+    │   │   │   │   ├── child #0 (kind: TriviumSkippedTerminal)
+    │   │   │   │   │   ├── leading_trivia (kind: Trivia) []
+    │   │   │   │   │   ├── token (kind: LBrace): '{'
+    │   │   │   │   │   └── trailing_trivia (kind: Trivia)
+    │   │   │   │   │       └── child #0 (kind: Newline).
+    │   │   │   │   └── child #1 (kind: Whitespace).
+    │   │   │   ├── token (kind: Function): 'func'
+    │   │   │   └── trailing_trivia (kind: Trivia)
+    │   │   │       └── child #0 (kind: Whitespace).
+    │   │   ├── name (kind: Terminal)
+    │   │   │   ├── leading_trivia (kind: Trivia) []
+    │   │   │   ├── token (kind: Identifier): 'bar'
+    │   │   │   └── trailing_trivia (kind: Trivia)
+    │   │   │       └── child #0 (kind: Whitespace).
     │   │   ├── signature (kind: FunctionSignature)
-    │   │   │   ├── funckw (kind: Terminal)
-    │   │   │   │   ├── leading_trivia (kind: Trivia)
-    │   │   │   │   │   ├── child #0 (kind: TriviumSkippedTerminal)
-    │   │   │   │   │   │   ├── leading_trivia (kind: Trivia) []
-    │   │   │   │   │   │   ├── token (kind: LBrace): '{'
-    │   │   │   │   │   │   └── trailing_trivia (kind: Trivia)
-    │   │   │   │   │   │       └── child #0 (kind: Newline).
-    │   │   │   │   │   └── child #1 (kind: Whitespace).
-    │   │   │   │   ├── token (kind: Function): 'func'
-    │   │   │   │   └── trailing_trivia (kind: Trivia)
-    │   │   │   │       └── child #0 (kind: Whitespace).
-    │   │   │   ├── name (kind: Terminal)
-    │   │   │   │   ├── leading_trivia (kind: Trivia) []
-    │   │   │   │   ├── token (kind: Identifier): 'bar'
-    │   │   │   │   └── trailing_trivia (kind: Trivia)
-    │   │   │   │       └── child #0 (kind: Whitespace).
     │   │   │   ├── lparen (kind: Terminal)
     │   │   │   │   ├── leading_trivia (kind: Trivia) []
     │   │   │   │   ├── token (kind: LParen): '('

--- a/crates/semantic/src/db.rs
+++ b/crates/semantic/src/db.rs
@@ -140,7 +140,7 @@ fn lookup_ast_free_function(
     let syntax_file = db.file_syntax(db.module_file(module_id)?).unwrap(diagnostics)?;
     for item in syntax_file.items(syntax_db).elements(syntax_db) {
         if let ast::Item::Function(function) = item {
-            if function.signature(syntax_db).name(syntax_db).text(syntax_db) == func_name {
+            if function.name(syntax_db).text(syntax_db) == func_name {
                 return Some(function);
             }
         }

--- a/crates/syntax/src/node/ast.rs
+++ b/crates/syntax/src/node/ast.rs
@@ -3105,14 +3105,12 @@ pub struct FunctionSignature {
 impl FunctionSignature {
     pub fn new_green(
         db: &dyn SyntaxGroup,
-        funckw: GreenId,
-        name: GreenId,
         lparen: GreenId,
         parameters: GreenId,
         rparen: GreenId,
         ret_ty: GreenId,
     ) -> GreenId {
-        let children: Vec<GreenId> = vec![funckw, name, lparen, parameters, rparen, ret_ty];
+        let children: Vec<GreenId> = vec![lparen, parameters, rparen, ret_ty];
         let width = children.iter().map(|id| db.lookup_intern_green(*id).width()).sum();
         db.intern_green(GreenNode::Internal(GreenNodeInternal {
             kind: SyntaxKind::FunctionSignature,
@@ -3120,23 +3118,17 @@ impl FunctionSignature {
             width,
         }))
     }
-    pub fn funckw(&self, db: &dyn SyntaxGroup) -> Terminal {
+    pub fn lparen(&self, db: &dyn SyntaxGroup) -> Terminal {
         Terminal::from_syntax_node(db, self.children[0].clone())
     }
-    pub fn name(&self, db: &dyn SyntaxGroup) -> Terminal {
-        Terminal::from_syntax_node(db, self.children[1].clone())
-    }
-    pub fn lparen(&self, db: &dyn SyntaxGroup) -> Terminal {
-        Terminal::from_syntax_node(db, self.children[2].clone())
-    }
     pub fn parameters(&self, db: &dyn SyntaxGroup) -> ParamList {
-        ParamList::from_syntax_node(db, self.children[3].clone())
+        ParamList::from_syntax_node(db, self.children[1].clone())
     }
     pub fn rparen(&self, db: &dyn SyntaxGroup) -> Terminal {
-        Terminal::from_syntax_node(db, self.children[4].clone())
+        Terminal::from_syntax_node(db, self.children[2].clone())
     }
     pub fn ret_ty(&self, db: &dyn SyntaxGroup) -> OptionReturnTypeClause {
-        OptionReturnTypeClause::from_syntax_node(db, self.children[5].clone())
+        OptionReturnTypeClause::from_syntax_node(db, self.children[3].clone())
     }
 }
 pub struct FunctionSignaturePtr(SyntaxStablePtrId);
@@ -3146,8 +3138,6 @@ impl TypedSyntaxNode for FunctionSignature {
         db.intern_green(GreenNode::Internal(GreenNodeInternal {
             kind: SyntaxKind::FunctionSignature,
             children: vec![
-                Terminal::missing(db),
-                Terminal::missing(db),
                 Terminal::missing(db),
                 ParamList::missing(db),
                 Terminal::missing(db),
@@ -3369,8 +3359,14 @@ pub struct ItemFunction {
     children: Vec<SyntaxNode>,
 }
 impl ItemFunction {
-    pub fn new_green(db: &dyn SyntaxGroup, signature: GreenId, body: GreenId) -> GreenId {
-        let children: Vec<GreenId> = vec![signature, body];
+    pub fn new_green(
+        db: &dyn SyntaxGroup,
+        funckw: GreenId,
+        name: GreenId,
+        signature: GreenId,
+        body: GreenId,
+    ) -> GreenId {
+        let children: Vec<GreenId> = vec![funckw, name, signature, body];
         let width = children.iter().map(|id| db.lookup_intern_green(*id).width()).sum();
         db.intern_green(GreenNode::Internal(GreenNodeInternal {
             kind: SyntaxKind::ItemFunction,
@@ -3378,11 +3374,17 @@ impl ItemFunction {
             width,
         }))
     }
+    pub fn funckw(&self, db: &dyn SyntaxGroup) -> Terminal {
+        Terminal::from_syntax_node(db, self.children[0].clone())
+    }
+    pub fn name(&self, db: &dyn SyntaxGroup) -> Terminal {
+        Terminal::from_syntax_node(db, self.children[1].clone())
+    }
     pub fn signature(&self, db: &dyn SyntaxGroup) -> FunctionSignature {
-        FunctionSignature::from_syntax_node(db, self.children[0].clone())
+        FunctionSignature::from_syntax_node(db, self.children[2].clone())
     }
     pub fn body(&self, db: &dyn SyntaxGroup) -> ExprBlock {
-        ExprBlock::from_syntax_node(db, self.children[1].clone())
+        ExprBlock::from_syntax_node(db, self.children[3].clone())
     }
 }
 pub struct ItemFunctionPtr(SyntaxStablePtrId);
@@ -3391,7 +3393,12 @@ impl TypedSyntaxNode for ItemFunction {
     fn missing(db: &dyn SyntaxGroup) -> GreenId {
         db.intern_green(GreenNode::Internal(GreenNodeInternal {
             kind: SyntaxKind::ItemFunction,
-            children: vec![FunctionSignature::missing(db), ExprBlock::missing(db)],
+            children: vec![
+                Terminal::missing(db),
+                Terminal::missing(db),
+                FunctionSignature::missing(db),
+                ExprBlock::missing(db),
+            ],
             width: 0,
         }))
     }
@@ -3432,10 +3439,12 @@ impl ItemExternFunction {
     pub fn new_green(
         db: &dyn SyntaxGroup,
         externkw: GreenId,
+        funckw: GreenId,
+        name: GreenId,
         signature: GreenId,
         semi: GreenId,
     ) -> GreenId {
-        let children: Vec<GreenId> = vec![externkw, signature, semi];
+        let children: Vec<GreenId> = vec![externkw, funckw, name, signature, semi];
         let width = children.iter().map(|id| db.lookup_intern_green(*id).width()).sum();
         db.intern_green(GreenNode::Internal(GreenNodeInternal {
             kind: SyntaxKind::ItemExternFunction,
@@ -3446,11 +3455,17 @@ impl ItemExternFunction {
     pub fn externkw(&self, db: &dyn SyntaxGroup) -> Terminal {
         Terminal::from_syntax_node(db, self.children[0].clone())
     }
+    pub fn funckw(&self, db: &dyn SyntaxGroup) -> Terminal {
+        Terminal::from_syntax_node(db, self.children[1].clone())
+    }
+    pub fn name(&self, db: &dyn SyntaxGroup) -> Terminal {
+        Terminal::from_syntax_node(db, self.children[2].clone())
+    }
     pub fn signature(&self, db: &dyn SyntaxGroup) -> FunctionSignature {
-        FunctionSignature::from_syntax_node(db, self.children[1].clone())
+        FunctionSignature::from_syntax_node(db, self.children[3].clone())
     }
     pub fn semi(&self, db: &dyn SyntaxGroup) -> Terminal {
-        Terminal::from_syntax_node(db, self.children[2].clone())
+        Terminal::from_syntax_node(db, self.children[4].clone())
     }
 }
 pub struct ItemExternFunctionPtr(SyntaxStablePtrId);
@@ -3460,6 +3475,8 @@ impl TypedSyntaxNode for ItemExternFunction {
         db.intern_green(GreenNode::Internal(GreenNodeInternal {
             kind: SyntaxKind::ItemExternFunction,
             children: vec![
+                Terminal::missing(db),
+                Terminal::missing(db),
                 Terminal::missing(db),
                 FunctionSignature::missing(db),
                 Terminal::missing(db),

--- a/crates/syntax_codegen/src/cairo_spec.rs
+++ b/crates/syntax_codegen/src/cairo_spec.rs
@@ -199,9 +199,8 @@ pub fn get_spec() -> Vec<Node> {
             .node("rbrace", "Terminal")
             .build(),
         // TODO(spapini): Add generic params.
+        // This is an unnamed signature, e.g. "() -> Type".
         StructBuilder::new("FunctionSignature")
-            .node("funckw", "Terminal")
-            .node("name", "Terminal")
             .node("lparen", "Terminal")
             .node("parameters", "ParamList")
             .node("rparen", "Terminal")
@@ -226,11 +225,15 @@ pub fn get_spec() -> Vec<Node> {
             .node("semi", "Terminal")
             .build(),
         StructBuilder::new("ItemFunction")
+            .node("funckw", "Terminal")
+            .node("name", "Terminal")
             .node("signature", "FunctionSignature")
             .node("body", "ExprBlock")
             .build(),
         StructBuilder::new("ItemExternFunction")
             .node("externkw", "Terminal")
+            .node("funckw", "Terminal")
+            .node("name", "Terminal")
             .node("signature", "FunctionSignature")
             .node("semi", "Terminal")
             .build(),


### PR DESCRIPTION
This change makes my life a lot easier when using stable ptrs as ids - the name can be a key field and be available in the id itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/237)
<!-- Reviewable:end -->
