### PR TITLE
Feat: dojo codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-dojo"
+version = "1.0.0-alpha.2"
+dependencies = [
+ "anyhow",
+ "cairo-lang-compiler",
+ "cairo-lang-defs",
+ "cairo-lang-diagnostics",
+ "cairo-lang-formatter",
+ "cairo-lang-lowering",
+ "cairo-lang-parser",
+ "cairo-lang-plugins",
+ "cairo-lang-semantic",
+ "cairo-lang-sierra-generator",
+ "cairo-lang-starknet",
+ "cairo-lang-syntax",
+ "cairo-lang-test-utils",
+ "cairo-lang-utils",
+ "clap 4.0.26",
+ "env_logger",
+ "indoc",
+ "itertools",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "test-case",
+ "test-case-macros",
+ "test-log",
+]
+
+[[package]]
 name = "cairo-lang-eq-solver"
 version = "1.0.0-alpha.2"
 dependencies = [
@@ -437,6 +467,7 @@ dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
+ "cairo-lang-dojo",
  "cairo-lang-filesystem",
  "cairo-lang-formatter",
  "cairo-lang-lowering",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
+ "cairo-lang-filesystem",
  "cairo-lang-formatter",
  "cairo-lang-lowering",
  "cairo-lang-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/cairo-lang-syntax-codegen",
     "crates/cairo-lang-syntax",
     "crates/cairo-lang-test-runner",
+    "crates/cairo-lang-dojo",
     "tests",
 ]
 

--- a/corelib/bases/lib.cairo
+++ b/corelib/bases/lib.cairo
@@ -1,0 +1,318 @@
+mod traits;
+use traits::Copy;
+use traits::Drop;
+use traits::Add;
+use traits::Sub;
+use traits::Mul;
+use traits::Div;
+use traits::Rem;
+use traits::PartialEq;
+use traits::BitAnd;
+use traits::BitOr;
+use traits::BitXor;
+use traits::PartialOrd;
+
+#[derive(Copy, Drop)]
+enum bool {
+    False: (),
+    True: (),
+}
+
+extern fn bool_and_impl(a: bool, b: bool) -> (bool, ) implicits() nopanic;
+impl BoolBitAnd of BitAnd::<bool> {
+    #[inline(always)]
+    fn bitand(a: bool, b: bool) -> bool {
+        let (r, ) = bool_and_impl(a, b);
+        r
+    }
+}
+
+extern fn bool_or_impl(a: bool, b: bool) -> (bool, ) implicits() nopanic;
+impl BoolBitOr of BitOr::<bool> {
+    #[inline(always)]
+    fn bitor(a: bool, b: bool) -> bool {
+        let (r, ) = bool_or_impl(a, b);
+        r
+    }
+}
+
+extern fn bool_not_impl(a: bool) -> (bool, ) implicits() nopanic;
+#[inline(always)]
+fn bool_not(a: bool) -> bool implicits() nopanic {
+    let (r, ) = bool_not_impl(a);
+    r
+}
+
+extern fn bool_xor_impl(a: bool, b: bool) -> (bool, ) implicits() nopanic;
+impl BoolBitXor of BitXor::<bool> {
+    #[inline(always)]
+    fn bitxor(a: bool, b: bool) -> bool {
+        let (r, ) = bool_xor_impl(a, b);
+        r
+    }
+}
+
+extern fn bool_eq(a: bool, b: bool) -> bool implicits() nopanic;
+
+impl BoolPartialEq of PartialEq::<bool> {
+    #[inline(always)]
+    fn eq(a: bool, b: bool) -> bool {
+        bool_eq(a, b)
+    }
+    #[inline(always)]
+    fn ne(a: bool, b: bool) -> bool {
+        !(a == b)
+    }
+}
+
+// Felt.
+extern type RangeCheck;
+
+#[derive(Copy, Drop)]
+extern type felt;
+extern fn felt_const<value>() -> felt nopanic;
+
+// TODO(spapini): Make unnamed.
+impl FeltCopy of Copy::<felt>;
+impl FeltDrop of Drop::<felt>;
+
+impl FeltAdd of Add::<felt> {
+    #[inline(always)]
+    fn add(a: felt, b: felt) -> felt {
+        felt_add(a, b)
+    }
+}
+extern fn felt_add(a: felt, b: felt) -> felt nopanic;
+impl FeltSub of Sub::<felt> {
+    #[inline(always)]
+    fn sub(a: felt, b: felt) -> felt {
+        felt_sub(a, b)
+    }
+}
+extern fn felt_sub(a: felt, b: felt) -> felt nopanic;
+impl FeltMul of Mul::<felt> {
+    #[inline(always)]
+    fn mul(a: felt, b: felt) -> felt {
+        felt_mul(a, b)
+    }
+}
+extern fn felt_mul(a: felt, b: felt) -> felt nopanic;
+#[inline(always)]
+fn felt_neg(a: felt) -> felt {
+    a * felt_const::<-1>()
+}
+
+extern type NonZero<T>;
+// TODO(spapini): Add generic impls for NonZero for Copy, Drop.
+enum JumpNzResult<T> {
+    Zero: (),
+    NonZero: NonZero::<T>,
+}
+extern fn unwrap_nz<T>(a: NonZero::<T>) -> T nopanic;
+
+impl NonZeroFeltCopy of Copy::<NonZero::<felt>>;
+impl NonZeroFeltDrop of Drop::<NonZero::<felt>>;
+extern fn felt_div(a: felt, b: NonZero::<felt>) -> felt nopanic;
+
+impl FeltPartialEq of PartialEq::<felt> {
+    #[inline(always)]
+    fn eq(a: felt, b: felt) -> bool {
+        match a - b {
+            0 => bool::True(()),
+            _ => bool::False(()),
+        }
+    }
+    #[inline(always)]
+    fn ne(a: felt, b: felt) -> bool {
+        !(a == b)
+    }
+}
+
+impl PartialOrdFelt of PartialOrd::<felt> {
+    #[inline(always)]
+    fn le(a: felt, b: felt) -> bool {
+        !(b < a)
+    }
+    #[inline(always)]
+    fn ge(a: felt, b: felt) -> bool {
+        !(a < b)
+    }
+    #[inline(always)]
+    fn lt(a: felt, b: felt) -> bool {
+        u256_from_felt(a) < u256_from_felt(b)
+    }
+    #[inline(always)]
+    fn gt(a: felt, b: felt) -> bool {
+        b < a
+    }
+}
+
+extern fn felt_jump_nz(a: felt) -> JumpNzResult::<felt> nopanic;
+
+// TODO(spapini): Constraint using Copy and Drop traits.
+extern fn dup<T>(obj: T) -> (T, T) nopanic;
+extern fn drop<T>(obj: T) nopanic;
+
+// Boxes.
+mod box;
+use box::Box;
+use box::into_box;
+use box::unbox;
+
+// Nullable
+mod nullable;
+use nullable::FromNullableResult;
+use nullable::Nullable;
+use nullable::null;
+use nullable::into_nullable;
+use nullable::from_nullable;
+
+// Arrays.
+mod array;
+use array::Array;
+use array::array_new;
+use array::array_append;
+use array::array_pop_front;
+use array::array_get;
+use array::array_at;
+use array::array_len;
+use array::ArrayTrait;
+use array::ArrayImpl;
+impl ArrayFeltDrop of Drop::<Array::<felt>>;
+
+// Dictionary.
+mod dict;
+use dict::DictFeltTo;
+use dict::SquashedDictFeltTo;
+use dict::dict_felt_to_new;
+use dict::dict_felt_to_write;
+use dict::dict_felt_to_read;
+use dict::dict_felt_to_squash;
+use dict::DictFeltToTrait;
+use dict::DictFeltToImpl;
+
+// Result.
+mod result;
+use result::Result;
+
+// Option.
+mod option;
+use option::Option;
+use option::OptionUnitCopy;
+use option::OptionUnitDrop;
+
+// EC.
+mod ec;
+use ec::EcOp;
+use ec::EcPoint;
+use ec::EcPointAdd;
+use ec::EcPointSub;
+use ec::EcState;
+use ec::OptionEcPointCopy;
+use ec::ec_mul;
+use ec::ec_neg;
+use ec::ec_point_from_x;
+use ec::ec_point_new;
+use ec::ec_point_try_new;
+use ec::ec_point_unwrap;
+use ec::ec_state_add_mul;
+use ec::ec_state_add;
+use ec::ec_state_finalize;
+use ec::ec_state_init;
+
+mod ecdsa;
+
+// Integer.
+mod integer;
+use integer::u128;
+use integer::u128_const;
+use integer::u128_from_felt;
+use integer::u128_try_from_felt;
+use integer::u128_to_felt;
+use integer::U128Add;
+use integer::U128Sub;
+use integer::U128Mul;
+use integer::U128Div;
+use integer::U128Rem;
+use integer::U128PartialOrd;
+use integer::U128PartialEq;
+use integer::U128BitAnd;
+use integer::U128BitOr;
+use integer::U128BitXor;
+use integer::u128_jump_nz;
+use integer::u8;
+use integer::u8_const;
+use integer::u8_from_felt;
+use integer::u8_try_from_felt;
+use integer::u8_to_felt;
+use integer::U8Add;
+use integer::U8Sub;
+use integer::U8PartialOrd;
+use integer::U8PartialEq;
+use integer::u64;
+use integer::u64_const;
+use integer::u64_from_felt;
+use integer::u64_try_from_felt;
+use integer::u64_to_felt;
+use integer::U64Add;
+use integer::U64Sub;
+use integer::U64PartialOrd;
+use integer::U64PartialEq;
+use integer::u256;
+use integer::U256Add;
+use integer::U256Sub;
+use integer::U256Mul;
+use integer::U256PartialOrd;
+use integer::U256PartialEq;
+use integer::U256BitAnd;
+use integer::U256BitOr;
+use integer::U256BitXor;
+use integer::u256_from_felt;
+use integer::Bitwise;
+
+// Gas.
+mod gas;
+use gas::BuiltinCosts;
+use gas::GasBuiltin;
+use gas::get_builtin_costs;
+use gas::get_gas;
+use gas::get_gas_all;
+
+// Panics.
+enum PanicResult<T> {
+    Ok: T,
+    Err: Array::<felt>,
+}
+enum never {}
+extern fn panic(data: Array::<felt>) -> never;
+
+fn assert(cond: bool, err_code: felt) {
+    if !cond {
+        let mut data = ArrayTrait::new();
+        data.append(err_code);
+        panic(data);
+    }
+}
+
+// Serialization and Deserialization.
+mod serde;
+
+// Hash functions.
+mod hash;
+use hash::pedersen;
+use hash::Pedersen;
+
+// Debug.
+mod debug;
+
+// StarkNet
+mod starknet;
+use starknet::System;
+use starknet::ContractAddress;
+
+
+#[cfg(test)]
+mod test;
+
+// Dojo
+mod dojo;

