### PR TITLE
feat: Support generic types in Derive statements

### DIFF
--- a/crates/cairo-lang-plugins/src/plugins/derive.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive.rs
@@ -93,8 +93,8 @@ fn extract_struct_extra_info(db: &dyn SyntaxGroup, struct_ast: &ItemStruct) -> E
 }
 
 fn format_generics_with_trait(
-    type_generics: &Vec<SmolStr>,
-    other_generics: &Vec<String>,
+    type_generics: &[SmolStr],
+    other_generics: &[String],
     f: impl Fn(&SmolStr) -> String,
 ) -> String {
     format!(
@@ -105,7 +105,7 @@ fn format_generics_with_trait(
     )
 }
 
-fn format_generics(type_generics: &Vec<SmolStr>, other_generics: &Vec<String>) -> String {
+fn format_generics(type_generics: &[SmolStr], other_generics: &[String]) -> String {
     format!(
         "<{}{}>",
         type_generics.iter().map(|s| format!("{}, ", s)).collect::<String>(),
@@ -312,7 +312,8 @@ fn get_partial_eq_impl(name: &str, extra_info: &ExtraInfo) -> String {
                 }).join("\n        "),
                 generics = format_generics(type_generics, other_generics),
                 // TODO(spapini): Remove the Destruct requirement by changing member borrowing logic to recognize snapshots.
-                generics_impl = format_generics_with_trait(type_generics, other_generics, |t| format!("impl {t}PartialEq: PartialEq<{t}>, impl {t}Destruct: Destruct<{t}>"))
+                generics_impl = format_generics_with_trait(type_generics, other_generics,
+                    |t| format!("impl {t}PartialEq: PartialEq<{t}>, impl {t}Destruct: Destruct<{t}>"))
             }
         }
         ExtraInfo::Extern => unreachable!(),

--- a/crates/cairo-lang-plugins/src/plugins/derive.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive.rs
@@ -7,7 +7,9 @@ use cairo_lang_semantic::plugin::{AsDynMacroPlugin, SemanticPlugin, TrivialPlugi
 use cairo_lang_syntax::attribute::structured::{
     AttributeArg, AttributeArgVariant, AttributeStructurize,
 };
-use cairo_lang_syntax::node::ast::{AttributeList, MemberList};
+use cairo_lang_syntax::node::ast::{
+    AttributeList, ItemStruct, MemberList, OptionWrappedGenericParamList,
+};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{ast, Terminal};
@@ -26,7 +28,10 @@ impl MacroPlugin for DerivePlugin {
                 db,
                 struct_ast.name(db),
                 struct_ast.attributes(db),
-                ExtraInfo::Struct(member_names(db, struct_ast.members(db))),
+                ExtraInfo::Struct(
+                    member_names(db, struct_ast.members(db)),
+                    extract_generics(db, &struct_ast),
+                ),
             ),
             ast::Item::Enum(enum_ast) => generate_derive_code_for_type(
                 db,
@@ -56,12 +61,47 @@ impl SemanticPlugin for DerivePlugin {}
 
 enum ExtraInfo {
     Enum(Vec<SmolStr>),
-    Struct(Vec<SmolStr>),
+    Struct(Vec<SmolStr>, Vec<SmolStr>),
     Extern,
 }
 
 fn member_names(db: &dyn SyntaxGroup, members: MemberList) -> Vec<SmolStr> {
     members.elements(db).into_iter().map(|member| member.name(db).text(db)).collect()
+}
+
+fn extract_generics(db: &dyn SyntaxGroup, struct_ast: &ItemStruct) -> Vec<SmolStr> {
+    match struct_ast.generic_params(db) {
+        OptionWrappedGenericParamList::WrappedGenericParamList(gens) => gens
+            .generic_params(db)
+            .elements(db)
+            .into_iter()
+            .map(|member| match member {
+                ast::GenericParam::Type(t) => t.name(db).text(db),
+                ast::GenericParam::Const(c) => c.name(db).text(db),
+                ast::GenericParam::Impl(i) => i.name(db).text(db),
+            })
+            .collect(),
+        OptionWrappedGenericParamList::Empty(_) => vec![],
+    }
+}
+
+fn format_generics_with_trait(
+    generic_args: &Vec<SmolStr>,
+    f: impl Fn(&SmolStr) -> String,
+) -> String {
+    match generic_args.is_empty() {
+        true => "".into(),
+        false => {
+            format!("<{}, {}>", generic_args.join(", "), generic_args.iter().map(f).join(", "))
+        }
+    }
+}
+
+fn format_generics(generic_args: &Vec<SmolStr>) -> String {
+    match generic_args.is_empty() {
+        true => "".into(),
+        false => format!("<{}>", generic_args.iter().join(", ")),
+    }
 }
 
 /// Adds an implementation for all requested derives for the type.
@@ -107,7 +147,7 @@ fn generate_derive_code_for_type(
             let name = ident.text(db);
             let derived = segment.ident(db).text(db);
             match derived.as_str() {
-                "Copy" | "Drop" => impls.push(get_empty_impl(&name, &derived)),
+                "Copy" | "Drop" => impls.push(get_empty_impl(&name, &derived, &extra_info)),
                 "Clone" if !matches!(extra_info, ExtraInfo::Extern) => {
                     impls.push(get_clone_impl(&name, &extra_info))
                 }
@@ -163,18 +203,21 @@ fn get_clone_impl(name: &str, extra_info: &ExtraInfo) -> String {
                 format!("{name}::{variant}(x) => {name}::{variant}(x.clone()),")
             }).join("\n            ")}
         }
-        ExtraInfo::Struct(members) => {
+        ExtraInfo::Struct(members, generic_args) => {
             formatdoc! {"
-                    impl {name}Clone of Clone::<{name}> {{
-                        fn clone(self: @{name}) -> {name} {{
+                    impl {name}Clone{generics_impl} of Clone::<{name}{generics}> {{
+                        fn clone(self: @{name}{generics}) -> {name}{generics} {{
                             {name} {{
                                 {}
                             }}
                         }}
                     }}
                 ", members.iter().map(|member| {
-                format!("{member}: self.{member}.clone(),")
-            }).join("\n            ")}
+                    format!("{member}: self.{member}.clone(),")
+                }).join("\n            "),
+                generics = format_generics(generic_args),
+                generics_impl = format_generics_with_trait(generic_args, |t| format!("impl {t}Clone: Clone<{t}>"))
+            }
         }
         ExtraInfo::Extern => unreachable!(),
     }
@@ -195,16 +238,19 @@ fn get_destruct_impl(name: &str, extra_info: &ExtraInfo) -> String {
                 format!("{name}::{variant}(x) => traits::Destruct::destruct(x),")
             }).join("\n            ")}
         }
