### PR TITLE
Revert "Avoid lowering functions with semantic errors (#1546)"

### DIFF
--- a/crates/cairo-diagnostics/src/diagnostics.rs
+++ b/crates/cairo-diagnostics/src/diagnostics.rs
@@ -118,10 +118,6 @@ impl<TEntry: DiagnosticEntry> Diagnostics<TEntry> {
         Self(DiagnosticsBuilder::default().into())
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.0.leaves.is_empty() && self.0.subtrees.iter().all(|subtree| subtree.is_empty())
-    }
-
     pub fn format(&self, db: &TEntry::DbType) -> String {
         let mut res = String::new();
         // Format leaves.

--- a/crates/cairo-lowering/src/test.rs
+++ b/crates/cairo-lowering/src/test.rs
@@ -40,21 +40,12 @@ fn test_function_lowering(
         inputs["module_code"].as_str(),
     )
     .split();
-    let lowered = lower(db, test_function.function_id);
+    let lowered = lower(db, test_function.function_id).unwrap();
 
+    let lowered_formatter = LoweredFormatter { db, lowered: &lowered };
     OrderedHashMap::from([
         ("semantic_diagnostics".into(), semantic_diagnostics),
-        (
-            "lowering_diagnostics".into(),
-            lowered.as_ref().map(|lowered| lowered.diagnostics.format(db)).unwrap_or_default(),
-        ),
-        (
-            "lowering_format".into(),
-            lowered
-                .map(|lowered| {
-                    format!("{:?}", lowered.debug(&LoweredFormatter { db, lowered: &lowered }))
-                })
-                .unwrap_or_default(),
-        ),
+        ("lowering_diagnostics".into(), lowered.diagnostics.format(db)),
+        ("lowering_format".into(), format!("{:?}", lowered.debug(&lowered_formatter))),
     ])
 }

--- a/crates/cairo-lowering/src/test_data/tests
+++ b/crates/cairo-lowering/src/test_data/tests
@@ -6,7 +6,7 @@ test_function_lowering
 //! > function
 fn foo(a: felt) -> felt {
     return a + a * a;
-    5;6;7
+    5;6;7;
 }
 
 //! > function_name
@@ -15,12 +15,16 @@ foo
 //! > module_code
 
 //! > semantic_diagnostics
