### PR TITLE
Fix incorrect handling of --check when formatting stdin

### DIFF
--- a/crates/cairo-lang-formatter/src/bin/cli.rs
+++ b/crates/cairo-lang-formatter/src/bin/cli.rs
@@ -154,18 +154,20 @@ fn format_path(start_path: &str, args: &FormatterArgs, fmt: &CairoFormatter) -> 
 
 fn format_stdin(args: &FormatterArgs, fmt: &CairoFormatter) -> bool {
     match fmt.format_to_string(&StdinFmt) {
-        Ok(outcome) => match outcome {
-            FormatOutcome::Identical(_) => {
-                if !args.check {
-                    println!("{}", FormatOutcome::into_output_text(outcome));
+        Ok(outcome) => {
+            if args.check {
+                match outcome {
+                    FormatOutcome::Identical(_) => true,
+                    FormatOutcome::DiffFound(diff) => {
+                        println!("{diff}");
+                        false
+                    }
                 }
+            } else {
+                print!("{}", FormatOutcome::into_output_text(outcome));
                 true
             }
-            FormatOutcome::DiffFound(diff) => {
-                println!("{diff}");
-                !args.check
-            }
-        },
+        }
         Err(parsing_error) => {
             print_error(parsing_error, String::from("standard input"), args);
             false


### PR DESCRIPTION
Superseds #2268.

After submitting #2268 to fix the extra line bug, I also discovered that the whole handling of `--check` is likely incorrect.

Currently the formatter always prints the diff in any is found, regardless of whether `--check` is supplied. This is unexpected: it should only do that when `--check` is used. If `--check` is absent, the formatter should always print the formatted text unless a parsing error occurs.

This PR fixes the handling of `--check` to only check whether diffs are found if `--check` is used.

This issue, together with the one fixed in #2268 are breaking editors that use `cairo-format -` for code formatting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2269)
<!-- Reviewable:end -->
