### PR TITLE
feat: keccak_uint256s_be output in big-endian

### DIFF
--- a/corelib/src/keccak.cairo
+++ b/corelib/src/keccak.cairo
@@ -18,6 +18,12 @@ fn u128_split(input: u128) -> (u64, u64) {
     (u128_to_u64(high), u128_to_u64(low))
 }
 
+fn uint256_reverse_endian(input: u256) -> u256 {
+    u256 {
+        low: integer::u128_byte_reverse(input.high), high: integer::u128_byte_reverse(input.low)
+    }
+}
+
 fn keccak_add_uint256_le(ref keccak_input: Array::<u64>, v: u256) {
     let (high, low) = u128_split(v.low);
     keccak_input.append(low);
@@ -29,7 +35,7 @@ fn keccak_add_uint256_le(ref keccak_input: Array::<u64>, v: u256) {
 
 
 // Computes the keccak256 of multiple uint256 values.
-// The values are interpreted as little-endian.
+// The input and output are interpreted as little-endian.
 fn keccak_uint256s_le(mut input: Span<u256>) -> u256 {
     let mut keccak_input: Array::<u64> = ArrayTrait::new();
 
@@ -58,7 +64,7 @@ fn keccak_add_uint256_be(ref keccak_input: Array::<u64>, v: u256) {
 }
 
 // Computes the keccak256 of multiple uint256 values.
-// The values are interpreted as big-endian.
+// The input and output are interpreted as big-endian.
 fn keccak_uint256s_be(mut input: Span<u256>) -> u256 {
     let mut keccak_input: Array::<u64> = ArrayTrait::new();
 
@@ -74,7 +80,7 @@ fn keccak_uint256s_be(mut input: Span<u256>) -> u256 {
     };
 
     add_padding(ref keccak_input);
-    starknet::syscalls::keccak_syscall(keccak_input.span()).unwrap_syscall()
+    uint256_reverse_endian(starknet::syscalls::keccak_syscall(keccak_input.span()).unwrap_syscall())
 }
 
 

--- a/corelib/src/test/keccak_test.cairo
+++ b/corelib/src/test/keccak_test.cairo
@@ -44,8 +44,8 @@ fn test_keccak_hash() {
 
     let res = keccak::keccak_uint256s_be(input.span());
 
-    assert_eq(res.low, 0x326a7e71fdcdee263b071276522d0eb1, 'Wrong hash value3');
-    assert_eq(res.high, 0xf60cfab7e2cb9f2d73b0c2fa4a4bf40c, 'Wrong hash value4');
+    assert_eq(res.low, 0x0cf44b4afac2b0732d9fcbe2b7fa0cf6, 'Wrong hash value3');
+    assert_eq(res.high, 0xb10e2d527612073b26eecdfd717e6a32, 'Wrong hash value4');
 
     input.append(u256 { low: 2, high: 0 });
     input.append(u256 { low: 3, high: 0 });
@@ -56,6 +56,6 @@ fn test_keccak_hash() {
     assert_eq(res.high, 0x17a2126cf7391a26b41c36a687090cc5, 'Wrong hash value6');
 
     let res = keccak::keccak_uint256s_be(input.span());
-    assert_eq(res.low, 0x6510e6fd534f267a01086462df912739, 'Wrong hash value7');
-    assert_eq(res.high, 0x2d9982dfaf468a9ddf7101b6323aa9d5, 'Wrong hash value8');
+    assert_eq(res.low, 0xd5a93a32b60171df9d8a46afdf82992d, 'Wrong hash value7');
+    assert_eq(res.high, 0x392791df626408017a264f53fde61065, 'Wrong hash value8');
 }


### PR DESCRIPTION
The function `keccak_uint256s_be` takes input in big-endian format but returns output in little-endian format, which is not only inconvenient for users but also incompatible with the expression of `cairo_keccak_felts_bigend` in Cairo0. 
This commit reverses the return value of `keccak_uint256s_be` to represent it in big-endian format, similar to the usage of keccak256 in Solidity. This provides convenience for migrating EVM contracts to Cairo1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3222)
<!-- Reviewable:end -->