--- a/corelib/bases/serde.cairo
+++ b/corelib/bases/serde.cairo
@@ -1,0 +1,110 @@
+use array::ArrayTrait;
+trait Serde<T> {
+    fn serialize(ref serialized: Array::<felt>, input: T);
+    fn deserialize(ref serialized: Array::<felt>) -> Option::<T>;
+}
+
+impl FeltSerde of Serde::<felt> {
+    fn serialize(ref serialized: Array::<felt>, input: felt) {
+        serialized.append(input);
+    }
+    fn deserialize(ref serialized: Array::<felt>) -> Option::<felt> {
+        serialized.pop_front()
+    }
+}
+
+impl BoolSerde of Serde::<bool> {
+    fn serialize(ref serialized: Array::<felt>, input: bool) {
+        Serde::<felt>::serialize(ref serialized, if input {
+            1
+        } else {
+            0
+        });
+    }
+    fn deserialize(ref serialized: Array::<felt>) -> Option::<bool> {
+        Option::Some(Serde::<felt>::deserialize(ref serialized)? != 0)
+    }
+}
+
+impl U8Serde of Serde::<u8> {
+    fn serialize(ref serialized: Array::<felt>, input: u8) {
+        Serde::<felt>::serialize(ref serialized, u8_to_felt(input));
+    }
+    fn deserialize(ref serialized: Array::<felt>) -> Option::<u8> {
+        Option::Some(u8_try_from_felt(Serde::<felt>::deserialize(ref serialized)?)?)
+    }
+}
+
+impl U128Serde of Serde::<u128> {
+    fn serialize(ref serialized: Array::<felt>, input: u128) {
+        Serde::<felt>::serialize(ref serialized, u128_to_felt(input));
+    }
+    fn deserialize(ref serialized: Array::<felt>) -> Option::<u128> {
+        Option::Some(u128_try_from_felt(Serde::<felt>::deserialize(ref serialized)?)?)
+    }
+}
+
+impl U256Serde of Serde::<u256> {
+    fn serialize(ref serialized: Array::<felt>, input: u256) {
+        Serde::<u128>::serialize(ref serialized, input.low);
+        Serde::<u128>::serialize(ref serialized, input.high);
+    }
+    fn deserialize(ref serialized: Array::<felt>) -> Option::<u256> {
+        Option::Some(
+            u256 {
+                low: Serde::<u128>::deserialize(ref serialized)?,
+                high: Serde::<u128>::deserialize(ref serialized)?,
+            }
+        )
+    }
+}
+
+impl ArrayFeltSerde of Serde::<Array::<felt>> {
+    fn serialize(ref serialized: Array::<felt>, mut input: Array::<felt>) {
+        Serde::<u128>::serialize(ref serialized, input.len())
+        serialize_array_felt_helper(ref serialized, ref input);
+    }
+    fn deserialize(ref serialized: Array::<felt>) -> Option::<Array::<felt>> {
+        let length = Serde::<felt>::deserialize(ref serialized)?;
+        let mut arr = ArrayTrait::new();
+        deserialize_array_felt_helper(ref serialized, arr, length)
+    }
+}
+
+fn serialize_array_felt_helper(ref serialized: Array::<felt>, ref input: Array::<felt>) {
+    // TODO(orizi): Replace with simple call once inlining is supported.
+    match get_gas() {
+        Option::Some(_) => {},
+        Option::None(_) => {
+            let mut data = ArrayTrait::new();
+            data.append('Out of gas');
+            panic(data);
+        },
+    }
+    match input.pop_front() {
+        Option::Some(value) => {
+            Serde::<felt>::serialize(ref serialized, value);
+            serialize_array_felt_helper(ref serialized, ref input);
+        },
+        Option::None(_) => {},
+    }
+}
+
+fn deserialize_array_felt_helper(
+    ref serialized: Array::<felt>, mut curr_output: Array::<felt>, remaining: felt
+) -> Option::<Array::<felt>> {
+    // TODO(orizi): Replace with simple call once inlining is supported.
+    match get_gas() {
+        Option::Some(_) => {},
+        Option::None(_) => {
+            let mut data = ArrayTrait::new();
+            data.append('Out of gas');
+            panic(data);
+        },
+    }
+    if remaining == 0 {
+        return Option::<Array::<felt>>::Some(curr_output);
+    }
+    curr_output.append(Serde::<felt>::deserialize(ref serialized)?);
+    deserialize_array_felt_helper(ref serialized, curr_output, remaining - 1)
+}

--- a/corelib/bases/starknet.cairo
+++ b/corelib/bases/starknet.cairo
@@ -1,0 +1,147 @@
+extern type System;
+#[derive(Copy, Drop)]
+extern type StorageBaseAddress;
+#[derive(Copy, Drop)]
+extern type StorageAddress;
+#[derive(Copy, Drop)]
+extern type ContractAddress;
+
+// An Helper function to force the inclusion of `System` in the list of implicits.
+fn use_system_implicit() implicits(System) {}
+
+// Storage.
+extern fn storage_base_address_const<address>() -> StorageBaseAddress nopanic;
+extern fn storage_base_address_from_felt(
+    addr: felt
+) -> StorageBaseAddress implicits(RangeCheck) nopanic;
+extern fn storage_address_from_base_and_offset(
+    base: StorageBaseAddress, offset: u8
+) -> StorageAddress nopanic;
+extern fn storage_address_from_base(base: StorageBaseAddress) -> StorageAddress nopanic;
+
+// Only address_domain 0 is currently supported.
+// This parameter is going to be used to access address spaces with different
+// data availability guarantees.
+extern fn storage_read_syscall(
+    address_domain: felt, address: StorageAddress, 
+) -> SyscallResult::<felt> implicits(GasBuiltin, System) nopanic;
+extern fn storage_write_syscall(
+    address_domain: felt, address: StorageAddress, value: felt
+) -> SyscallResult::<()> implicits(GasBuiltin, System) nopanic;
+
+// Interoperability.
+extern fn contract_address_const<address>() -> ContractAddress nopanic;
+extern fn call_contract_syscall(
+    address: ContractAddress, calldata: Array::<felt>
+) -> SyscallResult::<Array::<felt>> implicits(GasBuiltin, System) nopanic;
+
+extern fn contract_address_try_from_felt(
+    address: felt
+) -> Option::<ContractAddress> implicits(RangeCheck) nopanic;
+
+// Events.
+extern fn emit_event_syscall(
+    keys: Array::<felt>, data: Array::<felt>
+) -> SyscallResult::<()> implicits(GasBuiltin, System) nopanic;
+
+// Getters.
+extern fn get_caller_address_syscall() -> SyscallResult::<felt> implicits(
+    GasBuiltin, System
+) nopanic;
+
+fn get_caller_address() -> felt {
+    get_caller_address_syscall().unwrap_syscall()
+}
+
+trait StorageAccess<T> {
+    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<T>;
+    fn write(address_domain: felt, base: StorageBaseAddress, value: T) -> SyscallResult::<()>;
+}
+
+impl StorageAccessFelt of StorageAccess::<felt> {
+    #[inline(always)]
+    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<felt> {
+        storage_read_syscall(address_domain, storage_address_from_base(base))
+    }
+    #[inline(always)]
+    fn write(address_domain: felt, base: StorageBaseAddress, value: felt) -> SyscallResult::<()> {
+        storage_write_syscall(address_domain, storage_address_from_base(base), value)
+    }
+}
+
+impl StorageAccessBool of StorageAccess::<bool> {
+    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<bool> {
+        Result::Ok(StorageAccess::<felt>::read(address_domain, base)? != 0)
+    }
+    #[inline(always)]
+    fn write(address_domain: felt, base: StorageBaseAddress, value: bool) -> SyscallResult::<()> {
+        StorageAccess::<felt>::write(address_domain, base, if value {
+            1
+        } else {
+            0
+        })
+    }
+}
+
+impl StorageAccessU8 of StorageAccess::<u8> {
+    fn read(address_domain: felt, base: StorageBaseAddress) -> Result::<u8, Array::<felt>> {
+        Result::Ok(u8_from_felt(StorageAccess::<felt>::read(address_domain, base)?))
+    }
+    #[inline(always)]
+    fn write(
+        address_domain: felt, base: StorageBaseAddress, value: u8
+    ) -> Result::<(), Array::<felt>> {
+        StorageAccess::<felt>::write(address_domain, base, u8_to_felt(value))
+    }
+}
+
+impl StorageAccessU128 of StorageAccess::<u128> {
+    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<u128> {
+        Result::Ok(u128_from_felt(StorageAccess::<felt>::read(address_domain, base)?))
+    }
+    #[inline(always)]
+    fn write(address_domain: felt, base: StorageBaseAddress, value: u128) -> SyscallResult::<()> {
+        StorageAccess::<felt>::write(address_domain, base, u128_to_felt(value))
+    }
+}
+
+impl StorageAccessU256 of StorageAccess::<u256> {
+    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<u256> {
+        Result::Ok(
+            u256 {
+                low: StorageAccess::<u128>::read(address_domain, base)?,
+                high: u128_from_felt(
+                    storage_read_syscall(
+                        address_domain, storage_address_from_base_and_offset(base, 1_u8)
+                    )?
+                )
+            }
+        )
+    }
+    fn write(address_domain: felt, base: StorageBaseAddress, value: u256) -> SyscallResult::<()> {
+        StorageAccess::<u128>::write(address_domain, base, value.low)?;
+        storage_write_syscall(
+            address_domain,
+            storage_address_from_base_and_offset(base, 1_u8),
+            u128_to_felt(value.high)
+        )
+    }
+}
+
+/// The result type for a syscall.
+type SyscallResult<T> = Result::<T, Array::<felt>>;
+
+trait SyscallResultTrait<T> {
+    /// If `val` is `Result::Ok(x)`, returns `x`. Otherwise, panics with the revert reason.
+    fn unwrap_syscall(self: SyscallResult::<T>) -> T;
+}
+impl SyscallResultTraitImpl<T> of SyscallResultTrait::<T> {
+    fn unwrap_syscall(self: SyscallResult::<T>) -> T {
+        match self {
+            Result::Ok(x) => x,
+            Result::Err(revert_reason) => {
+                panic(revert_reason)
+            },
+        }
+    }
+}

