### PR TITLE
no_std-support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,10 @@ jobs:
     strategy:
       matrix:
         cmd:
-          - nextest run -p cairo-lang-casm
-          - nextest run -p cairo-lang-casm --no-default-features
-          - nextest run -p cairo-lang-casm --no-default-features --features serde
-          - nextest run -p cairo-lang-compiler
-          - nextest run -p cairo-lang-compiler --features serde
+          - nextest run -p cairo-lang-casm --all-features
+          - nextest run -p cairo-lang-casm --no-default-features --features serde,parity-scale-codec
+          - nextest run -p cairo-lang-compiler --all-features
+          - nextest run -p cairo-lang-compiler --no-default-features --features serde
           - nextest run -p cairo-lang-debug
           - nextest run -p cairo-lang-defs
           - nextest run -p cairo-lang-diagnostics
@@ -30,7 +29,6 @@ jobs:
           - nextest run -p cairo-lang-lowering
           - nextest run -p cairo-lang-parser
           - nextest run -p cairo-lang-plugins
-          - nextest run -p cairo-lang-plugins --features serde
           - nextest run -p cairo-lang-proc-macros
           - nextest run -p cairo-lang-project
           - nextest run -p cairo-lang-project --features serde
@@ -44,20 +42,18 @@ jobs:
           - nextest run -p cairo-lang-sierra-to-casm
           - nextest run -p cairo-lang-sierra-type-size
           - test -p cairo-lang-starknet
+          - test -p cairo-lang-starknet --features serde
           - nextest run -p cairo-lang-syntax
           - nextest run -p cairo-lang-syntax-codegen
           - nextest run -p cairo-lang-test-runner
           - nextest run -p cairo-lang-test-runner --features serde
           - nextest run -p cairo-lang-test-utils
           - nextest run -p cairo-lang-utils
-          - nextest run -p cairo-lang-utils --no-default-features
-          - nextest run -p cairo-lang-utils --no-default-features --features parity-scale-codec
-          - nextest run -p cairo-lang-utils --no-default-features --features serde
-          - nextest run -p cairo-lang-utils --no-default-features --all-features
+          - nextest run -p cairo-lang-utils --all-features
+          - nextest run -p cairo-lang-utils --no-default-features --features parity-scale-codec,serde
           - nextest run -p cairo-lang-vm-utils
-          - nextest run -p cairo-lang-vm-utils --no-default-features
-          - nextest run -p cairo-lang-casm-contract-class
-          - nextest run -p cairo-lang-casm-contract-class --no-default-features
+          - nextest run -p cairo-lang-vm-utils --no-default-features --features execute_core_hints
+          - nextest run -p cairo-lang-casm-contract-class --all-features
           - nextest run -p cairo-lang-casm-contract-class --no-default-features --features serde
           - test -p tests
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,24 +13,31 @@ jobs:
     strategy:
       matrix:
         cmd:
-          - nextest run -p cairo-lang-casm --no-default-features
           - nextest run -p cairo-lang-casm
+          - nextest run -p cairo-lang-casm --no-default-features
+          - nextest run -p cairo-lang-casm --no-default-features --features serde
           - nextest run -p cairo-lang-compiler
+          - nextest run -p cairo-lang-compiler --features serde
           - nextest run -p cairo-lang-debug
           - nextest run -p cairo-lang-defs
           - nextest run -p cairo-lang-diagnostics
           - nextest run -p cairo-lang-eq-solver
           - nextest run -p cairo-lang-filesystem
+          - nextest run -p cairo-lang-filesystem --features serde
           - nextest run -p cairo-lang-formatter
           - nextest run -p cairo-lang-language-server
+          - nextest run -p cairo-lang-language-server --features serde
           - nextest run -p cairo-lang-lowering
           - nextest run -p cairo-lang-parser
           - nextest run -p cairo-lang-plugins
+          - nextest run -p cairo-lang-plugins --features serde
           - nextest run -p cairo-lang-proc-macros
           - nextest run -p cairo-lang-project
+          - nextest run -p cairo-lang-project --features serde
           - nextest run -p cairo-lang-runner
           - nextest run -p cairo-lang-semantic
           - nextest run -p cairo-lang-sierra
+          - nextest run -p cairo-lang-sierra --features serde
           - nextest run -p cairo-lang-sierra-ap-change
           - nextest run -p cairo-lang-sierra-gas
           - nextest run -p cairo-lang-sierra-generator
@@ -40,14 +47,18 @@ jobs:
           - nextest run -p cairo-lang-syntax
           - nextest run -p cairo-lang-syntax-codegen
           - nextest run -p cairo-lang-test-runner
+          - nextest run -p cairo-lang-test-runner --features serde
           - nextest run -p cairo-lang-test-utils
           - nextest run -p cairo-lang-utils
           - nextest run -p cairo-lang-utils --no-default-features
           - nextest run -p cairo-lang-utils --no-default-features --features parity-scale-codec
+          - nextest run -p cairo-lang-utils --no-default-features --features serde
+          - nextest run -p cairo-lang-utils --no-default-features --all-features
           - nextest run -p cairo-lang-vm-utils
           - nextest run -p cairo-lang-vm-utils --no-default-features
           - nextest run -p cairo-lang-casm-contract-class
           - nextest run -p cairo-lang-casm-contract-class --no-default-features
+          - nextest run -p cairo-lang-casm-contract-class --no-default-features --features serde
           - test -p tests
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         cmd:
+          - nextest run -p cairo-lang-casm --no-default-features
           - nextest run -p cairo-lang-casm
           - nextest run -p cairo-lang-compiler
           - nextest run -p cairo-lang-debug
@@ -41,6 +42,12 @@ jobs:
           - nextest run -p cairo-lang-test-runner
           - nextest run -p cairo-lang-test-utils
           - nextest run -p cairo-lang-utils
+          - nextest run -p cairo-lang-utils --no-default-features
+          - nextest run -p cairo-lang-utils --no-default-features --features parity-scale-codec
+          - nextest run -p cairo-lang-vm-utils
+          - nextest run -p cairo-lang-vm-utils --no-default-features
+          - nextest run -p cairo-lang-casm-contract-class
+          - nextest run -p cairo-lang-casm-contract-class --no-default-features
           - test -p tests
     steps:
       - uses: actions/checkout@v3
@@ -120,6 +127,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/clippy.sh
+
+  nostd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - run: >
+          cd ensure_no_std && cargo b -r
 
   docs:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 .spr.yml
 node_modules
 .DS_Store
+
+# This crate has to be built with nighlty and specific target
+# so it is kept out of the workspace meaning it produce it's own target and Cairo.lock files
+ensure_no_std/target
+ensure_no_std/Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 node_modules
 .DS_Store
 
-# This crate has to be built with nighlty and specific target
-# so it is kept out of the workspace meaning it produce it's own target and Cairo.lock files
+# This crate has to be built with nightly and specific target.
+# So it is kept out of the workspace meaning it produce it's own target and Cairo.lock files.
 ensure_no_std/target
 ensure_no_std/Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,9 +2180,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
 dependencies = [
  "arrayvec",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,15 +41,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
@@ -59,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
@@ -114,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "ark-ec"
@@ -131,7 +122,7 @@ dependencies = [
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "zeroize",
 ]
 
@@ -149,7 +140,7 @@ dependencies = [
  "digest",
  "itertools 0.10.5",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "paste",
  "rustc_version",
  "zeroize",
@@ -172,7 +163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -242,7 +233,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "rand",
 ]
 
@@ -269,13 +260,13 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -422,7 +413,7 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "serde",
 ]
 
@@ -445,18 +436,29 @@ version = "2.1.0-rc0"
 dependencies = [
  "cairo-lang-utils",
  "env_logger",
+ "hashbrown 0.14.0",
  "indoc",
  "itertools 0.11.0",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "parity-scale-codec",
- "parity-scale-codec-derive",
  "pretty_assertions",
  "schemars",
  "serde",
  "test-case",
  "test-log",
- "thiserror",
+ "thiserror-no-std",
+]
+
+[[package]]
+name = "cairo-lang-casm-contract-class"
+version = "2.1.0-rc0"
+dependencies = [
+ "cairo-lang-casm",
+ "cairo-lang-utils",
+ "itertools 0.11.0",
+ "num-bigint",
+ "serde",
 ]
 
 [[package]]
@@ -636,7 +638,7 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "pretty_assertions",
  "salsa",
  "smol_str",
@@ -658,7 +660,7 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "pretty_assertions",
  "salsa",
  "smol_str",
@@ -698,7 +700,7 @@ version = "2.1.0-rc0"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -740,14 +742,14 @@ dependencies = [
  "cairo-lang-sierra-type-size",
  "cairo-lang-starknet",
  "cairo-lang-utils",
+ "cairo-lang-vm-utils",
  "cairo-vm",
  "itertools 0.11.0",
  "keccak",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "pretty_assertions",
- "salsa",
  "test-case",
  "thiserror",
 ]
@@ -773,7 +775,7 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "pretty_assertions",
  "salsa",
  "smol_str",
@@ -797,7 +799,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "pretty_assertions",
  "regex",
  "salsa",
@@ -891,7 +893,7 @@ dependencies = [
  "itertools 0.11.0",
  "log",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "pretty_assertions",
  "test-case",
  "test-log",
@@ -913,6 +915,7 @@ dependencies = [
  "anyhow",
  "cairo-felt",
  "cairo-lang-casm",
+ "cairo-lang-casm-contract-class",
  "cairo-lang-compiler",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -938,7 +941,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "once_cell",
  "pretty_assertions",
  "serde",
@@ -959,12 +962,11 @@ dependencies = [
  "cairo-lang-utils",
  "env_logger",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "pretty_assertions",
  "salsa",
  "smol_str",
  "test-log",
- "thiserror",
  "unescaper",
 ]
 
@@ -1005,10 +1007,9 @@ dependencies = [
  "colored",
  "itertools 0.11.0",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "rayon",
  "salsa",
- "thiserror",
 ]
 
 [[package]]
@@ -1026,13 +1027,15 @@ dependencies = [
 name = "cairo-lang-utils"
 version = "2.1.0-rc0"
 dependencies = [
+ "cairo-felt",
  "env_logger",
+ "hashbrown 0.14.0",
  "indexmap 2.0.0",
  "itertools 0.11.0",
  "log",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "parity-scale-codec",
  "schemars",
  "serde",
@@ -1040,6 +1043,23 @@ dependencies = [
  "test-case",
  "test-log",
  "time",
+]
+
+[[package]]
+name = "cairo-lang-vm-utils"
+version = "2.1.0-rc0"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "cairo-felt",
+ "cairo-lang-casm",
+ "cairo-lang-utils",
+ "cairo-vm",
+ "hashbrown 0.14.0",
+ "log",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -1092,12 +1112,11 @@ dependencies = [
  "hex",
  "keccak",
  "lazy_static",
- "mimalloc",
  "nom",
  "num-bigint",
  "num-integer",
  "num-prime",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "rand",
  "serde",
  "serde_json",
@@ -1109,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
 ]
@@ -1130,9 +1149,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.11"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1141,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.11"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1153,14 +1172,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1353,15 +1372,15 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "ena"
@@ -1495,7 +1514,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1602,11 +1621,11 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+checksum = "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "bstr",
  "fnv",
  "log",
@@ -1615,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "good_lp"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed4d07599e3cdb52477f1d36bef936c89ce854c452e7026b2ba327b93c86f61"
+checksum = "c0833c2bc3cee9906df9969ade12b0b3b8759faa7bc2682b428be767033cdcd4"
 dependencies = [
  "fnv",
  "minilp",
@@ -1774,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761cde40c27e2a9877f8c928fd248b7eec9dd48623dd514b256858ca593fbba7"
+checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
 
 [[package]]
 name = "instant"
@@ -1818,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -1886,16 +1905,6 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
-
-[[package]]
-name = "libmimalloc-sys"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1966,15 +1975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
-dependencies = [
- "libmimalloc-sys",
-]
-
-[[package]]
 name = "minilp"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,7 +2019,7 @@ dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "rawpointer",
 ]
 
@@ -2057,7 +2057,7 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "rand",
  "serde",
 ]
@@ -2069,7 +2069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -2079,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -2090,7 +2090,7 @@ checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -2105,7 +2105,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-modular",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "rand",
 ]
 
@@ -2115,14 +2115,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -2175,22 +2175,21 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.3"
+version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756d439303e94fae44f288ba881ad29670c65b0c4b0e05674ca81061bb65f2c5"
+checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
 dependencies = [
  "arrayvec",
- "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "serde",
+ "parity-scale-codec-derive",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.3"
+version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d884d78fcf214d70b1e239fcd1c6e5e95aa3be1881918da2e488cc946c7a476"
+checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2248,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "path-clean"
@@ -2306,7 +2305,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2379,18 +2378,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2494,7 +2493,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
- "aho-corasick 1.0.2",
+ "aho-corasick",
  "memchr",
  "regex-automata",
  "regex-syntax",
@@ -2502,11 +2501,11 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
- "aho-corasick 1.0.2",
+ "aho-corasick",
  "memchr",
  "regex-syntax",
 ]
@@ -2558,7 +2557,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.25",
+ "syn 2.0.27",
  "unicode-ident",
 ]
 
@@ -2598,15 +2597,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "salsa"
@@ -2686,37 +2685,37 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "5d25439cd7397d044e2748a6fe2432b5e85db703d6d097bd014b3c0ad1ebff0b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2732,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -2743,13 +2742,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731"
+checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2882,7 +2881,7 @@ dependencies = [
  "hmac",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "rfc6979",
  "sha2",
  "starknet-crypto-codegen",
@@ -2899,7 +2898,7 @@ checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
  "starknet-curve 0.4.0",
  "starknet-ff",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2937,6 +2936,7 @@ name = "starknet-sierra-compile"
 version = "2.1.0-rc0"
 dependencies = [
  "anyhow",
+ "cairo-lang-casm-contract-class",
  "cairo-lang-sierra",
  "cairo-lang-starknet",
  "cairo-lang-utils",
@@ -2983,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3101,22 +3101,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3230,7 +3230,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3270,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.12"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -3361,7 +3361,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3396,9 +3396,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -3482,7 +3482,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -3504,7 +3504,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3614,9 +3614,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
 dependencies = [
  "memchr",
 ]
@@ -3668,5 +3668,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ id-arena = "2.2.1"
 ignore = "0.4.20"
 indent = "0.1.1"
 indexmap = { version = "2.0.0", default-features = false }
-indoc = { version = "2.0.1", default-features = false }
+indoc = { version = "2.0.1" }
 itertools = { version = "0.11.0", default-features = false, features = [
     "use_alloc",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [profile.release]
-overflow-checks = true     # Enable integer overflow checks.
+overflow-checks = true # Enable integer overflow checks.
 
 [workspace]
 
 members = [
     "crates/cairo-lang-casm",
+    "crates/cairo-lang-casm-contract-class",
     "crates/cairo-lang-compiler",
     "crates/cairo-lang-debug",
     "crates/cairo-lang-defs",
@@ -31,6 +32,7 @@ members = [
     "crates/cairo-lang-syntax-codegen",
     "crates/cairo-lang-test-runner",
     "crates/cairo-lang-utils",
+    "crates/cairo-lang-vm-utils",
     "crates/bin/cairo-language-server",
     "crates/bin/cairo-compile",
     "crates/bin/cairo-format",
@@ -43,6 +45,8 @@ members = [
     "tests",
 ]
 
+exclude = ["ensure_no_std"]
+
 [workspace.package]
 version = "2.1.0-rc0"
 edition = "2021"
@@ -52,14 +56,14 @@ license-file = "LICENSE"
 
 [workspace.dependencies]
 anyhow = "1.0.66"
-ark-ff = "0.4.0-alpha.7"
+ark-std = { version = "0.4.0", default-features = false }
+ark-ff = { version = "0.4.0-alpha.7", default-features = false }
 ark-secp256k1 = "0.4.0"
 ark-secp256r1 = "0.4.0"
-ark-std = "0.4.0"
 assert_matches = "1.5"
 bimap = "0.6.2"
-cairo-felt = "0.8.2"
-cairo-vm = "0.8.2"
+cairo-felt = { version = "0.8.2", default-features = false }
+cairo-vm = { version = "0.8.2", default-features = false }
 clap = { version = "4.0", features = ["derive"] }
 colored = "2"
 const-fnv1a-hash = "1.1.0"
@@ -69,22 +73,24 @@ diffy = "0.3.0"
 env_logger = "0.10.0"
 genco = "0.17.0"
 good_lp = { version = "1.3.2", features = ["minilp"], default-features = false }
+hashbrown = { version = "0.14.0", features = ["serde"] }
 id-arena = "2.2.1"
 ignore = "0.4.20"
 indent = "0.1.1"
-indexmap = { version = "2.0.0", features = ["serde"] }
-indoc = "2.0.1"
-itertools = "0.11.0"
+indexmap = { version = "2.0.0", features = ["serde"], default-features = false }
+indoc = { version = "2.0.1", default-features = false }
+itertools = { version = "0.11.0", default-features = false, features = [
+    "use_alloc",
+] }
 keccak = "0.1.3"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 log = "0.4"
 lsp = { version = "0.94", package = "lsp-types" }
-num-bigint = "0.4"
-num-integer = "0.1"
-num-traits = "0.2"
+num-bigint = { version = "0.4", default-features = false, features = ["serde"] }
+num-integer = { version = "0.1", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 once_cell = "1.17.1"
-parity-scale-codec = "3.5.0"
-parity-scale-codec-derive = "3.1.4"
+parity-scale-codec = { version = "3.5.0", default-features = false }
 path-clean = "1.0.1"
 pretty_assertions = "1.2.1"
 proc-macro2 = "1.0"
@@ -94,7 +100,10 @@ rstest = "0.18.1"
 salsa = "0.16.1"
 scarb-metadata = "1.4.2"
 schemars = { version = "0.8.12", features = ["preserve_order"] }
-serde = { version = "1.0.130", features = ["derive"] }
+serde = { version = "1.0.130", default-features = false, features = [
+    "derive",
+    "alloc",
+] }
 serde_json = "1.0"
 sha3 = "0.10.6"
 smol_str = { version = "0.2.0", features = ["serde"] }
@@ -102,6 +111,7 @@ syn = { version = "2.0.25", features = ["full", "extra-traits"] }
 test-case = "3.1.0"
 test-case-macros = "2.2.2"
 test-log = "0.2.11"
+thiserror-no-std = "2.0.2"
 thiserror = "1.0.32"
 time = { version = "0.3.20", features = [
     "formatting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,11 @@ diffy = "0.3.0"
 env_logger = "0.10.0"
 genco = "0.17.0"
 good_lp = { version = "1.3.2", features = ["minilp"], default-features = false }
-hashbrown = { version = "0.14.0", features = ["serde"] }
+hashbrown = { version = "0.14.0" }
 id-arena = "2.2.1"
 ignore = "0.4.20"
 indent = "0.1.1"
-indexmap = { version = "2.0.0", features = ["serde"], default-features = false }
+indexmap = { version = "2.0.0", default-features = false }
 indoc = { version = "2.0.1", default-features = false }
 itertools = { version = "0.11.0", default-features = false, features = [
     "use_alloc",
@@ -86,11 +86,13 @@ keccak = "0.1.3"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 log = "0.4"
 lsp = { version = "0.94", package = "lsp-types" }
-num-bigint = { version = "0.4", default-features = false, features = ["serde"] }
+num-bigint = { version = "0.4", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = "1.17.1"
-parity-scale-codec = { version = "3.5.0", default-features = false }
+parity-scale-codec = { version = "3.6.4", default-features = false, features = [
+    "derive",
+] }
 path-clean = "1.0.1"
 pretty_assertions = "1.2.1"
 proc-macro2 = "1.0"
@@ -106,7 +108,7 @@ serde = { version = "1.0.130", default-features = false, features = [
 ] }
 serde_json = "1.0"
 sha3 = "0.10.6"
-smol_str = { version = "0.2.0", features = ["serde"] }
+smol_str = { version = "0.2.0" }
 syn = { version = "2.0.25", features = ["full", "extra-traits"] }
 test-case = "3.1.0"
 test-case-macros = "2.2.2"

--- a/crates/bin/cairo-compile/Cargo.toml
+++ b/crates/bin/cairo-compile/Cargo.toml
@@ -11,7 +11,9 @@ anyhow.workspace = true
 clap.workspace = true
 log.workspace = true
 
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "2.1.0-rc0" }
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "2.1.0-rc0", features = [
+    "serde",
+] }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.1.0-rc0", features = [
     "env_logger",
 ] }

--- a/crates/bin/cairo-language-server/Cargo.toml
+++ b/crates/bin/cairo-language-server/Cargo.toml
@@ -10,7 +10,9 @@ description = "Language server executable for the Cairo programming language"
 tokio.workspace = true
 log.workspace = true
 
-cairo-lang-language-server = { path = "../../cairo-lang-language-server", version = "2.1.0-rc0" }
+cairo-lang-language-server = { path = "../../cairo-lang-language-server", version = "2.1.0-rc0", features = [
+    "serde",
+] }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.1.0-rc0", features = [
     "env_logger",
 ] }

--- a/crates/bin/cairo-run/src/main.rs
+++ b/crates/bin/cairo-run/src/main.rs
@@ -7,7 +7,6 @@ use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::{check_compiler_path, setup_project};
 use cairo_lang_diagnostics::ToOption;
-use cairo_lang_runner::short_string::as_cairo_short_string;
 use cairo_lang_runner::{SierraCasmRunner, StarknetState};
 use cairo_lang_sierra::extensions::gas::{
     BuiltinCostWithdrawGasLibfunc, RedepositGasLibfunc, WithdrawGasLibfunc,
@@ -16,6 +15,7 @@ use cairo_lang_sierra::extensions::NamedLibfunc;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_sierra_generator::replace_ids::{DebugReplacer, SierraIdReplacer};
 use cairo_lang_starknet::contract::get_contracts_info;
+use cairo_lang_utils::short_string::as_cairo_short_string;
 use clap::Parser;
 
 /// Command line args parser.

--- a/crates/bin/cairo-test/Cargo.toml
+++ b/crates/bin/cairo-test/Cargo.toml
@@ -11,4 +11,6 @@ anyhow.workspace = true
 clap.workspace = true
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "2.1.0-rc0" }
-cairo-lang-test-runner = { path = "../../cairo-lang-test-runner", version = "2.1.0-rc0" }
+cairo-lang-test-runner = { path = "../../cairo-lang-test-runner", version = "2.1.0-rc0", features = [
+    "serde",
+] }

--- a/crates/bin/starknet-compile/Cargo.toml
+++ b/crates/bin/starknet-compile/Cargo.toml
@@ -11,4 +11,6 @@ anyhow.workspace = true
 clap.workspace = true
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "2.1.0-rc0" }
-cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.1.0-rc0" }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.1.0-rc0", features = [
+    "serde",
+] }

--- a/crates/bin/starknet-sierra-compile/Cargo.toml
+++ b/crates/bin/starknet-sierra-compile/Cargo.toml
@@ -12,6 +12,7 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
-cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "2.1.0-rc0" }
-cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.1.0-rc0" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.1.0-rc0" }
+cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "2.1.0-rc0", default-features = false }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.1.0-rc0", default-features = false }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.1.0-rc0", default-features = false }
+cairo-lang-casm-contract-class = { path = "../../cairo-lang-casm-contract-class", version = "2.1.0-rc0", default-features = false }

--- a/crates/bin/starknet-sierra-compile/Cargo.toml
+++ b/crates/bin/starknet-sierra-compile/Cargo.toml
@@ -15,4 +15,6 @@ serde_json.workspace = true
 cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "2.1.0-rc0", default-features = false }
 cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.1.0-rc0", default-features = false }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.1.0-rc0", default-features = false }
