### PR TITLE
Printed the parsing errors from the formatter tests, on failure.

### DIFF
--- a/crates/cairo-lang-formatter/src/test.rs
+++ b/crates/cairo-lang-formatter/src/test.rs
@@ -33,7 +33,10 @@ fn format_and_compare_file(unformatted_filename: &str, expected_filename: &str) 
 
     let (syntax_root, diagnostics) =
         get_syntax_root_and_diagnostics_from_file(db, unformatted_filename);
-    diagnostics.expect("A parsing error occurred while trying to format the code.");
+    diagnostics.expect(&format!(
+        "There were parsing errors while trying to format the code:\n{}",
+        diagnostics.format(db)
+    ));
     let config = FormatterConfig::default();
     let formatted_file = get_formatted_file(db, &syntax_root, config);
     let expected_file =


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/1994)
<!-- Reviewable:end -->
