### PR TITLE
Cairo-LS: Add fallback corelib path config key

### DIFF
--- a/vscode-cairo/package.json
+++ b/vscode-cairo/package.json
@@ -58,9 +58,20 @@
             "description": "Path to the Cairo language server (cairo-language-server).",
             "scope": "window"
           },
+          "cairo1.enableScarb": {
+            "type": "boolean",
+            "default": "true",
+            "description": "Enable the use of Scarb package manager.",
+            "scope": "window"
+          },
           "cairo1.scarbPath": {
             "type": "string",
             "description": "Path to the Scarb package manager binary.",
+            "scope": "window"
+          },
+          "cairo1.corelibPath": {
+            "type": "string",
+            "description": "Path to the Cairo core library, used as a fallback.",
             "scope": "window"
           }
         }


### PR DESCRIPTION
- Add configuration option for providing corelib path (if other ways of corelib detection fail)
- Add option to disable Scarb based resolution
- Run standalone Cairo-LS for non Scarb projects if provided explicitly in config

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3235)
<!-- Reviewable:end -->
