### PR TITLE
Search asdf directories for scarb executable

### DIFF
--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -106,15 +106,26 @@ async function findExecutableFromPathVar(name: string) {
 }
 
 async function findScarbExecutablePathInAsdfDir() {
-  if (os.platform() === "win32") return undefined;
+  if (os.platform() === "win32") {
+    return undefined;
+  }
 
-  const asdfDataDir = process.env.ASDF_DATA_DIR ?? `${process.env.HOME}/.asdf`;
+  let asdfDataDir = process.env.ASDF_DATA_DIR;
+  if (!asdfDataDir) {
+    const home = process.env.HOME;
+    if (!home) {
+      return undefined;
+    }
+    asdfDataDir = path.join(home, ".asdf");
+  }
   const scarbExecutablePath = path.join(asdfDataDir, "shims", "scarb");
 
-  return fs.promises
-    .access(scarbExecutablePath, fs.constants.X_OK)
-    .then(() => scarbExecutablePath)
-    .catch(() => undefined);
+  try {
+    await fs.promises.access(scarbExecutablePath, fs.constants.X_OK);
+    return scarbExecutablePath;
+  } catch (e) {
+    return undefined;
+  }
 }
 
 async function findScarbExecutablePath(

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -3,6 +3,7 @@ import { SemanticTokensFeature } from "vscode-languageclient/lib/common/semantic
 import * as child_process from "child_process";
 import * as fs from "fs";
 import * as path from "path";
+import * as os from "os";
 
 import {
   LanguageClient,
@@ -104,6 +105,18 @@ async function findExecutableFromPathVar(name: string) {
   }
 }
 
+async function findScarbExecutablePathInAsdfDir() {
+  if (os.platform() === "win32") return undefined;
+
+  const asdfDataDir = process.env.ASDF_DATA_DIR ?? `${process.env.HOME}/.asdf`;
+  const scarbExecutablePath = path.join(asdfDataDir, "shims", "scarb");
+
+  return fs.promises
+    .access(scarbExecutablePath, fs.constants.X_OK)
+    .then(() => scarbExecutablePath)
+    .catch(() => undefined);
+}
+
 async function findScarbExecutablePath(
   config: vscode.WorkspaceConfiguration,
   context: vscode.ExtensionContext
@@ -120,7 +133,10 @@ async function findScarbExecutablePath(
   }
 
   // Check PATH env var for scarb path.
-  return await findExecutableFromPathVar("scarb");
+  const envPath = await findExecutableFromPathVar("scarb");
+  if (envPath) return envPath;
+
+  return findScarbExecutablePathInAsdfDir();
 }
 
 function notifyScarbMissing(outputChannel: vscode.OutputChannel) {


### PR DESCRIPTION
Sometimes due to specific setup (like having custom ASDF_DATA_DIR variable) asdf scarb shim might not available through PATH variable. To solve this problem we can look for the executable in asdf directories as a fallback. Concept based on [what intellij does](https://github.com/JetBrains/intellij-community/blob/d81e9a70bc6ea0576646354c77fe0e25393db26a/platform/lang-impl/src/com/intellij/openapi/projectRoots/impl/JavaHomeFinderBasic.java#L359) when looking for java.

Worth noting that asdf is not supported on Windows machines outside WSL so when win32 platform is detected we just return undefined.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3665)
<!-- Reviewable:end -->
