### PR TITLE
fix(lsp): wrong TextEdit range on formatting requests

### DIFF
--- a/crates/filesystem/src/span.rs
+++ b/crates/filesystem/src/span.rs
@@ -71,3 +71,10 @@ impl TextOffset {
         Some(TextPosition { line: line_number, col: *self - line_offset })
     }
 }
+
+impl FileSummary {
+    /// Gets the number of lines
+    pub fn line_count(&self) -> usize {
+        self.line_offsets.len()
+    }
+}

--- a/crates/languageserver/src/lib.rs
+++ b/crates/languageserver/src/lib.rs
@@ -317,10 +317,24 @@ impl LanguageServer for Backend {
             &syntax.as_syntax_node(),
             FormatterConfig::default(),
         );
+
+        let file_summary = if let Some(summary) = db.file_summary(file) {
+            summary
+        } else {
+            eprintln!("Formatting failed. Cannot get summary for file '{file_uri}'.");
+            return Ok(None);
+        };
+        let old_line_count = if let Ok(count) = file_summary.line_count().try_into() {
+            count
+        } else {
+            eprintln!("Formatting failed. Line count out of bound in file '{file_uri}'.");
+            return Ok(None);
+        };
+
         Ok(Some(vec![TextEdit {
             range: Range {
                 start: Position { line: 0, character: 0 },
-                end: Position { line: u32::MAX, character: 0 },
+                end: Position { line: old_line_count, character: 0 },
             },
             new_text,
         }]))


### PR DESCRIPTION
Fixes #1141.

After this PR the language server can generate the correct range for the entire document. Tested in Helix and formatting works like a charm with this patch applied.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/1156)
<!-- Reviewable:end -->