-cairo-lang-casm-contract-class = { path = "../../cairo-lang-casm-contract-class", version = "2.1.0-rc0", default-features = false }
+cairo-lang-casm-contract-class = { path = "../../cairo-lang-casm-contract-class", version = "2.1.0-rc0", default-features = false, features = [
+    "serde",
+] }

--- a/crates/bin/starknet-sierra-compile/Cargo.toml
+++ b/crates/bin/starknet-sierra-compile/Cargo.toml
@@ -9,7 +9,7 @@ description = "Compiler executable for the Sierra intemediate representation wit
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["std"] }
 serde_json.workspace = true
 
 cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "2.1.0-rc0", default-features = false }

--- a/crates/bin/starknet-sierra-compile/src/main.rs
+++ b/crates/bin/starknet-sierra-compile/src/main.rs
@@ -2,7 +2,6 @@ use std::fs;
 
 use anyhow::Context;
 use cairo_lang_starknet::allowed_libfuncs::{validate_compatible_sierra_version, ListSelector};
-use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract_class::{ContractClass, ContractEntryPoints};
 use cairo_lang_utils::bigint::BigUintAsHex;
 use clap::Parser;
@@ -63,9 +62,9 @@ fn main() -> anyhow::Result<()> {
         abi: None,
     };
     validate_compatible_sierra_version(&contract_class, list_selector)?;
-    let casm_contract =
-        CasmContractClass::from_contract_class(contract_class, args.add_pythonic_hints)
-            .with_context(|| "Compilation failed.")?;
+    let casm_contract = contract_class
+        .into_casm_contract_class(args.add_pythonic_hints)
+        .with_context(|| "Compilation failed.")?;
 
     let res = serde_json::to_string_pretty(&casm_contract)
         .with_context(|| "Casm contract Serialization failed.")?;

--- a/crates/cairo-lang-casm-contract-class/Cargo.toml
+++ b/crates/cairo-lang-casm-contract-class/Cargo.toml
@@ -20,6 +20,6 @@ std = [
     "cairo-lang-utils/std",
     "num-bigint/std",
     "itertools/use_std",
-    "serde/std",
+    "serde?/std",
 ]
 serde = ["dep:serde", "cairo-lang-casm/serde"]

--- a/crates/cairo-lang-casm-contract-class/Cargo.toml
+++ b/crates/cairo-lang-casm-contract-class/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cairo-lang-casm-contract-class"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "Casm representaion of a starknet contract"
+
+[dependencies]
+cairo-lang-casm = { path = "../cairo-lang-casm", default-features = false }
+cairo-lang-utils = { path = "../cairo-lang-utils", default-features = false }
+num-bigint.workspace = true
+serde.workspace = true
+itertools = { workspace = true, default-features = false }
+[features]
+default = ["std"]
+std = [
+    "cairo-lang-casm/std",
+    "cairo-lang-utils/std",
+    "num-bigint/std",
+    "serde/std",
+]

--- a/crates/cairo-lang-casm-contract-class/Cargo.toml
+++ b/crates/cairo-lang-casm-contract-class/Cargo.toml
@@ -7,11 +7,12 @@ license-file.workspace = true
 description = "Casm representaion of a starknet contract"
 
 [dependencies]
-cairo-lang-casm = { path = "../cairo-lang-casm", default-features = false }
-cairo-lang-utils = { path = "../cairo-lang-utils", default-features = false }
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.1.0-rc0", default-features = false }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0", default-features = false }
+itertools.workspace = true
 num-bigint.workspace = true
 serde = { workspace = true, optional = true }
-itertools = { workspace = true, default-features = false }
+
 [features]
 default = ["std"]
 std = [
@@ -19,5 +20,6 @@ std = [
     "cairo-lang-utils/std",
     "num-bigint/std",
     "itertools/use_std",
+    "serde/std",
 ]
-serde = ["serde/std"]
+serde = ["dep:serde", "cairo-lang-casm/serde"]

--- a/crates/cairo-lang-casm-contract-class/Cargo.toml
+++ b/crates/cairo-lang-casm-contract-class/Cargo.toml
@@ -10,7 +10,7 @@ description = "Casm representaion of a starknet contract"
 cairo-lang-casm = { path = "../cairo-lang-casm", default-features = false }
 cairo-lang-utils = { path = "../cairo-lang-utils", default-features = false }
 num-bigint.workspace = true
-serde.workspace = true
+serde = { workspace = true, optional = true }
 itertools = { workspace = true, default-features = false }
 [features]
 default = ["std"]
@@ -18,5 +18,6 @@ std = [
     "cairo-lang-casm/std",
     "cairo-lang-utils/std",
     "num-bigint/std",
-    "serde/std",
+    "itertools/use_std",
 ]
+serde = ["serde/std"]

--- a/crates/cairo-lang-casm-contract-class/src/lib.rs
+++ b/crates/cairo-lang-casm-contract-class/src/lib.rs
@@ -1,0 +1,48 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use cairo_lang_casm::hints::Hint;
+use cairo_lang_utils::bigint::{deserialize_big_uint, serialize_big_uint, BigUintAsHex};
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+
+/// Represents a contract in the Starknet network.
+#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CasmContractClass {
+    #[serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")]
+    pub prime: BigUint,
+    pub compiler_version: String,
+    pub bytecode: Vec<BigUintAsHex>,
+    pub hints: Vec<(usize, Vec<Hint>)>,
+
+    // Optional pythonic hints in a format that can be executed by the python vm.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pythonic_hints: Option<Vec<(usize, Vec<String>)>>,
+    pub entry_points_by_type: CasmContractEntryPoints,
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CasmContractEntryPoints {
+    #[serde(rename = "EXTERNAL")]
+    pub external: Vec<CasmContractEntryPoint>,
+    #[serde(rename = "L1_HANDLER")]
+    pub l1_handler: Vec<CasmContractEntryPoint>,
+    #[serde(rename = "CONSTRUCTOR")]
+    pub constructor: Vec<CasmContractEntryPoint>,
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CasmContractEntryPoint {
+    /// A field element that encodes the signature of the called function.
+    #[serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")]
+    pub selector: BigUint,
+    /// The offset of the instruction that should be called within the contract bytecode.
+    pub offset: usize,
+    // list of builtins.
+    pub builtins: Vec<String>,
+}

--- a/crates/cairo-lang-casm-contract-class/src/lib.rs
+++ b/crates/cairo-lang-casm-contract-class/src/lib.rs
@@ -7,39 +7,51 @@ extern crate alloc;
 use alloc::{string::String, vec::Vec};
 
 use cairo_lang_casm::hints::Hint;
-use cairo_lang_utils::bigint::{deserialize_big_uint, serialize_big_uint, BigUintAsHex};
+use cairo_lang_utils::bigint::BigUintAsHex;
+#[cfg(feature = "serde")]
+use cairo_lang_utils::bigint::{deserialize_big_uint, serialize_big_uint};
 use num_bigint::BigUint;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Represents a contract in the Starknet network.
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CasmContractClass {
-    #[serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")
+    )]
     pub prime: BigUint,
     pub compiler_version: String,
     pub bytecode: Vec<BigUintAsHex>,
     pub hints: Vec<(usize, Vec<Hint>)>,
 
     // Optional pythonic hints in a format that can be executed by the python vm.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub pythonic_hints: Option<Vec<(usize, Vec<String>)>>,
     pub entry_points_by_type: CasmContractEntryPoints,
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CasmContractEntryPoints {
-    #[serde(rename = "EXTERNAL")]
+    #[cfg_attr(feature = "serde", serde(rename = "EXTERNAL"))]
     pub external: Vec<CasmContractEntryPoint>,
-    #[serde(rename = "L1_HANDLER")]
+    #[cfg_attr(feature = "serde", serde(rename = "L1_HANDLER"))]
     pub l1_handler: Vec<CasmContractEntryPoint>,
-    #[serde(rename = "CONSTRUCTOR")]
+    #[cfg_attr(feature = "serde", serde(rename = "CONSTRUCTOR"))]
     pub constructor: Vec<CasmContractEntryPoint>,
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CasmContractEntryPoint {
     /// A field element that encodes the signature of the called function.
-    #[serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")
+    )]
     pub selector: BigUint,
     /// The offset of the instruction that should be called within the contract bytecode.
     pub offset: usize,

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -27,7 +27,14 @@ test-log.workspace = true
 
 [features]
 default = ["std"]
-std = ["cairo-lang-utils/std"]
+std = [
+    "cairo-lang-utils/std",
+    "itertools/use_std",
+    "num-bigint/std",
+    "num-traits/std",
+    "parity-scale-codec?/std",
+    "serde?/std",
+]
 schemars = ["std", "dep:schemars", "cairo-lang-utils/schemars"]
 parity-scale-codec = [
     "dep:parity-scale-codec",

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -7,15 +7,20 @@ license-file.workspace = true
 description = "Cairo assembly encoding."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0", default-features = false, features = [
+    "parity-scale-codec",
+] }
 indoc.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
-parity-scale-codec.workspace = true
-parity-scale-codec-derive.workspace = true
-schemars = { workspace = true, features = ["preserve_order"] }
+parity-scale-codec = { workspace = true, optional = true, features = [
+    "derive",
+] }
 serde.workspace = true
-thiserror.workspace = true
+hashbrown.workspace = true
+thiserror-no-std.workspace = true
+# Optional feature
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 env_logger.workspace = true
@@ -23,3 +28,8 @@ itertools.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+
+[features]
+default = ["std"]
+std = ["cairo-lang-utils/std"]
+schemars = ["std", "dep:schemars", "cairo-lang-utils/schemars"]

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -7,16 +7,12 @@ license-file.workspace = true
 description = "Cairo assembly encoding."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0", default-features = false, features = [
-    "parity-scale-codec",
-] }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0", default-features = false }
 indoc.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
-parity-scale-codec = { workspace = true, optional = true, features = [
-    "derive",
-] }
-serde.workspace = true
+parity-scale-codec = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 hashbrown.workspace = true
 thiserror-no-std.workspace = true
 # Optional feature
@@ -33,3 +29,8 @@ test-log.workspace = true
 default = ["std"]
 std = ["cairo-lang-utils/std"]
 schemars = ["std", "dep:schemars", "cairo-lang-utils/schemars"]
+parity-scale-codec = [
+    "dep:parity-scale-codec",
+    "cairo-lang-utils/parity-scale-codec",
+]
+serde = ["dep:serde", "cairo-lang-utils/serde"]

--- a/crates/cairo-lang-casm/src/ap_change.rs
+++ b/crates/cairo-lang-casm/src/ap_change.rs
@@ -1,7 +1,7 @@
-use std::fmt::Display;
+use core::fmt;
 
 use cairo_lang_utils::casts::IntoOrPanic;
-use thiserror::Error;
+use thiserror_no_std::Error;
 
 use crate::operand::{BinOpOperand, CellRef, DerefOrImmediate, Register, ResOperand};
 
@@ -14,8 +14,8 @@ pub enum ApChange {
     Known(usize),
     Unknown,
 }
-impl Display for ApChange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ApChange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ApChange::Known(change) => write!(f, "ApChange::Known({change})"),
             ApChange::Unknown => write!(f, "ApChange::Unknown"),

--- a/crates/cairo-lang-casm/src/ap_change_test.rs
+++ b/crates/cairo-lang-casm/src/ap_change_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use test_log::test;
 
 use super::{BinOpOperand, DerefOrImmediate};

--- a/crates/cairo-lang-casm/src/builder.rs
+++ b/crates/cairo-lang-casm/src/builder.rs
@@ -1,5 +1,27 @@
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+#[cfg(not(feature = "std"))]
+use no_std_imports::*;
+#[cfg(feature = "std")]
+use std_imports::*;
+#[cfg(not(feature = "std"))]
+mod no_std_imports {
+    pub use alloc::borrow::ToOwned;
+    pub use alloc::string::String;
+    pub use alloc::vec;
+    pub use alloc::vec::Vec;
+
+    pub use hashbrown::hash_map::Entry;
+    pub use hashbrown::HashMap;
+}
+
+#[cfg(feature = "std")]
+mod std_imports {
+    pub use std::collections::hash_map::Entry;
+    pub use std::collections::HashMap;
+}
+
+use core::mem;
+#[cfg(feature = "std")]
+pub use std::borrow::ToOwned;
 
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::extract_matches;
@@ -405,7 +427,7 @@ impl CasmBuilder {
         );
         self.statements.push(Statement::Jump(label.clone(), instruction));
         let mut state = State::default();
-        std::mem::swap(&mut state, &mut self.main_state);
+        mem::swap(&mut state, &mut self.main_state);
         self.set_or_test_label_state(label, state);
         self.reachable = false;
     }
@@ -610,7 +632,7 @@ impl CasmBuilder {
         }
         self.main_state.steps += 1;
         let mut hints = vec![];
-        std::mem::swap(&mut hints, &mut self.current_hints);
+        mem::swap(&mut hints, &mut self.current_hints);
         Instruction { body, inc_ap, hints }
     }
 }
@@ -778,15 +800,15 @@ macro_rules! casm_build_extend {
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, jump $target:ident; $($tok:tt)*) => {
-        $builder.jump(std::stringify!($target).to_owned());
+        $builder.jump($crate::builder::ToOwned::to_owned(core::stringify!($target)));
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, jump $target:ident if $condition:ident != 0; $($tok:tt)*) => {
-        $builder.jump_nz($condition, std::stringify!($target).to_owned());
+        $builder.jump_nz($condition, $crate::builder::ToOwned::to_owned(core::stringify!($target)));
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, let ($($var_name:ident),*) = call $target:ident; $($tok:tt)*) => {
-        $builder.call(std::stringify!($target).to_owned());
+        $builder.call($crate::builder::ToOwned::to_owned(core::stringify!($target)));
 
         let __var_count = {0i16 $(+ (stringify!($var_name), 1i16).1)*};
         let mut __var_index = 0;
@@ -804,7 +826,7 @@ macro_rules! casm_build_extend {
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, $label:ident: $($tok:tt)*) => {
-        $builder.label(std::stringify!($label).to_owned());
+        $builder.label($crate::builder::ToOwned::to_owned(core::stringify!($label)));
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, fail; $($tok:tt)*) => {

--- a/crates/cairo-lang-casm/src/builder_test.rs
+++ b/crates/cairo-lang-casm/src/builder_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::format;
+
 use indoc::indoc;
 use itertools::join;
 use pretty_assertions::assert_eq;

--- a/crates/cairo-lang-casm/src/encoder.rs
+++ b/crates/cairo-lang-casm/src/encoder.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 use num_bigint::BigInt;
 
 use crate::assembler::{ApUpdate, FpUpdate, InstructionRepr, Op1Addr, Opcode, PcUpdate, Res};

--- a/crates/cairo-lang-casm/src/encoder_test.rs
+++ b/crates/cairo-lang-casm/src/encoder_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 use num_bigint::BigInt;
 use pretty_assertions::assert_eq;
 use test_case::test_case;

--- a/crates/cairo-lang-casm/src/hints/mod.rs
+++ b/crates/cairo-lang-casm/src/hints/mod.rs
@@ -9,6 +9,7 @@ use cairo_lang_utils::bigint::BigIntAsHex;
 use indoc::formatdoc;
 #[cfg(feature = "parity-scale-codec")]
 use parity_scale_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::operand::{CellRef, DerefOrImmediate, ResOperand};
@@ -19,10 +20,11 @@ mod test;
 // Represents a cairo hint.
 // Note: Hint encoding should be backwards-compatible. This is an API guarantee.
 // For example, new variants should have new `index`.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
-#[serde(untagged)]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum Hint {
     #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Core(CoreHintBase),
@@ -63,7 +65,8 @@ impl PythonicHint for Hint {
 }
 
 /// Represents a hint that triggers a system call.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 
@@ -81,10 +84,11 @@ pub enum StarknetHint {
 }
 
 // Represents a cairo core hint.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
-#[serde(untagged)]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum CoreHintBase {
     #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Core(CoreHint),
@@ -103,7 +107,8 @@ impl From<DeprecatedHint> for CoreHintBase {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 
@@ -243,7 +248,8 @@ pub enum CoreHint {
 
 /// Represents a deprecated hint which is kept for backward compatibility of previously deployed
 /// contracts.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 

--- a/crates/cairo-lang-casm/src/hints/test.rs
+++ b/crates/cairo-lang-casm/src/hints/test.rs
@@ -1,11 +1,18 @@
+#[cfg(all(not(feature = "std"), feature = "parity-scale-codec"))]
+use alloc::str::FromStr;
+#[cfg(all(feature = "std", feature = "parity-scale-codec"))]
 use std::str::FromStr;
 
+#[cfg(feature = "parity-scale-codec")]
 use cairo_lang_utils::bigint::BigIntAsHex;
 use indoc::indoc;
+#[cfg(feature = "parity-scale-codec")]
 use parity_scale_codec::{Decode, Encode};
 use test_log::test;
 
-use crate::hints::{CoreHint, CoreHintBase, Hint, PythonicHint, StarknetHint};
+use crate::hints::{CoreHint, PythonicHint, StarknetHint};
+#[cfg(feature = "parity-scale-codec")]
+use crate::hints::{CoreHintBase, Hint};
 use crate::operand::{BinOpOperand, CellRef, DerefOrImmediate, Operation, Register, ResOperand};
 use crate::res;
 
@@ -117,6 +124,7 @@ fn test_debug_hint_format() {
 }
 
 #[test]
+#[cfg(feature = "parity-scale-codec")]
 fn encode_hint() {
     let hint = Hint::Core(CoreHintBase::Core(CoreHint::TestLessThan {
         lhs: ResOperand::Deref(CellRef { register: Register::FP, offset: -3 }),

--- a/crates/cairo-lang-casm/src/inline.rs
+++ b/crates/cairo-lang-casm/src/inline.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::hints::Hint;
 use crate::instructions::Instruction;
 
@@ -215,7 +218,7 @@ macro_rules! casm_extend {
 #[macro_export]
 macro_rules! append_instruction {
     ($ctx:ident, $body:ident $(,$ap:ident++)?) => {
-        let current_hints = std::mem::take(&mut $ctx.current_hints);
+        let current_hints = core::mem::take(&mut $ctx.current_hints);
         let instr = $crate::instructions::Instruction {
             body: $body,
             inc_ap: $crate::is_inc_ap!($($ap++)?),

--- a/crates/cairo-lang-casm/src/inline_test.rs
+++ b/crates/cairo-lang-casm/src/inline_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use indoc::indoc;
 use itertools::join;
 use pretty_assertions::assert_eq;

--- a/crates/cairo-lang-casm/src/instructions.rs
+++ b/crates/cairo-lang-casm/src/instructions.rs
@@ -1,5 +1,13 @@
-use std::fmt::Display;
-use std::vec;
+use core::fmt::Display;
+
+#[cfg(not(feature = "std"))]
+use no_std_imports::*;
+#[cfg(not(feature = "std"))]
+mod no_std_imports {
+    pub use alloc::string::ToString;
+    pub use alloc::vec;
+    pub use alloc::vec::Vec;
+}
 
 use crate::hints::{Hint, PythonicHint};
 use crate::operand::{CellRef, DerefOrImmediate, ResOperand};
@@ -32,7 +40,7 @@ impl InstructionBody {
     }
 }
 impl Display for InstructionBody {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             InstructionBody::AddAp(insn) => write!(f, "{insn}",),
             InstructionBody::AssertEq(insn) => write!(f, "{insn}",),
@@ -58,7 +66,7 @@ impl Instruction {
 }
 
 impl Display for Instruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for hint in &self.hints {
             let hint_str = hint.get_pythonic_hint();
             // Skip leading and trailing space if hint starts with `\n`.
@@ -84,7 +92,7 @@ pub struct CallInstruction {
     pub relative: bool,
 }
 impl Display for CallInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "call {} {}", if self.relative { "rel" } else { "abs" }, self.target,)
     }
 }
@@ -112,7 +120,7 @@ impl JumpInstruction {
     }
 }
 impl Display for JumpInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "jmp {} {}", if self.relative { "rel" } else { "abs" }, self.target,)
     }
 }
@@ -132,7 +140,7 @@ impl JnzInstruction {
     }
 }
 impl Display for JnzInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "jmp rel {} if {} != 0", self.jump_offset, self.condition)
     }
 }
@@ -162,7 +170,7 @@ impl AssertEqInstruction {
     }
 }
 impl Display for AssertEqInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} = {}", self.a, self.b)
     }
 }
@@ -171,7 +179,7 @@ impl Display for AssertEqInstruction {
 #[derive(Debug, Eq, PartialEq)]
 pub struct RetInstruction {}
 impl Display for RetInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ret")
     }
 }
@@ -193,7 +201,7 @@ impl AddApInstruction {
     }
 }
 impl Display for AddApInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ap += {}", self.operand)
     }
 }

--- a/crates/cairo-lang-casm/src/instructions_test.rs
+++ b/crates/cairo-lang-casm/src/instructions_test.rs
@@ -1,3 +1,11 @@
+#[cfg(not(feature = "std"))]
+use no_std_imports::*;
+#[cfg(not(feature = "std"))]
+mod no_std_imports {
+    pub use alloc::string::ToString;
+    pub use alloc::vec;
+}
+
 use indoc::indoc;
 use test_log::test;
 

