### PR TITLE
Added validation that all merges would be recompilable.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/annotations.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/annotations.rs
@@ -81,7 +81,7 @@ pub enum AnnotationError {
 }
 
 /// Annotation that represent the state at each program statement.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct StatementAnnotations {
     pub refs: StatementRefs,
     /// The function id that the statement belongs to.
@@ -89,6 +89,10 @@ pub struct StatementAnnotations {
     /// Indicates whether convergence in allowed in the given statement.
     pub convergence_allowed: bool,
     pub environment: Environment,
+    /// A path of jumps to the current statement from some ap-change base.
+    /// The path includes all the statement indices with branching libfuncs starting from ap-change
+    /// base.
+    pub jump_path: Vec<StatementIdx>,
 }
 
 /// Annotations of the program statements.
@@ -133,6 +137,7 @@ impl ProgramAnnotations {
                         },
                         func.entry_point,
                     ),
+                    jump_path: vec![],
                 },
             )?
         }
@@ -153,13 +158,9 @@ impl ProgramAnnotations {
         match self.per_statement_annotations.get(idx).ok_or(AnnotationError::InvalidStatementIdx)? {
             None => self.per_statement_annotations[idx] = Some(annotations),
             Some(expected_annotations) => {
-                if expected_annotations.refs != annotations.refs {
-                    return Err(AnnotationError::InconsistentReferencesAnnotation(statement_idx));
-                }
                 if expected_annotations.function_id != annotations.function_id {
                     return Err(AnnotationError::InconsistentFunctionId { statement_idx });
                 }
-
                 validate_environment_equality(
                     &expected_annotations.environment,
                     &annotations.environment,
@@ -168,6 +169,9 @@ impl ProgramAnnotations {
                     statement_idx,
                     error,
                 })?;
+                if !self.test_references_consistency(&annotations, expected_annotations) {
+                    return Err(AnnotationError::InconsistentReferencesAnnotation(statement_idx));
+                }
 
                 // Note that we ignore annotations here.
                 // a flow cannot converge with a branch target.
@@ -177,6 +181,63 @@ impl ProgramAnnotations {
             }
         };
         Ok(())
+    }
+
+    /// Returns whether or not `actual` and `expected` references are consistent.
+    fn test_references_consistency(
+        &self,
+        actual: &StatementAnnotations,
+        expected: &StatementAnnotations,
+    ) -> bool {
+        // Finds the last point on the stack where the merging pathes have yet to diverge.
+        // Note that we can `rfind` to find the divergance - since at the position both paths
+        // becomes the same - all previous steps must be the same as well, as this would have been
+        // the stack at the point of reaching that jump statement - and it would have been
+        // propagated to both diverging branches.
+        let divergance_point = actual
+            .jump_path
+            .iter()
+            .zip(expected.jump_path.iter())
+            .rfind(|(s1, s2)| s1 == s2)
+            .map(|(s, _)| *s)
+            .or(actual.environment.ap_tracking_base);
+        // The generation of the references at the divergence point.
+        // Only references with generation up to this one are available at the merge as newer
+        // reference were not ap-alinged.
+        let divergance_point_generation = divergance_point.map(|idx| {
+            self.per_statement_annotations[idx.0].as_ref().unwrap().environment.generation
+        });
+        // Check if there is a mismatch at the number of variables.
+        if actual.refs.len() != expected.refs.len() {
+            return false;
+        }
+        for (var_id, ReferenceValue { expression, ty, stack_idx, generation }) in actual.refs.iter()
+        {
+            // Check if var exists in just one of the branches.
+            let Some(expected_ref) = expected.refs.get(var_id) else {
+                return false;
+            };
+            // Check if var don't match on type, expression or stack information.
+            if *ty != expected_ref.ty
+                || *expression != expected_ref.expression
+                || *stack_idx != expected_ref.stack_idx
+            {
+                return false;
+            }
+            // If the variable is not on stack.
+            if stack_idx.is_none()
+                // And is either empty, or somewhat ap-dependent.
+                && (expression.cells.is_empty() || !expression.can_apply_unknown())
+                // Check that the generation of the variable matches in both branches, and that
+                // it is older than the generation at the divergance point.
+                && (*generation != expected_ref.generation
+                    || divergance_point_generation.is_none()
+                    || *generation > divergance_point_generation.unwrap())
+            {
+                return false;
+            }
+        }
+        true
     }
 
     /// Returns the result of applying take_args to the StatementAnnotations at statement_idx.
@@ -240,6 +301,7 @@ impl ProgramAnnotations {
                     } else {
                         ref_value.stack_idx
                     },
+                    generation: ref_value.generation,
                 },
             );
         }
