### PR TITLE
feature: add throw(felt252) to corelib

### DIFF
--- a/corelib/src/lib.cairo
+++ b/corelib/src/lib.cairo
@@ -375,6 +375,12 @@ enum PanicResult<T> {
 enum never {}
 extern fn panic(data: Array<felt252>) -> never;
 
+fn throw(err_code: felt252) -> never {
+    let mut data = ArrayTrait::new();
+    data.append(err_code);
+    panic(data)
+}
+
 fn assert(cond: bool, err_code: felt252) {
     if !cond {
         let mut data = ArrayTrait::new();

--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -10,6 +10,12 @@ use box::BoxTrait;
 
 
 #[test]
+#[should_panic(expected = ('throw()', ))]
+fn test_throw() {
+    throw('throw()');
+}
+
+#[test]
 #[should_panic(expected = ('assert(false)', ))]
 fn test_assert_false() {
     assert(false, 'assert(false)');


### PR DESCRIPTION
Some contract use `assert` to check a condition, and panic if the condition is not meet. There are cases where the panic is not conditional, or at least not the result of a boolean expression.

```
match someFunction(args) {
   A() => doSomething(),
   B() => doSomethingElse(),
   C() => assert(false, 'should not happen')
}
```

The issue with `assert(false, code)` is that its return type is void, causing possible type conflict with the other branches of the match. Here we want a function that returns `never`. `panic(Array<felt252>)` does that, but is not as user friendly as `assert` because you need to build `Array<felt252>`.

This PR adds a `throw` function (open to other names) that uses code_error just like `assert` but returns `never` just like `panic`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2564)
<!-- Reviewable:end -->
