### PR TITLE
Made name multiple usage errors point at the name itself.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/module.rs
+++ b/crates/cairo-lang-semantic/src/items/module.rs
@@ -43,8 +43,7 @@ pub fn priv_module_items_data(
         if items.insert(name.clone(), *item).is_some() {
             let stable_location = StableLocation::new(
                 item.module_file_id(def_db),
-                // TODO(ilya): Give the name as the location.
-                item.untyped_stable_ptr(def_db),
+                db.module_item_name_stable_ptr(module_id, *item)?,
             );
             let kind = SemanticDiagnosticKind::NameDefinedMultipleTimes { name: name.clone() };
             diagnostics.add(SemanticDiagnostic::new(stable_location, kind));

--- a/crates/cairo-lang-semantic/src/items/tests/module
+++ b/crates/cairo-lang-semantic/src/items/tests/module
@@ -14,6 +14,11 @@ fn abc() {}
 
 fn abc(a : felt) {}
 
+mod inner {
+   struct abc {}
+}
+use inner::abc;
+
 struct abc {
    a: felt,
 }
@@ -30,36 +35,41 @@ impl abc of abc;
 
 //! > expected_diagnostics
 error: The name `abc` is defined multiple times.
- --> lib.cairo:3:1
+ --> lib.cairo:3:4
 fn abc(a : felt) {}
-^*****************^
+   ^*^
 
 error: The name `abc` is defined multiple times.
- --> lib.cairo:5:1
+ --> lib.cairo:8:12
+use inner::abc;
+           ^*^
+
+error: The name `abc` is defined multiple times.
+ --> lib.cairo:10:8
 struct abc {
-^**********^
+       ^*^
 
 error: The name `abc` is defined multiple times.
- --> lib.cairo:9:1
+ --> lib.cairo:14:6
 enum abc {
-^********^
+     ^*^
 
 error: The name `abc` is defined multiple times.
- --> lib.cairo:13:1
+ --> lib.cairo:18:5
 mod abc {}
-^********^
+    ^*^
 
 error: The name `abc` is defined multiple times.
- --> lib.cairo:15:1
+ --> lib.cairo:20:7
 trait abc {}
-^**********^
+      ^*^
 
 error: The name `abc` is defined multiple times.
- --> lib.cairo:17:1
+ --> lib.cairo:22:6
 impl abc of abc;
-^**************^
+     ^*^
 
 error: Not a trait.
- --> lib.cairo:17:13
+ --> lib.cairo:22:13
 impl abc of abc;
             ^*^

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/diagnostics
@@ -1136,3 +1136,83 @@ error: Plugin diagnostic: `raw_output` functions must return `Array::<felt>`.
  --> lib.cairo:28:25
     fn bar4(a: felt) -> my_felt_array_type {
                         ^****************^
+
+//! > ==========================================================================
+
+//! > Test reusage of storage var name diagnostics.
+
+//! > test_runner_name
+ExpandContractTestRunner
+
+//! > cairo_code
+#[contract]
+mod TestContract {
+    struct Storage {
+        same_name: felt,
+    }
+    fn same_name() -> felt {
+        1
+    }
+}
+
+//! > generated_cairo_code
+mod TestContract {
+    use starknet::SyscallResultTrait;
+    use starknet::SyscallResultTraitImpl;
+
+    fn same_name() -> felt {
+        1
+    }
+
+    
+    mod same_name {
+        use starknet::SyscallResultTrait;
+        use starknet::SyscallResultTraitImpl;
+
+        fn address() -> starknet::StorageBaseAddress {
+            starknet::storage_base_address_const::<0x26673b81123c540a9238f376b833c3914834c3c0cdf4e609f834963616d3ef9>()
+        }
+        fn read() -> felt {
+            // Only address_domain 0 is currently supported.
+            let address_domain = 0;
+            starknet::StorageAccess::<felt>::read(
+                address_domain,
+                address(),
+            ).unwrap_syscall()
+        }
+        fn write(value: felt) {
+            // Only address_domain 0 is currently supported.
+            let address_domain = 0;
+            starknet::StorageAccess::<felt>::write(
+                address_domain,
+                address(),
+                value,
+            ).unwrap_syscall()
+        }
+    }
+
+    
+
+    trait __abi {
+        
+        
+    }
+
+    mod __external {
+        use starknet::contract_address::ContractAddressSerde;
+
+        
+    }
+
+    mod __constructor {
+        use starknet::contract_address::ContractAddressSerde;
+
+        
+    }
+}
+
+//! > expected_diagnostics
+error: Plugin diagnostic: The name `same_name` is defined multiple times.
+ --> lib.cairo:4:9
+        same_name: felt,
+        ^*******^


### PR DESCRIPTION
this made plugin based errors of named more readable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2332)
<!-- Reviewable:end -->
