### PR TITLE
Introduce `DiagnosticsError` and `ensure_diagnostics`

### DIFF
--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -5,6 +5,7 @@ use cairo_lang_filesystem::ids::FileLongId;
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_semantic::db::SemanticGroup;
+use thiserror::Error;
 
 use crate::db::RootDatabase;
 
@@ -12,11 +13,15 @@ use crate::db::RootDatabase;
 #[path = "diagnostics_test.rs"]
 mod test;
 
+#[derive(Error, Debug, Eq, PartialEq)]
+#[error("Compilation failed.")]
+pub struct DiagnosticsError;
+
 /// Checks if there are diagnostics and reports them to the provided callback as strings.
 /// Returns `true` if diagnostics were found.
-pub fn check_diagnostics<'a>(
+pub fn check_diagnostics(
     db: &mut RootDatabase,
-    on_diagnostic: Option<&mut (dyn FnMut(String) + 'a)>,
+    on_diagnostic: Option<&mut (dyn FnMut(String) + '_)>,
 ) -> bool {
     let mut ignore = |_| ();
     let on_diagnostic = on_diagnostic.unwrap_or(&mut ignore);
@@ -64,6 +69,15 @@ pub fn check_diagnostics<'a>(
         }
     }
     found_diagnostics
+}
+
+/// Checks if there are diagnostics and reports them to the provided callback as strings.
+/// Returns `Err` if diagnostics were found.
+pub fn ensure_diagnostics(
+    db: &mut RootDatabase,
+    on_diagnostic: Option<&mut (dyn FnMut(String) + '_)>,
+) -> Result<(), DiagnosticsError> {
+    if check_diagnostics(db, on_diagnostic) { Err(DiagnosticsError) } else { Ok(()) }
 }
 
 pub fn check_and_eprint_diagnostics(db: &mut RootDatabase) -> bool {

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -6,14 +6,14 @@ use std::path::Path;
 use std::sync::Arc;
 
 use ::cairo_lang_diagnostics::ToOption;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use cairo_lang_filesystem::ids::CrateId;
 use cairo_lang_sierra::program::Program;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_sierra_generator::replace_ids::replace_sierra_ids_in_program;
 
 use crate::db::RootDatabase;
-use crate::diagnostics::{check_diagnostics, eprint_diagnostic};
+use crate::diagnostics::{ensure_diagnostics, eprint_diagnostic};
 use crate::project::{get_main_crate_ids_from_project, setup_project, ProjectConfig};
 
 pub mod db;
@@ -91,9 +91,7 @@ pub fn compile_prepared_db(
     main_crate_ids: Vec<CrateId>,
     mut compiler_config: CompilerConfig,
 ) -> Result<SierraProgram> {
-    if check_diagnostics(db, compiler_config.on_diagnostic.as_deref_mut()) {
-        bail!("Compilation failed.");
-    }
+    ensure_diagnostics(db, compiler_config.on_diagnostic.as_deref_mut())?;
 
     let mut sierra_program = db
         .get_sierra_program(main_crate_ids)

--- a/crates/cairo-lang-starknet/src/contract_class.rs
+++ b/crates/cairo-lang-starknet/src/contract_class.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{ensure, Context, Result};
 use cairo_lang_compiler::db::RootDatabase;
-use cairo_lang_compiler::diagnostics::check_diagnostics;
+use cairo_lang_compiler::diagnostics::ensure_diagnostics;
 use cairo_lang_compiler::project::setup_project;
 use cairo_lang_compiler::CompilerConfig;
 use cairo_lang_defs::ids::TopLevelLanguageElementId;
@@ -135,9 +135,7 @@ pub fn compile_prepared_db(
     contracts: &[&ContractDeclaration],
     mut compiler_config: CompilerConfig,
 ) -> Result<Vec<ContractClass>> {
-    if check_diagnostics(db, compiler_config.on_diagnostic.as_deref_mut()) {
-        bail!("Compilation failed.");
-    }
+    ensure_diagnostics(db, compiler_config.on_diagnostic.as_deref_mut())?;
 
     contracts
         .iter()
@@ -150,8 +148,8 @@ pub fn compile_prepared_db(
 /// Compile declared StarkNet contract.
 ///
 /// The `contract` value **must** come from `db`, for example as a result of calling
-/// [`find_contracts`]. Does not check diagnostics, it is expected that [`check_diagnostics`] is
-/// called by caller of this function.
+/// [`find_contracts`]. Does not check diagnostics, it is expected that they are checked by caller
+/// of this function.
 fn compile_contract_with_prepared_and_checked_db(
     db: &mut RootDatabase,
     contract: &ContractDeclaration,


### PR DESCRIPTION
This allows catching the `Compilation failed.` error in more machine-friendly way, by using `anyhow::Error::downcast_ref` function.

commit-id:ce5928a4

---

**Stack**:
- #2018
- #2012 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*