### PR TITLE
Fix package version in Scarb.toml

### DIFF
--- a/corelib/Scarb.toml
+++ b/corelib/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 
 # NOTE: This is non-public, unstable Scarb's field, which instructs resolver that this package does not
 #   depend on `core`, which is only true for this particular package. Nobody else should use it.


### PR DESCRIPTION
The alpha 4 is unusable in Scarb because of this :(

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2475)
<!-- Reviewable:end -->
