### PR TITLE
Fix `calldata` parameter clash in ABI

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -73,7 +73,7 @@ pub fn handle_trait(db: &dyn SyntaxGroup, trait_ast: ast::ItemTrait) -> PluginRe
                     serialization_code.push(RewriteNode::interpolate_patched(
                         &formatdoc!(
                             "        serde::Serde::<{type_name}>::serialize(@$arg_name$, ref \
-                             calldata);\n"
+                             LOCAL_CALLDATA);\n"
                         ),
                         HashMap::from([(
                             "arg_name".to_string(),
@@ -233,13 +233,13 @@ fn declaration_method_impl(
 ) -> RewriteNode {
     RewriteNode::interpolate_patched(
         "$func_decl$ {
-        let mut calldata = array::ArrayTrait::new();
+        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
 $serialization_code$
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::$syscall$(
                 self.$member$,
                 $entry_point_selector$,
-                array::ArrayTrait::span(@calldata),
+                array::ArrayTrait::span(@LOCAL_CALLDATA),
             )
         );
 $deserialization_code$

--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -73,7 +73,7 @@ pub fn handle_trait(db: &dyn SyntaxGroup, trait_ast: ast::ItemTrait) -> PluginRe
                     serialization_code.push(RewriteNode::interpolate_patched(
                         &formatdoc!(
                             "        serde::Serde::<{type_name}>::serialize(@$arg_name$, ref \
-                             LOCAL_CALLDATA);\n"
+                             ABI_CALLDATA);\n"
                         ),
                         HashMap::from([(
                             "arg_name".to_string(),
@@ -233,13 +233,13 @@ fn declaration_method_impl(
 ) -> RewriteNode {
     RewriteNode::interpolate_patched(
         "$func_decl$ {
-        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
+        let mut ABI_CALLDATA = array::ArrayTrait::new();
 $serialization_code$
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::$syscall$(
                 self.$member$,
                 $entry_point_selector$,
-                array::ArrayTrait::span(@LOCAL_CALLDATA),
+                array::ArrayTrait::span(@ABI_CALLDATA),
             )
         );
 $deserialization_code$

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/dispatcher
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/dispatcher
@@ -40,15 +40,15 @@ struct IContractDispatcher {
 
 impl IContractDispatcherImpl of IContractDispatcherTrait::<IContractDispatcher> {
     fn get_something(self: IContractDispatcher, arg: felt252, num: felt252) -> felt252 {
-        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
-        serde::Serde::<felt252>::serialize(@arg, ref LOCAL_CALLDATA);
-        serde::Serde::<felt252>::serialize(@num, ref LOCAL_CALLDATA);
+        let mut ABI_CALLDATA = array::ArrayTrait::new();
+        serde::Serde::<felt252>::serialize(@arg, ref ABI_CALLDATA);
+        serde::Serde::<felt252>::serialize(@num, ref ABI_CALLDATA);
 
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::call_contract_syscall(
                 self.contract_address,
                 0x3c52d61651de3dcab6ceaa9f6505f7aed8f1ffc0f694ce2a9ed76e758d87a3,
-                array::ArrayTrait::span(@LOCAL_CALLDATA),
+                array::ArrayTrait::span(@ABI_CALLDATA),
             )
         );
 
@@ -59,13 +59,13 @@ impl IContractDispatcherImpl of IContractDispatcherTrait::<IContractDispatcher> 
     }
 
     fn empty(self: IContractDispatcher, ) {
-        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
+        let mut ABI_CALLDATA = array::ArrayTrait::new();
 
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::call_contract_syscall(
                 self.contract_address,
                 0x1fc3f77ebc090777f567969ad9823cf6334ab888acb385ca72668ec5adbde80,
-                array::ArrayTrait::span(@LOCAL_CALLDATA),
+                array::ArrayTrait::span(@ABI_CALLDATA),
             )
         );
 
@@ -80,15 +80,15 @@ struct IContractLibraryDispatcher {
 
 impl IContractLibraryDispatcherImpl of IContractDispatcherTrait::<IContractLibraryDispatcher> {
     fn get_something(self: IContractLibraryDispatcher, arg: felt252, num: felt252) -> felt252 {
-        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
-        serde::Serde::<felt252>::serialize(@arg, ref LOCAL_CALLDATA);
-        serde::Serde::<felt252>::serialize(@num, ref LOCAL_CALLDATA);
+        let mut ABI_CALLDATA = array::ArrayTrait::new();
+        serde::Serde::<felt252>::serialize(@arg, ref ABI_CALLDATA);
+        serde::Serde::<felt252>::serialize(@num, ref ABI_CALLDATA);
 
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::syscalls::library_call_syscall(
                 self.class_hash,
                 0x3c52d61651de3dcab6ceaa9f6505f7aed8f1ffc0f694ce2a9ed76e758d87a3,
-                array::ArrayTrait::span(@LOCAL_CALLDATA),
+                array::ArrayTrait::span(@ABI_CALLDATA),
             )
         );
 
@@ -99,13 +99,13 @@ impl IContractLibraryDispatcherImpl of IContractDispatcherTrait::<IContractLibra
     }
 
     fn empty(self: IContractLibraryDispatcher, ) {
-        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
+        let mut ABI_CALLDATA = array::ArrayTrait::new();
 
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::syscalls::library_call_syscall(
                 self.class_hash,
                 0x1fc3f77ebc090777f567969ad9823cf6334ab888acb385ca72668ec5adbde80,
-                array::ArrayTrait::span(@LOCAL_CALLDATA),
+                array::ArrayTrait::span(@ABI_CALLDATA),
             )
         );
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/dispatcher
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/dispatcher
@@ -40,15 +40,15 @@ struct IContractDispatcher {
 
 impl IContractDispatcherImpl of IContractDispatcherTrait::<IContractDispatcher> {
     fn get_something(self: IContractDispatcher, arg: felt252, num: felt252) -> felt252 {
-        let mut calldata = array::ArrayTrait::new();
-        serde::Serde::<felt252>::serialize(@arg, ref calldata);
-        serde::Serde::<felt252>::serialize(@num, ref calldata);
+        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
+        serde::Serde::<felt252>::serialize(@arg, ref LOCAL_CALLDATA);
+        serde::Serde::<felt252>::serialize(@num, ref LOCAL_CALLDATA);
 
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::call_contract_syscall(
                 self.contract_address,
                 0x3c52d61651de3dcab6ceaa9f6505f7aed8f1ffc0f694ce2a9ed76e758d87a3,
-                array::ArrayTrait::span(@calldata),
+                array::ArrayTrait::span(@LOCAL_CALLDATA),
             )
         );
 
@@ -59,13 +59,13 @@ impl IContractDispatcherImpl of IContractDispatcherTrait::<IContractDispatcher> 
     }
 
     fn empty(self: IContractDispatcher, ) {
-        let mut calldata = array::ArrayTrait::new();
+        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
 
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::call_contract_syscall(
                 self.contract_address,
                 0x1fc3f77ebc090777f567969ad9823cf6334ab888acb385ca72668ec5adbde80,
-                array::ArrayTrait::span(@calldata),
+                array::ArrayTrait::span(@LOCAL_CALLDATA),
             )
         );
 
@@ -80,15 +80,15 @@ struct IContractLibraryDispatcher {
 
 impl IContractLibraryDispatcherImpl of IContractDispatcherTrait::<IContractLibraryDispatcher> {
     fn get_something(self: IContractLibraryDispatcher, arg: felt252, num: felt252) -> felt252 {
-        let mut calldata = array::ArrayTrait::new();
-        serde::Serde::<felt252>::serialize(@arg, ref calldata);
-        serde::Serde::<felt252>::serialize(@num, ref calldata);
+        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
+        serde::Serde::<felt252>::serialize(@arg, ref LOCAL_CALLDATA);
+        serde::Serde::<felt252>::serialize(@num, ref LOCAL_CALLDATA);
 
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::syscalls::library_call_syscall(
                 self.class_hash,
                 0x3c52d61651de3dcab6ceaa9f6505f7aed8f1ffc0f694ce2a9ed76e758d87a3,
-                array::ArrayTrait::span(@calldata),
+                array::ArrayTrait::span(@LOCAL_CALLDATA),
             )
         );
 
@@ -99,13 +99,13 @@ impl IContractLibraryDispatcherImpl of IContractDispatcherTrait::<IContractLibra
     }
 
     fn empty(self: IContractLibraryDispatcher, ) {
-        let mut calldata = array::ArrayTrait::new();
+        let mut LOCAL_CALLDATA = array::ArrayTrait::new();
 
         let mut ret_data = starknet::SyscallResultTrait::unwrap_syscall(
             starknet::syscalls::library_call_syscall(
                 self.class_hash,
                 0x1fc3f77ebc090777f567969ad9823cf6334ab888acb385ca72668ec5adbde80,
-                array::ArrayTrait::span(@calldata),
+                array::ArrayTrait::span(@LOCAL_CALLDATA),
             )
         );
 

--- a/tests/bug_samples/issue3192.cairo
+++ b/tests/bug_samples/issue3192.cairo
@@ -1,0 +1,25 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+use option::OptionTrait;
+use serde::Serde;
+use serde::serialize_array_helper;
+use serde::deserialize_array_helper;
+
+#[abi]
+trait IContract {
+    fn foo(calldata: Span<felt252>);
+}
+
+impl SpanSerde<
+    T, impl TSerde: Serde<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>
+> of Serde<Span<T>> {
+    fn serialize(self: @Span<T>, ref output: Array<felt252>) {
+        (*self).len().serialize(ref output);
+        serialize_array_helper(*self, ref output);
+    }
+    fn deserialize(ref serialized: Span<felt252>) -> Option<Span<T>> {
+        let length = *serialized.pop_front()?;
+        let mut arr = ArrayTrait::new();
+        Option::Some(deserialize_array_helper(ref serialized, arr, length)?.span())
+    }
+}

--- a/tests/bug_samples/issue3192.cairo
+++ b/tests/bug_samples/issue3192.cairo
@@ -1,25 +1,4 @@
-use array::ArrayTrait;
-use array::SpanTrait;
-use option::OptionTrait;
-use serde::Serde;
-use serde::serialize_array_helper;
-use serde::deserialize_array_helper;
-
 #[abi]
 trait IContract {
-    fn foo(calldata: Span<felt252>);
-}
-
-impl SpanSerde<
-    T, impl TSerde: Serde<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>
-> of Serde<Span<T>> {
-    fn serialize(self: @Span<T>, ref output: Array<felt252>) {
-        (*self).len().serialize(ref output);
-        serialize_array_helper(*self, ref output);
-    }
-    fn deserialize(ref serialized: Span<felt252>) -> Option<Span<T>> {
-        let length = *serialized.pop_front()?;
-        let mut arr = ArrayTrait::new();
-        Option::Some(deserialize_array_helper(ref serialized, arr, length)?.span())
-    }
+    fn foo(calldata: felt252);
 }

--- a/tests/bug_samples/lib.cairo
+++ b/tests/bug_samples/lib.cairo
@@ -15,6 +15,7 @@ mod issue2932;
 mod issue2939;
 mod issue2961;
 mod issue2964;
+mod issue3192;
 mod loop_only_change;
 mod inconsistent_gas;
 mod partial_param_local;


### PR DESCRIPTION
This PR resolves #3192.

If the reviewers prefer a different variable name than `ABI_CALLDATA`, I'll update accordingly. 