### PR TITLE
📝 Documentation for `corelib`: Array and Box modules

### DIFF
--- a/docs/reference/src/cairo/modules/ROOT/pages/corelib/Introduction/introduction.adoc
+++ b/docs/reference/src/cairo/modules/ROOT/pages/corelib/Introduction/introduction.adoc
@@ -1,0 +1,137 @@
+[id="corelib"]
+= Introduction to the Cairo Core Library
+
+The "Cairo Core Library" encompasses a variety of components designed to facilitate the development of Cairo smart contracts and applications.
+
+== Structure
+
+This documentation is organized into the following sections:
+
+* Modules: A collection of modules that offer various functionalities, grouped by their application domains. Each module contains an in-depth exploration of its components, such as structs, functions, and more.
+* Native Types: A list of Cairo's primitive types that serve as the building blocks for more complex data structures
+* Keywords: Core keywords in the Cairo language that define its syntax and structure.
+* Macros: Predefined macros that provide convenient shortcuts and enable code generation during compilation.
+
+By following this structure, we will first provide a quick overview of Cairo's native types, macros, keywords, and modules on this page. Then, we will create directories for each module and delve deeper into their components, such as structs, functions, and more.
+
+== How to Read This Documentation
+
+If you already know the name of what you are looking for, the fastest way to find it is to use the search bar at the top of the page.
+
+Otherwise, you may want to jump to one of these useful sections:
+
+* TODO
+
+If this is your first time, the documentation for the standard library is written to be casually perused. Clicking on interesting things should generally lead you to interesting places. Still, there are important bits you don't want to miss, so read on for a tour of the standard library and its documentation!
+
+Notice the source link. Cairo's documentation comes with the source code, and you are encouraged to read it. The standard library source is generally high quality, and a peek behind the curtains is often enlightening.
+
+Let the show begin!
+
+== Modules
+
+A list of modules in the Cairo Standard Library, along with a brief description of each module's purpose and functionality:
+
+[cols="1,2",options="header"]
+|===
+| Module | Description
+| starknet | Provides core functionality for interacting with StarkNet, including smart contract deployment and data retrieval.
+| starknet::class_hash | Utilities for working with class hashes in StarkNet contracts.
+| starknet::contract_address | Functions for handling and validating contract addresses in StarkNet.
+| starknet::info | Offers utilities for retrieving contract and network information.
+| starknet::storage_access | Functions for accessing contract storage in StarkNet.
+| starknet::syscalls | Implements StarkNet system call functionality.
+| starknet::testing | Provides tools for testing StarkNet contracts.
+| test | Offers utilities for writing and executing unit tests for Cairo smart contracts.
+| array | Implements a collection of functions for working with arrays, including creating, and manipulating.
+| box | Provides a mechanism for encapsulating a value within a "box" to allow for more efficient memory management.
+| clone | Implements cloning functionality, allowing the creation of deep copies of complex data structures.
+| debug | Offers debugging utilities, such as logging and tracing, to assist with the development and troubleshooting of Cairo code.
+| dict | Implements a dictionary data structure, allowing for efficient key-value storage and retrieval.
+| ec | Provides utilities for working with elliptic curve cryptography, including key generation, signing, and verification.
+| ecdsa | Implements the Elliptic Curve Digital Signature Algorithm (ECDSA) for signing and verifying messages.
+| hash | Provides hashing functions, including support for various cryptographic hash algorithms.
+| integer | Implements utilities for working with integer values, including arithmetic operations and comparisons.
+| gas | Offers utilities for tracking and managing gas consumption in Cairo smart contracts.
+| nullable | Implements a wrapper type for nullable values, allowing for the optional presence of a value.
+| option | Provides the Option type, which represents a value that may or may not be present.
+| poseidon | Implements the Poseidon hash function, a cryptographic hash function optimized for zero-knowledge proofs.
+| result | Provides the Result type, which represents the outcome of a computation that may result in an error.
+| serde | Offers serialization and deserialization utilities for converting between Cairo data structures and various data formats.
+| zeroable | Implements a trait for types that can be safely zero-initialized.
+| traits | Contains a collection of traits that define common behaviors and interfaces for Cairo types.
+|===
+
+
+== Primitive Types
+
+A list of primitive types in Cairo, along with a brief description of each type's purpose and functionality:
+
+[cols="1,2",options="header"]
+
+|===
+| Primitive Type | Description
+| u8 | Represents an unsigned 8-bit integer.
+| u16 | Represents an unsigned 16-bit integer.
+| u32 | Represents an unsigned 32-bit integer.
+| u64 | Represents an unsigned 64-bit integer.
+| u128 | Represents an unsigned 128-bit integer.
+| u256 | Represents an unsigned 256-bit integer.
+| bool | Represents a boolean value, which can be either true or false.
+| felt252 | Represents a field element.
+| ContractAddress | A type representing a StarkNet contract address, used for identifying and interacting with smart contracts.
+| T | Represents a generic type placeholder, which can be replaced with any specific type during compilation.
+| @T | Represents a reference to a value of type T, used for passing values by reference and storing pointers.
+| Box<T> | A wrapper data structure for elements of type T, used for heap allocation and indirection.
+| Option<T> | Represents a value that may or may not be present, used for optional values and error handling.
+| Result<T, E> | Represents the outcome of a computation that may result in an error, used for error handling and control flow.
+| Array<T> | A dynamic array data structure for elements of type T, used for creating and manipulating arrays.
+| Span<T> | A utility structure that provides a view over an Array<T> for efficient iteration and manipulation.
+|===
+
+== Macros
+
+A list of macros in Cairo, along with a brief description of each macro's purpose and functionality:
+
+[cols="1,2",options="header"]
+|===
+| Macro | Description
+| assert | A macro that checks if a given condition is true, and if not, raises an error. Used for enforcing invariants and validating input.
+| fn | A macro that defines a function, specifying its name, input parameters, and return type. Used for creating reusable code blocks.
+| panic | A macro that immediately aborts the execution of the current function and unwinds the call stack. Used for error handling and control flow when an unrecoverable error occurs.
+|===
+
+In the following sections, we will explore each of these modules in depth, providing you with detailed information on their purpose, functionality, and usage examples.
+
+== Keywords
+
+A list of keywords in Cairo, along with a brief description of each keyword's purpose and functionality:
+
+[cols="1,2",options="header"]
+|===
+| Keyword | Description
+| await | Used to suspend the execution of a function until a future or asynchronous operation is completed.
+| const | Indicates that the declared value is a constant and cannot be changed after initialization.
+| let | Used to declare and bind a value to a variable name.
+| if | A conditional branching keyword used to execute a code block only if a given condition is true.
+| fn | Used to define a function, specifying its name, input parameters, and return type.
+| false | A boolean literal representing the "false" value.
+| enum | Defines an enumeration, a distinct type that consists of a set of named values.
+| extern | Indicates that the following block contains external functions or items that are implemented elsewhere.
+| else | A conditional branching keyword used in conjunction with `if` to provide an alternative code block to execute when the `if` condition is false.
+| impl | Used to implement a trait for a specific type, providing the actual code for the trait's methods.
+| loop | Creates an infinite loop, which can be terminated using a control flow keyword like `break` or `return`.
+| match | A keyword for pattern matching, allowing the execution of a specific code block based on the value of an expression.
+| mod | Declares a module, which is a collection of related functions, types, and items.
+| mut | Indicates that a variable is mutable and its value can be changed after initialization.
+| pub | Specifies that a function, type, or item is public and can be accessed from outside its module.
+| ref | Used to create a reference to a value or variable, allowing it to be shared without copying or transferring ownership.
+| return | A keyword used to return a value from a function.
+| self | Refers to the current instance of an object or the current module when used in a function or method.
+| struct | Defines a structured data type, which is a composite type that contains named fields.
+| super | Refers to the parent module or namespace when used in a path.
+| trait | Defines a trait, which is a collection of methods and associated types that can be implemented by different types.
+| true | A boolean literal representing the "true" value.
+| type | Used to create a type alias, which is a new name for an existing type.
+| use | Imports a function, type, or item from another module, making it available for use in the current scope.
+|===

