### PR TITLE
Refactor semantic diagnostics

### DIFF
--- a/crates/semantic/src/corelib.rs
+++ b/crates/semantic/src/corelib.rs
@@ -5,7 +5,6 @@ use syntax::node::ids::SyntaxStablePtrId;
 use utils::{extract_matches, OptionFrom};
 
 use crate::db::SemanticGroup;
-use crate::diagnostic::SemanticDiagnosticKind;
 use crate::{semantic, Expr, ExprId, ExprTuple, TypeId, TypeLongId};
 
 pub fn core_module(db: &dyn SemanticGroup) -> ModuleId {
@@ -87,8 +86,8 @@ pub fn unit_expr(db: &dyn SemanticGroup, stable_ptr: SyntaxStablePtrId) -> ExprI
 
 pub fn core_binary_operator(
     db: &dyn SemanticGroup,
-    binary_op: BinaryOperator,
-) -> Result<GenericFunctionId, SemanticDiagnosticKind> {
+    binary_op: &BinaryOperator,
+) -> Option<GenericFunctionId> {
     let core_module = db.core_module();
     let function_name = match binary_op {
         BinaryOperator::Plus(_) => "felt_add",
@@ -100,11 +99,11 @@ pub fn core_binary_operator(
         BinaryOperator::OrOr(_) => "bool_or",
         BinaryOperator::Not(_) => "bool_not",
         BinaryOperator::LE(_) => "felt_le",
-        _ => return Err(SemanticDiagnosticKind::UnknownBinaryOperator),
+        _ => return None,
     };
     let generic_function = db
         .module_item_by_name(core_module, function_name.into())
         .and_then(GenericFunctionId::option_from)
         .expect("Operator function not found in core lib.");
-    Ok(generic_function)
+    Some(generic_function)
 }

--- a/crates/semantic/src/diagnostic.rs
+++ b/crates/semantic/src/diagnostic.rs
@@ -3,12 +3,36 @@
 mod test;
 
 use defs::diagnostic_utils::StableLocation;
-use defs::ids::{EnumId, LanguageElementId, StructId};
-use diagnostics::{DiagnosticEntry, DiagnosticLocation};
+use defs::ids::{EnumId, LanguageElementId, ModuleId, StructId};
+use diagnostics::{DiagnosticEntry, DiagnosticLocation, Diagnostics};
 use smol_str::SmolStr;
+use syntax::node::ids::SyntaxStablePtrId;
+use syntax::node::TypedSyntaxNode;
 
 use crate::db::SemanticGroup;
 use crate::semantic;
+
+pub struct SemanticDiagnostics {
+    pub diagnostics: Diagnostics<SemanticDiagnostic>,
+    pub module_id: ModuleId,
+}
+impl SemanticDiagnostics {
+    pub fn new(module_id: ModuleId) -> Self {
+        Self { module_id, diagnostics: Diagnostics::default() }
+    }
+    pub fn report<TNode: TypedSyntaxNode>(&mut self, node: &TNode, kind: SemanticDiagnosticKind) {
+        self.diagnostics.add(SemanticDiagnostic {
+            stable_location: StableLocation::from_ast(self.module_id, node),
+            kind,
+        });
+    }
+    pub fn report_by_ptr(&mut self, stable_ptr: SyntaxStablePtrId, kind: SemanticDiagnosticKind) {
+        self.diagnostics.add(SemanticDiagnostic {
+            stable_location: StableLocation::new(self.module_id, stable_ptr),
+            kind,
+        });
+    }
+}
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SemanticDiagnostic {

--- a/crates/semantic/src/expr/test.rs
+++ b/crates/semantic/src/expr/test.rs
@@ -154,24 +154,24 @@ fn test_member_access_failures() {
         diagnostics,
         indoc! {"
             error: Struct test_crate::A has not member f
-             --> lib.cairo:7:5
+             --> lib.cairo:7:7
                 a.f
-                ^*^
+                  ^
 
             error: Invalid member expression.
-             --> lib.cairo:8:5
+             --> lib.cairo:8:7
                 a.a::b;
-                ^****^
+                  ^**^
 
             error: Invalid member expression.
-             --> lib.cairo:9:5
+             --> lib.cairo:9:7
                 a.4.4;
-                ^*^
+                  ^
 
             error: Type core::felt has no members.
-             --> lib.cairo:10:5
+             --> lib.cairo:10:7
                 5.a;
-                ^*^
+                  ^
 
         "}
     );

--- a/crates/semantic/src/items/enm.rs
+++ b/crates/semantic/src/items/enm.rs
@@ -1,4 +1,3 @@
-use defs::diagnostic_utils::StableLocation;
 use defs::ids::{EnumId, LanguageElementId, VariantId, VariantLongId};
 use diagnostics::Diagnostics;
 use diagnostics_proc_macros::DebugWithDb;
@@ -7,7 +6,8 @@ use syntax::node::{Terminal, TypedSyntaxNode};
 use utils::ordered_hash_map::OrderedHashMap;
 
 use crate::db::SemanticGroup;
-use crate::diagnostic::SemanticDiagnosticKind;
+use crate::diagnostic::SemanticDiagnosticKind::*;
+use crate::diagnostic::SemanticDiagnostics;
 use crate::types::resolve_type;
 use crate::{semantic, SemanticDiagnostic};
 
@@ -47,8 +47,8 @@ pub fn enum_variants(
 pub fn priv_enum_semantic_data(db: &dyn SemanticGroup, enum_id: EnumId) -> Option<EnumData> {
     // TODO(spapini): When asts are rooted on items, don't query module_data directly. Use a
     // selector.
-    let mut diagnostics = Diagnostics::default();
     let module_id = enum_id.module(db.upcast());
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let module_data = db.module_data(module_id)?;
     let enum_ast = module_data.enums.get(&enum_id)?;
     let syntax_db = db.upcast();
@@ -56,19 +56,16 @@ pub fn priv_enum_semantic_data(db: &dyn SemanticGroup, enum_id: EnumId) -> Optio
     for variant in enum_ast.variants(syntax_db).elements(syntax_db) {
         let id = db.intern_variant(VariantLongId(module_id, variant.stable_ptr()));
         let ty = resolve_type(
-            &mut diagnostics,
             db,
+            &mut diagnostics,
             module_id,
             variant.type_clause(syntax_db).ty(syntax_db),
         );
         let variant_name = variant.name(syntax_db).text(syntax_db);
         if let Some(_other_variant) = variants.insert(variant_name.clone(), Variant { id, ty }) {
-            diagnostics.add(SemanticDiagnostic {
-                stable_location: StableLocation::from_ast(module_id, &variant),
-                kind: SemanticDiagnosticKind::EnumVariantRedefinition { enum_id, variant_name },
-            })
+            diagnostics.report(&variant, EnumVariantRedefinition { enum_id, variant_name })
         }
     }
 
-    Some(EnumData { diagnostics, variants })
+    Some(EnumData { diagnostics: diagnostics.diagnostics, variants })
 }

--- a/crates/semantic/src/items/extern_function.rs
+++ b/crates/semantic/src/items/extern_function.rs
@@ -5,6 +5,7 @@ use diagnostics_proc_macros::DebugWithDb;
 use super::functions::{function_signature_params, function_signature_return_type};
 use super::generics::semantic_generic_params;
 use crate::db::SemanticGroup;
+use crate::diagnostic::SemanticDiagnostics;
 use crate::{semantic, SemanticDiagnostic};
 
 #[cfg(test)]
@@ -43,8 +44,8 @@ pub fn priv_extern_function_declaration_data(
     db: &dyn SemanticGroup,
     extern_function_id: ExternFunctionId,
 ) -> Option<ExternFunctionDeclarationData> {
-    let mut diagnostics = Diagnostics::default();
     let module_id = extern_function_id.module(db.upcast());
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let module_data = db.module_data(module_id)?;
     let function_syntax = module_data.extern_functions.get(&extern_function_id)?;
     let signature_syntax = function_syntax.signature(db.upcast());
@@ -53,13 +54,13 @@ pub fn priv_extern_function_declaration_data(
     let (params, _environment) =
         function_signature_params(&mut diagnostics, db, module_id, &signature_syntax);
     let generic_params = semantic_generic_params(
-        &mut diagnostics,
         db,
+        &mut diagnostics,
         module_id,
         &function_syntax.generic_params(db.upcast()),
     );
     Some(ExternFunctionDeclarationData {
-        diagnostics,
+        diagnostics: diagnostics.diagnostics,
         signature: semantic::Signature { params, generic_params, return_type },
     })
 }

--- a/crates/semantic/src/items/generics.rs
+++ b/crates/semantic/src/items/generics.rs
@@ -1,14 +1,13 @@
 use defs::ids::{GenericParamId, GenericParamLongId, ModuleId};
-use diagnostics::Diagnostics;
 use syntax::node::{ast, TypedSyntaxNode};
 
 use crate::db::SemanticGroup;
-use crate::SemanticDiagnostic;
+use crate::diagnostic::SemanticDiagnostics;
 
 /// Returns the parameters of the given function signature's AST.
 pub fn semantic_generic_params(
-    _diagnostics: &mut Diagnostics<SemanticDiagnostic>,
     db: &dyn SemanticGroup,
+    _diagnostics: &mut SemanticDiagnostics,
     module_id: ModuleId,
     generic_args: &ast::OptionGenericParams,
 ) -> Vec<GenericParamId> {

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -29,3 +29,16 @@ pub fn write_comma_separated<Iter: IntoIterator<Item = V>, V: std::fmt::Display>
     }
     Ok(())
 }
+
+/// Helper operations on Option<T>.
+pub trait OptionHelper {
+    fn on_none<F: FnOnce()>(self, f: F) -> Self;
+}
+impl<T> OptionHelper for Option<T> {
+    fn on_none<F: FnOnce()>(self, f: F) -> Self {
+        if self.is_none() {
+            f();
+        }
+        self
+    }
+}


### PR DESCRIPTION
This refactor is done to:
1. Allow better locations on diagnostics.
2. Unify how to report diagnostics in semantic.
3. More ergonomic way of reporting errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/480)
<!-- Reviewable:end -->
