### PR TITLE
Add a .nvmrc file and update the README with info about NVM

### DIFF
--- a/vscode-cairo/.nvmrc
+++ b/vscode-cairo/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/vscode-cairo/README.md
+++ b/vscode-cairo/README.md
@@ -1,9 +1,13 @@
 # Installation
 
-Install Node.js 18 LTS:
+Use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to get the correct version of Node for this project. From the directory of this file, run:
+```
+nvm use
+```
+or install Node.js 18 LTS manually:
 See troubleshooting section.
 
-From the directory of this file, run:
+Still in the directory of this file, run:
 
 ```
 sudo npm install --global @vscode/vsce

--- a/vscode-cairo/README.md
+++ b/vscode-cairo/README.md
@@ -1,6 +1,8 @@
 # Installation
 
-Use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to get the correct version of Node for this project. From the directory of this file, run:
+Use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to get the correct version of Node
+for this project. From the directory of this file, run:
+
 ```
 nvm use
 ```
@@ -57,7 +59,8 @@ If successful, go back to `sudo npm install -g vsce` and continue from there.
 
 # Debugging
 
-To make the "Debug"/"Run" CodeLens above your tests work - add this to your ~/.config/Code/User/settings.json:
+To make the "Debug"/"Run" CodeLens above your tests work - add this to your
+~/.config/Code/User/settings.json:
 
 ```
 "rust-analyzer.runnableEnv": {
@@ -65,7 +68,8 @@ To make the "Debug"/"Run" CodeLens above your tests work - add this to your ~/.c
 },
 ```
 
-If you also want logs to be printed in your VSCode terminal when you click the "Debug"/"Run" CodeLens above your tests, also add the "RUST_LOG" field:
+If you also want logs to be printed in your VSCode terminal when you click the "Debug"/"Run"
+CodeLens above your tests, also add the "RUST_LOG" field:
 
 ```
 "rust-analyzer.runnableEnv": {


### PR DESCRIPTION
This PR will solve the issue [#3011](https://github.com/starkware-libs/cairo/issues/3011).

* A new file that defines the Node version to use is added, .nvmrc
* README is updated to mention that it is possible to use NVM

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3012)
<!-- Reviewable:end -->