+error: Unexpected return type. Expected: "core::felt", found: "()".
+ --> lib.cairo:1:25
+fn foo(a: felt) -> felt {
+                        ^
 
 //! > lowering_diagnostics
 error: Unreachable code
  --> lib.cairo:3:5
-    5;6;7
-    ^**^
+    5;6;7;
+    ^****^
 
 //! > lowering_format
 blk0 (root):

--- a/crates/cairo-semantic/src/expr/test.rs
+++ b/crates/cairo-semantic/src/expr/test.rs
@@ -47,7 +47,7 @@ semantic_test!(
 #[test_case(r"'\x12\x34'_u128", 0x1234, "u128")]
 fn test_expr_literal(expr: &str, value: i128, ty_name: &str) {
     let mut db_val = SemanticDatabaseForTesting::default();
-    let test_expr = setup_test_expr(&mut db_val, expr, "", "").unwrap().unwrap();
+    let test_expr = setup_test_expr(&mut db_val, expr, "", "").unwrap();
     let db = &db_val;
     let expr = db.expr_semantic(test_expr.function_id, test_expr.expr_id);
     let expr_formatter = ExprFormatter { db, free_function_id: test_expr.function_id };
@@ -78,8 +78,7 @@ fn test_expr_literal(expr: &str, value: i128, ty_name: &str) {
 #[test]
 fn test_expr_assignment() {
     let mut db_val = SemanticDatabaseForTesting::default();
-    let test_expr =
-        setup_test_expr(&mut db_val, "a = a * 3", "", "let mut a = 5;").unwrap().unwrap();
+    let test_expr = setup_test_expr(&mut db_val, "a = a * 3", "", "let mut a = 5;").unwrap();
     let db = &db_val;
     let expr = db.expr_semantic(test_expr.function_id, test_expr.expr_id);
     let expr_formatter = ExprFormatter { db, free_function_id: test_expr.function_id };
@@ -96,7 +95,7 @@ fn test_expr_assignment() {
 #[test]
 fn test_expr_operator() {
     let mut db_val = SemanticDatabaseForTesting::default();
-    let test_expr = setup_test_expr(&mut db_val, "!(-5 + 9 * 3 == 0)", "", "").unwrap().unwrap();
+    let test_expr = setup_test_expr(&mut db_val, "!(-5 + 9 * 3 == 0)", "", "").unwrap();
     let db = &db_val;
     let expr = db.expr_semantic(test_expr.function_id, test_expr.expr_id);
     let expr_formatter = ExprFormatter { db, free_function_id: test_expr.function_id };
@@ -314,7 +313,7 @@ fn test_let_statement() {
     )
     .unwrap();
     let db = &db_val;
-    let expr = db.expr_semantic(test_function.function_id, test_function.body.unwrap());
+    let expr = db.expr_semantic(test_function.function_id, test_function.body);
     let expr_formatter = ExprFormatter { db, free_function_id: test_function.function_id };
 
     assert_eq!(
@@ -369,7 +368,7 @@ fn test_expr_var() {
     let db = &db_val;
 
     let semantic::ExprBlock { statements: _, tail, ty: _, stable_ptr: _ } = extract_matches!(
-        db.expr_semantic(test_function.function_id, test_function.body.unwrap()),
+        db.expr_semantic(test_function.function_id, test_function.body),
         crate::Expr::Block
     );
 
@@ -427,7 +426,7 @@ fn test_expr_match() {
     .unwrap();
     let db = &db_val;
     let semantic::ExprBlock { statements: _, tail, ty: _, stable_ptr: _ } = extract_matches!(
-        db.expr_semantic(test_function.function_id, test_function.body.unwrap()),
+        db.expr_semantic(test_function.function_id, test_function.body),
         crate::Expr::Block
     );
     let expr = db.expr_semantic(test_function.function_id, tail.unwrap());
@@ -474,7 +473,7 @@ fn test_expr_match_failures() {
 #[test]
 fn test_expr_block() {
     let mut db_val = SemanticDatabaseForTesting::default();
-    let test_expr = setup_test_expr(&mut db_val, "{6;8;}", "", "").unwrap().unwrap();
+    let test_expr = setup_test_expr(&mut db_val, "{6;8;}", "", "").unwrap();
     let db = &db_val;
     let expr = db.expr_semantic(test_expr.function_id, test_expr.expr_id);
 
@@ -498,7 +497,7 @@ fn test_expr_block() {
 #[test]
 fn test_expr_block_with_tail_expression() {
     let mut db_val = SemanticDatabaseForTesting::default();
-    let test_expr = setup_test_expr(&mut db_val, "{6;8;9}", "", "").unwrap().unwrap();
+    let test_expr = setup_test_expr(&mut db_val, "{6;8;9}", "", "").unwrap();
     let db = &db_val;
     let expr = db.expr_semantic(test_expr.function_id, test_expr.expr_id);
 
@@ -531,7 +530,7 @@ fn test_expr_block_with_tail_expression() {
 fn test_expr_call() {
     let mut db_val = SemanticDatabaseForTesting::default();
     // TODO(spapini): Add types.
-    let test_expr = setup_test_expr(&mut db_val, "foo()", "fn foo() {6;}", "").unwrap().unwrap();
+    let test_expr = setup_test_expr(&mut db_val, "foo()", "fn foo() {6;}", "").unwrap();
     let db = &db_val;
     let expr = db.expr_semantic(test_expr.function_id, test_expr.expr_id);
 
@@ -547,7 +546,9 @@ fn test_expr_call() {
 fn test_expr_call_failures() {
     let mut db_val = SemanticDatabaseForTesting::default();
     // TODO(spapini): Add types.
-    let diagnostics = setup_test_expr(&mut db_val, "foo()", "", "").get_diagnostics();
+    let (test_expr, diagnostics) = setup_test_expr(&mut db_val, "foo()", "", "").split();
+    let db = &db_val;
+    let expr_formatter = ExprFormatter { db, free_function_id: test_expr.function_id };
 
     // Check expr.
     assert_eq!(
@@ -559,6 +560,14 @@ fn test_expr_call_failures() {
             ^*^
 
         "}
+    );
+    assert_eq!(format!("{:?}", test_expr.module_id.debug(db)), "ModuleId(test)");
+    assert_eq!(
+        format!(
+            "{:?}",
+            db.expr_semantic(test_expr.function_id, test_expr.expr_id).debug(&expr_formatter)
+        ),
+        "Missing(ExprMissing { ty: <missing> })"
     );
 }
 
@@ -618,7 +627,6 @@ fn test_expr_struct_ctor() {
         "},
         "let b = 2;",
     )
-    .unwrap()
     .unwrap();
     let db = &db_val;
     let expr = db.expr_semantic(test_expr.function_id, test_expr.expr_id);
@@ -634,7 +642,7 @@ fn test_expr_struct_ctor() {
 #[test]
 fn test_expr_tuple() {
     let mut db_val = SemanticDatabaseForTesting::default();
-    let test_expr = setup_test_expr(&mut db_val, "(1 + 2, (2, 3))", "", "").unwrap().unwrap();
+    let test_expr = setup_test_expr(&mut db_val, "(1 + 2, (2, 3))", "", "").unwrap();
     let db = &db_val;
     let expr = db.expr_semantic(test_expr.function_id, test_expr.expr_id);
     let expr_formatter = ExprFormatter { db, free_function_id: test_expr.function_id };

--- a/crates/cairo-semantic/src/items/free_function.rs
+++ b/crates/cairo-semantic/src/items/free_function.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use cairo_defs::ids::{FreeFunctionId, GenericFunctionId, GenericParamId, LanguageElementId};
-use cairo_diagnostics::{DiagnosticAdded, Diagnostics, Maybe, ToMaybe};
+use cairo_diagnostics::{Diagnostics, Maybe, ToMaybe};
 use cairo_proc_macros::DebugWithDb;
 use cairo_syntax::node::ast;
 use cairo_utils::unordered_hash_map::UnorderedHashMap;
@@ -139,7 +139,7 @@ pub struct FreeFunctionDefinitionData {
     diagnostics: Diagnostics<SemanticDiagnostic>,
     expr_lookup: UnorderedHashMap<ast::ExprPtr, ExprId>,
     resolved_lookback: Arc<ResolvedLookback>,
-    definition: Maybe<Arc<FreeFunctionDefinition>>,
+    definition: Arc<FreeFunctionDefinition>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, DebugWithDb)]
@@ -170,7 +170,7 @@ pub fn free_function_definition_body(
     db: &dyn SemanticGroup,
     free_function_id: FreeFunctionId,
 ) -> Maybe<semantic::ExprId> {
-    Ok(db.priv_free_function_definition_data(free_function_id)?.definition?.body)
+    Ok(db.priv_free_function_definition_data(free_function_id)?.definition.body)
 }
 
 /// Query implementation of [crate::db::SemanticGroup::free_function_definition_direct_callees].
@@ -178,7 +178,7 @@ pub fn free_function_definition_direct_callees(
     db: &dyn SemanticGroup,
     free_function_id: FreeFunctionId,
 ) -> Maybe<Vec<FunctionId>> {
-    Ok(db.priv_free_function_definition_data(free_function_id)?.definition?.direct_callees.clone())
+    Ok(db.priv_free_function_definition_data(free_function_id)?.definition.direct_callees.clone())
 }
 
 /// Query implementation of
@@ -204,7 +204,7 @@ pub fn free_function_definition(
     db: &dyn SemanticGroup,
     free_function_id: FreeFunctionId,
 ) -> Maybe<Arc<FreeFunctionDefinition>> {
-    db.priv_free_function_definition_data(free_function_id)?.definition
+    Ok(db.priv_free_function_definition_data(free_function_id)?.definition)
 }
 
 /// Query implementation of [crate::db::SemanticGroup::free_function_definition_resolved_lookback].
@@ -266,18 +266,17 @@ pub fn priv_free_function_definition_data(
     let expr_lookup: UnorderedHashMap<_, _> =
         exprs.iter().map(|(expr_id, expr)| (expr.stable_ptr(), expr_id)).collect();
     let resolved_lookback = Arc::new(resolver.lookback);
-    let diagnostics = diagnostics.build();
-    let definition = if diagnostics.is_empty() {
-        Ok(Arc::new(FreeFunctionDefinition {
+    Ok(FreeFunctionDefinitionData {
+        diagnostics: diagnostics.build(),
+        expr_lookup,
+        resolved_lookback,
+        definition: Arc::new(FreeFunctionDefinition {
             exprs,
             statements,
             body,
             direct_callees: direct_callees.into_iter().collect(),
-        }))
-    } else {
-        Err(DiagnosticAdded)
-    };
-    Ok(FreeFunctionDefinitionData { diagnostics, expr_lookup, resolved_lookback, definition })
+        }),
+    })
 }
 
 /// Query implementation of [crate::db::SemanticGroup::expr_semantic].
@@ -290,7 +289,6 @@ pub fn expr_semantic(
     db.priv_free_function_definition_data(free_function_id)
         .unwrap()
         .definition
-        .unwrap()
         .exprs
         .get(id)
         .unwrap()
@@ -307,7 +305,6 @@ pub fn statement_semantic(
     db.priv_free_function_definition_data(free_function_id)
         .unwrap()
         .definition
-        .unwrap()
         .statements
         .get(id)
         .unwrap()

--- a/crates/cairo-semantic/src/items/free_function_test.rs
+++ b/crates/cairo-semantic/src/items/free_function_test.rs
@@ -38,7 +38,7 @@ fn test_expr_lookup() {
     let expr_formatter = ExprFormatter { db, free_function_id };
     let definition_data = db.priv_free_function_definition_data(free_function_id).unwrap();
     let mut expr_debugs = Vec::new();
-    for (expr_id, expr) in &definition_data.definition.unwrap().exprs {
+    for (expr_id, expr) in &definition_data.definition.exprs {
         assert_eq!(db.lookup_expr_by_ptr(free_function_id, expr.stable_ptr()), Ok(expr_id));
         expr_debugs.push(format!("{:?}", expr.debug(&expr_formatter)));
     }


### PR DESCRIPTION
This reverts commit 5e4d2b200cdc22a7a05671ed30d5bdab236699b0.

This changes actually guts the language server. I forgot that the whole reason for keeping Partial semantic results is for language server info.

Ill try to only stop the lowering from doing stuff on bad semantic things, in another PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/1551)
<!-- Reviewable:end -->
