### PR TITLE
feat: impl Into<T,T>

### DIFF
--- a/corelib/src/debug.cairo
+++ b/corelib/src/debug.cairo
@@ -84,8 +84,8 @@ impl U128PrintImpl of PrintTrait<u128> {
 
 impl U256PrintImpl of PrintTrait<u256> {
     fn print(self: u256) {
-        self.low.into().print();
-        self.high.into().print();
+        Into::<u128, felt252>::into(self.low);
+        Into::<u128, felt252>::into(self.high);
     }
 }
 

--- a/corelib/src/serde.cairo
+++ b/corelib/src/serde.cairo
@@ -68,7 +68,7 @@ impl U64Serde of Serde<u64> {
 
 impl U128Serde of Serde<u128> {
     fn serialize(self: @u128, ref output: Array<felt252>) {
-        (*self).into().serialize(ref output);
+        Into::<u128, felt252>::into(*self).serialize(ref output);
     }
     fn deserialize(ref serialized: Span<felt252>) -> Option<u128> {
         Option::Some(((*serialized.pop_front()?).try_into())?)

--- a/corelib/src/test/integer_test.cairo
+++ b/corelib/src/test/integer_test.cairo
@@ -708,7 +708,7 @@ fn test_max_u128_plus_1_overflow() {
 #[test]
 #[should_panic]
 fn test_max_u256_plus_1_overflow() {
-    BoundedInt::max() + 1.into();
+    BoundedInt::max() + Into::<felt252, u256>::into(1);
 }
 
 #[test]
@@ -786,6 +786,27 @@ fn proper_cast() {
     assert(cast_must_pass(0xFFFFFFFF_u32, 0xFFFFFFFF_u128), 'u32 to_and_fro u128');
     assert(cast_must_pass(0xFFFFFFFFFFFFFFFF_u64, 0xFFFFFFFFFFFFFFFF_u128), 'u64 to_and_fro u128');
 }
+
+#[test]
+fn test_into_self_type() {
+    assert(0xFF_u8.into() == 0xFF_u8, 'u8 into u8');
+    assert(0xFFFF_u16.into() == 0xFFFF_u16, 'u16 into u16');
+    assert(0xFFFFFFFF_u32.into() == 0xFFFFFFFF_u32, 'u32 into u32');
+    assert(0xFFFFFFFFFFFFFFFF_u64.into() == 0xFFFFFFFFFFFFFFFF_u64, 'u64 into u64');
+    assert(
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u128.into() == 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u128,
+        'u128 into u128'
+    );
+    assert(
+        u256 {
+            low: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, high: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+            }.into() == u256 {
+            high: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, low: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        },
+        'u256 into u256'
+    );
+}
+
 #[test]
 #[should_panic]
 fn panic_u16_u8_1() {

--- a/corelib/src/traits.cairo
+++ b/corelib/src/traits.cairo
@@ -80,6 +80,12 @@ trait Into<T, S> {
     fn into(self: T) -> S;
 }
 
+impl TIntoT<T> of Into<T, T> {
+    fn into(self: T) -> T {
+        self
+    }
+}
+
 /// Trait for fallible conversion between types.
 trait TryInto<T, S> {
     fn try_into(self: T) -> Option<S>;

--- a/tests/bug_samples/issue2171.cairo
+++ b/tests/bug_samples/issue2171.cairo
@@ -1,5 +1,12 @@
 use traits::Into;
+use starknet::ContractAddress;
 
-fn foo(contract_address: starknet::ContractAddress) {
-    assert(contract_address.into() == contract_address.into(), 'Some message');
+fn foo(contract_address: ContractAddress) {
+    assert(
+        Into::<ContractAddress,
+        felt252>::into(
+            contract_address
+        ) == Into::<ContractAddress, felt252>::into(contract_address),
+        'Some message'
+    );
 }


### PR DESCRIPTION
This PR includes the following:
- Implementation for `Into<T,T>` added into traits.cairo
- Fix inferences issues caused by the implementation
- Testing Into<Numeric, Numeric>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3036)
<!-- Reviewable:end -->
