### PR TITLE
Let `check_diagnostics` only take a reference to the `on_diagnostic` …

### DIFF
--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -16,9 +16,10 @@ mod test;
 /// Returns `true` if diagnostics were found.
 pub fn check_diagnostics<'a>(
     db: &mut RootDatabase,
-    on_diagnostic: Option<Box<dyn FnMut(String) + 'a>>,
+    on_diagnostic: Option<&mut (dyn FnMut(String) + 'a)>,
 ) -> bool {
-    let mut on_diagnostic = on_diagnostic.unwrap_or_else(|| Box::new(|_| ()));
+    let mut ignore = |_| ();
+    let on_diagnostic = on_diagnostic.unwrap_or(&mut ignore);
 
     let mut found_diagnostics = false;
     for crate_id in db.crates() {
@@ -66,7 +67,7 @@ pub fn check_diagnostics<'a>(
 }
 
 pub fn check_and_eprint_diagnostics(db: &mut RootDatabase) -> bool {
-    check_diagnostics(db, Some(Box::new(eprint_diagnostic)))
+    check_diagnostics(db, Some(&mut eprint_diagnostic))
 }
 
 pub fn eprint_diagnostic(diag: String) {
@@ -76,6 +77,6 @@ pub fn eprint_diagnostic(diag: String) {
 /// Returns a string with all the diagnostics in the db.
 pub fn get_diagnostics_as_string(db: &mut RootDatabase) -> String {
     let mut diagnostics = String::default();
-    check_diagnostics(db, Some(Box::new(|s| diagnostics += &s)));
+    check_diagnostics(db, Some(&mut |s| diagnostics += &s));
     diagnostics
 }

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -93,9 +93,9 @@ pub fn compile(
 pub fn compile_prepared_db(
     mut db: RootDatabase,
     main_crate_ids: Vec<CrateId>,
-    compiler_config: CompilerConfig,
+    mut compiler_config: CompilerConfig,
 ) -> Result<SierraProgram> {
-    if check_diagnostics(&mut db, compiler_config.on_diagnostic) {
+    if check_diagnostics(&mut db, compiler_config.on_diagnostic.as_deref_mut()) {
         bail!("Compilation failed.");
     }
 

--- a/crates/cairo-lang-starknet/src/contract_class.rs
+++ b/crates/cairo-lang-starknet/src/contract_class.rs
@@ -64,7 +64,7 @@ pub struct ContractEntryPoint {
 }
 
 /// Compile the contract given by path.
-pub fn compile_path(path: &Path, compiler_config: CompilerConfig) -> Result<ContractClass> {
+pub fn compile_path(path: &Path, mut compiler_config: CompilerConfig) -> Result<ContractClass> {
     let mut db_val = {
         let mut b = RootDatabase::builder();
         b.with_dev_corelib().unwrap();
@@ -75,7 +75,7 @@ pub fn compile_path(path: &Path, compiler_config: CompilerConfig) -> Result<Cont
 
     let main_crate_ids = setup_project(db, Path::new(&path))?;
 
-    if check_diagnostics(db, compiler_config.on_diagnostic) {
+    if check_diagnostics(db, compiler_config.on_diagnostic.as_deref_mut()) {
         bail!("Compilation failed.");
     }
 


### PR DESCRIPTION
…callback

Taking this callback by-value was a bit artificial requirement, and it prevented passing `CompilerConfig` around, as calling `check_diagnostic` consumed its field.

commit-id:83f91bb9

---

**Stack**:
- #1999
- #1993
- #1992
- #1991 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*