### PR TITLE
Establish a convention that plugins do not take construction arguments

### DIFF
--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -34,9 +34,9 @@ impl Default for DatabaseForTesting {
         let mut res = Self {
             storage: Default::default(),
             plugins: vec![
-                Arc::new(FooToBarPlugin {}),
-                Arc::new(RemoveOrigPlugin {}),
-                Arc::new(DummyPlugin {}),
+                Arc::new(FooToBarPlugin),
+                Arc::new(RemoveOrigPlugin),
+                Arc::new(DummyPlugin),
             ],
         };
         init_files_group(&mut res);
@@ -219,7 +219,7 @@ impl GeneratedFileAuxData for DummyAuxData {
 }
 
 #[derive(Debug)]
-struct DummyPlugin {}
+struct DummyPlugin;
 impl MacroPlugin for DummyPlugin {
     fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {
         match item_ast {
@@ -307,7 +307,7 @@ fn test_plugin_remove_original() {
 /// If the original item is a function that is marked with #[remove_orig], only removes it, without
 /// generating any new code.
 #[derive(Debug)]
-struct RemoveOrigPlugin {}
+struct RemoveOrigPlugin;
 impl MacroPlugin for RemoveOrigPlugin {
     fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {
         let Some(free_function_ast) = try_extract_matches!(item_ast, ast::Item::FreeFunction) else { return PluginResult::default(); };
@@ -326,7 +326,7 @@ impl MacroPlugin for RemoveOrigPlugin {
 /// Changes a function 'foo' to 'bar' if annotated with #[foo_to_bar]. Doesn't remove the original
 /// item.
 #[derive(Debug)]
-struct FooToBarPlugin {}
+struct FooToBarPlugin;
 impl MacroPlugin for FooToBarPlugin {
     fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {
         let Some(free_function_ast) = try_extract_matches!(item_ast, ast::Item::FreeFunction) else { return PluginResult::default(); };

--- a/crates/cairo-lang-plugins/src/lib.rs
+++ b/crates/cairo-lang-plugins/src/lib.rs
@@ -12,5 +12,9 @@ mod test;
 
 /// Gets the list of default plugins to load into the Cairo compiler.
 pub fn get_default_plugins() -> Vec<Arc<dyn SemanticPlugin>> {
-    vec![Arc::new(DerivePlugin {}), Arc::new(PanicablePlugin {}), Arc::new(ConfigPlugin {})]
+    vec![
+        Arc::new(DerivePlugin::default()),
+        Arc::new(PanicablePlugin::default()),
+        Arc::new(ConfigPlugin::default()),
+    ]
 }

--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -10,8 +10,9 @@ use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 /// Plugin that enables ignoring modules not involved in the current config.
 /// Mostly useful for marking test modules to prevent usage of their functionality out of tests,
 /// and reduce compilation time when the tests data isn't required.
-#[derive(Debug)]
-pub struct ConfigPlugin {}
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct ConfigPlugin;
 
 impl MacroPlugin for ConfigPlugin {
     fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {

--- a/crates/cairo-lang-plugins/src/plugins/derive.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive.rs
@@ -11,8 +11,9 @@ use indoc::formatdoc;
 use itertools::Itertools;
 use smol_str::SmolStr;
 
-#[derive(Debug)]
-pub struct DerivePlugin {}
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct DerivePlugin;
 
 impl MacroPlugin for DerivePlugin {
     fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {

--- a/crates/cairo-lang-plugins/src/plugins/panicable.rs
+++ b/crates/cairo-lang-plugins/src/plugins/panicable.rs
@@ -10,8 +10,9 @@ use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 use cairo_lang_utils::try_extract_matches;
 use itertools::Itertools;
 
-#[derive(Debug)]
-pub struct PanicablePlugin {}
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct PanicablePlugin;
 
 impl MacroPlugin for PanicablePlugin {
     fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -70,7 +70,7 @@ fn test_missing_module_file() {
 // in the original module).
 // Used to test error location inside plugin generated inline modules.
 #[derive(Debug)]
-struct AddInlineModuleDummyPlugin {}
+struct AddInlineModuleDummyPlugin;
 
 impl MacroPlugin for AddInlineModuleDummyPlugin {
     fn generate_code(
@@ -181,7 +181,7 @@ impl PluginAuxData for PatchMapper {
 fn test_inline_module_diagnostics() {
     let mut db_val = SemanticDatabaseForTesting::default();
     let db = &mut db_val;
-    db.set_semantic_plugins(vec![Arc::new(AddInlineModuleDummyPlugin {})]);
+    db.set_semantic_plugins(vec![Arc::new(AddInlineModuleDummyPlugin)]);
     let crate_id = setup_test_crate(
         db,
         indoc! {"

--- a/crates/cairo-lang-starknet/src/db.rs
+++ b/crates/cairo-lang-starknet/src/db.rs
@@ -26,7 +26,7 @@ impl StarknetRootDatabaseBuilderEx for RootDatabaseBuilder {
         ];
 
         let mut plugins = get_default_plugins();
-        plugins.push(Arc::new(StarkNetPlugin {}));
+        plugins.push(Arc::new(StarkNetPlugin::default()));
 
         self.with_implicit_precedence(&precedence).with_plugins(plugins)
     }

--- a/crates/cairo-lang-starknet/src/plugin/mod.rs
+++ b/crates/cairo-lang-starknet/src/plugin/mod.rs
@@ -21,8 +21,9 @@ mod utils;
 use contract::handle_mod;
 use dispatcher::handle_trait;
 
-#[derive(Debug)]
-pub struct StarkNetPlugin {}
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct StarkNetPlugin;
 
 impl MacroPlugin for StarkNetPlugin {
     fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {

--- a/crates/cairo-lang-starknet/src/plugin/test.rs
+++ b/crates/cairo-lang-starknet/src/plugin/test.rs
@@ -27,7 +27,7 @@ impl TestFileRunner for ExpandContractTestRunner {
         let file_id = self.db.module_main_file(test_module.module_id).unwrap();
         let syntax_file = self.db.file_syntax(file_id).unwrap();
 
-        let plugin = StarkNetPlugin {};
+        let plugin = StarkNetPlugin::default();
         let mut generated_items: Vec<String> = Vec::new();
 
         for item in syntax_file.items(&self.db).elements(&self.db).into_iter() {

--- a/crates/cairo-lang-test-runner/src/cli.rs
+++ b/crates/cairo-lang-test-runner/src/cli.rs
@@ -12,12 +12,11 @@ use cairo_lang_defs::ids::{FreeFunctionId, FunctionWithBodyId, ModuleItemId};
 use cairo_lang_diagnostics::ToOption;
 use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
 use cairo_lang_filesystem::ids::CrateId;
-use cairo_lang_plugins::plugins::{ConfigPlugin, DerivePlugin, PanicablePlugin};
+use cairo_lang_plugins::get_default_plugins;
 use cairo_lang_runner::short_string::as_cairo_short_string;
 use cairo_lang_runner::{RunResultValue, SierraCasmRunner};
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::items::functions::GenericFunctionId;
-use cairo_lang_semantic::plugin::SemanticPlugin;
 use cairo_lang_semantic::{ConcreteFunction, ConcreteFunctionWithBodyId, FunctionLongId};
 use cairo_lang_sierra::extensions::builtin_cost::CostTokenType;
 use cairo_lang_sierra::ids::FunctionId;
@@ -72,15 +71,10 @@ enum TestStatus {
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    // TODO(orizi): Use `get_default_plugins` and just update the config plugin.
-    let mut plugins: Vec<Arc<dyn SemanticPlugin>> = vec![
-        Arc::new(DerivePlugin {}),
-        Arc::new(PanicablePlugin {}),
-        Arc::new(ConfigPlugin {}),
-        Arc::new(TestPlugin {}),
-    ];
+    let mut plugins = get_default_plugins();
+    plugins.push(Arc::new(TestPlugin::default()));
     if args.starknet {
-        plugins.push(Arc::new(StarkNetPlugin {}));
+        plugins.push(Arc::new(StarkNetPlugin::default()));
     }
     let db = &mut RootDatabase::builder()
         .with_cfg(CfgSet::from_iter([Cfg::tag("test")]))

--- a/crates/cairo-lang-test-runner/src/plugin.rs
+++ b/crates/cairo-lang-test-runner/src/plugin.rs
@@ -9,7 +9,8 @@ use cairo_lang_syntax::node::db::SyntaxGroup;
 use crate::test_config::try_extract_test_config;
 
 /// Plugin to create diagnostics for tests attributes.
-#[derive(Debug)]
+#[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct TestPlugin;
 
 impl MacroPlugin for TestPlugin {


### PR DESCRIPTION
Instead, I suggest keeping all necessary information in databases, like I did with `cfg` in #2589.
This eases reasoning on plugin construction.
For example, I have now idea how could I gather construction parameters from Scarb in an elegant way.

Additionally, test runner now uses `get_default_plugins`, because it can so.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2590)
<!-- Reviewable:end -->
