### PR TITLE
feat: nullable new method

### DIFF
--- a/corelib/src/nullable.cairo
+++ b/corelib/src/nullable.cairo
@@ -16,6 +16,7 @@ extern fn match_nullable<T>(value: Nullable<T>) -> FromNullableResult<T> nopanic
 
 trait NullableTrait<T> {
     fn deref(self: Nullable<T>) -> T;
+    fn new(value: T) -> Nullable<T>;
 }
 
 impl NullableImpl<T> of NullableTrait<T> {
@@ -24,6 +25,10 @@ impl NullableImpl<T> of NullableTrait<T> {
             FromNullableResult::Null => panic_with_felt252('Attempted to deref null value'),
             FromNullableResult::NotNull(value) => value.unbox(),
         }
+    }
+    fn new(value: T) -> Nullable<T> {
+        let nullable = nullable_from_box(BoxTrait::new(value));
+        nullable
     }
 }
 

--- a/corelib/src/nullable.cairo
+++ b/corelib/src/nullable.cairo
@@ -27,8 +27,7 @@ impl NullableImpl<T> of NullableTrait<T> {
         }
     }
     fn new(value: T) -> Nullable<T> {
-        let nullable = nullable_from_box(BoxTrait::new(value));
-        nullable
+        nullable_from_box(BoxTrait::new(value))
     }
 }
 


### PR DESCRIPTION
Closes #3827
Adds a `new` method to the `NullableTrait` to create a Nullable<T> from T

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3841)
<!-- Reviewable:end -->
