### PR TITLE
Fix doc & Display for `Cfg` to use `:` instead of `=`

### DIFF
--- a/crates/cairo-lang-filesystem/src/cfg.rs
+++ b/crates/cairo-lang-filesystem/src/cfg.rs
@@ -17,7 +17,7 @@ impl Cfg {
         Self { key: key.into(), value: None }
     }
 
-    /// Creates an `cfg` item that is matchable as `#[cfg(key = "value")]`.
+    /// Creates an `cfg` item that is matchable as `#[cfg(key: "value")]`.
     pub fn kv(key: impl Into<SmolStr>, value: impl Into<SmolStr>) -> Self {
         Self { key: key.into(), value: Some(value.into()) }
     }
@@ -28,7 +28,7 @@ impl fmt::Display for Cfg {
         write!(f, "{}", self.key)?;
 
         if let Some(value) = &self.value {
-            write!(f, " = {value:?}")?;
+            write!(f, ": {value:?}")?;
         }
 
         Ok(())


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2863)
<!-- Reviewable:end -->