--- a/crates/cairo-lang-casm/src/lib.rs
+++ b/crates/cairo-lang-casm/src/lib.rs
@@ -1,4 +1,8 @@
 //! Cairo assembly representation, formatting and construction utilities.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 pub mod ap_change;
 pub mod assembler;

--- a/crates/cairo-lang-casm/src/operand.rs
+++ b/crates/cairo-lang-casm/src/operand.rs
@@ -74,7 +74,6 @@ impl<T: Into<BigIntAsHex>> From<T> for ResOperand {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
-
 pub struct CellRef {
     pub register: Register,
     pub offset: i16,

--- a/crates/cairo-lang-casm/src/operand.rs
+++ b/crates/cairo-lang-casm/src/operand.rs
@@ -3,13 +3,15 @@ use core::fmt::Display;
 use cairo_lang_utils::bigint::BigIntAsHex;
 #[cfg(feature = "parity-scale-codec")]
 use parity_scale_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 #[path = "operand_test.rs"]
 mod test;
 
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub enum Register {
@@ -28,7 +30,8 @@ impl Display for Register {
 }
 
 // Represents the rhs operand of an assert equal InstructionBody.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub enum ResOperand {
@@ -67,7 +70,8 @@ impl<T: Into<BigIntAsHex>> From<T> for ResOperand {
 }
 
 /// Represents an operand of the form [reg + offset].
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 
@@ -86,7 +90,8 @@ pub fn ap_cell_ref(offset: i16) -> CellRef {
     CellRef { register: Register::AP, offset }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub enum DerefOrImmediate {
@@ -114,7 +119,8 @@ impl From<CellRef> for DerefOrImmediate {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub enum Operation {
@@ -132,7 +138,8 @@ impl Display for Operation {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub struct BinOpOperand {

--- a/crates/cairo-lang-casm/src/operand.rs
+++ b/crates/cairo-lang-casm/src/operand.rs
@@ -1,25 +1,25 @@
-use std::fmt::Display;
+use core::fmt::Display;
 
 use cairo_lang_utils::bigint::BigIntAsHex;
-use parity_scale_codec_derive::{Decode, Encode};
-use schemars::JsonSchema;
+#[cfg(feature = "parity-scale-codec")]
+use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 #[path = "operand_test.rs"]
 mod test;
 
-#[derive(
-    Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, JsonSchema,
-)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub enum Register {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     AP,
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     FP,
 }
 impl Display for Register {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Register::AP => write!(f, "ap"),
             Register::FP => write!(f, "fp"),
@@ -28,19 +28,21 @@ impl Display for Register {
 }
 
 // Represents the rhs operand of an assert equal InstructionBody.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub enum ResOperand {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Deref(CellRef),
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     DoubleDeref(CellRef, i16),
-    #[codec(index = 2)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 2))]
     Immediate(BigIntAsHex),
-    #[codec(index = 3)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 3))]
     BinOp(BinOpOperand),
 }
 impl Display for ResOperand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ResOperand::Deref(operand) => write!(f, "{operand}"),
             ResOperand::DoubleDeref(operand, offset) => write!(f, "[{operand} + {offset}]"),
@@ -65,13 +67,16 @@ impl<T: Into<BigIntAsHex>> From<T> for ResOperand {
 }
 
 /// Represents an operand of the form [reg + offset].
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
+
 pub struct CellRef {
     pub register: Register,
     pub offset: i16,
 }
 impl Display for CellRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "[{} + {}]", self.register, self.offset)
     }
 }
@@ -81,15 +86,17 @@ pub fn ap_cell_ref(offset: i16) -> CellRef {
     CellRef { register: Register::AP, offset }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub enum DerefOrImmediate {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Deref(CellRef),
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     Immediate(BigIntAsHex),
 }
 impl Display for DerefOrImmediate {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             DerefOrImmediate::Deref(operand) => write!(f, "{operand}"),
             DerefOrImmediate::Immediate(operand) => write!(f, "{}", operand.value),
@@ -107,15 +114,17 @@ impl From<CellRef> for DerefOrImmediate {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub enum Operation {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Add,
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     Mul,
 }
 impl Display for Operation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Operation::Add => write!(f, "+"),
             Operation::Mul => write!(f, "*"),
@@ -123,14 +132,16 @@ impl Display for Operation {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "parity-scale-codec", derive(Encode, Decode))]
 pub struct BinOpOperand {
     pub op: Operation,
     pub a: CellRef,
     pub b: DerefOrImmediate,
 }
 impl Display for BinOpOperand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} {} {}", self.a, self.op, self.b)
     }
 }

--- a/crates/cairo-lang-casm/src/operand_test.rs
+++ b/crates/cairo-lang-casm/src/operand_test.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+#[cfg(feature = "std")]
+use std::string::ToString;
+
 use test_log::test;
 
 use super::{BinOpOperand, DerefOrImmediate, Operation};

--- a/crates/cairo-lang-compiler/Cargo.toml
+++ b/crates/cairo-lang-compiler/Cargo.toml
@@ -26,7 +26,6 @@ smol_str.workspace = true
 thiserror.workspace = true
 
 [features]
-default = []
 serde = ["cairo-lang-project/serde"]
 
 [dev-dependencies]

--- a/crates/cairo-lang-compiler/Cargo.toml
+++ b/crates/cairo-lang-compiler/Cargo.toml
@@ -25,5 +25,9 @@ salsa.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true
 
+[features]
+default = []
+serde = ["cairo-lang-project/serde"]
+
 [dev-dependencies]
 test-log.workspace = true

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This crate is responsible for compiling a Cairo project into a Sierra program.
 //! It is the main entry point for the compiler.
+#[cfg(feature = "serde")]
 use std::path::Path;
 use std::sync::Arc;
 
@@ -14,7 +15,9 @@ use cairo_lang_sierra_generator::replace_ids::replace_sierra_ids_in_program;
 
 use crate::db::RootDatabase;
 use crate::diagnostics::DiagnosticsReporter;
-use crate::project::{get_main_crate_ids_from_project, setup_project, ProjectConfig};
+#[cfg(feature = "serde")]
+use crate::project::setup_project;
+use crate::project::{get_main_crate_ids_from_project, ProjectConfig};
 
 pub mod db;
 pub mod diagnostics;
@@ -55,6 +58,7 @@ pub type SierraProgram = Arc<Program>;
 /// # Returns
 /// * `Ok(SierraProgram)` - The compiled program.
 /// * `Err(anyhow::Error)` - Compilation failed.
+#[cfg(feature = "serde")]
 pub fn compile_cairo_project_at_path(
     path: &Path,
     compiler_config: CompilerConfig<'_>,

--- a/crates/cairo-lang-compiler/src/project.rs
+++ b/crates/cairo-lang-compiler/src/project.rs
@@ -73,6 +73,7 @@ pub fn update_crate_roots_from_project_config(db: &mut dyn SemanticGroup, config
 /// Setup the 'db' to compile the project in the given path.
 /// The path can be either a directory with cairo project file or a .cairo file.
 /// Returns the ids of the project crates.
+#[cfg(feature = "serde")]
 pub fn setup_project(
     db: &mut dyn SemanticGroup,
     path: &Path,

--- a/crates/cairo-lang-defs/Cargo.toml
+++ b/crates/cairo-lang-defs/Cargo.toml
@@ -13,8 +13,8 @@ cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.1.0-rc
 cairo-lang-parser = { path = "../cairo-lang-parser", version = "2.1.0-rc0" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
-indexmap.workspace = true
-itertools.workspace = true
+indexmap = { workspace = true, features = ["std"] }
+itertools = { workspace = true, features = ["use_std"] }
 salsa.workspace = true
 smol_str.workspace = true
 

--- a/crates/cairo-lang-diagnostics/Cargo.toml
+++ b/crates/cairo-lang-diagnostics/Cargo.toml
@@ -10,7 +10,7 @@ description = "Diagnostic utilities."
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.1.0-rc0" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 salsa.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-eq-solver/Cargo.toml
+++ b/crates/cairo-lang-eq-solver/Cargo.toml
@@ -9,8 +9,8 @@ description = "Equation solving for Sierra generation."
 [dependencies]
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 good_lp.workspace = true
-indexmap.workspace = true
-itertools.workspace = true
+indexmap = { workspace = true, features = ["std"] }
+itertools = { workspace = true, features = ["use_std"] }
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/cairo-lang-filesystem/Cargo.toml
+++ b/crates/cairo-lang-filesystem/Cargo.toml
@@ -11,10 +11,13 @@ cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 path-clean.workspace = true
 salsa.workspace = true
-serde.workspace = true
+serde = { workspace = true, optional = true }
 smol_str.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
 serde_json.workspace = true
 test-log.workspace = true
+
+[features]
+serde = ["dep:serde", "smol_str/serde"]

--- a/crates/cairo-lang-filesystem/Cargo.toml
+++ b/crates/cairo-lang-filesystem/Cargo.toml
@@ -11,7 +11,7 @@ cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 path-clean.workspace = true
 salsa.workspace = true
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["std"] }
 smol_str.workspace = true
 
 [dev-dependencies]
@@ -20,4 +20,4 @@ serde_json.workspace = true
 test-log.workspace = true
 
 [features]
-serde = ["dep:serde", "smol_str/serde"]
+serde = ["dep:serde", "smol_str/serde", "cairo-lang-utils/serde"]

--- a/crates/cairo-lang-filesystem/src/cfg.rs
+++ b/crates/cairo-lang-filesystem/src/cfg.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smol_str::SmolStr;
 
@@ -41,6 +42,7 @@ impl fmt::Debug for Cfg {
     }
 }
 
+#[cfg(feature = "serde")]
 mod serde_ext {
     use serde::{Deserialize, Serialize};
     use smol_str::SmolStr;
@@ -53,6 +55,7 @@ mod serde_ext {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for Cfg {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let sd = if let Some(value) = &self.value {
@@ -64,6 +67,7 @@ impl Serialize for Cfg {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Cfg {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let sd = serde_ext::Cfg::deserialize(deserializer)?;
@@ -78,7 +82,8 @@ impl<'de> Deserialize<'de> for Cfg {
 ///
 /// Behaves like a multimap, i.e. it permits storing multiple values for the same key.
 /// This allows expressing, for example, the `feature` option that Rust/Cargo does.
-#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CfgSet(OrderedHashSet<Cfg>);
 
 impl CfgSet {
@@ -197,6 +202,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde() {
         let cfg = CfgSet::from_iter([
             Cfg::name("name"),

--- a/crates/cairo-lang-formatter/Cargo.toml
+++ b/crates/cairo-lang-formatter/Cargo.toml
@@ -16,7 +16,7 @@ cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 colored.workspace = true
 diffy.workspace = true
 ignore.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 log.workspace = true
 salsa.workspace = true
 smol_str.workspace = true

--- a/crates/cairo-lang-language-server/Cargo.toml
+++ b/crates/cairo-lang-language-server/Cargo.toml
@@ -27,7 +27,7 @@ log.workspace = true
 lsp.workspace = true
 salsa.workspace = true
 scarb-metadata.workspace = true
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["std"] }
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 tokio.workspace = true
@@ -37,7 +37,6 @@ tower-lsp.workspace = true
 test-log.workspace = true
 
 [features]
-default = []
 serde = [
     "dep:serde",
     "dep:serde_json",

--- a/crates/cairo-lang-language-server/Cargo.toml
+++ b/crates/cairo-lang-language-server/Cargo.toml
@@ -27,11 +27,20 @@ log.workspace = true
 lsp.workspace = true
 salsa.workspace = true
 scarb-metadata.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 tokio.workspace = true
 tower-lsp.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true
+
+[features]
+default = []
+serde = [
+    "dep:serde",
+    "dep:serde_json",
+    "cairo-lang-filesystem/serde",
+    "cairo-lang-compiler/serde",
+]

--- a/crates/cairo-lang-language-server/src/scarb_service.rs
+++ b/crates/cairo-lang-language-server/src/scarb_service.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use cairo_lang_filesystem::ids::{CrateLongId, Directory};
+#[cfg(feature = "serde")]
 use lsp::Url;
 use scarb_metadata::Metadata;
 
@@ -13,6 +14,7 @@ const SCARB_PROJECT_FILE_NAME: &str = "Scarb.toml";
 
 pub struct ScarbService {
     scarb_path: Option<PathBuf>,
+    #[allow(dead_code)]
     notification: NotificationService,
 }
 
@@ -22,6 +24,7 @@ impl ScarbService {
         ScarbService { scarb_path, notification }
     }
 
+    #[cfg(feature = "serde")]
     fn scarb_path(&self) -> Option<PathBuf> {
         self.scarb_path.clone()
     }
@@ -46,6 +49,7 @@ impl ScarbService {
         None
     }
 
+    #[cfg(feature = "serde")]
     fn get_scarb_metadata(&self, root_path: PathBuf) -> Result<Metadata> {
         let manifest_path = self
             .scarb_manifest_path(root_path)
@@ -62,6 +66,7 @@ impl ScarbService {
     }
 
     /// Reads Scarb project metadata from manifest file.
+    #[cfg(feature = "serde")]
     pub async fn scarb_metadata(&self, root_path: PathBuf) -> Result<Metadata> {
         self.notification.notify_resolving_start().await;
         let result = self.get_scarb_metadata(root_path);
@@ -69,6 +74,7 @@ impl ScarbService {
         result
     }
 
+    #[cfg(feature = "serde")]
     pub async fn crate_roots(&self, root_path: PathBuf) -> Result<Vec<(CrateLongId, Directory)>> {
         let metadata = self
             .scarb_metadata(root_path)
@@ -88,6 +94,7 @@ impl ScarbService {
         Ok(crate_roots)
     }
 
+    #[cfg(feature = "serde")]
     pub async fn corelib_path(&self, root_path: PathBuf) -> Result<Option<PathBuf>> {
         let metadata = self
             .scarb_metadata(root_path)
@@ -104,6 +111,7 @@ impl ScarbService {
     }
 }
 
+#[cfg(feature = "serde")]
 pub fn is_scarb_manifest_path(file_path: &Url) -> bool {
     file_path.path().ends_with(SCARB_PROJECT_FILE_NAME)
 }

--- a/crates/cairo-lang-language-server/src/vfs.rs
+++ b/crates/cairo-lang-language-server/src/vfs.rs
@@ -1,26 +1,31 @@
 use lsp::notification::Notification;
 use lsp::Url;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub enum UpdateVirtualFile {}
 
+#[cfg(feature = "serde")]
 impl Notification for UpdateVirtualFile {
     type Params = UpdateVirtualFileParams;
     const METHOD: &'static str = "vfs/update";
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct UpdateVirtualFileParams {
     pub uri: Url,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ProvideVirtualFileRequest {
     pub uri: Url,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ProvideVirtualFileResponse {
     pub content: Option<String>,
 }

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -17,17 +17,19 @@ cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "2.1.0-rc0" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 id-arena.workspace = true
-indexmap.workspace = true
-itertools.workspace = true
+indexmap = { workspace = true, features = ["std"] }
+itertools = { workspace = true, features = ["use_std"] }
 log.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 salsa.workspace = true
 smol_str.workspace = true
 
 [dev-dependencies]
 cairo-lang-plugins = { path = "../cairo-lang-plugins" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", features = [
+    "testing",
+] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils" }
 env_logger.workspace = true
 indoc.workspace = true

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -879,7 +879,7 @@ fn lower_expr_match(
                     let variant_expr =
                         LoweredExpr::AtVariable(VarUsage { var_id, location: pattern_location });
 
-                    lower_single_pattern(ctx, &mut subscope, inner_pattern.clone(), variant_expr)
+                    lower_single_pattern(ctx, &mut subscope, inner_pattern, variant_expr)
                 }
                 None => {
                     let var_id = ctx.new_var(VarRequest {

--- a/crates/cairo-lang-parser/Cargo.toml
+++ b/crates/cairo-lang-parser/Cargo.toml
@@ -16,10 +16,10 @@ cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.1.0-rc0" }
 cairo-lang-syntax-codegen = { path = "../cairo-lang-syntax-codegen", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 colored.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 log.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 salsa.workspace = true
 smol_str.workspace = true
 unescaper.workspace = true

--- a/crates/cairo-lang-plugins/Cargo.toml
+++ b/crates/cairo-lang-plugins/Cargo.toml
@@ -24,9 +24,16 @@ smol_str.workspace = true
 [dev-dependencies]
 cairo-lang-debug = { path = "../cairo-lang-debug" }
 cairo-lang-parser = { path = "../cairo-lang-parser" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", features = [
+    "serde",
+] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils" }
 env_logger.workspace = true
 indoc.workspace = true
 serde_json.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+
+[features]
+default = []
+serde = []

--- a/crates/cairo-lang-plugins/Cargo.toml
+++ b/crates/cairo-lang-plugins/Cargo.toml
@@ -16,8 +16,8 @@ cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 indent.workspace = true
 indoc.workspace = true
-itertools.workspace = true
-num-bigint.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
+num-bigint = { workspace = true, features = ["std"] }
 salsa.workspace = true
 smol_str.workspace = true
 
@@ -33,7 +33,3 @@ indoc.workspace = true
 serde_json.workspace = true
 test-case.workspace = true
 test-log.workspace = true
-
-[features]
-default = []
-serde = []

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::sync::Arc;
 
 use cairo_lang_defs::plugin::PluginGeneratedFile;

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "serde")]
 use std::sync::Arc;
 
 use cairo_lang_defs::plugin::PluginGeneratedFile;

--- a/crates/cairo-lang-project/Cargo.toml
+++ b/crates/cairo-lang-project/Cargo.toml
@@ -9,7 +9,7 @@ description = "Cairo project specification. For example, crates and flags used f
 [dependencies]
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["std"] }
 smol_str.workspace = true
 thiserror.workspace = true
 toml.workspace = true
@@ -19,4 +19,4 @@ indoc.workspace = true
 test-log.workspace = true
 
 [features]
-serde = ["dep:serde", "smol_str/serde"]
+serde = ["dep:serde", "smol_str/serde", "cairo-lang-utils/serde"]

--- a/crates/cairo-lang-project/Cargo.toml
+++ b/crates/cairo-lang-project/Cargo.toml
@@ -9,7 +9,7 @@ description = "Cairo project specification. For example, crates and flags used f
 [dependencies]
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
-serde.workspace = true
+serde = { workspace = true, optional = true }
 smol_str.workspace = true
 thiserror.workspace = true
 toml.workspace = true
@@ -17,3 +17,6 @@ toml.workspace = true
 [dev-dependencies]
 indoc.workspace = true
 test-log.workspace = true
+
+[features]
+serde = ["dep:serde", "smol_str/serde"]

--- a/crates/cairo-lang-project/src/lib.rs
+++ b/crates/cairo-lang-project/src/lib.rs
@@ -2,10 +2,13 @@
 #[cfg(test)]
 mod test;
 
-use std::path::{Path, PathBuf};
+#[cfg(feature = "serde")]
+use std::path::Path;
+use std::path::PathBuf;
 
 use cairo_lang_filesystem::ids::Directory;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
@@ -18,6 +21,7 @@ pub enum DeserializationError {
     #[error("PathError")]
     PathError,
 }
+#[cfg(feature = "serde")]
 const PROJECT_FILE_NAME: &str = "cairo_project.toml";
 
 /// Cairo project config, including its file content and metadata about the file.
@@ -30,11 +34,13 @@ pub struct ProjectConfig {
     pub content: ProjectConfigContent,
 }
 /// Contents of a Cairo project config file.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProjectConfigContent {
     pub crate_roots: OrderedHashMap<SmolStr, PathBuf>,
 }
 
+#[cfg(feature = "serde")]
 impl ProjectConfig {
     pub fn from_directory(directory: &Path) -> Result<Self, DeserializationError> {
         Self::from_file(&directory.join(PROJECT_FILE_NAME))

--- a/crates/cairo-lang-project/src/test.rs
+++ b/crates/cairo-lang-project/src/test.rs
@@ -1,8 +1,10 @@
+#![cfg(feature = "serde")]
 use indoc::indoc;
 
 use crate::ProjectConfigContent;
 
 #[test]
+
 fn test_serde() {
     let config = ProjectConfigContent {
         crate_roots: [("crate".into(), "dir".into())].into_iter().collect(),

--- a/crates/cairo-lang-runner/Cargo.toml
+++ b/crates/cairo-lang-runner/Cargo.toml
@@ -13,7 +13,9 @@ ark-secp256k1.workspace = true
 ark-secp256r1.workspace = true
 ark-std.workspace = true
 cairo-felt.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.1.0-rc0" }
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.1.0-rc0", features = [
+    "std",
+] }
 cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "2.1.0-rc0" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "2.1.0-rc0" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "2.1.0-rc0" }
@@ -25,16 +27,21 @@ cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version
 cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "2.1.0-rc0" }
 cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "2.1.0-rc0" }
 cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "2.1.0-rc0" }
-cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.1.0-rc0" }
 cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "2.1.0-rc0" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0", features = [
+    "std",
+] }
+cairo-lang-vm-utils = { path = "../cairo-lang-vm-utils", features = [
+    "std",
+    "execute_core_hints",
+] }
+cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.1.0-rc0" }
 cairo-vm.workspace = true
 itertools.workspace = true
 keccak.workspace = true
 num-bigint.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true
-salsa.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-runner/Cargo.toml
+++ b/crates/cairo-lang-runner/Cargo.toml
@@ -8,11 +8,11 @@ description = "Basic cairo runner."
 
 [dependencies]
 anyhow.workspace = true
-ark-ff.workspace = true
+ark-ff = { workspace = true, features = ["std"] }
 ark-secp256k1.workspace = true
 ark-secp256r1.workspace = true
-ark-std.workspace = true
-cairo-felt.workspace = true
+ark-std = { workspace = true, features = ["std"] }
+cairo-felt = { workspace = true, features = ["std"] }
 cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.1.0-rc0", features = [
     "std",
 ] }
@@ -36,12 +36,12 @@ cairo-lang-vm-utils = { path = "../cairo-lang-vm-utils", features = [
     "execute_core_hints",
 ] }
 cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.1.0-rc0" }
-cairo-vm.workspace = true
-itertools.workspace = true
+cairo-vm = { workspace = true, features = ["std"] }
+itertools = { workspace = true, features = ["use_std"] }
 keccak.workspace = true
-num-bigint.workspace = true
-num-integer.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
+num-integer = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -3,18 +3,14 @@ use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::ops::{Deref, Shl};
 
-use ark_ff::fields::{Fp256, MontBackend, MontConfig};
-use ark_ff::{BigInteger, Field, PrimeField};
-use ark_std::UniformRand;
-use cairo_felt::{felt_str as felt252_str, Felt252};
-use cairo_lang_casm::hints::{CoreHint, DeprecatedHint, Hint, StarknetHint};
+use ark_ff::{BigInteger, PrimeField};
+use cairo_felt::Felt252;
+use cairo_lang_casm::hints::{Hint, StarknetHint};
 use cairo_lang_casm::instructions::Instruction;
-use cairo_lang_casm::operand::{
-    BinOpOperand, CellRef, DerefOrImmediate, Operation, Register, ResOperand,
-};
+use cairo_lang_casm::operand::{CellRef, DerefOrImmediate, Operation, Register, ResOperand};
 use cairo_lang_sierra::ids::FunctionId;
 use cairo_lang_utils::bigint::BigIntAsHex;
-use cairo_lang_utils::extract_matches;
+use cairo_lang_vm_utils::{execute_core_hint_base, extract_relocatable, insert_value_to_cellref};
 use cairo_vm::hint_processor::hint_processor_definition::{
     HintProcessor, HintProcessorLogic, HintReference,
 };
@@ -30,32 +26,15 @@ use cairo_vm::vm::errors::memory_errors::MemoryError;
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use cairo_vm::vm::runners::cairo_runner::{CairoRunner, ResourceTracker, RunResources};
 use cairo_vm::vm::vm_core::VirtualMachine;
-use dict_manager::DictManagerExecScope;
 use num_bigint::BigUint;
 use num_integer::Integer;
-use num_traits::{FromPrimitive, ToPrimitive, Zero};
+use num_traits::{ToPrimitive, Zero};
 use {ark_secp256k1 as secp256k1, ark_secp256r1 as secp256r1};
 
-use self::dict_manager::DictSquashExecScope;
-use crate::short_string::as_cairo_short_string;
 use crate::{build_hints_dict, Arg, RunResultValue, SierraCasmRunner};
 
 #[cfg(test)]
 mod test;
-
-mod dict_manager;
-
-// TODO(orizi): This def is duplicated.
-/// Returns the Beta value of the Starkware elliptic curve.
-fn get_beta() -> Felt252 {
-    felt252_str!("3141592653589793238462643383279502884197169399375105820974944592307816406665")
-}
-
-#[derive(MontConfig)]
-#[modulus = "3618502788666131213697322783095070105623107215331596699973092056135872020481"]
-#[generator = "3"]
-struct FqConfig;
-type Fq = Fp256<MontBackend<FqConfig, 4>>;
 
 /// Convert a Hint to the cairo-vm class HintParams by canonically serializing it to a string.
 pub fn hint_to_hint_params(hint: &Hint) -> HintParams {
@@ -167,32 +146,10 @@ struct TxInfo {
     chain_id: Felt252,
     nonce: Felt252,
 }
-/// Execution scope for constant memory allocation.
-struct MemoryExecScope {
-    /// The first free address in the segment.
-    next_address: Relocatable,
-}
 
 /// Fetches the value of a cell from the vm.
 fn get_cell_val(vm: &VirtualMachine, cell: &CellRef) -> Result<Felt252, VirtualMachineError> {
     Ok(vm.get_integer(cell_ref_to_relocatable(cell, vm))?.as_ref().clone())
-}
-
-/// Fetch the `MaybeRelocatable` value from an address.
-fn get_maybe_from_addr(
-    vm: &VirtualMachine,
-    addr: Relocatable,
-) -> Result<MaybeRelocatable, VirtualMachineError> {
-    vm.get_maybe(&addr)
-        .ok_or_else(|| VirtualMachineError::InvalidMemoryValueTemporaryAddress(Box::new(addr)))
-}
-
-/// Fetches the maybe relocatable value of a cell from the vm.
-fn get_cell_maybe(
-    vm: &VirtualMachine,
-    cell: &CellRef,
-) -> Result<MaybeRelocatable, VirtualMachineError> {
-    get_maybe_from_addr(vm, cell_ref_to_relocatable(cell, vm))
 }
 
 /// Fetches the value of a cell plus an offset from the vm, useful for pointers.
@@ -211,25 +168,6 @@ fn get_double_deref_val(
     offset: &Felt252,
 ) -> Result<Felt252, VirtualMachineError> {
     Ok(vm.get_integer(get_ptr(vm, cell, offset)?)?.as_ref().clone())
-}
-
-/// Fetches the maybe relocatable value of a pointer described by the value at `cell` plus an offset
-/// from the vm.
-fn get_double_deref_maybe(
-    vm: &VirtualMachine,
-    cell: &CellRef,
-    offset: &Felt252,
-) -> Result<MaybeRelocatable, VirtualMachineError> {
-    get_maybe_from_addr(vm, get_ptr(vm, cell, offset)?)
-}
-
-/// Extracts a parameter assumed to be a buffer, and converts it into a relocatable.
-pub fn extract_relocatable(
-    vm: &VirtualMachine,
-    buffer: &ResOperand,
-) -> Result<Relocatable, VirtualMachineError> {
-    let (base, offset) = extract_buffer(buffer);
-    get_ptr(vm, base, &offset)
 }
 
 /// Fetches the value of `res_operand` from the vm.
@@ -319,36 +257,6 @@ macro_rules! deduct_gas {
         }
         *$gas -= gas_costs::$amount;
     };
-}
-
-/// Fetches the maybe relocatable value of `res_operand` from the vm.
-fn get_maybe(
-    vm: &VirtualMachine,
-    res_operand: &ResOperand,
-) -> Result<MaybeRelocatable, VirtualMachineError> {
-    match res_operand {
-        ResOperand::Deref(cell) => get_cell_maybe(vm, cell),
-        ResOperand::DoubleDeref(cell, offset) => {
-            get_double_deref_maybe(vm, cell, &(*offset).into())
-        }
-        ResOperand::Immediate(x) => Ok(Felt252::from(x.value.clone()).into()),
-        ResOperand::BinOp(op) => {
-            let a = get_cell_maybe(vm, &op.a)?;
-            let b = match &op.b {
-                DerefOrImmediate::Deref(cell) => get_cell_val(vm, cell)?,
-                DerefOrImmediate::Immediate(x) => Felt252::from(x.value.clone()),
-            };
-            Ok(match op.op {
-                Operation::Add => a.add_int(&b)?,
-                Operation::Mul => match a {
-                    MaybeRelocatable::RelocatableValue(_) => {
-                        panic!("mul not implemented for relocatable values")
-                    }
-                    MaybeRelocatable::Int(a) => (a * b).into(),
-                },
-            })
-        }
-    }
 }
 
 impl HintProcessorLogic for CairoHintProcessor<'_> {
@@ -1391,478 +1299,6 @@ fn get_secp256r1_exec_scope(
     exec_scopes.get_mut_ref::<Secp256r1ExecutionScope>(NAME)
 }
 
-// ---
-
-pub fn execute_core_hint_base(
-    vm: &mut VirtualMachine,
-    exec_scopes: &mut ExecutionScopes,
-    core_hint_base: &cairo_lang_casm::hints::CoreHintBase,
-) -> Result<(), HintError> {
-    match core_hint_base {
-        cairo_lang_casm::hints::CoreHintBase::Core(core_hint) => {
-            execute_core_hint(vm, exec_scopes, core_hint)
-        }
-        cairo_lang_casm::hints::CoreHintBase::Deprecated(deprecated_hint) => {
-            execute_deprecated_hint(vm, exec_scopes, deprecated_hint)
-        }
-    }
-}
-
-pub fn execute_deprecated_hint(
-    vm: &mut VirtualMachine,
-    exec_scopes: &mut ExecutionScopes,
-    deprecated_hint: &cairo_lang_casm::hints::DeprecatedHint,
-) -> Result<(), HintError> {
-    match deprecated_hint {
-        DeprecatedHint::Felt252DictRead { dict_ptr, key, value_dst } => {
-            let dict_address = extract_relocatable(vm, dict_ptr)?;
-            let key = get_val(vm, key)?;
-            let dict_manager_exec_scope = exec_scopes
-                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
-                .expect("Trying to read from a dict while dict manager was not initialized.");
-            let value = dict_manager_exec_scope
-                .get_from_tracker(dict_address, &key)
-                .unwrap_or_else(|| DictManagerExecScope::DICT_DEFAULT_VALUE.into());
-            insert_value_to_cellref!(vm, value_dst, value)?;
-        }
-        DeprecatedHint::Felt252DictWrite { dict_ptr, key, value } => {
-            let dict_address = extract_relocatable(vm, dict_ptr)?;
-            let key = get_val(vm, key)?;
-            let value = get_maybe(vm, value)?;
-            let dict_manager_exec_scope = exec_scopes
-                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
-                .expect("Trying to write to a dict while dict manager was not initialized.");
-            let prev_value = dict_manager_exec_scope
-                .get_from_tracker(dict_address, &key)
-                .unwrap_or_else(|| DictManagerExecScope::DICT_DEFAULT_VALUE.into());
-            vm.insert_value((dict_address + 1)?, prev_value)?;
-            dict_manager_exec_scope.insert_to_tracker(dict_address, key, value);
-        }
-        DeprecatedHint::AssertCurrentAccessIndicesIsEmpty
-        | DeprecatedHint::AssertAllAccessesUsed { .. }
-        | DeprecatedHint::AssertAllKeysUsed
-        | DeprecatedHint::AssertLeAssertThirdArcExcluded
-        | DeprecatedHint::AssertLtAssertValidInput { .. } => {}
-    }
-    Ok(())
-}
-
-/// Executes a core hint.
-pub fn execute_core_hint(
-    vm: &mut VirtualMachine,
-    exec_scopes: &mut ExecutionScopes,
-    core_hint: &cairo_lang_casm::hints::CoreHint,
-) -> Result<(), HintError> {
-    match core_hint {
-        CoreHint::AllocSegment { dst } => {
-            let segment = vm.add_memory_segment();
-            insert_value_to_cellref!(vm, dst, segment)?;
-        }
-        CoreHint::TestLessThan { lhs, rhs, dst } => {
-            let lhs_val = get_val(vm, lhs)?;
-            let rhs_val = get_val(vm, rhs)?;
-            insert_value_to_cellref!(
-                vm,
-                dst,
-                if lhs_val < rhs_val { Felt252::from(1) } else { Felt252::from(0) }
-            )?;
-        }
-        CoreHint::TestLessThanOrEqual { lhs, rhs, dst } => {
-            let lhs_val = get_val(vm, lhs)?;
-            let rhs_val = get_val(vm, rhs)?;
-            insert_value_to_cellref!(
-                vm,
-                dst,
-                if lhs_val <= rhs_val { Felt252::from(1) } else { Felt252::from(0) }
-            )?;
-        }
-        CoreHint::WideMul128 { lhs, rhs, high, low } => {
-            let mask128 = BigUint::from(u128::MAX);
-            let lhs_val = get_val(vm, lhs)?.to_biguint();
-            let rhs_val = get_val(vm, rhs)?.to_biguint();
-            let prod = lhs_val * rhs_val;
-            insert_value_to_cellref!(vm, high, Felt252::from(prod.clone() >> 128))?;
-            insert_value_to_cellref!(vm, low, Felt252::from(prod & mask128))?;
-        }
-        CoreHint::DivMod { lhs, rhs, quotient, remainder } => {
-            let lhs_val = get_val(vm, lhs)?.to_biguint();
-            let rhs_val = get_val(vm, rhs)?.to_biguint();
-            insert_value_to_cellref!(
-                vm,
-                quotient,
-                Felt252::from(lhs_val.clone() / rhs_val.clone())
-            )?;
-            insert_value_to_cellref!(vm, remainder, Felt252::from(lhs_val % rhs_val))?;
-        }
-        CoreHint::Uint256DivMod {
-            dividend0,
-            dividend1,
-            divisor0,
-            divisor1,
-            quotient0,
-            quotient1,
-            remainder0,
-            remainder1,
-        } => {
-            let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
-            let dividend0 = get_val(vm, dividend0)?.to_biguint();
-            let dividend1 = get_val(vm, dividend1)?.to_biguint();
-            let divisor0 = get_val(vm, divisor0)?.to_biguint();
-            let divisor1 = get_val(vm, divisor1)?.to_biguint();
-            let dividend: BigUint = dividend0 + dividend1.shl(128);
-            let divisor = divisor0 + divisor1.shl(128);
-            let (quotient, remainder) = dividend.div_rem(&divisor);
-            let (limb1, limb0) = quotient.div_rem(&pow_2_128);
-            insert_value_to_cellref!(vm, quotient0, Felt252::from(limb0))?;
-            insert_value_to_cellref!(vm, quotient1, Felt252::from(limb1))?;
-            let (limb1, limb0) = remainder.div_rem(&pow_2_128);
-            insert_value_to_cellref!(vm, remainder0, Felt252::from(limb0))?;
-            insert_value_to_cellref!(vm, remainder1, Felt252::from(limb1))?;
-        }
-        CoreHint::Uint512DivModByUint256 {
-            dividend0,
-            dividend1,
-            dividend2,
-            dividend3,
-            divisor0,
-            divisor1,
-            quotient0,
-            quotient1,
-            quotient2,
-            quotient3,
-            remainder0,
-            remainder1,
-        } => {
-            let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
-            let dividend0 = get_val(vm, dividend0)?.to_biguint();
-            let dividend1 = get_val(vm, dividend1)?.to_biguint();
-            let dividend2 = get_val(vm, dividend2)?.to_biguint();
-            let dividend3 = get_val(vm, dividend3)?.to_biguint();
-            let divisor0 = get_val(vm, divisor0)?.to_biguint();
-            let divisor1 = get_val(vm, divisor1)?.to_biguint();
-            let dividend: BigUint =
-                dividend0 + dividend1.shl(128) + dividend2.shl(256) + dividend3.shl(384);
-            let divisor = divisor0 + divisor1.shl(128);
-            let (quotient, remainder) = dividend.div_rem(&divisor);
-            let (quotient, limb0) = quotient.div_rem(&pow_2_128);
-            insert_value_to_cellref!(vm, quotient0, Felt252::from(limb0))?;
-            let (quotient, limb1) = quotient.div_rem(&pow_2_128);
-            insert_value_to_cellref!(vm, quotient1, Felt252::from(limb1))?;
-            let (limb3, limb2) = quotient.div_rem(&pow_2_128);
-            insert_value_to_cellref!(vm, quotient2, Felt252::from(limb2))?;
-            insert_value_to_cellref!(vm, quotient3, Felt252::from(limb3))?;
-            let (limb1, limb0) = remainder.div_rem(&pow_2_128);
-            insert_value_to_cellref!(vm, remainder0, Felt252::from(limb0))?;
-            insert_value_to_cellref!(vm, remainder1, Felt252::from(limb1))?;
-        }
-        CoreHint::SquareRoot { value, dst } => {
-            let val = get_val(vm, value)?.to_biguint();
-            insert_value_to_cellref!(vm, dst, Felt252::from(val.sqrt()))?;
-        }
-        CoreHint::Uint256SquareRoot {
-            value_low,
-            value_high,
-            sqrt0,
-            sqrt1,
-            remainder_low,
-            remainder_high,
-            sqrt_mul_2_minus_remainder_ge_u128,
-        } => {
-            let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
-            let pow_2_64 = BigUint::from(u64::MAX) + 1u32;
-            let value_low = get_val(vm, value_low)?.to_biguint();
-            let value_high = get_val(vm, value_high)?.to_biguint();
-            let value = value_low + value_high * pow_2_128.clone();
-            let sqrt = value.sqrt();
-            let remainder = value - sqrt.clone() * sqrt.clone();
-            let sqrt_mul_2_minus_remainder_ge_u128_val =
-                sqrt.clone() * 2u32 - remainder.clone() >= pow_2_128;
-
-            // Guess sqrt limbs.
-            let (sqrt1_val, sqrt0_val) = sqrt.div_rem(&pow_2_64);
-            insert_value_to_cellref!(vm, sqrt0, Felt252::from(sqrt0_val))?;
-            insert_value_to_cellref!(vm, sqrt1, Felt252::from(sqrt1_val))?;
-
-            let (remainder_high_val, remainder_low_val) = remainder.div_rem(&pow_2_128);
-            // Guess remainder limbs.
-            insert_value_to_cellref!(vm, remainder_low, Felt252::from(remainder_low_val))?;
-            insert_value_to_cellref!(vm, remainder_high, Felt252::from(remainder_high_val))?;
-            insert_value_to_cellref!(
-                vm,
-                sqrt_mul_2_minus_remainder_ge_u128,
-                Felt252::from(usize::from(sqrt_mul_2_minus_remainder_ge_u128_val))
-            )?;
-        }
-        CoreHint::LinearSplit { value, scalar, max_x, x, y } => {
-            let value = get_val(vm, value)?.to_biguint();
-            let scalar = get_val(vm, scalar)?.to_biguint();
-            let max_x = get_val(vm, max_x)?.to_biguint();
-            let x_value = (value.clone() / scalar.clone()).min(max_x);
-            let y_value = value - x_value.clone() * scalar;
-            insert_value_to_cellref!(vm, x, Felt252::from(x_value))?;
-            insert_value_to_cellref!(vm, y, Felt252::from(y_value))?;
-        }
-        CoreHint::RandomEcPoint { x, y } => {
-            // Keep sampling a random field element `X` until `X^3 + X + beta` is a quadratic
-            // residue.
-            let beta = Fq::from(get_beta().to_biguint());
-            let mut rng = ark_std::test_rng();
-            let (random_x, random_y_squared) = loop {
-                let random_x = Fq::rand(&mut rng);
-                let random_y_squared = random_x * random_x * random_x + random_x + beta;
-                if random_y_squared.legendre().is_qr() {
-                    break (random_x, random_y_squared);
-                }
-            };
-            let x_bigint: BigUint = random_x.into_bigint().into();
-            let y_bigint: BigUint = random_y_squared.sqrt().unwrap().into_bigint().into();
-            insert_value_to_cellref!(vm, x, Felt252::from(x_bigint))?;
-            insert_value_to_cellref!(vm, y, Felt252::from(y_bigint))?;
-        }
-        CoreHint::FieldSqrt { val, sqrt } => {
-            let val = Fq::from(get_val(vm, val)?.to_biguint());
-            insert_value_to_cellref!(vm, sqrt, {
-                let three_fq = Fq::from(BigUint::from_usize(3).unwrap());
-                let res =
-                    (if val.legendre().is_qr() { val } else { val * three_fq }).sqrt().unwrap();
-                let root0: BigUint = res.into_bigint().into();
-                let root1: BigUint = (-res).into_bigint().into();
-                let res_big_uint = std::cmp::min(root0, root1);
-                Felt252::from(res_big_uint)
-            })?;
-        }
-        CoreHint::AllocFelt252Dict { segment_arena_ptr } => {
-            let dict_manager_address = extract_relocatable(vm, segment_arena_ptr)?;
-            let n_dicts = vm
-                .get_integer((dict_manager_address - 2)?)?
-                .into_owned()
-                .to_usize()
-                .expect("Number of dictionaries too large.");
-            let dict_infos_base = vm.get_relocatable((dict_manager_address - 3)?)?;
-
-            let dict_manager_exec_scope = match exec_scopes
-                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
-            {
-                Ok(dict_manager_exec_scope) => dict_manager_exec_scope,
-                Err(_) => {
-                    exec_scopes.assign_or_update_variable(
-                        "dict_manager_exec_scope",
-                        Box::<DictManagerExecScope>::default(),
-                    );
-                    exec_scopes.get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")?
-                }
-            };
-            let new_dict_segment = dict_manager_exec_scope.new_default_dict(vm);
-            vm.insert_value((dict_infos_base + 3 * n_dicts)?, new_dict_segment)?;
-        }
-        CoreHint::Felt252DictEntryInit { dict_ptr, key } => {
-            let dict_address = extract_relocatable(vm, dict_ptr)?;
-            let key = get_val(vm, key)?;
-            let dict_manager_exec_scope = exec_scopes
-                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
-                .expect("Trying to write to a dict while dict manager was not initialized.");
-            let prev_value = dict_manager_exec_scope
-                .get_from_tracker(dict_address, &key)
-                .unwrap_or_else(|| DictManagerExecScope::DICT_DEFAULT_VALUE.into());
-            vm.insert_value((dict_address + 1)?, prev_value)?;
-        }
-        CoreHint::Felt252DictEntryUpdate { dict_ptr, value } => {
-            let (dict_base, dict_offset) = extract_buffer(dict_ptr);
-            let dict_address = get_ptr(vm, dict_base, &dict_offset)?;
-            let key = get_double_deref_val(vm, dict_base, &(dict_offset + Felt252::from(-3)))?;
-            let value = get_maybe(vm, value)?;
-            let dict_manager_exec_scope = exec_scopes
-                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
-                .expect("Trying to write to a dict while dict manager was not initialized.");
-            dict_manager_exec_scope.insert_to_tracker(dict_address, key, value);
-        }
-        CoreHint::GetSegmentArenaIndex { dict_end_ptr, dict_index, .. } => {
-            let dict_address = extract_relocatable(vm, dict_end_ptr)?;
-            let dict_manager_exec_scope = exec_scopes
-                .get_ref::<DictManagerExecScope>("dict_manager_exec_scope")
-                .expect("Trying to read from a dict while dict manager was not initialized.");
-            let dict_infos_index = dict_manager_exec_scope.get_dict_infos_index(dict_address);
-            insert_value_to_cellref!(vm, dict_index, Felt252::from(dict_infos_index))?;
-        }
-        CoreHint::InitSquashData { dict_accesses, n_accesses, first_key, big_keys, .. } => {
-            let dict_access_size = 3;
-            let rangecheck_bound = Felt252::from(u128::MAX) + 1u32;
-
-            exec_scopes.assign_or_update_variable(
-                "dict_squash_exec_scope",
-                Box::<DictSquashExecScope>::default(),
-            );
-            let dict_squash_exec_scope =
-                exec_scopes.get_mut_ref::<DictSquashExecScope>("dict_squash_exec_scope")?;
-            let dict_accesses_address = extract_relocatable(vm, dict_accesses)?;
-            let n_accesses = get_val(vm, n_accesses)?
-                .to_usize()
-                .expect("Number of accesses is too large or negative.");
-            for i in 0..n_accesses {
-                let current_key =
-                    vm.get_integer((dict_accesses_address + i * dict_access_size)?)?;
-                dict_squash_exec_scope
-                    .access_indices
-                    .entry(current_key.into_owned())
-                    .and_modify(|indices| indices.push(Felt252::from(i)))
-                    .or_insert_with(|| vec![Felt252::from(i)]);
-            }
-            // Reverse the accesses in order to pop them in order later.
-            for (_, accesses) in dict_squash_exec_scope.access_indices.iter_mut() {
-                accesses.reverse();
-            }
-            dict_squash_exec_scope.keys =
-                dict_squash_exec_scope.access_indices.keys().cloned().collect();
-            dict_squash_exec_scope.keys.sort_by(|a, b| b.cmp(a));
-            // big_keys indicates if the keys are greater than rangecheck_bound. If they are not
-            // a simple range check is used instead of assert_le_felt252.
-            insert_value_to_cellref!(
-                vm,
-                big_keys,
-                if dict_squash_exec_scope.keys[0] < rangecheck_bound {
-                    Felt252::from(0)
-                } else {
-                    Felt252::from(1)
-                }
-            )?;
-            insert_value_to_cellref!(vm, first_key, dict_squash_exec_scope.current_key().unwrap())?;
-        }
-        CoreHint::GetCurrentAccessIndex { range_check_ptr } => {
-            let dict_squash_exec_scope: &mut DictSquashExecScope =
-                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
-            let range_check_ptr = extract_relocatable(vm, range_check_ptr)?;
-            let current_access_index = dict_squash_exec_scope.current_access_index().unwrap();
-            vm.insert_value(range_check_ptr, current_access_index)?;
-        }
-        CoreHint::ShouldSkipSquashLoop { should_skip_loop } => {
-            let dict_squash_exec_scope: &mut DictSquashExecScope =
-                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
-            insert_value_to_cellref!(
-                vm,
-                should_skip_loop,
-                // The loop verifies that each two consecutive accesses are valid, thus we
-                // break when there is only one remaining access.
-                if dict_squash_exec_scope.current_access_indices().unwrap().len() > 1 {
-                    Felt252::from(0)
-                } else {
-                    Felt252::from(1)
-                }
-            )?;
-        }
-        CoreHint::GetCurrentAccessDelta { index_delta_minus1 } => {
-            let dict_squash_exec_scope: &mut DictSquashExecScope =
-                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
-            let prev_access_index = dict_squash_exec_scope.pop_current_access_index().unwrap();
-            let index_delta_minus_1_val =
-                dict_squash_exec_scope.current_access_index().unwrap().clone()
-                    - prev_access_index
-                    - 1_u32;
-            insert_value_to_cellref!(vm, index_delta_minus1, index_delta_minus_1_val)?;
-        }
-        CoreHint::ShouldContinueSquashLoop { should_continue } => {
-            let dict_squash_exec_scope: &mut DictSquashExecScope =
-                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
-            insert_value_to_cellref!(
-                vm,
-                should_continue,
-                // The loop verifies that each two consecutive accesses are valid, thus we
-                // break when there is only one remaining access.
-                if dict_squash_exec_scope.current_access_indices().unwrap().len() > 1 {
-                    Felt252::from(1)
-                } else {
-                    Felt252::from(0)
-                }
-            )?;
-        }
-        CoreHint::GetNextDictKey { next_key } => {
-            let dict_squash_exec_scope: &mut DictSquashExecScope =
-                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
-            dict_squash_exec_scope.pop_current_key();
-            insert_value_to_cellref!(vm, next_key, dict_squash_exec_scope.current_key().unwrap())?;
-        }
-        CoreHint::AssertLeFindSmallArcs { a, b, range_check_ptr } => {
-            let a_val = get_val(vm, a)?;
-            let b_val = get_val(vm, b)?;
-            let mut lengths_and_indices = vec![
-                (a_val.clone(), 0),
-                (b_val.clone() - a_val, 1),
-                (Felt252::from(-1) - b_val, 2),
-            ];
-            lengths_and_indices.sort();
-            exec_scopes
-                .assign_or_update_variable("excluded_arc", Box::new(lengths_and_indices[2].1));
-            // ceil((PRIME / 3) / 2 ** 128).
-            let prime_over_3_high = 3544607988759775765608368578435044694_u128;
-            // ceil((PRIME / 2) / 2 ** 128).
-            let prime_over_2_high = 5316911983139663648412552867652567041_u128;
-            let range_check_ptr = extract_relocatable(vm, range_check_ptr)?;
-            vm.insert_value(
-                range_check_ptr,
-                Felt252::from(lengths_and_indices[0].0.to_biguint() % prime_over_3_high),
-            )?;
-            vm.insert_value(
-                (range_check_ptr + 1)?,
-                Felt252::from(lengths_and_indices[0].0.to_biguint() / prime_over_3_high),
-            )?;
-            vm.insert_value(
-                (range_check_ptr + 2)?,
-                Felt252::from(lengths_and_indices[1].0.to_biguint() % prime_over_2_high),
-            )?;
-            vm.insert_value(
-                (range_check_ptr + 3)?,
-                Felt252::from(lengths_and_indices[1].0.to_biguint() / prime_over_2_high),
-            )?;
-        }
-        CoreHint::AssertLeIsFirstArcExcluded { skip_exclude_a_flag } => {
-            let excluded_arc: i32 = exec_scopes.get("excluded_arc")?;
-            insert_value_to_cellref!(
-                vm,
-                skip_exclude_a_flag,
-                if excluded_arc != 0 { Felt252::from(1) } else { Felt252::from(0) }
-            )?;
-        }
-        CoreHint::AssertLeIsSecondArcExcluded { skip_exclude_b_minus_a } => {
-            let excluded_arc: i32 = exec_scopes.get("excluded_arc")?;
-            insert_value_to_cellref!(
-                vm,
-                skip_exclude_b_minus_a,
-                if excluded_arc != 1 { Felt252::from(1) } else { Felt252::from(0) }
-            )?;
-        }
-        CoreHint::DebugPrint { start, end } => {
-            let mut curr = extract_relocatable(vm, start)?;
-            let end = extract_relocatable(vm, end)?;
-            while curr != end {
-                let value = vm.get_integer(curr)?;
-                if let Some(shortstring) = as_cairo_short_string(&value) {
-                    println!("[DEBUG]\t{shortstring: <31}\t(raw: {:#x}", value.to_bigint());
-                } else {
-                    println!("[DEBUG]\t{:<31}\t(raw: {:#x} ", ' ', value.to_bigint());
-                }
-                curr += 1;
-            }
-            println!();
-        }
-        CoreHint::AllocConstantSize { size, dst } => {
-            let object_size = get_val(vm, size)?.to_usize().expect("Object size too large.");
-            let memory_exec_scope =
-                match exec_scopes.get_mut_ref::<MemoryExecScope>("memory_exec_scope") {
-                    Ok(memory_exec_scope) => memory_exec_scope,
-                    Err(_) => {
-                        exec_scopes.assign_or_update_variable(
-                            "memory_exec_scope",
-                            Box::new(MemoryExecScope { next_address: vm.add_memory_segment() }),
-                        );
-                        exec_scopes.get_mut_ref::<MemoryExecScope>("memory_exec_scope")?
-                    }
-                };
-            insert_value_to_cellref!(vm, dst, memory_exec_scope.next_address)?;
-            memory_exec_scope.next_address.offset += object_size;
-        }
-    };
-    Ok(())
-}
-
 /// Reads the result of a function call that returns `Array<felt252>`.
 fn read_array_result_as_vec(memory: &[Option<Felt252>], value: &[Felt252]) -> Vec<Felt252> {
     // TODO(spapini): Handle failures.
@@ -1887,18 +1323,6 @@ pub fn vm_get_range(
         calldata_start_ptr.offset += 1;
     }
     Ok(values)
-}
-
-/// Extracts a parameter assumed to be a buffer.
-pub fn extract_buffer(buffer: &ResOperand) -> (&CellRef, Felt252) {
-    let (cell, base_offset) = match buffer {
-        ResOperand::Deref(cell) => (cell, 0.into()),
-        ResOperand::BinOp(BinOpOperand { op: Operation::Add, a, b }) => {
-            (a, extract_matches!(b, DerefOrImmediate::Immediate).clone().value.into())
-        }
-        _ => panic!("Illegal argument for a buffer."),
-    };
-    (cell, base_offset)
 }
 
 /// Provides context for the `additional_initialization` callback function of [run_function].

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -40,7 +40,6 @@ use num_traits::ToPrimitive;
 use thiserror::Error;
 
 pub mod casm_run;
-pub mod short_string;
 
 #[derive(Debug, Error)]
 pub enum RunnerError {

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -19,10 +19,10 @@ cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "2.1.0-
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 id-arena.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 log.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 salsa.workspace = true
 smol_str.workspace = true
 

--- a/crates/cairo-lang-sierra-ap-change/Cargo.toml
+++ b/crates/cairo-lang-sierra-ap-change/Cargo.toml
@@ -11,7 +11,7 @@ cairo-lang-eq-solver = { path = "../cairo-lang-eq-solver", version = "2.1.0-rc0"
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.1.0-rc0" }
 cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-sierra-gas/Cargo.toml
+++ b/crates/cairo-lang-sierra-gas/Cargo.toml
@@ -11,7 +11,7 @@ cairo-lang-eq-solver = { path = "../cairo-lang-eq-solver", version = "2.1.0-rc0"
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.1.0-rc0" }
 cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-sierra-generator/Cargo.toml
+++ b/crates/cairo-lang-sierra-generator/Cargo.toml
@@ -23,14 +23,16 @@ cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.1.0-rc0" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 id-arena.workspace = true
-indexmap.workspace = true
-itertools.workspace = true
-num-bigint.workspace = true
+indexmap = { workspace = true, features = ["std"] }
+itertools = { workspace = true, features = ["use_std"] }
+num-bigint = { workspace = true, features = ["std"] }
 salsa.workspace = true
 smol_str.workspace = true
 
 [dev-dependencies]
-cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", features = [
+    "testing",
+] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils" }
 env_logger.workspace = true
 indoc.workspace = true

--- a/crates/cairo-lang-sierra-to-casm/Cargo.toml
+++ b/crates/cairo-lang-sierra-to-casm/Cargo.toml
@@ -8,7 +8,7 @@ description = "Emitting of CASM instructions from Sierra code."
 
 [dependencies]
 assert_matches.workspace = true
-cairo-felt.workspace = true
+cairo-felt = { workspace = true, features = ["std"] }
 cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.1.0-rc0" }
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.1.0-rc0" }
 cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "2.1.0-rc0" }
@@ -16,10 +16,10 @@ cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "2.1.0-rc
 cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 indoc.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 log.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -16,12 +16,12 @@ cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
 const-fnv1a-hash.workspace = true
 convert_case.workspace = true
 derivative.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 lalrpop-util.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 salsa.workspace = true
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["std"] }
 sha3.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true

--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -21,7 +21,7 @@ lalrpop-util.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
 salsa.workspace = true
-serde.workspace = true
+serde = { workspace = true, optional = true }
 sha3.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true
@@ -34,3 +34,6 @@ indoc.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+
+[features]
+serde = ["dep:serde", "smol_str/serde"]

--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 repository.workspace = true
 license-file.workspace = true
 description = "Sierra representation."
-build = "src/build.rs" # LALRPOP preprocessing
+build = "src/build.rs"                 # LALRPOP preprocessing
 
 [build-dependencies]
 lalrpop = "0.20.0"

--- a/crates/cairo-lang-sierra/src/debug_info.rs
+++ b/crates/cairo-lang-sierra/src/debug_info.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
+#[cfg(feature = "serde")]
 use itertools::Itertools;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
@@ -13,21 +15,31 @@ use crate::program::{GenericArg, Program, Statement};
 mod test;
 
 /// Debug information for a Sierra program, to get readable names.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DebugInfo {
-    #[serde(
-        serialize_with = "serialize_map::<ConcreteTypeId, _>",
-        deserialize_with = "deserialize_map::<ConcreteTypeId, _>"
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "serialize_map::<ConcreteTypeId, _>",
+            deserialize_with = "deserialize_map::<ConcreteTypeId, _>"
+        )
     )]
     pub type_names: HashMap<ConcreteTypeId, SmolStr>,
-    #[serde(
-        serialize_with = "serialize_map::<ConcreteLibfuncId, _>",
-        deserialize_with = "deserialize_map::<ConcreteLibfuncId, _>"
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "serialize_map::<ConcreteLibfuncId, _>",
+            deserialize_with = "deserialize_map::<ConcreteLibfuncId, _>"
+        )
     )]
     pub libfunc_names: HashMap<ConcreteLibfuncId, SmolStr>,
-    #[serde(
-        serialize_with = "serialize_map::<FunctionId, _>",
-        deserialize_with = "deserialize_map::<FunctionId, _>"
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "serialize_map::<FunctionId, _>",
+            deserialize_with = "deserialize_map::<FunctionId, _>"
+        )
     )]
     pub user_func_names: HashMap<FunctionId, SmolStr>,
 }
@@ -164,6 +176,7 @@ impl IdAsHashKey for FunctionId {
     }
 }
 
+#[cfg(feature = "serde")]
 fn serialize_map<Id: IdAsHashKey, S: serde::Serializer>(
     m: &HashMap<Id, SmolStr>,
     serializer: S,
@@ -172,6 +185,7 @@ fn serialize_map<Id: IdAsHashKey, S: serde::Serializer>(
     v.serialize(serializer)
 }
 
+#[cfg(feature = "serde")]
 fn deserialize_map<'de, Id: IdAsHashKey, D: serde::Deserializer<'de>>(
     deserializer: D,
 ) -> Result<HashMap<Id, SmolStr>, D::Error> {

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -8,7 +8,7 @@ description = "Starknet capabilities and utilities on top of Cairo."
 
 [dependencies]
 anyhow.workspace = true
-cairo-felt.workspace = true
+cairo-felt = { workspace = true, features = ["std"] }
 cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.1.0-rc0" }
 cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "2.1.0-rc0" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "2.1.0-rc0" }
@@ -29,13 +29,13 @@ cairo-lang-casm-contract-class = { path = "../cairo-lang-casm-contract-class", v
 convert_case.workspace = true
 genco.workspace = true
 indoc.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 log.workspace = true
-num-bigint.workspace = true
-num-integer.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
+num-integer = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 once_cell.workspace = true
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["std"] }
 serde_json = { workspace = true, optional = true }
 sha3.workspace = true
 smol_str.workspace = true

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -25,6 +25,7 @@ cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version
 cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "2.1.0-rc0" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
+cairo-lang-casm-contract-class = { path = "../cairo-lang-casm-contract-class", version = "2.1.0-rc0" }
 convert_case.workspace = true
 genco.workspace = true
 indoc.workspace = true

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -52,3 +52,6 @@ env_logger.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+cairo-lang-casm-contract-class = { path = "../cairo-lang-casm-contract-class", version = "2.1.0-rc0", features = [
+    "serde",
+] }

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -35,12 +35,21 @@ num-bigint.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true
 once_cell.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 sha3.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true
 indent.workspace = true
+
+[features]
+serde = [
+    "dep:serde",
+    "serde_json",
+    "cairo-lang-casm-contract-class/serde",
+    "cairo-lang-sierra/serde",
+    "cairo-lang-compiler/serde",
+]
 
 [dev-dependencies]
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics" }
@@ -52,6 +61,3 @@ env_logger.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
-cairo-lang-casm-contract-class = { path = "../cairo-lang-casm-contract-class", version = "2.1.0-rc0", features = [
-    "serde",
-] }

--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -17,6 +17,7 @@ use cairo_lang_semantic::{
 };
 use cairo_lang_utils::{extract_matches, try_extract_matches};
 use itertools::zip_eq;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use thiserror::Error;
@@ -33,12 +34,15 @@ use crate::plugin::events::{EventData, EventFieldKind};
 mod test;
 
 /// Contract ABI.
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Contract {
     // TODO(spapini): Add storage variables.
     pub items: Vec<Item>,
 }
+
+#[cfg(feature = "serde")]
 impl Contract {
     pub fn json(&self) -> String {
         serde_json::to_string_pretty(&self).unwrap()
@@ -669,51 +673,56 @@ impl From<DiagnosticAdded> for ABIError {
 }
 
 /// Enum of contract item ABIs.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum Item {
-    #[serde(rename = "function")]
+    #[cfg_attr(feature = "serde", serde(rename = "function"))]
     Function(Function),
-    #[serde(rename = "constructor")]
+    #[cfg_attr(feature = "serde", serde(rename = "constructor"))]
     Constructor(Constructor),
-    #[serde(rename = "l1_handler")]
+    #[cfg_attr(feature = "serde", serde(rename = "l1_handler"))]
     L1Handler(L1Handler),
-    #[serde(rename = "event")]
+    #[cfg_attr(feature = "serde", serde(rename = "event"))]
     Event(Event),
-    #[serde(rename = "struct")]
+    #[cfg_attr(feature = "serde", serde(rename = "struct"))]
     Struct(Struct),
-    #[serde(rename = "enum")]
+    #[cfg_attr(feature = "serde", serde(rename = "enum"))]
     Enum(Enum),
-    #[serde(rename = "interface")]
+    #[cfg_attr(feature = "serde", serde(rename = "interface"))]
     Interface(Interface),
-    #[serde(rename = "impl")]
+    #[cfg_attr(feature = "serde", serde(rename = "impl"))]
     Impl(Imp),
 }
 
 /// Contract interface ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Interface {
     pub name: String,
     pub items: Vec<Item>,
 }
 
 /// Contract impl ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Imp {
     pub name: String,
     pub interface_name: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum StateMutability {
-    #[serde(rename = "external")]
+    #[cfg_attr(feature = "serde", serde(rename = "external"))]
     External,
-    #[serde(rename = "view")]
+    #[cfg_attr(feature = "serde", serde(rename = "view"))]
     View,
 }
 
 /// Contract function ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Function {
     pub name: String,
     pub inputs: Vec<Input>,
@@ -724,14 +733,16 @@ pub struct Function {
 }
 
 /// Contract constructor ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Constructor {
     pub name: String,
     pub inputs: Vec<Input>,
 }
 
 /// Contract L1 handler ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct L1Handler {
     pub name: String,
     pub inputs: Vec<Input>,
@@ -742,73 +753,82 @@ pub struct L1Handler {
 }
 
 /// Contract event.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Event {
     pub name: String,
-    #[serde(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub kind: EventKind,
 }
 
 /// Contract event kind.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(tag = "kind"))]
 pub enum EventKind {
-    #[serde(rename = "struct")]
+    #[cfg_attr(feature = "serde", serde(rename = "struct"))]
     Struct { members: Vec<EventField> },
-    #[serde(rename = "enum")]
+    #[cfg_attr(feature = "serde", serde(rename = "enum"))]
     Enum { variants: Vec<EventField> },
 }
 
 /// Contract event field (member/variant).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EventField {
     pub name: String,
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub ty: String,
     pub kind: EventFieldKind,
 }
 
 /// Function input ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Input {
     pub name: String,
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub ty: String,
 }
 
 /// Function Output ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Output {
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub ty: String,
 }
 
 /// Struct ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Struct {
     pub name: String,
     pub members: Vec<StructMember>,
 }
 
 /// Struct member.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct StructMember {
     pub name: String,
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub ty: String,
 }
 
 /// Enum ABI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Enum {
     pub name: String,
     pub variants: Vec<EnumVariant>,
 }
 
 /// Enum variant.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct EnumVariant {
     pub name: String,