--- a/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/array/Array.adoc
+++ b/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/array/Array.adoc
@@ -1,0 +1,79 @@
+[id="array"]
+
+= Array<T>
+
+`Array<T>` is a generic, dynamic, growable array data structure, where `T` represents the type of elements stored in the array. It provides several operations, such as creating a new array, appending elements to an array, popping elements from the front of an array, and accessing elements by their index.
+
+== Array<T> Native Functions
+
+These native functions serve as the building blocks for higher-level abstractions, such as traits. By providing the low-level implementation for array operations, they enable the creation of traits like `ArrayTrait<T>`. The `ArrayTrait<T>` trait is an example of how these native functions can be wrapped to create a coherent interface for working with arrays. By defining methods like `new`, `append`, `pop_front`, `get`, and others, the trait leverages the native functions to perform the underlying operations, while presenting a more convenient and idiomatic API for the library users.
+
+=== array_new
+* Signature: `extern fn array_new<T>() -> Array<T> nopanic`
+* Description: Creates a new empty array of type `T`.
+
+=== array_append
+* Signature: `extern fn array_append<T>(ref arr: Array<T>, value: T) nopanic`
+* Description: Appends an element of type `T` to the end of the array.
+
+=== array_pop_front
+* Signature: `extern fn array_pop_front<T>(ref arr: Array<T>) -> Option<Box<T>> nopanic`
+* Description: Removes and returns the first element of the array, if it exists.
+
+=== array_snapshot_pop_front
+* Signature: `extern fn array_snapshot_pop_front<T>(ref arr: @Array<T>) -> Option<Box<@T>> nopanic`
+* Description: Removes and returns the first element of the array snapshot, if it exists.
+
+=== array_snapshot_pop_back
+* Signature: `extern fn array_snapshot_pop_back<T>(ref arr: @Array<T>) -> Option<Box<@T>> nopanic`
+* Description: Removes and returns the last element of the array snapshot, if it exists.
+
+=== array_get
+* Signature: `extern fn array_get<T>(arr: @Array<T>, index: usize) -> Option<Box<@T>> implicits(RangeCheck) nopanic`
+* Description: Returns an `Option<Box<@T>>` of the element at the given index in the array, if it exists.
+
+=== array_slice
+* Signature: `extern fn array_slice<T>(arr: @Array<T>, start: usize, length: usize) -> Option<@Array<T>> implicits(RangeCheck) nopanic`
+* Description: Returns a slice of the array as an `Option<@Array<T>>` starting at the given index and with the specified length, if the range is valid.
+
+=== array_len
+* Signature: `extern fn array_len<T>(arr: @Array<T>) -> usize nopanic`
+* Description: Returns the length of the array.
+
+== Example
+
+Here's an example demonstrating how to create and work with an `Array<T>`:
+
+[source,cairo]
+----
+TODO
+----
+
+// TODO: make a proper example. Here's the old one:
+
+// [source,cairo]
+// ----
+// from array import Array, ArrayTrait
+// using array : ArrayTrait
+
+// func main() -> ():
+//     let arr : Array(i32) = Array.new()
+//     arr.append(1)
+//     arr.append(2)
+//     arr.append(3)
+
+//     let first = arr.pop_front().unwrap()
+//     assert first == 1
+
+//     let len = arr.len()
+//     assert len == 2
+
+//     let second = arr.at(0)
+//     assert second == 2
+
+//     let third = arr.get(1).unwrap().unbox()
+//     assert third == 3
+// end
+// ----
+
+// This example creates a new Array<i32> and performs various operations, such as appending elements, popping the first element, checking the length, and accessing elements by index.

