### PR TITLE
Moved TestCollector to the TestRunner crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,8 @@ dependencies = [
  "cairo-lang-runner",
  "cairo-lang-semantic",
  "cairo-lang-sierra",
+ "cairo-lang-sierra-ap-change",
+ "cairo-lang-sierra-gas",
  "cairo-lang-sierra-generator",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-starknet",
@@ -906,9 +908,11 @@ dependencies = [
  "colored",
  "itertools",
  "num-bigint",
+ "num-integer",
  "num-traits 0.2.15",
  "rayon",
  "salsa",
+ "serde",
  "thiserror",
 ]
 

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -23,6 +23,8 @@ cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "1.1.0-rc0" }
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "1.1.0-rc0" }
 cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "1.1.0-rc0" }
 cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "1.1.0-rc0" }
+cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "1.1.0-rc0" }
+cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "1.1.0-rc0" }
 cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "1.1.0-rc0" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "1.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "1.1.0-rc0" }
@@ -32,6 +34,8 @@ colored.workspace = true
 itertools.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
+num-integer.workspace = true
+serde.workspace = true
 rayon.workspace = true
 salsa.workspace = true
 thiserror.workspace = true

--- a/crates/cairo-lang-test-runner/src/casm_generator.rs
+++ b/crates/cairo-lang-test-runner/src/casm_generator.rs
@@ -1,0 +1,330 @@
+//! Basic runner for running a Sierra program on the vm.
+use std::collections::HashMap;
+
+use cairo_felt::Felt252;
+use cairo_lang_casm::instructions::Instruction;
+use cairo_lang_casm::{casm, casm_extend};
+use cairo_lang_sierra::extensions::bitwise::BitwiseType;
+use cairo_lang_sierra::extensions::core::{CoreLibfunc, CoreType};
+use cairo_lang_sierra::extensions::ec::EcOpType;
+use cairo_lang_sierra::extensions::gas::GasBuiltinType;
+use cairo_lang_sierra::extensions::pedersen::PedersenType;
+use cairo_lang_sierra::extensions::range_check::RangeCheckType;
+use cairo_lang_sierra::extensions::segment_arena::SegmentArenaType;
+use cairo_lang_sierra::extensions::starknet::syscalls::SystemType;
+use cairo_lang_sierra::extensions::{ConcreteType, NamedType};
+use cairo_lang_sierra::program::Function;
+use cairo_lang_sierra::program_registry::{ProgramRegistry, ProgramRegistryError};
+use cairo_lang_sierra_ap_change::{calc_ap_changes, ApChangeError};
+use cairo_lang_sierra_gas::gas_info::GasInfo;
+use cairo_lang_sierra_to_casm::compiler::{CairoProgram, CompilationError};
+use cairo_lang_sierra_to_casm::metadata::{calc_metadata, Metadata, MetadataError};
+use cairo_lang_utils::bigint::{deserialize_big_uint, serialize_big_uint, BigUintAsHex};
+use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
+use itertools::chain;
+use num_bigint::BigUint;
+use num_integer::Integer;
+use num_traits::{Num, Signed};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GeneratorError {
+    #[error("Failed calculating gas usage, it is likely a call for `get_gas` is missing.")]
+    FailedGasCalculation,
+    #[error("Function with suffix `{suffix}` to run not found.")]
+    MissingFunction { suffix: String },
+    #[error("Function expects arguments of size {expected} and received {actual} instead.")]
+    ArgumentsSizeMismatch { expected: usize, actual: usize },
+    #[error(transparent)]
+    ProgramRegistryError(#[from] Box<ProgramRegistryError>),
+    #[error(transparent)]
+    SierraCompilationError(#[from] CompilationError),
+    #[error(transparent)]
+    ApChangeError(#[from] ApChangeError),
+    #[error(transparent)]
+    VirtualMachineError(#[from] Box<VirtualMachineError>),
+    #[error("At least one test expected but none detected.")]
+    NoTestsDetected,
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestEntrypoint {
+    pub offset: usize,
+    pub name: String,
+}
+
+pub struct TestConfig {
+    pub name: String,
+    pub available_gas: Option<usize>,
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtostarCasm {
+    #[serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")]
+    pub prime: BigUint,
+    pub bytecode: Vec<BigUintAsHex>,
+    pub hints: Vec<(usize, Vec<String>)>,
+    pub test_entry_points: Vec<TestEntrypoint>,
+}
+
+pub struct SierraCasmGenerator {
+    /// The sierra program.
+    sierra_program: cairo_lang_sierra::program::Program,
+    /// Program registry for the Sierra program.
+    sierra_program_registry: ProgramRegistry<CoreType, CoreLibfunc>,
+    /// The casm program matching the Sierra code.
+    casm_program: CairoProgram,
+}
+
+impl SierraCasmGenerator {
+    pub fn new(
+        sierra_program: cairo_lang_sierra::program::Program,
+    ) -> Result<Self, GeneratorError> {
+        let metadata = create_metadata(&sierra_program, true)?;
+        let sierra_program_registry =
+            ProgramRegistry::<CoreType, CoreLibfunc>::new(&sierra_program)?;
+        let casm_program =
+            cairo_lang_sierra_to_casm::compiler::compile(&sierra_program, &metadata, true)
+                .expect("Compilation failed.");
+        Ok(Self { sierra_program, sierra_program_registry, casm_program })
+    }
+
+    pub fn build_casm(
+        &self,
+        collected_tests: &Vec<TestConfig>,
+    ) -> Result<ProtostarCasm, GeneratorError> {
+        if collected_tests.is_empty() {
+            return Err(GeneratorError::NoTestsDetected);
+        }
+        let mut entry_codes_offsets = Vec::new();
+        for test in collected_tests {
+            let func = self.find_function(&test.name)?;
+            let initial_gas =
+                if let Some(config_gas) = test.available_gas { config_gas } else { usize::MAX };
+            let (_, _, offset) = self.create_entry_code(func, &vec![], initial_gas, 0)?;
+            entry_codes_offsets.push(offset);
+        }
+
+        let mut entry_codes = Vec::new();
+        let mut acc = entry_codes_offsets.iter().sum();
+        acc -= entry_codes_offsets[0];
+        let mut i = 0;
+        for test in collected_tests {
+            let func = self.find_function(&test.name)?;
+            let initial_gas =
+                if let Some(config_gas) = test.available_gas { config_gas } else { usize::MAX };
+            let (proper_entry_code, _, _) =
+                self.create_entry_code(func, &vec![], initial_gas, acc)?;
+            if entry_codes_offsets.len() > i + 1 {
+                acc -= entry_codes_offsets[i + 1];
+                i += 1;
+            }
+            entry_codes.push(proper_entry_code);
+        }
+
+        let footer = self.create_code_footer();
+        let prime = BigUint::from_str_radix(
+            "800000000000011000000000000000000000000000000000000000000000001",
+            16,
+        )
+        .unwrap();
+
+        let mut bytecode = vec![];
+        let mut hints = vec![];
+
+        for entry_code in &entry_codes {
+            for instruction in entry_code {
+                if !instruction.hints.is_empty() {
+                    hints.push((
+                        bytecode.len(),
+                        instruction.hints.iter().map(|hint| hint.to_string()).collect(),
+                    ))
+                }
+                bytecode.extend(instruction.assemble().encode().iter().map(|big_int| {
+                    let (_q, reminder) = big_int.magnitude().div_rem(&prime);
+
+                    BigUintAsHex {
+                        value: if big_int.is_negative() { &prime - reminder } else { reminder },
+                    }
+                }))
+            }
+        }
+
+        for instruction in chain!(self.casm_program.instructions.iter(), footer.iter()) {
+            if !instruction.hints.is_empty() {
+                hints.push((
+                    bytecode.len(),
+                    instruction.hints.iter().map(|hint| hint.to_string()).collect(),
+                ))
+            }
+            bytecode.extend(instruction.assemble().encode().iter().map(|big_int| {
+                let (_q, reminder) = big_int.magnitude().div_rem(&prime);
+
+                BigUintAsHex {
+                    value: if big_int.is_negative() { &prime - reminder } else { reminder },
+                }
+            }))
+        }
+
+        let mut test_entry_points = Vec::new();
+        let mut acc = 0;
+        for (test, entry_code_offset) in collected_tests.iter().zip(entry_codes_offsets.iter()) {
+            test_entry_points.push(TestEntrypoint { offset: acc, name: test.name.to_string() });
+            acc += entry_code_offset;
+        }
+        Ok(ProtostarCasm { prime, bytecode, hints, test_entry_points })
+    }
+
+    // Copied from crates/cairo-lang-runner/src/lib.rs
+    /// Finds first function ending with `name_suffix`.
+    pub fn find_function(&self, name_suffix: &str) -> Result<&Function, GeneratorError> {
+        self.sierra_program
+            .funcs
+            .iter()
+            .find(|f| {
+                if let Some(name) = &f.id.debug_name {
+                    name.ends_with(name_suffix)
+                } else {
+                    false
+                }
+            })
+            .ok_or_else(|| GeneratorError::MissingFunction { suffix: name_suffix.to_owned() })
+    }
+
+    // Copied from crates/cairo-lang-runner/src/lib.rs
+    /// Returns the instructions to add to the beginning of the code to successfully call the main
+    /// function, as well as the builtins required to execute the program.
+    fn create_entry_code(
+        &self,
+        func: &Function,
+        args: &[Felt252],
+        initial_gas: usize,
+        entry_offset: usize,
+    ) -> Result<(Vec<Instruction>, Vec<String>, usize), GeneratorError> {
+        let mut arg_iter = args.iter();
+        let mut expected_arguments_size = 0;
+        let mut ctx = casm! {};
+        // The builtins in the formatting expected by the runner.
+        let builtins: Vec<_> = ["pedersen", "range_check", "bitwise", "ec_op"]
+            .map(&str::to_string)
+            .into_iter()
+            .collect();
+        // The offset [fp - i] for each of this builtins in this configuration.
+        let builtin_offset: HashMap<cairo_lang_sierra::ids::GenericTypeId, i16> = HashMap::from([
+            (PedersenType::ID, 6),
+            (RangeCheckType::ID, 5),
+            (BitwiseType::ID, 4),
+            (EcOpType::ID, 3),
+        ]);
+        if func
+            .signature
+            .param_types
+            .iter()
+            .any(|ty| self.get_info(ty).long_id.generic_id == SegmentArenaType::ID)
+        {
+            casm_extend! {ctx,
+                // SegmentArena segment.
+                %{ memory[ap + 0] = segments.add() %}
+                // Infos segment.
+                %{ memory[ap + 1] = segments.add() %}
+                ap += 2;
+                [ap + 0] = 0, ap++;
+                // Write Infos segment, n_constructed (0), and n_destructed (0) to the segment.
+                [ap - 2] = [[ap - 3]];
+                [ap - 1] = [[ap - 3] + 1];
+                [ap - 1] = [[ap - 3] + 2];
+            }
+        }
+        for (i, ty) in func.signature.param_types.iter().enumerate() {
+            let info = self.get_info(ty);
+            let generic_ty = &info.long_id.generic_id;
+            if let Some(offset) = builtin_offset.get(generic_ty) {
+                casm_extend! {ctx,
+                    [ap + 0] = [fp - offset], ap++;
+                }
+            } else if generic_ty == &SystemType::ID {
+                casm_extend! {ctx,
+                    %{ memory[ap + 0] = segments.add() %}
+                    ap += 1;
+                }
+            } else if generic_ty == &GasBuiltinType::ID {
+                casm_extend! {ctx,
+                    [ap + 0] = initial_gas, ap++;
+                }
+            } else if generic_ty == &SegmentArenaType::ID {
+                let offset = -(i as i16) - 3;
+                casm_extend! {ctx,
+                    [ap + 0] = [ap + offset] + 3, ap++;
+                }
+            } else {
+                let arg_size = info.size;
+                expected_arguments_size += arg_size as usize;
+                for _ in 0..arg_size {
+                    if let Some(value) = arg_iter.next() {
+                        casm_extend! {ctx,
+                            [ap + 0] = (value.to_bigint()), ap++;
+                        }
+                    }
+                }
+            }
+        }
+        if expected_arguments_size != args.len() {
+            return Err(GeneratorError::ArgumentsSizeMismatch {
+                expected: expected_arguments_size,
+                actual: args.len(),
+            });
+        }
+        let before_final_call = ctx.current_code_offset;
+        let final_call_size = 3;
+
+        let offset = final_call_size
+            + entry_offset
+            + self.casm_program.debug_info.sierra_statement_info[func.entry_point.0].code_offset;
+
+        casm_extend! {ctx,
+            call rel offset;
+            ret;
+        }
+        assert_eq!(before_final_call + final_call_size, ctx.current_code_offset);
+        Ok((ctx.instructions, builtins, ctx.current_code_offset))
+    }
+
+    // Copied from crates/cairo-lang-runner/src/lib.rs
+    /// Creates a list of instructions that will be appended to the program's bytecode.
+    pub fn create_code_footer(&self) -> Vec<Instruction> {
+        casm! {
+            // Add a `ret` instruction used in libfuncs that retrieve the current value of the `fp`
+            // and `pc` registers.
+            ret;
+        }
+        .instructions
+    }
+
+    pub fn get_info(
+        &self,
+        ty: &cairo_lang_sierra::ids::ConcreteTypeId,
+    ) -> &cairo_lang_sierra::extensions::types::TypeInfo {
+        self.sierra_program_registry.get_type(ty).unwrap().info()
+    }
+}
+
+fn create_metadata(
+    sierra_program: &cairo_lang_sierra::program::Program,
+    calc_gas: bool,
+) -> Result<Metadata, GeneratorError> {
+    if calc_gas {
+        calc_metadata(sierra_program, Default::default()).map_err(|err| match err {
+            MetadataError::ApChangeError(err) => GeneratorError::ApChangeError(err),
+            MetadataError::CostError(_) => GeneratorError::FailedGasCalculation,
+        })
+    } else {
+        Ok(Metadata {
+            ap_change_info: calc_ap_changes(sierra_program, |_, _| 0)?,
+            gas_info: GasInfo {
+                variable_values: Default::default(),
+                function_costs: Default::default(),
+            },
+        })
+    }
+}

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -38,7 +38,9 @@ use test_config::{try_extract_test_config, TestConfig};
 
 use crate::test_config::{PanicExpectation, TestExpectation};
 
+pub mod casm_generator;
 mod plugin;
+pub mod test_collector;
 mod test_config;
 
 pub struct TestRunner {

--- a/crates/cairo-lang-test-runner/src/test_collector.rs
+++ b/crates/cairo-lang-test-runner/src/test_collector.rs
@@ -1,0 +1,263 @@
+use std::fs;
+use std::path::Path;
+
+use crate::casm_generator::{SierraCasmGenerator, TestConfig as TestConfigInternal};
+use crate::find_all_tests;
+use crate::plugin::TestPlugin;
+use anyhow::{Context, Result};
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_compiler::project::setup_project;
+use cairo_lang_debug::DebugWithDb;
+use cairo_lang_diagnostics::ToOption;
+use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
+use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
+use cairo_lang_semantic::items::functions::GenericFunctionId;
+use cairo_lang_semantic::{ConcreteFunction, FunctionLongId};
+use cairo_lang_sierra::extensions::enm::EnumType;
+use cairo_lang_sierra::extensions::NamedType;
+use cairo_lang_sierra::program::{GenericArg, Program};
+use cairo_lang_sierra_generator::db::SierraGenGroup;
+use cairo_lang_sierra_generator::replace_ids::{DebugReplacer, SierraIdReplacer};
+use cairo_lang_starknet::contract::{find_contracts, get_module_functions};
+use cairo_lang_starknet::plugin::consts::{CONSTRUCTOR_MODULE, EXTERNAL_MODULE, L1_HANDLER_MODULE};
+use cairo_lang_starknet::plugin::StarkNetPlugin;
+use itertools::{chain, Itertools};
+use std::sync::Arc;
+
+pub fn collect_tests(
+    input_path: &String,
+    output_path: Option<&String>,
+    maybe_cairo_paths: Option<Vec<&String>>,
+    maybe_builtins: Option<Vec<&String>>,
+) -> Result<(Option<String>, Vec<TestConfigInternal>)> {
+    let db = &mut {
+        let mut b = RootDatabase::builder();
+        b.detect_corelib();
+        b.with_cfg(CfgSet::from_iter([Cfg::name("test")]));
+        b.with_semantic_plugin(Arc::new(TestPlugin::default()));
+        b.with_semantic_plugin(Arc::new(StarkNetPlugin::default()));
+        b.build()?
+    };
+
+    let main_crate_ids = setup_project(db, Path::new(&input_path))?;
+
+    if let Some(cairo_paths) = maybe_cairo_paths {
+        for cairo_path in cairo_paths {
+            setup_project(db, Path::new(cairo_path))
+                .with_context(|| format!("Failed to add linked library ({})", input_path))?;
+        }
+    }
+
+    let all_entry_points: Vec<ConcreteFunctionWithBodyId> = find_contracts(db, &main_crate_ids)
+        .iter()
+        .flat_map(|contract| {
+            chain!(
+                get_module_functions(db, contract, EXTERNAL_MODULE).unwrap(),
+                get_module_functions(db, contract, CONSTRUCTOR_MODULE).unwrap(),
+                get_module_functions(db, contract, L1_HANDLER_MODULE).unwrap()
+            )
+        })
+        .flat_map(|func_id| ConcreteFunctionWithBodyId::from_no_generics_free(db, func_id))
+        .collect();
+
+    // let function_set_costs: OrderedHashMap<FunctionId, OrderedHashMap<CostTokenType, i32>> =
+    //     all_entry_points
+    //         .iter()
+    //         .map(|func_id| {
+    //             (
+    //                 db.function_with_body_sierra(*func_id).unwrap().id.clone(),
+    //                 [(CostTokenType::Const, ENTRY_POINT_COST)].into(),
+    //             )
+    //         })
+    //         .collect();
+
+    let all_tests = find_all_tests(db, main_crate_ids.clone());
+    let sierra_program = db
+        .get_sierra_program_for_functions(
+            chain!(
+                all_entry_points.into_iter(),
+                all_tests.iter().flat_map(|(func_id, _cfg)| {
+                    ConcreteFunctionWithBodyId::from_no_generics_free(db, *func_id)
+                })
+            )
+            .collect(),
+        )
+        .to_option()
+        .with_context(|| "Compilation failed without any diagnostics.")?;
+    let replacer = DebugReplacer { db };
+    let sierra_program = replacer.apply(&sierra_program);
+
+    let collected_tests = all_tests
+        .into_iter()
+        .map(|(func_id, test)| {
+            (
+                format!(
+                    "{:?}",
+                    FunctionLongId {
+                        function: ConcreteFunction {
+                            generic_function: GenericFunctionId::Free(func_id),
+                            generic_args: vec![]
+                        }
+                    }
+                    .debug(db)
+                ),
+                test,
+            )
+        })
+        .collect_vec()
+        .into_iter()
+        .map(|(test_name, config)| TestConfigInternal {
+            name: test_name,
+            available_gas: config.available_gas,
+        })
+        .collect();
+
+    // // code taken from crates/cairo-lang-test-runner/src/cli.rs
+    // let plugins: Vec<Arc<dyn SemanticPlugin>> = vec![
+    //     Arc::new(DerivePlugin {}),
+    //     Arc::new(PanicablePlugin {}),
+    //     Arc::new(ConfigPlugin { configs: HashSet::from(["test".to_string()]) }),
+    //     Arc::new(StarkNetPlugin {}),
+    // ];
+    // let db = &mut RootDatabase::builder()
+    //     .with_plugins(plugins)
+    //     .detect_corelib()
+    //     .build()
+    //     .context("Failed to build database")?;
+
+    // let main_crate_ids = setup_project(db, Path::new(&input_path))
+    //     .with_context(|| format!("Failed to setup project for path({})", input_path))?;
+
+    // if let Some(cairo_paths) = maybe_cairo_paths {
+    //     for cairo_path in cairo_paths {
+    //         setup_project(db, Path::new(cairo_path))
+    //             .with_context(|| format!("Failed to add linked library ({})", input_path))?;
+    //     }
+    // }
+
+    // if DiagnosticsReporter::stderr().check(db) {
+    //     return Err(anyhow!(
+    //         "Failed to add linked library, for a detailed information, please go through the logs \
+    //          above"
+    //     ));
+    // }
+    // let all_tests = find_all_tests(db, main_crate_ids);
+
+    // let sierra_program = db
+    //     .get_sierra_program_for_functions(
+    //         all_tests
+    //             .iter()
+    //             .flat_map(|(func_id, _cfg)| {
+    //                 ConcreteFunctionWithBodyId::from_no_generics_free(db, *func_id)
+    //             })
+    //             .collect(),
+    //     )
+    //     .to_option()
+    //     .context("Compilation failed without any diagnostics")
+    //     .context("Failed to get sierra program")?;
+
+    // let collected_tests: Vec<TestConfigInternal> = all_tests
+    //     .into_iter()
+    //     .map(|(func_id, test)| {
+    //         (
+    //             format!(
+    //                 "{:?}",
+    //                 FunctionLongId {
+    //                     function: ConcreteFunction {
+    //                         generic_function: GenericFunctionId::Free(func_id),
+    //                         generic_args: vec![]
+    //                     }
+    //                 }
+    //                 .debug(db)
+    //             ),
+    //             test,
+    //         )
+    //     })
+    //     .collect_vec()
+    //     .into_iter()
+    //     .map(|(test_name, config)| TestConfigInternal {
+    //         name: test_name,
+    //         available_gas: config.available_gas,
+    //     })
+    //     .collect();
+
+    // let sierra_program = replace_sierra_ids_in_program(db, &sierra_program);
+
+    let mut builtins = vec![];
+    if let Some(unwrapped_builtins) = maybe_builtins {
+        builtins = unwrapped_builtins.iter().map(|s| s.to_string()).collect();
+    }
+
+    validate_tests(sierra_program.clone(), &collected_tests, builtins)
+        .context("Test validation failed")?;
+
+    let mut result_contents = None;
+    if let Some(path) = output_path {
+        fs::write(path, &sierra_program.to_string()).context("Failed to write output")?;
+    } else {
+        result_contents = Some(sierra_program.to_string());
+    }
+    Ok((result_contents, collected_tests))
+}
+
+fn validate_tests(
+    sierra_program: Program,
+    collected_tests: &Vec<TestConfigInternal>,
+    ignored_params: Vec<String>,
+) -> Result<(), anyhow::Error> {
+    let casm_generator = match SierraCasmGenerator::new(sierra_program) {
+        Ok(casm_generator) => casm_generator,
+        Err(e) => panic!("{}", e),
+    };
+    for test in collected_tests {
+        let func = casm_generator.find_function(&test.name)?;
+        let mut filtered_params: Vec<String> = Vec::new();
+        for param in &func.params {
+            let param_str = &param.ty.debug_name.as_ref().unwrap().to_string();
+            if !ignored_params.contains(&param_str) {
+                filtered_params.push(param_str.to_string());
+            }
+        }
+        if !filtered_params.is_empty() {
+            anyhow::bail!(format!(
+                "Invalid number of parameters for test {}: expected 0, got {}",
+                test.name,
+                func.params.len()
+            ));
+        }
+        let signature = &func.signature;
+        let ret_types = &signature.ret_types;
+        let tp = &ret_types[ret_types.len() - 1];
+        let info = casm_generator.get_info(&tp);
+        let mut maybe_return_type_name = None;
+        if info.long_id.generic_id == EnumType::ID {
+            if let GenericArg::UserType(ut) = &info.long_id.generic_args[0] {
+                if let Some(name) = ut.debug_name.as_ref() {
+                    maybe_return_type_name = Some(name.as_str());
+                }
+            }
+        }
+        if let Some(return_type_name) = maybe_return_type_name {
+            if !return_type_name.starts_with("core::PanicResult::") {
+                anyhow::bail!("Test function {} must be panicable but it's not", test.name);
+            }
+            if return_type_name != "core::PanicResult::<((),)>" {
+                anyhow::bail!(
+                    "Test function {} returns a value {}, it is required that test functions do \
+                     not return values",
+                    test.name,
+                    return_type_name
+                );
+            }
+        } else {
+            anyhow::bail!(
+                "Couldn't read result type for test function {} possible cause: Test function {} \
+                 must be panicable but it's not",
+                test.name,
+                test.name
+            );
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR is meant to move test collection from the internal Protostar modules and make it a part of the Cairo Test Runner.

[Related issue in Protostar repository
]( https://github.com/software-mansion/protostar/issues/1887)

MVP has code repetition issues.
TODO: 
- [x] MVP
- [ ] Refactor CASM Generator (crates/cairo-lang-test-runner/src/casm_generator.rs)
- [ ] Create TestCollector (from `collect_tests`) with builtin test validation (`validate_tests`)
- [ ] Use TestCollector in the TestRunner (former will be used in Protostar directly)
    - [ ] Make them share RootDataBase
    - [ ] Resolve issue with `starknet` flag in test validation
      > Current TestCollector needs the Starknet plugin, however it may be unused by the TestRunner

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3227)
<!-- Reviewable:end -->
