### PR TITLE
Removed space after enum/struct patterns in match arms.

### DIFF
--- a/crates/formatter/src/node_properties.rs
+++ b/crates/formatter/src/node_properties.rs
@@ -67,6 +67,8 @@ impl SyntaxNodeFormat for SyntaxNode {
                         SyntaxKind::ItemFreeFunction
                             | SyntaxKind::ItemExternFunction
                             | SyntaxKind::ExprFunctionCall
+                            | SyntaxKind::PatternEnum
+                            | SyntaxKind::PatternStruct
                     )
                 ) =>
             {

--- a/examples/corelib_usage.cairo
+++ b/examples/corelib_usage.cairo
@@ -3,12 +3,12 @@ impl MyCopy of Copy::<Option::<(felt, felt)>>;
 func foo(x: Option::<(felt, felt)>) -> Option::<felt> {
     let y = x;
     match x {
-        Option::Some (x) => {
+        Option::Some(x) => {
             let (x, y) = x;
             Option::<felt>::Some(x)
         },
         // TODO(spapini): Replace with _.
-        Option::None (o) => {
+        Option::None(o) => {
             return Option::<felt>::None(());
         },
     }

--- a/examples/enum_flow.cairo
+++ b/examples/enum_flow.cairo
@@ -21,10 +21,10 @@ func main() -> felt {
 
 func match_short(e: MyEnumShort) -> felt {
     match e {
-        MyEnumShort::a (x) => {
+        MyEnumShort::a(x) => {
             x
         },
-        MyEnumShort::b (x) => {
+        MyEnumShort::b(x) => {
             x
         },
     }
@@ -32,13 +32,13 @@ func match_short(e: MyEnumShort) -> felt {
 
 func match_long(e: MyEnumLong) -> felt {
     match e {
-        MyEnumLong::a (x) => {
+        MyEnumLong::a(x) => {
             x
         },
-        MyEnumLong::b (x) => {
+        MyEnumLong::b(x) => {
             x
         },
-        MyEnumLong::c (x) => {
+        MyEnumLong::c(x) => {
             x
         },
     }

--- a/examples/fib_gas.cairo
+++ b/examples/fib_gas.cairo
@@ -1,9 +1,9 @@
 // Calculates fib...
 func fib(a: felt, b: felt, n: felt) -> felt implicits (rc: RangeCheck, gb: GasBuiltin) {
     match get_gas() {
-        Option::Some (x) => {
+        Option::Some(x) => {
         },
-        Option::None (x) => {
+        Option::None(x) => {
             let data = array_new::<felt>();
             // TODO(spapini): Add when working.
             // array_append::<felt>(data, 1);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/1142)
<!-- Reviewable:end -->
