### PR TITLE
feat: debug u16/u32

### DIFF
--- a/corelib/src/debug.cairo
+++ b/corelib/src/debug.cairo
@@ -59,6 +59,18 @@ impl U8PrintImpl of PrintTrait<u8> {
     }
 }
 
+impl U16PrintImpl of PrintTrait<u16> {
+    fn print(self: u16) {
+        self.into().print();
+    }
+}
+
+impl U32PrintImpl of PrintTrait<u32> {
+    fn print(self: u32) {
+        self.into().print();
+    }
+}
+
 impl U64PrintImpl of PrintTrait<u64> {
     fn print(self: u64) {
         self.into().print();


### PR DESCRIPTION
Adds the `Print` implementation for `u16` and `u32`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2778)
<!-- Reviewable:end -->
