### PR TITLE
Fixed issue with access of empty types out of the cells array.

### DIFF
--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -201,7 +201,7 @@ impl SierraCasmRunner {
         for ty in func.signature.ret_types.iter().rev() {
             let size = self.sierra_program_registry.get_type(ty)?.info().size as usize;
             let values: Vec<Felt> =
-                cells[(ap - size)..ap].iter().cloned().map(|cell| cell.unwrap()).collect();
+                ((ap - size)..ap).map(|index| cells[index].clone().unwrap()).collect();
             ap -= size;
             results_data.push((ty.clone(), values));
         }


### PR DESCRIPTION
Fixing the crash caused when testing a non-panicable function.

commit-id:28d0bbf7

---

**Stack**:
- #1886
- #1884 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*