### PR TITLE
Rename `Cfg::tag` to `Cfg::name` and `item` to `option` to be consistent with Rust naming

### DIFF
--- a/crates/cairo-lang-filesystem/src/db_test.rs
+++ b/crates/cairo-lang-filesystem/src/db_test.rs
@@ -43,12 +43,12 @@ fn test_flags() {
 fn test_cfgs() {
     let mut db = FilesDatabaseForTesting::default();
 
-    db.use_cfg(&CfgSet::from_iter([Cfg::tag("test"), Cfg::kv("k", "v1")]));
+    db.use_cfg(&CfgSet::from_iter([Cfg::name("test"), Cfg::kv("k", "v1")]));
 
     db.use_cfg(&CfgSet::from_iter([Cfg::kv("k", "v2")]));
 
     assert_eq!(
         *db.cfg_set(),
-        CfgSet::from_iter([Cfg::tag("test"), Cfg::kv("k", "v1"), Cfg::kv("k", "v2")])
+        CfgSet::from_iter([Cfg::name("test"), Cfg::kv("k", "v1"), Cfg::kv("k", "v2")])
     )
 }

--- a/crates/cairo-lang-language-server/src/bin/language_server.rs
+++ b/crates/cairo-lang-language-server/src/bin/language_server.rs
@@ -17,7 +17,7 @@ async fn main() {
     let (stdin, stdout) = (stdin.compat(), stdout.compat_write());
 
     let db = RootDatabase::builder()
-        .with_cfg(CfgSet::from_iter([Cfg::tag("test")]))
+        .with_cfg(CfgSet::from_iter([Cfg::name("test")]))
         .detect_corelib()
         .with_starknet()
         .build()

--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -104,7 +104,7 @@ fn parse_predicate_item(
                 return None;
             };
             let key = segment.ident(db).text(db);
-            Some(Cfg::tag(key))
+            Some(Cfg::name(key))
         }
     }
 }

--- a/crates/cairo-lang-test-runner/src/cli.rs
+++ b/crates/cairo-lang-test-runner/src/cli.rs
@@ -78,7 +78,7 @@ fn main() -> anyhow::Result<()> {
         plugins.push(Arc::new(StarkNetPlugin::default()));
     }
     let db = &mut RootDatabase::builder()
-        .with_cfg(CfgSet::from_iter([Cfg::tag("test")]))
+        .with_cfg(CfgSet::from_iter([Cfg::name("test")]))
         .with_plugins(plugins)
         .detect_corelib()
         .build()?;


### PR DESCRIPTION
To be consistent with Rust naming https://doc.rust-lang.org/reference/conditional-compilation.html:

> Configuration options are names and key-value pairs that are either set or unset.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2867)
<!-- Reviewable:end -->
