### PR TITLE
Autoclosing, {}, [], "", (), + auto surround {}, [], "", ()

### DIFF
--- a/vscode-cairo/language-configuration.json
+++ b/vscode-cairo/language-configuration.json
@@ -5,16 +5,21 @@
     },
     // Symbols used as brackets.
     "brackets": [
-        [
-            "[",
-            "]"
-        ]
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
     ],
     // Symbols that are auto closed when typing.
     "autoClosingPairs": [
-        [
-            "[",
-            "]"
-        ],
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "\"", "close": "\"", "notIn": ["string"] },
     ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+    ]
 }

--- a/vscode-cairo/language-configuration.json
+++ b/vscode-cairo/language-configuration.json
@@ -15,11 +15,13 @@
         { "open": "[", "close": "]" },
         { "open": "(", "close": ")" },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
+        { "open": "'", "close": "'", "notIn": ["string"] },
     ],
     "surroundingPairs": [
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
+        ["'", "'"],
     ]
 }


### PR DESCRIPTION
Right now the extension automatically closes only the `[` which is not enough. I added autoclosing for the most used things (and strings even if we don't have them yet). And also surronding pairs (when you select a block of code and type `{` for example it'll surround the selected code with `{ code code code }`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2258)
<!-- Reviewable:end -->
