### PR TITLE
Renamed and moved Patch to DiagnosticsMapper.

### DIFF
--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -13,7 +13,6 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::Upcast;
 
 use crate::ids::*;
-use crate::patcher::Patches;
 use crate::plugin::{
     DynGeneratedFileAuxData, InlineMacroExprPlugin, MacroPlugin, PluginDiagnostic,
 };
@@ -256,7 +255,6 @@ pub struct GeneratedFileInfo {
     pub aux_data: Option<DynGeneratedFileAuxData>,
     /// The module and file index from which the current file was generated.
     pub origin: ModuleFileId,
-    pub patches: Arc<Patches>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -355,12 +353,12 @@ fn priv_module_data(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<ModuleData
                         parent: Some(module_file),
                         name: generated.name,
                         content: Arc::new(generated.content),
+                        diagnostics_mappings: Arc::new(generated.diagnostics_mappings),
                         kind: FileKind::Module,
                     }));
                     generated_file_infos.push(Some(GeneratedFileInfo {
                         aux_data: generated.aux_data,
                         origin: module_file_id,
-                        patches: Arc::new(generated.patches),
                     }));
                     module_queue
                         .push_back((new_file, db.file_module_syntax(new_file)?.items(syntax_db)));

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -2,12 +2,11 @@ use std::any::Any;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use cairo_lang_filesystem::ids::DiagnosticMapping;
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use smol_str::SmolStr;
-
-use crate::patcher::Patches;
 
 /// A trait for arbitrary data that a macro generates along with a generated file.
 pub trait GeneratedFileAuxData: std::fmt::Debug + Sync + Send {
@@ -44,7 +43,7 @@ pub struct PluginGeneratedFile {
     pub content: String,
     /// A diagnostics mapper, to allow more readable diagnostics that originate in plugin generated
     /// virtual files.
-    pub patches: Patches,
+    pub diagnostics_mappings: Vec<DiagnosticMapping>,
     /// Arbitrary data that the plugin generates along with the file.
     pub aux_data: Option<DynGeneratedFileAuxData>,
 }
@@ -78,7 +77,7 @@ pub trait MacroPlugin: std::fmt::Debug + Sync + Send {
 /// Result of plugin code generation.
 #[derive(Default)]
 pub struct InlinePluginResult {
-    pub code: Option<String>,
+    pub code: Option<PluginGeneratedFile>,
     /// Diagnostics.
     pub diagnostics: Vec<PluginDiagnostic>,
 }

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -226,7 +226,7 @@ impl MacroPlugin for DummyPlugin {
                     code: Some(PluginGeneratedFile {
                         name: "virt".into(),
                         content: format!("fn f(x:{}){{}}", struct_ast.name(db).text(db)),
-                        patches: Default::default(),
+                        diagnostics_mappings: Default::default(),
                         aux_data: None,
                     }),
                     diagnostics: vec![],
@@ -237,7 +237,7 @@ impl MacroPlugin for DummyPlugin {
                 code: Some(PluginGeneratedFile {
                     name: "virt2".into(),
                     content: "extern type B;".into(),
-                    patches: Default::default(),
+                    diagnostics_mappings: Default::default(),
                     aux_data: None,
                 }),
                 diagnostics: vec![PluginDiagnostic {
@@ -337,7 +337,7 @@ impl MacroPlugin for FooToBarPlugin {
             code: Some(PluginGeneratedFile {
                 name: "virt".into(),
                 content: "fn bar() {}".to_string(),
-                patches: Default::default(),
+                diagnostics_mappings: vec![],
                 aux_data: None,
             }),
             diagnostics: vec![],

--- a/crates/cairo-lang-diagnostics/src/diagnostics_test.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics_test.rs
@@ -38,6 +38,7 @@ fn setup() -> (FilesDatabaseForTesting, FileId) {
         parent: None,
         name: "dummy_file.sierra".into(),
         content: Arc::new("abcd\nefg.\n".into()),
+        diagnostics_mappings: Arc::new(vec![]),
         kind: FileKind::Module,
     }));
     (db_val, file_id)

--- a/crates/cairo-lang-diagnostics/src/location_marks_test.rs
+++ b/crates/cairo-lang-diagnostics/src/location_marks_test.rs
@@ -24,6 +24,7 @@ fn test_location_marks() {
         parent: None,
         name: "name".into(),
         content: Arc::new(content.into()),
+        diagnostics_mappings: Default::default(),
         kind: FileKind::Module,
     }));
     let summary = db.file_summary(file).unwrap();

--- a/crates/cairo-lang-filesystem/src/span_test.rs
+++ b/crates/cairo-lang-filesystem/src/span_test.rs
@@ -17,6 +17,7 @@ fn test_span() {
         parent: None,
         name: "name".into(),
         content: Arc::new(TEST_STRING.into()),
+        diagnostics_mappings: Default::default(),
         kind: FileKind::Module,
     }));
     assert_eq!(
@@ -82,6 +83,7 @@ fn should_panic_test_span_out_of_range() {
         parent: None,
         name: "name".into(),
         content: Arc::new(TEST_STRING.into()),
+        diagnostics_mappings: Default::default(),
         kind: FileKind::Module,
     }));
     TextOffset(TextWidth(TEST_STRING.len() as u32 + 1)).position_in_file(&db, file);