-        ExtraInfo::Struct(members) => {
+        ExtraInfo::Struct(members, generic_args) => {
             formatdoc! {"
-                    impl {name}Destruct of Destruct::<{name}> {{
-                        fn destruct(self: {name}) nopanic {{
+                    impl {name}Destruct{generics_impl} of Destruct::<{name}{generics}> {{
+                        fn destruct(self: {name}{generics}) nopanic {{
                             {}
                         }}
                     }}
                 ", members.iter().map(|member| {
-                format!("traits::Destruct::destruct(self.{member});")
-            }).join("\n        ")}
+                            format!("traits::Destruct::destruct(self.{member});")
+                        }).join("\n        "),
+                        generics = format_generics(generic_args),
+                        generics_impl = format_generics_with_trait(generic_args, |t| format!("impl {t}Destruct: Destruct<{t}>"))
+            }
         }
         ExtraInfo::Extern => unreachable!(),
     }
@@ -238,23 +284,26 @@ fn get_partial_eq_impl(name: &str, extra_info: &ExtraInfo) -> String {
                 )
             }).join("\n            ")}
         }
-        ExtraInfo::Struct(members) => {
+        ExtraInfo::Struct(members, generic_args) => {
             formatdoc! {"
-                    impl {name}PartialEq of PartialEq::<{name}> {{
+                    impl {name}PartialEq{generics_impl} of PartialEq::<{name}{generics}> {{
                         #[inline(always)]
-                        fn eq(lhs: {name}, rhs: {name}) -> bool {{
+                        fn eq(lhs: {name}{generics}, rhs: {name}{generics}) -> bool {{
                             {}
                             true
                         }}
                         #[inline(always)]
-                        fn ne(lhs: {name}, rhs: {name}) -> bool {{
+                        fn ne(lhs: {name}{generics}, rhs: {name}{generics}) -> bool {{
                             !(lhs == rhs)
                         }}
                     }}
                 ", members.iter().map(|member| {
-                // TODO(orizi): Use `&&` when supported.
-                format!("if lhs.{member} != rhs.{member} {{ return false; }}")
-            }).join("\n        ")}
+                            // TODO(orizi): Use `&&` when supported.
+                            format!("if lhs.{member} != rhs.{member} {{ return false; }}")
+                        }).join("\n        "),
+                        generics = format_generics(generic_args),
+                        generics_impl = format_generics_with_trait(generic_args, |t| format!("impl {t}Destruct: Destruct<{t}>"))
+            }
         }
         ExtraInfo::Extern => unreachable!(),
     }
@@ -291,13 +340,13 @@ fn get_serde_impl(name: &str, extra_info: &ExtraInfo) -> String {
                 }).join("\n            else "),
             }
         }
