### PR TITLE
Made interning of concrete types only based on sierra types.

### DIFF
--- a/crates/sierra_generator/src/expr_generator_context.rs
+++ b/crates/sierra_generator/src/expr_generator_context.rs
@@ -65,7 +65,7 @@ impl<'a> ExprGeneratorContext<'a> {
     /// Generates a label id and a label statement.
     // TODO(lior): Consider using stable ids, instead of allocating sequential ids.
     pub fn new_label(&mut self) -> (pre_sierra::Statement, pre_sierra::LabelId) {
-        let id = self.get_db().intern_label_id(pre_sierra::LabelLongId {
+        let id = self.db.intern_label_id(pre_sierra::LabelLongId {
             parent: self.function_id,
             id: self.label_id_allocator.allocate(),
         });
@@ -90,9 +90,13 @@ impl<'a> ExprGeneratorContext<'a> {
     }
 
     pub fn store_temp_libfunc_id(&self, ty: semantic::TypeId) -> sierra::ids::ConcreteLibFuncId {
+        // TODO(orizi): Propagate the diagnostics or extract `get_concrete_type_id` usage out of
+        // this function.
         self.db.intern_concrete_lib_func(sierra::program::ConcreteLibFuncLongId {
             generic_id: sierra::ids::GenericLibFuncId::from_string("store_temp"),
-            args: vec![sierra::program::GenericArg::Type(self.db.intern_type_id(ty))],
+            args: vec![sierra::program::GenericArg::Type(
+                self.db.get_concrete_type_id(ty).expect("got unexpected diagnostics").unwrap(),
+            )],
         })
     }
 
@@ -118,6 +122,6 @@ impl<'a> ExprGeneratorContext<'a> {
         &self,
         extern_id: defs::ids::ExternFunctionId,
     ) -> sierra::ids::ConcreteLibFuncId {
-        self.get_extension_id_without_generics(extern_id.name(self.get_db().as_defs_group()))
+        self.get_extension_id_without_generics(extern_id.name(self.db.as_defs_group()))
     }
 }

--- a/crates/sierra_generator/src/function_generator.rs
+++ b/crates/sierra_generator/src/function_generator.rs
@@ -27,11 +27,22 @@ pub fn generate_function_code(
         .iter()
         .map(|param| {
             let sierra_var = context.allocate_sierra_variable();
+            // TODO(orizi): Propagate the diagnostics or extract `get_concrete_type_id` usage out of
+            // this function.
             context.register_variable(defs::ids::VarId::Param(param.id), sierra_var.clone());
-            sierra::program::Param { id: sierra_var, ty: db.intern_type_id(param.ty) }
+            sierra::program::Param {
+                id: sierra_var,
+                ty: db.get_concrete_type_id(param.ty).expect("got unexpected diagnostics").unwrap(),
+            }
         })
         .collect();
-    let ret_types = vec![db.intern_type_id(function_semantic.signature.return_type)];
+    // TODO(orizi): Propagate the diagnostics or extract `get_concrete_type_id` usage out of this
+    // function.
+    let ret_types = vec![
+        db.get_concrete_type_id(function_semantic.signature.return_type)
+            .expect("got unexpected diagnostics")
+            .unwrap(),
+    ];
 
     let mut statements: Vec<pre_sierra::Statement> = vec![label];
 


### PR DESCRIPTION
Interning now is only from long id - in order to get a concrete type id
from a sematic type added a fetch function.

commit-id:6d48f276

---

**Stack**:
- #276
- #282
- #275 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/275)
<!-- Reviewable:end -->