--- a/corelib/dojo.cairo
+++ b/corelib/dojo.cairo
@@ -1,0 +1,5 @@
+#[derive(Copy, Drop)]
+struct Position {
+    x: felt,
+    y: felt,
+}

--- a/corelib/lib.cairo
+++ b/corelib/lib.cairo
@@ -310,5 +310,9 @@ mod starknet;
 use starknet::System;
 use starknet::ContractAddress;
 
+// Dojo
+mod dojo;
+use dojo::Position;
+
 #[cfg(test)]
 mod test;

--- a/corelib/serde.cairo
+++ b/corelib/serde.cairo
@@ -59,6 +59,21 @@ impl U256Serde of Serde::<u256> {
     }
 }
 
+impl PositionSerde of Serde::<Position> {
+    fn serialize(ref serialized: Array::<felt>, input: Position) {
+        Serde::<felt>::serialize(ref serialized, input.x);
+        Serde::<felt>::serialize(ref serialized, input.y);
+    }
+    fn deserialize(ref serialized: Array::<felt>) -> Option::<Position> {
+        Option::Some(
+            Position {
+                x: Serde::<felt>::deserialize(ref serialized)?,
+                y: Serde::<felt>::deserialize(ref serialized)?,
+            }
+        )
+    }
+}
+
 impl ArrayFeltSerde of Serde::<Array::<felt>> {
     fn serialize(ref serialized: Array::<felt>, mut input: Array::<felt>) {
         Serde::<u128>::serialize(ref serialized, input.len())

--- a/corelib/starknet.cairo
+++ b/corelib/starknet.cairo
@@ -128,6 +128,27 @@ impl StorageAccessU256 of StorageAccess::<u256> {
     }
 }
 
+impl StorageAccessPosition of StorageAccess::<Position> {
+    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<Position> {
+        Result::Ok(
+            Position {
+                x: StorageAccess::<felt>::read(address_domain, base)?,
+                y: storage_read_syscall(
+                    address_domain, storage_address_from_base_and_offset(base, 1_u8)
+                )?
+            }
+        )
+    }
+    fn write(
+        address_domain: felt, base: StorageBaseAddress, value: Position
+    ) -> SyscallResult::<()> {
+        StorageAccess::<felt>::write(address_domain, base, value.x)?;
+        storage_write_syscall(
+            address_domain, storage_address_from_base_and_offset(base, 1_u8), value.y
+        )
+    }
+}
+
 /// The result type for a syscall.
 type SyscallResult<T> = Result::<T, Array::<felt>>;
 

--- a/crates/cairo-lang-dojo/Cargo.toml
+++ b/crates/cairo-lang-dojo/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "cairo-lang-dojo"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "Dojo capabilities and utilities on top of Starknet."
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.66"
+clap = { version = "4.0", features = ["derive"] }
+cairo-lang-compiler = { path = "../cairo-lang-compiler" }
+cairo-lang-defs = { path = "../cairo-lang-defs" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering" }
+cairo-lang-formatter = { path = "../cairo-lang-formatter" }
+cairo-lang-parser = { path = "../cairo-lang-parser" }
+cairo-lang-plugins = { path = "../cairo-lang-plugins" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic" }
+cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator" }
+cairo-lang-starknet = { path = "../cairo-lang-starknet" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax" }
+cairo-lang-utils = { path = "../cairo-lang-utils" }
+indoc.workspace = true
+itertools.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+smol_str.workspace = true
+
+[dev-dependencies]
+env_logger.workspace = true
+cairo-lang-semantic = { path = "../cairo-lang-semantic",  features = ["testing"] }
+cairo-lang-test-utils = { path = "../cairo-lang-test-utils" }
+test-case = "2.2.2"
+test-case-macros = "2.2.2"
+test-log.workspace = true
+
+[[bin]]
+name = "dojo-compile"
+path = "src/cli.rs"

--- a/crates/cairo-lang-dojo/Cargo.toml
+++ b/crates/cairo-lang-dojo/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.66"
 clap = { version = "4.0", features = ["derive"] }
 cairo-lang-compiler = { path = "../cairo-lang-compiler" }
 cairo-lang-defs = { path = "../cairo-lang-defs" }
+cairo-lang-filesystem = {path = "../cairo-lang-filesystem" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics" }
 cairo-lang-lowering = { path = "../cairo-lang-lowering" }
 cairo-lang-formatter = { path = "../cairo-lang-formatter" }

--- a/crates/cairo-lang-dojo/README.md
+++ b/crates/cairo-lang-dojo/README.md
@@ -1,0 +1,15 @@
+# cairo-lang-dojo
+
+Cairo language plugin for compiling the Dojo Entity Component System to Starknet contracts.
+
+## Testing
+
+Expected test outputs are defined in `crates/cairo-lang-dojo/src/plugin_test_data/component`.
+
+To run the tests, run:
+
+```
+cargo test --package cairo-lang-dojo --lib -- plugin::test::expand_contract::component --exact --nocapture
+```
+
+To regenerate, set `CAIRO_FIX_TESTS=1`.

--- a/crates/cairo-lang-dojo/src/build.rs
+++ b/crates/cairo-lang-dojo/src/build.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+
+
+
+use cairo_lang_filesystem::detect::detect_corelib;
+use cairo_lang_filesystem::ids::{FileId};
+
+use cairo_lang_parser::utils::{get_syntax_file_and_diagnostics, SimpleParserDatabase};
+
+use crate::plugin::DojoPlugin;
+
+pub fn build_corelib(path: PathBuf) {
+    reset_corelib();
+    let db = &mut SimpleParserDatabase::default();
+    let file_id = FileId::new(db, path.clone());
+    let mut file = File::open(path).unwrap();
+    // update file contents by appending node
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    let (syntax_file, _diagnostics) = get_syntax_file_and_diagnostics(db, file_id, contents.as_str());
+    let plugin = DojoPlugin {};
+    for item in syntax_file.items(db).elements(db).into_iter() {
+            plugin.generate_corelib(db, item.clone());
+    }
+}
+
+fn reset_corelib(){
+    let corelib_path = detect_corelib().unwrap();
+    println!("Corelib path: {}", corelib_path.display());
+
+    fs::copy(corelib_path.join("bases/starknet.cairo"), corelib_path.join("starknet.cairo")).unwrap();
+    fs::copy(corelib_path.join("bases/dojo.cairo"), corelib_path.join("dojo.cairo")).unwrap();
+    fs::copy(corelib_path.join("bases/serde.cairo"), corelib_path.join("serde.cairo")).unwrap();
+    fs::copy(corelib_path.join("bases/lib.cairo"), corelib_path.join("lib.cairo")).unwrap();
+}

--- a/crates/cairo-lang-dojo/src/cairo_level_tests/cairo_project.toml
+++ b/crates/cairo-lang-dojo/src/cairo_level_tests/cairo_project.toml
@@ -1,0 +1,2 @@
+[crate_roots]
+cairo_level_tests = "."

--- a/crates/cairo-lang-dojo/src/cairo_level_tests/component.cairo
+++ b/crates/cairo-lang-dojo/src/cairo_level_tests/component.cairo
@@ -1,0 +1,34 @@
+#[derive(Component)]
+struct Position { x: felt, y: felt }
+
+#[contract]
+mod PositionComponent {
+    struct Storage {
+        world_address: felt,
+        state: Map::<felt, Position>,
+     }
+
+     // Initialize PositionComponent.
+     #[external]
+     fn initialize(world_addr: felt) {
+         let world = world_address::read();
+         assert(world == 0, 'PositionComponent: Already initialized.');
+         world_address::write(world_addr);
+     }
+
+     // Set the state of an entity.
+     #[external]
+     fn set(entity_id: felt, value: Position) {
+         state::write(entity_id, value);
+     }
+
+     // Get the state of an entity.
+     #[view]
+     fn get(entity_id: felt) -> Position {
+         return state::read(entity_id);
+     }
+}
+
+trait IPosition {
+    fn is_zero(self: Position) -> bool;
+}

--- a/crates/cairo-lang-dojo/src/cairo_level_tests/system.cairo
+++ b/crates/cairo-lang-dojo/src/cairo_level_tests/system.cairo
@@ -1,0 +1,5 @@
+extern type Query<T>;
+
+fn move(query: Query::<Position, Health>) {
+    return ();
+}

--- a/crates/cairo-lang-dojo/src/cli.rs
+++ b/crates/cairo-lang-dojo/src/cli.rs
@@ -6,9 +6,10 @@ use cairo_lang_compiler::diagnostics::check_and_eprint_diagnostics;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_compiler::project::setup_project;
 use cairo_lang_diagnostics::ToOption;
-use cairo_lang_dojo::db::{DojoRootDatabaseBuilderEx, get_dojo_database};
+use cairo_lang_dojo::db::{DojoRootDatabaseBuilderEx};
 use clap::Parser;
 use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_dojo::build::build_corelib;
 
 /// Command line args parser.
 /// Exits with 0/1 if the input is formatted correctly/incorrectly.
@@ -27,6 +28,7 @@ struct Args {
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let path = &PathBuf::from(args.path);
+    build_corelib(path.clone());
 
     let mut db_val = {
         let mut b = RootDatabase::builder();
@@ -43,13 +45,13 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Failed to compile: {}", path.display());
     }
 
+
     let sierra_program = db
         .get_sierra_program(main_crate_ids)
         .to_option()
         .context("Compilation failed without any diagnostics")?;
 
 
-    // let contract = compile_path(path, args.replace_ids)?;
     match args.output {
         Some(path) => {
             fs::write(path, format!("{}", sierra_program)).context("Failed to write output.")?
@@ -59,3 +61,4 @@ fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
+

--- a/crates/cairo-lang-dojo/src/cli.rs
+++ b/crates/cairo-lang-dojo/src/cli.rs
@@ -6,8 +6,9 @@ use cairo_lang_compiler::diagnostics::check_and_eprint_diagnostics;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_compiler::project::setup_project;
 use cairo_lang_diagnostics::ToOption;
-use cairo_lang_dojo::db::get_dojo_database;
+use cairo_lang_dojo::db::{DojoRootDatabaseBuilderEx, get_dojo_database};
 use clap::Parser;
+use cairo_lang_compiler::db::RootDatabase;
 
 /// Command line args parser.
 /// Exits with 0/1 if the input is formatted correctly/incorrectly.
@@ -27,7 +28,13 @@ fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let path = &PathBuf::from(args.path);
 
-    let mut db_val = get_dojo_database();
+    let mut db_val = {
+        let mut b = RootDatabase::builder();
+        b.with_dev_corelib();
+        b.with_dojo_and_starknet();
+        b.build()
+    };
+
     let db = &mut db_val;
 
     let main_crate_ids = setup_project(db, Path::new(&path))?;

--- a/crates/cairo-lang-dojo/src/cli.rs
+++ b/crates/cairo-lang-dojo/src/cli.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::path::{PathBuf, Path};
+
+use anyhow::Context;
+use cairo_lang_compiler::diagnostics::check_and_eprint_diagnostics;
+use cairo_lang_sierra_generator::db::SierraGenGroup;
+use cairo_lang_compiler::project::setup_project;
+use cairo_lang_diagnostics::ToOption;
+use cairo_lang_dojo::db::get_dojo_database;
+use clap::Parser;
+
+/// Command line args parser.
+/// Exits with 0/1 if the input is formatted correctly/incorrectly.
+#[derive(Parser, Debug)]
+#[clap(version, verbatim_doc_comment)]
+struct Args {
+    /// The file to compile
+    path: String,
+    /// The output file name (default: stdout).
+    output: Option<String>,
+    /// Replaces sierra ids with human readable ones.
+    #[arg(short, long, default_value_t = false)]
+    replace_ids: bool,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let path = &PathBuf::from(args.path);
+
+    let mut db_val = get_dojo_database();
+    let db = &mut db_val;
+
+    let main_crate_ids = setup_project(db, Path::new(&path))?;
+
+    if check_and_eprint_diagnostics(db) {
+        anyhow::bail!("Failed to compile: {}", path.display());
+    }
+
+    let sierra_program = db
+        .get_sierra_program(main_crate_ids)
+        .to_option()
+        .context("Compilation failed without any diagnostics")?;
+
+
+    // let contract = compile_path(path, args.replace_ids)?;
+    match args.output {
+        Some(path) => {
+            fs::write(path, format!("{}", sierra_program)).context("Failed to write output.")?
+        }
+        None => println!("{}", sierra_program),
+    }
+
+    Ok(())
+}

--- a/crates/cairo-lang-dojo/src/component.rs
+++ b/crates/cairo-lang-dojo/src/component.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+
+use cairo_lang_defs::plugin::{
+    DynGeneratedFileAuxData, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+};
+use cairo_lang_semantic::patcher::{ModifiedNode, PatchBuilder, RewriteNode};
+use cairo_lang_semantic::plugin::DynDiagnosticMapper;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
+use indoc::formatdoc;
+use smol_str::SmolStr;
+
+use crate::plugin::DiagnosticRemapper;
+
+pub struct Component {
+    pub name: SmolStr,
+    pub rewrite_nodes: Vec<RewriteNode>,
+    pub diagnostics: Vec<PluginDiagnostic>,
+}
+
+impl Component {
+    pub fn from_module_body(db: &dyn SyntaxGroup, name: SmolStr, body: ast::ModuleBody) -> Self {
+        let diagnostics = vec![];
+        let rewrite_nodes: Vec<RewriteNode> = vec![];
+        let mut component = Component { rewrite_nodes, name, diagnostics };
+
+        let mut matched_struct = false;
+        for item in body.items(db).elements(db) {
+            match &item {
+                ast::Item::Struct(item_struct) => {
+                    if matched_struct {
+                        component.diagnostics.push(PluginDiagnostic {
+                            message: "Only one struct per module is supported.".to_string(),
+                            stable_ptr: item_struct.stable_ptr().untyped(),
+                        });
+                        continue;
+                    }
+
+                    component.handle_component_struct(db, item_struct.clone());
+                    matched_struct = true;
+                }
+                ast::Item::FreeFunction(item_function) => {
+                    component.handle_component_functions(db, item_function.clone());
+                }
+                _ => (),
+            }
+        }
+
+        component
+    }
+
+    pub fn result(self, db: &dyn SyntaxGroup) -> PluginResult {
+        let name = self.name;
+        let mut builder = PatchBuilder::new(db);
+        builder.add_modified(RewriteNode::interpolate_patched(
+            &formatdoc!(
+                "
+                #[contract]
+                mod {name} {{
+                    $body$
+                }}
+                ",
+            ),
+            HashMap::from([(
+                "body".to_string(),
+                RewriteNode::Modified(ModifiedNode { children: self.rewrite_nodes }),
+            )]),
+        ));
+
+        PluginResult {
+            code: Some(PluginGeneratedFile {
+                name,
+                content: builder.code,
+                aux_data: DynGeneratedFileAuxData::new(DynDiagnosticMapper::new(
+                    DiagnosticRemapper { patches: builder.patches },
+                )),
+            }),
+            diagnostics: self.diagnostics,
+            remove_original_item: true,
+        }
+    }
+
+    fn handle_component_struct(&mut self, db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct) {
+        self.rewrite_nodes.push(RewriteNode::Copied(struct_ast.as_syntax_node()));
+        self.rewrite_nodes.push(RewriteNode::interpolate_patched(
+            "
+                    struct Storage {
+                        world_address: felt,
+                        state: Map::<felt, $type_name$>,
+                    }
+    
+                    // Initialize $type_name$Component.
+                    #[external]
+                    fn initialize(world_addr: felt) {
+                        let world = world_address::read();
+                        assert(world == 0, '$type_name$Component: Already initialized.');
+                        world_address::write(world_addr);
+                    }
+    
+                    // Set the state of an entity.
+                    #[external]
+                    fn set(entity_id: felt, value: $type_name$) {
+                        state::write(entity_id, value);
+                    }
+    
+                    // Get the state of an entity.
+                    #[view]
+                    fn get(entity_id: felt) -> $type_name$ {
+                        return state::read(entity_id);
+                    }
+                    ",
+            HashMap::from([(
+                "type_name".to_string(),
+                RewriteNode::Trimmed(struct_ast.name(db).as_syntax_node()),
+            )]),
+        ))
+    }
+
+    fn handle_component_functions(&mut self, db: &dyn SyntaxGroup, func: ast::FunctionWithBody) {
+        let declaration = func.declaration(db);
+
+        let mut func_declaration = RewriteNode::from_ast(&declaration);
+        func_declaration
+            .modify_child(db, ast::FunctionDeclaration::INDEX_SIGNATURE)
+            .modify_child(db, ast::FunctionSignature::INDEX_PARAMETERS)
+            .modify(db)
+            .children
+            .splice(0..1, vec![RewriteNode::Text("entity_id: felt".to_string())]);
+
+        self.rewrite_nodes.push(RewriteNode::interpolate_patched(
+            "
+                            #[view]
+                            $func_decl$ {
+                                let self = state::read(entity_id);
+                                $body$
+                            }
+                            ",
+            HashMap::from([
+                ("func_decl".to_string(), func_declaration),
+                (
+                    "body".to_string(),
+                    RewriteNode::Trimmed(func.body(db).statements(db).as_syntax_node()),
+                ),
+            ]),
+        ))
+    }
+}

--- a/crates/cairo-lang-dojo/src/component.rs
+++ b/crates/cairo-lang-dojo/src/component.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::fmt::Debug;
+use std::path::PathBuf;
 
 use cairo_lang_defs::plugin::{
     DynGeneratedFileAuxData, PluginDiagnostic, PluginGeneratedFile, PluginResult,
@@ -9,6 +11,12 @@ use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
 use indoc::formatdoc;
 use smol_str::SmolStr;
+use cairo_lang_diagnostics::DiagnosticsBuilder;
+use cairo_lang_filesystem::detect::detect_corelib;
+use cairo_lang_filesystem::ids::FileId;
+use cairo_lang_parser::db::{file_syntax, priv_file_syntax_data};
+use cairo_lang_parser::parser::Parser;
+use cairo_lang_parser::utils::{get_syntax_root_and_diagnostics, get_syntax_root_and_diagnostics_from_file};
 
 use crate::plugin::DiagnosticRemapper;
 
@@ -16,6 +24,11 @@ pub struct Component {
     pub name: SmolStr,
     pub rewrite_nodes: Vec<RewriteNode>,
     pub diagnostics: Vec<PluginDiagnostic>,
+}
+
+pub struct ComponentImplementation {
+    storage_impl: RewriteNode,
+    serde_impl: RewriteNode,
 }
 
 impl Component {
@@ -36,7 +49,11 @@ impl Component {
                         continue;
                     }
 
-                    component.handle_component_struct(db, item_struct.clone());
+                    let component_impl = component.handle_component_struct(db, item_struct.clone());
+                    let corelib_path = detect_corelib().unwrap();
+                    modify_starknet_lib(db,&corelib_path, component_impl.storage_impl);
+                    modify_serde_lib(&corelib_path, component_impl.serde_impl);
+
                     matched_struct = true;
                 }
                 ast::Item::FreeFunction(item_function) => {
@@ -80,8 +97,117 @@ impl Component {
         }
     }
 
-    fn handle_component_struct(&mut self, db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct) {
+    fn handle_component_struct(&mut self, db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct) -> ComponentImplementation {
         self.rewrite_nodes.push(RewriteNode::Copied(struct_ast.as_syntax_node()));
+
+        let mut serialize = vec![];
+        let mut deserialize = vec![];
+        let mut read = vec![];
+        let mut write = vec![];
+        struct_ast.members(db).elements(db).iter().enumerate().for_each(|(i, member)| {
+            serialize.push(RewriteNode::interpolate_patched(
+                "Serde::<felt>::serialize(ref serialized, input.$key$);",
+                HashMap::from([(
+                    "key".to_string(),
+                    RewriteNode::Trimmed(member.name(db).as_syntax_node()),
+                )]),
+            ));
+
+            deserialize.push(RewriteNode::interpolate_patched(
+                "$key$: Serde::<felt>::deserialize(ref serialized)?,",
+                HashMap::from([(
+                    "key".to_string(),
+                    RewriteNode::Trimmed(member.name(db).as_syntax_node()),
+                )]),
+            ));
+
+            read.push(RewriteNode::interpolate_patched(
+                "$key$: storage_read_syscall(
+                    address_domain, storage_address_from_base_and_offset(base, $offset$_u8)
+                )?,",
+                HashMap::from([
+                    ("key".to_string(), RewriteNode::Trimmed(member.name(db).as_syntax_node())),
+                    ("offset".to_string(), RewriteNode::Text(i.to_string())),
+                ]),
+            ));
+
+            let final_token = if i == struct_ast.members(db).elements(db).len() - 1 { ";" } else { "" };
+            write.push(RewriteNode::interpolate_patched(
+                format!("storage_write_syscall(
+                    address_domain, storage_address_from_base_and_offset(base, $offset$_u8), \
+                 value.$key$){final_token}").as_str(),
+                HashMap::from([
+                    ("key".to_string(), RewriteNode::Trimmed(member.name(db).as_syntax_node())),
+                    ("offset".to_string(), RewriteNode::Text(i.to_string())),
+                ]),
+            ));
+        });
+
+        let serde_impl = RewriteNode::interpolate_patched(
+            "
+                impl $type_name$Serde of Serde::<$type_name$> {
+                    fn serialize(ref serialized: Array::<felt>, input: $type_name$) {
+                        $serialize$
+                    }
+                    fn deserialize(ref serialized: Array::<felt>) -> Option::<$type_name$> {
+                        Option::Some(
+                            $type_name$ {
+                                $deserialize$
+                            }
+                        )
+                    }
+                }
+            ",
+            HashMap::from([
+                (
+                    "type_name".to_string(),
+                    RewriteNode::Trimmed(struct_ast.name(db).as_syntax_node()),
+                ),
+                (
+                    "serialize".to_string(),
+                    RewriteNode::Modified(ModifiedNode { children: serialize }),
+                ),
+                (
+                    "deserialize".to_string(),
+                    RewriteNode::Modified(ModifiedNode { children: deserialize }),
+                ),
+            ]),
+        );
+
+        let storage_impl = RewriteNode::interpolate_patched(
+            "
+                impl StorageAccess$type_name$ of StorageAccess::<$type_name$> {
+                    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<$type_name$> {
+                        Result::Ok(
+                            $type_name$ {
+                                $read$
+                            }
+                        )
+                    }
+                    fn write(
+                        address_domain: felt, base: StorageBaseAddress, value: $type_name$
+                    ) -> SyscallResult::<()> {
+                        $write$
+                    }
+                }
+            ",
+            HashMap::from([
+                (
+                    "type_name".to_string(),
+                    RewriteNode::Trimmed(struct_ast.name(db).as_syntax_node()),
+                ),
+                (
+                    "read".to_string(),
+                    RewriteNode::Modified(ModifiedNode { children: read }),
+                ),
+                (
+                    "write".to_string(),
+                    RewriteNode::Modified(ModifiedNode { children: write }),
+                ),
+            ]),
+        );
+
+
         self.rewrite_nodes.push(RewriteNode::interpolate_patched(
             "
                     struct Storage {
@@ -113,7 +239,12 @@ impl Component {
                 "type_name".to_string(),
                 RewriteNode::Trimmed(struct_ast.name(db).as_syntax_node()),
             )]),
-        ))
+        ));
+
+        ComponentImplementation {
+            storage_impl,
+            serde_impl,
+        }
     }
 
     fn handle_component_functions(&mut self, db: &dyn SyntaxGroup, func: ast::FunctionWithBody) {
@@ -144,4 +275,13 @@ impl Component {
             ]),
         ))
     }
+}
+
+
+fn modify_starknet_lib(db: &dyn SyntaxGroup,path: &PathBuf, node: RewriteNode) {
+    todo!()
+}
+
+fn modify_serde_lib(path: &PathBuf, node: RewriteNode) {
+    todo!()
 }

--- a/crates/cairo-lang-dojo/src/db.rs
+++ b/crates/cairo-lang-dojo/src/db.rs
@@ -10,6 +10,34 @@ use itertools::Itertools;
 
 use crate::plugin::DojoPlugin;
 
+pub trait DojoRootDatabaseBuilderEx {
+    /// Tunes a compiler database to Dojo (e.g. Dojo plugin).
+    fn with_dojo(&mut self) -> &mut Self;
+
+    /// Tunes a compiler database to Dojo and Starknet
+    fn with_dojo_and_starknet(&mut self) -> &mut Self;
+}
+
+impl DojoRootDatabaseBuilderEx for RootDatabaseBuilder {
+    fn with_dojo(&mut self) -> &mut Self {
+
+        let mut plugins = get_default_plugins();
+        plugins.push(Arc::new(DojoPlugin {}));
+
+        self.with_plugins(plugins)
+    }
+
+    fn with_dojo_and_starknet(&mut self) -> &mut Self {
+
+        let precedence = vec!["Pedersen", "RangeCheck", "Bitwise", "EcOp", "GasBuiltin", "System"];
+
+        let mut plugins = get_default_plugins();
+        plugins.push(Arc::new(DojoPlugin {}));
+        plugins.push(Arc::new(StarkNetPlugin {}));
+
+        self.with_implicit_precedence(precedence).with_plugins(plugins)
+    }
+}
 /// Returns a compiler database tuned to Dojo (e.g. Dojo plugin).
 pub fn get_dojo_database() -> RootDatabase {
     let mut db_val = RootDatabase::default();
@@ -27,23 +55,6 @@ pub fn get_dojo_database() -> RootDatabase {
     plugins.push(Arc::new(DojoPlugin {}));
     db.set_semantic_plugins(plugins);
     db_val
-}
-
-pub trait DojoRootDatabaseBuilderEx {
-    /// Tunes a compiler database to Dojo (e.g. Dojo plugin).
-    fn with_dojo(&mut self) -> &mut Self;
-}
-
-impl DojoRootDatabaseBuilderEx for RootDatabaseBuilder {
-    fn with_dojo(&mut self) -> &mut Self {
-        // Override implicit precedence for compatibility with the Starknet OS.
-        let precedence = vec!["Pedersen", "RangeCheck", "Bitwise", "GasBuiltin", "System"];
-
-        let mut plugins = get_default_plugins();
-        plugins.push(Arc::new(DojoPlugin {}));
-
-        self.with_implicit_precedence(precedence).with_plugins(plugins)
-    }
 }
 
 pub trait StarknetRootDatabaseBuilderEx {

--- a/crates/cairo-lang-dojo/src/db.rs
+++ b/crates/cairo-lang-dojo/src/db.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use cairo_lang_compiler::db::{RootDatabase, RootDatabaseBuilder};
+use cairo_lang_lowering::db::LoweringGroup;
+use cairo_lang_plugins::get_default_plugins;
+use cairo_lang_semantic::corelib::get_core_ty_by_name;
+use cairo_lang_semantic::db::SemanticGroup;
+use cairo_lang_starknet::plugin::StarkNetPlugin;
+use itertools::Itertools;
+
+use crate::plugin::DojoPlugin;
+
+/// Returns a compiler database tuned to Dojo (e.g. Dojo plugin).
+pub fn get_dojo_database() -> RootDatabase {
+    let mut db_val = RootDatabase::default();
+    let db = &mut db_val;
+
+    // Override implicit precedence for compatibility with the Starknet OS.
+    db.set_implicit_precedence(Arc::new(
+        ["Pedersen", "RangeCheck", "Bitwise", "GasBuiltin", "System"]
+            .iter()
+            .map(|name| get_core_ty_by_name(db, name.into(), vec![]))
+            .collect_vec(),
+    ));
+
+    let mut plugins = get_default_plugins();
+    plugins.push(Arc::new(DojoPlugin {}));
+    db.set_semantic_plugins(plugins);
+    db_val
+}
+
+pub trait DojoRootDatabaseBuilderEx {
+    /// Tunes a compiler database to Dojo (e.g. Dojo plugin).
+    fn with_dojo(&mut self) -> &mut Self;
+}
+
+impl DojoRootDatabaseBuilderEx for RootDatabaseBuilder {
+    fn with_dojo(&mut self) -> &mut Self {
+        // Override implicit precedence for compatibility with the Starknet OS.
+        let precedence = vec!["Pedersen", "RangeCheck", "Bitwise", "GasBuiltin", "System"];
+
+        let mut plugins = get_default_plugins();
+        plugins.push(Arc::new(DojoPlugin {}));
+
+        self.with_implicit_precedence(precedence).with_plugins(plugins)
+    }
+}
+
+pub trait StarknetRootDatabaseBuilderEx {
+    /// Tunes a compiler database to StarkNet (e.g. StarkNet plugin).
+    fn with_starknet(&mut self) -> &mut Self;
+}
+
+impl StarknetRootDatabaseBuilderEx for RootDatabaseBuilder {
+    fn with_starknet(&mut self) -> &mut Self {
+        // Override implicit precedence for compatibility with the StarkNet OS.
+        let precedence = vec!["Pedersen", "RangeCheck", "Bitwise", "EcOp", "GasBuiltin", "System"];
+
+        let mut plugins = get_default_plugins();
+        plugins.push(Arc::new(StarkNetPlugin {}));
+
+        self.with_implicit_precedence(precedence).with_plugins(plugins)
+    }
+}

--- a/crates/cairo-lang-dojo/src/lib.rs
+++ b/crates/cairo-lang-dojo/src/lib.rs
@@ -8,3 +8,4 @@ pub mod plugin;
 mod component;
 mod system;
 mod query;
+pub mod build;

--- a/crates/cairo-lang-dojo/src/lib.rs
+++ b/crates/cairo-lang-dojo/src/lib.rs
@@ -1,0 +1,10 @@
+//! Dojo capabilities and utilities on top of Starknet.
+//!
+//! Dojo is a full stack toolchain for developing onchain games in Cairo.
+//!
+//! Learn more at [dojoengine.gg](http://dojoengine.gg).
+pub mod db;
+pub mod plugin;
+mod component;
+mod system;
+mod query;

--- a/crates/cairo-lang-dojo/src/plugin.rs
+++ b/crates/cairo-lang-dojo/src/plugin.rs
@@ -92,10 +92,7 @@ fn handle_mod(db: &dyn SyntaxGroup, module_ast: ast::ItemModule) -> PluginResult
         MaybeModuleBody::None(empty_body) => {
             return PluginResult {
                 code: None,
-                diagnostics: vec![PluginDiagnostic {
-                    message: "Modules without body are not supported.".to_string(),
-                    stable_ptr: empty_body.stable_ptr().untyped(),
-                }],
+                diagnostics: vec![],
                 remove_original_item: false,
             };
         }
@@ -111,10 +108,7 @@ fn handle_mod(db: &dyn SyntaxGroup, module_ast: ast::ItemModule) -> PluginResult
 
     PluginResult {
             code: None,
-            diagnostics: vec![PluginDiagnostic {
-                message: "Unsupported module type. Only modules annotated with `component` or `system` supported.".to_string(),
-                stable_ptr: module_ast.stable_ptr().untyped(),
-            }],
-            remove_original_item: true,
+            diagnostics: vec![],
+            remove_original_item: false,
         }
 }

--- a/crates/cairo-lang-dojo/src/plugin.rs
+++ b/crates/cairo-lang-dojo/src/plugin.rs
@@ -1,0 +1,120 @@
+use std::sync::Arc;
+use std::vec;
+
+use cairo_lang_defs::plugin::{GeneratedFileAuxData, MacroPlugin, PluginDiagnostic, PluginResult};
+use cairo_lang_diagnostics::DiagnosticEntry;
+use cairo_lang_semantic::db::SemanticGroup;
+use cairo_lang_semantic::patcher::Patches;
+use cairo_lang_semantic::plugin::{
+    AsDynGeneratedFileAuxData, AsDynMacroPlugin, DiagnosticMapper, PluginMappedDiagnostic,
+    SemanticPlugin,
+};
+use cairo_lang_semantic::SemanticDiagnostic;
+use cairo_lang_syntax::node::ast::MaybeModuleBody;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::helpers::QueryAttrs;
+use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
+
+use crate::component::Component;
+use crate::system::System;
+
+const COMPONENT_ATTR: &str = "component";
+const SYSTEM_ATTR: &str = "system";
+
+/// The diagnostics remapper of the plugin.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DiagnosticRemapper {
+    pub patches: Patches,
+}
+impl GeneratedFileAuxData for DiagnosticRemapper {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn eq(&self, other: &dyn GeneratedFileAuxData) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<Self>() {
+            self == other
+        } else {
+            false
+        }
+    }
+}
+impl AsDynGeneratedFileAuxData for DiagnosticRemapper {
+    fn as_dyn_macro_token(&self) -> &(dyn GeneratedFileAuxData + 'static) {
+        self
+    }
+}
+impl DiagnosticMapper for DiagnosticRemapper {
+    fn map_diag(
+        &self,
+        db: &(dyn SemanticGroup + 'static),
+        diag: &dyn std::any::Any,
+    ) -> Option<PluginMappedDiagnostic> {
+        let Some(diag) = diag.downcast_ref::<SemanticDiagnostic>() else {return None;};
+        let span = self
+            .patches
+            .translate(db.upcast(), diag.stable_location.diagnostic_location(db.upcast()).span)?;
+        Some(PluginMappedDiagnostic { span, message: diag.format(db) })
+    }
+}
+
+#[cfg(test)]
+#[path = "plugin_test.rs"]
+mod test;
+
+#[derive(Debug)]
+pub struct DojoPlugin {}
+
+impl MacroPlugin for DojoPlugin {
+    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {
+        match item_ast {
+            ast::Item::Module(module_ast) => handle_mod(db, module_ast),
+            //FIXME: Remove other items clashes with the corelib
+            // _ => PluginResult { remove_original_item: true, ..PluginResult::default() },
+            _ => PluginResult::default() ,
+        }
+    }
+}
+
+impl AsDynMacroPlugin for DojoPlugin {
+    fn as_dyn_macro_plugin<'a>(self: Arc<Self>) -> Arc<dyn MacroPlugin + 'a>
+    where
+        Self: 'a,
+    {
+        self
+    }
+}
+impl SemanticPlugin for DojoPlugin {}
+
+fn handle_mod(db: &dyn SyntaxGroup, module_ast: ast::ItemModule) -> PluginResult {
+    let name = module_ast.name(db).text(db);
+    let body = match module_ast.body(db) {
+        MaybeModuleBody::Some(body) => body,
+        MaybeModuleBody::None(empty_body) => {
+            return PluginResult {
+                code: None,
+                diagnostics: vec![PluginDiagnostic {
+                    message: "Modules without body are not supported.".to_string(),
+                    stable_ptr: empty_body.stable_ptr().untyped(),
+                }],
+                remove_original_item: false,
+            };
+        }
+    };
+
+    if module_ast.has_attr(db, COMPONENT_ATTR) {
+        return Component::from_module_body(db, name, body).result(db);
+    }
+
+    if module_ast.has_attr(db, SYSTEM_ATTR) {
+        return System::from_module_body(db, name, body).result(db);
+    }
+
+    PluginResult {
+            code: None,
+            diagnostics: vec![PluginDiagnostic {
+                message: "Unsupported module type. Only modules annotated with `component` or `system` supported.".to_string(),
+                stable_ptr: module_ast.stable_ptr().untyped(),
+            }],
+            remove_original_item: true,
+        }
+}

--- a/crates/cairo-lang-dojo/src/plugin_test.rs
+++ b/crates/cairo-lang-dojo/src/plugin_test.rs
@@ -1,0 +1,62 @@
+use cairo_lang_defs::plugin::{MacroPlugin, PluginGeneratedFile, PluginResult};
+use cairo_lang_diagnostics::{format_diagnostics, DiagnosticLocation};
+use cairo_lang_parser::test_utils::create_virtual_file;
+use cairo_lang_parser::utils::{get_syntax_file_and_diagnostics, SimpleParserDatabase};
+use cairo_lang_syntax::node::TypedSyntaxNode;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_formatter::format_string;
+
+use crate::plugin::DojoPlugin;
+
+pub fn test_expand_contract(
+    inputs: &OrderedHashMap<String, String>,
+) -> OrderedHashMap<String, String> {
+    let db = &mut SimpleParserDatabase::default();
+    let cairo_code = &inputs["cairo_code"];
+    let file_id = create_virtual_file(db, "dummy_file.cairo", cairo_code);
+
+    let (syntax_file, diagnostics) = get_syntax_file_and_diagnostics(db, file_id, cairo_code);
+    assert_eq!(diagnostics.format(db), "");
+    let file_syntax_node = syntax_file.as_syntax_node();
+    let plugin = DojoPlugin {};
+    let mut generated_items: Vec<String> = Vec::new();
+    let mut diagnostic_items: Vec<String> = Vec::new();
+    for item in syntax_file.items(db).elements(db).into_iter() {
+        let PluginResult { code, diagnostics, remove_original_item } =
+            plugin.generate_code(db, item.clone());
+
+        diagnostic_items.extend(diagnostics.iter().map(|diag| {
+            let syntax_node = file_syntax_node.lookup_ptr(db, diag.stable_ptr);
+
+            let location =
+                DiagnosticLocation { file_id, span: syntax_node.span_without_trivia(db) };
+            format_diagnostics(db, &diag.message, location)
+        }));
+
+        if !remove_original_item {
+            generated_items.push(format_string(db, item.as_syntax_node().get_text(db)));
+        }
+
+        let content = match code {
+            Some(PluginGeneratedFile { content, .. }) => content,
+            None => continue,
+        };
+
+        generated_items.push(format_string(db, content));
+    }
+
+    OrderedHashMap::from([
+        ("generated_cairo_code".into(), generated_items.join("\n")),
+        ("expected_diagnostics".into(), diagnostic_items.join("\n")),
+    ])
+}
+
+cairo_lang_test_utils::test_file_test!(
+    expand_contract,
+    "src/plugin_test_data",
+    {
+        component: "component",
+        system: "system",
+    },
+    test_expand_contract
+);

--- a/crates/cairo-lang-dojo/src/plugin_test_data/com.cairo
+++ b/crates/cairo-lang-dojo/src/plugin_test_data/com.cairo
@@ -1,59 +1,12 @@
-#[contract]
+#[component]
 mod PositionComponent {
-    struct Postion {
+    struct Position {
         x: felt,
         y: felt
     }
 
-    impl StorageAccessPosition of StorageAccess::<Position> {
-    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<Position> {
-        Result::Ok(
-            Position {
-                x: StorageAccess::<felt>::read(address_domain, base)?,
-                y: storage_read_syscall(
-                    address_domain, storage_address_from_base_and_offset(base, 1_u8)
-                )?
-            }
-        )
-    }
-    fn write(
-        address_domain: felt, base: StorageBaseAddress, value: Position
-    ) -> SyscallResult::<()> {
-        StorageAccess::<felt>::write(address_domain, base, value.x)?;
-        storage_write_syscall(
-            address_domain, storage_address_from_base_and_offset(base, 1_u8), value.y
-        )
-    }
-}
-
-    struct Storage {
-        world_address: felt,
-        state: Map::<felt, Position>,
-    }
-
-    // Initialize PositionComponent.
-    #[external]
-    fn initialize(world_addr: felt) {
-        let world = world_address::read();
-        assert(world == 0, 'PositionComponent: Already initialized.');
-        world_address::write(world_addr);
-    }
-
-    // Set the state of an entity.
-    #[external]
-    fn set(entity_id: felt, value: Position) {
-        state::write(entity_id, value);
-    }
-
-    // Get the state of an entity.
     #[view]
-    fn get(entity_id: felt) -> Position {
-        return state::read(entity_id);
-    }
-
-    #[view]
-    fn is_zero(entity_id: felt) -> bool {
-        let self = state::read(entity_id);
+    fn is_zero(self: Position) -> bool {
         match self.x - self.y {
             0 => bool::True(()),
             _ => bool::False(()),
@@ -61,8 +14,7 @@ mod PositionComponent {
     }
 
     #[view]
-    fn is_equal(entity_id: felt, b: Position) -> bool {
-        let self = state::read(entity_id);
+    fn is_equal(self: Position, b: Position) -> bool {
         self.x == b.x & self.y == b.y
     }
 }

--- a/crates/cairo-lang-dojo/src/plugin_test_data/com.cairo
+++ b/crates/cairo-lang-dojo/src/plugin_test_data/com.cairo
@@ -1,0 +1,68 @@
+#[contract]
+mod PositionComponent {
+    struct Postion {
+        x: felt,
+        y: felt
+    }
+
+    impl StorageAccessPosition of StorageAccess::<Position> {
+    fn read(address_domain: felt, base: StorageBaseAddress) -> SyscallResult::<Position> {
+        Result::Ok(
+            Position {
+                x: StorageAccess::<felt>::read(address_domain, base)?,
+                y: storage_read_syscall(
+                    address_domain, storage_address_from_base_and_offset(base, 1_u8)
+                )?
+            }
+        )
+    }
+    fn write(
+        address_domain: felt, base: StorageBaseAddress, value: Position
+    ) -> SyscallResult::<()> {
+        StorageAccess::<felt>::write(address_domain, base, value.x)?;
+        storage_write_syscall(
+            address_domain, storage_address_from_base_and_offset(base, 1_u8), value.y
+        )
+    }
+}
+
+    struct Storage {
+        world_address: felt,
+        state: Map::<felt, Position>,
+    }
+
+    // Initialize PositionComponent.
+    #[external]
+    fn initialize(world_addr: felt) {
+        let world = world_address::read();
+        assert(world == 0, 'PositionComponent: Already initialized.');
+        world_address::write(world_addr);
+    }
+
+    // Set the state of an entity.
+    #[external]
+    fn set(entity_id: felt, value: Position) {
+        state::write(entity_id, value);
+    }
+
+    // Get the state of an entity.
+    #[view]
+    fn get(entity_id: felt) -> Position {
+        return state::read(entity_id);
+    }
+
+    #[view]
+    fn is_zero(entity_id: felt) -> bool {
+        let self = state::read(entity_id);
+        match self.x - self.y {
+            0 => bool::True(()),
+            _ => bool::False(()),
+        }
+    }
+
+    #[view]
+    fn is_equal(entity_id: felt, b: Position) -> bool {
+        let self = state::read(entity_id);
+        self.x == b.x & self.y == b.y
+    }
+}

--- a/crates/cairo-lang-dojo/src/plugin_test_data/component
+++ b/crates/cairo-lang-dojo/src/plugin_test_data/component
@@ -28,11 +28,6 @@ mod PositionComponent {
 //! > generated_cairo_code
 #[contract]
 mod PositionComponent {
-    struct Position {
-        x: felt,
-        y: felt
-    }
-
     struct Storage {
         world_address: felt,
         state: Map::<felt, Position>,

--- a/crates/cairo-lang-dojo/src/plugin_test_data/component
+++ b/crates/cairo-lang-dojo/src/plugin_test_data/component
@@ -1,0 +1,77 @@
+//! > Test expansion of the component contract.
+
+//! > test_function_name
+test_expand_contract
+
+//! > cairo_code
+#[component]
+mod PositionComponent {
+    struct Position {
+        x: felt,
+        y: felt
+    }
+
+    #[view]
+    fn is_zero(self: Position) -> bool {
+        match self.x - self.y {
+            0 => bool::True(()),
+            _ => bool::False(()),
+        }
+    }
+
+    #[view]
+    fn is_equal(self: Position, b: Position) -> bool {
+        self.x == b.x & self.y == b.y
+    }
+}
+
+//! > generated_cairo_code
+#[contract]
+mod PositionComponent {
+    struct Position {
+        x: felt,
+        y: felt
+    }
+
+    struct Storage {
+        world_address: felt,
+        state: Map::<felt, Position>,
+    }
+
+    // Initialize PositionComponent.
+    #[external]
+    fn initialize(world_addr: felt) {
+        let world = world_address::read();
+        assert(world == 0, 'PositionComponent: Already initialized.');
+        world_address::write(world_addr);
+    }
+
+    // Set the state of an entity.
+    #[external]
+    fn set(entity_id: felt, value: Position) {
+        state::write(entity_id, value);
+    }
+
+    // Get the state of an entity.
+    #[view]
+    fn get(entity_id: felt) -> Position {
+        return state::read(entity_id);
+    }
+
+    #[view]
+    fn is_zero(entity_id: felt) -> bool {
+        let self = state::read(entity_id);
+        match self.x - self.y {
+            0 => bool::True(()),
+            _ => bool::False(()),
+        }
+    }
+
+    #[view]
+    fn is_equal(entity_id: felt, b: Position) -> bool {
+        let self = state::read(entity_id);
+        self.x == b.x & self.y == b.y
+    }
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-dojo/src/plugin_test_data/system
+++ b/crates/cairo-lang-dojo/src/plugin_test_data/system
@@ -1,0 +1,52 @@
+//! > Test expansion of the component contract.
+
+//! > test_function_name
+test_expand_contract
+
+//! > cairo_code
+extern type Query<T>;
+
+#[system]
+mod MoveSystem {
+    fn execute_inner(query: Query::<(PositionComponent::Position, HealthComponent::Health)>) {
+        return ();
+    }
+
+    fn execute(
+        world: felt, query: Query::<(PositionComponent::Position, HealthComponent::Health)>
+    ) {
+        return ();
+    }
+}
+
+//! > generated_cairo_code
+#[contract]
+mod MoveSystem {
+    struct Storage {
+        world_address: felt, 
+    }
+
+    #[external]
+    fn initialize(world_addr: felt) {
+        let world = world_address::read();
+        assert(world == 0, 'MoveSystem: Already initialized.');
+        world_address::write(world_addr);
+    }
+
+    #[external]
+    fn execute() {
+        let world = world_address::read();
+        assert(world != 0, 'MoveSystem: Not initialized.');
+
+        let position_ids = IWorld.lookup(
+            world, 0x1a42f66f387f576f66678aa85131976ee602be23c3d1bc7597fdeb1e40b9687
+        );
+        let health_ids = IWorld.lookup(
+            world, 0x737c494e6fbf007e7b84f73bc84f202746ae6a51bc789d374fe8290ce2a8ab
+        );
+
+        return ();
+    }
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-dojo/src/query.rs
+++ b/crates/cairo-lang-dojo/src/query.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+use cairo_lang_defs::plugin::PluginDiagnostic;
+use cairo_lang_semantic::patcher::RewriteNode;
+use cairo_lang_starknet::contract::starknet_keccak;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
+
+pub struct Query {
+    pub rewrite_nodes: Vec<RewriteNode>,
+    pub diagnostics: Vec<PluginDiagnostic>,
+}
+
+impl Query {
+    pub fn from_expr(db: &dyn SyntaxGroup, expr: ast::Expr) -> Self {
+        let diagnostics = vec![];
+        let rewrite_nodes: Vec<RewriteNode> = vec![];
+        let mut query = Query { diagnostics, rewrite_nodes };
+
+        match expr {
+            ast::Expr::Path(path) => match &path.elements(db)[0] {
+                ast::PathSegment::WithGenericArgs(segment) => {
+                    let generic = segment.generic_args(db);
+                    let parameters = generic.generic_args(db).elements(db);
+                    for parameter in parameters {
+                        query.handle_parameter(db, parameter);
+                    }
+                }
+                _ => {
+                    query.diagnostics.push(PluginDiagnostic {
+                        message: "Invalid query type".to_string(),
+                        stable_ptr: path.stable_ptr().untyped(),
+                    });
+                }
+            },
+            _ => {
+                query.diagnostics.push(PluginDiagnostic {
+                    message: "Invalid query type".to_string(),
+                    stable_ptr: expr.stable_ptr().untyped(),
+                });
+            }
+        }
+        query
+    }
+
+    fn handle_parameter(&mut self, db: &dyn SyntaxGroup, parameter: ast::Expr) {
+        match parameter {
+            ast::Expr::Tuple(tuple) => {
+                for element in tuple.expressions(db).elements(db) {
+                    self.handle_parameter(db, element);
+                }
+            }
+
+            ast::Expr::Path(path) => {
+                let var_prefix = match path.elements(db).last() {
+                    Some(segment) => segment.as_syntax_node().get_text(db).to_ascii_lowercase(),
+                    None => {
+                        return self.diagnostics.push(PluginDiagnostic {
+                            message: "Resolving query name.".to_string(),
+                            stable_ptr: path.stable_ptr().untyped(),
+                        });
+                    }
+                };
+
+                // TODO: Properly compute component id
+                let component_id = format!(
+                    "{:#x}",
+                    starknet_keccak(path.as_syntax_node().get_text(db).as_bytes())
+                );
+
+                self.rewrite_nodes.push(RewriteNode::interpolate_patched(
+                    "let $var_prefix$_ids = IWorld.lookup(world, $component_address$);",
+                    HashMap::from([
+                        ("var_prefix".to_string(), RewriteNode::Text(var_prefix)),
+                        ("component_address".to_string(), RewriteNode::Text(component_id)),
+                    ]),
+                ))
+            }
+            _ => {
+                return self.diagnostics.push(PluginDiagnostic {
+                    message: "Unsupported query type. Must be tuple or single struct.".to_string(),
+                    stable_ptr: parameter.stable_ptr().untyped(),
+                });
+            }
+        }
+    }
+}

--- a/crates/cairo-lang-dojo/src/system.rs
+++ b/crates/cairo-lang-dojo/src/system.rs
@@ -1,0 +1,158 @@
+use std::collections::HashMap;
+
+use cairo_lang_defs::plugin::{
+    DynGeneratedFileAuxData, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+};
+use cairo_lang_semantic::patcher::{ModifiedNode, PatchBuilder, RewriteNode};
+use cairo_lang_semantic::plugin::DynDiagnosticMapper;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
+use cairo_lang_utils::try_extract_matches;
+use indoc::formatdoc;
+use smol_str::SmolStr;
+
+use crate::plugin::DiagnosticRemapper;
+use crate::query::Query;
+
+pub struct System {
+    pub name: SmolStr,
+    pub rewrite_nodes: Vec<RewriteNode>,
+    pub diagnostics: Vec<PluginDiagnostic>,
+}
+
+impl System {
+    pub fn from_module_body(db: &dyn SyntaxGroup, name: SmolStr, body: ast::ModuleBody) -> Self {
+        let diagnostics = vec![];
+        let rewrite_nodes: Vec<RewriteNode> = vec![];
+        let mut system = System { rewrite_nodes, name, diagnostics };
+
+        let mut matched_execute = false;
+        for item in body.items(db).elements(db) {
+            match &item {
+                ast::Item::FreeFunction(item_function) => {
+                    let name = item_function.declaration(db).name(db).text(db);
+                    if name == "execute" && matched_execute {
+                        system.diagnostics.push(PluginDiagnostic {
+                            message: "Only one execute function per module is supported."
+                                .to_string(),
+                            stable_ptr: item_function.stable_ptr().untyped(),
+                        });
+                        continue;
+                    }
+
+                    if name == "execute" {
+                        system.handle_function(db, item_function.clone());
+                        matched_execute = true;
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        system
+    }
+
+    pub fn result(self, db: &dyn SyntaxGroup) -> PluginResult {
+        let name = self.name;
+        let mut builder = PatchBuilder::new(db);
+        builder.add_modified(RewriteNode::interpolate_patched(
+            &formatdoc!(
+                "
+                #[contract]
+                mod {name} {{
+                    $body$
+                }}
+                ",
+            ),
+            HashMap::from([(
+                "body".to_string(),
+                RewriteNode::Modified(ModifiedNode { children: self.rewrite_nodes }),
+            )]),
+        ));
+
+        PluginResult {
+            code: Some(PluginGeneratedFile {
+                name,
+                content: builder.code,
+                aux_data: DynGeneratedFileAuxData::new(DynDiagnosticMapper::new(
+                    DiagnosticRemapper { patches: builder.patches },
+                )),
+            }),
+            diagnostics: self.diagnostics,
+            remove_original_item: true,
+        }
+    }
+
+    fn handle_function(&mut self, db: &dyn SyntaxGroup, function_ast: ast::FunctionWithBody) {
+        let signature = function_ast.declaration(db).signature(db);
+        let parameters = signature.parameters(db).elements(db);
+        let mut preprocess_rewrite_nodes = vec![];
+
+        for param in parameters.iter() {
+            let type_ast = param.type_clause(db).ty(db);
+
+            match try_extract_types(db, &type_ast) {
+                Some(SystemArgType::Query) => {
+                    let query = Query::from_expr(db, type_ast.clone());
+                    preprocess_rewrite_nodes.extend(query.rewrite_nodes);
+                }
+                None => (),
+            }
+        }
+
+        let name = self.name.clone();
+        self.rewrite_nodes.push(RewriteNode::interpolate_patched(
+            &formatdoc!(
+                "
+                struct Storage {{
+                    world_address: felt,
+                }}
+    
+                #[external]
+                fn initialize(world_addr: felt) {{
+                    let world = world_address::read();
+                    assert(world == 0, '{name}: Already initialized.');
+                    world_address::write(world_addr);
+                }}
+    
+                #[external]
+                fn execute() {{
+                    let world = world_address::read();
+                    assert(world != 0, '{name}: Not initialized.');
+    
+                    $preprocessing$
+    
+                    $body$
+                }}
+                "
+            ),
+            HashMap::from([
+                (
+                    "body".to_string(),
+                    RewriteNode::Trimmed(function_ast.body(db).statements(db).as_syntax_node()),
+                ),
+                (
+                    "preprocessing".to_string(),
+                    RewriteNode::Modified(ModifiedNode { children: preprocess_rewrite_nodes }),
+                ),
+            ]),
+        ));
+    }
+}
+
+enum SystemArgType {
+    Query,
+}
+
+fn try_extract_types(db: &dyn SyntaxGroup, type_ast: &ast::Expr) -> Option<SystemArgType> {
+    let as_path = try_extract_matches!(type_ast, ast::Expr::Path)?;
+    let [ast::PathSegment::WithGenericArgs(segment)] = &as_path.elements(db)[..] else {
+        return None;
+    };
+    let ty = segment.ident(db).text(db);
+    if ty == "Query" {
+        Some(SystemArgType::Query)
+    } else {
+        None
+    }
+}

--- a/crates/cairo-lang-language-server/Cargo.toml
+++ b/crates/cairo-lang-language-server/Cargo.toml
@@ -24,6 +24,7 @@ cairo-lang-project = { path = "../cairo-lang-project", version = "1.0.0-alpha.2"
 cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "1.0.0-alpha.2" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "1.0.0-alpha.2" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "1.0.0-alpha.2" }
+cairo-lang-dojo = {path = "../cairo-lang-dojo" }
 tokio.workspace = true
 tower-lsp.workspace = true
 lsp.workspace = true

--- a/crates/cairo-lang-language-server/src/bin/language_server.rs
+++ b/crates/cairo-lang-language-server/src/bin/language_server.rs
@@ -1,6 +1,7 @@
 use cairo_lang_language_server::{Backend, State};
-use cairo_lang_starknet::db::get_starknet_database;
 use tower_lsp::{LspService, Server};
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_dojo::db::DojoRootDatabaseBuilderEx;
 
 #[tokio::main]
 async fn main() {
@@ -11,7 +12,12 @@ async fn main() {
     #[cfg(feature = "runtime-agnostic")]
     let (stdin, stdout) = (stdin.compat(), stdout.compat_write());
 
-    let db = get_starknet_database();
+    let db = {
+        let mut b = RootDatabase::builder();
+        b.with_dev_corelib();
+        b.with_dojo_and_starknet();
+        b.build()
+    };
 
     let (service, socket) = LspService::build(|client| Backend {
         client,


### PR DESCRIPTION
## What has changed
- Builds Dojo components contracts
- Extends corelib during build phase to enable compilation

### Details

We need to proceed in two steps:
1. We need to extend the corelibrary to define the component struct in `Dojo.cairo`, expose it under `lib.cairo`, and implement the `Serde` and `StorageAccess` traits.
2. Once this is done, we can actually generate the starknet contract from the dojo component with the Dojo plugin.
3. The `dojo-compile` command abstracts steps 1. and 2. and compiles dojo components directly to sierra programs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2044)
<!-- Reviewable:end -->
