### PR TITLE
Replace OutputVarReferenceInfo::NewTempVar { idx: None } with SimpleDerefs.

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/store_variables/state.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/state.rs
@@ -3,6 +3,7 @@ use cairo_lang_sierra::extensions::lib_func::{
     BranchSignature, DeferredOutputKind, OutputVarInfo, SierraApChange,
 };
 use cairo_lang_sierra::extensions::OutputVarReferenceInfo;
+use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 
 use super::known_stack::KnownStack;
@@ -95,7 +96,7 @@ impl State {
                 });
             }
             OutputVarReferenceInfo::NewTempVar { idx } => {
-                add_to_known_stack = idx.map(|idx| idx.try_into().unwrap());
+                add_to_known_stack = Some(idx.into_or_panic::<isize>());
                 is_temp_var = true;
             }
             OutputVarReferenceInfo::SimpleDerefs => {

--- a/crates/cairo-lang-sierra-generator/src/store_variables/test.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/test.rs
@@ -128,7 +128,7 @@ fn get_lib_func_signature(db: &dyn SierraGenGroup, libfunc: ConcreteLibfuncId) -
             let vars: Vec<_> = (0..4)
                 .map(|idx| OutputVarInfo {
                     ty: felt252_ty.clone(),
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(idx) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx },
                 })
                 .collect();
             LibfuncSignature {
@@ -186,7 +186,7 @@ fn get_lib_func_signature(db: &dyn SierraGenGroup, libfunc: ConcreteLibfuncId) -
             branch_signatures: vec![BranchSignature {
                 vars: vec![OutputVarInfo {
                     ty: felt252_ty,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                 }],
                 ap_change: SierraApChange::Known { new_vars_only: true },
             }],
@@ -197,7 +197,7 @@ fn get_lib_func_signature(db: &dyn SierraGenGroup, libfunc: ConcreteLibfuncId) -
             vec![OutputVarInfo {
                 ty: felt252_ty,
                 // Simulate the case where the returned value is not on the top of the stack.
-                ref_info: OutputVarReferenceInfo::NewTempVar { idx: None },
+                ref_info: OutputVarReferenceInfo::SimpleDerefs,
             }],
             SierraApChange::Known { new_vars_only: false },
         ),

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
@@ -205,7 +205,7 @@ fn calc_output_var_stack_idx<'a, ParamRef: Fn(usize) -> &'a ReferenceValue>(
     param_ref: &ParamRef,
 ) -> Option<usize> {
     match ref_info {
-        OutputVarReferenceInfo::NewTempVar { idx } => idx.map(|idx| stack_base + idx),
+        OutputVarReferenceInfo::NewTempVar { idx } => Some(stack_base + idx),
         OutputVarReferenceInfo::SameAsParam { param_idx } if !clear_old_stack => {
             param_ref(*param_idx).stack_idx
         }

--- a/crates/cairo-lang-sierra/src/extensions/lib_func.rs
+++ b/crates/cairo-lang-sierra/src/extensions/lib_func.rs
@@ -338,10 +338,13 @@ pub enum OutputVarReferenceInfo {
     /// Information, such as whether the parameter was a temporary or local variable, will be
     /// copied to the output variable.
     PartialParam { param_idx: usize },
-    /// The output was allocated as a temporary variable.
-    /// For the outputs that are at the top of the stack (contiguously), contains the index of the
-    /// temporary variable in the stack (0 is the lowest variable).
-    NewTempVar { idx: Option<usize> },
+    /// The output was allocated as a temporary variable and it is at the top of the stack
+    /// (contiguously).
+    NewTempVar {
+        /// The index of the temporary variable in the stack (0 is the variable with the lowest
+        /// memory address).
+        idx: usize,
+    },
     /// The output was allocated as a local variable.
     NewLocalVar,
     /// The output is the result of a computation. For example `[ap] + [fp]`,

--- a/crates/cairo-lang-sierra/src/extensions/modules/array.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/array.rs
@@ -67,7 +67,7 @@ impl SignatureOnlyGenericLibfunc for ArrayNewLibfunc {
             vec![],
             vec![OutputVarInfo {
                 ty: context.get_wrapped_concrete_type(ArrayType::id(), ty)?,
-                ref_info: OutputVarReferenceInfo::NewTempVar { idx: None },
+                ref_info: OutputVarReferenceInfo::SimpleDerefs,
             }],
             SierraApChange::Known { new_vars_only: false },
         ))

--- a/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
@@ -52,7 +52,7 @@ impl SignatureAndTypeGenericLibfunc for IntoBoxLibfuncWrapped {
             vec![ty.clone()],
             vec![OutputVarInfo {
                 ty: context.get_wrapped_concrete_type(BoxType::id(), ty)?,
-                ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
             }],
             SierraApChange::Known { new_vars_only: true },
         ))

--- a/crates/cairo-lang-sierra/src/extensions/modules/ec.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/ec.rs
@@ -339,7 +339,7 @@ impl NoGenericArgsGenericLibfunc for EcStateFinalizeLibfunc {
                 BranchSignature {
                     vars: vec![OutputVarInfo {
                         ty: nonzero_ecpoint_ty,
-                        ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                        ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                     }],
                     ap_change: SierraApChange::Known { new_vars_only: false },
                 },

--- a/crates/cairo-lang-sierra/src/extensions/modules/felt252.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/felt252.rs
@@ -102,7 +102,7 @@ impl GenericLibfunc for Felt252BinaryOperationWithVarLibfunc {
         let ty = context.get_concrete_type(Felt252Type::id(), &[])?;
         let (second_param_type, output_ref_info) =
             if matches!(self.operator, Felt252BinaryOperator::Div) {
-                (nonzero_ty(context, &ty)?, OutputVarReferenceInfo::NewTempVar { idx: Some(0) })
+                (nonzero_ty(context, &ty)?, OutputVarReferenceInfo::NewTempVar { idx: 0 })
             } else {
                 (ty.clone(), OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic))
             };

--- a/crates/cairo-lang-sierra/src/extensions/modules/felt252_dict.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/felt252_dict.rs
@@ -174,7 +174,7 @@ impl SignatureOnlyGenericLibfunc for Felt252DictReadLibfunc {
                 },
                 OutputVarInfo {
                     ty: generic_ty,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                 },
             ],
             SierraApChange::Known { new_vars_only: true },
@@ -211,19 +211,19 @@ impl SignatureOnlyGenericLibfunc for Felt252DictSquashLibfunc {
             vec![
                 OutputVarInfo {
                     ty: range_check_type,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                 },
                 OutputVarInfo {
                     ty: gas_builtin_type,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(1) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 1 },
                 },
                 OutputVarInfo {
                     ty: segment_arena_ty,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(2) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 2 },
                 },
                 OutputVarInfo {
                     ty: squashed_dict_ty,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(3) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 3 },
                 },
             ],
             SierraApChange::Unknown,