--- a/crates/cairo-lang-formatter/src/cairo_formatter.rs
+++ b/crates/cairo-lang-formatter/src/cairo_formatter.rs
@@ -112,6 +112,7 @@ impl FormattableInput for String {
             parent: None,
             name: "string_to_format".into(),
             content: Arc::new(self.clone()),
+            diagnostics_mappings: Default::default(),
             kind: FileKind::Module,
         })))
     }
@@ -129,6 +130,7 @@ impl FormattableInput for StdinFmt {
             parent: None,
             name: "<stdin>".into(),
             content: Arc::new(buffer),
+            diagnostics_mappings: Default::default(),
             kind: FileKind::Module,
         })))
     }

--- a/crates/cairo-lang-formatter/src/lib.rs
+++ b/crates/cairo-lang-formatter/src/lib.rs
@@ -48,6 +48,7 @@ pub fn format_string(db: &dyn SyntaxGroup, content: String) -> String {
         parent: None,
         name: "string_to_format".into(),
         content: Arc::new(content.clone()),
+        diagnostics_mappings: Default::default(),
         kind: FileKind::Module,
     }));
     let mut diagnostics = DiagnosticsBuilder::new();

--- a/crates/cairo-lang-parser/src/test_utils.rs
+++ b/crates/cairo-lang-parser/src/test_utils.rs
@@ -36,6 +36,7 @@ pub fn create_virtual_file(
         parent: None,
         name: file_name.into(),
         content: Arc::new(content.into()),
+        diagnostics_mappings: Default::default(),
         kind: FileKind::Module,
     }))
 }

--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -39,7 +39,7 @@ impl MacroPlugin for ConfigPlugin {
                 code: Some(PluginGeneratedFile {
                     name: "config".into(),
                     content: data.result_code.clone(),
-                    patches: Default::default(),
+                    diagnostics_mappings: vec![],
                     aux_data: None,
                 }),
                 diagnostics: data.diagnostics,

--- a/crates/cairo-lang-plugins/src/plugins/derive.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive.rs
@@ -282,7 +282,7 @@ fn generate_derive_code_for_type(db: &dyn SyntaxGroup, info: DeriveInfo) -> Plug
             Some(PluginGeneratedFile {
                 name: "impls".into(),
                 content: impls.join(""),
-                patches: Default::default(),
+                diagnostics_mappings: Default::default(),
                 aux_data: None,
             })
         },

--- a/crates/cairo-lang-plugins/src/plugins/generate_trait.rs
+++ b/crates/cairo-lang-plugins/src/plugins/generate_trait.rs
@@ -162,7 +162,7 @@ fn generate_trait_for_impl(db: &dyn SyntaxGroup, impl_ast: ast::ItemImpl) -> Plu
                 {trait_attrs}trait {trait_identifier}{impl_generic_params} {{
                 {signatures}}}
             "},
-            patches: Default::default(),
+            diagnostics_mappings: Default::default(),
             aux_data: None,
         }),
         diagnostics,

--- a/crates/cairo-lang-plugins/src/plugins/panicable.rs
+++ b/crates/cairo-lang-plugins/src/plugins/panicable.rs
@@ -116,7 +116,7 @@ fn generate_panicable_code(
                     }}
                 "#
             ),
