### PR TITLE
Files to modules mapping

### DIFF
--- a/crates/defs/src/test.rs
+++ b/crates/defs/src/test.rs
@@ -127,4 +127,12 @@ fn test_submodules() {
 
     db.module_item_by_name(subsubmodule_id, "foo".into())
         .expect("Expected to find foo() in subsubmodule.");
+
+    // Test file mappings.
+    assert_eq!(db.file_modules(db.module_file(module_id).unwrap()).unwrap(), vec![module_id]);
+    assert_eq!(db.file_modules(db.module_file(submodule_id).unwrap()).unwrap(), vec![submodule_id]);
+    assert_eq!(
+        db.file_modules(db.module_file(subsubmodule_id).unwrap()).unwrap(),
+        vec![subsubmodule_id]
+    );
 }

--- a/crates/utils/src/ordered_hash_map.rs
+++ b/crates/utils/src/ordered_hash_map.rs
@@ -12,8 +12,16 @@ impl<Key: Hash + Eq, Value> OrderedHashMap<Key, Value> {
         self.0.get(key)
     }
 
+    pub fn get_mut(&mut self, key: &Key) -> Option<&mut Value> {
+        self.0.get_mut(key)
+    }
+
     pub fn iter(&self) -> indexmap::map::Iter<'_, Key, Value> {
         self.0.iter()
+    }
+
+    pub fn keys(&self) -> indexmap::map::Keys<'_, Key, Value> {
+        self.0.keys()
     }
 
     pub fn insert(&mut self, key: Key, value: Value) -> Option<Value> {


### PR DESCRIPTION
Mapping from file to modules. Required for collecting diagnostics for a file form modules in the semantic model.
In the future, a file might contain more than 1 module (inline modules or macros).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/387)
<!-- Reviewable:end -->
