### PR TITLE
Prevent duplicate tags in tests, and add a missing separator.

### DIFF
--- a/crates/semantic/src/expr/test_data/tests
+++ b/crates/semantic/src/expr/test_data/tests
@@ -190,6 +190,7 @@ error: Wrong number of generic arguments. Expected 2, found: 3
       (A::b(x), 1, _) => { x },
       ^*************^
 
+//! > ==========================================================================
 
 //! > Test assignment.
 

--- a/crates/utils/src/parse_test_file.rs
+++ b/crates/utils/src/parse_test_file.rs
@@ -55,6 +55,12 @@ impl TestBuilder {
     /// Closes a tag if one is open, otherwise does nothing.
     fn close_open_tag(&mut self) {
         if let Some(tag) = &mut self.current_tag {
+            assert!(
+                !self.current_test.contains_key(&tag.name),
+                "Duplicate tag '{}' found in test (test name: {}).",
+                tag.name,
+                self.current_test_name.as_ref().unwrap_or(&"<unknown>".into())
+            );
             self.current_test.insert(std::mem::take(&mut tag.name), tag.content.trim().to_string());
             self.current_tag = None;
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/584)
<!-- Reviewable:end -->
