### PR TITLE
fix(semantic): remove node comments from macro name

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -282,7 +282,7 @@ fn compute_expr_inline_macro_semantic(
 ) -> Maybe<Expr> {
     let syntax_db = ctx.db.upcast();
 
-    let macro_name = syntax.path(syntax_db).as_syntax_node().get_text(syntax_db).trim().to_string();
+    let macro_name = syntax.path(syntax_db).as_syntax_node().get_text_without_trivia(syntax_db);
     let Some(macro_plugin) = ctx.db.inline_macro_plugins().get(&macro_name).cloned() else {
         return Err(ctx
             .diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -157,3 +157,23 @@ error: Inline macro `foo` not found.
  --> lib.cairo:2:12
    let x = foo!(0);
            ^*****^
+
+//! > ==========================================================================
+
+//! > Test comment affects macro name
+
+//! > test_runner_name
+test_function_diagnostics
+
+//! > function
+fn foo() {
+   // This comment should not appear in the macro name
+   array![0_felt252];
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics


### PR DESCRIPTION
Previously:
```rs
// This is a random comment
array![0_felt252]
```
Would throw something like that
```sh
error: Inline macro `// This is a random comment
    array` not found.
 --> lucas.cairo:3:5
    array![0_felt252]
    ^***************^

Error: Compilation failed.
```
Now we simply ignore everything above the inline macro name.

Also tried to just ignore the comments in text formatter but it seemed to break everything

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3946)
<!-- Reviewable:end -->