--- a/crates/cairo-lang-sierra/src/extensions/modules/function_call.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/function_call.rs
@@ -29,7 +29,7 @@ impl NamedLibfunc for FunctionCallLibfunc {
                         .enumerate()
                         .map(|(i, ty)| OutputVarInfo {
                             ty: ty.clone(),
-                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(i) },
+                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: i },
                         })
                         .collect(),
                     ap_change,

--- a/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
@@ -70,7 +70,7 @@ impl NoGenericArgsGenericLibfunc for WithdrawGasLibfunc {
                         },
                         OutputVarInfo {
                             ty: gas_builtin_type.clone(),
-                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                         },
                     ],
                     ap_change: SierraApChange::Known { new_vars_only: false },
@@ -274,7 +274,7 @@ impl NoGenericArgsGenericLibfunc for BuiltinCostWithdrawGasLibfunc {
                         },
                         OutputVarInfo {
                             ty: gas_builtin_type.clone(),
-                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                         },
                     ],
                     ap_change: SierraApChange::Known { new_vars_only: false },

--- a/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned.rs
@@ -191,7 +191,7 @@ impl<TUintTraits: UintTraits> NoGenericArgsGenericLibfunc for UintSquareRootLibf
                 },
                 OutputVarInfo {
                     ty: sqrt_ty,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                 },
             ],
             SierraApChange::Known { new_vars_only: false },
@@ -331,12 +331,12 @@ impl<TUintTraits: UintTraits> GenericLibfunc for UintOperationLibfunc<TUintTrait
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
 
         let wrapping_result_ref_info = match (self.operator, TUintTraits::IS_SMALL) {
-            (IntOperator::OverflowingAdd, true) => OutputVarReferenceInfo::NewTempVar { idx: None },
+            (IntOperator::OverflowingAdd, true) => OutputVarReferenceInfo::SimpleDerefs,
             (IntOperator::OverflowingSub, true) => {
                 OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic)
             }
             (IntOperator::OverflowingAdd, false) | (IntOperator::OverflowingSub, false) => {
-                OutputVarReferenceInfo::NewTempVar { idx: Some(0) }
+                OutputVarReferenceInfo::NewTempVar { idx: 0 }
             }
         };
 
