### PR TITLE
Use function_idx instead of function_id.

### DIFF
--- a/crates/starknet/examples/test_contract.entry_points
+++ b/crates/starknet/examples/test_contract.entry_points
@@ -2,7 +2,7 @@
   "EXTERNAL": [
     {
       "selector": "0x22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658",
-      "function_id": 1
+      "function_idx": 1
     }
   ],
   "L1_HANDLER": [],

--- a/crates/starknet/src/contract_class.rs
+++ b/crates/starknet/src/contract_class.rs
@@ -58,8 +58,8 @@ pub struct ContractEntryPoint {
     /// A field element that encodes the signature of the called function.
     #[serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")]
     pub selector: BigUint,
-    // The function in the sierra program.
-    pub function_id: u64,
+    // The idx of the user function declaration in the sierra program.
+    pub function_idx: usize,
 }
 
 // Compile the contract given by path.
@@ -156,7 +156,7 @@ fn get_entry_points(
 
         entry_points_by_type.external.push(ContractEntryPoint {
             selector: starknet_keccak(function_name.as_bytes()),
-            function_id: replacer.replace_function_id(&sierra_id).id,
+            function_idx: replacer.replace_function_id(&sierra_id).id as usize,
         });
     }
     Ok(entry_points_by_type)

--- a/crates/starknet/src/contract_class_test.rs
+++ b/crates/starknet/src/contract_class_test.rs
@@ -10,7 +10,7 @@ use crate::contract_class::{compile_path, ContractClass, ContractEntryPoint, Con
 
 #[test]
 fn test_serialization() {
-    let external = vec![ContractEntryPoint { selector: BigUint::from(u128::MAX), function_id: 7 }];
+    let external = vec![ContractEntryPoint { selector: BigUint::from(u128::MAX), function_idx: 7 }];
 
     let contract = ContractClass {
         sierra_program: sierra::program::Program {
@@ -39,7 +39,7 @@ fn test_serialization() {
             "EXTERNAL": [
               {
                 "selector": "0xffffffffffffffffffffffffffffffff",
-                "function_id": 7
+                "function_idx": 7
               }
             ],
             "L1_HANDLER": [],


### PR DESCRIPTION
This makes the code correct when using non-canonical ids.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/1259)
<!-- Reviewable:end -->
