### PR TITLE
Restructure VariableLifetimeResult::drops so that it can be used to a…

### DIFF
--- a/crates/cairo-sierra-generator/src/lifetime_test.rs
+++ b/crates/cairo-sierra-generator/src/lifetime_test.rs
@@ -53,7 +53,14 @@ fn check_variable_lifetime(
     let drop_str = find_variable_lifetime_res
         .drops
         .iter()
-        .map(|(var_id, location)| format!("{:?}: {location:?}", var_id.debug(&lowered_formatter)))
+        .map(|(location, vars)| {
+            format!(
+                "{location:?}: {}",
+                vars.iter()
+                    .map(|var_id| format!("{:?}", var_id.debug(&lowered_formatter)))
+                    .join(", ")
+            )
+        })
         .join("\n");
 
     OrderedHashMap::from([

--- a/crates/cairo-sierra-generator/src/lifetime_test_data/block
+++ b/crates/cairo-sierra-generator/src/lifetime_test_data/block
@@ -60,5 +60,5 @@ v3: [(Id { idx: 1 }, 2)]
 v0: [(Id { idx: 2 }, 0)]
 
 //! > drops
-v5: [PostStatement((Id { idx: 1 }, 3))]
-v4: [PostStatement((Id { idx: 1 }, 2))]
+PostStatement((Id { idx: 1 }, 3)): v5
+PostStatement((Id { idx: 1 }, 2)): v4

--- a/crates/cairo-sierra-generator/src/lifetime_test_data/enum
+++ b/crates/cairo-sierra-generator/src/lifetime_test_data/enum
@@ -118,10 +118,8 @@ v15: [(Id { idx: 5 }, 0)]
 v0: [(Id { idx: 6 }, 0)]
 
 //! > drops
-v21: [PostStatement((Id { idx: 6 }, 0))]
-v6: [PostStatement((Id { idx: 0 }, 1))]
-v4: [BeginningOfBlock(Id { idx: 3 })]
-v16: [PostStatement((Id { idx: 5 }, 0))]
-v17: [PostStatement((Id { idx: 5 }, 0))]
-v2: [BeginningOfBlock(Id { idx: 3 })]
-v1: [BeginningOfBlock(Id { idx: 3 }), BeginningOfBlock(Id { idx: 5 })]
+PostStatement((Id { idx: 6 }, 0)): v21
+PostStatement((Id { idx: 0 }, 1)): v6
+BeginningOfBlock(Id { idx: 3 }): v4, v2, v1
+PostStatement((Id { idx: 5 }, 0)): v16, v17
+BeginningOfBlock(Id { idx: 5 }): v1

--- a/crates/cairo-sierra-generator/src/lifetime_test_data/match
+++ b/crates/cairo-sierra-generator/src/lifetime_test_data/match
@@ -47,8 +47,7 @@ v3: [(Id { idx: 1 }, 1)]
 v0: [(Id { idx: 2 }, 0)]
 
 //! > drops
-v2: [BeginningOfBlock(Id { idx: 1 })]
-v1: [BeginningOfBlock(Id { idx: 1 })]
+BeginningOfBlock(Id { idx: 1 }): v2, v1
 
 //! > ==========================================================================
 
@@ -101,8 +100,8 @@ v3: [(Id { idx: 1 }, 1)]
 v0: [(Id { idx: 2 }, 0)]
 
 //! > drops
-v4: [PostStatement((Id { idx: 2 }, 0))]
-v2: [BeginningOfBlock(Id { idx: 1 })]
+PostStatement((Id { idx: 2 }, 0)): v4
+BeginningOfBlock(Id { idx: 1 }): v2
 
 //! > ==========================================================================
 
@@ -158,8 +157,8 @@ v3: [(Id { idx: 1 }, 1)]
 v0: [(Id { idx: 2 }, 0)]
 
 //! > drops
-v5: [PostStatement((Id { idx: 2 }, 0))]
-v2: [BeginningOfBlock(Id { idx: 1 })]
+PostStatement((Id { idx: 2 }, 0)): v5
+BeginningOfBlock(Id { idx: 1 }): v2
 
 //! > ==========================================================================
 
@@ -271,9 +270,8 @@ v4: [(Id { idx: 5 }, 2)]
 v3: [(Id { idx: 5 }, 1)]
 
 //! > drops
-v12: [PostStatement((Id { idx: 6 }, 0))]
-v6: [BeginningOfBlock(Id { idx: 1 })]
-v1: [BeginningOfBlock(Id { idx: 1 }), BeginningOfBlock(Id { idx: 3 })]
-v9: [BeginningOfBlock(Id { idx: 3 })]
-v0: [BeginningOfBlock(Id { idx: 3 }), BeginningOfBlock(Id { idx: 4 })]
-v2: [BeginningOfBlock(Id { idx: 5 })]
+PostStatement((Id { idx: 6 }, 0)): v12
+BeginningOfBlock(Id { idx: 1 }): v6, v1
+BeginningOfBlock(Id { idx: 3 }): v9, v1, v0
+BeginningOfBlock(Id { idx: 5 }): v2
+BeginningOfBlock(Id { idx: 4 }): v0

--- a/crates/cairo-sierra-generator/src/lifetime_test_data/simple
+++ b/crates/cairo-sierra-generator/src/lifetime_test_data/simple
@@ -39,7 +39,7 @@ v5: [(Id { idx: 0 }, 4)]
 v0: [(Id { idx: 0 }, 0)]
 
 //! > drops
-v7: [PostStatement((Id { idx: 0 }, 5))]
-v6: [PostStatement((Id { idx: 0 }, 4))]
-v4: [PostStatement((Id { idx: 0 }, 2))]
-v1: [BeginningOfBlock(Id { idx: 0 })]
+PostStatement((Id { idx: 0 }, 5)): v7
+PostStatement((Id { idx: 0 }, 4)): v6
+PostStatement((Id { idx: 0 }, 2)): v4
+BeginningOfBlock(Id { idx: 0 }): v1

--- a/crates/cairo-sierra-generator/src/lifetime_test_data/struct
+++ b/crates/cairo-sierra-generator/src/lifetime_test_data/struct
@@ -49,8 +49,8 @@ v4: [(Id { idx: 0 }, 2)]
 v0: [(Id { idx: 0 }, 1)]
 
 //! > drops
-v10: [PostStatement((Id { idx: 0 }, 5))]
-v8: [PostStatement((Id { idx: 0 }, 4))]
-v7: [PostStatement((Id { idx: 0 }, 3))]
-v3: [PostStatement((Id { idx: 0 }, 1))]
-v2: [PostStatement((Id { idx: 0 }, 0))]
+PostStatement((Id { idx: 0 }, 5)): v10
+PostStatement((Id { idx: 0 }, 4)): v8
+PostStatement((Id { idx: 0 }, 3)): v7
+PostStatement((Id { idx: 0 }, 1)): v3
+PostStatement((Id { idx: 0 }, 0)): v2


### PR DESCRIPTION
…dd the drop statements.

commit-id:d1c17414

---

**Stack**:
- #1563
- #1562
- #1561
- #1556
- #1555
- #1554
- #1553
- #1552 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*