### PR TITLE
Make `RootDatabaseBuilder` non-consuming

### DIFF
--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::{anyhow, Result};
 use cairo_lang_defs::db::{DefsDatabase, DefsGroup, HasMacroPlugins};
 use cairo_lang_defs::plugin::MacroPlugin;
 use cairo_lang_filesystem::db::{
@@ -18,7 +19,6 @@ use cairo_lang_semantic::plugin::SemanticPlugin;
 use cairo_lang_sierra_generator::db::SierraGenDatabase;
 use cairo_lang_syntax::node::db::{SyntaxDatabase, SyntaxGroup};
 use cairo_lang_utils::Upcast;
-use {cairo_lang_defs as defs, cairo_lang_lowering as lowering, cairo_lang_semantic as semantic};
 
 use crate::project::update_crate_roots_from_project_config;
 
@@ -60,53 +60,75 @@ impl Default for RootDatabase {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RootDatabaseBuilder {
-    db: RootDatabase,
+    plugins: Option<Vec<Arc<dyn SemanticPlugin>>>,
+    detect_corelib: bool,
+    project_config: Option<Box<ProjectConfig>>,
+    implicit_precedence: Option<Vec<String>>,
 }
 
 impl RootDatabaseBuilder {
     pub fn empty() -> Self {
-        Self { db: RootDatabase::empty() }
+        Default::default()
     }
 
     pub fn with_plugins(&mut self, plugins: Vec<Arc<dyn SemanticPlugin>>) -> &mut Self {
-        self.db.set_semantic_plugins(plugins);
+        self.plugins = Some(plugins);
         self
     }
 
-    pub fn with_dev_corelib(&mut self) -> Option<&mut Self> {
-        if let Some(path) = detect_corelib() {
-            init_dev_corelib(&mut self.db, path);
-            Some(self)
-        } else {
-            None
-        }
+    pub fn detect_corelib(&mut self) -> &mut Self {
+        self.detect_corelib = true;
+        self
     }
 
     pub fn with_project_config(&mut self, config: ProjectConfig) -> &mut Self {
-        update_crate_roots_from_project_config(&mut self.db, config.clone());
+        self.project_config = Some(Box::new(config));
+        self
+    }
 
-        if let Some(corelib) = config.corelib {
-            let core_crate = self.db.intern_crate(CrateLongId(CORELIB_CRATE_NAME.into()));
-            self.db.set_crate_root(core_crate, Some(corelib));
+    pub fn with_implicit_precedence(&mut self, precedence: &[impl ToString]) -> &mut Self {
+        self.implicit_precedence = Some(precedence.iter().map(ToString::to_string).collect());
+        self
+    }
+
+    pub fn build(&mut self) -> Result<RootDatabase> {
+        // NOTE: Order of operations matters here!
+        //   Errors if something is not OK are very subtle, mostly this results in missing
+        //   identifier diagnostics, or panics regarding lack of corelib items.
+
+        let mut db = RootDatabase::default();
+
+        if self.detect_corelib {
+            let path =
+                detect_corelib().ok_or_else(|| anyhow!("Failed to find development corelib."))?;
+            init_dev_corelib(&mut db, path);
         }
 
-        self
-    }
+        if let Some(config) = self.project_config.clone() {
+            update_crate_roots_from_project_config(&mut db, *config.clone());
 
-    pub fn with_implicit_precedence(&mut self, precedence: Vec<&str>) -> &mut Self {
-        self.db.set_implicit_precedence(Arc::new(
-            precedence
-                .iter()
-                .map(|name| get_core_ty_by_name(&self.db, name.into(), vec![]))
-                .collect::<Vec<_>>(),
-        ));
-        self
-    }
+            if let Some(corelib) = config.corelib {
+                let core_crate = db.intern_crate(CrateLongId(CORELIB_CRATE_NAME.into()));
+                db.set_crate_root(core_crate, Some(corelib));
+            }
+        }
 
-    pub fn build(self) -> RootDatabase {
-        self.db
+        if let Some(precedence) = self.implicit_precedence.clone() {
+            db.set_implicit_precedence(Arc::new(
+                precedence
+                    .into_iter()
+                    .map(|name| get_core_ty_by_name(&db, name.into(), vec![]))
+                    .collect::<Vec<_>>(),
+            ));
+        }
+
+        if let Some(plugins) = self.plugins.clone() {
+            db.set_semantic_plugins(plugins);
+        }
+
+        Ok(db)
     }
 }
 
@@ -126,17 +148,17 @@ impl Upcast<dyn SyntaxGroup> for RootDatabase {
     }
 }
 impl Upcast<dyn DefsGroup> for RootDatabase {
-    fn upcast(&self) -> &(dyn defs::db::DefsGroup + 'static) {
+    fn upcast(&self) -> &(dyn DefsGroup + 'static) {
         self
     }
 }
 impl Upcast<dyn SemanticGroup> for RootDatabase {
-    fn upcast(&self) -> &(dyn semantic::db::SemanticGroup + 'static) {
+    fn upcast(&self) -> &(dyn SemanticGroup + 'static) {
         self
     }
 }
 impl Upcast<dyn LoweringGroup> for RootDatabase {
-    fn upcast(&self) -> &(dyn lowering::db::LoweringGroup + 'static) {
+    fn upcast(&self) -> &(dyn LoweringGroup + 'static) {
         self
     }
 }

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -51,9 +51,7 @@ pub fn compile_cairo_project_at_path(
     path: &Path,
     compiler_config: CompilerConfig,
 ) -> Result<SierraProgram> {
-    let mut builder = RootDatabase::builder();
-    builder.with_dev_corelib().unwrap();
-    let mut db = builder.build();
+    let mut db = RootDatabase::builder().detect_corelib().build()?;
     let main_crate_ids = setup_project(&mut db, path)?;
     compile_prepared_db(&mut db, main_crate_ids, compiler_config)
 }
@@ -71,9 +69,7 @@ pub fn compile(
     project_config: ProjectConfig,
     compiler_config: CompilerConfig,
 ) -> Result<SierraProgram> {
-    let mut builder = RootDatabase::builder();
-    builder.with_project_config(project_config.clone());
-    let mut db = builder.build();
+    let mut db = RootDatabase::builder().with_project_config(project_config.clone()).build()?;
     let main_crate_ids = get_main_crate_ids_from_project(&mut db, &project_config);
 
     compile_prepared_db(&mut db, main_crate_ids, compiler_config)

--- a/crates/cairo-lang-language-server/src/bin/language_server.rs
+++ b/crates/cairo-lang-language-server/src/bin/language_server.rs
@@ -12,12 +12,11 @@ async fn main() {
     #[cfg(feature = "runtime-agnostic")]
     let (stdin, stdout) = (stdin.compat(), stdout.compat_write());
 
-    let db = {
-        let mut b = RootDatabase::builder();
-        b.with_dev_corelib().unwrap();
-        b.with_starknet();
-        b.build()
-    };
+    let db = RootDatabase::builder()
+        .detect_corelib()
+        .with_starknet()
+        .build()
+        .expect("Failed to initialize Cairo compiler database.");
 
     let (service, socket) = LspService::build(|client| Backend {
         client,

--- a/crates/cairo-lang-runner/src/cli.rs
+++ b/crates/cairo-lang-runner/src/cli.rs
@@ -31,10 +31,7 @@ struct Args {
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let mut builder = RootDatabase::builder();
-    builder.with_dev_corelib().unwrap();
-    let mut db_val = builder.build();
-    let db = &mut db_val;
+    let db = &mut RootDatabase::builder().detect_corelib().build()?;
 
     let main_crate_ids = setup_project(db, Path::new(&args.path))?;
 

--- a/crates/cairo-lang-starknet/src/contract_class.rs
+++ b/crates/cairo-lang-starknet/src/contract_class.rs
@@ -94,12 +94,7 @@ pub struct ContractEntryPoint {
 ///
 /// Errors if no contracts or more than 1 are found.
 pub fn compile_path(path: &Path, compiler_config: CompilerConfig) -> Result<ContractClass> {
-    let mut db = {
-        let mut b = RootDatabase::builder();
-        b.with_dev_corelib().unwrap();
-        b.with_starknet();
-        b.build()
-    };
+    let mut db = RootDatabase::builder().detect_corelib().with_starknet().build()?;
 
     let main_crate_ids = setup_project(&mut db, Path::new(&path))?;
 

--- a/crates/cairo-lang-starknet/src/contract_test.rs
+++ b/crates/cairo-lang-starknet/src/contract_test.rs
@@ -11,13 +11,7 @@ use crate::plugin::EXTERNAL_MODULE;
 
 #[test]
 fn test_contract_resolving() {
-    let mut db_val = {
-        let mut b = RootDatabase::builder();
-        b.with_dev_corelib().unwrap();
-        b.with_starknet();
-        b.build()
-    };
-    let db = &mut db_val;
+    let db = &mut RootDatabase::builder().detect_corelib().with_starknet().build().unwrap();
     let _crate_id = setup_test_crate(
         db,
         indoc! {"

--- a/crates/cairo-lang-starknet/src/db.rs
+++ b/crates/cairo-lang-starknet/src/db.rs
@@ -13,11 +13,11 @@ pub trait StarknetRootDatabaseBuilderEx {
 impl StarknetRootDatabaseBuilderEx for RootDatabaseBuilder {
     fn with_starknet(&mut self) -> &mut Self {
         // Override implicit precedence for compatibility with the StarkNet OS.
-        let precedence = vec!["Pedersen", "RangeCheck", "Bitwise", "EcOp", "GasBuiltin", "System"];
+        let precedence = ["Pedersen", "RangeCheck", "Bitwise", "EcOp", "GasBuiltin", "System"];
 
         let mut plugins = get_default_plugins();
         plugins.push(Arc::new(StarkNetPlugin {}));
 
-        self.with_implicit_precedence(precedence).with_plugins(plugins)
+        self.with_implicit_precedence(&precedence).with_plugins(plugins)
     }
 }

--- a/crates/cairo-lang-starknet/src/plugin_test.rs
+++ b/crates/cairo-lang-starknet/src/plugin_test.rs
@@ -13,13 +13,7 @@ use crate::plugin::StarkNetPlugin;
 pub fn test_expand_contract(
     inputs: &OrderedHashMap<String, String>,
 ) -> OrderedHashMap<String, String> {
-    let mut db_val = {
-        let mut b = RootDatabase::builder();
-        b.with_dev_corelib().unwrap();
-        b.with_starknet();
-        b.build()
-    };
-    let db = &mut db_val;
+    let db = &mut RootDatabase::builder().detect_corelib().with_starknet().build().unwrap();
 
     let (test_module, _semantic_diagnostics) =
         setup_test_module(db, inputs["cairo_code"].as_str()).split();

--- a/crates/cairo-lang-test-runner/src/cli.rs
+++ b/crates/cairo-lang-test-runner/src/cli.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use anyhow::{bail, Context};
-use cairo_lang_compiler::db::RootDatabaseBuilder;
+use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::check_and_eprint_diagnostics;
 use cairo_lang_compiler::project::setup_project;
 use cairo_lang_debug::DebugWithDb;
@@ -72,15 +72,12 @@ fn main() -> anyhow::Result<()> {
     if args.starknet {
         plugins.push(Arc::new(StarkNetPlugin {}));
     }
-    let mut builder = RootDatabaseBuilder::empty();
-    builder.with_plugins(plugins).with_dev_corelib().unwrap();
-    let mut db_val = builder.build();
-    let db = &mut db_val;
+    let db = &mut RootDatabase::builder().with_plugins(plugins).detect_corelib().build()?;
 
     let main_crate_ids = setup_project(db, Path::new(&args.path))?;
 
     if check_and_eprint_diagnostics(db) {
-        anyhow::bail!("failed to compile: {}", args.path);
+        bail!("failed to compile: {}", args.path);
     }
     let all_tests = find_all_tests(db, main_crate_ids);
     let sierra_program = db

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -40,9 +40,7 @@ cairo_lang_test_utils::test_file_test!(
 );
 
 fn run_small_e2e_test(inputs: &OrderedHashMap<String, String>) -> OrderedHashMap<String, String> {
-    let mut builder = RootDatabase::builder();
-    builder.with_dev_corelib().unwrap();
-    let db = &mut builder.build();
+    let db = &mut RootDatabase::builder().detect_corelib().build().unwrap();
     // Parse code and create semantic model.
     let test_module = setup_test_module(db, inputs["cairo"].as_str()).unwrap();
     assert!(!check_and_eprint_diagnostics(db));

--- a/tests/examples_test.rs
+++ b/tests/examples_test.rs
@@ -22,9 +22,7 @@ fn setup(name: &str) -> (RootDatabase, Vec<CrateId>) {
     path.push("examples");
     path.push(format!("{name}.cairo"));
 
-    let mut builder = RootDatabase::builder();
-    builder.with_dev_corelib().unwrap();
-    let mut db = builder.build();
+    let mut db = RootDatabase::builder().detect_corelib().build().unwrap();
     let main_crate_ids = setup_project(&mut db, path.as_path()).expect("Project setup failed.");
     assert!(!check_and_eprint_diagnostics(&mut db));
     (db, main_crate_ids)


### PR DESCRIPTION
There are multiple benefits of this change:
1. This enables writing one-liners (all usage places were rewritten to be such).
2. Previous implementation had a subtle issue that some orders of calls to the `with_*` methods could panic. For example, `RootDatabase::builder().with_starknet()` would panic, because nothing had set up `core` library yet. This PR fixes this problem by setting in stone internally the order of configuring the database.
3. The builder is now `Clone` and `Debug`, which may be handy.

commit-id:f0b62cd4

---

**Stack**:
- #2018
- #2012
- #1999 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*