### PR TITLE
Fixed is_{none,some,ok,err} to be snapshot based.

### DIFF
--- a/corelib/ec.cairo
+++ b/corelib/ec.cairo
@@ -19,6 +19,7 @@ type NonZeroEcPoint = NonZero::<EcPoint>;
 impl NonZeroEcPointCopy of Copy::<NonZeroEcPoint>;
 impl OptionNonZeroEcPointCopy of Copy::<Option::<NonZeroEcPoint>>;
 impl NonZeroEcPointDrop of Drop::<NonZeroEcPoint>;
+impl OptionNonZeroEcPointDrop of Drop::<Option::<NonZeroEcPoint>>;
 
 /// Returns the zero point of the curve ("the point at infinity").
 extern fn ec_point_zero() -> EcPoint nopanic;

--- a/corelib/option.cairo
+++ b/corelib/option.cairo
@@ -10,9 +10,9 @@ trait OptionTrait<T> {
     /// If `val` is `Option::Some(x)`, returns `x`. Otherwise, panics.
     fn unwrap(self: Option::<T>) -> T;
     /// Returns `true` if the `Option` is `Option::Some`.
-    fn is_some(self: Option::<T>) -> bool;
+    fn is_some(self: @Option::<T>) -> bool;
     /// Returns `true` if the `Option` is `Option::None`.
-    fn is_none(self: Option::<T>) -> bool;
+    fn is_none(self: @Option::<T>) -> bool;
 }
 impl OptionTraitImpl<T> of OptionTrait::<T> {
     fn expect(self: Option::<T>, err: felt) -> T {
@@ -28,13 +28,13 @@ impl OptionTraitImpl<T> of OptionTrait::<T> {
     fn unwrap(self: Option::<T>) -> T {
         self.expect('Option::unwrap failed.')
     }
-    fn is_some(self: Option::<T>) -> bool {
+    fn is_some(self: @Option::<T>) -> bool {
         match self {
             Option::Some(_) => true,
             Option::None(_) => false,
         }
     }
-    fn is_none(self: Option::<T>) -> bool {
+    fn is_none(self: @Option::<T>) -> bool {
         match self {
             Option::Some(_) => false,
             Option::None(_) => true,

--- a/corelib/result.cairo
+++ b/corelib/result.cairo
@@ -13,9 +13,9 @@ trait ResultTrait<T, E> {
     /// If `val` is `Result::Err(x)`, returns `x`. Otherwise, panics.
     fn unwrap_err(self: Result::<T, E>) -> E;
     /// Returns `true` if the `Result` is `Result::Ok`.
-    fn is_ok(self: Result::<T, E>) -> bool;
+    fn is_ok(self: @Result::<T, E>) -> bool;
     /// Returns `true` if the `Result` is `Result::Err`.
-    fn is_err(self: Result::<T, E>) -> bool;
+    fn is_err(self: @Result::<T, E>) -> bool;
 }
 impl ResultTraitImpl<T, E> of ResultTrait::<T, E> {
     fn expect(self: Result::<T, E>, err: felt) -> T {
@@ -44,13 +44,13 @@ impl ResultTraitImpl<T, E> of ResultTrait::<T, E> {
     fn unwrap_err(self: Result::<T, E>) -> E {
         self.expect_err('Result::unwrap_err failed.')
     }
-    fn is_ok(self: Result::<T, E>) -> bool {
+    fn is_ok(self: @Result::<T, E>) -> bool {
         match self {
             Result::Ok(_) => true,
             Result::Err(_) => false,
         }
     }
-    fn is_err(self: Result::<T, E>) -> bool {
+    fn is_err(self: @Result::<T, E>) -> bool {
         match self {
             Result::Ok(_) => false,
             Result::Err(_) => true,

--- a/corelib/test.cairo
+++ b/corelib/test.cairo
@@ -38,8 +38,7 @@ fn test_bool_operators() {
     assert(!(true ^ true), '!(t ^ t)');
 }
 
-impl OptionEcPointCopy of Copy::<Option::<NonZeroEcPoint>>;
-impl NonZeroEcPointDrop of Drop::<NonZeroEcPoint>;
+use ec::OptionNonZeroEcPointDrop;
 
 #[test]
 fn test_ec_operations() {


### PR DESCRIPTION
**Stack**:
- #2200
- #2199
- #2197 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2197)
<!-- Reviewable:end -->
