### PR TITLE
Expose `run_tests` in test runner

### DIFF
--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -228,7 +228,7 @@ pub struct TestsSummary {
 }
 
 /// Runs the tests and process the results for a summary.
-fn run_tests(
+pub fn run_tests(
     named_tests: Vec<(String, TestConfig)>,
     sierra_program: cairo_lang_sierra::program::Program,
     function_set_costs: OrderedHashMap<FunctionId, OrderedHashMap<CostTokenType, i32>>,


### PR DESCRIPTION
Can we expose this function as a public one? We need this in protostar. Thanks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3126)
<!-- Reviewable:end -->