--- a/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/array/ArrayTrait.adoc
+++ b/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/array/ArrayTrait.adoc
@@ -1,0 +1,65 @@
+[id="arraytrait"]
+
+= ArrayTrait<T>
+
+`ArrayTrait<T>` is a trait that defines the interface for working with `Array<T>`. It provides methods for creating a new array, appending elements, popping elements from the front, and accessing elements by their index, among others.
+
+[source,cairo]
+----
+trait ArrayTrait<T> {
+    fn new() -> Array<T>;
+    fn append(ref self: Array<T>, value: T);
+    fn pop_front(ref self: Array<T>) -> Option<T> nopanic;
+    fn get(self: @Array<T>, index: usize) -> Option<Box<@T>>;
+    fn at(self: @Array<T>, index: usize) -> @T;
+    fn len(self: @Array<T>) -> usize;
+    fn is_empty(self: @Array<T>) -> bool;
+    fn span(self: @Array<T>) -> Span<T>;
+}
+----
+
+== ArrayTrait<T> Methods
+
+=== new
+* Signature: `fn new() -> Array<T>`
+* Description: Creates a new empty `Array<T>`.
+
+=== append
+* Signature: `fn append(ref self: Array<T>, value: T)`
+* Description: Appends a value of type `T` to the end of the `Array<T>`.
+
+=== pop_front
+* Signature: `fn pop_front(ref self: Array<T>) -> Option<T> nopanic`
+* Description: Removes and returns the first element of the array as an `Option<T>`, if it exists.
+
+=== get
+* Signature: `fn get(self: @Array<T>, index: usize) -> Option<Box<@T>>`
+* Description: Returns an `Option<Box<@T>>` of the element at the given index in the array, if it exists.
+
+=== at
+* Signature: `fn at(self: @Array<T>, index: usize) -> @T`
+* Description: Returns the element at the given index in the array.
+
+=== len
+* Signature: `fn len(self: @Array<T>) -> usize`
+* Description: Returns the length of the array.
+
+=== is_empty
+* Signature: `fn is_empty(self: @Array<T>) -> bool`
+* Description: Returns `true` if the array is empty; otherwise, returns `false`.
+
+=== span
+* Signature: `fn span(self: @Array<T>) -> Span<T>`
+* Description: Returns a `Span<T>` snapshot of the `Array<T>`, which allows performing operations on the snapshot without modifying the original array.
+
+
+== Example
+
+// TODO: Add example
+
+Here's an example demonstrating how to implement `ArrayTrait<T>`:
+
+[source,cairo]
+----
+TODO
+----