-    #[serde(rename = "type")]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub ty: String,
 }

--- a/crates/cairo-lang-starknet/src/abi_test.rs
+++ b/crates/cairo-lang-starknet/src/abi_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::sync::Arc;
 
 use cairo_lang_compiler::db::RootDatabase;

--- a/crates/cairo-lang-starknet/src/allowed_libfuncs.rs
+++ b/crates/cairo-lang-starknet/src/allowed_libfuncs.rs
@@ -1,13 +1,18 @@
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
+#[cfg(feature = "serde")]
 use std::fs;
 
 use cairo_lang_sierra::ids::GenericLibfuncId;
+#[cfg(feature = "serde")]
 use serde::Deserialize;
+#[cfg(feature = "serde")]
 use smol_str::SmolStr;
 use thiserror::Error;
 
+#[cfg(feature = "serde")]
 use crate::contract_class::ContractClass;
+#[cfg(feature = "serde")]
 use crate::felt252_serde::sierra_from_felt252s;
 
 #[cfg(test)]
@@ -68,12 +73,14 @@ impl Display for ListSelector {
 }
 
 /// Represents a list of allowed sierra libfuncs.
-#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct AllowedLibfuncs {
-    #[serde(deserialize_with = "deserialize_libfuncs_set::<_>")]
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_libfuncs_set::<_>"))]
     pub allowed_libfuncs: HashSet<GenericLibfuncId>,
 }
 
