### PR TITLE
Added ability to get ap_change variables at post-gas calculation.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost.rs
@@ -61,7 +61,7 @@ pub fn core_libfunc_cost<InfoProvider: InvocationCostInfoProvider>(
     libfunc: &CoreConcreteLibfunc,
     info_provider: &InfoProvider,
 ) -> Vec<Option<OrderedHashMap<CostTokenType, i64>>> {
-    let precost = core_libfunc_precost(&mut Ops { gas_info, idx: *idx }, libfunc, info_provider);
+    let precost = core_libfunc_precost(&mut Ops { gas_info, idx: *idx }, libfunc);
     let postcost = core_libfunc_postcost(&mut Ops { gas_info, idx: *idx }, libfunc, info_provider);
     zip_eq(precost, postcost)
         .map(|(precost, postcost)| {

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -59,15 +59,16 @@ pub trait InvocationCostInfoProvider {
     /// Number of tokens provided by the libfunc invocation (currently only relevant for
     /// `get_gas_all`).
     fn token_usages(&self, token_type: CostTokenType) -> usize;
+    /// Provides the ap change variable value of the current statement.
+    fn ap_change_var_value(&self) -> usize;
 }
 
 /// Returns a precost value for a libfunc - the cost of non-step tokens.
 /// This is a helper function to implement costing both for creating
 /// gas equations and getting actual gas usage after having a solution.
-pub fn core_libfunc_precost<Ops: CostOperations, InfoProvider: InvocationCostInfoProvider>(
+pub fn core_libfunc_precost<Ops: CostOperations>(
     ops: &mut Ops,
     libfunc: &CoreConcreteLibfunc,
-    _info_provider: &InfoProvider,
 ) -> Vec<Ops::CostType> {
     match libfunc {
         FunctionCall(FunctionCallConcreteLibfunc { function, .. }) => {

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_expr.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_expr.rs
@@ -56,13 +56,12 @@ impl CostOperations for Ops<'_> {
 }
 
 /// Returns an expression for the gas cost for core libfuncs.
-pub fn core_libfunc_precost_expr<InfoProvider: InvocationCostInfoProvider>(
+pub fn core_libfunc_precost_expr(
     statement_future_cost: &mut dyn StatementFutureCost,
     idx: &StatementIdx,
     libfunc: &CoreConcreteLibfunc,
-    info_provider: &InfoProvider,
 ) -> Vec<CostExprMap> {
-    core_libfunc_precost(&mut Ops { statement_future_cost, idx: *idx }, libfunc, info_provider)
+    core_libfunc_precost(&mut Ops { statement_future_cost, idx: *idx }, libfunc)
 }
 
 /// Returns an expression for the gas cost for core libfuncs.

--- a/crates/cairo-lang-sierra-gas/src/lib.rs
+++ b/crates/cairo-lang-sierra-gas/src/lib.rs
@@ -40,15 +40,22 @@ pub enum CostError {
 }
 
 /// Helper to implement the `InvocationCostInfoProvider` for the equation generation.
-struct InvocationCostInfoProviderForEqGen<'a, TokenUsages: Fn(CostTokenType) -> usize> {
+struct InvocationCostInfoProviderForEqGen<
+    'a,
+    TokenUsages: Fn(CostTokenType) -> usize,
+    ApChangeVarValue: Fn() -> usize,
+> {
     /// Registry for providing the sizes of the types.
     registry: &'a ProgramRegistry<CoreType, CoreLibfunc>,
     /// Closure providing the token usages for the invocation.
     token_usages: TokenUsages,
+    /// Closure providing the ap changes for the invocation.
+    ap_change_var_value: ApChangeVarValue,
 }
 
-impl<'a, TokenUsages: Fn(CostTokenType) -> usize> InvocationCostInfoProvider
-    for InvocationCostInfoProviderForEqGen<'a, TokenUsages>
+impl<'a, TokenUsages: Fn(CostTokenType) -> usize, ApChangeVarValue: Fn() -> usize>
+    InvocationCostInfoProvider
+    for InvocationCostInfoProviderForEqGen<'a, TokenUsages, ApChangeVarValue>
 {
     fn type_size(&self, ty: &ConcreteTypeId) -> usize {
         self.registry.get_type(ty).unwrap().info().size as usize
@@ -56,6 +63,10 @@ impl<'a, TokenUsages: Fn(CostTokenType) -> usize> InvocationCostInfoProvider
 
     fn token_usages(&self, token_type: CostTokenType) -> usize {
         (self.token_usages)(token_type)
+    }
+
+    fn ap_change_var_value(&self) -> usize {
+        (self.ap_change_var_value)()
     }
 }
 
@@ -71,15 +82,7 @@ pub fn calc_gas_precost_info(
             let libfunc = registry
                 .get_libfunc(libfunc_id)
                 .expect("Program registery creation would have already failed.");
-            core_libfunc_cost_expr::core_libfunc_precost_expr(
-                statement_future_cost,
-                idx,
-                libfunc,
-                &InvocationCostInfoProviderForEqGen {
-                    registry: &registry,
-                    token_usages: |_| panic!("Token costs not available at precost calculation."),
-                },
-            )
+            core_libfunc_cost_expr::core_libfunc_precost_expr(statement_future_cost, idx, libfunc)
         },
         function_set_costs,
         &registry,
@@ -87,10 +90,11 @@ pub fn calc_gas_precost_info(
 }
 
 /// Calculates gas postcost information for a given program - the gas costs of step token.
-pub fn calc_gas_postcost_info(
+pub fn calc_gas_postcost_info<ApChangeVarValue: Fn(StatementIdx) -> usize>(
     program: &Program,
     function_set_costs: OrderedHashMap<FunctionId, OrderedHashMap<CostTokenType, i32>>,
     precost_gas_info: &GasInfo,
+    ap_change_var_value: ApChangeVarValue,
 ) -> Result<GasInfo, CostError> {
     let registry = ProgramRegistry::<CoreType, CoreLibfunc>::new(program)?;
     calc_gas_info_inner(
@@ -108,6 +112,7 @@ pub fn calc_gas_postcost_info(
                     token_usages: |token_type| {
                         precost_gas_info.variable_values[(*idx, token_type)] as usize
                     },
+                    ap_change_var_value: || ap_change_var_value(*idx),
                 },
             )
         },

--- a/crates/cairo-lang-sierra-gas/src/test.rs
+++ b/crates/cairo-lang-sierra-gas/src/test.rs
@@ -28,7 +28,8 @@ fn test_solve_gas(inputs: &OrderedHashMap<String, String>) -> OrderedHashMap<Str
     let program = get_example_program(path);
 
     let gas_info0 = calc_gas_precost_info(&program, Default::default()).unwrap();
-    let gas_info1 = calc_gas_postcost_info(&program, Default::default(), &gas_info0).unwrap();
+    let gas_info1 =
+        calc_gas_postcost_info(&program, Default::default(), &gas_info0, |_| 0).unwrap();
     let gas_info = gas_info0.combine(gas_info1);
 
     OrderedHashMap::from([("gas_solution".into(), format!("{gas_info}"))])

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
@@ -192,6 +192,16 @@ impl<'a> InvocationCostInfoProvider for CompiledInvocationBuilder<'a> {
         self.program_info.type_sizes[ty] as usize
     }
 
+    fn ap_change_var_value(&self) -> usize {
+        self.program_info
+            .metadata
+            .ap_change_info
+            .variable_values
+            .get(&self.idx)
+            .copied()
+            .unwrap_or_default()
+    }
+
     fn token_usages(&self, token_type: CostTokenType) -> usize {
         InvocationApChangeInfoProvider::token_usages(self, token_type)
     }

--- a/crates/cairo-lang-sierra-to-casm/src/metadata.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/metadata.rs
@@ -66,7 +66,10 @@ pub fn calc_metadata(
             )
         })
         .collect();
-    let post_gas_info = calc_gas_postcost_info(program, post_function_set_costs, &pre_gas_info)?;
+    let post_gas_info =
+        calc_gas_postcost_info(program, post_function_set_costs, &pre_gas_info, |idx| {
+            ap_change_info.variable_values.get(&idx).copied().unwrap_or_default()
+        })?;
 
     Ok(Metadata { ap_change_info, gas_info: pre_gas_info.combine(post_gas_info) })
 }


### PR DESCRIPTION
commit-id:3bf5cf93

---

**Stack**:
- #1951
- #1957
- #1943
- #1942 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*