### PR TITLE
Ensuring builder counts all steps.

### DIFF
--- a/crates/cairo-lang-casm/src/builder.rs
+++ b/crates/cairo-lang-casm/src/builder.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::extract_matches;
@@ -65,13 +65,19 @@ impl State {
 
     /// Intersect the states of branches leading to the same label, validating that the states can
     /// intersect.
-    fn intersect(&mut self, other: &Self) {
+    fn intersect(&mut self, other: &Self, read_only: bool) {
         assert_eq!(self.ap_change, other.ap_change, "Merged branches not aligned on AP change.");
         assert_eq!(
             self.allocated, other.allocated,
             "Merged branches not aligned on number of allocations."
         );
-        self.steps = self.steps.max(other.steps);
+        if read_only {
+            assert!(self.steps >= other.steps, "Finalized branch cannot be updated.");
+        } else {
+            self.steps = self.steps.max(other.steps);
+        }
+        // Allowing removal of variables as valid code won't be producable in that case anyway, and
+        // otherwise merging branches becomes very difficult.
         self.vars.retain(|var, value| {
             other
                 .vars
@@ -106,6 +112,8 @@ pub struct CasmBuildResult<const BRANCH_COUNT: usize> {
 pub struct CasmBuilder {
     /// The state at a point of jumping into a label, per label.
     label_state: HashMap<String, State>,
+    /// The set of labels that were already read, so cannot be updated.
+    read_labels: HashSet<String>,
     /// The state at the last added statement.
     main_state: State,
     /// The added statements.
@@ -296,7 +304,7 @@ impl CasmBuilder {
             },
         };
         let instruction =
-            self.get_instruction(InstructionBody::AssertEq(AssertEqInstruction { a, b }), true);
+            self.next_instruction(InstructionBody::AssertEq(AssertEqInstruction { a, b }), true);
         self.statements.push(Statement::Final(instruction));
     }
 
@@ -350,7 +358,7 @@ impl CasmBuilder {
 
     /// Increases AP by `size`.
     pub fn add_ap(&mut self, size: usize) {
-        let instruction = self.get_instruction(
+        let instruction = self.next_instruction(
             InstructionBody::AddAp(AddApInstruction { operand: BigInt::from(size).into() }),
             false,
         );
@@ -386,7 +394,8 @@ impl CasmBuilder {
     fn set_or_test_label_state(&mut self, label: String, state: State) {
         match self.label_state.entry(label) {
             Entry::Occupied(mut e) => {
-                e.get_mut().intersect(&state);
+                let read_only = self.read_labels.contains(e.key());
+                e.get_mut().intersect(&state, read_only);
             }
             Entry::Vacant(e) => {
                 e.insert(state);
@@ -396,7 +405,7 @@ impl CasmBuilder {
 
     /// Add a statement to jump to `label`.
     pub fn jump(&mut self, label: String) {
-        let instruction = self.get_instruction(
+        let instruction = self.next_instruction(
             InstructionBody::Jump(JumpInstruction {
                 target: deref_or_immediate!(0),
                 relative: true,
@@ -414,7 +423,7 @@ impl CasmBuilder {
     /// `condition` must be a cell reference.
     pub fn jump_nz(&mut self, condition: Var, label: String) {
         let cell = self.as_cell_ref(condition, true);
-        let instruction = self.get_instruction(
+        let instruction = self.next_instruction(
             InstructionBody::Jnz(JnzInstruction {
                 condition: cell,
                 jump_offset: deref_or_immediate!(0),
@@ -430,6 +439,7 @@ impl CasmBuilder {
         if self.reachable {
             self.set_or_test_label_state(name.clone(), self.main_state.clone());
         }
+        self.read_labels.insert(name.clone());
         self.main_state = self
             .label_state
             .get(&name)
@@ -505,7 +515,7 @@ impl CasmBuilder {
             }
         }
 
-        let instruction = self.get_instruction(
+        let instruction = self.next_instruction(
             InstructionBody::Call(CallInstruction {
                 relative: true,
                 target: deref_or_immediate!(0),
@@ -524,7 +534,7 @@ impl CasmBuilder {
     /// A return statement in the code.
     pub fn ret(&mut self) {
         self.main_state.validate_finality();
-        let instruction = self.get_instruction(InstructionBody::Ret(RetInstruction {}), false);
+        let instruction = self.next_instruction(InstructionBody::Ret(RetInstruction {}), false);
         self.statements.push(Statement::Final(instruction));
         self.reachable = false;
     }
@@ -542,7 +552,7 @@ impl CasmBuilder {
     /// Create an assert that would always fail.
     pub fn fail(&mut self) {
         let cell = CellRef { offset: -1, register: Register::FP };
-        let instruction = self.get_instruction(
+        let instruction = self.next_instruction(
             InstructionBody::AssertEq(AssertEqInstruction {
                 a: cell,
                 b: ResOperand::BinOp(BinOpOperand {
@@ -600,9 +610,9 @@ impl CasmBuilder {
         }
     }
 
-    /// Returns an instruction wrapping the instruction body.
+    /// Returns an instruction wrapping the instruction body, and updates the state.
     /// If `inc_ap_supported` may add an `ap++` to the instruction.
-    fn get_instruction(&mut self, body: InstructionBody, inc_ap_supported: bool) -> Instruction {
+    fn next_instruction(&mut self, body: InstructionBody, inc_ap_supported: bool) -> Instruction {
         assert!(self.reachable, "Cannot add instructions at unreachable code.");
         let inc_ap =
             inc_ap_supported && self.main_state.allocated as usize > self.main_state.ap_change;
@@ -620,6 +630,7 @@ impl Default for CasmBuilder {
     fn default() -> Self {
         Self {
             label_state: Default::default(),
+            read_labels: Default::default(),
             main_state: Default::default(),
             statements: Default::default(),
             current_hints: Default::default(),

--- a/crates/cairo-lang-casm/src/builder_test.rs
+++ b/crates/cairo-lang-casm/src/builder_test.rs
@@ -185,6 +185,7 @@ fn test_calculation_loop() {
         tempvar b = one;
         rescope{a = a, b = b, n = n, one = one};
         FIB:
+        #{ steps = 0; }
         tempvar new_n = n - one;
         tempvar new_b = a + b;
         rescope{a = b, b = new_b, n = new_n, one = one};
@@ -225,6 +226,7 @@ fn test_call_ret() {
         assert res_b = fib11;
         jump FT;
         FIB:
+        #{ steps = 0; }
         tempvar new_a = b;
         tempvar new_n = n - one;
         tempvar new_b = a + b;
@@ -275,6 +277,7 @@ fn test_local_fib() {
         tempvar b = one;
         rescope{a = a, b = b, n = n, one = one, res = res};
         FIB:
+        #{ steps = 0; }
         tempvar new_n = n - one;
         tempvar new_b = a + b;
         rescope{a = b, b = new_b, n = new_n, one = one, res = res};


### PR DESCRIPTION
Done by making sure we do not update step count of labels that were read.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3845)
<!-- Reviewable:end -->
