### PR TITLE
Restore `starknet-compile`

### DIFF
--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -51,5 +51,9 @@ test-case.workspace = true
 test-log.workspace = true
 
 [[bin]]
+name = "starknet-compile"
+path = "src/cli.rs"
+
+[[bin]]
 name = "starknet-sierra-compile"
 path = "src/starknet_sierra_compile.rs"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -38,5 +38,9 @@ test-case.workspace = true
 test-log.workspace = true
 
 [[test]]
+name = "examples_test"
+path = "examples_test.rs"
+
+[[test]]
 name = "e2e_test"
 path = "e2e_test.rs"


### PR DESCRIPTION
I've found that `starknet-compile` binary is not present after building the code from the main branch.
It seems this PR https://github.com/starkware-libs/cairo/pull/2915 removed it (It may have been done by mistake. The description says it only sorts dependencies).

I've also restored `examples_test.ts in the `tests/Cargo.toml`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2943)
<!-- Reviewable:end -->
