### PR TITLE
Reorder branches in felt_jump_nz.

### DIFF
--- a/crates/sierra/examples/collatz.sierra
+++ b/crates/sierra/examples/collatz.sierra
@@ -44,7 +44,7 @@ int_dup(n) -> (n, parity);
 int_mod_2(parity) -> (parity);
 store_temp_int(parity) -> (parity);
 store_temp_gb(gb) -> (gb);
-int_jump_nz(parity) { 26(to_drop) fallthrough() };
+int_jump_nz(parity) { fallthrough() 26(to_drop) };
 // Statement # 20 - Handling even case. Adding [_, n/2, gb] to memory.
 align_temps() -> ();
 int_div_2(n) -> (n);
@@ -68,7 +68,7 @@ store_temp_int(counter) -> (counter);
 int_dup(n) -> (n, n_1);
 int_sub_1(n_1) -> (n_1);
 store_temp_int(n_1) -> (n_1);
-int_jump_nz(n_1) { 5(to_drop) fallthrough() };
+int_jump_nz(n_1) { fallthrough() 5(to_drop) };
 // Statement # 40 - n == 1 - we are done - returning the counter result.
 int_drop(n) -> ();
 refund_gas(gb) -> (gb); // Statement 41.

--- a/crates/sierra/examples/fib_jumps.sierra
+++ b/crates/sierra/examples/fib_jumps.sierra
@@ -18,7 +18,7 @@ libfunc get_gas = get_gas;
 libfunc refund_gas = refund_gas;
 
 // Statement #  0 - tests if n == 0.
-int_jump_nz(n) { 6(n) fallthrough() };
+int_jump_nz(n) { fallthrough() 6(n) };
 // Statement #  1 - n == 0, so we return updated gb and 1.
 refund_gas(gb) -> (gb);
 store_temp_gb(gb) -> (gb);
@@ -29,7 +29,7 @@ return(gb, one);
 int_unwrap_nz(n) -> (n);
 int_sub_1(n) -> (n);
 store_temp_int(n) -> (n);
-int_jump_nz(n) { 15(n) fallthrough() };
+int_jump_nz(n) { fallthrough() 15(n) };
 // Statement # 10  - n == 1, so we return updated gb and 1.
 refund_gas(gb) -> (gb);
 store_temp_gb(gb) -> (gb);
@@ -67,7 +67,7 @@ int_sub_1(n) -> (n);
 store_temp_int(n) -> (n);
 store_temp_gb(gb) -> (gb);
 store_temp_int(a) -> (a);
-int_jump_nz(n) { 21(n) fallthrough() };
+int_jump_nz(n) { fallthrough() 21(n) };
 // Statement # 40 - n == 0, so we can return the latest a.
 int_drop(b) -> ();
 refund_gas(gb) -> (gb); // Statement 41.

--- a/crates/sierra/examples/fib_no_gas.sierra
+++ b/crates/sierra/examples/fib_no_gas.sierra
@@ -12,7 +12,7 @@ libfunc felt_unwrap_nz = unwrap_nz<felt>;
 libfunc call_lib = function_call<user@Fibonacci>;
 
 // Statement #  0 - tests if n == 0.
-felt_jump_nz(n) { 4(n) fallthrough() };
+felt_jump_nz(n) { fallthrough() 4(n) };
 // Statement #  1 - n == 0, so we return a.
 felt_drop(b) -> ();
 store_temp_felt(a)  -> (a);

--- a/crates/sierra/examples/fib_recursive.sierra
+++ b/crates/sierra/examples/fib_recursive.sierra
@@ -24,7 +24,7 @@ libfunc call_fib = function_call<user@Fibonacci>;
 // Statement #  0 - tests if n == 0 and initiates 1 for the early return values.
 int_const_1() -> (one);
 store_temp_int(one) -> (one);