@@ -362,7 +362,7 @@ impl<TUintTraits: UintTraits> GenericLibfunc for UintOperationLibfunc<TUintTrait
                         },
                         OutputVarInfo {
                             ty: ty.clone(),
-                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                         },
                     ],
                     ap_change: SierraApChange::Known { new_vars_only: false },
@@ -470,9 +470,9 @@ impl<TUintTraits: UintTraits> NoGenericArgsGenericLibfunc for UintDivmodLibfunc<
                 },
                 OutputVarInfo {
                     ty: ty.clone(),
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                 },
-                OutputVarInfo { ty, ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(1) } },
+                OutputVarInfo { ty, ref_info: OutputVarReferenceInfo::NewTempVar { idx: 1 } },
             ],
             SierraApChange::Known { new_vars_only: false },
         ))

--- a/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned128.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned128.rs
@@ -140,7 +140,7 @@ impl GenericLibfunc for Uint128OperationLibfunc {
                         },
                         OutputVarInfo {
                             ty: ty.clone(),
-                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                         },
                     ],
                     ap_change: SierraApChange::Known { new_vars_only: false },
@@ -156,7 +156,7 @@ impl GenericLibfunc for Uint128OperationLibfunc {
                         },
                         OutputVarInfo {
                             ty,
-                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                         },
                     ],
                     ap_change: SierraApChange::Known { new_vars_only: false },
@@ -195,12 +195,12 @@ impl NoGenericArgsGenericLibfunc for U128GuaranteeMulLibfunc {
                 // High.
                 OutputVarInfo {
                     ty: u128_type.clone(),
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                 },
                 // Low.
                 OutputVarInfo {
                     ty: u128_type,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(1) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 1 },
                 },
                 // Guarantee.
                 OutputVarInfo {
@@ -293,11 +293,11 @@ impl NoGenericArgsGenericLibfunc for Uint128sFromFelt252Libfunc {
                         },
                         OutputVarInfo {
                             ty: context.get_concrete_type(Uint128Type::id(), &[])?,
-                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                         },
                         OutputVarInfo {
                             ty: context.get_concrete_type(Uint128Type::id(), &[])?,
-                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(1) },
+                            ref_info: OutputVarReferenceInfo::NewTempVar { idx: 1 },
                         },
                     ],
                     ap_change: SierraApChange::Known { new_vars_only: false },

--- a/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned256.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned256.rs
@@ -82,11 +82,8 @@ impl NoGenericArgsGenericLibfunc for Uint256DivmodLibfunc {
                         param_idx: 0,
                     }),
                 },
-                OutputVarInfo {
-                    ty: ty.clone(),
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: None },
-                },
-                OutputVarInfo { ty, ref_info: OutputVarReferenceInfo::NewTempVar { idx: None } },
+                OutputVarInfo { ty: ty.clone(), ref_info: OutputVarReferenceInfo::SimpleDerefs },
+                OutputVarInfo { ty, ref_info: OutputVarReferenceInfo::SimpleDerefs },
             ],
             SierraApChange::Known { new_vars_only: false },
         ))
@@ -123,7 +120,7 @@ impl NoGenericArgsGenericLibfunc for Uint256SquareRootLibfunc {
                 },
                 OutputVarInfo {
                     ty: context.get_concrete_type(Uint128Type::id(), &[])?,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: None },
+                    ref_info: OutputVarReferenceInfo::SimpleDerefs,
                 },
             ],
             SierraApChange::Known { new_vars_only: false },

--- a/crates/cairo-lang-sierra/src/extensions/modules/mem.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/mem.rs
@@ -41,10 +41,7 @@ impl SignatureAndTypeGenericLibfunc for StoreTempLibfuncWrapped {
                 allow_add_const: true,
                 allow_const: true,
             }],
-            vec![OutputVarInfo {
-                ty,
-                ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
-            }],
+            vec![OutputVarInfo { ty, ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 } }],
             SierraApChange::Known { new_vars_only: true },
         ))
     }

--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/storage.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/storage.rs
@@ -166,7 +166,7 @@ impl NoGenericArgsGenericLibfunc for StorageBaseAddressFromFelt252Libfunc {
                 },
                 OutputVarInfo {
                     ty: context.get_concrete_type(StorageBaseAddressType::id(), &[])?,
-                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: Some(0) },
+                    ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                 },
             ],
             SierraApChange::Known { new_vars_only: false },


### PR DESCRIPTION
**Stack**:
- #2986
- #2983 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/2983)
<!-- Reviewable:end -->
