### PR TITLE
Remove 'use integer::upcast' from lib.cairo.

### DIFF
--- a/corelib/src/lib.cairo
+++ b/corelib/src/lib.cairo
@@ -286,7 +286,6 @@ mod integer;
 use integer::u128;
 use integer::u128_const;
 use integer::u128_sqrt;
-use integer::upcast;
 use integer::U128Add;
 use integer::U128Sub;
 use integer::U128Mul;

--- a/tests/e2e_test_data/libfuncs/casts
+++ b/tests/e2e_test_data/libfuncs/casts
@@ -5,7 +5,7 @@ SmallE2ETestRunner
 
 //! > cairo
 fn foo(a: u16) -> u64 {
-    upcast(a)
+    integer::upcast(a)
 }
 
 //! > casm


### PR DESCRIPTION
**Stack**:
- #2354
- #2353
- #2352 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2352)
<!-- Reviewable:end -->