+#[cfg(feature = "serde")]
 fn deserialize_libfuncs_set<'de, D: serde::Deserializer<'de>>(
     deserializer: D,
 ) -> Result<HashSet<GenericLibfuncId>, D::Error> {
@@ -92,6 +99,7 @@ pub const BUILTIN_EXPERIMENTAL_LIBFUNCS_LIST: &str = "experimental";
 pub const BUILTIN_ALL_LIBFUNCS_LIST: &str = "all";
 
 /// Returns the sierra version corresponding to the given version id.
+#[cfg(feature = "serde")]
 pub fn lookup_allowed_libfuncs_list(
     list_selector: ListSelector,
 ) -> Result<AllowedLibfuncs, AllowedLibfuncsError> {
@@ -131,6 +139,7 @@ pub fn lookup_allowed_libfuncs_list(
 
 /// Checks that all the used libfuncs in the contract class are allowed in the contract class
 /// sierra version.
+#[cfg(feature = "serde")]
 pub fn validate_compatible_sierra_version(
     contract: &ContractClass,
     list_selector: ListSelector,

--- a/crates/cairo-lang-starknet/src/allowed_libfuncs_test.rs
+++ b/crates/cairo-lang-starknet/src/allowed_libfuncs_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::collections::{BTreeSet, HashSet};
 
 use cairo_lang_sierra::extensions::core::CoreLibfunc;

--- a/crates/cairo-lang-starknet/src/contract_class_into_casm_contract_class_test.rs
+++ b/crates/cairo-lang-starknet/src/contract_class_into_casm_contract_class_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use std::io::BufReader;
 
 use cairo_felt::Felt252;

--- a/crates/cairo-lang-starknet/src/contract_class_into_casm_contract_class_test.rs
+++ b/crates/cairo-lang-starknet/src/contract_class_into_casm_contract_class_test.rs
@@ -4,8 +4,10 @@ use cairo_felt::Felt252;
 use cairo_lang_test_utils::compare_contents_or_fix_with_path;
 use test_case::test_case;
 
-use crate::casm_contract_class::{BigUintAsHex, CasmContractClass, StarknetSierraCompilationError};
 use crate::contract_class::ContractClass;
+use crate::contract_class_into_casm_contract_class::{
+    BigUintAsHex, StarknetSierraCompilationError,
+};
 use crate::test_utils::{get_example_file_path, get_test_contract};
 
 /// Tests that the casm compiled from <test_case>.cairo is the same as in <test_case>.casm.json.
@@ -19,8 +21,7 @@ use crate::test_utils::{get_example_file_path, get_test_contract};
 fn test_casm_contract_from_contract_class(example_file_name: &str) {
     let contract_class = get_test_contract(format!("{example_file_name}.cairo").as_str());
     let add_pythonic_hints = true;
-    let casm_contract =
-        CasmContractClass::from_contract_class(contract_class, add_pythonic_hints).unwrap();
+    let casm_contract = contract_class.into_casm_contract_class(add_pythonic_hints).unwrap();
 
     compare_contents_or_fix_with_path(
         &get_example_file_path(format!("{example_file_name}.casm.json").as_str()),
@@ -38,7 +39,7 @@ fn test_casm_contract_from_contract_class_failure(example_file_name: &str) {
 
     let add_pythonic_hints = false;
     assert_eq!(
-        CasmContractClass::from_contract_class(contract_class, add_pythonic_hints),
+        contract_class.into_casm_contract_class(add_pythonic_hints),
         Err(StarknetSierraCompilationError::ValueOutOfRange)
     );
 }

--- a/crates/cairo-lang-starknet/src/contract_class_test.rs
+++ b/crates/cairo-lang-starknet/src/contract_class_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "serde")]
 use cairo_lang_test_utils::compare_contents_or_fix_with_path;
 use indoc::indoc;
 use num_bigint::BigUint;

--- a/crates/cairo-lang-starknet/src/lib.rs
+++ b/crates/cairo-lang-starknet/src/lib.rs
@@ -6,10 +6,10 @@
 //! Learn more at [starkware.io](http://starknet.io/).
 pub mod abi;
 pub mod allowed_libfuncs;
-pub mod casm_contract_class;
 mod compiler_version;
 pub mod contract;
 pub mod contract_class;
+pub mod contract_class_into_casm_contract_class;
 mod felt252_serde;
 mod felt252_vec_compression;
 pub mod plugin;

--- a/crates/cairo-lang-starknet/src/plugin/events.rs
+++ b/crates/cairo-lang-starknet/src/plugin/events.rs
@@ -11,6 +11,7 @@ use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode};
 use indoc::indoc;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
@@ -25,16 +26,17 @@ pub enum EventData {
 }
 
 /// Describes how to serialize the event's field.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EventFieldKind {
     // Serialize to `keys` using `Serde`.
-    #[serde(rename = "key")]
+    #[cfg_attr(feature = "serde", serde(rename = "key"))]
     KeySerde,
     // Serialize to `data` using `Serde`.
-    #[serde(rename = "data")]
+    #[cfg_attr(feature = "serde", serde(rename = "data"))]
     DataSerde,
     // Serialize as a nested event.
-    #[serde(rename = "nested")]
+    #[cfg_attr(feature = "serde", serde(rename = "nested"))]
     Nested,
 }
 

--- a/crates/cairo-lang-starknet/src/test_utils.rs
+++ b/crates/cairo-lang-starknet/src/test_utils.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use cairo_lang_compiler::db::RootDatabase;
+#[cfg(feature = "serde")]
 use cairo_lang_compiler::project::setup_project;
 use cairo_lang_compiler::CompilerConfig;
 use cairo_lang_test_utils::test_lock;
@@ -32,6 +33,7 @@ static SHARED_DB: Lazy<Mutex<RootDatabase>> = Lazy::new(|| {
 });
 
 /// Returns the compiled test contract, with replaced ids.
+#[cfg(feature = "serde")]
 pub fn get_test_contract(example_file_name: &str) -> crate::contract_class::ContractClass {
     let path = get_example_file_path(example_file_name);
     let mut locked_db = test_lock(&SHARED_DB);

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -14,7 +14,6 @@ num-bigint.workspace = true
 num-traits.workspace = true
 salsa.workspace = true
 smol_str.workspace = true
-thiserror.workspace = true
 unescaper.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -10,8 +10,8 @@ description = "Cairo syntax representation."
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.1.0-rc0" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 salsa.workspace = true
 smol_str.workspace = true
 unescaper.workspace = true

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -33,3 +33,11 @@ num-bigint.workspace = true
 num-traits.workspace = true
 rayon.workspace = true
 salsa.workspace = true
+
+[features]
+default = []
+serde = [
+    "cairo-lang-filesystem/serde",
+    "cairo-lang-compiler/serde",
+    "cairo-lang-starknet/serde",
+]

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -8,7 +8,7 @@ description = "Cairo tests runner. Used to run tests written in Cairo."
 
 [dependencies]
 anyhow.workspace = true
-cairo-felt.workspace = true
+cairo-felt = { workspace = true, features = ["std"] }
 cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.1.0-rc0" }
 cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "2.1.0-rc0" }
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.1.0-rc0" }
@@ -26,11 +26,11 @@ cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "
 cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "2.1.0-rc0" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.1.0-rc0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.1.0-rc0" }
-cairo-vm.workspace = true
+cairo-vm = { workspace = true, features = ["std"] }
 colored.workspace = true
-itertools.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
+num-bigint = { workspace = true, features = ["std"] }
+num-traits = { workspace = true, features = ["std"] }
 rayon.workspace = true
 salsa.workspace = true
 

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -33,4 +33,3 @@ num-bigint.workspace = true
 num-traits.workspace = true
 rayon.workspace = true
 salsa.workspace = true
-thiserror.workspace = true

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -1,14 +1,18 @@
-use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
+#[cfg(feature = "serde")]
+use std::{path::Path, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use cairo_felt::Felt252;
 use cairo_lang_compiler::db::RootDatabase;
+#[cfg(feature = "serde")]
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
+#[cfg(feature = "serde")]
 use cairo_lang_compiler::project::setup_project;
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{FreeFunctionId, FunctionWithBodyId, ModuleItemId};
 use cairo_lang_diagnostics::ToOption;
+#[cfg(feature = "serde")]
 use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
 use cairo_lang_filesystem::ids::CrateId;
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
@@ -26,6 +30,7 @@ use cairo_lang_starknet::contract::{
 };
 use cairo_lang_starknet::contract_class_into_casm_contract_class::ENTRY_POINT_COST;
 use cairo_lang_starknet::plugin::consts::{CONSTRUCTOR_MODULE, EXTERNAL_MODULE, L1_HANDLER_MODULE};
+#[cfg(feature = "serde")]
 use cairo_lang_starknet::plugin::StarkNetPlugin;
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -33,6 +38,7 @@ use cairo_lang_utils::short_string::as_cairo_short_string;
 use colored::Colorize;
 use itertools::{chain, Itertools};
 use num_traits::ToPrimitive;
+#[cfg(feature = "serde")]
 use plugin::TestPlugin;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use test_config::{try_extract_test_config, TestConfig};
@@ -61,6 +67,7 @@ impl TestRunner {
     /// * `include_ignored` - Include ignored tests as well
     /// * `ignored` - Run ignored tests only
     /// * `starknet` - Add the starknet plugin to run the tests
+    #[cfg(feature = "serde")]
     pub fn new(
         path: &Path,
         filter: &str,

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -12,7 +12,6 @@ use cairo_lang_diagnostics::ToOption;
 use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
 use cairo_lang_filesystem::ids::CrateId;
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
-use cairo_lang_runner::short_string::as_cairo_short_string;
 use cairo_lang_runner::{RunResultValue, SierraCasmRunner};
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::items::functions::GenericFunctionId;
@@ -22,14 +21,15 @@ use cairo_lang_sierra::ids::FunctionId;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_sierra_generator::replace_ids::{DebugReplacer, SierraIdReplacer};
 use cairo_lang_sierra_to_casm::metadata::MetadataComputationConfig;
-use cairo_lang_starknet::casm_contract_class::ENTRY_POINT_COST;
 use cairo_lang_starknet::contract::{
     find_contracts, get_contracts_info, get_module_functions, ContractInfo,
 };
+use cairo_lang_starknet::contract_class_into_casm_contract_class::ENTRY_POINT_COST;
 use cairo_lang_starknet::plugin::consts::{CONSTRUCTOR_MODULE, EXTERNAL_MODULE, L1_HANDLER_MODULE};
 use cairo_lang_starknet::plugin::StarkNetPlugin;
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::short_string::as_cairo_short_string;
 use colored::Colorize;
 use itertools::{chain, Itertools};
 use num_traits::ToPrimitive;

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -12,7 +12,7 @@ itertools.workspace = true
 num-bigint.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true
-parity-scale-codec = { workspace = true, optional = true, features = [
+parity-scale-codec = { workspace = true, optional = true, default-features = false, features = [
     "derive",
 ] }
 serde.workspace = true
@@ -43,6 +43,8 @@ std = [
     "num-traits/std",
     "serde/std",
     "cairo-felt/std",
+    "parity-scale-codec?/std",
 ]
 env_logger = ["std", "dep:env_logger", "dep:time", "dep:log"]
+schemars = ["std", "dep:schemars"]
 testing = []

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -12,12 +12,18 @@ itertools.workspace = true
 num-bigint.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true
-parity-scale-codec.workspace = true
-schemars = { workspace = true, features = ["preserve_order"] }
+parity-scale-codec = { workspace = true, optional = true, features = [
+    "derive",
+] }
 serde.workspace = true
+cairo-felt = { workspace = true, features = ["alloc"] }
+hashbrown.workspace = true
 
-# Optional
+# Optional features
+schemars = { workspace = true, optional = true }
 env_logger = { workspace = true, optional = true }
+
+# Optional dependencies
 time = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 
@@ -28,5 +34,15 @@ test-log.workspace = true
 env_logger.workspace = true
 
 [features]
+default = ["std"]
+std = [
+    "indexmap/std",
+    "itertools/use_std",
+    "num-bigint/std",
+    "num-integer/std",
+    "num-traits/std",
+    "serde/std",
+    "cairo-felt/std",
+]
+env_logger = ["std", "dep:env_logger", "dep:time", "dep:log"]
 testing = []
-env_logger = ["dep:env_logger", "dep:time", "dep:log"]

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -39,7 +39,7 @@ std = [
     "num-bigint/std",
     "num-integer/std",
     "num-traits/std",
-    "serde/std",
+    "serde?/std",
     "cairo-felt/std",
     "parity-scale-codec?/std",
 ]

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -12,10 +12,8 @@ itertools.workspace = true
 num-bigint.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true
-parity-scale-codec = { workspace = true, optional = true, default-features = false, features = [
-    "derive",
-] }
-serde.workspace = true
+parity-scale-codec = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 cairo-felt = { workspace = true, features = ["alloc"] }
 hashbrown.workspace = true
 
@@ -48,3 +46,4 @@ std = [
 env_logger = ["std", "dep:env_logger", "dep:time", "dep:log"]
 schemars = ["std", "dep:schemars"]
 testing = []
+serde = ["dep:serde", "hashbrown/serde", "indexmap/serde"]

--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -2,12 +2,16 @@
 #[path = "bigint_test.rs"]
 mod test;
 
-use std::ops::Neg;
+#[cfg(all(feature = "parity-scale-codec", not(feature = "std")))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::{format, string::String};
+use core::ops::Neg;
 
 use num_bigint::{BigInt, BigUint, ToBigInt};
 use num_traits::{Num, Signed};
+#[cfg(feature = "parity-scale-codec")]
 use parity_scale_codec::{Decode, Encode};
-use schemars::JsonSchema;
 use serde::ser::Serializer;
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -47,17 +51,21 @@ where
 }
 
 // A wrapper for BigInt that serializes as hex.
-#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct BigIntAsHex {
     /// A field element that encodes the signature of the called function.
     #[serde(serialize_with = "serialize_big_int", deserialize_with = "deserialize_big_int")]
-    #[schemars(schema_with = "big_int_schema")]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "big_int_schema"))]
     pub value: BigInt,
 }
 
 // BigInt doesn't implement JsonSchema, so we need to manually define it.
+#[cfg(feature = "schemars")]
 fn big_int_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    use schemars::JsonSchema;
+
     #[allow(dead_code)]
     #[derive(JsonSchema)]
     pub enum Sign {
@@ -110,6 +118,7 @@ where
     }
 }
 
+#[cfg(feature = "parity-scale-codec")]
 impl Encode for BigIntAsHex {
     fn size_hint(&self) -> usize {
         // sign, len, data.
@@ -131,6 +140,7 @@ impl Encode for BigIntAsHex {
     }
 }
 
+#[cfg(feature = "parity-scale-codec")]
 impl Decode for BigIntAsHex {
     fn decode<I: parity_scale_codec::Input>(
         input: &mut I,

--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -4,26 +4,35 @@ mod test;
 
 #[cfg(all(feature = "parity-scale-codec", not(feature = "std")))]
 use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), feature = "serde"))]
 use alloc::{format, string::String};
+#[cfg(feature = "serde")]
 use core::ops::Neg;
 
-use num_bigint::{BigInt, BigUint, ToBigInt};
+#[cfg(feature = "serde")]
+use num_bigint::ToBigInt;
+use num_bigint::{BigInt, BigUint};
+#[cfg(feature = "serde")]
 use num_traits::{Num, Signed};
 #[cfg(feature = "parity-scale-codec")]
 use parity_scale_codec::{Decode, Encode};
-use serde::ser::Serializer;
-use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "serde")]
+use serde::{ser::Serializer, Deserialize, Deserializer, Serialize};
 
 /// A wrapper for BigUint that serializes as hex.
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct BigUintAsHex {
     /// A field element that encodes the signature of the called function.
-    #[serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")
+    )]
     pub value: BigUint,
 }
 
