### PR TITLE
Parser: add recovery set

### DIFF
--- a/crates/parser/src/diagnostic.rs
+++ b/crates/parser/src/diagnostic.rs
@@ -12,7 +12,8 @@ pub struct ParserDiagnostic {
 }
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ParserDiagnosticKind {
-    SkippedElement { element_name: &'static str, closing: TokenKind },
+    // TODO(spapini): Add tokens from the recovery set to the message.
+    SkippedElement { element_name: &'static str },
     MissingToken(TokenKind),
     MissingExpression,
     MissingPathSegment,
@@ -25,10 +26,8 @@ impl DiagnosticEntry for ParserDiagnostic {
     fn format(&self, _db: &dyn FilesGroup) -> String {
         match self.kind {
             // TODO(yuval): replace line breaks with "\n".
-            ParserDiagnosticKind::SkippedElement { element_name, closing } => {
-                format!(
-                    "Skipped tokens. Expected element: {element_name} or a closing {closing:?}."
-                )
+            ParserDiagnosticKind::SkippedElement { element_name } => {
+                format!("Skipped tokens. Expected element: {element_name}.")
             }
             ParserDiagnosticKind::MissingToken(kind) => {
                 format!("Missing token {kind:?}.")

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -7,6 +7,7 @@ pub mod lexer;
 pub mod operators;
 pub mod parser;
 pub mod printer;
+pub mod recovery;
 pub mod test_utils;
 
 pub use diagnostic::ParserDiagnostic;

--- a/crates/parser/src/recovery.rs
+++ b/crates/parser/src/recovery.rs
@@ -1,0 +1,61 @@
+/// Macro that produces an inline function that gets a token kind and returns true iff it is on of
+/// the supplied groups.
+macro_rules! is_of_kind {
+    ($($element:ident),*) => {
+        |kind: TokenKind| {
+            match kind{
+                $($crate::recovery::$element!() => true,)*
+                TokenKind::EndOfFile => true,
+                _ => false
+            }
+        }
+    };
+}
+pub(crate) use is_of_kind;
+
+macro_rules! lbrace {
+    () => {
+        TokenKind::LBrace
+    };
+}
+pub(crate) use lbrace;
+
+macro_rules! rbrace {
+    () => {
+        TokenKind::RBrace
+    };
+}
+pub(crate) use rbrace;
+
+macro_rules! rparen {
+    () => {
+        TokenKind::RParen
+    };
+}
+pub(crate) use rparen;
+
+macro_rules! rangle {
+    () => {
+        TokenKind::GT
+    };
+}
+pub(crate) use rangle;
+
+macro_rules! top_level {
+    () => {
+        TokenKind::Extern
+            | TokenKind::Type
+            | TokenKind::Function
+            | TokenKind::Module
+            | TokenKind::Struct
+            | TokenKind::Use
+    };
+}
+pub(crate) use top_level;
+
+macro_rules! block {
+    () => {
+        TokenKind::Let | TokenKind::Match | TokenKind::Return
+    };
+}
+pub(crate) use block;

--- a/crates/parser/test_data/cairo_files/test1.cairo
+++ b/crates/parser/test_data/cairo_files/test1.cairo
@@ -17,7 +17,6 @@ func foo(,var1: int,, var2: felt,) -> int {
     func1(x);
     func2(x)
     return x;
-}
 
 func bar<A, B>() -> felt { }
 

--- a/crates/parser/test_data/expected_results/test1_tree_no_trivia
+++ b/crates/parser/test_data/expected_results/test1_tree_no_trivia
@@ -165,7 +165,7 @@
     │   │       │       │       ├── ident (kind: Identifier): 'x'
     │   │       │       │       └── generic_args (kind: OptionGenericArgsEmpty) []
     │   │       │       └── semicolon (kind: Semicolon): ';'
-    │   │       └── rbrace (kind: RBrace): '}'
+    │   │       └── rbrace: Missing
     │   ├── child #3 (kind: ItemFreeFunction)
     │   │   ├── funckw (kind: Function): 'func'
     │   │   ├── name (kind: Identifier): 'bar'
@@ -298,43 +298,48 @@
     │       └── rbrace (kind: RBrace): '}'
     └── eof (kind: EndOfFile).
 --------------------
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> test1.cairo:6:1
 ;
 ^
 
-error: Skipped tokens. Expected element: parameter or a closing RParen.
+error: Skipped tokens. Expected element: parameter.
  --> test1.cairo:7:10
 func foo(,var1: int,, var2: felt,) -> int {
          ^
 
-error: Skipped tokens. Expected element: parameter or a closing RParen.
+error: Skipped tokens. Expected element: parameter.
  --> test1.cairo:7:21
 func foo(,var1: int,, var2: felt,) -> int {
                     ^
 
+error: Missing token RBrace.
+ --> test1.cairo:21:1
+func bar<A, B>() -> felt { }
+^**^
+
 error: Missing token Semicolon.
- --> test1.cairo:25:47
+ --> test1.cairo:24:47
 extern func glee<A, b>(var1: int,) -> crate::S<int>;
                                               ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
- --> test1.cairo:25:47
+error: Skipped tokens. Expected element: item.
+ --> test1.cairo:24:47
 extern func glee<A, b>(var1: int,) -> crate::S<int>;
                                               ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
- --> test1.cairo:25:48
+error: Skipped tokens. Expected element: item.
+ --> test1.cairo:24:48
 extern func glee<A, b>(var1: int,) -> crate::S<int>;
                                                ^*^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
- --> test1.cairo:25:51
+error: Skipped tokens. Expected element: item.
+ --> test1.cairo:24:51
 extern func glee<A, b>(var1: int,) -> crate::S<int>;
                                                   ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
- --> test1.cairo:25:52
+error: Skipped tokens. Expected element: item.
+ --> test1.cairo:24:52
 extern func glee<A, b>(var1: int,) -> crate::S<int>;
                                                    ^
 

--- a/crates/parser/test_data/expected_results/test1_tree_with_trivia
+++ b/crates/parser/test_data/expected_results/test1_tree_with_trivia
@@ -483,9 +483,8 @@
     │   │       │               └── child #0 (kind: Newline).
     │   │       └── rbrace (kind: Terminal)
     │   │           ├── leading_trivia (kind: Trivia) []
-    │   │           ├── token (kind: RBrace): '}'
-    │   │           └── trailing_trivia (kind: Trivia)
-    │   │               └── child #0 (kind: Newline).
+    │   │           ├── token: Missing
+    │   │           └── trailing_trivia (kind: Trivia) []
     │   ├── child #3 (kind: ItemFreeFunction)
     │   │   ├── funckw (kind: Terminal)
     │   │   │   ├── leading_trivia (kind: Trivia)

--- a/crates/parser/test_data/expected_results/test2_tree_no_trivia
+++ b/crates/parser/test_data/expected_results/test2_tree_no_trivia
@@ -263,7 +263,7 @@ error: Missing token Semicolon.
 mod my_mod{
           ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> test2.cairo:13:11
 mod my_mod{
           ^
@@ -278,17 +278,17 @@ error: Missing tokens: 'missing expression'.
         x.a *+-. s.s * foo(1,3)
                ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> test2.cairo:22:1
 }
 ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> test2.cairo:24:1
 skipped tokens
 ^*****^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> test2.cairo:24:9
 skipped tokens
         ^****^

--- a/crates/semantic/src/diagnostic_test_data/tests
+++ b/crates/semantic/src/diagnostic_test_data/tests
@@ -12,27 +12,27 @@
 //! > Function Body
 
 //! > Expected Result
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> lib.cairo:1:1
 3 + 4 +;
 ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> lib.cairo:1:3
 3 + 4 +;
   ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> lib.cairo:1:5
 3 + 4 +;
     ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> lib.cairo:1:7
 3 + 4 +;
       ^
 
-error: Skipped tokens. Expected element: item or a closing EndOfFile.
+error: Skipped tokens. Expected element: item.
  --> lib.cairo:1:8
 3 + 4 +;
        ^


### PR DESCRIPTION
Parser list recovery set - when parsing a list and encountering an unexpected token, determines whether list parsing should stop.

Note that there is still another recovery set feature missing: Determining when to skip token.
This should probably be done at a token level, when calling parse_token(), or peeking.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/419)
<!-- Reviewable:end -->