-int_jump_nz(n) { 7(n) fallthrough() };
+int_jump_nz(n) { fallthrough() 7(n) };
 // Statement #  3 - n == 0, so we return updated gb and 1.
 refund_gas(gb) -> (gb);
 store_temp_gb(gb) -> (gb);
@@ -34,7 +34,7 @@ return(gb, one);
 int_unwrap_nz(n) -> (n);
 int_sub_1(n) -> (n_1);
 store_temp_int(n_1) -> (n_1);
-int_jump_nz(n_1) { 15(n_1) fallthrough() };
+int_jump_nz(n_1) { fallthrough() 15(n_1) };
 // Statement # 11 - n == 1, so we return updated gb and 1.
 refund_gas(gb) -> (gb);
 store_temp_gb(gb) -> (gb);

--- a/crates/sierra/src/extensions/modules/jump_not_zero.rs
+++ b/crates/sierra/src/extensions/modules/jump_not_zero.rs
@@ -38,7 +38,9 @@ impl<TJumpNotZeroTraits: JumpNotZeroTraits> NoGenericArgsGenericLibFunc
         Ok(LibFuncSignature {
             param_signatures: vec![ParamSignature::new(ty.clone())],
             branch_signatures: vec![
-                // Success:
+                // Zero.
+                BranchSignature { vars: vec![], ap_change: SierraApChange::Known },
+                // NonZero.
                 BranchSignature {
                     vars: vec![OutputVarInfo {
                         ty: context.get_wrapped_concrete_type(NonZeroType::id(), ty)?,
@@ -46,10 +48,8 @@ impl<TJumpNotZeroTraits: JumpNotZeroTraits> NoGenericArgsGenericLibFunc
                     }],
                     ap_change: SierraApChange::Known,
                 },
-                // Failure:
-                BranchSignature { vars: vec![], ap_change: SierraApChange::Known },
             ],
-            fallthrough: Some(1),
+            fallthrough: Some(0),
         })
     }
 

