### PR TITLE
Preventing contruction of type info with `..` as future proofing.

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/array.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/array.rs
@@ -24,18 +24,12 @@ impl GenericTypeArgGenericType for ArrayTypeWrapped {
     fn calc_info(
         &self,
         long_id: crate::program::ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        TypeInfo { storable, droppable, .. }: TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if !wrapped_info.storable {
-            Err(SpecializationError::UnsupportedGenericArg)
+        if storable {
+            Ok(TypeInfo { long_id, duplicatable: false, droppable, storable: true, size: 2 })
         } else {
-            Ok(TypeInfo {
-                long_id,
-                duplicatable: false,
-                droppable: wrapped_info.droppable,
-                storable: true,
-                size: 2,
-            })
+            Err(SpecializationError::UnsupportedGenericArg)
         }
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
@@ -19,12 +19,12 @@ impl GenericTypeArgGenericType for BoxTypeWrapped {
     fn calc_info(
         &self,
         long_id: crate::program::ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        TypeInfo { storable, droppable, duplicatable, .. }: TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if !wrapped_info.storable {
-            Err(SpecializationError::UnsupportedGenericArg)
+        if storable {
+            Ok(TypeInfo { long_id, size: 1, storable, droppable, duplicatable })
         } else {
-            Ok(TypeInfo { long_id, size: 1, ..wrapped_info })
+            Err(SpecializationError::UnsupportedGenericArg)
         }
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/dict_felt_to.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/dict_felt_to.rs
@@ -29,7 +29,7 @@ impl GenericTypeArgGenericType for DictFeltToTypeWrapped {
     fn calc_info(
         &self,
         long_id: crate::program::ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        TypeInfo { long_id: wrapped_long_id, storable, droppable, duplicatable, .. }: TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
         // List of specific types allowed as dictionary values.
         // TODO(Gil): Check in the higher level compiler and raise proper diagnostic (when we'll
@@ -37,14 +37,14 @@ impl GenericTypeArgGenericType for DictFeltToTypeWrapped {
         // TODO(Gil): Allow any type of size 1 which implement the 'Default' trait.
         let allowed_types =
             [FeltType::id(), Uint128Type::id(), Uint8Type::id(), NullableType::id()];
-        if !allowed_types.contains(&wrapped_info.long_id.generic_id)
-            || !wrapped_info.storable
-            || !wrapped_info.droppable
-            || !wrapped_info.duplicatable
+        if allowed_types.contains(&wrapped_long_id.generic_id)
+            && storable
+            && droppable
+            && duplicatable
         {
-            Err(SpecializationError::UnsupportedGenericArg)
-        } else {
             Ok(TypeInfo { long_id, duplicatable: false, droppable: false, storable: true, size: 1 })
+        } else {
+            Err(SpecializationError::UnsupportedGenericArg)
         }
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/non_zero.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/non_zero.rs
@@ -20,12 +20,12 @@ impl GenericTypeArgGenericType for NonZeroTypeWrapped {
     fn calc_info(
         &self,
         long_id: crate::program::ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        TypeInfo { size, storable, droppable, duplicatable, .. }: TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if !wrapped_info.storable {
-            Err(SpecializationError::UnsupportedGenericArg)
+        if storable {
+            Ok(TypeInfo { long_id, size, storable, droppable, duplicatable })
         } else {
-            Ok(TypeInfo { long_id, ..wrapped_info })
+            Err(SpecializationError::UnsupportedGenericArg)
         }
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/nullable.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/nullable.rs
@@ -27,12 +27,12 @@ impl GenericTypeArgGenericType for NullableTypeWrapped {
     fn calc_info(
         &self,
         long_id: crate::program::ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        TypeInfo { storable, droppable, duplicatable, .. }: TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if !wrapped_info.storable {
-            Err(SpecializationError::UnsupportedGenericArg)
+        if storable {
+            Ok(TypeInfo { long_id, size: 1, storable, droppable, duplicatable })
         } else {
-            Ok(TypeInfo { long_id, size: 1, ..wrapped_info })
+            Err(SpecializationError::UnsupportedGenericArg)
         }
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/squashed_dict_felt_to.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/squashed_dict_felt_to.rs
@@ -13,20 +13,14 @@ impl GenericTypeArgGenericType for SquashedDictFeltToTypeWrapped {
     fn calc_info(
         &self,
         long_id: crate::program::ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        TypeInfo { size, storable, droppable, .. }: TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
         // TODO(Gil): the implementation support values of size 1. Remove when other sizes are
         // supported.
-        if !wrapped_info.storable || wrapped_info.size != 1 {
-            Err(SpecializationError::UnsupportedGenericArg)
+        if storable && size == 1 {
+            Ok(TypeInfo { long_id, duplicatable: false, droppable, storable: true, size: 2 })
         } else {
-            Ok(TypeInfo {
-                long_id,
-                duplicatable: false,
-                droppable: wrapped_info.droppable,
-                storable: true,
-                size: 2,
-            })
+            Err(SpecializationError::UnsupportedGenericArg)
         }
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/uninitialized.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/uninitialized.rs
@@ -13,12 +13,12 @@ impl GenericTypeArgGenericType for UninitializedTypeWrapped {
     fn calc_info(
         &self,
         long_id: crate::program::ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        TypeInfo { storable, .. }: TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if !wrapped_info.storable {
-            Err(SpecializationError::UnsupportedGenericArg)
-        } else {
+        if storable {
             Ok(TypeInfo { long_id, storable: false, droppable: true, duplicatable: false, size: 0 })
+        } else {
+            Err(SpecializationError::UnsupportedGenericArg)
         }
     }
 }


### PR DESCRIPTION
commit-id:c5b38d81

---

**Stack**:
- #2050
- #2049
- #2048 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*