### PR TITLE
Add starknet::get_block_number

### DIFF
--- a/corelib/src/starknet/info.cairo
+++ b/corelib/src/starknet/info.cairo
@@ -67,5 +67,5 @@ fn get_block_timestamp() -> u64 {
 }
 
 fn get_block_number() -> u64 {
-    get_block_number().unbox().block_number
+    get_block_info().unbox().block_number
 }

--- a/corelib/src/starknet/info.cairo
+++ b/corelib/src/starknet/info.cairo
@@ -65,3 +65,7 @@ fn get_tx_info() -> Box<TxInfo> {
 fn get_block_timestamp() -> u64 {
     get_block_info().unbox().block_timestamp
 }
+
+fn get_block_number() -> u64 {
+    get_block_number().unbox().block_number
+}


### PR DESCRIPTION
This was present in Cairo 0.10 and its absence surprised me. I can't find a good reason to omit it, so I'm proposing to add it to C1.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2838)
<!-- Reviewable:end -->
