### PR TITLE
fix(formatter): incorrect exit code on files with syntax errors

### DIFF
--- a/crates/formatter/src/bin/cli.rs
+++ b/crates/formatter/src/bin/cli.rs
@@ -29,7 +29,7 @@ fn format_file(file_path: &str, args: &FormatterArgs, config: &FormatterConfig) 
             format!("A parsing error occurred in file: {file_path}. The file was not formatted.")
                 .red()
         );
-        return true;
+        return false;
     }
     let formatted_file = get_formatted_file(db, &syntax_root, config.clone());
 


### PR DESCRIPTION
Fixes #1088.

For the PR title and commit message, since I failed to find a consistent commit style across the recent Git history, I'm using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) instead. Please let me know if there's a desired style, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/1089)
<!-- Reviewable:end -->