-            patches: Default::default(),
+            diagnostics_mappings: Default::default(),
             aux_data: None,
         }),
         diagnostics: vec![],

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -106,7 +106,7 @@ impl MacroPlugin for AddInlineModuleDummyPlugin {
                     code: Some(PluginGeneratedFile {
                         name: "virt2".into(),
                         content: builder.code,
-                        patches: builder.patches,
+                        diagnostics_mappings: builder.diagnostics_mappings,
                         aux_data: None,
                     }),
                     diagnostics: vec![],

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -303,8 +303,9 @@ fn compute_expr_inline_macro_semantic(
     // Create a file
     let new_file = ctx.db.intern_file(FileLongId::Virtual(VirtualFile {
         parent: Some(ctx.diagnostics.file_id),
-        name: "inline_macro.cairo".into(),
-        content: Arc::new(code),
+        name: code.name,
+        content: Arc::new(code.content),
+        diagnostics_mappings: Arc::new(code.diagnostics_mappings),
         kind: FileKind::Expr,
     }));
     let expr_syntax = ctx.db.file_expr_syntax(new_file)?;

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/inline_macros
@@ -205,7 +205,7 @@ Block(
 
 //! > semantic_diagnostics
 error: Type annotations needed. Failed to infer ?0
- --> inline_macro.cairo:2:54
+ --> array_inline_macro:2:54
             let mut __array_builder_macro_result__ = ArrayTrait::new();
                                                      ^********^
 

--- a/crates/cairo-lang-semantic/src/inline_macros/array.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/array.rs
@@ -1,4 +1,4 @@
-use cairo_lang_defs::plugin::{InlineMacroExprPlugin, InlinePluginResult};
+use cairo_lang_defs::plugin::{InlineMacroExprPlugin, InlinePluginResult, PluginGeneratedFile};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
 
@@ -29,6 +29,14 @@ impl InlineMacroExprPlugin for ArrayMacro {
             "\n            __array_builder_macro_result__
         }",
         );
-        InlinePluginResult { code: Some(code), diagnostics: vec![] }
+        InlinePluginResult {
+            code: Some(PluginGeneratedFile {
+                name: "array_inline_macro".into(),
+                content: code,
+                diagnostics_mappings: vec![],
+                aux_data: None,
+            }),
+            diagnostics: vec![],
+        }
     }
 }

--- a/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
@@ -1,4 +1,6 @@
-use cairo_lang_defs::plugin::{InlineMacroExprPlugin, InlinePluginResult, PluginDiagnostic};
+use cairo_lang_defs::plugin::{
+    InlineMacroExprPlugin, InlinePluginResult, PluginDiagnostic, PluginGeneratedFile,
+};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
 use num_bigint::BigInt;
@@ -24,7 +26,15 @@ impl InlineMacroExprPlugin for ConstevalIntMacro {
             return InlinePluginResult { code: None, diagnostics };
         }
         let code = compute_constant_expr(db, &constant_expression.unwrap(), &mut diagnostics);
-        InlinePluginResult { code: code.map(|x| x.to_string()), diagnostics }
+        InlinePluginResult {
+            code: code.map(|x| PluginGeneratedFile {
+                name: "consteval_int_inline_macro".into(),
+                content: x.to_string(),
+                diagnostics_mappings: vec![],
+                aux_data: None,
+            }),
+            diagnostics,
+        }
     }
 }
 

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -115,6 +115,7 @@ pub fn setup_test_crate(db: &dyn SemanticGroup, content: &str) -> CrateId {
         parent: None,
         name: "lib.cairo".into(),
         content: Arc::new(content.into()),
+        diagnostics_mappings: Default::default(),
         kind: FileKind::Module,
     }));
 

--- a/crates/cairo-lang-starknet/src/inline_macros/selector.rs
+++ b/crates/cairo-lang-starknet/src/inline_macros/selector.rs
@@ -1,4 +1,6 @@
-use cairo_lang_defs::plugin::{InlineMacroExprPlugin, InlinePluginResult, PluginDiagnostic};
+use cairo_lang_defs::plugin::{
+    InlineMacroExprPlugin, InlinePluginResult, PluginDiagnostic, PluginGeneratedFile,
+};
 use cairo_lang_semantic::inline_macros::unsupported_bracket_diagnostic;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