@@ -263,24 +325,30 @@ impl ProgramAnnotations {
         } else {
             branch_changes.new_stack_size
         };
-        let (ap_tracking, ap_tracking_base) = match branch_changes.ap_tracking_change {
-            ApTrackingChange::Disable => {
-                (ApChange::Unknown, annotations.environment.ap_tracking_base)
-            }
+        let ap_tracking = match branch_changes.ap_tracking_change {
+            ApTrackingChange::Disable => ApChange::Unknown,
             ApTrackingChange::Enable
                 if matches!(annotations.environment.ap_tracking, ApChange::Unknown) =>
             {
-                (ApChange::Known(0), destination_statement_idx)
+                ApChange::Known(0)
             }
-            _ => (
-                update_ap_tracking(annotations.environment.ap_tracking, branch_changes.ap_change)
-                    .map_err(|error| AnnotationError::ApTrackingError {
+            _ => update_ap_tracking(annotations.environment.ap_tracking, branch_changes.ap_change)
+                .map_err(|error| AnnotationError::ApTrackingError {
                     source_statement_idx,
                     destination_statement_idx,
                     error,
                 })?,
-                annotations.environment.ap_tracking_base,
-            ),
+        };
+        let ap_tracking_base = if matches!(ap_tracking, ApChange::Unknown) {
+            // Unknown ap tracking - we don't have a base.
+            None
+        } else if matches!(annotations.environment.ap_tracking, ApChange::Unknown) {
+            // Ap tracking was changed from unknown to known; meaning ap tracking was just enabled -
+            // the new destination is the base.
+            Some(destination_statement_idx)
+        } else {
+            // Was previously enabled but still is - keeping the same base.
+            annotations.environment.ap_tracking_base
         };
         self.set_or_assert(
             destination_statement_idx,
@@ -302,6 +370,14 @@ impl ProgramAnnotations {
                             destination_statement_idx,
                             error,
                         })?,
+                    generation: annotations.environment.generation
+                        + usize::from(branch_changes.clear_old_stack),
+                },
+                // If the ap changes are untracked - we don't have a path from it to use.
+                jump_path: if ap_tracking_base.is_none() {
+                    vec![]
+                } else {
+                    annotations.jump_path.clone()
                 },
             },
         )

--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -208,12 +208,15 @@ pub fn compile(
                 }
                 instructions.extend(compiled_invocation.instructions);
 
