### PR TITLE
feat: SpanSerde

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -113,6 +113,19 @@ struct Span<T> {
 impl SpanCopy<T> of Copy<Span<T>>;
 impl SpanDrop<T> of Drop<Span<T>>;
 
+impl SpanSerde<T, impl TSerde: Serde<T>, impl TDrop: Drop<T>> of Serde<Span<T>> {
+    fn serialize(self: @Span<T>, ref output: Array<felt252>) {
+        (*self).len().serialize(ref output);
+        serialize_array_helper(*self, ref output)
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<Span<T>> {
+        let length = *serialized.pop_front()?;
+        let mut arr = array_new();
+        Option::Some(deserialize_array_helper(ref serialized, arr, length)?.span())
+    }
+}
+
 #[generate_trait]
 impl SpanImpl<T> of SpanTrait<T> {
     #[inline(always)]


### PR DESCRIPTION
There's no Serde implementation for Spans. That means we can't for example emit events with Spans. This won't compile:

```rust
#[contract]
mod Foo {
    use array::SpanTrait;

    #[event]
    fn Sup(values: Span<u8>) {}

    #[external]
    fn do_something(s: Span<u8>) {
        Sup(s);
    }
}
```

The error is:

```sh
error: Trait has no implementation in context: core::serde::Serde::<core::array::Span::<core::integer::u8>>
 --> contract:21:35
        serde::Serde::<Span<u8>>::serialize(@values, ref __data);
                                  ^*******^

error: Trait has no implementation in context: core::serde::Serde::<core::array::Span::<core::integer::u8>>
 --> contract:53:43
                serde::Serde::<Span<u8>>::deserialize(ref data).expect('Input too short for arguments');
                                          ^*********^

Error: Compilation failed.
```

This PR adds a `SpanSerde` that fixes the above error. I hope it's just as simple as I imagine it to be, please tell me if I'm missing something.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3145)
<!-- Reviewable:end -->
