### PR TITLE
Derive traits for `RunResult` and `RunResultValue`

### DIFF
--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -74,6 +74,7 @@ pub struct RunResultStarknet {
 }
 
 /// The full result of a run.
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct RunResult {
     pub gas_counter: Option<Felt252>,
     pub memory: Vec<Option<Felt252>>,
@@ -81,7 +82,7 @@ pub struct RunResult {
 }
 
 /// The ran function return value.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum RunResultValue {
     /// Run ended successfully, returning the memory of the non-implicit returns.
     Success(Vec<Felt252>),
@@ -106,7 +107,7 @@ impl From<Felt252> for Arg {
 
 /// Builds hints_dict required in cairo_vm::types::program::Program from instructions.
 pub fn build_hints_dict<'b>(
-    instructions: impl Iterator<Item = &'b Instruction>,
+    instructions: impl Iterator<Item=&'b Instruction>,
 ) -> (HashMap<usize, Vec<HintParams>>, HashMap<String, Hint>) {
     let mut hints_dict: HashMap<usize, Vec<HintParams>> = HashMap::new();
     let mut string_to_hint: HashMap<String, Hint> = HashMap::new();

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -107,7 +107,7 @@ impl From<Felt252> for Arg {
 
 /// Builds hints_dict required in cairo_vm::types::program::Program from instructions.
 pub fn build_hints_dict<'b>(
-    instructions: impl Iterator<Item=&'b Instruction>,
+    instructions: impl Iterator<Item = &'b Instruction>,
 ) -> (HashMap<usize, Vec<HintParams>>, HashMap<String, Hint>) {
     let mut hints_dict: HashMap<usize, Vec<HintParams>> = HashMap::new();
     let mut string_to_hint: HashMap<String, Hint> = HashMap::new();


### PR DESCRIPTION
Made both structs derive `#[derive(Debug, Eq, PartialEq, Clone)]` so they can be used in other code dependent on cairo runner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3632)
<!-- Reviewable:end -->
