### PR TITLE
Fix extra line when formatting stdin

### DIFF
--- a/crates/cairo-lang-formatter/src/bin/cli.rs
+++ b/crates/cairo-lang-formatter/src/bin/cli.rs
@@ -157,7 +157,7 @@ fn format_stdin(args: &FormatterArgs, fmt: &CairoFormatter) -> bool {
         Ok(outcome) => match outcome {
             FormatOutcome::Identical(_) => {
                 if !args.check {
-                    println!("{}", FormatOutcome::into_output_text(outcome));
+                    print!("{}", FormatOutcome::into_output_text(outcome));
                 }
                 true
             }


### PR DESCRIPTION
With the current `cairo-format` implementation, there's an extra line being printed when formatting `stdin` without using `--check`. Many editors rely on stdin formatting to integrate formatters, and this is breaking them.

This issue was caused by an incorrect use of `println` instead of `print`. To see the problem:

```console
$ echo "" | cairo-format -


```

Note that 2 empty lines have been printed instead of 1.

This PR fixes the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2268)
<!-- Reviewable:end -->
