### PR TITLE
Added `super::` usages in inner contract modules.

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin_test.rs
+++ b/crates/cairo-lang-starknet/src/plugin_test.rs
@@ -53,6 +53,7 @@ cairo_lang_test_utils::test_file_test!(
         storage: "storage",
         hello_starknet: "hello_starknet",
         dispatcher: "dispatcher",
+        user_defined_types: "user_defined_types",
     },
     test_expand_contract
 );

--- a/crates/cairo-lang-starknet/src/plugin_test_data/user_defined_types
+++ b/crates/cairo-lang-starknet/src/plugin_test_data/user_defined_types
@@ -1,0 +1,168 @@
+//! > Test expansion of StarkNet for user types.
+
+//! > test_function_name
+test_expand_contract
+
+//! > cairo_code
+#[contract]
+mod TestContract {
+    struct Storage {
+        var: WrappedFelt,
+        mapping: LegacyMap::<WrappedFelt, WrappedFelt>,
+    }
+    struct WrappedFelt {
+        value: felt,
+    }
+    use array::ArrayTrait;
+    impl WrappedFeltSerde of serde::Serde::<WrappedFelt> {
+        fn serialize(ref serialized: Array::<felt>, input: WrappedFelt) {
+            serialized.append(input.value);
+        }
+        fn deserialize(ref serialized: Array::<felt>) -> Option::<WrappedFelt> {
+            Option::<WrappedFelt>::Some(WrappedFelt { value: (serialized.pop_front())? })
+        }
+    }
+    impl WrappedFeltStorageAccess of starknet::StorageAccess::<WrappedFelt> {
+        fn read(address_domain: felt, base: starknet::StorageBaseAddress) -> starknet::SyscallResult::<WrappedFelt> {
+            starknet::SyscallResult::<WrappedFelt>::Ok(WrappedFelt {
+                value: starknet::StorageAccess::read(address_domain, base)?
+            })
+        }
+        #[inline(always)]
+        fn write(address_domain: felt, base: starknet::StorageBaseAddress, value: WrappedFelt) -> starknet::SyscallResult::<()> {
+            starknet::StorageAccess::write(address_domain, base, value.value)
+        }
+    }
+    impl WrappedFeltLegacyHash of hash::LegacyHash::<WrappedFelt> {
+        #[inline(always)]
+        fn hash(state: felt, value: WrappedFelt) -> felt {
+            hash::LegacyHash::hash(state, value.value)
+        }
+    }
+}
+
+//! > generated_cairo_code
+mod TestContract {
+    use starknet::SyscallResultTrait;
+    use starknet::SyscallResultTraitImpl;
+
+    struct WrappedFelt {
+        value: felt,
+    }
+    use array::ArrayTrait;
+    impl WrappedFeltSerde of serde::Serde::<WrappedFelt> {
+        fn serialize(ref serialized: Array::<felt>, input: WrappedFelt) {
+            serialized.append(input.value);
+        }
+        fn deserialize(ref serialized: Array::<felt>) -> Option::<WrappedFelt> {
+            Option::<WrappedFelt>::Some(WrappedFelt { value: (serialized.pop_front())? })
+        }
+    }
+    impl WrappedFeltStorageAccess of starknet::StorageAccess::<WrappedFelt> {
+        fn read(address_domain: felt, base: starknet::StorageBaseAddress) -> starknet::SyscallResult::<WrappedFelt> {
+            starknet::SyscallResult::<WrappedFelt>::Ok(WrappedFelt {
+                value: starknet::StorageAccess::read(address_domain, base)?
+            })
+        }
+        #[inline(always)]
+        fn write(address_domain: felt, base: starknet::StorageBaseAddress, value: WrappedFelt) -> starknet::SyscallResult::<()> {
+            starknet::StorageAccess::write(address_domain, base, value.value)
+        }
+    }
+    impl WrappedFeltLegacyHash of hash::LegacyHash::<WrappedFelt> {
+        #[inline(always)]
+        fn hash(state: felt, value: WrappedFelt) -> felt {
+            hash::LegacyHash::hash(state, value.value)
+        }
+    }
+
+    
+    mod var {
+        use super::WrappedFelt;
+        use super::ArrayTrait;
+        use super::WrappedFeltSerde;
+        use super::WrappedFeltStorageAccess;
+        use super::WrappedFeltLegacyHash;
+        use starknet::SyscallResultTrait;
+        use starknet::SyscallResultTraitImpl;
+
+        fn address() -> starknet::StorageBaseAddress {
+            starknet::storage_base_address_const::<0x1c1c14d56e959d57ab94facd0d6c86740ac46c453bf9107bba1c735d7783c71>()
+        }
+        fn read() -> WrappedFelt {
+            // Only address_domain 0 is currently supported.
+            let address_domain = 0;
+            starknet::StorageAccess::<WrappedFelt>::read(
+                address_domain,
+                address(),
+            ).unwrap_syscall()
+        }
+        fn write(value: WrappedFelt) {
+            // Only address_domain 0 is currently supported.
+            let address_domain = 0;
+            starknet::StorageAccess::<WrappedFelt>::write(
+                address_domain,
+                address(),
+                value,
+            ).unwrap_syscall()
+        }
+    }
+    mod mapping {
+        use super::WrappedFelt;
+        use super::ArrayTrait;
+        use super::WrappedFeltSerde;
+        use super::WrappedFeltStorageAccess;
+        use super::WrappedFeltLegacyHash;
+        use starknet::SyscallResultTrait;
+        use starknet::SyscallResultTraitImpl;
+
+        fn address(key: WrappedFelt) -> starknet::StorageBaseAddress {
+            starknet::storage_base_address_from_felt(
+                hash::LegacyHash::<WrappedFelt>::hash(0x3043534c8400cf510f61f13082bd823461a59a867690d0148bae4bfcbdb1a4, key))
+        }
+        fn read(key: WrappedFelt) -> WrappedFelt {
+            // Only address_domain 0 is currently supported.
+            let address_domain = 0;
+            starknet::StorageAccess::<WrappedFelt>::read(
+                address_domain,
+                address(key),
+            ).unwrap_syscall()
+        }
+        fn write(key: WrappedFelt, value: WrappedFelt) {
+            // Only address_domain 0 is currently supported.
+            let address_domain = 0;
+            starknet::StorageAccess::<WrappedFelt>::write(
+                address_domain,
+                address(key),
+                value,
+            ).unwrap_syscall()
+        }
+    }
+
+    
+
+    trait __abi {
+        
+        
+    }
+
+    mod __external {
+        use super::WrappedFelt;
+        use super::ArrayTrait;
+        use super::WrappedFeltSerde;
+        use super::WrappedFeltStorageAccess;
+        use super::WrappedFeltLegacyHash;
+        
+    }
+
+    mod __constructor {
+        use super::WrappedFelt;
+        use super::ArrayTrait;
+        use super::WrappedFeltSerde;
+        use super::WrappedFeltStorageAccess;
+        use super::WrappedFeltLegacyHash;
+        
+    }
+}
+
+//! > expected_diagnostics


### PR DESCRIPTION
for support of inline and general user types as part of the interfaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2051)
<!-- Reviewable:end -->
