### PR TITLE
Fix "Identifier not found" for storage_address_to_felt252

### DIFF
--- a/corelib/src/starknet.cairo
+++ b/corelib/src/starknet.cairo
@@ -21,8 +21,15 @@ use storage_access::storage_address_try_from_felt252;
 // Module containing all the extern declaration of the syscalls.
 mod syscalls;
 use syscalls::call_contract_syscall;
+use syscalls::deploy_syscall;
+use syscalls::emit_event_syscall;
+use syscalls::get_execution_info_syscall;
+use syscalls::library_call_syscall;
+use syscalls::send_message_to_l1_syscall;
 use syscalls::storage_read_syscall;
 use syscalls::storage_write_syscall;
+use syscalls::replace_class_syscall;
+use syscalls::keccak_syscall;
 
 // secp256k1
 mod secp256k1;
@@ -50,6 +57,8 @@ use class_hash::ClassHash;
 use class_hash::ClassHashIntoFelt252;
 use class_hash::Felt252TryIntoClassHash;
 use class_hash::class_hash_const;
+use class_hash::class_hash_to_felt252;
+use class_hash::class_hash_try_from_felt252;
 
 mod info;
 use info::ExecutionInfo;

--- a/corelib/src/starknet.cairo
+++ b/corelib/src/starknet.cairo
@@ -15,6 +15,7 @@ use storage_access::storage_base_address_const;
 use storage_access::storage_base_address_from_felt252;
 use storage_access::storage_address_from_base;
 use storage_access::storage_address_from_base_and_offset;
+use storage_access::storage_address_to_felt252;
 use storage_access::storage_address_try_from_felt252;
 
 // Module containing all the extern declaration of the syscalls.


### PR DESCRIPTION
Trying to import storage_address_to_felt252 will result in error

`use starknet::storage_address_to_felt252;
`

```
error: Plugin diagnostic: Identifier not found.
 --> custom_map.cairo:9:19
    use starknet::storage_address_to_felt252;
```

The way around would be directly using
`extern fn storage_address_to_felt252(address: StorageAddress) -> felt252 nopanic;
`
in contract file.

But this is not consistent with other functions like `storage_address_from_base_and_offset` and so on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2941)
<!-- Reviewable:end -->