--- a/crates/sierra/src/simulation/core.rs
+++ b/crates/sierra/src/simulation/core.rs
@@ -189,14 +189,14 @@ fn simulate_integer_libfunc(
         },
         IntegerConcrete::JumpNotZero(_) => {
             match inputs {
+                [CoreValue::Integer(value)] if *value == 0 => {
+                    // Zero - jumping to the failure branch.
+                    Ok((vec![], 0))
+                }
                 [CoreValue::Integer(value)] if *value != 0 => {
                     // Non-zero - jumping to the success branch and providing a NonZero wrap to the
                     // given value.
-                    Ok((vec![CoreValue::NonZero(Box::new(CoreValue::Integer(*value)))], 0))
-                }
-                [CoreValue::Integer(value)] if *value == 0 => {
-                    // Zero - jumping to the failure branch.
-                    Ok((vec![], 1))
+                    Ok((vec![CoreValue::NonZero(Box::new(CoreValue::Integer(*value)))], 1))
                 }
                 [_] => Err(LibFuncSimulationError::MemoryLayoutMismatch),
                 _ => Err(LibFuncSimulationError::WrongNumberOfArgs),
@@ -271,14 +271,14 @@ fn simulate_felt_libfunc(
         },
         FeltConcrete::JumpNotZero(_) => {
             match inputs {
+                [CoreValue::Felt(value)] if *value == 0 => {
+                    // Zero - jumping to the failure branch.
+                    Ok((vec![], 0))
+                }
                 [CoreValue::Felt(value)] if *value != 0 => {
                     // Non-zero - jumping to the success branch and providing a NonZero wrap to the
                     // given value.
-                    Ok((vec![CoreValue::NonZero(Box::new(CoreValue::Felt(*value)))], 0))
-                }
-                [CoreValue::Felt(value)] if *value == 0 => {
-                    // Zero - jumping to the failure branch.
-                    Ok((vec![], 1))
+                    Ok((vec![CoreValue::NonZero(Box::new(CoreValue::Felt(*value)))], 1))
                 }
                 [_] => Err(LibFuncSimulationError::MemoryLayoutMismatch),
                 _ => Err(LibFuncSimulationError::WrongNumberOfArgs),

--- a/crates/sierra/src/simulation/test.rs
+++ b/crates/sierra/src/simulation/test.rs
@@ -133,8 +133,8 @@ fn simulate(
 
 #[test_case("get_gas", vec![], vec![GasBuiltin(5)] => Ok((vec![GasBuiltin(1)], 0)); "get_gas(5)")]
 #[test_case("get_gas", vec![], vec![GasBuiltin(2)] => Ok((vec![GasBuiltin(2)], 1)); "get_gas(2)")]
-#[test_case("int_jump_nz", vec![], vec![Integer(2)] => Ok((vec![NonZero(Box::new(Integer(2)))], 0)); "int_jump_nz(2)")]
-#[test_case("int_jump_nz", vec![], vec![Integer(0)] => Ok((vec![], 1)); "int_jump_nz(0)")]
+#[test_case("int_jump_nz", vec![], vec![Integer(2)] => Ok((vec![NonZero(Box::new(Integer(2)))], 1)); "int_jump_nz(2)")]
+#[test_case("int_jump_nz", vec![], vec![Integer(0)] => Ok((vec![], 0)); "int_jump_nz(0)")]
 #[test_case("jump", vec![], vec![] => Ok((vec![], 0)); "jump()")]
 fn simulate_branch(
     id: &str,

--- a/crates/sierra_generator/src/expr_generator.rs
+++ b/crates/sierra_generator/src/expr_generator.rs
@@ -225,15 +225,15 @@ fn handle_felt_match(
                     libfunc_id: context.felt_jump_nz_libfunc_id(),
                     args: vec![match_expr_res],
                     branches: vec![
-                        // If not zero, jump to the "otherwise" block.
-                        program::GenBranchInfo {
-                            target: program::GenBranchTarget::Statement(otherwise_label_id),
-                            results: vec![context.allocate_sierra_variable()],
-                        },
                         // If zero, continue to the next instruction.
                         program::GenBranchInfo {
                             target: program::GenBranchTarget::Fallthrough,
                             results: vec![],
+                        },
+                        // If not zero, jump to the "otherwise" block.
+                        program::GenBranchInfo {
+                            target: program::GenBranchTarget::Statement(otherwise_label_id),
+                            results: vec![context.allocate_sierra_variable()],
                         },
                     ],
                 },

--- a/crates/sierra_generator/src/expr_generator_test.rs
+++ b/crates/sierra_generator/src/expr_generator_test.rs
@@ -161,7 +161,7 @@ fn test_match() {
             // let x = 7;
             "felt_const<7>() -> ([0])",
             // match {
-            "felt_jump_nz([0]) { label0([1]) fallthrough() }",
+            "felt_jump_nz([0]) { fallthrough() label0([1]) }",
             // Branch 0.
             "PushValues([0]: [0]) -> ([2])",
             "jump() { label1() }",

--- a/crates/sierra_to_casm/src/compiler_test.rs
+++ b/crates/sierra_to_casm/src/compiler_test.rs
@@ -60,7 +60,7 @@ fn read_sierra_example_file(name: &str) -> String {
                 return([7], [8], [4]);                          // #9
 
                 finalize_locals() -> ();                        // #10
-                felt_jump_nz([1]) { 16([1]) fallthrough() };    // #11
+                felt_jump_nz([1]) { fallthrough() 16([1]) };    // #11
                 felt_dup([2]) -> ([1], [2]);                    // #12
                 store_temp_felt([1]) -> ([1]);                  // #13
                 store_temp_felt([2]) -> ([2]);                  // #14
@@ -335,7 +335,7 @@ fn sierra_to_casm(sierra_code: &str, metadata: &Metadata, expected_casm: &str) {
                 libfunc store_temp_felt = store_temp<felt>;
                 libfunc store_temp_nz_felt = store_temp<NonZeroFelt>;
 
-                felt_jump_nz([1]) { 3([1]) fallthrough() };
+                felt_jump_nz([1]) { fallthrough() 3([1]) };
                 store_temp_felt([2]) -> ([2]);
                 return ([2]);
                 felt_drop([2]) -> ();
@@ -375,7 +375,7 @@ of the libfunc or return statement.";
                 libfunc felt_unwrap_nz = unwrap_nz<felt>;
                 libfunc jump = jump;
 
-                felt_jump_nz([1]) { 3([1]) fallthrough() };
+                felt_jump_nz([1]) { fallthrough() 3([1]) };
                 revoke_ap_tracking() -> ();
                 jump() { 5() };
                 felt_unwrap_nz([1]) -> ([1]);

--- a/crates/sierra_to_casm/src/invocations.rs
+++ b/crates/sierra_to_casm/src/invocations.rs
@@ -345,7 +345,10 @@ impl CompiledInvocationBuilder<'_> {
         };
 
         let target_statement_id = match self.invocation.branches.as_slice() {
-            [BranchInfo { target: BranchTarget::Statement(statement_id), .. }, _] => statement_id,
+            [
+                BranchInfo { target: BranchTarget::Fallthrough, .. },
+                BranchInfo { target: BranchTarget::Statement(statement_id), .. },
+            ] => statement_id,
             _ => panic!("malformed invocation"),
         };
 
@@ -362,7 +365,7 @@ impl CompiledInvocationBuilder<'_> {
                 relocation: Relocation::RelativeStatementId(*target_statement_id),
             }],
             [ApChange::Known(0), ApChange::Known(0)].into_iter(),
-            [vec![ReferenceExpression::Deref(*condition)].into_iter(), vec![].into_iter()]
+            [vec![].into_iter(), vec![ReferenceExpression::Deref(*condition)].into_iter()]
                 .into_iter(),
         ))
     }

--- a/tests/test_data/fib.sierra
+++ b/tests/test_data/fib.sierra
@@ -16,7 +16,7 @@ libfunc function_call<user@[0]> = function_call<user@[0]>;
 
 revoke_ap_tracking() -> ();
 dup<[0]>([2]) -> ([2], [13]);
-felt_jump_nz([13]) { 7([3]) fallthrough() };
+felt_jump_nz([13]) { fallthrough() 7([3]) };
 drop<[0]>([1]) -> ();
 drop<[0]>([2]) -> ();
 store_temp<[0]>([0]) -> ([4]);

--- a/tests/test_data/fib_array.sierra
+++ b/tests/test_data/fib_array.sierra
@@ -33,7 +33,7 @@ rename<[1]>([8]) -> ([9]);
 return([9]);
 revoke_ap_tracking() -> ();
 dup<[0]>([2]) -> ([2], [16]);
-felt_jump_nz([16]) { 20([4]) fallthrough() };
+felt_jump_nz([16]) { fallthrough() 20([4]) };
 drop<[0]>([0]) -> ();
 drop<[0]>([1]) -> ();
 drop<[0]>([2]) -> ();

--- a/tests/test_data/fib_box.sierra
+++ b/tests/test_data/fib_box.sierra
@@ -24,7 +24,7 @@ revoke_ap_tracking() -> ();
 unbox<[0]>([2]) -> ([3]);
 store_temp<[0]>([3]) -> ([3]);
 dup<[0]>([3]) -> ([3], [18]);
-felt_jump_nz([18]) { 9([4]) fallthrough() };
+felt_jump_nz([18]) { fallthrough() 9([4]) };
 drop<[1]>([1]) -> ();
 drop<[0]>([3]) -> ();
 store_temp<[1]>([0]) -> ([5]);


### PR DESCRIPTION
Move fallthrough to be the first branch, so that it will be consitent with the way the code compiles.

This is also consistent with the order:
```
enum JumpNzResult {
    Zero: (),
    NonZero: (NonZero<felt>,),
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/676)
<!-- Reviewable:end -->