--- a/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/array/Span.adoc
+++ b/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/array/Span.adoc
@@ -1,0 +1,108 @@
+[id="span"]
+
+= Span<T> and SpanTrait<T>
+
+== Span<T>
+
+`Span<T>` is a struct that represents a snapshot of an `Array<T>` object. It allows you to perform operations on the snapshot without modifying the original array.
+
+[source,cairo]
+----
+struct Span<T> {
+    snapshot: @Array<T>
+}
+----
+
+The functionality of `Span<T>` is provided through the `SpanTrait<T>` trait.
+
+== SpanTrait<T>
+
+`SpanTrait<T>` is a trait that provides the functionality for the `Span<T>` struct. It includes methods for querying and modifying the snapshot, such as `pop_front`, `pop_back`, `get`, `at`, `len`, and `is_empty`.
+
+[source,cairo]
+----
+trait SpanTrait<T> {
+    fn pop_front(ref self: Span<T>) -> Option<@T>;
+    fn pop_back(ref self: Span<T>) -> Option<@T>;
+    fn get(self: Span<T>, index: usize) -> Option<Box<@T>>;
+    fn at(self: Span<T>, index: usize) -> @T;
+    fn len(self: Span<T>) -> usize;
+    fn is_empty(self: Span<T>) -> bool;
+}
+----
+
+The `SpanTrait<T>` trait is implemented for `Span<T>` in the `SpanImpl<T>` implementation block, which includes the actual code for each method.
+
+The `SpanIndex<T>` implementation block provides an `IndexView` for `Span<T>`, allowing you to use indexing syntax with a `Span<T>` object.
+
+== SpanTrait<T> Methods
+
+=== pop_front
+* Signature: `fn pop_front(ref self: Span<T>) -> Option<@T>`
+* Description: Removes and returns the first element of the snapshot, if it exists.
+
+=== pop_back
+* Signature: `fn pop_back(ref self: Span<T>) -> Option<@T>`
+* Description: Removes and returns the last element of the snapshot, if it exists.
+
+=== get
+* Signature: `fn get(self: Span<T>, index: usize) -> Option<Box<@T>>`
+* Description: Returns an `Option<Box<@T>>` of the element at the given index in the snapshot, if it exists.
+
+=== at
+* Signature: `fn at(self: Span<T>, index: usize) -> @T`
+* Description: Returns the element at the given index in the snapshot.
+
+=== len
+* Signature: `fn len(self: Span<T>) -> usize`
+* Description: Returns the length of the snapshot.
+
+=== is_empty
+* Signature: `fn is_empty(self: Span<T>) -> bool`
+* Description: Returns `true` if the snapshot is empty; otherwise, returns `false`.
+
+== Example
+
+[source,cairo]
+----
+TODO
+----
+
+
+// TODO: add example likely like this (which is based on a rust example):
+
+// In this example, we create an `Array<T>` and a corresponding `Span<T>` to demonstrate the usage of the `SpanTrait<T>` methods.
+
+// [source,cairo]
+// ----
+// let array: Array<i32> = Array::<i32>::new();
+// array.append(1);
+// array.append(2);
+// array.append(3);
+// array.append(4);
+// array.append(5);
+
+// let span: Span<i32> = array.span();
+
+// // Prints 5
+// println!("Length: {}", span.len());
+
+// // Prints 1
+// println!("First element: {}", span.at(0));
+
+// // Prints 3
+// println!("Element at index 2: {}", span.at(2));
+
+// // Removes and prints the first element (1)
+// if let Option::Some(value) = span.pop_front() {
+//     println!("Popped front element: {}", value);
+// }
+
+// // Removes and prints the last element (5)
+// if let Option::Some(value) = span.pop_back() {
+//     println!("Popped back element: {}", value);
+// }
+
+// // Prints 3, the new length of the snapshot after removing two elements
+// println!("New length: {}", span.len());
+// ----

