### PR TITLE
format plugin test outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
+ "cairo-lang-formatter",
  "cairo-lang-lowering",
  "cairo-lang-parser",
  "cairo-lang-plugins",

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -41,6 +41,7 @@ cairo-lang-parser = { path = "../cairo-lang-parser", version = "1.0.0-alpha.3" }
 
 [dev-dependencies]
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "1.0.0-alpha.3" }
+cairo-lang-formatter = { path = "../cairo-lang-formatter", version = "1.0.0-alpha.3" }
 env_logger.workspace = true
 pretty_assertions.workspace = true
 cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contract
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contract
@@ -42,9 +42,7 @@ mod TestContract {
     #[external]
     fn set_something(ref arg: felt, num: felt) {}
 
-    
 
-    
     #[event]
     fn awesome_event(x: felt, data: Array::<felt>) {
         let mut __keys = array_new();
@@ -52,31 +50,29 @@ mod TestContract {
         let mut __data = array_new();
         serde::Serde::<felt>::serialize(ref __data, x);
         serde::Serde::<Array::<felt>>::serialize(ref __data, data);
-        
+
         starknet::emit_event_syscall(__keys, __data).unwrap_syscall()
     }
-            
+
     #[event]
     fn best_event_ever() {
         let mut __keys = array_new();
         array_append(ref __keys, 0x29b3fe9ff633bec5975af85435def23fd937c48169dcbc8718cbdfb5efdd46f);
         let mut __data = array_new();
-        
+
         starknet::emit_event_syscall(__keys, __data).unwrap_syscall()
     }
-            
+
 
     trait __abi {
         #[view]
         fn get_something(ref arg: felt, num: felt) -> felt;
         #[external]
         fn set_something(ref arg: felt, num: felt);
-        
         #[event]
         fn awesome_event(x: felt, data: Array::<felt>);
         #[event]
         fn best_event_ever();
-        
     }
 
     mod __external {
@@ -85,35 +81,34 @@ mod TestContract {
         fn get_something(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            let mut __arg_arg =
-                match serde::Serde::<felt>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
 
-            let __arg_num =
-                match serde::Serde::<felt>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
-            if !array::ArrayTrait::is_empty(@data) {
+            let mut __arg_arg = match serde::Serde::<felt>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+
+            let __arg_num = match serde::Serde::<felt>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -122,15 +117,14 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
+
             let res = super::get_something(ref __arg_arg, __arg_num);
             let mut arr = array_new();
             // References.
@@ -142,35 +136,34 @@ mod TestContract {
         fn set_something(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            let mut __arg_arg =
-                match serde::Serde::<felt>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
 
-            let __arg_num =
-                match serde::Serde::<felt>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
-            if !array::ArrayTrait::is_empty(@data) {
+            let mut __arg_arg = match serde::Serde::<felt>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+
+            let __arg_num = match serde::Serde::<felt>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -179,8 +172,7 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
@@ -194,13 +186,10 @@ mod TestContract {
             // Result.
             arr
         }
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/diagnostics
@@ -41,25 +41,14 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
 
-    
-
-    
-
-    trait __abi {
-        
-        
-    }
+    trait __abi {}
 
     mod __external {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -90,18 +79,12 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
     #[external]
-    fn foo(x: (felt, felt)) {
-    }
+    fn foo(x: (felt, felt)) {}
 
-    
-
-    
 
     trait __abi {
         #[external]
         fn foo(x: (felt, felt));
-        
-        
     }
 
     mod __external {
@@ -110,25 +93,25 @@ mod TestContract {
         fn foo(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            let __arg_x =
-                match serde::Serde::<(felt, felt)>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
-            if !array::ArrayTrait::is_empty(@data) {
+
+            let __arg_x = match serde::Serde::<(felt, felt)>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -137,8 +120,7 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
@@ -151,13 +133,10 @@ mod TestContract {
             // Result.
             arr
         }
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -188,18 +167,12 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
     #[external]
-    fn foo() -> (felt, felt) {
-    }
+    fn foo() -> (felt, felt) {}
 
-    
-
-    
 
     trait __abi {
         #[external]
         fn foo() -> (felt, felt);
-        
-        
     }
 
     mod __external {
@@ -208,16 +181,17 @@ mod TestContract {
         fn foo(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            if !array::ArrayTrait::is_empty(@data) {
+
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -226,15 +200,14 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
+
             let res = super::foo();
             let mut arr = array_new();
             // References.
@@ -242,13 +215,10 @@ mod TestContract {
             serde::Serde::<(felt, felt)>::serialize(ref arr, res);
             arr
         }
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -284,18 +254,12 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
     #[external]
-    fn foo<T>(x: T) {
-    }
+    fn foo<T>(x: T) {}
 
-    
-
-    
 
     trait __abi {
         #[external]
         fn foo<T>(x: T);
-        
-        
     }
 
     mod __external {
@@ -304,25 +268,25 @@ mod TestContract {
         fn foo(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            let __arg_x =
-                match serde::Serde::<T>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
-            if !array::ArrayTrait::is_empty(@data) {
+
+            let __arg_x = match serde::Serde::<T>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -331,8 +295,7 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
@@ -345,13 +308,10 @@ mod TestContract {
             // Result.
             arr
         }
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -402,18 +362,12 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
     #[external]
-    fn foo(x: (felt, felt), y: (felt, felt)) -> (felt, felt) {
-    }
+    fn foo(x: (felt, felt), y: (felt, felt)) -> (felt, felt) {}
 
-    
-
-    
 
     trait __abi {
         #[external]
         fn foo(x: (felt, felt), y: (felt, felt)) -> (felt, felt);
-        
-        
     }
 
     mod __external {
@@ -422,35 +376,34 @@ mod TestContract {
         fn foo(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            let __arg_x =
-                match serde::Serde::<(felt, felt)>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
 
-            let __arg_y =
-                match serde::Serde::<(felt, felt)>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
-            if !array::ArrayTrait::is_empty(@data) {
+            let __arg_x = match serde::Serde::<(felt, felt)>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+
+            let __arg_y = match serde::Serde::<(felt, felt)>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -459,15 +412,14 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
+
             let res = super::foo(__arg_x, __arg_y);
             let mut arr = array_new();
             // References.
@@ -475,13 +427,10 @@ mod TestContract {
             serde::Serde::<(felt, felt)>::serialize(ref arr, res);
             arr
         }
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -528,25 +477,14 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
 
-    
-
-    
-
-    trait __abi {
-        
-        
-    }
+    trait __abi {}
 
     mod __external {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -577,25 +515,14 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
 
-    
-
-    
-
-    trait __abi {
-        
-        
-    }
+    trait __abi {}
 
     mod __external {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -626,25 +553,14 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
 
-    
-
-    
-
-    trait __abi {
-        
-        
-    }
+    trait __abi {}
 
     mod __external {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -675,25 +591,14 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
 
-    
-
-    
-
-    trait __abi {
-        
-        
-    }
+    trait __abi {}
 
     mod __external {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -725,25 +630,14 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
 
-    
-
-    
-
-    trait __abi {
-        
-        
-    }
+    trait __abi {}
 
     mod __external {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 
@@ -802,9 +696,6 @@ mod TestContract {
     #[external]
     fn __execute__() {}
 
-    
-
-    
 
     trait __abi {
         #[external]
@@ -815,8 +706,6 @@ mod TestContract {
         fn __validate_deploy__();
         #[external]
         fn __execute__();
-        
-        
     }
 
     mod __external {
@@ -825,16 +714,17 @@ mod TestContract {
         fn __validate__(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            if !array::ArrayTrait::is_empty(@data) {
+
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -843,8 +733,7 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
@@ -860,16 +749,17 @@ mod TestContract {
         fn __validate_declare__(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            if !array::ArrayTrait::is_empty(@data) {
+
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -878,8 +768,7 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
@@ -895,16 +784,17 @@ mod TestContract {
         fn __validate_deploy__(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            if !array::ArrayTrait::is_empty(@data) {
+
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -913,8 +803,7 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
@@ -930,16 +819,17 @@ mod TestContract {
         fn __execute__(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            if !array::ArrayTrait::is_empty(@data) {
+
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -948,8 +838,7 @@ mod TestContract {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
@@ -962,13 +851,10 @@ mod TestContract {
             // Result.
             arr
         }
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/dispatcher
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/dispatcher
@@ -20,14 +20,12 @@ trait IContract {
 #[abi]
 trait IContract {
     fn get_something(arg: felt, num: felt) -> felt;
-
     fn empty();
-
     fn bad_sig(ref arg1: felt, ref arg2: felt) -> felt;
-
     #[event]
     fn my_event();
 }
+
 mod IContractDispatcher {
     use super;
     use starknet::SyscallResultTrait;
@@ -41,24 +39,19 @@ mod IContractDispatcher {
         serde::Serde::<felt>::serialize(ref calldata, num);
 
         let mut ret_data = starknet::call_contract_syscall(
-            contract_address,
-            calldata,
+            contract_address, calldata, 
         ).unwrap_syscall();
 
-        serde::Serde::<felt>::deserialize(ref ret_data).expect(
-            'Returned data too short')
+        serde::Serde::<felt>::deserialize(ref ret_data).expect('Returned data too short')
     }
 
     fn empty(contract_address: ContractAddress, ) {
         let mut calldata = array_new();
 
         let mut ret_data = starknet::call_contract_syscall(
-            contract_address,
-            calldata,
+            contract_address, calldata, 
         ).unwrap_syscall();
-
     }
-
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/hello_starknet
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/hello_starknet
@@ -39,7 +39,7 @@ mod HelloStarknet {
         balance::read()
     }
 
-    
+
     mod balance {
         use starknet::SyscallResultTrait;
         use starknet::SyscallResultTraitImpl;
@@ -50,31 +50,23 @@ mod HelloStarknet {
         fn read() -> felt {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
-            starknet::StorageAccess::<felt>::read(
-                address_domain,
-                address(),
-            ).unwrap_syscall()
+            starknet::StorageAccess::<felt>::read(address_domain, address(), ).unwrap_syscall()
         }
         fn write(value: felt) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<felt>::write(
-                address_domain,
-                address(),
-                value,
+                address_domain, address(), value, 
             ).unwrap_syscall()
         }
     }
 
-    
 
     trait __abi {
         #[external]
         fn increase_balance(amount: felt);
         #[view]
         fn get_balance() -> felt;
-        
-        
     }
 
     mod __external {
@@ -83,25 +75,25 @@ mod HelloStarknet {
         fn increase_balance(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            let __arg_amount =
-                match serde::Serde::<felt>::deserialize(ref data) {
-                    Option::Some(x) => x,
-                    Option::None(()) => {
-                        let mut err_data = array_new();
-                        array_append(ref err_data, 'Input too short for arguments');
-                        panic(err_data)
-                    },
-                };
-            if !array::ArrayTrait::is_empty(@data) {
+
+            let __arg_amount = match serde::Serde::<felt>::deserialize(ref data) {
+                Option::Some(x) => x,
+                Option::None(()) => {
+                    let mut err_data = array_new();
+                    array_append(ref err_data, 'Input too short for arguments');
+                    panic(err_data)
+                },
+            };
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -110,8 +102,7 @@ mod HelloStarknet {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
@@ -127,16 +118,17 @@ mod HelloStarknet {
         fn get_balance(mut data: Array::<felt>) -> Array::<felt> {
             internal::revoke_ap_tracking();
             match get_gas() {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
-            if !array::ArrayTrait::is_empty(@data) {
+
+            if !array::ArrayTrait::is_empty(
+                @data
+            ) {
                 // Force the inclusion of `System` in the list of implicits.
                 starknet::use_system_implicit();
 
@@ -145,15 +137,14 @@ mod HelloStarknet {
                 panic(err_data);
             }
             match get_gas_all(get_builtin_costs()) {
-                Option::Some(_) => {
-                },
+                Option::Some(_) => {},
                 Option::None(_) => {
                     let mut err_data = array_new();
                     array_append(ref err_data, 'Out of gas');
                     panic(err_data)
                 },
             }
-            
+
             let res = super::get_balance();
             let mut arr = array_new();
             // References.
@@ -161,13 +152,10 @@ mod HelloStarknet {
             serde::Serde::<felt>::serialize(ref arr, res);
             arr
         }
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/storage
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/storage
@@ -23,7 +23,6 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
 
-    
     mod var_felt {
         use starknet::SyscallResultTrait;
         use starknet::SyscallResultTraitImpl;
@@ -34,18 +33,13 @@ mod TestContract {
         fn read() -> felt {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
-            starknet::StorageAccess::<felt>::read(
-                address_domain,
-                address(),
-            ).unwrap_syscall()
+            starknet::StorageAccess::<felt>::read(address_domain, address(), ).unwrap_syscall()
         }
         fn write(value: felt) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<felt>::write(
-                address_domain,
-                address(),
-                value,
+                address_domain, address(), value, 
             ).unwrap_syscall()
         }
     }
@@ -59,18 +53,13 @@ mod TestContract {
         fn read() -> u128 {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
-            starknet::StorageAccess::<u128>::read(
-                address_domain,
-                address(),
-            ).unwrap_syscall()
+            starknet::StorageAccess::<u128>::read(address_domain, address(), ).unwrap_syscall()
         }
         fn write(value: u128) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<u128>::write(
-                address_domain,
-                address(),
-                value,
+                address_domain, address(), value, 
             ).unwrap_syscall()
         }
     }
@@ -84,18 +73,13 @@ mod TestContract {
         fn read() -> bool {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
-            starknet::StorageAccess::<bool>::read(
-                address_domain,
-                address(),
-            ).unwrap_syscall()
+            starknet::StorageAccess::<bool>::read(address_domain, address(), ).unwrap_syscall()
         }
         fn write(value: bool) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<bool>::write(
-                address_domain,
-                address(),
-                value,
+                address_domain, address(), value, 
             ).unwrap_syscall()
         }
     }
@@ -105,23 +89,21 @@ mod TestContract {
 
         fn address(key: felt) -> starknet::StorageBaseAddress {
             starknet::storage_base_address_from_felt(
-                hash::LegacyHash::<felt>::hash(0x15175cf0328aa18a0a81843d18051cb34c3c8dfb6630b7f1876e0f32874f713, key))
+                hash::LegacyHash::<felt>::hash(
+                    0x15175cf0328aa18a0a81843d18051cb34c3c8dfb6630b7f1876e0f32874f713, key
+                )
+            )
         }
         fn read(key: felt) -> u128 {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
-            starknet::StorageAccess::<u128>::read(
-                address_domain,
-                address(key),
-            ).unwrap_syscall()
+            starknet::StorageAccess::<u128>::read(address_domain, address(key), ).unwrap_syscall()
         }
         fn write(key: felt, value: u128) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<u128>::write(
-                address_domain,
-                address(key),
-                value,
+                address_domain, address(key), value, 
             ).unwrap_syscall()
         }
     }
@@ -131,23 +113,21 @@ mod TestContract {
 
         fn address(key: u128) -> starknet::StorageBaseAddress {
             starknet::storage_base_address_from_felt(
-                hash::LegacyHash::<u128>::hash(0xaef662bd0e6cbe2fe1d8a16c45579f35b9c40069d967c414f98cd2e1975d7a, key))
+                hash::LegacyHash::<u128>::hash(
+                    0xaef662bd0e6cbe2fe1d8a16c45579f35b9c40069d967c414f98cd2e1975d7a, key
+                )
+            )
         }
         fn read(key: u128) -> bool {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
-            starknet::StorageAccess::<bool>::read(
-                address_domain,
-                address(key),
-            ).unwrap_syscall()
+            starknet::StorageAccess::<bool>::read(address_domain, address(key), ).unwrap_syscall()
         }
         fn write(key: u128, value: bool) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<bool>::write(
-                address_domain,
-                address(key),
-                value,
+                address_domain, address(key), value, 
             ).unwrap_syscall()
         }
     }
@@ -157,44 +137,34 @@ mod TestContract {
 
         fn address(key: bool) -> starknet::StorageBaseAddress {
             starknet::storage_base_address_from_felt(
-                hash::LegacyHash::<bool>::hash(0x3c31d0ad7707ffa998b560cd96f530ee47a702c8bc179f068375322b19448e9, key))
+                hash::LegacyHash::<bool>::hash(
+                    0x3c31d0ad7707ffa998b560cd96f530ee47a702c8bc179f068375322b19448e9, key
+                )
+            )
         }
         fn read(key: bool) -> felt {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
-            starknet::StorageAccess::<felt>::read(
-                address_domain,
-                address(key),
-            ).unwrap_syscall()
+            starknet::StorageAccess::<felt>::read(address_domain, address(key), ).unwrap_syscall()
         }
         fn write(key: bool, value: felt) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<felt>::write(
-                address_domain,
-                address(key),
-                value,
+                address_domain, address(key), value, 
             ).unwrap_syscall()
         }
     }
 
-    
 
-    trait __abi {
-        
-        
-    }
+    trait __abi {}
 
     mod __external {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 
     mod __constructor {
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/user_defined_types
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/user_defined_types
@@ -47,7 +47,7 @@ mod TestContract {
     use starknet::SyscallResultTraitImpl;
 
     struct WrappedFelt {
-        value: felt,
+        value: felt, 
     }
     use array::ArrayTrait;
     impl WrappedFeltSerde of serde::Serde::<WrappedFelt> {
@@ -59,13 +59,17 @@ mod TestContract {
         }
     }
     impl WrappedFeltStorageAccess of starknet::StorageAccess::<WrappedFelt> {
-        fn read(address_domain: felt, base: starknet::StorageBaseAddress) -> starknet::SyscallResult::<WrappedFelt> {
-            starknet::SyscallResult::<WrappedFelt>::Ok(WrappedFelt {
-                value: starknet::StorageAccess::read(address_domain, base)?
-            })
+        fn read(
+            address_domain: felt, base: starknet::StorageBaseAddress
+        ) -> starknet::SyscallResult::<WrappedFelt> {
+            starknet::SyscallResult::<WrappedFelt>::Ok(
+                WrappedFelt { value: starknet::StorageAccess::read(address_domain, base)? }
+            )
         }
         #[inline(always)]
-        fn write(address_domain: felt, base: starknet::StorageBaseAddress, value: WrappedFelt) -> starknet::SyscallResult::<()> {
+        fn write(
+            address_domain: felt, base: starknet::StorageBaseAddress, value: WrappedFelt
+        ) -> starknet::SyscallResult::<()> {
             starknet::StorageAccess::write(address_domain, base, value.value)
         }
     }
@@ -76,7 +80,7 @@ mod TestContract {
         }
     }
 
-    
+
     mod var {
         use super::WrappedFelt;
         use super::ArrayTrait;
@@ -93,17 +97,14 @@ mod TestContract {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<WrappedFelt>::read(
-                address_domain,
-                address(),
+                address_domain, address(), 
             ).unwrap_syscall()
         }
         fn write(value: WrappedFelt) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<WrappedFelt>::write(
-                address_domain,
-                address(),
-                value,
+                address_domain, address(), value, 
             ).unwrap_syscall()
         }
     }
@@ -118,33 +119,29 @@ mod TestContract {
 
         fn address(key: WrappedFelt) -> starknet::StorageBaseAddress {
             starknet::storage_base_address_from_felt(
-                hash::LegacyHash::<WrappedFelt>::hash(0x3043534c8400cf510f61f13082bd823461a59a867690d0148bae4bfcbdb1a4, key))
+                hash::LegacyHash::<WrappedFelt>::hash(
+                    0x3043534c8400cf510f61f13082bd823461a59a867690d0148bae4bfcbdb1a4, key
+                )
+            )
         }
         fn read(key: WrappedFelt) -> WrappedFelt {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<WrappedFelt>::read(
-                address_domain,
-                address(key),
+                address_domain, address(key), 
             ).unwrap_syscall()
         }
         fn write(key: WrappedFelt, value: WrappedFelt) {
             // Only address_domain 0 is currently supported.
             let address_domain = 0;
             starknet::StorageAccess::<WrappedFelt>::write(
-                address_domain,
-                address(key),
-                value,
+                address_domain, address(key), value, 
             ).unwrap_syscall()
         }
     }
 
-    
 
-    trait __abi {
-        
-        
-    }
+    trait __abi {}
 
     mod __external {
         use super::WrappedFelt;
@@ -153,8 +150,6 @@ mod TestContract {
         use super::WrappedFeltStorageAccess;
         use super::WrappedFeltLegacyHash;
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 
     mod __constructor {
@@ -164,8 +159,6 @@ mod TestContract {
         use super::WrappedFeltStorageAccess;
         use super::WrappedFeltLegacyHash;
         use starknet_serde::ContractAddressSerde;
-
-        
     }
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/test.rs
+++ b/crates/cairo-lang-starknet/src/plugin/test.rs
@@ -2,6 +2,7 @@ use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::get_diagnostics_as_string;
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::plugin::{MacroPlugin, PluginGeneratedFile, PluginResult};
+use cairo_lang_formatter::format_string;
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_semantic::test_utils::setup_test_module;
 use cairo_lang_syntax::node::TypedSyntaxNode;
@@ -39,9 +40,10 @@ impl TestFileRunner for ExpandContractTestRunner {
                 None => continue,
             };
             if !remove_original_item {
-                generated_items.push(item.as_syntax_node().get_text(&self.db));
+                generated_items
+                    .push(format_string(&self.db, item.as_syntax_node().get_text(&self.db)));
             }
-            generated_items.push(content);
+            generated_items.push(format_string(&self.db, content));
         }
 
         OrderedHashMap::from([


### PR DESCRIPTION
quality of life improvement. i noticed some places the code blocks are awkwardly formatted to preserve output formatting, for example here: https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-starknet/src/plugin/dispatcher.rs#L113

this removes the tradeoff between code and output readability

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2235)
<!-- Reviewable:end -->
