### PR TITLE
Pull crates metadata from workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ members = [
     "crates/syntax_codegen",
     "tests",
 ]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"

--- a/crates/casm/Cargo.toml
+++ b/crates/casm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "casm"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 thiserror = "1.0.32"

--- a/crates/db_utils/Cargo.toml
+++ b/crates/db_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db_utils"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]

--- a/crates/debug/Cargo.toml
+++ b/crates/debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "debug"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dev_dependencies]
 db_utils = { path = "../db_utils" }

--- a/crates/defs/Cargo.toml
+++ b/crates/defs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "defs"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 db_utils = { path = "../db_utils" }

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diagnostics"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 db_utils = { path = "../db_utils" }

--- a/crates/diagnostics_proc_macros/Cargo.toml
+++ b/crates/diagnostics_proc_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diagnostics_proc_macros"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "filesystem"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 db_utils = { path = "../db_utils" }

--- a/crates/formatter/Cargo.toml
+++ b/crates/formatter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "formatter"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "formatter_cli"

--- a/crates/languageserver/Cargo.toml
+++ b/crates/languageserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "languageserver"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "languageserver"

--- a/crates/lowering/Cargo.toml
+++ b/crates/lowering/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lowering"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 db_utils = { path = "../db_utils" }

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parser"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [features]
 fix_parser_tests = ["utils/testing"]

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "project"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 serde = { version = "1.0.130", features = ["derive"] }

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "semantic"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [features]
 testing = []

--- a/crates/sierra/Cargo.toml
+++ b/crates/sierra/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sierra"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 build = "src/build.rs" # LALRPOP preprocessing
 
 [build-dependencies]

--- a/crates/sierra_gas/Cargo.toml
+++ b/crates/sierra_gas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sierra_gas"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 sierra = { path = "../sierra" }

--- a/crates/sierra_generator/Cargo.toml
+++ b/crates/sierra_generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sierra_generator"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 db_utils = { path = "../db_utils" }

--- a/crates/sierra_to_casm/Cargo.toml
+++ b/crates/sierra_to_casm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sierra_to_casm"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "syntax"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 db_utils = { path = "../db_utils" }

--- a/crates/syntax_codegen/Cargo.toml
+++ b/crates/syntax_codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "syntax_codegen"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["syntax"]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utils"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [features]
 testing = []

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tests"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dev-dependencies]
 defs = { path = "../crates/defs" }


### PR DESCRIPTION
Reference: https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html#package-metadata-can-reference-other-workspace-members.

---

**Stack**:
- #845
- #844 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo2/844)
<!-- Reviewable:end -->
