### PR TITLE
Update Rust to Nightly at 2022-11-03

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: rustfmt
-          toolchain: nightly-2022-07-27
+          toolchain: nightly-2022-11-03
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: |
@@ -27,9 +27,9 @@ jobs:
         with:
           profile: minimal
           components: rustfmt
-          toolchain: nightly-2022-07-27
+          toolchain: nightly-2022-11-03
       - uses: Swatinem/rust-cache@v2
-      - run: cargo +nightly-2022-07-27 fmt --all -- --check
+      - run: cargo +nightly-2022-11-03 fmt --all -- --check
 
   # Checks all .cairo files in the repo are formatted correctly.
   cairofmt:
@@ -39,7 +39,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-07-27
+          toolchain: nightly-2022-11-03
       - uses: Swatinem/rust-cache@v2
       - run: cargo run --bin formatter_cli -- --check --recursive
 
@@ -52,7 +52,7 @@ jobs:
         name: "Rust Toolchain Setup"
         with:
           profile: minimal
-          toolchain: nightly-2022-07-27
+          toolchain: nightly-2022-11-03
       - uses: actions/cache@v2
         name: "Cache Setup"
         with:
@@ -67,7 +67,7 @@ jobs:
           tar -xzf cargo-udeps-v0.1.30-x86_64-unknown-linux-gnu.tar.gz;
           cargo-udeps-v0.1.30-x86_64-unknown-linux-gnu/cargo-udeps udeps
         env:
-          RUSTUP_TOOLCHAIN: nightly-2022-07-27
+          RUSTUP_TOOLCHAIN: nightly-2022-11-03
 
   clippy:
     runs-on: ubuntu-latest

--- a/crates/syntax_codegen/src/generator.rs
+++ b/crates/syntax_codegen/src/generator.rs
@@ -49,7 +49,7 @@ pub fn reformat_rust_code(text: String) -> String {
 }
 pub fn reformat_rust_code_inner(text: String) -> String {
     let sh = Shell::new().unwrap();
-    sh.set_var("RUSTUP_TOOLCHAIN", "nightly-2022-07-27");
+    sh.set_var("RUSTUP_TOOLCHAIN", "nightly-2022-11-03");
     let rustfmt_toml = project_root().join("rustfmt.toml");
     let mut stdout = cmd!(sh, "rustfmt --config-path {rustfmt_toml}").stdin(text).read().unwrap();
     if !stdout.ends_with('\n') {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,11 +23,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2022-07-27",
+#         "nightly-2022-11-03",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2021",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2022-07-27".
+# and run "rustup toolchain install nightly-2022-11-03".


### PR DESCRIPTION
Subsequent pull requests from the stack will use features stabilized in Rust 1.64+.

commit-id:77910e56

---

**Stack**:
- #845
- #844
- #847
- #843 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/843)
<!-- Reviewable:end -->
