### PR TITLE
feat:serde for Result enum

### DIFF
--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -22,19 +22,13 @@ impl ResultSerde<
         }
     }
     fn deserialize(ref serialized: Span<felt252>) -> Option<Result<R, E>> {
-        match serialized.pop_front() {
-            Option::Some(variant) => {
-                if *variant == 0 {
-                    Option::Some(Result::Ok(Serde::<R>::deserialize(ref serialized)?))
-                } else if *variant == 1 {
-                    Option::Some(Result::Err(Serde::<E>::deserialize(ref serialized)?))
-                } else {
-                    Option::None(())
-                }
-            },
-            Option::None(_) => {
-                Option::None(())
-            }
+        let variant = *serialized.pop_front()?;
+        if variant == 0 {
+            Option::Some(Result::Ok(Serde::<R>::deserialize(ref serialized)?))
+        } else if variant == 1 {
+            Option::Some(Result::Err(Serde::<E>::deserialize(ref serialized)?))
+        } else {
+            Option::None(())
         }
     }
 }

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -22,13 +22,19 @@ impl ResultSerde<
         }
     }
     fn deserialize(ref serialized: Span<felt252>) -> Option<Result<R, E>> {
-        let variant = *serialized.pop_front()?;
-        if variant == 0 {
-            Option::Some(Result::Ok(Serde::<R>::deserialize(ref serialized)?))
-        } else if variant == 1 {
-            Option::Some(Result::Err(Serde::<E>::deserialize(ref serialized)?))
-        } else {
-            Option::None(())
+        match serialized.pop_front() {
+            Option::Some(variant) => {
+                if *variant == 0 {
+                    Option::Some(Result::Ok(Serde::<R>::deserialize(ref serialized)?))
+                } else if *variant == 1 {
+                    Option::Some(Result::Err(Serde::<E>::deserialize(ref serialized)?))
+                } else {
+                    Option::None(())
+                }
+            },
+            Option::None(_) => {
+                Option::None(())
+            }
         }
     }
 }

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -1,8 +1,38 @@
 use array::ArrayTrait;
+use serde::Serde;
+use array::SpanTrait;
+
 enum Result<T, E> {
     Ok: T,
     Err: E,
 }
+
+impl ResultSerde<
+    R, E, impl RSerde: Serde<R>, impl ESerde: Serde<E>, impl RDrop: Drop<R>, impl EDrop: Drop<E>> of Serde<Result<R,E>> {
+    fn serialize(self: @Result<R, E>, ref output: Array<felt252>) {
+        match self {
+            Result::Ok(x) => {
+                0.serialize(ref output);
+                x.serialize(ref output)
+            },
+            Result::Err(y) => {
+                1.serialize(ref output);
+                y.serialize(ref output)
+            },
+        }
+    }
+    fn deserialize(ref serialized: Span<felt252>) -> Option<Result<R, E>> {
+        let variant = *serialized.pop_front()?;
+        if variant == 0 {
+            Option::Some(Result::Ok(Serde::<R>::deserialize(ref serialized)?))
+        } else if variant == 1 {
+            Option::Some(Result::Err(Serde::<E>::deserialize(ref serialized)?))
+        } else {
+            Option::None(())
+        }
+    }
+}
+
 trait ResultTrait<T, E> {
     /// If `val` is `Result::Ok(x)`, returns `x`. Otherwise, panics with `err`.
     fn expect<impl EDrop: Drop<E>>(self: Result<T, E>, err: felt252) -> T;

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -8,7 +8,8 @@ enum Result<T, E> {
 }
 
 impl ResultSerde<
-    R, E, impl RSerde: Serde<R>, impl ESerde: Serde<E>, impl RDrop: Drop<R>, impl EDrop: Drop<E>> of Serde<Result<R,E>> {
+    R, E, impl RSerde: Serde<R>, impl ESerde: Serde<E>, impl RDrop: Drop<R>, impl EDrop: Drop<E>
+> of Serde<Result<R, E>> {
     fn serialize(self: @Result<R, E>, ref output: Array<felt252>) {
         match self {
             Result::Ok(x) => {


### PR DESCRIPTION
The Enum `Option` implements serialize/deserialize. So it can be used in Starknet contract function signatures.
Unfortunately, it's not implemented in `Result` Enum, that is at least as useful as `Option`.
This PR propose to implement serialize/deserialize in the Enum `Result`.
It has been made in accordance with @enitrat comment in Discord : https://discord.com/channels/793094838509764618/1065544063245365288/1124678948157141062
> Result::Ok((value))  would become [0,value] and Result::Err(value) would become [1,value]

So such code become possible in Cairo : 
```rust
fn test6(self: @ContractState, val1: u16) -> Result<u16, u16> {
    if val1 < 100 {
        return Result::Err(14);
    }
    Result::Ok(val1)
}

fn test8(self: @ContractState, inp: Result<Order, u16>) -> u16 {
    match inp {
        Result::Ok(x) => {
            return x.p2;
        },
        Result::Err(y) => {
            return y;
        }
    }
}
```
Several tests have been made with Starknet.js/Starknet-devnet, with success :
```typescript
const res10 = await myTestContract.call("test6", [90], { parseRequest: false, parseResponse: false });
// result is : [ '0x1', '0xe' ]
const res11 = await myTestContract.call("test6", [110], { parseRequest: false, parseResponse: false });
// result is : [ '0x0', '0x6e' ]
const res14 = await myTestContract.call("test8", [0,92,93], { parseRequest: false, parseResponse: false });
// result is : [ '0x5d' ]
const res15 = await myTestContract.call("test8", [1,112], { parseRequest: false, parseResponse: false });
// result is : [ '0x70' ]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3560)
<!-- Reviewable:end -->
