### PR TITLE
Made Destruct implementation do a single deconstruct.

### DIFF
--- a/crates/cairo-lang-plugins/src/plugins/derive/destruct.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/destruct.rs
@@ -13,29 +13,34 @@ pub fn handle_destruct(
     result: &mut DeriveResult,
 ) {
     let full_typename = info.full_typename();
+    let ty = &info.name;
     let header = info.format_impl_header("Destruct", &["Destruct"]);
     let body = indent_by(
         8,
         match &info.specific_info {
             TypeVariantInfo::Enum(variants) => {
                 formatdoc! {"
-                match self {{
-                    {}
-                }}",
+                    match self {{
+                        {}
+                    }}",
                     variants.iter().map(|variant| {
-                    format!(
-                        "{ty}::{variant}(x) => traits::Destruct::destruct(x),",
-                        ty=info.name,
-                        variant=variant.name,
-                    )
-                }).join("\n    ")}
+                        format!(
+                            "{ty}::{}(x) => traits::Destruct::destruct(x),",
+                            variant.name,
+                        )
+                    }).join("\n    ")
+                }
             }
-            TypeVariantInfo::Struct(members) => members
-                .iter()
-                .map(|member| {
-                    format!("traits::Destruct::destruct(self.{member});", member = member.name,)
-                })
-                .join("\n"),
+            TypeVariantInfo::Struct(members) => {
+                format!(
+                    "let {ty} {{ {} }} = self;{}",
+                    members.iter().map(|member| &member.name).join(", "),
+                    members
+                        .iter()
+                        .map(|member| format!("\ntraits::Destruct::destruct({});", member.name))
+                        .join(""),
+                )
+            }
             TypeVariantInfo::Extern => {
                 result.diagnostics.push(unsupported_for_extern_diagnostic(stable_ptr));
                 return;

--- a/crates/cairo-lang-plugins/src/test_data/derive
+++ b/crates/cairo-lang-plugins/src/test_data/derive
@@ -70,14 +70,16 @@ impl TwoMemberStructClone of Clone::<TwoMemberStruct> {
 }
 impl TwoMemberStructDestruct of Destruct::<TwoMemberStruct> {
     fn destruct(self: TwoMemberStruct) nopanic {
-        traits::Destruct::destruct(self.a);
-        traits::Destruct::destruct(self.b);
+        let TwoMemberStruct { a, b } = self;
+        traits::Destruct::destruct(a);
+        traits::Destruct::destruct(b);
     }
 }
 impl TwoMemberStructPanicDestruct of PanicDestruct::<TwoMemberStruct> {
     fn panic_destruct(self: TwoMemberStruct, ref panic: Panic) nopanic {
-        traits::PanicDestruct::panic_destruct(self.a, ref panic);
-        traits::PanicDestruct::panic_destruct(self.b, ref panic);
+        let TwoMemberStruct { a, b } = self;
+        traits::PanicDestruct::panic_destruct(a, ref panic);
+        traits::PanicDestruct::panic_destruct(b, ref panic);
     }
 }
 impl TwoMemberStructPartialEq of PartialEq::<TwoMemberStruct> {
@@ -111,12 +113,14 @@ struct GenericStruct<T> {
 impl GenericStructCopy<T, impl TCopy: Copy<T>> of Copy::<GenericStruct<T>>;
 impl GenericStructDestruct<T, impl TDestruct: Destruct<T>> of Destruct::<GenericStruct<T>> {
     fn destruct(self: GenericStruct<T>) nopanic {
-        traits::Destruct::destruct(self.a);
+        let GenericStruct { a } = self;
+        traits::Destruct::destruct(a);
     }
 }
 impl GenericStructPanicDestruct<T, impl TPanicDestruct: PanicDestruct<T>> of PanicDestruct::<GenericStruct<T>> {
     fn panic_destruct(self: GenericStruct<T>, ref panic: Panic) nopanic {
-        traits::PanicDestruct::panic_destruct(self.a, ref panic);
+        let GenericStruct { a } = self;
+        traits::PanicDestruct::panic_destruct(a, ref panic);
     }
 }
 


### PR DESCRIPTION
Now would work for empty structs correctly as well.

---

**Stack**:
- #3953
- #3948 ⬅
- #3936
- #3935


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3948)
<!-- Reviewable:end -->
