### PR TITLE
Filesystem supports file_overrides

### DIFF
--- a/crates/filesystem/src/test_utils.rs
+++ b/crates/filesystem/src/test_utils.rs
@@ -1,9 +1,15 @@
-use crate::db::FilesDatabase;
+use crate::db::{init_files_group, FilesDatabase};
 
 // Test salsa database.
 #[salsa::database(FilesDatabase)]
-#[derive(Default)]
 pub struct FilesDatabaseForTesting {
     storage: salsa::Storage<FilesDatabaseForTesting>,
 }
 impl salsa::Database for FilesDatabaseForTesting {}
+impl Default for FilesDatabaseForTesting {
+    fn default() -> Self {
+        let mut res = Self { storage: Default::default() };
+        init_files_group(&mut res);
+        res
+    }
+}

--- a/crates/parser/src/test_utils.rs
+++ b/crates/parser/src/test_utils.rs
@@ -1,15 +1,22 @@
-use filesystem::db::FilesDatabase;
+use filesystem::db::{init_files_group, FilesDatabase};
 use syntax::node::db::{AsSyntaxGroup, SyntaxDatabase, SyntaxGroup};
 
 use crate::db::ParserDatabase;
 
 // Test salsa database.
 #[salsa::database(ParserDatabase, SyntaxDatabase, FilesDatabase)]
-#[derive(Default)]
 pub struct ParserDatabaseForTesting {
     storage: salsa::Storage<ParserDatabaseForTesting>,
 }
 impl salsa::Database for ParserDatabaseForTesting {}
+impl Default for ParserDatabaseForTesting {
+    fn default() -> Self {
+        let mut res = Self { storage: Default::default() };
+        init_files_group(&mut res);
+        res
+    }
+}
+
 impl AsSyntaxGroup for ParserDatabaseForTesting {
     fn as_syntax_group(&self) -> &(dyn SyntaxGroup + 'static) {
         self

--- a/crates/sierra_generator/src/test_utils.rs
+++ b/crates/sierra_generator/src/test_utils.rs
@@ -1,5 +1,5 @@
 use defs::db::{AsDefsGroup, DefsDatabase};
-use filesystem::db::{AsFilesGroup, FilesDatabase, FilesGroup};
+use filesystem::db::{init_files_group, AsFilesGroup, FilesDatabase, FilesGroup};
 use parser::db::ParserDatabase;
 use semantic::db::{AsSemanticGroup, SemanticDatabase};
 use syntax::node::db::{AsSyntaxGroup, SyntaxDatabase, SyntaxGroup};
@@ -15,11 +15,17 @@ use crate::pre_sierra;
     SyntaxDatabase,
     FilesDatabase
 )]
-#[derive(Default)]
 pub struct SierraGenDatabaseForTesting {
     storage: salsa::Storage<SierraGenDatabaseForTesting>,
 }
 impl salsa::Database for SierraGenDatabaseForTesting {}
+impl Default for SierraGenDatabaseForTesting {
+    fn default() -> Self {
+        let mut res = Self { storage: Default::default() };
+        init_files_group(&mut res);
+        res
+    }
+}
 impl AsFilesGroup for SierraGenDatabaseForTesting {
     fn as_files_group(&self) -> &(dyn FilesGroup + 'static) {
         self


### PR DESCRIPTION
file_overrides() let's you override content of any file (including OnDisk).
This enables
1. Better testing - without VirtualFile.
2. Language server support - when a file changes in the IDE.
3. When support submodules, only support for OnDisk, instead of full blown virtual directories, etc.., while still testing this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/327)
<!-- Reviewable:end -->
