### PR TITLE
Removing usage of `(())` or `(_)` in unit variant matches.

### DIFF
--- a/corelib/src/keccak.cairo
+++ b/corelib/src/keccak.cairo
@@ -41,7 +41,7 @@ fn keccak_u256s_le_inputs(mut input: Span<u256>) -> u256 {
             Option::Some(v) => {
                 keccak_add_u256_le(ref keccak_input, *v);
             },
-            Option::None(_) => {
+            Option::None => {
                 break ();
             },
         };
@@ -71,7 +71,7 @@ fn keccak_u256s_be_inputs(mut input: Span<u256>) -> u256 {
             Option::Some(v) => {
                 keccak_add_u256_be(ref keccak_input, *v);
             },
-            Option::None(_) => {
+            Option::None => {
                 break ();
             },
         };

--- a/corelib/src/lib.cairo
+++ b/corelib/src/lib.cairo
@@ -69,15 +69,15 @@ impl BoolPartialEq of PartialEq<bool> {
     #[inline(always)]
     fn eq(lhs: @bool, rhs: @bool) -> bool {
         match lhs {
-            bool::False(_) => !*rhs,
-            bool::True(_) => *rhs,
+            bool::False => !*rhs,
+            bool::True => *rhs,
         }
     }
     #[inline(always)]
     fn ne(lhs: @bool, rhs: @bool) -> bool {
         match lhs {
-            bool::False(_) => *rhs,
-            bool::True(_) => !*rhs,
+            bool::False => *rhs,
+            bool::True => !*rhs,
         }
     }
 }

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -44,7 +44,7 @@ impl OptionTraitImpl<T> of OptionTrait<T> {
     fn expect(self: Option<T>, err: felt252) -> T {
         match self {
             Option::Some(x) => x,
-            Option::None(_) => panic_with_felt252(err),
+            Option::None => panic_with_felt252(err),
         }
     }
     #[inline(always)]

--- a/crates/cairo-lang-lowering/src/inline/test_data/inline
+++ b/crates/cairo-lang-lowering/src/inline/test_data/inline
@@ -75,7 +75,7 @@ foo
 fn bar<T, impl TDrop: Drop::<T>>(val: Option::<T>, val2: T) -> T {
     match val {
         Option::Some(x) => x,
-        Option::None(()) => val2,
+        Option::None => val2,
     }
 }
 
@@ -118,7 +118,6 @@ End:
 
 blk4:
 Statements:
-  () <- struct_destructure(v4)
 End:
   Goto(blk5, {v1 -> v5})
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/option
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/option
@@ -8,7 +8,7 @@ fn foo() -> Option<u16> {
    let v = get_option();
    match v {
         Option::Some(_) => Option::Some(1_u16),
-        Option::None(_) => Option::None(()),
+        Option::None => Option::None(()),
    }
 }
 
@@ -145,12 +145,12 @@ fn foo(a: felt252) -> Option<u16> {
    let a = a + a;
    let v1 = match v {
         Option::Some(_) => Option::Some(1_u16),
-        Option::None(_) => Option::None(()),
+        Option::None => Option::None(()),
    };
    match v1 {
         // v1 is used after the match.
         Option::Some(_) => v1,
-        Option::None(_) => Option::Some(2_u16),
+        Option::None => Option::Some(2_u16),
    }
 }
 
@@ -332,7 +332,7 @@ fn foo() -> felt252 {
    let opt = get_option();
    match opt {
       Option::Some(x) => Option::Some(x + 3),
-      Option::None(()) => Option::None(())
+      Option::None => Option::None(())
    }.unwrap()
 }
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/reorder_statements
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/reorder_statements
@@ -16,11 +16,11 @@ fn foo() -> felt252 {
 
    match opt {
         Option::Some(_) => one + two,
-        Option::None(_) => {
+        Option::None => {
             let four = 4;
             match opt {
                 Option::Some(_) => three + four,
-                Option::None(_) => one,
+                Option::None => one,
             }
         }
    }
@@ -194,7 +194,7 @@ fn foo() {
 
    match get_option() {
         Option::Some(_) => a,
-        Option::None(_) => false ^ b,
+        Option::None => false ^ b,
    };
 }
 

--- a/crates/cairo-lang-lowering/src/test_data/call
+++ b/crates/cairo-lang-lowering/src/test_data/call
@@ -65,7 +65,7 @@ impl OptionTraitImpl<T, impl TDrop: Drop::<T>> of OptionTrait::<T> {
   fn is_some(self: Option::<T>) -> bool {
       match self {
           Option::Some(_) => true,
-          Option::None(_) => false,
+          Option::None => false,
       }
   }
 }

--- a/crates/cairo-lang-lowering/src/test_data/lowering_phases
+++ b/crates/cairo-lang-lowering/src/test_data/lowering_phases
@@ -7,7 +7,7 @@ test_function_lowering_phases
 fn foo() {
   match Option::<felt252>::None(()) {
      Option::Some(_) => panic(Default::default()),
-     Option::None(_) => foo(),
+     Option::None => foo(),
   }
 }
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/method
+++ b/crates/cairo-lang-semantic/src/expr/test_data/method
@@ -21,7 +21,7 @@ impl OptionTraitImpl<T> of OptionTrait::<T> {
     fn is_some(self: Option::<T>) -> bool {
         match self {
             Option::Some(_) => true,
-            Option::None(_) => false,
+            Option::None => false,
         }
     }
 }
@@ -67,7 +67,7 @@ impl OptionTraitImpl<T> of OptionTrait::<T> {
     fn is_some(self: Option::<T>) -> bool {
         match self {
             Option::Some(_) => true,
-            Option::None(_) => false,
+            Option::None => false,
         }
     }
     fn is_bar(self: Option::<T>) -> bool { true }
@@ -76,7 +76,7 @@ impl AnotherOptionTraitImpl<T> of OptionTrait::<felt252> {
     fn is_some(self: Option::<felt252>) -> bool {
         match self {
             Option::Some(_) => true,
-            Option::None(_) => false,
+            Option::None => false,
         }
     }
     fn is_bar(self: Option::<felt252>) -> bool { true }

--- a/crates/cairo-lang-semantic/src/items/tests/type_alias
+++ b/crates/cairo-lang-semantic/src/items/tests/type_alias
@@ -78,7 +78,7 @@ test_function_diagnostics
 fn foo(a: OptionFelt252) -> felt252 {
     match a {
         Option::Some(v) => v,
-        Option::None(_) => 1,
+        Option::None => 1,
     }
 }
 

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test_data/match
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test_data/match
@@ -154,7 +154,7 @@ block_generator_test
 fn foo(opt : Option<@felt252>) -> felt252 {
   match opt {
     Option::Some(x) => *x,
-    Option::None(_) => 0,
+    Option::None => 0,
   }
 }
 

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test_data/panic
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test_data/panic
@@ -18,7 +18,7 @@ use array::ArrayTrait;
 fn expect(opt: Option<felt252>) -> felt252 {
    match opt {
       Option::Some(x) => x,
-      Option::None(_) => no_inline_panic(),
+      Option::None => no_inline_panic(),
   }
 }
 

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test_data/serialization
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test_data/serialization
@@ -10,7 +10,7 @@ fn serialize_array_felt_helper(ref serialized: Array<felt252>, mut input: Array<
             value.serialize(ref serialized);
             serialize_array_felt_helper(ref serialized, input);
         },
-        Option::None(_) => {},
+        Option::None => {},
     }
 }
 

--- a/crates/cairo-lang-sierra-generator/src/local_variables_test_data/match_extern
+++ b/crates/cairo-lang-sierra-generator/src/local_variables_test_data/match_extern
@@ -9,7 +9,7 @@ foo
 //! > function_code
 fn foo(x: felt252) -> felt252 {
     match felt252_is_zero(x) {
-        IsZeroResult::Zero(_) => 1,
+        IsZeroResult::Zero => 1,
         IsZeroResult::NonZero(y) => {
             revoke_ap();
             // y is not revoked, since it's the same as x, which is local.
@@ -18,7 +18,7 @@ fn foo(x: felt252) -> felt252 {
     }
     let x2 = x + x;
     match felt252_is_zero(x2) {
-        IsZeroResult::Zero(_) => 1,
+        IsZeroResult::Zero => 1,
         IsZeroResult::NonZero(y) => {
             revoke_ap();
             // x2 is revoked, since y is identical to x2.
@@ -185,7 +185,7 @@ fn foo(x: felt252) -> felt252 {
     let w1 = x + x;
 
     match felt252_is_zero(x) {
-        IsZeroResult::Zero(_) => 1,
+        IsZeroResult::Zero => 1,
         IsZeroResult::NonZero(y) => {
             revoke_ap();
             return 0;
@@ -196,7 +196,7 @@ fn foo(x: felt252) -> felt252 {
     let w2 = w1 + x;
 
     match felt252_is_zero(x) {
-        IsZeroResult::Zero(_) => 1,
+        IsZeroResult::Zero => 1,
         IsZeroResult::NonZero(y) => {
             // Same as above, without revoke_ap() and without an early return.
             2

--- a/crates/cairo-lang-starknet/test_data/account.cairo
+++ b/crates/cairo-lang-starknet/test_data/account.cairo
@@ -82,7 +82,7 @@ mod account {
                             .unwrap_syscall();
                         result.append(res);
                     },
-                    Option::None(()) => {
+                    Option::None => {
                         break; // Can't break result; because of 'variable was previously moved'
                     },
                 };

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
@@ -88,7 +88,7 @@ for example:
 ----
 match opt {
     Option::Some(x) => x,
-    Option::None(_) => 0,
+    Option::None => 0,
 }
 ----
 

--- a/tests/bug_samples/issue2152.cairo
+++ b/tests/bug_samples/issue2152.cairo
@@ -8,7 +8,7 @@ use option::OptionTrait;
 fn reproduce_bug() {
     match gas::withdraw_gas_all(get_builtin_costs()) {
         Option::Some(_) => {},
-        Option::None(_) => {
+        Option::None => {
             panic(array!['OOG']);
         }
     }

--- a/tests/bug_samples/issue2172.cairo
+++ b/tests/bug_samples/issue2172.cairo
@@ -10,10 +10,10 @@ fn traverse(node: Node) nopanic {
     let Node{value, left, right } = node;
     match left {
         Option::Some(x) => traverse(x.unbox()),
-        Option::None(_) => {},
+        Option::None => {},
     }
     match right {
         Option::Some(x) => traverse(x.unbox()),
-        Option::None(_) => {},
+        Option::None => {},
     }
 }

--- a/tests/bug_samples/issue3119.cairo
+++ b/tests/bug_samples/issue3119.cairo
@@ -13,7 +13,7 @@ fn index_of_min<
     let mut min_index = 0;
     let mut min = match span.pop_front() {
         Option::Some(item) => *item,
-        Option::None(_) => {
+        Option::None => {
             return Option::None(());
         },
     };
@@ -26,7 +26,7 @@ fn index_of_min<
                     min_index = current_index;
                 }
             },
-            Option::None(_) => {
+            Option::None => {
                 break Option::Some(min_index);
             },
         };

--- a/tests/bug_samples/issue3153.cairo
+++ b/tests/bug_samples/issue3153.cairo
@@ -13,7 +13,7 @@ impl U256TryIntoU64 of TryInto<u256, u64> {
         let intermediate: Option<felt252> = self.try_into();
         match intermediate {
             Option::Some(felt) => felt.try_into(),
-            Option::None(()) => Option::None(())
+            Option::None => Option::None(())
         }
     }
 }

--- a/tests/bug_samples/loop_break_in_match.cairo
+++ b/tests/bug_samples/loop_break_in_match.cairo
@@ -10,7 +10,7 @@ fn main() {
             Option::Some(v) => {
                 v
             },
-            Option::None(()) => {
+            Option::None => {
                 break 'hi';
             }
         };

--- a/tests/e2e_test_data/libfuncs/ec
+++ b/tests/e2e_test_data/libfuncs/ec
@@ -247,7 +247,7 @@ SmallE2ETestRunner
 use zeroable::IsZeroResult;
 fn foo(p: ec::EcPoint) -> felt252 {
     match ec::ec_point_is_zero(p) {
-        IsZeroResult::Zero(()) => 1,
+        IsZeroResult::Zero => 1,
         IsZeroResult::NonZero(p_nz) => {
             let (x, y) = ec::ec_point_unwrap(p_nz);
             x

--- a/tests/e2e_test_data/libfuncs/enum
+++ b/tests/e2e_test_data/libfuncs/enum
@@ -136,7 +136,7 @@ enum Option {
 fn foo(e: Option) -> felt252 {
     match e {
         Option::Some(_) => 0,
-        Option::None(_) => 1,
+        Option::None => 1,
     }
 }
 

--- a/tests/e2e_test_data/libfuncs/enum_snapshot
+++ b/tests/e2e_test_data/libfuncs/enum_snapshot
@@ -56,7 +56,7 @@ enum Option {
 fn foo(e: @Option) -> felt252 {
     match e {
         Option::Some(_) => 0,
-        Option::None(_) => 1,
+        Option::None => 1,
     }
 }
 

--- a/tests/e2e_test_data/libfuncs/i128
+++ b/tests/e2e_test_data/libfuncs/i128
@@ -154,7 +154,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: i128) -> i128 {
     match integer::i128_is_zero(a) {
-        IsZeroResult::Zero(()) => 123_i128,
+        IsZeroResult::Zero => 123_i128,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/i16
+++ b/tests/e2e_test_data/libfuncs/i16
@@ -154,7 +154,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: i16) -> i16 {
     match integer::i16_is_zero(a) {
-        IsZeroResult::Zero(()) => 123_i16,
+        IsZeroResult::Zero => 123_i16,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/i32
+++ b/tests/e2e_test_data/libfuncs/i32
@@ -154,7 +154,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: i32) -> i32 {
     match integer::i32_is_zero(a) {
-        IsZeroResult::Zero(()) => 123_i32,
+        IsZeroResult::Zero => 123_i32,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/i64
+++ b/tests/e2e_test_data/libfuncs/i64
@@ -154,7 +154,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: i64) -> i64 {
     match integer::i64_is_zero(a) {
-        IsZeroResult::Zero(()) => 123_i64,
+        IsZeroResult::Zero => 123_i64,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/i8
+++ b/tests/e2e_test_data/libfuncs/i8
@@ -154,7 +154,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: i8) -> i8 {
     match integer::i8_is_zero(a) {
-        IsZeroResult::Zero(()) => 123_i8,
+        IsZeroResult::Zero => 123_i8,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/u16
+++ b/tests/e2e_test_data/libfuncs/u16
@@ -334,7 +334,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: u16) -> u16 {
     match integer::u16_is_zero(a) {
-        IsZeroResult::Zero(()) => 1234_u16,
+        IsZeroResult::Zero => 1234_u16,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/u256
+++ b/tests/e2e_test_data/libfuncs/u256
@@ -158,7 +158,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: u256) -> u256 {
     match integer::u256_is_zero(a) {
-        IsZeroResult::Zero(()) => u256{low: 0, high: 0},
+        IsZeroResult::Zero => u256{low: 0, high: 0},
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/u32
+++ b/tests/e2e_test_data/libfuncs/u32
@@ -334,7 +334,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: u32) -> u32 {
     match integer::u32_is_zero(a) {
-        IsZeroResult::Zero(()) => 1234_u32,
+        IsZeroResult::Zero => 1234_u32,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/u64
+++ b/tests/e2e_test_data/libfuncs/u64
@@ -334,7 +334,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: u64) -> u64 {
     match integer::u64_is_zero(a) {
-        IsZeroResult::Zero(()) => 1234_u64,
+        IsZeroResult::Zero => 1234_u64,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/tests/e2e_test_data/libfuncs/u8
+++ b/tests/e2e_test_data/libfuncs/u8
@@ -334,7 +334,7 @@ use zeroable::NonZeroIntoImpl;
 use traits::Into;
 fn foo(a: u8) -> u8 {
     match integer::u8_is_zero(a) {
-        IsZeroResult::Zero(()) => 123_u8,
+        IsZeroResult::Zero => 123_u8,
         IsZeroResult::NonZero(x) => x.into(),
     }
 }

--- a/vscode-cairo/snippets/cairo.json
+++ b/vscode-cairo/snippets/cairo.json
@@ -65,7 +65,7 @@
       "\tOption::Some($1) => {",
       "\t\t$2",
       "\t},",
-      "\tOption::None(()) => {",
+      "\tOption::None => {",
       "\t\t$3",
       "\t},",
       "}"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3634)
<!-- Reviewable:end -->
