### PR TITLE
feat: export tests results as JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,8 @@ dependencies = [
  "num-traits 0.2.15",
  "rayon",
  "salsa",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/crates/bin/cairo-test/src/main.rs
+++ b/crates/bin/cairo-test/src/main.rs
@@ -29,6 +29,9 @@ struct Args {
     /// Should we add the starknet plugin to run the tests.
     #[arg(long, default_value_t = false)]
     starknet: bool,
+     /// Path to export tests results as JSON
+    #[arg(long, default_value_t = String::default())]
+    export: String,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -43,6 +46,7 @@ fn main() -> anyhow::Result<()> {
         args.include_ignored,
         args.ignored,
         args.starknet,
+        &args.export,
     )?;
     runner.run()?;
 

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -33,4 +33,6 @@ num-bigint.workspace = true
 num-traits.workspace = true
 rayon.workspace = true
 salsa.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
Add an --export parameter to cairo-test accepting a path to export tests results as JSON.

use : 

`cairo-test ./src/tests.cairo --single-file --export ./tests.json`

example results for Success / Fail :

```
[
  {
    "name": "tests::tests::test_1",
    "status": "Success",
    "gas_usage": 500
  },
 {
    "name": "tests::tests::test_2",
    "status": "Fail",
    "gas_usage": 1600,
    "error_messages": [
      "this is panic !!!",
      "with",
      "a long",
      "message"
    ]
  }
]
```