--- a/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/array/introduction.adoc
+++ b/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/array/introduction.adoc
@@ -1,0 +1,17 @@
+[id="array"]
+= Array module
+
+The array module provides a dynamic array data structure called Array<T> for elements of type T. This data structure allows you to create and manipulate arrays in a dynamic and efficient way. The module also provides a trait, ArrayTrait<T>, which defines common operations on an Array<T>.
+
+Here is a brief summary of the components in the array module:
+
+[cols="2*",options="header"]
+|===
+| Module Component | Description
+| Array<T> | The primary data structure representing a dynamic array of elements of type T.
+| ArrayTrait<T> | A trait that defines common operations on an Array<T> such as creating a new array, appending elements, popping elements from the front, and retrieving elements by index.
+| Span<T> | A utility structure that provides a view over an Array<T> for efficient iteration and manipulation.
+| SpanTrait<T> | A trait that defines common operations on a Span<T> such as popping elements from the front or back, and retrieving elements by index.
+|===
+
+In the following sections, we will explore each of these components in more detail and provide examples of how to use them effectively.

--- a/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/box/Box.adoc
+++ b/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/box/Box.adoc
@@ -1,0 +1,45 @@
+[id="box"]
+
+= Box<T> and BoxTrait<T>
+
+== Box<T>
+
+`Box<T>` is a data structure that wraps a single object of type `T`. It's useful for storing objects on the heap and returning them from functions without copying the contents.
+
+[source,cairo]
+----
+extern type Box<T>;
+----
+
+The functionality of `Box<T>` is provided through the `BoxTrait<T>` trait, which will be discussed in the following section.
+
+== `BoxTrait<T>`
+
+`BoxTrait<T>` is a trait that provides the functionality for the `Box<T>` data structure. It includes methods for creating and working with boxes, such as `new` and `unbox`.
+
+[source,cairo]
+----
+trait BoxTrait<T> {
+    fn new(value: T) -> Box<T> nopanic;
+    fn unbox(self: Box<T>) -> T nopanic;
+}
+----
+
+The `BoxTrait<T>` trait is implemented for `Box<T>` in the `BoxImpl<T>` implementation block, which includes the actual code for each method.
+
+== BoxTrait<T> Methods
+
+=== new
+Signature: `fn new(value: T) -> Box<T> nopanic`
+Description: Creates a new `Box<T>` containing the given value.
+
+=== unbox
+Signature: `fn unbox(self: Box<T>) -> T nopanic`
+Description: Unwraps the value contained in the `Box<T>` and returns it.
+
+== Example
+
+[source,cairo]
+----
+TODO
+----

--- a/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/box/introduction.adoc
+++ b/docs/reference/src/cairo/modules/ROOT/pages/corelib/Modules/box/introduction.adoc
@@ -1,0 +1,15 @@
+[id="box"]
+= Box module
+
+The box module provides a wrapper data structure called `Box<T>` for elements of type `T`. Similar to Rust's `Box<T>`, this data structure allows you to store and manage heap-allocated values of any type in a uniform way, making it easier to work with generic types and providing a level of indirection when needed. The module also provides a trait, `BoxTrait<T>`, which defines common operations on a `Box<T>`, such as creating a new Box and unwrapping the value stored in it.
+
+Here is a brief summary of the components in the box module:
+
+[cols="2*",options="header"]
+|===
+| Module Component | Description
+| `Box<T>` | The primary data structure representing a wrapper for elements of type `T`.
+| `BoxTrait<T>` | A trait that defines common operations on a `Box<T>` such as creating a new Box and unwrapping the stored value.
+|===
+
+We will explore each of these components in more detail and provide examples of how to use them effectively.


### PR DESCRIPTION
Adds:
* structure to `corelib` docs.
* introduction.
* docs for `Array` and `Box` modules