### PR TITLE
Define unified interface for Cairo compilation in `compiler` crate

### DIFF
--- a/crates/compiler/src/diagnostics.rs
+++ b/crates/compiler/src/diagnostics.rs
@@ -9,9 +9,17 @@ use sierra_generator::db::SierraGenGroup;
 
 use crate::db::RootDatabase;
 
-/// Check if there are diagnostics and prints them to stderr
-/// Returns true if diagnostics were found.
-pub fn check_diagnostics(db: &mut RootDatabase) -> bool {
+/// Checks if there are diagnostics and reports them to the provided callback as strings.
+///
+/// # Returns
+///
+/// Returns `true` if diagnostics were found.
+pub fn check_diagnostics(
+    db: &mut RootDatabase,
+    on_diagnostic: Option<Box<dyn FnMut(String)>>,
+) -> bool {
+    let mut on_diagnostic = on_diagnostic.unwrap_or_else(|| Box::new(|_| ()));
+
     let mut found_diagnostics = false;
     for crate_id in db.crates() {
         for module_id in &*db.crate_modules(crate_id) {
@@ -19,7 +27,9 @@ pub fn check_diagnostics(db: &mut RootDatabase) -> bool {
                 if db.file_content(file_id).is_none() {
                     if let ModuleId::CrateRoot(_) = *module_id {
                         match db.lookup_intern_file(file_id) {
-                            FileLongId::OnDisk(path) => eprintln!("{} not found", path.display()),
+                            FileLongId::OnDisk(path) => {
+                                on_diagnostic(format!("{} not found", path.display()))
+                            }
                             FileLongId::Virtual(_) => panic!("Missing virtual file."),
                         }
                         found_diagnostics = true;
@@ -28,7 +38,7 @@ pub fn check_diagnostics(db: &mut RootDatabase) -> bool {
                     let diag = db.file_syntax_diagnostics(file_id);
                     if !diag.get_all().is_empty() {
                         found_diagnostics = true;
-                        eprint!("{}", diag.format(db));
+                        on_diagnostic(diag.format(db));
                     }
                 }
             }
@@ -36,23 +46,31 @@ pub fn check_diagnostics(db: &mut RootDatabase) -> bool {
             if let Some(diag) = db.module_semantic_diagnostics(*module_id) {
                 if !diag.get_all().is_empty() {
                     found_diagnostics = true;
-                    eprint!("{}", diag.format(db));
+                    on_diagnostic(diag.format(db));
                 }
             }
 
             if let Some(diag) = db.module_lowering_diagnostics(*module_id) {
                 if !diag.get_all().is_empty() {
                     found_diagnostics = true;
-                    eprint!("{}", diag.format(db));
+                    on_diagnostic(diag.format(db));
                 }
             }
 
             let diag = db.module_sierra_diagnostics(*module_id);
             if !diag.get_all().is_empty() {
                 found_diagnostics = true;
-                eprint!("{}", diag.format(db));
+                on_diagnostic(diag.format(db));
             }
         }
     }
     found_diagnostics
+}
+
+pub fn check_and_eprint_diagnostics(db: &mut RootDatabase) -> bool {
+    check_diagnostics(db, Some(Box::new(eprint_diagnostic)))
+}
+
+pub fn eprint_diagnostic(diag: String) {
+    eprint!("{}", diag);
 }

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -1,3 +1,72 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use diagnostics::{check_diagnostics, eprint_diagnostic};
+use filesystem::db::FilesGroupEx;
+use filesystem::ids::CrateId;
+use sierra::program::Program;
+use sierra_generator::db::SierraGenGroup;
+use sierra_generator::replace_ids::replace_sierra_ids_in_program;
+
+use crate::db::RootDatabase;
+use crate::project::{get_main_crate_ids_from_project, setup_project, ProjectConfig};
+
 pub mod db;
 pub mod diagnostics;
 pub mod project;
+
+pub struct CompilerConfig {
+    pub on_diagnostic: Option<Box<dyn FnMut(String)>>,
+
+    /// Replaces sierra ids with human-readable ones.
+    pub replace_ids: bool,
+}
+
+impl Default for CompilerConfig {
+    fn default() -> Self {
+        CompilerConfig { on_diagnostic: Some(Box::new(eprint_diagnostic)), replace_ids: false }
+    }
+}
+
+pub type SierraProgram = Arc<Program>;
+
+pub fn compile_cairo_project_at_path(
+    path: &Path,
+    compiler_config: CompilerConfig,
+) -> Result<SierraProgram> {
+    let mut db = RootDatabase::default();
+    let main_crate_ids = setup_project(&mut db, path)?;
+    compile_prepared_db(db, main_crate_ids, compiler_config)
+}
+
+pub fn compile(
+    project_config: ProjectConfig,
+    compiler_config: CompilerConfig,
+) -> Result<SierraProgram> {
+    let mut db = RootDatabase::default();
+    db.with_project_config(project_config.clone());
+    let main_crate_ids = get_main_crate_ids_from_project(&mut db, &project_config);
+
+    compile_prepared_db(db, main_crate_ids, compiler_config)
+}
+
+fn compile_prepared_db(
+    mut db: RootDatabase,
+    main_crate_ids: Vec<CrateId>,
+    compiler_config: CompilerConfig,
+) -> Result<SierraProgram> {
+    if check_diagnostics(&mut db, compiler_config.on_diagnostic) {
+        bail!("Compilation failed.");
+    }
+
+    let mut sierra_program = db
+        .get_sierra_program(main_crate_ids)
+        .context("Compilation failed without any diagnostics")?;
+
+    if compiler_config.replace_ids {
+        sierra_program = Arc::new(replace_sierra_ids_in_program(&db, &sierra_program));
+    }
+
+    Ok(sierra_program)
+}

--- a/crates/runner/src/cli.rs
+++ b/crates/runner/src/cli.rs
@@ -9,7 +9,7 @@ use casm::instructions::Instruction;
 use casm::{casm, casm_extend};
 use clap::Parser;
 use compiler::db::RootDatabase;
-use compiler::diagnostics::check_diagnostics;
+use compiler::diagnostics::check_and_eprint_diagnostics;
 use compiler::project::setup_project;
 use itertools::chain;
 use sierra::program::StatementIdx;
@@ -43,7 +43,7 @@ fn main() -> anyhow::Result<()> {
 
     let main_crate_ids = setup_project(db, Path::new(&args.path))?;
 
-    if check_diagnostics(db) {
+    if check_and_eprint_diagnostics(db) {
         anyhow::bail!("failed to compile: {}", args.path);
     }
 

--- a/crates/starknet/src/contract_class.rs
+++ b/crates/starknet/src/contract_class.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use compiler::db::RootDatabase;
-use compiler::diagnostics::check_diagnostics;
+use compiler::diagnostics::check_and_eprint_diagnostics;
 use compiler::project::setup_project;
 use defs::db::DefsGroup;
 use itertools::join;
@@ -70,7 +70,7 @@ pub fn compile_path(path: &Path, replace_ids: bool) -> anyhow::Result<ContractCl
     plugins.push(Arc::new(StarkNetPlugin {}));
     db.set_macro_plugins(plugins);
 
-    if check_diagnostics(db) {
+    if check_and_eprint_diagnostics(db) {
         anyhow::bail!("Failed to compile: {}", path.display());
     }
 

--- a/tests/cairo_level_tests.rs
+++ b/tests/cairo_level_tests.rs
@@ -2,12 +2,8 @@
 
 use std::path::PathBuf;
 
-use compiler::db::RootDatabase;
-use compiler::diagnostics::check_diagnostics;
-use compiler::project::setup_project;
+use compiler::{compile_cairo_project_at_path, CompilerConfig};
 use num_bigint::BigInt;
-use sierra_generator::db::SierraGenGroup;
-use sierra_generator::replace_ids::replace_sierra_ids_in_program;
 
 use crate::common::run_sierra_program;
 
@@ -18,11 +14,11 @@ fn cairo_level_tests() {
     let dir = env!("CARGO_MANIFEST_DIR");
     let mut path = PathBuf::from(dir);
     path.push("cairo_level");
-    let mut db = RootDatabase::default();
-    let main_crate_ids = setup_project(&mut db, path.as_path()).expect("Project setup failed.");
-    assert!(!check_diagnostics(&mut db));
-    let sierra_program = db.get_sierra_program(main_crate_ids).unwrap();
-    let sierra_func = replace_sierra_ids_in_program(&db, &sierra_program);
+    let sierra_func = compile_cairo_project_at_path(
+        &path,
+        CompilerConfig { replace_ids: true, ..CompilerConfig::default() },
+    )
+    .expect("Compilation failed.");
     let results = run_sierra_program(&sierra_func, &[], 3, false);
     assert_eq!(
         results,

--- a/tests/examples_test.rs
+++ b/tests/examples_test.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use compiler::db::RootDatabase;
-use compiler::diagnostics::check_diagnostics;
+use compiler::diagnostics::check_and_eprint_diagnostics;
 use compiler::project::setup_project;
 use filesystem::ids::CrateId;
 use num_bigint::BigInt;
@@ -26,7 +26,7 @@ fn setup(name: &str) -> (RootDatabase, Vec<CrateId>) {
 
     let mut db = RootDatabase::default();
     let main_crate_ids = setup_project(&mut db, path.as_path()).expect("Project setup failed.");
-    assert!(!check_diagnostics(&mut db));
+    assert!(!check_and_eprint_diagnostics(&mut db));
     (db, main_crate_ids)
 }
 


### PR DESCRIPTION
This PR tries to make a proper _self-containing_ library out of the `compiler` crate, enabling users to call the compiler with a high-level API that does not depend on other crates from this project. Thanks to this change, the Package Manager only depends on the `compiler` crate and `compile` function and `ProjectConfig` struct from it, and thus it does not have to think about databases and other implementation details.

commit-id:429f0a74