### PR TITLE
Add `Scarb.toml` for `corelib`

### DIFF
--- a/corelib/Scarb.toml
+++ b/corelib/Scarb.toml
@@ -1,0 +1,7 @@
+[package]
+name = "core"
+version = "1.0.0-alpha.2"
+
+# NOTE: This is non-public, unstable Scarb's field, which instructs resolver that this package does not
+#   depend on `core`, which is only true for this particular package. Nobody else should use it.
+no-core = true


### PR DESCRIPTION
Scarb currently is internally "patching" corelib to include Scarb-provided manifest file. This PR upstreams it, allowing to pull `core` as a regular dependency, because now `core` has a regular package structure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2174)
<!-- Reviewable:end -->
