### PR TITLE
feat: selector!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,7 @@ name = "cairo-lang-semantic"
 version = "2.1.0-rc0"
 dependencies = [
  "assert_matches",
+ "cairo-felt",
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -776,6 +777,7 @@ dependencies = [
  "num-traits 0.2.15",
  "pretty_assertions",
  "salsa",
+ "sha3",
  "smol_str",
  "test-case",
  "test-log",

--- a/crates/cairo-lang-plugins/src/test_data/inline_macros
+++ b/crates/cairo-lang-plugins/src/test_data/inline_macros
@@ -133,7 +133,7 @@ fn some_func()
 
 //! > ==========================================================================
 
-//! > Test recursive consteval_int! 
+//! > Test recursive consteval_int!
 
 //! > test_runner_name
 test_expand_plugin
@@ -250,3 +250,63 @@ fn foo() {
 }
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test selector! macro
+
+//! > test_runner_name
+test_expand_plugin
+
+//! > cairo_code
+fn foo() {
+    let s = selector!('bar');
+}
+
+//! > generated_cairo_code
+fn foo() {
+    let s = 0x35cd288e3694b535549c3af56ad805c149f92961bf84a1c647f7d86fc2431b4;
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test incorrect use of selector! macro
+
+//! > test_runner_name
+test_expand_plugin
+
+//! > cairo_code
+fn foo() {
+    let a = selector!(20);
+
+    let b = selector!('foo', 'bar');
+
+    let c = selector!['foo'];
+}
+
+//! > generated_cairo_code
+fn foo() {
+    let a = selector!(20);
+
+    let b = selector!('foo', 'bar');
+
+    let c = selector!['foo'];
+}
+
+//! > expected_diagnostics
+error: selector macro argument must be a short string
+ --> dummy_file.cairo:2:23
+    let a = selector!(20);
+                      ^^
+
+error: selector macro must have a single argument
+ --> dummy_file.cairo:4:23
+    let b = selector!('foo', 'bar');
+                      ^**********^
+
+error: Macro selector does not support this bracket type
+ --> dummy_file.cairo:6:13
+    let c = selector!['foo'];
+            ^**************^

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -10,6 +10,7 @@ description = "Cairo semantic model."
 testing = []
 
 [dependencies]
+cairo-felt.workspace = true
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.1.0-rc0" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "2.1.0-rc0" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "2.1.0-rc0" }
@@ -24,6 +25,7 @@ log.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
 salsa.workspace = true
+sha3.workspace = true
 smol_str.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-semantic/src/inline_macros/mod.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/mod.rs
@@ -1,5 +1,6 @@
 pub mod array;
 pub mod consteval_int;
+pub mod selector;
 
 use cairo_lang_defs::plugin::{InlineMacroPlugin, InlinePluginResult, PluginDiagnostic};
 use cairo_lang_syntax::node::ast::{self};
@@ -8,12 +9,14 @@ use cairo_lang_syntax::node::TypedSyntaxNode;
 
 use super::inline_macros::array::ArrayMacro;
 use super::inline_macros::consteval_int::ConstevalIntMacro;
+use super::inline_macros::selector::SelectorMacro;
 
 /// Returns the inline macro plugin for the given macro name, or None if no such plugin exists.
 pub fn get_inline_macro_plugin(macro_name: &str) -> Option<Box<dyn InlineMacroPlugin>> {
     match macro_name {
         "array" => Some(Box::new(ArrayMacro)),
         "consteval_int" => Some(Box::new(ConstevalIntMacro)),
+        "selector" => Some(Box::new(SelectorMacro)),
         _ => None,
     }
 }

--- a/crates/cairo-lang-semantic/src/inline_macros/selector.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/selector.rs
@@ -1,0 +1,57 @@
+use cairo_felt::Felt252;
+use cairo_lang_defs::plugin::{InlineMacroPlugin, InlinePluginResult, PluginDiagnostic};
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
+use num_bigint::BigUint;
+use sha3::{Digest, Keccak256};
+
+use super::unsupported_bracket_diagnostic;
+
+#[derive(Debug)]
+pub struct SelectorMacro;
+
+// TODO: this is copied from cairo-lang-starknet due to circular dependency issue, how to fix?
+/// A variant of eth-keccak that computes a value that fits in a Starknet field element.
+pub fn starknet_keccak(data: &[u8]) -> BigUint {
+    let mut hasher = Keccak256::new();
+    hasher.update(data);
+    let mut result = hasher.finalize();
+
+    // Truncate result to 250 bits.
+    *result.first_mut().unwrap() &= 3;
+    BigUint::from_bytes_be(&result)
+}
+
+impl InlineMacroPlugin for SelectorMacro {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        syntax: &ast::ExprInlineMacro,
+    ) -> InlinePluginResult {
+        let ast::WrappedExprList::ParenthesizedExprList(args) = syntax.arguments(db) else {
+            return unsupported_bracket_diagnostic(db, syntax);
+        };
+
+        let arguments = &args.expressions(db).elements(db);
+        if arguments.len() != 1 {
+            let diagnostics = vec![PluginDiagnostic {
+                stable_ptr: syntax.stable_ptr().untyped(),
+                message: "selector macro must have a single argument".to_string(),
+            }];
+            return InlinePluginResult { code: None, diagnostics };
+        }
+
+        let ast::Expr::ShortString(short_string) = &arguments[0] else {
+            let diagnostics = vec![PluginDiagnostic {
+                stable_ptr: syntax.stable_ptr().untyped(),
+                message: "selector macro argument must be a short string".to_string(),
+            }];
+            return InlinePluginResult { code: None, diagnostics };
+        };
+        let selector_bytes = short_string.numeric_value(db).unwrap().to_signed_bytes_be();
+
+        let selector = Felt252::try_from(starknet_keccak(&selector_bytes)).unwrap();
+        let code: String = format!("0x{}", selector.to_str_radix(16));
+        InlinePluginResult { code: Some(code), diagnostics: vec![] }
+    }
+}


### PR DESCRIPTION
This PR adds a new `selector` macro which computes function selectors at compile time:

```rust
let endpoint = selector!('transfer_from');
```

It prevents the need for hardcoding the selectors as unreadable constants or passing them as arguments, both of which are error prone. This feature request comes up regularly in the community - just today on Discord or last week on Telegram - so I think it's a valuable addition to the repo.

There's currently one issue with the implementation - due to a circular dependency, I had to copy-paste the `starknet_keccak` fn directly into `selector.rs`. Can't think of a good way how to fix it.

Also, I do recognize that the macro is only valuable in the context of Starknet and irrelevant for Cairo.

I'm happy to address both of these concerns with some guidance 🙏 

Lastly, the `inline_macros` tests are not run (IDK why they are disabled), but I've added tests cases for this new macro which ought to verify it's working correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3811)
<!-- Reviewable:end -->