@@ -40,7 +42,14 @@ impl InlineMacroExprPlugin for SelectorMacro {
         let selector_string = input_string.string_value(db).unwrap();
 
         let selector = starknet_keccak(selector_string.as_bytes());
-        let code: String = format!("0x{}", selector.to_str_radix(16));
-        InlinePluginResult { code: Some(code), diagnostics: vec![] }
+        InlinePluginResult {
+            code: Some(PluginGeneratedFile {
+                name: "selector_inline_macro".into(),
+                content: format!("0x{}", selector.to_str_radix(16)),
+                diagnostics_mappings: vec![],
+                aux_data: None,
+            }),
+            diagnostics: vec![],
+        }
     }
 }

--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -272,7 +272,7 @@ pub fn handle_trait(db: &dyn SyntaxGroup, trait_ast: ast::ItemTrait) -> PluginRe
         code: Some(PluginGeneratedFile {
             name: dispatcher_trait_name.into(),
             content: builder.code,
-            patches: builder.patches,
+            diagnostics_mappings: builder.diagnostics_mappings,
             aux_data: None,
         }),
         diagnostics,

--- a/crates/cairo-lang-starknet/src/plugin/events.rs
+++ b/crates/cairo-lang-starknet/src/plugin/events.rs
@@ -117,7 +117,7 @@ pub fn handle_struct(db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct) -> Plugi
         code: Some(PluginGeneratedFile {
             name: "event_impl".into(),
             content: builder.code,
-            patches: builder.patches,
+            diagnostics_mappings: builder.diagnostics_mappings,
             aux_data: Some(DynGeneratedFileAuxData::new(StarkNetEventAuxData { event_data })),
         }),
         diagnostics,
@@ -313,7 +313,7 @@ pub fn handle_enum(db: &dyn SyntaxGroup, enum_ast: ast::ItemEnum) -> PluginResul
         code: Some(PluginGeneratedFile {
             name: "event_impl".into(),
             content: builder.code,
-            patches: builder.patches,
+            diagnostics_mappings: builder.diagnostics_mappings,
             aux_data: Some(DynGeneratedFileAuxData::new(StarkNetEventAuxData { event_data })),
         }),
         diagnostics,

--- a/crates/cairo-lang-starknet/src/plugin/includable.rs
+++ b/crates/cairo-lang-starknet/src/plugin/includable.rs
@@ -158,7 +158,7 @@ pub fn handle_includable(db: &dyn SyntaxGroup, item_impl: ast::ItemImpl) -> Plug
         code: Some(PluginGeneratedFile {
             name: "includable".into(),
             content: builder.code,
-            patches: builder.patches,
+            diagnostics_mappings: builder.diagnostics_mappings,
             aux_data: None,
         }),
         diagnostics,

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/mod.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/mod.rs
@@ -208,7 +208,7 @@ pub(super) fn handle_module_by_storage(
         code: Some(PluginGeneratedFile {
             name: module_kind.to_str_lower().into(),
             content: builder.code,
-            patches: builder.patches,
+            diagnostics_mappings: builder.diagnostics_mappings,
             aux_data: match module_kind {
                 StarknetModuleKind::Contract => {
                     Some(DynGeneratedFileAuxData::new(StarkNetContractAuxData {

--- a/crates/cairo-lang-starknet/src/plugin/storage_access.rs
+++ b/crates/cairo-lang-starknet/src/plugin/storage_access.rs
@@ -144,7 +144,7 @@ pub fn handle_struct(db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct) -> Plugi
         code: Some(PluginGeneratedFile {
             name: "storage_access_impl".into(),
             content: sa_impl,
-            patches: Default::default(),
+            diagnostics_mappings: Default::default(),
             aux_data: None,
         }),
         diagnostics,
@@ -280,7 +280,7 @@ pub fn handle_enum(db: &dyn SyntaxGroup, enum_ast: ast::ItemEnum) -> PluginResul
         code: Some(PluginGeneratedFile {
             name: "storage_access_impl".into(),
             content: sa_impl,
-            patches: Default::default(),
+            diagnostics_mappings: Default::default(),
             aux_data: None,
         }),
         diagnostics,


### PR DESCRIPTION
Allows diagnostics mappings for inline macros.

---

**Stack**:
- #3948
- #3936
- #3935
- #3934
- #3933
- #3922
- #3921
- #3920 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3920)
<!-- Reviewable:end -->
