### PR TITLE
Update README.md in vocde-cairo

### DIFF
--- a/vscode-cairo/README.md
+++ b/vscode-cairo/README.md
@@ -5,7 +5,7 @@ See troubleshooting section.
 
 From the directory of this file, run:
 ```
-sudo npm install -g vsce
+sudo npm install --global @vscode/vsce
 npm install
 vsce package
 code --install-extension cairo1*.vsix


### PR DESCRIPTION
vsce has renamed to @vscode/vsce, the old version is no longer updated

I also has an issue related, see https://github.com/starkware-libs/cairo/issues/2020

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2023)
<!-- Reviewable:end -->
