### PR TITLE
Send exit notification to Cairo Language Server from vscode extension

### DIFF
--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -10,6 +10,8 @@ import {
     ServerOptions,
 } from 'vscode-languageclient/node';
 
+let client: LanguageClient
+
 // Tries to find the development version of the language server executable,
 // assuming the workspace directory is inside the Cairo repository.
 function findDevLanguageServerAt(path: string, depth: number): string | undefined {
@@ -153,7 +155,7 @@ async function setupLanguageServer(
             { scheme: 'vfs', language: 'cairo' }],
     };
 
-    var client: LanguageClient = new LanguageClient(
+    client = new LanguageClient(
         'cairoLanguageServer', 'Cairo Language Server', serverOptions, clientOptions);
     client.registerFeature(new SemanticTokensFeature(client));
     client.onReady().then(() => {
@@ -189,4 +191,11 @@ export async function activate(context: vscode.ExtensionContext) {
         outputChannel.appendLine(
             "Language server is not enabled. Use the cairo1.enableLanguageServer config");
     }
+}
+
+export function deactivate(): Thenable<void> | undefined {
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
 }


### PR DESCRIPTION
Linked issue: #2461 

Send [exit notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#exit) to language server from vscode extension on deactivation (with [client stop function](https://github.com/microsoft/vscode-languageserver-node/blob/b491193996e01435e44b00d677516fa4449bee82/client/src/common/client.ts#L1383)). Guided by [extension samples](https://github.com/microsoft/vscode-extension-samples/blob/98346fc4fa81067e253df9b32922cc02e8b24274/lsp-sample/client/src/extension.ts#L56).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2764)
<!-- Reviewable:end -->