+#[cfg(feature = "serde")]
 fn deserialize_from_str<'a, D>(s: &str) -> Result<BigUint, D::Error>
 where
     D: Deserializer<'a>,
@@ -35,6 +44,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 pub fn serialize_big_uint<S>(num: &BigUint, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -42,6 +52,7 @@ where
     serializer.serialize_str(&format!("{num:#x}"))
 }
 
+#[cfg(feature = "serde")]
 pub fn deserialize_big_uint<'a, D>(deserializer: D) -> Result<BigUint, D::Error>
 where
     D: Deserializer<'a>,
@@ -51,12 +62,16 @@ where
 }
 
 // A wrapper for BigInt that serializes as hex.
-#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[serde(transparent)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct BigIntAsHex {
     /// A field element that encodes the signature of the called function.
-    #[serde(serialize_with = "serialize_big_int", deserialize_with = "deserialize_big_int")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "serialize_big_int", deserialize_with = "deserialize_big_int")
+    )]
     #[cfg_attr(feature = "schemars", schemars(schema_with = "big_int_schema"))]
     pub value: BigInt,
 }
@@ -96,6 +111,7 @@ impl<T: Into<BigInt>> From<T> for BigIntAsHex {
     }
 }
 
+#[cfg(feature = "serde")]
 pub fn serialize_big_int<S>(num: &BigInt, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -107,6 +123,7 @@ where
     ))
 }
 
+#[cfg(feature = "serde")]
 pub fn deserialize_big_int<'a, D>(deserializer: D) -> Result<BigInt, D::Error>
 where
     D: Deserializer<'a>,

--- a/crates/cairo-lang-utils/src/bigint_test.rs
+++ b/crates/cairo-lang-utils/src/bigint_test.rs
@@ -1,20 +1,26 @@
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), feature = "serde"))]
 use alloc::format;
+#[cfg(feature = "serde")]
 use core::ops::Neg;
 #[cfg(feature = "parity-scale-codec")]
 use core::str::FromStr;
 
+#[cfg(feature = "serde")]
 use num_bigint::BigInt;
+#[cfg(feature = "serde")]
 use num_traits::Num;
 #[cfg(feature = "parity-scale-codec")]
 use parity_scale_codec::{Decode, Encode};
+#[cfg(feature = "serde")]
 use test_case::test_case;
 
+#[cfg(any(feature = "serde", feature = "parity-scale-codec"))]
 use crate::bigint::BigIntAsHex;
 
 #[test_case("800000000000011000000000000000000000000000000000000000000000001", true; "positive")]
 #[test_case("800000000000011000000000000000000000000000000000000000000000001", false; "negative")]
 #[test_case("0", false; "zero")]
+#[cfg(feature = "serde")]
 fn test_bigint_serde(s: &str, is_negative: bool) {
     let mut num = BigIntAsHex { value: BigInt::from_str_radix(s, 16).unwrap() };
     if is_negative {

--- a/crates/cairo-lang-utils/src/bigint_test.rs
+++ b/crates/cairo-lang-utils/src/bigint_test.rs
@@ -1,8 +1,12 @@
-use std::ops::Neg;
-use std::str::FromStr;
+#[cfg(not(feature = "std"))]
+use alloc::format;
+use core::ops::Neg;
+#[cfg(feature = "parity-scale-codec")]
+use core::str::FromStr;
 
 use num_bigint::BigInt;
 use num_traits::Num;
+#[cfg(feature = "parity-scale-codec")]
 use parity_scale_codec::{Decode, Encode};
 use test_case::test_case;
 
@@ -24,6 +28,7 @@ fn test_bigint_serde(s: &str, is_negative: bool) {
 }
 
 #[test]
+#[cfg(feature = "parity-scale-codec")]
 fn encode_bigint() {
     let bigint = BigIntAsHex {
         value: num_bigint::BigInt::from_str(

--- a/crates/cairo-lang-utils/src/collection_arithmetics.rs
+++ b/crates/cairo-lang-utils/src/collection_arithmetics.rs
@@ -2,8 +2,8 @@
 #[path = "collection_arithmetics_test.rs"]
 mod test;
 
-use std::hash::Hash;
-use std::ops::{Add, Sub};
+use core::hash::Hash;
+use core::ops::{Add, Sub};
 
 use indexmap::map::Entry;
 

--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
@@ -1,5 +1,10 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+#[cfg(feature = "std")]
 use std::collections::HashSet;
 
+#[cfg(not(feature = "std"))]
+use hashbrown::HashSet;
 use itertools::chain;
 use test_case::test_case;
 use test_log::test;

--- a/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::hash::Hash;
 
 /// A trait for a node in a graph. Note that a GraphNode has to be able to provide its neighbors

--- a/crates/cairo-lang-utils/src/graph_algos/scc_graph_node.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/scc_graph_node.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use super::graph_node::GraphNode;
 use super::strongly_connected_components::ComputeScc;
 

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
@@ -1,5 +1,7 @@
 //! Logic for computing the strongly connected component of a node in a graph.
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::hash::Hash;
 
 use super::graph_node::GraphNode;
@@ -84,7 +86,7 @@ fn compute_scc_recursive<Node: GraphNode>(ctx: &mut SccAlgoContext<Node>, curren
                 // neighbor was not visited yet. Visit it and maybe apply its lowlink to root.
                 compute_scc_recursive(ctx, &neighbor);
                 // Now neighbor should be in known_nodes.
-                current_wrapper_node.lowlink = std::cmp::min(
+                current_wrapper_node.lowlink = core::cmp::min(
                     current_wrapper_node.lowlink,
                     ctx.known_nodes[&neighbor_id].lowlink,
                 );
@@ -93,7 +95,7 @@ fn compute_scc_recursive<Node: GraphNode>(ctx: &mut SccAlgoContext<Node>, curren
                 if ctx.known_nodes[&neighbor_id].on_stack {
                     // This is a back edge, meaning neighbor is in current_node's SCC.
                     current_wrapper_node.lowlink =
-                        std::cmp::min(current_wrapper_node.lowlink, neighbor_node.index);
+                        core::cmp::min(current_wrapper_node.lowlink, neighbor_node.index);
                 } else {
                     // If neighbor is known but not on stack, it's in a concluded dropped SCC.
                     // Ignore it.

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
@@ -1,5 +1,10 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+#[cfg(feature = "std")]
 use std::collections::HashSet;
 
+#[cfg(not(feature = "std"))]
+use hashbrown::HashSet;
 use itertools::chain;
 use test_case::test_case;
 use test_log::test;

--- a/crates/cairo-lang-utils/src/ordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_map.rs
@@ -8,16 +8,21 @@ type DefaultHashBuilder = std::hash::BuildHasherDefault<std::collections::hash_m
 
 use indexmap::{Equivalent, IndexMap};
 use itertools::zip_eq;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// The default serde derived implementations require `S: Serialize / Deserialize`,
 /// but `S` is not actualy part of serialized object, so it should not be required.
 /// This attribute allow us to replace the content of the `where` clauses.
-#[serde(bound(
-    serialize = "Key: Serialize, Value: Serialize",
-    deserialize = "Key: Deserialize<'de>, Value: Deserialize<'de>"
-))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "Key: Serialize, Value: Serialize",
+        deserialize = "Key: Deserialize<'de>, Value: Deserialize<'de>"
+    ))
+)]
 pub struct OrderedHashMap<
     Key: Hash + Eq,
     Value,

--- a/crates/cairo-lang-utils/src/ordered_hash_set.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_set.rs
@@ -8,6 +8,7 @@ type DefaultHashBuilder = std::hash::BuildHasherDefault<std::collections::hash_m
 
 use indexmap::{Equivalent, IndexSet};
 use itertools::zip_eq;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Clone, Debug)]
@@ -166,11 +167,14 @@ impl<'a, Key: Hash + Eq + Clone> Sub<&'a OrderedHashSet<Key>> for &'a OrderedHas
     }
 }
 
+#[cfg(feature = "serde")]
 impl<K: Hash + Eq + Serialize> Serialize for OrderedHashSet<K> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.0.serialize(serializer)
     }
 }
+
+#[cfg(feature = "serde")]
 impl<'de, K: Hash + Eq + Deserialize<'de>> Deserialize<'de> for OrderedHashSet<K> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         IndexSet::<K, DefaultHashBuilder>::deserialize(deserializer).map(|s| OrderedHashSet(s))

--- a/crates/cairo-lang-utils/src/short_string.rs
+++ b/crates/cairo-lang-utils/src/short_string.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+
 use cairo_felt::Felt252;
 
 /// Converts a bigint representing a felt252 to a Cairo short-string.