-        ExtraInfo::Struct(members) => {
+        ExtraInfo::Struct(members, generic_args) => {
             formatdoc! {"
-                    impl {name}Serde of serde::Serde::<{name}> {{
-                        fn serialize(self: @{name}, ref output: array::Array<felt252>) {{
+                    impl {name}Serde{generics_impl} of serde::Serde::<{name}{generics}> {{
+                        fn serialize(self: @{name}{generics}, ref output: array::Array<felt252>) {{
                             {}
                         }}
-                        fn deserialize(ref serialized: array::Span<felt252>) -> Option<{name}> {{
+                        fn deserialize(ref serialized: array::Span<felt252>) -> Option<{name}{generics}> {{
                             Option::Some({name} {{
                                 {}
                             }})
@@ -306,12 +355,24 @@ fn get_serde_impl(name: &str, extra_info: &ExtraInfo) -> String {
                 ",
                 members.iter().map(|member| format!("serde::Serde::serialize(self.{member}, ref output)")).join(";\n        "),
                 members.iter().map(|member| format!("{member}: serde::Serde::deserialize(ref serialized)?,")).join("\n            "),
+                generics = format_generics(generic_args),
+                generics_impl = format_generics_with_trait(generic_args, |t| format!("impl {t}Destruct: Destruct<{t}>"))
             }
         }
         ExtraInfo::Extern => unreachable!(),
     }
 }
 
-fn get_empty_impl(name: &str, derived_trait: &str) -> String {
-    format!("impl {name}{derived_trait} of {derived_trait}::<{name}>;\n")
+fn get_empty_impl(name: &str, derived_trait: &str, extra_info: &ExtraInfo) -> String {
+    match extra_info {
+        ExtraInfo::Struct(_, generic_args) => format!(
+            "impl {name}{derived_trait}{generics_impl} of {derived_trait}::<{name}{generics}>;\n",
+            generics = format_generics(generic_args),
+            generics_impl = format_generics_with_trait(generic_args, |t| format!(
+                "impl {t}{dt}: {dt}<{t}>",
+                dt = derived_trait
+            ))
+        ),
+        _ => format!("impl {name}{derived_trait} of {derived_trait}::<{name}>;\n"),
+    }
 }

--- a/crates/cairo-lang-plugins/src/plugins/derive.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive.rs
@@ -97,28 +97,20 @@ fn format_generics_with_trait(
     other_generics: &Vec<String>,
     f: impl Fn(&SmolStr) -> String,
 ) -> String {
-    match (type_generics.is_empty(), other_generics.is_empty()) {
-        (true, true) => "".into(),
-        (true, false) => format!("<{}>", other_generics.join(", ")),
-        (false, true) => {
-            format!("<{}, {}>", type_generics.join(", "), type_generics.iter().map(f).join(", "))
-        }
-        (false, false) => format!(
-            "<{}, {}, {}>",
-            type_generics.join(", "),
-            other_generics.join(", "),
-            type_generics.iter().map(f).join(", ")
-        ),
-    }
+    format!(
+        "<{}{}{}>",
+        type_generics.iter().map(|s| format!("{}, ", s)).collect::<String>(),
+        other_generics.iter().map(|s| format!("{}, ", s)).collect::<String>(),
+        type_generics.iter().map(f).join(", "),
+    )
 }
 
 fn format_generics(type_generics: &Vec<SmolStr>, other_generics: &Vec<String>) -> String {
-    match (type_generics.is_empty(), other_generics.is_empty()) {
-        (true, true) => "".into(),
-        (true, false) => format!("<{}>", other_generics.join(", ")),
-        (false, true) => format!("<{}>", type_generics.join(", ")),
-        (false, false) => format!("<{}, {}>", type_generics.join(", "), other_generics.join(", ")),
-    }
+    format!(
+        "<{}{}>",
+        type_generics.iter().map(|s| format!("{}, ", s)).collect::<String>(),
+        other_generics.iter().map(|s| format!("{}, ", s)).collect::<String>(),
+    )
 }
 
 /// Adds an implementation for all requested derives for the type.
@@ -233,7 +225,7 @@ fn get_clone_impl(name: &str, extra_info: &ExtraInfo) -> String {
                     format!("{member}: self.{member}.clone(),")
                 }).join("\n            "),
                 generics = format_generics(type_generics, other_generics),
-                generics_impl = format_generics_with_trait(type_generics, other_generics, |t| format!("impl {t}Clone: Clone<{t}>"))
+                generics_impl = format_generics_with_trait(type_generics, other_generics, |t| format!("impl {t}Clone: Clone<{t}>, impl {t}Destruct: Destruct<{t}>"))
             }
         }
         ExtraInfo::Extern => unreachable!(),
@@ -319,7 +311,7 @@ fn get_partial_eq_impl(name: &str, extra_info: &ExtraInfo) -> String {
                             format!("if lhs.{member} != rhs.{member} {{ return false; }}")
                         }).join("\n        "),
                         generics = format_generics(type_generics, other_generics),
-                        generics_impl = format_generics_with_trait(type_generics, other_generics, |t| format!("impl {t}PartialEq: PartialEq<{t}>"))
+                        generics_impl = format_generics_with_trait(type_generics, other_generics, |t| format!("impl {t}PartialEq: PartialEq<{t}>, impl {t}Destruct: Destruct<{t}>"))
             }
         }
         ExtraInfo::Extern => unreachable!(),
@@ -373,7 +365,7 @@ fn get_serde_impl(name: &str, extra_info: &ExtraInfo) -> String {
                 member_names.iter().map(|member| format!("serde::Serde::serialize(ref output, input.{member})")).join(";\n        "),
                 member_names.iter().map(|member| format!("{member}: serde::Serde::deserialize(ref serialized)?,")).join("\n            "),
                 generics = format_generics(type_generics, other_generics),
-                generics_impl = format_generics_with_trait(type_generics, other_generics, |t| format!("impl {t}Serde: serde::Serde<{t}>"))
+                generics_impl = format_generics_with_trait(type_generics, other_generics, |t| format!("impl {t}Serde: serde::Serde<{t}>, impl {t}Destruct: Destruct<{t}>"))
             }
         }
         ExtraInfo::Extern => unreachable!(),
@@ -385,10 +377,9 @@ fn get_empty_impl(name: &str, derived_trait: &str, extra_info: &ExtraInfo) -> St
         ExtraInfo::Struct { type_generics, other_generics, .. } => format!(
             "impl {name}{derived_trait}{generics_impl} of {derived_trait}::<{name}{generics}>;\n",
             generics = format_generics(type_generics, other_generics),
-            generics_impl =
-                format_generics_with_trait(type_generics, other_generics, |t| format!(
-                    "impl {t}{derived_trait}: {derived_trait}<{t}>"
-                ))
+            generics_impl = format_generics_with_trait(type_generics, other_generics, |t| format!(
+                "impl {t}{derived_trait}: {derived_trait}<{t}>"
+            ))
         ),
         _ => format!("impl {name}{derived_trait} of {derived_trait}::<{name}>;\n"),
     }

--- a/crates/cairo-lang-plugins/src/test_data/derive
+++ b/crates/cairo-lang-plugins/src/test_data/derive
@@ -16,8 +16,16 @@ struct TwoMemberStruct {
     b: B,
 }
 
+#[derive(Copy, Destruct)]
+struct GenericStruct<T> {
+    a: T,
+}
+
+
+trait SomeTrait<T, U> {}
+
 #[derive(Drop, Clone, PartialEq, Serde)]
-struct TwoMemberGenericStruct<T, U> {
+struct TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>> {
     a: T,
     b: U,
 }
@@ -92,39 +100,56 @@ impl TwoMemberStructSerde of serde::Serde::<TwoMemberStruct> {
 }
 
 
+#[derive(Copy, Destruct)]
+struct GenericStruct<T> {
+    a: T,
+}
+
+impl GenericStructCopy<T, impl TCopy: Copy<T>> of Copy::<GenericStruct<T>>;
+impl GenericStructDestruct<T, impl TDestruct: Destruct<T>> of Destruct::<GenericStruct<T>> {
+    fn destruct(self: GenericStruct<T>) nopanic {
+        traits::Destruct::destruct(self.a);
+    }
+}
+
+
+
+trait SomeTrait<T, U> {}
+
+
 #[derive(Drop, Clone, PartialEq, Serde)]
-struct TwoMemberGenericStruct<T, U> {
+struct TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>> {
     a: T,
     b: U,
 }
 
-impl TwoMemberGenericStructDrop<T, U, impl TDrop: Drop<T>, impl UDrop: Drop<U>> of Drop::<TwoMemberGenericStruct<T, U>>;
-impl TwoMemberGenericStructClone<T, U, impl TClone: Clone<T>, impl UClone: Clone<U>> of Clone::<TwoMemberGenericStruct<T, U>> {
-    fn clone(self: @TwoMemberGenericStruct<T, U>) -> TwoMemberGenericStruct<T, U> {
+impl TwoMemberGenericStructDrop<T, U, impl USomeTrait: SomeTrait<U, T>, impl TDrop: Drop<T>, impl UDrop: Drop<U>> of Drop::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>>;
+impl TwoMemberGenericStructClone<T, U, impl USomeTrait: SomeTrait<U, T>, impl TClone: Clone<T>, impl UClone: Clone<U>> of Clone::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>> {
+    fn clone(self: @TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>) -> TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>> {
         TwoMemberGenericStruct {
             a: self.a.clone(),
             b: self.b.clone(),
         }
     }
 }
-impl TwoMemberGenericStructPartialEq<T, U, impl TDestruct: Destruct<T>, impl UDestruct: Destruct<U>> of PartialEq::<TwoMemberGenericStruct<T, U>> {
+impl TwoMemberGenericStructPartialEq<T, U, impl USomeTrait: SomeTrait<U, T>, impl TPartialEq: PartialEq<T>, impl UPartialEq: PartialEq<U>> of PartialEq::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>> {
     #[inline(always)]
-    fn eq(lhs: TwoMemberGenericStruct<T, U>, rhs: TwoMemberGenericStruct<T, U>) -> bool {
+    fn eq(lhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>, rhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>) -> bool {
         if lhs.a != rhs.a { return false; }
         if lhs.b != rhs.b { return false; }
         true
     }
     #[inline(always)]
-    fn ne(lhs: TwoMemberGenericStruct<T, U>, rhs: TwoMemberGenericStruct<T, U>) -> bool {
+    fn ne(lhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>, rhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>) -> bool {
         !(lhs == rhs)
     }
 }
-impl TwoMemberGenericStructSerde<T, U, impl TDestruct: Destruct<T>, impl UDestruct: Destruct<U>> of serde::Serde::<TwoMemberGenericStruct<T, U>> {
-    fn serialize(ref output: array::Array<felt252>, input: TwoMemberGenericStruct<T, U>) {
+impl TwoMemberGenericStructSerde<T, U, impl USomeTrait: SomeTrait<U, T>, impl TSerde: serde::Serde<T>, impl USerde: serde::Serde<U>> of serde::Serde::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>> {
+    fn serialize(ref output: array::Array<felt252>, input: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>) {
         serde::Serde::serialize(ref output, input.a);
         serde::Serde::serialize(ref output, input.b)
     }
-    fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberGenericStruct<T, U>> {
+    fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>> {
         Option::Some(TwoMemberGenericStruct {
             a: serde::Serde::deserialize(ref serialized)?,
             b: serde::Serde::deserialize(ref serialized)?,

--- a/crates/cairo-lang-plugins/src/test_data/derive
+++ b/crates/cairo-lang-plugins/src/test_data/derive
@@ -87,7 +87,7 @@ impl TwoMemberStructPartialEq<> of PartialEq::<TwoMemberStruct<>> {
     }
 }
 impl TwoMemberStructSerde<> of serde::Serde::<TwoMemberStruct<>> {
-    fn serialize(ref output: array::Array<felt252>, input: TwoMemberStruct<>) {
+    fn serialize(self: @TwoMemberStruct<>, ref output: array::Array<felt252>) {
         serde::Serde::serialize(self.a, ref output);
         serde::Serde::serialize(self.b, ref output)
     }
@@ -145,9 +145,9 @@ impl TwoMemberGenericStructPartialEq<T, U, impl USomeTrait: SomeTrait<U, T>, imp
     }
 }
 impl TwoMemberGenericStructSerde<T, U, impl USomeTrait: SomeTrait<U, T>, impl TSerde: serde::Serde<T>, impl TDestruct: Destruct<T>, impl USerde: serde::Serde<U>, impl UDestruct: Destruct<U>> of serde::Serde::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >> {
-    fn serialize(ref output: array::Array<felt252>, input: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >) {
-        serde::Serde::serialize(ref output, input.a);
-        serde::Serde::serialize(ref output, input.b)
+    fn serialize(self: @TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >, ref output: array::Array<felt252>) {
+        serde::Serde::serialize(self.a, ref output);
+        serde::Serde::serialize(self.b, ref output)
     }
     fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >> {
         Option::Some(TwoMemberGenericStruct {

--- a/crates/cairo-lang-plugins/src/test_data/derive
+++ b/crates/cairo-lang-plugins/src/test_data/derive
@@ -16,6 +16,12 @@ struct TwoMemberStruct {
     b: B,
 }
 
+#[derive(Drop, Clone, PartialEq, Serde)]
+struct TwoMemberGenericStruct<T, U> {
+    a: T,
+    b: U,
+}
+
 #[derive(Clone, Destruct, PartialEq, Serde)]
 enum TwoVariantEnum {
     First: A,
@@ -79,6 +85,47 @@ impl TwoMemberStructSerde of serde::Serde::<TwoMemberStruct> {
     }
     fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberStruct> {
         Option::Some(TwoMemberStruct {
+            a: serde::Serde::deserialize(ref serialized)?,
+            b: serde::Serde::deserialize(ref serialized)?,
+        })
+    }
+}
+
+
+#[derive(Drop, Clone, PartialEq, Serde)]
+struct TwoMemberGenericStruct<T, U> {
+    a: T,
+    b: U,
+}
+
+impl TwoMemberGenericStructDrop<T, U, impl TDrop: Drop<T>, impl UDrop: Drop<U>> of Drop::<TwoMemberGenericStruct<T, U>>;
+impl TwoMemberGenericStructClone<T, U, impl TClone: Clone<T>, impl UClone: Clone<U>> of Clone::<TwoMemberGenericStruct<T, U>> {
+    fn clone(self: @TwoMemberGenericStruct<T, U>) -> TwoMemberGenericStruct<T, U> {
+        TwoMemberGenericStruct {
+            a: self.a.clone(),
+            b: self.b.clone(),
+        }
+    }
+}
+impl TwoMemberGenericStructPartialEq<T, U, impl TDestruct: Destruct<T>, impl UDestruct: Destruct<U>> of PartialEq::<TwoMemberGenericStruct<T, U>> {
+    #[inline(always)]
+    fn eq(lhs: TwoMemberGenericStruct<T, U>, rhs: TwoMemberGenericStruct<T, U>) -> bool {
+        if lhs.a != rhs.a { return false; }
+        if lhs.b != rhs.b { return false; }
+        true
+    }
+    #[inline(always)]
+    fn ne(lhs: TwoMemberGenericStruct<T, U>, rhs: TwoMemberGenericStruct<T, U>) -> bool {
+        !(lhs == rhs)
+    }
+}
+impl TwoMemberGenericStructSerde<T, U, impl TDestruct: Destruct<T>, impl UDestruct: Destruct<U>> of serde::Serde::<TwoMemberGenericStruct<T, U>> {
+    fn serialize(ref output: array::Array<felt252>, input: TwoMemberGenericStruct<T, U>) {
+        serde::Serde::serialize(ref output, input.a);
+        serde::Serde::serialize(ref output, input.b)
+    }
+    fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberGenericStruct<T, U>> {
+        Option::Some(TwoMemberGenericStruct {
             a: serde::Serde::deserialize(ref serialized)?,
             b: serde::Serde::deserialize(ref serialized)?,
         })

--- a/crates/cairo-lang-plugins/src/test_data/derive
+++ b/crates/cairo-lang-plugins/src/test_data/derive
@@ -43,15 +43,15 @@ extern type ExternType;
 #[derive(Copy, Drop)]
 struct A{}
 
-impl ACopy of Copy::<A>;
-impl ADrop of Drop::<A>;
+impl ACopy<> of Copy::<A<>>;
+impl ADrop<> of Drop::<A<>>;
 
 
 #[derive(Copy, Drop)]
 struct B{}
 
-impl BCopy of Copy::<B>;
-impl BDrop of Drop::<B>;
+impl BCopy<> of Copy::<B<>>;
+impl BDrop<> of Drop::<B<>>;
 
 
 #[derive(Clone, Destruct, PartialEq, Serde)]
@@ -60,38 +60,38 @@ struct TwoMemberStruct {
     b: B,
 }
 
-impl TwoMemberStructClone of Clone::<TwoMemberStruct> {
-    fn clone(self: @TwoMemberStruct) -> TwoMemberStruct {
+impl TwoMemberStructClone<> of Clone::<TwoMemberStruct<>> {
+    fn clone(self: @TwoMemberStruct<>) -> TwoMemberStruct<> {
         TwoMemberStruct {
             a: self.a.clone(),
             b: self.b.clone(),
         }
     }
 }
-impl TwoMemberStructDestruct of Destruct::<TwoMemberStruct> {
-    fn destruct(self: TwoMemberStruct) nopanic {
+impl TwoMemberStructDestruct<> of Destruct::<TwoMemberStruct<>> {
+    fn destruct(self: TwoMemberStruct<>) nopanic {
         traits::Destruct::destruct(self.a);
         traits::Destruct::destruct(self.b);
     }
 }
-impl TwoMemberStructPartialEq of PartialEq::<TwoMemberStruct> {
+impl TwoMemberStructPartialEq<> of PartialEq::<TwoMemberStruct<>> {
     #[inline(always)]
-    fn eq(lhs: TwoMemberStruct, rhs: TwoMemberStruct) -> bool {
+    fn eq(lhs: TwoMemberStruct<>, rhs: TwoMemberStruct<>) -> bool {
         if lhs.a != rhs.a { return false; }
         if lhs.b != rhs.b { return false; }
         true
     }
     #[inline(always)]
-    fn ne(lhs: TwoMemberStruct, rhs: TwoMemberStruct) -> bool {
+    fn ne(lhs: TwoMemberStruct<>, rhs: TwoMemberStruct<>) -> bool {
         !(lhs == rhs)
     }
 }
-impl TwoMemberStructSerde of serde::Serde::<TwoMemberStruct> {
-    fn serialize(self: @TwoMemberStruct, ref output: array::Array<felt252>) {
+impl TwoMemberStructSerde<> of serde::Serde::<TwoMemberStruct<>> {
+    fn serialize(ref output: array::Array<felt252>, input: TwoMemberStruct<>) {
         serde::Serde::serialize(self.a, ref output);
         serde::Serde::serialize(self.b, ref output)
     }
-    fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberStruct> {
+    fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberStruct<>> {
         Option::Some(TwoMemberStruct {
             a: serde::Serde::deserialize(ref serialized)?,
             b: serde::Serde::deserialize(ref serialized)?,
@@ -105,9 +105,9 @@ struct GenericStruct<T> {
     a: T,
 }
 
-impl GenericStructCopy<T, impl TCopy: Copy<T>> of Copy::<GenericStruct<T>>;
-impl GenericStructDestruct<T, impl TDestruct: Destruct<T>> of Destruct::<GenericStruct<T>> {
-    fn destruct(self: GenericStruct<T>) nopanic {
+impl GenericStructCopy<T, impl TCopy: Copy<T>> of Copy::<GenericStruct<T, >>;
+impl GenericStructDestruct<T, impl TDestruct: Destruct<T>> of Destruct::<GenericStruct<T, >> {
+    fn destruct(self: GenericStruct<T, >) nopanic {
         traits::Destruct::destruct(self.a);
     }
 }
@@ -123,33 +123,33 @@ struct TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>> {
     b: U,
 }
 
-impl TwoMemberGenericStructDrop<T, U, impl USomeTrait: SomeTrait<U, T>, impl TDrop: Drop<T>, impl UDrop: Drop<U>> of Drop::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>>;
-impl TwoMemberGenericStructClone<T, U, impl USomeTrait: SomeTrait<U, T>, impl TClone: Clone<T>, impl UClone: Clone<U>> of Clone::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>> {
-    fn clone(self: @TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>) -> TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>> {
+impl TwoMemberGenericStructDrop<T, U, impl USomeTrait: SomeTrait<U, T>, impl TDrop: Drop<T>, impl UDrop: Drop<U>> of Drop::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >>;
+impl TwoMemberGenericStructClone<T, U, impl USomeTrait: SomeTrait<U, T>, impl TClone: Clone<T>, impl TDestruct: Destruct<T>, impl UClone: Clone<U>, impl UDestruct: Destruct<U>> of Clone::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >> {
+    fn clone(self: @TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >) -> TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, > {
         TwoMemberGenericStruct {
             a: self.a.clone(),
             b: self.b.clone(),
         }
     }
 }
-impl TwoMemberGenericStructPartialEq<T, U, impl USomeTrait: SomeTrait<U, T>, impl TPartialEq: PartialEq<T>, impl UPartialEq: PartialEq<U>> of PartialEq::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>> {
+impl TwoMemberGenericStructPartialEq<T, U, impl USomeTrait: SomeTrait<U, T>, impl TPartialEq: PartialEq<T>, impl TDestruct: Destruct<T>, impl UPartialEq: PartialEq<U>, impl UDestruct: Destruct<U>> of PartialEq::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >> {
     #[inline(always)]
-    fn eq(lhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>, rhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>) -> bool {
+    fn eq(lhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >, rhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >) -> bool {
         if lhs.a != rhs.a { return false; }
         if lhs.b != rhs.b { return false; }
         true
     }
     #[inline(always)]
-    fn ne(lhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>, rhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>) -> bool {
+    fn ne(lhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >, rhs: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >) -> bool {
         !(lhs == rhs)
     }
 }
-impl TwoMemberGenericStructSerde<T, U, impl USomeTrait: SomeTrait<U, T>, impl TSerde: serde::Serde<T>, impl USerde: serde::Serde<U>> of serde::Serde::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>> {
-    fn serialize(ref output: array::Array<felt252>, input: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>) {
+impl TwoMemberGenericStructSerde<T, U, impl USomeTrait: SomeTrait<U, T>, impl TSerde: serde::Serde<T>, impl TDestruct: Destruct<T>, impl USerde: serde::Serde<U>, impl UDestruct: Destruct<U>> of serde::Serde::<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >> {
+    fn serialize(ref output: array::Array<felt252>, input: TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >) {
         serde::Serde::serialize(ref output, input.a);
         serde::Serde::serialize(ref output, input.b)
     }
-    fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>>> {
+    fn deserialize(ref serialized: array::Span<felt252>) -> Option<TwoMemberGenericStruct<T, U, impl USomeTrait: SomeTrait<U, T>, >> {
         Option::Some(TwoMemberGenericStruct {
             a: serde::Serde::deserialize(ref serialized)?,
             b: serde::Serde::deserialize(ref serialized)?,

--- a/tests/bug_samples/issue2964.cairo
+++ b/tests/bug_samples/issue2964.cairo
@@ -15,12 +15,6 @@ struct GenericStruct<T, U> {
     y: U,
 }
 
-// TODO(spapini): This doesn't actually work, fails with 'unknown literal' on U
-//#[derive(Drop)]
-struct GenericStructConst<T, const U: felt252> {
-    x: T, 
-}
-
 #[test]
 fn main() {
     // This assumes that Drop implies Destruct and Copy implies Clone
@@ -28,7 +22,7 @@ fn main() {
     a.x.x = 34;
     a.y.y = 5;
     let mut serialized = ArrayTrait::<felt252>::new();
-    serde::Serde::serialize(ref serialized, a);
+    a.serialize(ref serialized);
     let mut as_span = serialized.span();
     let deserialized = serde::Serde::<GenericStruct<SimpleStruct,
     SimpleStruct>>::deserialize(ref as_span).unwrap();

--- a/tests/bug_samples/issue2964.cairo
+++ b/tests/bug_samples/issue2964.cairo
@@ -1,0 +1,21 @@
+#[derive(Copy, Drop)]
+struct GenericStruct<T, U> {
+    x: T,
+    y: U,
+}
+
+//#[derive(Drop)]
+struct GenericStructConst<T, const U: felt252> {
+    x: T, 
+}
+
+// This doesn't actually work, fails with 'unknown literal' on U
+//impl GSCDrop<T, const U: felt252> of Destruct<GenericStructConst<T, U>> {
+//    fn destruct(self: GenericStructConst<T, U>) nopanic {}
+//}
+
+#[test]
+fn main() {
+    let a = GenericStruct { x: 1, y: 2 };
+//let b = GenericStructConst::<felt252, 245> { x: 1 };
+}

--- a/tests/bug_samples/issue2964.cairo
+++ b/tests/bug_samples/issue2964.cairo
@@ -1,21 +1,36 @@
-#[derive(Copy, Drop)]
+use serde::Serde;
+use clone::Clone;
+use array::ArrayTrait;
+use option::OptionTrait;
+
+#[derive(Copy, Drop, Serde, PartialEq)]
+struct SimpleStruct {
+    x: felt252,
+    y: felt252,
+}
+
+#[derive(Copy, Clone, Destruct, Serde, PartialEq)]
 struct GenericStruct<T, U> {
     x: T,
     y: U,
 }
 
+// TODO(spapini): This doesn't actually work, fails with 'unknown literal' on U
 //#[derive(Drop)]
 struct GenericStructConst<T, const U: felt252> {
     x: T, 
 }
 
-// This doesn't actually work, fails with 'unknown literal' on U
-//impl GSCDrop<T, const U: felt252> of Destruct<GenericStructConst<T, U>> {
-//    fn destruct(self: GenericStructConst<T, U>) nopanic {}
-//}
-
 #[test]
 fn main() {
-    let a = GenericStruct { x: 1, y: 2 };
-//let b = GenericStructConst::<felt252, 245> { x: 1 };
+    // This assumes that Drop implies Destruct and Copy implies Clone
+    let mut a = GenericStruct { x: SimpleStruct { x: 1, y: 2 }, y: SimpleStruct { x: 1, y: 2 } };
+    a.x.x = 34;
+    a.y.y = 5;
+    let mut serialized = ArrayTrait::<felt252>::new();
+    serde::Serde::serialize(ref serialized, a);
+    let mut as_span = serialized.span();
+    let deserialized = serde::Serde::<GenericStruct<SimpleStruct,
+    SimpleStruct>>::deserialize(ref as_span).unwrap();
+    assert(a == deserialized, 'Bad Serde');
 }

--- a/tests/bug_samples/lib.cairo
+++ b/tests/bug_samples/lib.cairo
@@ -14,6 +14,7 @@ mod issue2820;
 mod issue2932;
 mod issue2939;
 mod issue2961;
+mod issue2964;
 mod loop_only_change;
 mod inconsistent_gas;
 mod partial_param_local;


### PR DESCRIPTION
Fix #2956 

This implements derive support for all existing derive for structs with generic types.
I haven't done it for enums but can be added (not sure if those can take generic types?).

Also wondering if this should be actually tested in cairo somewhere ?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2964)
<!-- Reviewable:end -->
