### PR TITLE
Removed unused `ContractGenerationData` fields.

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/contract.rs
+++ b/crates/cairo-lang-starknet/src/plugin/contract.rs
@@ -90,8 +90,6 @@ struct ContractGenerationData {
     generated_constructor_functions: Vec<RewriteNode>,
     generated_l1_handler_functions: Vec<RewriteNode>,
     abi_functions: Vec<RewriteNode>,
-    event_functions: Vec<RewriteNode>,
-    abi_events: Vec<RewriteNode>,
 }
 
 /// If the module is annotated with CONTRACT_ATTR, generate the relevant contract logic.
@@ -331,11 +329,8 @@ pub fn handle_contract_by_storage(
             const TEST_CLASS_HASH: felt252 = {test_class_hash};
             $storage_code$
 
-            $event_functions$
-
             trait {ABI_TRAIT}<ContractState> {{
                 $abi_functions$
-                $abi_events$
             }}
 
             mod {EXTERNAL_MODULE} {{$extra_uses$
@@ -362,9 +357,7 @@ pub fn handle_contract_by_storage(
             ),
             ("original_items".to_string(), RewriteNode::new_modified(kept_original_items)),
             ("storage_code".to_string(), storage_code),
-            ("event_functions".to_string(), RewriteNode::new_modified(data.event_functions)),
             ("abi_functions".to_string(), RewriteNode::new_modified(data.abi_functions)),
-            ("abi_events".to_string(), RewriteNode::new_modified(data.abi_events)),
             ("extra_uses".to_string(), extra_uses_node),
             (
                 "generated_external_functions".to_string(),

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contract
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contract
@@ -142,8 +142,6 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn get_something(self: @ContractState, ref arg: felt252, num: felt252) -> felt252;
@@ -159,7 +157,6 @@ trait __abi<ContractState> {
         storage_address: StorageAddress,
     );
         
-    
 }
 
 mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/diagnostics
@@ -99,15 +99,12 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn foo();
         #[external]
         fn bar(_n: u32);
         
-    
 }
 
 mod __external {
@@ -249,13 +246,10 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[constructor]
         fn invalid_constructor_name(ref self: ContractState);
         
-    
 }
 
 mod __external {
@@ -407,10 +401,7 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
-    
     
 }
 
@@ -575,8 +566,6 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn foo_v0(ref self: ContractState, x: (felt252, felt252));
@@ -585,7 +574,6 @@ trait __abi<ContractState> {
         #[external]
         fn foo_v1(ref self: ContractState, x: (felt252, felt252));
         
-    
 }
 
 mod __external {
@@ -781,13 +769,10 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn foo(ref self: ContractState, x: (felt252, felt252));
         
-    
 }
 
 mod __external {
@@ -938,13 +923,10 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn foo(ref self: ContractState) -> (felt252, felt252);
         
-    
 }
 
 mod __external {
@@ -1098,13 +1080,10 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn foo<T>(ref self: ContractState, x: T);
         
-    
 }
 
 mod __external {
@@ -1198,7 +1177,7 @@ note: Trait has no implementation in context: core::traits::Drop::<T>
 note: Trait has no implementation in context: core::traits::Destruct::<T>
 
 error: Type not found.
- --> contract:62:32
+ --> contract:59:32
                 serde::Serde::<T>::deserialize(ref data)
                                ^
 
@@ -1276,13 +1255,10 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn foo(ref self: ContractState, x: (felt252, felt252), y: (felt252, felt252)) -> (felt252, felt252);
         
-    
 }
 
 mod __external {
@@ -1453,8 +1429,6 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn __validate__(ref self: ContractState);
@@ -1465,7 +1439,6 @@ trait __abi<ContractState> {
         #[external]
         fn __execute__(ref self: ContractState);
         
-    
 }
 
 mod __external {
@@ -1706,8 +1679,6 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn foo(ref self: ContractState, ref a: felt252, ref b: felt252);
@@ -1720,7 +1691,6 @@ trait __abi<ContractState> {
         #[external]
         fn bar4(ref self: ContractState, a: felt252) -> my_felt252_array_type;
         
-    
 }
 
 mod __external {
@@ -1938,10 +1908,7 @@ use starknet::event::EventEmitter;
     }
 
 
-
-
 trait __abi<ContractState> {
-    
     
 }
 
@@ -2157,10 +2124,7 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
-    
     
 }
 
@@ -2376,8 +2340,6 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn foo_external(ref self: ContractState);
@@ -2386,7 +2348,6 @@ trait __abi<ContractState> {
         #[external]
         fn foo_constructor(ref self: ContractState);
         
-    
 }
 
 mod __external {
@@ -2595,10 +2556,7 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
-    
     
 }
 
@@ -2746,10 +2704,7 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
-    
     
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/hello_starknet
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/hello_starknet
@@ -127,15 +127,12 @@ use starknet::event::EventEmitter;
     }
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn increase_balance(ref self: ContractState, amount: felt252);
         #[external]
         fn get_balance(self: @ContractState) -> felt252;
         
-    
 }
 
 mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/l1_handler
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/l1_handler
@@ -89,8 +89,6 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[l1_handler]
         fn good_l1_handler(ref self: ContractState, from_address: felt252, arg: felt252);
@@ -103,7 +101,6 @@ trait __abi<ContractState> {
         #[l1_handler]
         fn l1_handler_wrong_first_param_type(ref self: ContractState, from_address: u128);
         
-    
 }
 
 mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/raw_output
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/raw_output
@@ -87,15 +87,12 @@ use starknet::event::EventEmitter;
 
 
 
-
-
 trait __abi<ContractState> {
     #[external]
         fn test_raw_output(ref self: ContractState) -> Span::<felt252>;
         #[external]
         fn test_raw_output_with_spaces(ref self: ContractState) -> Span     ::   < felt252  >;
         
-    
 }
 
 mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/storage
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/storage
@@ -526,10 +526,7 @@ use starknet::event::EventEmitter;
     }
 
 
-
-
 trait __abi<ContractState> {
-    
     
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/user_defined_types
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/user_defined_types
@@ -186,10 +186,7 @@ use starknet::event::EventEmitter;
     }
 
 
-
-
 trait __abi<ContractState> {
-    
     
 }
 


### PR DESCRIPTION
**Stack**:
- #3848
- #3846 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3846)
<!-- Reviewable:end -->