-                let updated_annotations = StatementAnnotations {
+                let mut updated_annotations = StatementAnnotations {
                     environment: compiled_invocation.environment,
                     ..annotations
                 };
 
                 let branching_libfunc = compiled_invocation.results.len() > 1;
+                if branching_libfunc {
+                    updated_annotations.jump_path.push(statement_idx);
+                }
 
                 for (branch_info, branch_changes) in
                     zip_eq(&invocation.branches, compiled_invocation.results)

--- a/crates/cairo-lang-sierra-to-casm/src/environment/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/environment/mod.rs
@@ -14,6 +14,8 @@ pub mod gas_wallet;
 pub enum EnvironmentError {
     #[error("Inconsistent ap tracking.")]
     InconsistentApTracking,
+    #[error("Inconsistent ap tracking base.")]
+    InconsistentApTrackingBase,
     #[error("Inconsistent frame state.")]
     InconsistentFrameState,
     #[error("Inconsistent gas wallet state.")]
@@ -23,26 +25,30 @@ pub enum EnvironmentError {
 }
 
 /// Part of the program annotations that libfuncs may access as part of their run.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Environment {
     /// The ap change starting from `ap_tracking_base`.
     /// Once it changes to ApChange::Unknown it remains in that state, unless it is reenabled.
     pub ap_tracking: ApChange,
-    pub ap_tracking_base: StatementIdx,
+    pub ap_tracking_base: Option<StatementIdx>,
     /// The size of the continuous known stack.
     pub stack_size: usize,
     pub frame_state: FrameState,
     pub gas_wallet: GasWallet,
+    /// The generation of the currently created variables.
+    /// Defined by the number of continuous-stack invalidations that occurred.
+    pub generation: usize,
 }
 impl Environment {
     pub fn new(gas_wallet: GasWallet, ap_tracking_base: StatementIdx) -> Self {
         let ap_tracking = ApChange::Known(0);
         Self {
             ap_tracking,
-            ap_tracking_base,
+            ap_tracking_base: Some(ap_tracking_base),
             stack_size: 0,
             frame_state: FrameState::Allocating { allocated: 0, last_ap_tracking: ap_tracking },
             gas_wallet,
+            generation: 0,
         }
     }
 }
@@ -52,7 +58,9 @@ pub fn validate_environment_equality(
     a: &Environment,
     b: &Environment,
 ) -> Result<(), EnvironmentError> {
-    if a.ap_tracking != b.ap_tracking || a.ap_tracking_base != b.ap_tracking_base {
+    if a.ap_tracking_base != b.ap_tracking_base {
+        Err(EnvironmentError::InconsistentApTrackingBase)
+    } else if a.ap_tracking != b.ap_tracking {
         Err(EnvironmentError::InconsistentApTracking)
     } else if a.frame_state != b.frame_state {
         Err(EnvironmentError::InconsistentFrameState)

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/test_utils.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/test_utils.rs
@@ -268,6 +268,7 @@ pub fn compile_libfunc(libfunc: &str, refs: Vec<ReferenceExpression>) -> Reduced
             expression,
             ty: param.ty.clone(),
             stack_idx: None,
+            generation: 0,
         })
         .collect();
 

--- a/crates/cairo-lang-sierra-to-casm/src/references.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/references.rs
@@ -25,11 +25,14 @@ pub type StatementRefs = HashMap<VarId, ReferenceValue>;
 
 /// A Sierra reference to a value.
 /// Corresponds to an argument or return value of a Sierra statement.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ReferenceValue {
     pub expression: ReferenceExpression,
     pub ty: ConcreteTypeId,
+    /// The index of the variable on the continuous-stack.
     pub stack_idx: Option<usize>,
+    /// The generation where the value was introduced.
+    pub generation: usize,
 }
 
 /// A collection of Cell Expression which represents one logical object.
@@ -98,6 +101,7 @@ pub fn build_function_arguments_refs(
                     },
                     ty: param.ty.clone(),
                     stack_idx: None,
+                    generation: 0,
                 },
             )
             .is_some()

--- a/crates/cairo-lang-sierra/src/edit_state.rs
+++ b/crates/cairo-lang-sierra/src/edit_state.rs
@@ -25,7 +25,7 @@ impl EditStateError {
 }
 
 /// Given a map with var ids as keys, extracts out the given ids, failing if some id is missing.
-pub fn take_args<'a, V: 'a + std::cmp::PartialEq>(
+pub fn take_args<'a, V: 'a>(
     mut state: HashMap<VarId, V>,
     ids: impl Iterator<Item = &'a VarId>,
 ) -> Result<(HashMap<VarId, V>, Vec<V>), EditStateError> {


### PR DESCRIPTION
* Added bookkeeping that of jumps, so we'd be able to find an LCA of
merges (as the divergence point).
* Removed all Unused PartialEq, Eq - so we would not accidentally
compare using these.
* Compared var references one by one - checking that they are either:
- On continuous stack.
- On local.
- On where generated prior to divergence.

---

**Stack**:
- #2324
- #2292 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2292)
<!-- Reviewable:end -->
