### PR TITLE
Fixing snippets view fn without external

### DIFF
--- a/vscode-cairo/snippets/cairo.json
+++ b/vscode-cairo/snippets/cairo.json
@@ -87,7 +87,7 @@
   },
   "Creates a view function": {
     "prefix": ["view", "fn"],
-    "body": ["#[external]", "fn $1(self: @ContractState, ) {", "\t$5", "}"],
+    "body": ["fn $1(self: @ContractState, ) {", "\t$5", "}"],
     "description": "Creates a view function"
   },
   "Match": {


### PR DESCRIPTION
There was an extra `#[external]`existing from before in the snippets which is now removed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3857)
<!-- Reviewable:end -->
