### PR TITLE
Add array concat

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -128,3 +128,32 @@ fn clone_loop<T, impl TClone: Clone::<T>, impl TDrop: Drop::<T>>(
         Option::None(_) => {},
     }
 }
+
+trait ArrayTConcatTrait<T> {
+    fn concat(self: Array<T>, arr_2: @Array<T>) -> Array<T>;
+}
+
+impl ArrayTConcatImpl<T, impl TCopy: Copy::<T>> of ArrayTConcatTrait::<T> {
+    fn concat(mut self: Array<T>, arr_2: @Array<T>) -> Array<T> {
+        concat_loop::<T, TCopy>(ref self, arr_2.span());
+        self
+    }
+}
+
+fn concat_loop<T, impl TCopy: Copy::<T>>(ref arr_1: Array<T>, mut arr_2: Span<T>) {
+    match get_gas() {
+        Option::Some(_) => {},
+        Option::None(_) => {
+            let mut data = array_new();
+            array_append(ref data, 'OOG');
+            panic(data);
+        },
+    }
+    match arr_2.pop_front() {
+        Option::Some(v) => {
+            arr_1.append(*v);
+            concat_loop::<T, TCopy>(ref arr_1, arr_2);
+        },
+        Option::None(_) => (),
+    }
+}

--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -133,14 +133,14 @@ trait ArrayTConcatTrait<T> {
     fn concat(self: Array<T>, arr_2: @Array<T>) -> Array<T>;
 }
 
-impl ArrayTConcatImpl<T, impl TCopy: Copy::<T>> of ArrayTConcatTrait::<T> {
+impl ArrayTConcatImpl<T, impl TCopy: Copy::<T>, impl TDrop: Drop::<T>> of ArrayTConcatTrait::<T> {
     fn concat(mut self: Array<T>, arr_2: @Array<T>) -> Array<T> {
         concat_loop::<T, TCopy>(ref self, arr_2.span());
         self
     }
 }
 
-fn concat_loop<T, impl TCopy: Copy::<T>>(ref arr_1: Array<T>, mut arr_2: Span<T>) {
+fn concat_loop<T, impl TCopy: Copy::<T>, impl TDrop: Drop::<T>>(ref arr_1: Array<T>, mut arr_2: Span<T>) {
     match get_gas() {
         Option::Some(_) => {},
         Option::None(_) => {

--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -834,6 +834,25 @@ fn test_array_clone() {
     assert(*felt252_snap_array_clone.at(2_usize) == 12, 'array[2] == 12');
 }
 
+use array::ArrayTConcatTrait;
+#[test]
+#[available_gas(100000)]
+fn test_array_concat() {
+    let mut felt_array_1: Array<felt> = test_array_helper();
+    let felt_snap_array_2: @Array<felt> = @test_array_helper();
+
+    let felt_array_1 = felt_array_1.concat(felt_snap_array_2);
+
+    assert(felt_array_1.len() == 6_usize, 'array len == 6');
+    assert(*felt_array_1.at(0_usize) == 10, 'array[0] == 10');
+    assert(*felt_array_1.at(1_usize) == 11, 'array[1] == 11');
+    assert(*felt_array_1.at(2_usize) == 12, 'array[2] == 12');
+    assert(*felt_array_1.at(3_usize) == 10, 'array[3] == 10');
+    assert(*felt_array_1.at(4_usize) == 11, 'array[4] == 11');
+    assert(*felt_array_1.at(5_usize) == 12, 'array[5] == 12');
+}
+
+
 #[test]
 fn test_dict_new() -> DictFelt252To::<felt252> {
     DictFelt252ToTrait::new()

--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -838,18 +838,18 @@ use array::ArrayTConcatTrait;
 #[test]
 #[available_gas(100000)]
 fn test_array_concat() {
-    let mut felt_array_1: Array<felt> = test_array_helper();
-    let felt_snap_array_2: @Array<felt> = @test_array_helper();
+    let mut felt252_array_1: Array<felt252> = test_array_helper();
+    let felt252_snap_array_2: @Array<felt252> = @test_array_helper();
 
-    let felt_array_1 = felt_array_1.concat(felt_snap_array_2);
+    let felt252_array_1 = felt252_array_1.concat(felt252_snap_array_2);
 
-    assert(felt_array_1.len() == 6_usize, 'array len == 6');
-    assert(*felt_array_1.at(0_usize) == 10, 'array[0] == 10');
-    assert(*felt_array_1.at(1_usize) == 11, 'array[1] == 11');
-    assert(*felt_array_1.at(2_usize) == 12, 'array[2] == 12');
-    assert(*felt_array_1.at(3_usize) == 10, 'array[3] == 10');
-    assert(*felt_array_1.at(4_usize) == 11, 'array[4] == 11');
-    assert(*felt_array_1.at(5_usize) == 12, 'array[5] == 12');
+    assert(felt252_array_1.len() == 6_usize, 'array len == 6');
+    assert(*felt252_array_1.at(0_usize) == 10, 'array[0] == 10');
+    assert(*felt252_array_1.at(1_usize) == 11, 'array[1] == 11');
+    assert(*felt252_array_1.at(2_usize) == 12, 'array[2] == 12');
+    assert(*felt252_array_1.at(3_usize) == 10, 'array[3] == 10');
+    assert(*felt252_array_1.at(4_usize) == 11, 'array[4] == 11');
+    assert(*felt252_array_1.at(5_usize) == 12, 'array[5] == 12');
 }
 
 


### PR DESCRIPTION
Adds generic array concat feature. Quite useful to create L1 <-> L2 message payloads, or ERC721 URI for example.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2457)
<!-- Reviewable:end -->