--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -1,13 +1,31 @@
-use std::borrow::Borrow;
-use std::collections::{hash_map, HashMap};
-use std::hash::Hash;
-use std::ops::Index;
+use core::borrow::Borrow;
+use core::hash::{BuildHasher, Hash};
+use core::ops::Index;
+
+#[cfg(not(feature = "std"))]
+use no_std_imports::*;
+#[cfg(not(feature = "std"))]
+mod no_std_imports {
+    pub use hashbrown::hash_map::DefaultHashBuilder;
+    pub use hashbrown::HashMap;
+}
+
+#[cfg(feature = "std")]
+use std_imports::*;
+#[cfg(feature = "std")]
+mod std_imports {
+    pub use std::collections::HashMap;
+    pub type DefaultHashBuilder =
+        std::hash::BuildHasherDefault<std::collections::hash_map::DefaultHasher>;
+}
 
 /// A hash map that does not care about the order of insertion.
 /// In particular, it does not support iterating, in order to guarantee deterministic compilation.
 /// For an iterable version see [OrderedHashMap](crate::ordered_hash_map::OrderedHashMap).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UnorderedHashMap<Key: Hash + Eq, Value>(HashMap<Key, Value>);
+pub struct UnorderedHashMap<Key: Hash + Eq, Value, S: BuildHasher = DefaultHashBuilder>(
+    HashMap<Key, Value, S>,
+);
 
 impl<Key: Hash + Eq, Value> UnorderedHashMap<Key, Value> {
     /// Returns a reference to the value corresponding to the key.
@@ -59,7 +77,16 @@ impl<Key: Hash + Eq, Value> UnorderedHashMap<Key, Value> {
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
-    pub fn entry(&mut self, key: Key) -> hash_map::Entry<'_, Key, Value> {
+    #[cfg(feature = "std")]
+    pub fn entry(&mut self, key: Key) -> std::collections::hash_map::Entry<'_, Key, Value> {
+        self.0.entry(key)
+    }
+
+    #[cfg(not(feature = "std"))]
+    pub fn entry(
+        &mut self,
+        key: Key,
+    ) -> hashbrown::hash_map::Entry<'_, Key, Value, DefaultHashBuilder> {
         self.0.entry(key)
     }
 
@@ -112,6 +139,6 @@ impl<Key: Hash + Eq, Value, const N: usize> From<[(Key, Value); N]>
     for UnorderedHashMap<Key, Value>
 {
     fn from(items: [(Key, Value); N]) -> Self {
-        Self(HashMap::from(items))
+        Self(HashMap::<_, _, DefaultHashBuilder>::from_iter(items.into_iter()))
     }
 }

--- a/crates/cairo-lang-utils/src/unordered_hash_set.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_set.rs
@@ -1,7 +1,11 @@
-use std::borrow::Borrow;
+use core::borrow::Borrow;
+use core::hash::Hash;
+use core::ops::Sub;
+#[cfg(feature = "std")]
 use std::collections::HashSet;
-use std::hash::Hash;
-use std::ops::Sub;
+
+#[cfg(not(feature = "std"))]
+use hashbrown::HashSet;
 
 /// A hash set that does not care about the order of insertion.
 /// In particular, it does not support iterating, in order to guarantee deterministic compilation.

--- a/crates/cairo-lang-vm-utils/Cargo.toml
+++ b/crates/cairo-lang-vm-utils/Cargo.toml
@@ -13,7 +13,7 @@ cairo-lang-casm = { path = "../cairo-lang-casm", default-features = false }
 cairo-lang-utils = { path = "../cairo-lang-utils", default-features = false }
 cairo-vm.workspace = true
 cairo-felt.workspace = true
-log = { workspace = true, default-features = false }
+log.workspace = true
 # Optional dependencies
 ark-std = { workspace = true, optional = true }
 ark-ff = { workspace = true, optional = true }

--- a/crates/cairo-lang-vm-utils/Cargo.toml
+++ b/crates/cairo-lang-vm-utils/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "cairo-lang-vm-utils"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "Shared helper function to interact with the cairo-vm"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cairo-lang-casm = { path = "../cairo-lang-casm", default-features = false }
+cairo-lang-utils = { path = "../cairo-lang-utils", default-features = false }
+cairo-vm.workspace = true
+cairo-felt.workspace = true
+log = { workspace = true, default-features = false }
+# Optional dependencies
+ark-std = { workspace = true, optional = true }
+ark-ff = { workspace = true, optional = true }
+num-traits = { workspace = true, optional = true }
+num-bigint = { workspace = true, optional = true }
+num-integer = { workspace = true, optional = true }
+hashbrown = { workspace = true, optional = true }
+
+
+[features]
+default = ["std"]
+std = [
+    "cairo-lang-casm/std",
+    "cairo-lang-utils/std",
+    "cairo-vm/std",
+    "cairo-felt/std",
+    "ark-std?/std",
+    "ark-ff?/std",
+    "num-traits?/std",
+    "num-bigint?/std",
+    "num-integer?/std",
+]
+execute_core_hints = [
+    "dep:ark-std",
+    "dep:ark-ff",
+    "dep:num-traits",
+    "dep:num-bigint",
+    "dep:num-integer",
+    "dep:hashbrown",
+]

--- a/crates/cairo-lang-vm-utils/src/execute_core_hints/dict_manager.rs
+++ b/crates/cairo-lang-vm-utils/src/execute_core_hints/dict_manager.rs
@@ -1,8 +1,13 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
 use std::collections::HashMap;
 
 use cairo_felt::Felt252;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::vm_core::VirtualMachine;
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
 
 /// Stores the data of a specific dictionary.
 pub struct DictTrackerExecScope {

--- a/crates/cairo-lang-vm-utils/src/execute_core_hints/mod.rs
+++ b/crates/cairo-lang-vm-utils/src/execute_core_hints/mod.rs
@@ -1,0 +1,524 @@
+pub mod dict_manager;
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec};
+use core::cmp;
+use core::ops::Shl;
+
+use ark_ff::{Field, Fp256, MontBackend, MontConfig, PrimeField};
+use ark_std::UniformRand;
+use cairo_felt::{felt_str as felt252_str, Felt252};
+use cairo_lang_casm::hints::{CoreHint, DeprecatedHint};
+use cairo_lang_casm::operand::ResOperand;
+use cairo_lang_utils::short_string::as_cairo_short_string;
+use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::types::relocatable::Relocatable;
+use cairo_vm::vm::errors::hint_errors::HintError;
+use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+use dict_manager::{DictManagerExecScope, DictSquashExecScope};
+use num_bigint::BigUint;
+use num_integer::Integer;
+use num_traits::{FromPrimitive, ToPrimitive};
+
+use crate::{
+    extract_buffer, get_double_deref_val, get_maybe, get_ptr, get_val, insert_value_to_cellref,
+};
+
+// TODO(orizi): This def is duplicated.
+/// Returns the Beta value of the Starkware elliptic curve.
+fn get_beta() -> Felt252 {
+    felt252_str!("3141592653589793238462643383279502884197169399375105820974944592307816406665")
+}
+
+#[derive(MontConfig)]
+#[modulus = "3618502788666131213697322783095070105623107215331596699973092056135872020481"]
+#[generator = "3"]
+struct FqConfig;
+type Fq = Fp256<MontBackend<FqConfig, 4>>;
+
+/// Execution scope for constant memory allocation.
+struct MemoryExecScope {
+    /// The first free address in the segment.
+    next_address: Relocatable,
+}
+
+pub fn execute_core_hint_base(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    core_hint_base: &cairo_lang_casm::hints::CoreHintBase,
+) -> Result<(), HintError> {
+    match core_hint_base {
+        cairo_lang_casm::hints::CoreHintBase::Core(core_hint) => {
+            execute_core_hint(vm, exec_scopes, core_hint)
+        }
+        cairo_lang_casm::hints::CoreHintBase::Deprecated(deprecated_hint) => {
+            execute_deprecated_hint(vm, exec_scopes, deprecated_hint)
+        }
+    }
+}
+
+/// Extracts a parameter assumed to be a buffer, and converts it into a relocatable.
+pub fn extract_relocatable(
+    vm: &VirtualMachine,
+    buffer: &ResOperand,
+) -> Result<Relocatable, VirtualMachineError> {
+    let (base, offset) = extract_buffer(buffer);
+    get_ptr(vm, base, &offset)
+}
+
+// ---
+
+pub fn execute_deprecated_hint(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    deprecated_hint: &cairo_lang_casm::hints::DeprecatedHint,
+) -> Result<(), HintError> {
+    match deprecated_hint {
+        DeprecatedHint::Felt252DictRead { dict_ptr, key, value_dst } => {
+            let dict_address = extract_relocatable(vm, dict_ptr)?;
+            let key = get_val(vm, key)?;
+            let dict_manager_exec_scope = exec_scopes
+                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
+                .expect("Trying to read from a dict while dict manager was not initialized.");
+            let value = dict_manager_exec_scope
+                .get_from_tracker(dict_address, &key)
+                .unwrap_or_else(|| DictManagerExecScope::DICT_DEFAULT_VALUE.into());
+            insert_value_to_cellref!(vm, value_dst, value)?;
+        }
+        DeprecatedHint::Felt252DictWrite { dict_ptr, key, value } => {
+            let dict_address = extract_relocatable(vm, dict_ptr)?;
+            let key = get_val(vm, key)?;
+            let value = get_maybe(vm, value)?;
+            let dict_manager_exec_scope = exec_scopes
+                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
+                .expect("Trying to write to a dict while dict manager was not initialized.");
+            let prev_value = dict_manager_exec_scope
+                .get_from_tracker(dict_address, &key)
+                .unwrap_or_else(|| DictManagerExecScope::DICT_DEFAULT_VALUE.into());
+            vm.insert_value((dict_address + 1)?, prev_value)?;
+            dict_manager_exec_scope.insert_to_tracker(dict_address, key, value);
+        }
+        DeprecatedHint::AssertCurrentAccessIndicesIsEmpty
+        | DeprecatedHint::AssertAllAccessesUsed { .. }
+        | DeprecatedHint::AssertAllKeysUsed
+        | DeprecatedHint::AssertLeAssertThirdArcExcluded
+        | DeprecatedHint::AssertLtAssertValidInput { .. } => {}
+    }
+    Ok(())
+}
+
+/// Executes a core hint.
+pub fn execute_core_hint(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    core_hint: &cairo_lang_casm::hints::CoreHint,
+) -> Result<(), HintError> {
+    match core_hint {
+        CoreHint::AllocSegment { dst } => {
+            let segment = vm.add_memory_segment();
+            insert_value_to_cellref!(vm, dst, segment)?;
+        }
+        CoreHint::TestLessThan { lhs, rhs, dst } => {
+            let lhs_val = get_val(vm, lhs)?;
+            let rhs_val = get_val(vm, rhs)?;
+            insert_value_to_cellref!(
+                vm,
+                dst,
+                if lhs_val < rhs_val { Felt252::from(1) } else { Felt252::from(0) }
+            )?;
+        }
+        CoreHint::TestLessThanOrEqual { lhs, rhs, dst } => {
+            let lhs_val = get_val(vm, lhs)?;
+            let rhs_val = get_val(vm, rhs)?;
+            insert_value_to_cellref!(
+                vm,
+                dst,
+                if lhs_val <= rhs_val { Felt252::from(1) } else { Felt252::from(0) }
+            )?;
+        }
+        CoreHint::WideMul128 { lhs, rhs, high, low } => {
+            let mask128 = BigUint::from(u128::MAX);
+            let lhs_val = get_val(vm, lhs)?.to_biguint();
+            let rhs_val = get_val(vm, rhs)?.to_biguint();
+            let prod = lhs_val * rhs_val;
+            insert_value_to_cellref!(vm, high, Felt252::from(prod.clone() >> 128))?;
+            insert_value_to_cellref!(vm, low, Felt252::from(prod & mask128))?;
+        }
+        CoreHint::DivMod { lhs, rhs, quotient, remainder } => {
+            let lhs_val = get_val(vm, lhs)?.to_biguint();
+            let rhs_val = get_val(vm, rhs)?.to_biguint();
+            insert_value_to_cellref!(
+                vm,
+                quotient,
+                Felt252::from(lhs_val.clone() / rhs_val.clone())
+            )?;
+            insert_value_to_cellref!(vm, remainder, Felt252::from(lhs_val % rhs_val))?;
+        }
+        CoreHint::Uint256DivMod {
+            dividend0,
+            dividend1,
+            divisor0,
+            divisor1,
+            quotient0,
+            quotient1,
+            remainder0,
+            remainder1,
+        } => {
+            let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
+            let dividend0 = get_val(vm, dividend0)?.to_biguint();
+            let dividend1 = get_val(vm, dividend1)?.to_biguint();
+            let divisor0 = get_val(vm, divisor0)?.to_biguint();
+            let divisor1 = get_val(vm, divisor1)?.to_biguint();
+            let dividend: BigUint = dividend0 + dividend1.shl(128);
+            let divisor = divisor0 + divisor1.shl(128);
+            let (quotient, remainder) = dividend.div_rem(&divisor);
+            let (limb1, limb0) = quotient.div_rem(&pow_2_128);
+            insert_value_to_cellref!(vm, quotient0, Felt252::from(limb0))?;
+            insert_value_to_cellref!(vm, quotient1, Felt252::from(limb1))?;
+            let (limb1, limb0) = remainder.div_rem(&pow_2_128);
+            insert_value_to_cellref!(vm, remainder0, Felt252::from(limb0))?;
+            insert_value_to_cellref!(vm, remainder1, Felt252::from(limb1))?;
+        }
+        CoreHint::Uint512DivModByUint256 {
+            dividend0,
+            dividend1,
+            dividend2,
+            dividend3,
+            divisor0,
+            divisor1,
+            quotient0,
+            quotient1,
+            quotient2,
+            quotient3,
+            remainder0,
+            remainder1,
+        } => {
+            let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
+            let dividend0 = get_val(vm, dividend0)?.to_biguint();
+            let dividend1 = get_val(vm, dividend1)?.to_biguint();
+            let dividend2 = get_val(vm, dividend2)?.to_biguint();
+            let dividend3 = get_val(vm, dividend3)?.to_biguint();
+            let divisor0 = get_val(vm, divisor0)?.to_biguint();
+            let divisor1 = get_val(vm, divisor1)?.to_biguint();
+            let dividend: BigUint =
+                dividend0 + dividend1.shl(128) + dividend2.shl(256) + dividend3.shl(384);
+            let divisor = divisor0 + divisor1.shl(128);
+            let (quotient, remainder) = dividend.div_rem(&divisor);
+            let (quotient, limb0) = quotient.div_rem(&pow_2_128);
+            insert_value_to_cellref!(vm, quotient0, Felt252::from(limb0))?;
+            let (quotient, limb1) = quotient.div_rem(&pow_2_128);
+            insert_value_to_cellref!(vm, quotient1, Felt252::from(limb1))?;
+            let (limb3, limb2) = quotient.div_rem(&pow_2_128);
+            insert_value_to_cellref!(vm, quotient2, Felt252::from(limb2))?;
+            insert_value_to_cellref!(vm, quotient3, Felt252::from(limb3))?;
+            let (limb1, limb0) = remainder.div_rem(&pow_2_128);
+            insert_value_to_cellref!(vm, remainder0, Felt252::from(limb0))?;
+            insert_value_to_cellref!(vm, remainder1, Felt252::from(limb1))?;
+        }
+        CoreHint::SquareRoot { value, dst } => {
+            let val = get_val(vm, value)?.to_biguint();
+            insert_value_to_cellref!(vm, dst, Felt252::from(val.sqrt()))?;
+        }
+        CoreHint::Uint256SquareRoot {
+            value_low,
+            value_high,
+            sqrt0,
+            sqrt1,
+            remainder_low,
+            remainder_high,
+            sqrt_mul_2_minus_remainder_ge_u128,
+        } => {
+            let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
+            let pow_2_64 = BigUint::from(u64::MAX) + 1u32;
+            let value_low = get_val(vm, value_low)?.to_biguint();
+            let value_high = get_val(vm, value_high)?.to_biguint();
+            let value = value_low + value_high * pow_2_128.clone();
+            let sqrt = value.sqrt();
+            let remainder = value - sqrt.clone() * sqrt.clone();
+            let sqrt_mul_2_minus_remainder_ge_u128_val =
+                sqrt.clone() * 2u32 - remainder.clone() >= pow_2_128;
+
+            // Guess sqrt limbs.
+            let (sqrt1_val, sqrt0_val) = sqrt.div_rem(&pow_2_64);
+            insert_value_to_cellref!(vm, sqrt0, Felt252::from(sqrt0_val))?;
+            insert_value_to_cellref!(vm, sqrt1, Felt252::from(sqrt1_val))?;
+
+            let (remainder_high_val, remainder_low_val) = remainder.div_rem(&pow_2_128);
+            // Guess remainder limbs.
+            insert_value_to_cellref!(vm, remainder_low, Felt252::from(remainder_low_val))?;
+            insert_value_to_cellref!(vm, remainder_high, Felt252::from(remainder_high_val))?;
+            insert_value_to_cellref!(
+                vm,
+                sqrt_mul_2_minus_remainder_ge_u128,
+                Felt252::from(usize::from(sqrt_mul_2_minus_remainder_ge_u128_val))
+            )?;
+        }
+        CoreHint::LinearSplit { value, scalar, max_x, x, y } => {
+            let value = get_val(vm, value)?.to_biguint();
+            let scalar = get_val(vm, scalar)?.to_biguint();
+            let max_x = get_val(vm, max_x)?.to_biguint();
+            let x_value = (value.clone() / scalar.clone()).min(max_x);
+            let y_value = value - x_value.clone() * scalar;
+            insert_value_to_cellref!(vm, x, Felt252::from(x_value))?;
+            insert_value_to_cellref!(vm, y, Felt252::from(y_value))?;
+        }
+        CoreHint::RandomEcPoint { x, y } => {
+            // Keep sampling a random field element `X` until `X^3 + X + beta` is a quadratic
+            // residue.
+            let beta = Fq::from(get_beta().to_biguint());
+            let mut rng = ark_std::test_rng();
+            let (random_x, random_y_squared) = loop {
+                let random_x = Fq::rand(&mut rng);
+                let random_y_squared = random_x * random_x * random_x + random_x + beta;
+                if random_y_squared.legendre().is_qr() {
+                    break (random_x, random_y_squared);
+                }
+            };
+            let x_bigint: BigUint = random_x.into_bigint().into();
+            let y_bigint: BigUint = random_y_squared.sqrt().unwrap().into_bigint().into();
+            insert_value_to_cellref!(vm, x, Felt252::from(x_bigint))?;
+            insert_value_to_cellref!(vm, y, Felt252::from(y_bigint))?;
+        }
+        CoreHint::FieldSqrt { val, sqrt } => {
+            let val = Fq::from(get_val(vm, val)?.to_biguint());
+            insert_value_to_cellref!(vm, sqrt, {
+                let three_fq = Fq::from(BigUint::from_usize(3).unwrap());
+                let res =
+                    (if val.legendre().is_qr() { val } else { val * three_fq }).sqrt().unwrap();
+                let root0: BigUint = res.into_bigint().into();
+                let root1: BigUint = (-res).into_bigint().into();
+                let res_big_uint = cmp::min(root0, root1);
+                Felt252::from(res_big_uint)
+            })?;
+        }
+        CoreHint::AllocFelt252Dict { segment_arena_ptr } => {
+            let dict_manager_address = extract_relocatable(vm, segment_arena_ptr)?;
+            let n_dicts = vm
+                .get_integer((dict_manager_address - 2)?)?
+                .into_owned()
+                .to_usize()
+                .expect("Number of dictionaries too large.");
+            let dict_infos_base = vm.get_relocatable((dict_manager_address - 3)?)?;
+
+            let dict_manager_exec_scope = match exec_scopes
+                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
+            {
+                Ok(dict_manager_exec_scope) => dict_manager_exec_scope,
+                Err(_) => {
+                    exec_scopes.assign_or_update_variable(
+                        "dict_manager_exec_scope",
+                        Box::<DictManagerExecScope>::default(),
+                    );
+                    exec_scopes.get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")?
+                }
+            };
+            let new_dict_segment = dict_manager_exec_scope.new_default_dict(vm);
+            vm.insert_value((dict_infos_base + 3 * n_dicts)?, new_dict_segment)?;
+        }
+        CoreHint::Felt252DictEntryInit { dict_ptr, key } => {
+            let dict_address = extract_relocatable(vm, dict_ptr)?;
+            let key = get_val(vm, key)?;
+            let dict_manager_exec_scope = exec_scopes
+                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
+                .expect("Trying to write to a dict while dict manager was not initialized.");
+            let prev_value = dict_manager_exec_scope
+                .get_from_tracker(dict_address, &key)
+                .unwrap_or_else(|| DictManagerExecScope::DICT_DEFAULT_VALUE.into());
+            vm.insert_value((dict_address + 1)?, prev_value)?;
+        }
+        CoreHint::Felt252DictEntryUpdate { dict_ptr, value } => {
+            let (dict_base, dict_offset) = extract_buffer(dict_ptr);
+            let dict_address = get_ptr(vm, dict_base, &dict_offset)?;
+            let key = get_double_deref_val(vm, dict_base, &(dict_offset + Felt252::from(-3)))?;
+            let value = get_maybe(vm, value)?;
+            let dict_manager_exec_scope = exec_scopes
+                .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
+                .expect("Trying to write to a dict while dict manager was not initialized.");
+            dict_manager_exec_scope.insert_to_tracker(dict_address, key, value);
+        }
+        CoreHint::GetSegmentArenaIndex { dict_end_ptr, dict_index, .. } => {
+            let dict_address = extract_relocatable(vm, dict_end_ptr)?;
+            let dict_manager_exec_scope = exec_scopes
+                .get_ref::<DictManagerExecScope>("dict_manager_exec_scope")
+                .expect("Trying to read from a dict while dict manager was not initialized.");
+            let dict_infos_index = dict_manager_exec_scope.get_dict_infos_index(dict_address);
+            insert_value_to_cellref!(vm, dict_index, Felt252::from(dict_infos_index))?;
+        }
+        CoreHint::InitSquashData { dict_accesses, n_accesses, first_key, big_keys, .. } => {
+            let dict_access_size = 3;
+            let rangecheck_bound = Felt252::from(u128::MAX) + 1u32;
+
+            exec_scopes.assign_or_update_variable(
+                "dict_squash_exec_scope",
+                Box::<DictSquashExecScope>::default(),
+            );
+            let dict_squash_exec_scope =
+                exec_scopes.get_mut_ref::<DictSquashExecScope>("dict_squash_exec_scope")?;
+            let dict_accesses_address = extract_relocatable(vm, dict_accesses)?;
+            let n_accesses = get_val(vm, n_accesses)?
+                .to_usize()
+                .expect("Number of accesses is too large or negative.");
+            for i in 0..n_accesses {
+                let current_key =
+                    vm.get_integer((dict_accesses_address + i * dict_access_size)?)?;
+                dict_squash_exec_scope
+                    .access_indices
+                    .entry(current_key.into_owned())
+                    .and_modify(|indices| indices.push(Felt252::from(i)))
+                    .or_insert_with(|| vec![Felt252::from(i)]);
+            }
+            // Reverse the accesses in order to pop them in order later.
+            for (_, accesses) in dict_squash_exec_scope.access_indices.iter_mut() {
+                accesses.reverse();
+            }
+            dict_squash_exec_scope.keys =
+                dict_squash_exec_scope.access_indices.keys().cloned().collect();
+            dict_squash_exec_scope.keys.sort_by(|a, b| b.cmp(a));
+            // big_keys indicates if the keys are greater than rangecheck_bound. If they are not
+            // a simple range check is used instead of assert_le_felt252.
+            insert_value_to_cellref!(
+                vm,
+                big_keys,
+                if dict_squash_exec_scope.keys[0] < rangecheck_bound {
+                    Felt252::from(0)
+                } else {
+                    Felt252::from(1)
+                }
+            )?;
+            insert_value_to_cellref!(vm, first_key, dict_squash_exec_scope.current_key().unwrap())?;
+        }
+        CoreHint::GetCurrentAccessIndex { range_check_ptr } => {
+            let dict_squash_exec_scope: &mut DictSquashExecScope =
+                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
+            let range_check_ptr = extract_relocatable(vm, range_check_ptr)?;
+            let current_access_index = dict_squash_exec_scope.current_access_index().unwrap();
+            vm.insert_value(range_check_ptr, current_access_index)?;
+        }
+        CoreHint::ShouldSkipSquashLoop { should_skip_loop } => {
+            let dict_squash_exec_scope: &mut DictSquashExecScope =
+                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
+            insert_value_to_cellref!(
+                vm,
+                should_skip_loop,
+                // The loop verifies that each two consecutive accesses are valid, thus we
+                // break when there is only one remaining access.
+                if dict_squash_exec_scope.current_access_indices().unwrap().len() > 1 {
+                    Felt252::from(0)
+                } else {
+                    Felt252::from(1)
+                }
+            )?;
+        }
+        CoreHint::GetCurrentAccessDelta { index_delta_minus1 } => {
+            let dict_squash_exec_scope: &mut DictSquashExecScope =
+                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
+            let prev_access_index = dict_squash_exec_scope.pop_current_access_index().unwrap();
+            let index_delta_minus_1_val =
+                dict_squash_exec_scope.current_access_index().unwrap().clone()
+                    - prev_access_index
+                    - 1_u32;
+            insert_value_to_cellref!(vm, index_delta_minus1, index_delta_minus_1_val)?;
+        }
+        CoreHint::ShouldContinueSquashLoop { should_continue } => {
+            let dict_squash_exec_scope: &mut DictSquashExecScope =
+                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
+            insert_value_to_cellref!(
+                vm,
+                should_continue,
+                // The loop verifies that each two consecutive accesses are valid, thus we
+                // break when there is only one remaining access.
+                if dict_squash_exec_scope.current_access_indices().unwrap().len() > 1 {
+                    Felt252::from(1)
+                } else {
+                    Felt252::from(0)
+                }
+            )?;
+        }
+        CoreHint::GetNextDictKey { next_key } => {
+            let dict_squash_exec_scope: &mut DictSquashExecScope =
+                exec_scopes.get_mut_ref("dict_squash_exec_scope")?;
+            dict_squash_exec_scope.pop_current_key();
+            insert_value_to_cellref!(vm, next_key, dict_squash_exec_scope.current_key().unwrap())?;
+        }
+        CoreHint::AssertLeFindSmallArcs { a, b, range_check_ptr } => {
+            let a_val = get_val(vm, a)?;
+            let b_val = get_val(vm, b)?;
+            let mut lengths_and_indices = vec![
+                (a_val.clone(), 0),
+                (b_val.clone() - a_val, 1),
+                (Felt252::from(-1) - b_val, 2),
+            ];
+            lengths_and_indices.sort();
+            exec_scopes
+                .assign_or_update_variable("excluded_arc", Box::new(lengths_and_indices[2].1));
+            // ceil((PRIME / 3) / 2 ** 128).
+            let prime_over_3_high = 3544607988759775765608368578435044694_u128;
+            // ceil((PRIME / 2) / 2 ** 128).
+            let prime_over_2_high = 5316911983139663648412552867652567041_u128;
+            let range_check_ptr = extract_relocatable(vm, range_check_ptr)?;
+            vm.insert_value(
+                range_check_ptr,
+                Felt252::from(lengths_and_indices[0].0.to_biguint() % prime_over_3_high),
+            )?;
+            vm.insert_value(
+                (range_check_ptr + 1)?,
+                Felt252::from(lengths_and_indices[0].0.to_biguint() / prime_over_3_high),
+            )?;
+            vm.insert_value(
+                (range_check_ptr + 2)?,
+                Felt252::from(lengths_and_indices[1].0.to_biguint() % prime_over_2_high),
+            )?;
+            vm.insert_value(
+                (range_check_ptr + 3)?,
+                Felt252::from(lengths_and_indices[1].0.to_biguint() / prime_over_2_high),
+            )?;
+        }
+        CoreHint::AssertLeIsFirstArcExcluded { skip_exclude_a_flag } => {
+            let excluded_arc: i32 = exec_scopes.get("excluded_arc")?;
+            insert_value_to_cellref!(
+                vm,
+                skip_exclude_a_flag,
+                if excluded_arc != 0 { Felt252::from(1) } else { Felt252::from(0) }
+            )?;
+        }
+        CoreHint::AssertLeIsSecondArcExcluded { skip_exclude_b_minus_a } => {
+            let excluded_arc: i32 = exec_scopes.get("excluded_arc")?;
+            insert_value_to_cellref!(
+                vm,
+                skip_exclude_b_minus_a,
+                if excluded_arc != 1 { Felt252::from(1) } else { Felt252::from(0) }
+            )?;
+        }
+        CoreHint::DebugPrint { start, end } => {
+            let mut curr = extract_relocatable(vm, start)?;
+            let end = extract_relocatable(vm, end)?;
+            while curr != end {
+                let value = vm.get_integer(curr)?;
+                if let Some(shortstring) = as_cairo_short_string(&value) {
+                    log::debug!("{shortstring: <31}\t(raw: {:#x} \n", value.to_bigint());
+                } else {
+                    log::debug!("{:<31}\t(raw: {:#x} ", " \n", value.to_bigint());
+                }
+                curr += 1;
+            }
+        }
+        CoreHint::AllocConstantSize { size, dst } => {
+            let object_size = get_val(vm, size)?.to_usize().expect("Object size too large.");
+            let memory_exec_scope =
+                match exec_scopes.get_mut_ref::<MemoryExecScope>("memory_exec_scope") {
+                    Ok(memory_exec_scope) => memory_exec_scope,
+                    Err(_) => {
+                        exec_scopes.assign_or_update_variable(
+                            "memory_exec_scope",
+                            Box::new(MemoryExecScope { next_address: vm.add_memory_segment() }),
+                        );
+                        exec_scopes.get_mut_ref::<MemoryExecScope>("memory_exec_scope")?
+                    }
+                };
+            insert_value_to_cellref!(vm, dst, memory_exec_scope.next_address)?;
+            memory_exec_scope.next_address.offset += object_size;
+        }
+    };
+    Ok(())
+}

