### PR TITLE
Update README.md in vscode-cairo

### DIFF
--- a/vscode-cairo/README.md
+++ b/vscode-cairo/README.md
@@ -5,7 +5,7 @@ See troubleshooting section.
 
 From the directory of this file, run:
 ```
-sudo npm install -g vsce
+npm install --global @vscode/vsce
 npm install
 vsce package
 code --install-extension cairo1*.vsix


### PR DESCRIPTION
Update README.md in vscode-cairo since vsce has renamed to @vscode/vsce, the old command line doesn't work anymore

I have an issue reported here https://github.com/starkware-libs/cairo/issues/2020#issue-1567598159
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2021)
<!-- Reviewable:end -->
