### PR TITLE
move get_available_gas

### DIFF
--- a/corelib/src/lib.cairo
+++ b/corelib/src/lib.cairo
@@ -333,6 +333,3 @@ use byte_array::{ByteArray, ByteArrayIndexView, ByteArrayTrait};
 
 #[cfg(test)]
 mod test;
-
-// Module for testing only.
-mod testing;

--- a/corelib/src/starknet/testing.cairo
+++ b/corelib/src/starknet/testing.cairo
@@ -81,3 +81,6 @@ fn pop_log<T, impl TEvent: starknet::Event<T>>(address: ContractAddress) -> Opti
     let (mut keys, mut data) = pop_log_raw(address)?;
     starknet::Event::deserialize(ref keys, ref data)
 }
+
+// Allows to get available gas. If you have a zero value use also 'gas::withdraw_gas().unwrap();'
+extern fn get_available_gas() -> u128 implicits(GasBuiltin) nopanic;

--- a/corelib/src/test/testing_test.cairo
+++ b/corelib/src/test/testing_test.cairo
@@ -20,11 +20,11 @@ fn test_assert_true() {
 
 #[test]
 fn test_get_available_gas_no_gas_supply() {
-    assert_eq(@testing::get_available_gas(), @0, 'expected no_gas_supply')
+    assert_eq(@starknet::testing::get_available_gas(), @0, 'expected no_gas_supply')
 }
 
 #[test]
 #[available_gas(10000)]
 fn test_get_available_gas_with_gas_supply() {
-    assert_gt(testing::get_available_gas(), 5000, 'high amount of gas used')
+    assert_gt(starknet::testing::get_available_gas(), 5000, 'high amount of gas used')
 }

--- a/corelib/src/testing.cairo
+++ b/corelib/src/testing.cairo
@@ -1,1 +1,0 @@
-extern fn get_available_gas() -> u128 implicits(GasBuiltin) nopanic;


### PR DESCRIPTION
As this should only be use in testing I think it is safe to move it to the testing file within the Starknet folder

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3833)
<!-- Reviewable:end -->