--- a/crates/cairo-lang-vm-utils/src/execute_core_hints/mod.rs
+++ b/crates/cairo-lang-vm-utils/src/execute_core_hints/mod.rs
@@ -2,7 +2,6 @@ pub mod dict_manager;
 
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, vec};
-use core::cmp;
 use core::ops::Shl;
 
 use ark_ff::{Field, Fp256, MontBackend, MontConfig, PrimeField};
@@ -42,6 +41,8 @@ struct MemoryExecScope {
     /// The first free address in the segment.
     next_address: Relocatable,
 }
+
+// ---
 
 pub fn execute_core_hint_base(
     vm: &mut VirtualMachine,
@@ -288,7 +289,7 @@ pub fn execute_core_hint(
                     (if val.legendre().is_qr() { val } else { val * three_fq }).sqrt().unwrap();
                 let root0: BigUint = res.into_bigint().into();
                 let root1: BigUint = (-res).into_bigint().into();
-                let res_big_uint = cmp::min(root0, root1);
+                let res_big_uint = core::cmp::min(root0, root1);
                 Felt252::from(res_big_uint)
             })?;
         }
@@ -496,12 +497,13 @@ pub fn execute_core_hint(
             while curr != end {
                 let value = vm.get_integer(curr)?;
                 if let Some(shortstring) = as_cairo_short_string(&value) {
-                    log::debug!("{shortstring: <31}\t(raw: {:#x} \n", value.to_bigint());
+                    log::debug!("{shortstring: <31}\t(raw: {:#x}", value.to_bigint());
                 } else {
-                    log::debug!("{:<31}\t(raw: {:#x} ", " \n", value.to_bigint());
+                    log::debug!("{:<31}\t(raw: {:#x} ", ' ', value.to_bigint());
                 }
                 curr += 1;
             }
+            log::debug!("");
         }
         CoreHint::AllocConstantSize { size, dst } => {
             let object_size = get_val(vm, size)?.to_usize().expect("Object size too large.");

--- a/crates/cairo-lang-vm-utils/src/lib.rs
+++ b/crates/cairo-lang-vm-utils/src/lib.rs
@@ -1,0 +1,154 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
+use cairo_felt::Felt252;
+use cairo_lang_casm::operand::{
+    BinOpOperand, CellRef, DerefOrImmediate, Operation, Register, ResOperand,
+};
+use cairo_lang_utils::extract_matches;
+use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
+use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+
+#[cfg(feature = "execute_core_hints")]
+mod execute_core_hints;
+#[cfg(feature = "execute_core_hints")]
+pub use execute_core_hints::{execute_core_hint_base, extract_relocatable};
+
+pub fn cell_ref_to_relocatable(cell_ref: &CellRef, vm: &VirtualMachine) -> Relocatable {
+    let base = match cell_ref.register {
+        Register::AP => vm.get_ap(),
+        Register::FP => vm.get_fp(),
+    };
+    (base + (cell_ref.offset as i32)).unwrap()
+}
+
+mod my_macro {
+    /// Inserts a value into the vm memory cell represented by the cellref.
+    #[macro_export]
+    macro_rules! insert_value_to_cellref {
+        ($vm:ident, $cell_ref:ident, $value:expr) => {
+            $vm.insert_value($crate::cell_ref_to_relocatable($cell_ref, $vm), $value)
+        };
+    }
+}
+
+/// Extracts a parameter assumed to be a buffer.
+fn extract_buffer(buffer: &ResOperand) -> (&CellRef, Felt252) {
+    let (cell, base_offset) = match buffer {
+        ResOperand::Deref(cell) => (cell, 0.into()),
+        ResOperand::BinOp(BinOpOperand { op: Operation::Add, a, b }) => {
+            (a, extract_matches!(b, DerefOrImmediate::Immediate).clone().value.into())
+        }
+        _ => panic!("Illegal argument for a buffer."),
+    };
+    (cell, base_offset)
+}
+
+/// Fetches the value of a cell from the vm.
+pub fn get_cell_val(vm: &VirtualMachine, cell: &CellRef) -> Result<Felt252, VirtualMachineError> {
+    Ok(vm.get_integer(cell_ref_to_relocatable(cell, vm))?.as_ref().clone())
+}
+
+/// Fetch the `MaybeRelocatable` value from an address.
+pub fn get_maybe_from_addr(
+    vm: &VirtualMachine,
+    addr: Relocatable,
+) -> Result<MaybeRelocatable, VirtualMachineError> {
+    vm.get_maybe(&addr)
+        .ok_or_else(|| VirtualMachineError::InvalidMemoryValueTemporaryAddress(Box::new(addr)))
+}
+
+/// Fetches the maybe relocatable value of a cell from the vm.
+pub fn get_cell_maybe(
+    vm: &VirtualMachine,
+    cell: &CellRef,
+) -> Result<MaybeRelocatable, VirtualMachineError> {
+    get_maybe_from_addr(vm, cell_ref_to_relocatable(cell, vm))
+}
+
+/// Fetches the value of a cell plus an offset from the vm, useful for pointers.
+pub fn get_ptr(
+    vm: &VirtualMachine,
+    cell: &CellRef,
+    offset: &Felt252,
+) -> Result<Relocatable, VirtualMachineError> {
+    Ok((vm.get_relocatable(cell_ref_to_relocatable(cell, vm))? + offset)?)
+}
+
+/// Fetches the value of a pointer described by the value at `cell` plus an offset from the vm.
+pub fn get_double_deref_val(
+    vm: &VirtualMachine,
+    cell: &CellRef,
+    offset: &Felt252,
+) -> Result<Felt252, VirtualMachineError> {
+    Ok(vm.get_integer(get_ptr(vm, cell, offset)?)?.as_ref().clone())
+}
+
+/// Fetches the maybe relocatable value of a pointer described by the value at `cell` plus an offset
+/// from the vm.
+pub fn get_double_deref_maybe(
+    vm: &VirtualMachine,
+    cell: &CellRef,
+    offset: &Felt252,
+) -> Result<MaybeRelocatable, VirtualMachineError> {
+    get_maybe_from_addr(vm, get_ptr(vm, cell, offset)?)
+}
+
+/// Fetches the value of `res_operand` from the vm.
+pub fn get_val(
+    vm: &VirtualMachine,
+    res_operand: &ResOperand,
+) -> Result<Felt252, VirtualMachineError> {
+    match res_operand {
+        ResOperand::Deref(cell) => get_cell_val(vm, cell),
+        ResOperand::DoubleDeref(cell, offset) => get_double_deref_val(vm, cell, &(*offset).into()),
+        ResOperand::Immediate(x) => Ok(Felt252::from(x.value.clone())),
+        ResOperand::BinOp(op) => {
+            let a = get_cell_val(vm, &op.a)?;
+            let b = match &op.b {
+                DerefOrImmediate::Deref(cell) => get_cell_val(vm, cell)?,
+                DerefOrImmediate::Immediate(x) => Felt252::from(x.value.clone()),
+            };
+            match op.op {
+                Operation::Add => Ok(a + b),
+                Operation::Mul => Ok(a * b),
+            }
+        }
+    }
+}
+
+/// Fetches the maybe relocatable value of `res_operand` from the vm.
+pub fn get_maybe(
+    vm: &VirtualMachine,
+    res_operand: &ResOperand,
+) -> Result<MaybeRelocatable, VirtualMachineError> {
+    match res_operand {
+        ResOperand::Deref(cell) => get_cell_maybe(vm, cell),
+        ResOperand::DoubleDeref(cell, offset) => {
+            get_double_deref_maybe(vm, cell, &(*offset).into())
+        }
+        ResOperand::Immediate(x) => Ok(Felt252::from(x.value.clone()).into()),
+        ResOperand::BinOp(op) => {
+            let a = get_cell_maybe(vm, &op.a)?;
+            let b = match &op.b {
+                DerefOrImmediate::Deref(cell) => get_cell_val(vm, cell)?,
+                DerefOrImmediate::Immediate(x) => Felt252::from(x.value.clone()),
+            };
+            Ok(match op.op {
+                Operation::Add => a.add_int(&b)?,
+                Operation::Mul => match a {
+                    MaybeRelocatable::RelocatableValue(_) => {
+                        panic!("mul not implemented for relocatable values")
+                    }
+                    MaybeRelocatable::Int(a) => (a * b).into(),
+                },
+            })
+        }
+    }
+}

--- a/crates/cairo-lang-vm-utils/src/lib.rs
+++ b/crates/cairo-lang-vm-utils/src/lib.rs
@@ -7,9 +7,10 @@ extern crate alloc;
 use alloc::boxed::Box;
 
 use cairo_felt::Felt252;
-use cairo_lang_casm::operand::{
-    BinOpOperand, CellRef, DerefOrImmediate, Operation, Register, ResOperand,
-};
+#[cfg(feature = "execute_core_hints")]
+use cairo_lang_casm::operand::BinOpOperand;
+use cairo_lang_casm::operand::{CellRef, DerefOrImmediate, Operation, Register, ResOperand};
+#[cfg(feature = "execute_core_hints")]
 use cairo_lang_utils::extract_matches;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
@@ -39,6 +40,7 @@ mod my_macro {
 }
 
 /// Extracts a parameter assumed to be a buffer.
+#[cfg(feature = "execute_core_hints")]
 fn extract_buffer(buffer: &ResOperand) -> (&CellRef, Felt252) {
     let (cell, base_offset) = match buffer {
         ResOperand::Deref(cell) => (cell, 0.into()),

--- a/ensure_no_std/.cargo/config.toml
+++ b/ensure_no_std/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ensure_no_std"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cairo-lang-utils = { path = "../crates/cairo-lang-utils", default-features = false }
+cairo-lang-casm = { path = "../crates/cairo-lang-casm", default-features = false }
+cairo-lang-vm-utils = { path = "../crates/cairo-lang-vm-utils", default-features = false, features = [
+    "execute_core_hints",
+] }
+cairo-lang-casm-contract-class = { path = "../crates/cairo-lang-casm-contract-class", default-features = false }
+
+wee_alloc = "0.4.5"
+
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/ensure_no_std/Cargo.toml
+++ b/ensure_no_std/Cargo.toml
@@ -4,12 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cairo-lang-utils = { path = "../crates/cairo-lang-utils", default-features = false }
-cairo-lang-casm = { path = "../crates/cairo-lang-casm", default-features = false }
+cairo-lang-utils = { path = "../crates/cairo-lang-utils", default-features = false, features = [
+    "serde",
+] }
+cairo-lang-casm = { path = "../crates/cairo-lang-casm", default-features = false, features = [
+    "serde",
+] }
 cairo-lang-vm-utils = { path = "../crates/cairo-lang-vm-utils", default-features = false, features = [
     "execute_core_hints",
 ] }
-cairo-lang-casm-contract-class = { path = "../crates/cairo-lang-casm-contract-class", default-features = false }
+cairo-lang-casm-contract-class = { path = "../crates/cairo-lang-casm-contract-class", default-features = false, features = [
+    "serde",
+] }
 
 wee_alloc = "0.4.5"
 

--- a/ensure_no_std/src/main.rs
+++ b/ensure_no_std/src/main.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+/// This function is called on panic.
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    loop {}
+}
+
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+#[allow(unused_imports)]
+use {cairo_lang_casm, cairo_lang_casm_contract_class, cairo_lang_utils, cairo_lang_vm_utils};

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,7 +10,9 @@ description = ""
 assert_matches.workspace = true
 cairo-felt.workspace = true
 cairo-lang-casm = { path = "../crates/cairo-lang-casm" }
-cairo-lang-compiler = { path = "../crates/cairo-lang-compiler" }
+cairo-lang-compiler = { path = "../crates/cairo-lang-compiler", features = [
+    "serde",
+] }
 cairo-lang-defs = { path = "../crates/cairo-lang-defs" }
 cairo-lang-diagnostics = { path = "../crates/cairo-lang-diagnostics" }
 cairo-lang-filesystem = { path = "../crates/cairo-lang-filesystem" }
@@ -18,11 +20,17 @@ cairo-lang-lowering = { path = "../crates/cairo-lang-lowering" }
 cairo-lang-parser = { path = "../crates/cairo-lang-parser" }
 cairo-lang-plugins = { path = "../crates/cairo-lang-plugins" }
 cairo-lang-runner = { path = "../crates/cairo-lang-runner" }
-cairo-lang-semantic = { path = "../crates/cairo-lang-semantic", features = ["testing"] }
+cairo-lang-semantic = { path = "../crates/cairo-lang-semantic", features = [
+    "testing",
+] }
 cairo-lang-sierra = { path = "../crates/cairo-lang-sierra" }
 cairo-lang-sierra-gas = { path = "../crates/cairo-lang-sierra-gas" }
-cairo-lang-sierra-generator = { path = "../crates/cairo-lang-sierra-generator", features = ["testing"] }
-cairo-lang-sierra-to-casm = { path = "../crates/cairo-lang-sierra-to-casm", features = ["testing"] }
+cairo-lang-sierra-generator = { path = "../crates/cairo-lang-sierra-generator", features = [
+    "testing",
+] }
+cairo-lang-sierra-to-casm = { path = "../crates/cairo-lang-sierra-to-casm", features = [
+    "testing",
+] }
 cairo-lang-syntax = { path = "../crates/cairo-lang-syntax" }
 cairo-lang-test-utils = { path = "../crates/cairo-lang-test-utils" }
 cairo-lang-utils = { path = "../crates/cairo-lang-utils" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,7 +8,7 @@ description = ""
 
 [dev-dependencies]
 assert_matches.workspace = true
-cairo-felt.workspace = true
+cairo-felt = { workspace = true, features = ["std"] }
 cairo-lang-casm = { path = "../crates/cairo-lang-casm" }
 cairo-lang-compiler = { path = "../crates/cairo-lang-compiler", features = [
     "serde",
@@ -35,9 +35,9 @@ cairo-lang-syntax = { path = "../crates/cairo-lang-syntax" }
 cairo-lang-test-utils = { path = "../crates/cairo-lang-test-utils" }
 cairo-lang-utils = { path = "../crates/cairo-lang-utils" }
 env_logger.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, features = ["use_std"] }
 log.workspace = true
-num-bigint.workspace = true
+num-bigint = { workspace = true, features = ["std"] }
 once_cell.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true


### PR DESCRIPTION
We created 2 new crates to break some dependencies and have less crates to turn no_std. Note that this PR introduces no_std compatibility for :
* `cairo-lang-casm`
* `cairo-lang-casm-contract-class` 
* `cairo-lang-utils` 
* `cairo-lang-vm-utils`

Introduction of a serde feature for all the crates that use serde.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3771)
<!-- Reviewable:end -->
