### PR TITLE
Making all implicit params in the corelib actually implicit.

### DIFF
--- a/corelib/gas.cairo
+++ b/corelib/gas.cairo
@@ -2,4 +2,4 @@ extern type GasBuiltin;
 
 enum GetGasResult { Success: (), Failure: (), }
 
-extern func get_gas(ref rc: RangeCheck, ref gb: GasBuiltin) -> GetGasResult;
+extern func get_gas() -> GetGasResult implicits (rc: RangeCheck, gb: GasBuiltin);

--- a/corelib/integer.cairo
+++ b/corelib/integer.cairo
@@ -1,14 +1,11 @@
 extern type uint128;
 
-// TODO(orizi): Consider making `Result::<(RangeCheck, uin128), RangeCheck>` into a new type, that
-// would be marked as an extern enum.
-
-extern func uint128_from_felt(ref rc: RangeCheck, a: felt) -> Option::<uint128>;
+extern func uint128_from_felt(a: felt) -> Option::<uint128> implicits (rc: RangeCheck);
 extern func uint128_to_felt(a: uint128) -> felt;
-extern func uint128_add(ref rc: RangeCheck, a: uint128, b: uint128) -> Option::<uint128>;
-extern func uint128_sub(ref rc: RangeCheck, a: uint128, b: uint128) -> Option::<uint128>;
-extern func uint128_mul(ref rc: RangeCheck, a: uint128, b: uint128) -> Option::<uint128>;
-extern func uint128_div(ref rc: RangeCheck, a: uint128, b: NonZero::<uint128>) -> uint128;
-extern func uint128_mod(ref rc: RangeCheck, a: uint128, b: NonZero::<uint128>) -> uint128;
+extern func uint128_add(a: uint128, b: uint128) -> Option::<uint128> implicits (rc: RangeCheck);
+extern func uint128_sub(a: uint128, b: uint128) -> Option::<uint128> implicits (rc: RangeCheck);
+extern func uint128_mul(a: uint128, b: uint128) -> Option::<uint128> implicits (rc: RangeCheck);
+extern func uint128_div(a: uint128, b: NonZero::<uint128>) -> uint128 implicits (rc: RangeCheck);
+extern func uint128_mod(a: uint128, b: NonZero::<uint128>) -> uint128 implicits (rc: RangeCheck);
 
 extern func uint128_jump_nz(a: uint128) -> JumpNzResult::<uint128>;

--- a/crates/lowering/src/lower.rs
+++ b/crates/lowering/src/lower.rs
@@ -52,8 +52,7 @@ pub fn lower(db: &dyn SemanticGroup, free_function_id: FreeFunctionId) -> Option
 
     // Params.
     let ref_params: Vec<_> = signature
-        .params
-        .iter()
+        .all_params()
         .filter(|param| param.mutability == Mutability::Reference)
         .map(|param| VarId::Param(param.id))
         .collect();

--- a/crates/semantic/src/items/functions.rs
+++ b/crates/semantic/src/items/functions.rs
@@ -78,7 +78,7 @@ pub struct Signature {
 impl Signature {
     /// Gets references of all the params of the signature (both normal and implicits).
     pub fn all_params(&self) -> impl Iterator<Item = &semantic::Parameter> {
-        chain!(self.params.iter(), self.implicits.iter())
+        chain!(self.implicits.iter(), self.params.iter())
     }
 }
 

--- a/crates/sierra_generator/src/db.rs
+++ b/crates/sierra_generator/src/db.rs
@@ -99,7 +99,7 @@ fn get_function_signature(
     let signature = db.concrete_function_signature(semantic_function_id)?;
     let mut param_types = Vec::new();
     let mut ret_types = Vec::new();
-    for param in signature.params {
+    for param in signature.all_params() {
         let concrete_type_id = db.get_concrete_type_id(param.ty)?;
         param_types.push(concrete_type_id.clone());
         if param.mutability == Mutability::Reference {

--- a/examples/fib_gas.cairo
+++ b/examples/fib_gas.cairo
@@ -1,8 +1,8 @@
 // Calculates fib...
 
 // TODO(ilya): Return an error in case of out of gas.
-func fib(ref rc: RangeCheck, ref gb: GasBuiltin, a: felt, b: felt, n: felt) -> felt {
-    match get_gas(rc, gb) {
+func fib(a: felt, b: felt, n: felt) -> felt implicits (rc: RangeCheck, gb: GasBuiltin) {
+    match get_gas() {
         GetGasResult::Success (()) => {
         },
         GetGasResult::Failure (()) => {
@@ -11,6 +11,6 @@ func fib(ref rc: RangeCheck, ref gb: GasBuiltin, a: felt, b: felt, n: felt) -> f
     }
     match n {
         0 => a,
-        _ => fib(rc, gb, b, a + b, n - 1),
+        _ => fib(b, a + b, n - 1),
     }
 }

--- a/examples/fib_uint128.cairo
+++ b/examples/fib_uint128.cairo
@@ -1,31 +1,31 @@
 // Calculates fib...
 // TODO(orizi): Switch all matches to `?` usages.
 // TODO(orizi): Make `rc` implicit.
-func fib(ref rc: RangeCheck, a: uint128, b: uint128, n: uint128) -> felt {
+func fib(a: uint128, b: uint128, n: uint128) -> felt implicits (rc: RangeCheck) {
     // TODO(orizi): Use match on uint128 when supported.
     match uint128_to_felt(n) {
         0 => uint128_to_felt(a),
         _ => {
-            let new_b = match uint128_add(rc, a, b) {
+            let new_b = match uint128_add(a, b) {
                 Option::Some (t) => t,
                 Option::None (_) => {
                     return 0;
                 },
             };
             // TODO(orizi): Use uint128 literal when supported.
-            let one = match uint128_from_felt(rc, 1) {
+            let one = match uint128_from_felt(1) {
                 Option::Some (t) => t,
                 Option::None (_) => {
                     return 0;
                 },
             };
-            let new_n = match uint128_sub(rc, n, one) {
+            let new_n = match uint128_sub(n, one) {
                 Option::Some (t) => t,
                 Option::None (_) => {
                     return 0;
                 },
             };
-            fib(rc, b, new_b, new_n)
+            fib(b, new_b, new_n)
         },
     }
 }


### PR DESCRIPTION
Updated example tessts accordingly.
Fixed ordering of implicits to be the first params and not the last to
support this.

commit-id:2ca0279a

---

**Stack**:
- #839
- #838
- #837
- #836 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/836)
<!-- Reviewable:end -->
