### PR TITLE
Add debug::print_available_gas

### DIFF
--- a/corelib/src/debug.cairo
+++ b/corelib/src/debug.cairo
@@ -1,6 +1,7 @@
 use array::ArrayTrait;
 use traits::Into;
 use starknet::ContractAddressIntoFelt252;
+use testing::get_available_gas;
 use option::Option;
 
 // Usage:
@@ -25,6 +26,10 @@ fn print_felt252(message: felt252) {
     let mut arr = ArrayTrait::new();
     arr.append(message);
     print(arr);
+}
+
+fn print_available_gas(){
+    get_available_gas().print();
 }
 
 trait PrintTrait<T> {


### PR DESCRIPTION
Often I need to print gas to see which option is the most gas efficient. I then need to import get_available_gas and debug::PrintTrait and write get_available_gas. With this change, it is possible to directly print_available_gas

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2531)
<!-- Reviewable:end -->
