### PR TITLE
Remove the costs of ret instructions from dict squash.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -46,12 +46,12 @@ impl ConstCost {
 // The costs of the dict_squash libfunc, divided into different parts.
 /// The cost per each unique key in the dictionary.
 pub const DICT_SQUASH_UNIQUE_KEY_COST: i32 =
-    ConstCost { steps: 64, holes: 0, range_checks: 6 }.cost();
+    ConstCost { steps: 62, holes: 0, range_checks: 6 }.cost();
 /// The cost per each access to a key after the first access.
 pub const DICT_SQUASH_REPEATED_ACCESS_COST: i32 =
     ConstCost { steps: 12, holes: 0, range_checks: 1 }.cost();
 /// The cost not dependent on the number of keys and access.
-pub const DICT_SQUASH_FIXED_COST: i32 = ConstCost { steps: 90, holes: 0, range_checks: 3 }.cost();
+pub const DICT_SQUASH_FIXED_COST: i32 = ConstCost { steps: 86, holes: 0, range_checks: 3 }.cost();
 /// The cost to charge per each read/write access. `DICT_SQUASH_UNIQUE_KEY_COST` is refunded for
 /// each repeated access in dict_squash.
 pub const DICT_SQUASH_ACCESS_COST: i32 =

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/dict_felt_to.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/dict_felt_to.rs
@@ -238,8 +238,8 @@ fn build_dict_felt_to_squash(
             tempvar returned_dict_manager_ptr = new_dict_manager_ptr;
             tempvar returned_squashed_dict_start = local_squashed_dict_start;
             tempvar returned_squashed_dict_end = local_squashed_dict_end;
-            ret;
             #{ fixed_steps += steps; steps = 0; }
+            ret;
         };
         (
             dict_access_size,
@@ -264,8 +264,8 @@ fn build_dict_felt_to_squash(
             DefaultDictFinalizeInner:
             #{ validate steps == 0; }
             jump DictFinalizeInnerAssert if dict_finalize_inner_arg_n_accesses != 0;
-            ret;
             #{ fixed_steps += steps; steps = 0; }
+            ret;
             DictFinalizeInnerAssert:
             assert dict_finalize_inner_arg_default_value =
                 dict_finalize_inner_arg_dict_accesses_start[1];
@@ -274,8 +274,8 @@ fn build_dict_felt_to_squash(
             tempvar rec_arg_n_accesses = dict_finalize_inner_arg_n_accesses - one;
             tempvar rec_arg_default_value = dict_finalize_inner_arg_default_value;
             let () = call DefaultDictFinalizeInner;
-            ret;
             #{ unique_key_steps += steps; steps = 0; }
+            ret;
         }
     };
 
@@ -396,8 +396,8 @@ fn build_dict_felt_to_squash(
             let (range_check_ptr, squashed_dict_end) = call SquashDictInner;
             tempvar returned_range_check_ptr = range_check_ptr;
             tempvar returned_squashed_dict_end = squashed_dict_end;
-            ret;
             #{ fixed_steps += steps; steps = 0; }
+            ret;
         };
         (
             squash_dict_inner_arg_range_check_ptr,
@@ -560,8 +560,8 @@ fn build_dict_felt_to_squash(
             tempvar retuened_range_check_ptr = arg_range_check_ptr;
             tempvar retuened_squashed_dict =
                 squash_dict_inner_arg_squashed_dict_end+dict_access_size;
-            ret;
             #{ fixed_steps += steps; steps = 0; }
+            ret;
         }
         // Split just to avoid recursion limit when the macro is parsed.
         casm_build_extend! {casm_builder,
@@ -625,8 +625,8 @@ fn build_dict_felt_to_squash(
                 squash_dict_inner_arg_squashed_dict_end + dict_access_size;
             tempvar rec_arg_big_keys = squash_dict_inner_arg_big_keys;
             let () = call SquashDictInner;
-            ret;
             #{ unique_key_steps += steps; steps = 0; }
+            ret;
         };
     }
     casm_build_extend! {casm_builder,

--- a/tests/e2e_test_data/libfuncs/dict_felt_to
+++ b/tests/e2e_test_data/libfuncs/dict_felt_to
@@ -83,7 +83,7 @@ dict_tracker.data[memory[fp + -4]] = memory[fp + -3]
 ret;
 
 //! > function_costs
-test::foo: OrderedHashMap({Const: 8490})
+test::foo: OrderedHashMap({Const: 8290})
 
 //! > sierra_code
 type felt = felt;
@@ -131,7 +131,7 @@ dict_tracker.current_ptr += 3
 ret;
 
 //! > function_costs
-test::foo: OrderedHashMap({Const: 8590})
+test::foo: OrderedHashMap({Const: 8390})
 
 //! > sierra_code
 type felt = felt;
@@ -212,7 +212,7 @@ call rel 15;
 [fp + 5] = [ap + 0] + [fp + 4], ap++;
 [fp + 1] = [ap + 0] + [ap + -1], ap++;
 [ap + -1] = [ap + 0] * 3, ap++;
-[ap + 0] = [ap + -1] * 6820, ap++;
+[ap + 0] = [ap + -1] * 6620, ap++;
 [ap + 0] = [fp + 3], ap++;
 [ap + 0] = [fp + 2] + [ap + -2], ap++;
 [ap + 0] = [fp + -4] + 3, ap++;
@@ -424,7 +424,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: OrderedHashMap({Const: 9710})
+test::foo: OrderedHashMap({Const: 9310})
 
 //! > sierra_code
 type RangeCheck = RangeCheck;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2159)
<!-- Reviewable:end -->
