### PR TITLE
Use internally tagged representation for `VersionedProgram`

### DIFF
--- a/crates/cairo-lang-sierra/src/program.rs
+++ b/crates/cairo-lang-sierra/src/program.rs
@@ -17,7 +17,9 @@ use crate::ids::{
 ///
 /// Always prefer using this struct as saved artifacts instead of inner ones.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "version")]
 pub enum VersionedProgram {
+    #[serde(rename = "1")]
     V1(Program),
 }
 

--- a/crates/cairo-lang-sierra/src/test_data/fib_jumps
+++ b/crates/cairo-lang-sierra/src/test_data/fib_jumps
@@ -5,1460 +5,957 @@ test_sierra_serde_json
 
 //! > pretty_json
 {
-  "V1": {
-    "type_declarations": [
-      {
-        "id": {
-          "id": 18197987107266074389,
-          "debug_name": "felt252"
-        },
-        "long_id": {
-          "generic_id": "felt252",
-          "generic_args": []
-        },
-        "declared_type_info": null
+  "version": "1",
+  "type_declarations": [
+    {
+      "id": {
+        "id": 18197987107266074389,
+        "debug_name": "felt252"
       },
-      {
-        "id": {
-          "id": 8338741463261264245,
-          "debug_name": "GasBuiltin"
-        },
-        "long_id": {
-          "generic_id": "GasBuiltin",
-          "generic_args": []
-        },
-        "declared_type_info": null
+      "long_id": {
+        "generic_id": "felt252",
+        "generic_args": []
       },
-      {
-        "id": {
-          "id": 5158587525321846130,
-          "debug_name": "RangeCheck"
-        },
-        "long_id": {
-          "generic_id": "RangeCheck",
-          "generic_args": []
-        },
-        "declared_type_info": null
+      "declared_type_info": null
+    },
+    {
+      "id": {
+        "id": 8338741463261264245,
+        "debug_name": "GasBuiltin"
       },
-      {
-        "id": {
-          "id": 12132746703728246991,
-          "debug_name": "NonZeroInt"
-        },
-        "long_id": {
-          "generic_id": "NonZero",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
+      "long_id": {
+        "generic_id": "GasBuiltin",
+        "generic_args": []
+      },
+      "declared_type_info": null
+    },
+    {
+      "id": {
+        "id": 5158587525321846130,
+        "debug_name": "RangeCheck"
+      },
+      "long_id": {
+        "generic_id": "RangeCheck",
+        "generic_args": []
+      },
+      "declared_type_info": null
+    },
+    {
+      "id": {
+        "id": 12132746703728246991,
+        "debug_name": "NonZeroInt"
+      },
+      "long_id": {
+        "generic_id": "NonZero",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        },
-        "declared_type_info": null
+          }
+        ]
+      },
+      "declared_type_info": null
+    }
+  ],
+  "libfunc_declarations": [
+    {
+      "id": {
+        "id": 3328301606880823183,
+        "debug_name": "branch_align"
+      },
+      "long_id": {
+        "generic_id": "branch_align",
+        "generic_args": []
       }
-    ],
-    "libfunc_declarations": [
-      {
-        "id": {
-          "id": 3328301606880823183,
-          "debug_name": "branch_align"
-        },
-        "long_id": {
-          "generic_id": "branch_align",
-          "generic_args": []
-        }
+    },
+    {
+      "id": {
+        "id": 5573091817713561949,
+        "debug_name": "felt252_add"
       },
-      {
-        "id": {
-          "id": 5573091817713561949,
-          "debug_name": "felt252_add"
-        },
-        "long_id": {
-          "generic_id": "felt252_add",
-          "generic_args": []
-        }
+      "long_id": {
+        "generic_id": "felt252_add",
+        "generic_args": []
+      }
+    },
+    {
+      "id": {
+        "id": 5747884298157259530,
+        "debug_name": "felt252_const_0"
       },
-      {
-        "id": {
-          "id": 5747884298157259530,
-          "debug_name": "felt252_const_0"
-        },
-        "long_id": {
-          "generic_id": "felt252_const",
-          "generic_args": [
-            {
-              "Value": [
-                0,
-                []
+      "long_id": {
+        "generic_id": "felt252_const",
+        "generic_args": [
+          {
+            "Value": [
+              0,
+              []
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 5747885397668887741,
+        "debug_name": "felt252_const_1"
+      },
+      "long_id": {
+        "generic_id": "felt252_const",
+        "generic_args": [
+          {
+            "Value": [
+              1,
+              [
+                1
               ]
-            }
-          ]
-        }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 3075775707538119114,
+        "debug_name": "felt252_const_minus_1"
       },
-      {
-        "id": {
-          "id": 5747885397668887741,
-          "debug_name": "felt252_const_1"
-        },
-        "long_id": {
-          "generic_id": "felt252_const",
-          "generic_args": [
-            {
-              "Value": [
-                1,
-                [
-                  1
-                ]
+      "long_id": {
+        "generic_id": "felt252_const",
+        "generic_args": [
+          {
+            "Value": [
+              -1,
+              [
+                1
               ]
-            }
-          ]
-        }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 6741348721511978627,
+        "debug_name": "felt252_drop"
       },
-      {
-        "id": {
-          "id": 3075775707538119114,
-          "debug_name": "felt252_const_minus_1"
-        },
-        "long_id": {
-          "generic_id": "felt252_const",
-          "generic_args": [
-            {
-              "Value": [
-                -1,
-                [
-                  1
-                ]
+      "long_id": {
+        "generic_id": "drop",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 2468470103186650467,
+        "debug_name": "felt252_dup"
+      },
+      "long_id": {
+        "generic_id": "dup",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 4730041110748051225,
+        "debug_name": "felt252_is_zero"
+      },
+      "long_id": {
+        "generic_id": "felt252_is_zero",
+        "generic_args": []
+      }
+    },
+    {
+      "id": {
+        "id": 10451117352454336008,
+        "debug_name": "felt252_sub_1"
+      },
+      "long_id": {
+        "generic_id": "felt252_sub_const",
+        "generic_args": [
+          {
+            "Value": [
+              1,
+              [
+                1
               ]
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 9547199891349871288,
+        "debug_name": "felt252_unwrap_non_zero"
+      },
+      "long_id": {
+        "generic_id": "unwrap_non_zero",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 566598754701111445,
+        "debug_name": "withdraw_gas"
       },
-      {
-        "id": {
-          "id": 6741348721511978627,
-          "debug_name": "felt252_drop"
-        },
-        "long_id": {
-          "generic_id": "drop",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
+      "long_id": {
+        "generic_id": "withdraw_gas",
+        "generic_args": []
+      }
+    },
+    {
+      "id": {
+        "id": 16940139219101328589,
+        "debug_name": "jump"
+      },
+      "long_id": {
+        "generic_id": "jump",
+        "generic_args": []
+      }
+    },
+    {
+      "id": {
+        "id": 17829783910969655620,
+        "debug_name": "redeposit_gas"
+      },
+      "long_id": {
+        "generic_id": "redeposit_gas",
+        "generic_args": []
+      }
+    },
+    {
+      "id": {
+        "id": 940060015955306962,
+        "debug_name": "rename_felt252"
+      },
+      "long_id": {
+        "generic_id": "rename",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 16869075576697926123,
+        "debug_name": "revoke_ap_tracking"
       },
-      {
-        "id": {
-          "id": 2468470103186650467,
-          "debug_name": "felt252_dup"
-        },
-        "long_id": {
-          "generic_id": "dup",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
+      "long_id": {
+        "generic_id": "revoke_ap_tracking",
+        "generic_args": []
+      }
+    },
+    {
+      "id": {
+        "id": 14115798396771957644,
+        "debug_name": "store_temp_felt252"
+      },
+      "long_id": {
+        "generic_id": "store_temp",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 7943736942875005115,
+        "debug_name": "store_temp_gb"
       },
-      {
-        "id": {
-          "id": 4730041110748051225,
-          "debug_name": "felt252_is_zero"
-        },
-        "long_id": {
-          "generic_id": "felt252_is_zero",
-          "generic_args": []
-        }
-      },
-      {
-        "id": {
-          "id": 10451117352454336008,
-          "debug_name": "felt252_sub_1"
-        },
-        "long_id": {
-          "generic_id": "felt252_sub_const",
-          "generic_args": [
-            {
-              "Value": [
-                1,
-                [
-                  1
-                ]
-              ]
+      "long_id": {
+        "generic_id": "store_temp",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 8338741463261264245,
+              "debug_name": "GasBuiltin"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 7931306963920539685,
+        "debug_name": "store_temp_rc"
       },
-      {
-        "id": {
-          "id": 9547199891349871288,
-          "debug_name": "felt252_unwrap_non_zero"
-        },
-        "long_id": {
-          "generic_id": "unwrap_non_zero",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
+      "long_id": {
+        "generic_id": "store_temp",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 5158587525321846130,
+              "debug_name": "RangeCheck"
             }
-          ]
-        }
-      },
-      {
-        "id": {
-          "id": 566598754701111445,
-          "debug_name": "withdraw_gas"
-        },
-        "long_id": {
-          "generic_id": "withdraw_gas",
-          "generic_args": []
-        }
-      },
-      {
-        "id": {
-          "id": 16940139219101328589,
-          "debug_name": "jump"
-        },
-        "long_id": {
-          "generic_id": "jump",
-          "generic_args": []
-        }
-      },
-      {
-        "id": {
-          "id": 17829783910969655620,
-          "debug_name": "redeposit_gas"
-        },
-        "long_id": {
-          "generic_id": "redeposit_gas",
-          "generic_args": []
-        }
-      },
-      {
-        "id": {
-          "id": 940060015955306962,
-          "debug_name": "rename_felt252"
-        },
-        "long_id": {
-          "generic_id": "rename",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": {
+          }
+        ]
+      }
+    }
+  ],
+  "statements": [
+    {
+      "Invocation": {
+        "libfunc_id": {
           "id": 16869075576697926123,
           "debug_name": "revoke_ap_tracking"
         },
-        "long_id": {
-          "generic_id": "revoke_ap_tracking",
-          "generic_args": []
-        }
-      },
-      {
-        "id": {
-          "id": 14115798396771957644,
-          "debug_name": "store_temp_felt252"
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 4730041110748051225,
+          "debug_name": "felt252_is_zero"
         },
-        "long_id": {
-          "generic_id": "store_temp",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          },
+          {
+            "target": {
+              "Statement": 9
+            },
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
               }
-            }
-          ]
-        }
-      },
-      {
-        "id": {
-          "id": 7943736942875005115,
-          "debug_name": "store_temp_gb"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3328301606880823183,
+          "debug_name": "branch_align"
         },
-        "long_id": {
-          "generic_id": "store_temp",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 8338741463261264245,
-                "debug_name": "GasBuiltin"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": {
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
           "id": 7931306963920539685,
           "debug_name": "store_temp_rc"
         },
-        "long_id": {
-          "generic_id": "store_temp",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 5158587525321846130,
-                "debug_name": "RangeCheck"
-              }
-            }
-          ]
-        }
-      }
-    ],
-    "statements": [
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 16869075576697926123,
-            "debug_name": "revoke_ap_tracking"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 4730041110748051225,
-            "debug_name": "felt252_is_zero"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            },
-            {
-              "target": {
-                "Statement": 9
-              },
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3328301606880823183,
-            "debug_name": "branch_align"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7931306963920539685,
-            "debug_name": "store_temp_rc"
-          },
-          "args": [
-            {
-              "id": 638478738777676098,
-              "debug_name": "rc"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 638478738777676098,
-                  "debug_name": "rc"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 17829783910969655620,
-            "debug_name": "redeposit_gas"
-          },
-          "args": [
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7943736942875005115,
-            "debug_name": "store_temp_gb"
-          },
-          "args": [
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 5747885397668887741,
-            "debug_name": "felt252_const_1"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 1875936269717626031,
-                  "debug_name": "one"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 1875936269717626031,
-              "debug_name": "one"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 1875936269717626031,
-                  "debug_name": "one"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Return": [
+        "args": [
           {
             "id": 638478738777676098,
             "debug_name": "rc"
-          },
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 638478738777676098,
+                "debug_name": "rc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 17829783910969655620,
+          "debug_name": "redeposit_gas"
+        },
+        "args": [
           {
             "id": 618457731543555724,
             "debug_name": "gb"
-          },
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7943736942875005115,
+          "debug_name": "store_temp_gb"
+        },
+        "args": [
+          {
+            "id": 618457731543555724,
+            "debug_name": "gb"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 5747885397668887741,
+          "debug_name": "felt252_const_1"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 1875936269717626031,
+                "debug_name": "one"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
           {
             "id": 1875936269717626031,
             "debug_name": "one"
           }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 1875936269717626031,
+                "debug_name": "one"
+              }
+            ]
+          }
         ]
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3328301606880823183,
-            "debug_name": "branch_align"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
+      }
+    },
+    {
+      "Return": [
+        {
+          "id": 638478738777676098,
+          "debug_name": "rc"
+        },
+        {
+          "id": 618457731543555724,
+          "debug_name": "gb"
+        },
+        {
+          "id": 1875936269717626031,
+          "debug_name": "one"
         }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 9547199891349871288,
-            "debug_name": "felt252_unwrap_non_zero"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7931306963920539685,
-            "debug_name": "store_temp_rc"
-          },
-          "args": [
-            {
-              "id": 638478738777676098,
-              "debug_name": "rc"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 638478738777676098,
-                  "debug_name": "rc"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7943736942875005115,
-            "debug_name": "store_temp_gb"
-          },
-          "args": [
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 5747885397668887741,
-            "debug_name": "felt252_const_1"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638187200555641996,
-                  "debug_name": "a"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638187200555641996,
-                  "debug_name": "a"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 5747884298157259530,
-            "debug_name": "felt252_const_0"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638190499090526629,
-                  "debug_name": "b"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638190499090526629,
-                  "debug_name": "b"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 4730041110748051225,
-            "debug_name": "felt252_is_zero"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            },
-            {
-              "target": {
-                "Statement": 26
-              },
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3328301606880823183,
-            "debug_name": "branch_align"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 6741348721511978627,
-            "debug_name": "felt252_drop"
-          },
-          "args": [
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7931306963920539685,
-            "debug_name": "store_temp_rc"
-          },
-          "args": [
-            {
-              "id": 638478738777676098,
-              "debug_name": "rc"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 638478738777676098,
-                  "debug_name": "rc"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 17829783910969655620,
-            "debug_name": "redeposit_gas"
-          },
-          "args": [
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7943736942875005115,
-            "debug_name": "store_temp_gb"
-          },
-          "args": [
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638187200555641996,
-                  "debug_name": "a"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Return": [
+      ]
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3328301606880823183,
+          "debug_name": "branch_align"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 9547199891349871288,
+          "debug_name": "felt252_unwrap_non_zero"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7931306963920539685,
+          "debug_name": "store_temp_rc"
+        },
+        "args": [
           {
             "id": 638478738777676098,
             "debug_name": "rc"
-          },
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 638478738777676098,
+                "debug_name": "rc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7943736942875005115,
+          "debug_name": "store_temp_gb"
+        },
+        "args": [
           {
             "id": 618457731543555724,
             "debug_name": "gb"
-          },
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 5747885397668887741,
+          "debug_name": "felt252_const_1"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638187200555641996,
+                "debug_name": "a"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
           {
             "id": 12638187200555641996,
             "debug_name": "a"
           }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638187200555641996,
+                "debug_name": "a"
+              }
+            ]
+          }
         ]
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3328301606880823183,
-            "debug_name": "branch_align"
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 5747884298157259530,
+          "debug_name": "felt252_const_0"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638190499090526629,
+                "debug_name": "b"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638190499090526629,
+                "debug_name": "b"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 4730041110748051225,
+          "debug_name": "felt252_is_zero"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
           },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 9547199891349871288,
-            "debug_name": "felt252_unwrap_non_zero"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 566598754701111445,
-            "debug_name": "withdraw_gas"
-          },
-          "args": [
-            {
-              "id": 638478738777676098,
-              "debug_name": "rc"
+          {
+            "target": {
+              "Statement": 26
             },
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 638478738777676098,
-                  "debug_name": "rc"
-                },
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            },
-            {
-              "target": {
-                "Statement": 40
-              },
-              "results": [
-                {
-                  "id": 638478738777676098,
-                  "debug_name": "rc"
-                },
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3328301606880823183,
+          "debug_name": "branch_align"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 6741348721511978627,
+          "debug_name": "felt252_drop"
+        },
+        "args": [
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7931306963920539685,
+          "debug_name": "store_temp_rc"
+        },
+        "args": [
+          {
+            "id": 638478738777676098,
+            "debug_name": "rc"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 638478738777676098,
+                "debug_name": "rc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 17829783910969655620,
+          "debug_name": "redeposit_gas"
+        },
+        "args": [
+          {
+            "id": 618457731543555724,
+            "debug_name": "gb"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7943736942875005115,
+          "debug_name": "store_temp_gb"
+        },
+        "args": [
+          {
+            "id": 618457731543555724,
+            "debug_name": "gb"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 12638187200555641996,
+            "debug_name": "a"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638187200555641996,
+                "debug_name": "a"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Return": [
+        {
+          "id": 638478738777676098,
+          "debug_name": "rc"
+        },
+        {
+          "id": 618457731543555724,
+          "debug_name": "gb"
+        },
+        {
+          "id": 12638187200555641996,
+          "debug_name": "a"
         }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3328301606880823183,
-            "debug_name": "branch_align"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 2468470103186650467,
-            "debug_name": "felt252_dup"
-          },
-          "args": [
-            {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638187200555641996,
-                  "debug_name": "a"
-                },
-                {
-                  "id": 5124477032042102868,
-                  "debug_name": "prev_a"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 5573091817713561949,
-            "debug_name": "felt252_add"
-          },
-          "args": [
-            {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            },
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638187200555641996,
-                  "debug_name": "a"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 940060015955306962,
-            "debug_name": "rename_felt252"
-          },
-          "args": [
-            {
-              "id": 5124477032042102868,
-              "debug_name": "prev_a"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638190499090526629,
-                  "debug_name": "b"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 10451117352454336008,
-            "debug_name": "felt252_sub_1"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7931306963920539685,
-            "debug_name": "store_temp_rc"
-          },
-          "args": [
-            {
-              "id": 638478738777676098,
-              "debug_name": "rc"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 638478738777676098,
-                  "debug_name": "rc"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7943736942875005115,
-            "debug_name": "store_temp_gb"
-          },
-          "args": [
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638187200555641996,
-                  "debug_name": "a"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638190499090526629,
-                  "debug_name": "b"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 16940139219101328589,
-            "debug_name": "jump"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": {
-                "Statement": 18
-              },
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3328301606880823183,
-            "debug_name": "branch_align"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 6741348721511978627,
-            "debug_name": "felt252_drop"
-          },
-          "args": [
-            {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 6741348721511978627,
-            "debug_name": "felt252_drop"
-          },
-          "args": [
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 6741348721511978627,
-            "debug_name": "felt252_drop"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7931306963920539685,
-            "debug_name": "store_temp_rc"
-          },
-          "args": [
-            {
-              "id": 638478738777676098,
-              "debug_name": "rc"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 638478738777676098,
-                  "debug_name": "rc"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 17829783910969655620,
-            "debug_name": "redeposit_gas"
-          },
-          "args": [
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 7943736942875005115,
-            "debug_name": "store_temp_gb"
-          },
-          "args": [
-            {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 618457731543555724,
-                  "debug_name": "gb"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3075775707538119114,
-            "debug_name": "felt252_const_minus_1"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 14050392017135853004,
-                  "debug_name": "err"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 14050392017135853004,
-              "debug_name": "err"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 14050392017135853004,
-                  "debug_name": "err"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Return": [
+      ]
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3328301606880823183,
+          "debug_name": "branch_align"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 9547199891349871288,
+          "debug_name": "felt252_unwrap_non_zero"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 566598754701111445,
+          "debug_name": "withdraw_gas"
+        },
+        "args": [
           {
             "id": 638478738777676098,
             "debug_name": "rc"
@@ -1466,84 +963,586 @@ test_sierra_serde_json
           {
             "id": 618457731543555724,
             "debug_name": "gb"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 638478738777676098,
+                "debug_name": "rc"
+              },
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
           },
+          {
+            "target": {
+              "Statement": 40
+            },
+            "results": [
+              {
+                "id": 638478738777676098,
+                "debug_name": "rc"
+              },
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3328301606880823183,
+          "debug_name": "branch_align"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 2468470103186650467,
+          "debug_name": "felt252_dup"
+        },
+        "args": [
+          {
+            "id": 12638187200555641996,
+            "debug_name": "a"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638187200555641996,
+                "debug_name": "a"
+              },
+              {
+                "id": 5124477032042102868,
+                "debug_name": "prev_a"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 5573091817713561949,
+          "debug_name": "felt252_add"
+        },
+        "args": [
+          {
+            "id": 12638187200555641996,
+            "debug_name": "a"
+          },
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638187200555641996,
+                "debug_name": "a"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 940060015955306962,
+          "debug_name": "rename_felt252"
+        },
+        "args": [
+          {
+            "id": 5124477032042102868,
+            "debug_name": "prev_a"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638190499090526629,
+                "debug_name": "b"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 10451117352454336008,
+          "debug_name": "felt252_sub_1"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7931306963920539685,
+          "debug_name": "store_temp_rc"
+        },
+        "args": [
+          {
+            "id": 638478738777676098,
+            "debug_name": "rc"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 638478738777676098,
+                "debug_name": "rc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7943736942875005115,
+          "debug_name": "store_temp_gb"
+        },
+        "args": [
+          {
+            "id": 618457731543555724,
+            "debug_name": "gb"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 12638187200555641996,
+            "debug_name": "a"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638187200555641996,
+                "debug_name": "a"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638190499090526629,
+                "debug_name": "b"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 16940139219101328589,
+          "debug_name": "jump"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": {
+              "Statement": 18
+            },
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3328301606880823183,
+          "debug_name": "branch_align"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 6741348721511978627,
+          "debug_name": "felt252_drop"
+        },
+        "args": [
+          {
+            "id": 12638187200555641996,
+            "debug_name": "a"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 6741348721511978627,
+          "debug_name": "felt252_drop"
+        },
+        "args": [
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 6741348721511978627,
+          "debug_name": "felt252_drop"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7931306963920539685,
+          "debug_name": "store_temp_rc"
+        },
+        "args": [
+          {
+            "id": 638478738777676098,
+            "debug_name": "rc"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 638478738777676098,
+                "debug_name": "rc"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 17829783910969655620,
+          "debug_name": "redeposit_gas"
+        },
+        "args": [
+          {
+            "id": 618457731543555724,
+            "debug_name": "gb"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 7943736942875005115,
+          "debug_name": "store_temp_gb"
+        },
+        "args": [
+          {
+            "id": 618457731543555724,
+            "debug_name": "gb"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 618457731543555724,
+                "debug_name": "gb"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3075775707538119114,
+          "debug_name": "felt252_const_minus_1"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 14050392017135853004,
+                "debug_name": "err"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
           {
             "id": 14050392017135853004,
             "debug_name": "err"
           }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 14050392017135853004,
+                "debug_name": "err"
+              }
+            ]
+          }
         ]
       }
-    ],
-    "funcs": [
-      {
-        "id": {
-          "id": 2313213558037562915,
-          "debug_name": "Fibonacci"
+    },
+    {
+      "Return": [
+        {
+          "id": 638478738777676098,
+          "debug_name": "rc"
         },
-        "signature": {
-          "param_types": [
-            {
-              "id": 5158587525321846130,
-              "debug_name": "RangeCheck"
-            },
-            {
-              "id": 8338741463261264245,
-              "debug_name": "GasBuiltin"
-            },
-            {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            }
-          ],
-          "ret_types": [
-            {
-              "id": 5158587525321846130,
-              "debug_name": "RangeCheck"
-            },
-            {
-              "id": 8338741463261264245,
-              "debug_name": "GasBuiltin"
-            },
-            {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            }
-          ]
+        {
+          "id": 618457731543555724,
+          "debug_name": "gb"
         },
-        "params": [
+        {
+          "id": 14050392017135853004,
+          "debug_name": "err"
+        }
+      ]
+    }
+  ],
+  "funcs": [
+    {
+      "id": {
+        "id": 2313213558037562915,
+        "debug_name": "Fibonacci"
+      },
+      "signature": {
+        "param_types": [
           {
-            "id": {
-              "id": 638478738777676098,
-              "debug_name": "rc"
-            },
-            "ty": {
-              "id": 5158587525321846130,
-              "debug_name": "RangeCheck"
-            }
+            "id": 5158587525321846130,
+            "debug_name": "RangeCheck"
           },
           {
-            "id": {
-              "id": 618457731543555724,
-              "debug_name": "gb"
-            },
-            "ty": {
-              "id": 8338741463261264245,
-              "debug_name": "GasBuiltin"
-            }
+            "id": 8338741463261264245,
+            "debug_name": "GasBuiltin"
           },
           {
-            "id": {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            },
-            "ty": {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            }
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
           }
         ],
-        "entry_point": 0
-      }
-    ]
-  }
+        "ret_types": [
+          {
+            "id": 5158587525321846130,
+            "debug_name": "RangeCheck"
+          },
+          {
+            "id": 8338741463261264245,
+            "debug_name": "GasBuiltin"
+          },
+          {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          }
+        ]
+      },
+      "params": [
+        {
+          "id": {
+            "id": 638478738777676098,
+            "debug_name": "rc"
+          },
+          "ty": {
+            "id": 5158587525321846130,
+            "debug_name": "RangeCheck"
+          }
+        },
+        {
+          "id": {
+            "id": 618457731543555724,
+            "debug_name": "gb"
+          },
+          "ty": {
+            "id": 8338741463261264245,
+            "debug_name": "GasBuiltin"
+          }
+        },
+        {
+          "id": {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          },
+          "ty": {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          }
+        }
+      ],
+      "entry_point": 0
+    }
+  ]
 }

--- a/crates/cairo-lang-sierra/src/test_data/fib_no_gas
+++ b/crates/cairo-lang-sierra/src/test_data/fib_no_gas
@@ -5,642 +5,641 @@ test_sierra_serde_json
 
 //! > pretty_json
 {
-  "V1": {
-    "type_declarations": [
-      {
-        "id": {
-          "id": 18197987107266074389,
-          "debug_name": "felt252"
-        },
-        "long_id": {
-          "generic_id": "felt252",
-          "generic_args": []
-        },
-        "declared_type_info": null
+  "version": "1",
+  "type_declarations": [
+    {
+      "id": {
+        "id": 18197987107266074389,
+        "debug_name": "felt252"
       },
-      {
-        "id": {
-          "id": 7714117757135972556,
-          "debug_name": "NonZeroFelt252"
-        },
-        "long_id": {
-          "generic_id": "NonZero",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
+      "long_id": {
+        "generic_id": "felt252",
+        "generic_args": []
+      },
+      "declared_type_info": null
+    },
+    {
+      "id": {
+        "id": 7714117757135972556,
+        "debug_name": "NonZeroFelt252"
+      },
+      "long_id": {
+        "generic_id": "NonZero",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        },
-        "declared_type_info": null
+          }
+        ]
+      },
+      "declared_type_info": null
+    }
+  ],
+  "libfunc_declarations": [
+    {
+      "id": {
+        "id": 3328301606880823183,
+        "debug_name": "branch_align"
+      },
+      "long_id": {
+        "generic_id": "branch_align",
+        "generic_args": []
       }
-    ],
-    "libfunc_declarations": [
-      {
-        "id": {
-          "id": 3328301606880823183,
-          "debug_name": "branch_align"
-        },
-        "long_id": {
-          "generic_id": "branch_align",
-          "generic_args": []
-        }
+    },
+    {
+      "id": {
+        "id": 14115798396771957644,
+        "debug_name": "store_temp_felt252"
       },
-      {
-        "id": {
-          "id": 14115798396771957644,
-          "debug_name": "store_temp_felt252"
-        },
-        "long_id": {
-          "generic_id": "store_temp",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
+      "long_id": {
+        "generic_id": "store_temp",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 7886916414467468699,
+        "debug_name": "store_temp_nz_felt252"
       },
-      {
-        "id": {
-          "id": 7886916414467468699,
-          "debug_name": "store_temp_nz_felt252"
-        },
-        "long_id": {
-          "generic_id": "store_temp",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 7714117757135972556,
-                "debug_name": "NonZeroFelt252"
-              }
+      "long_id": {
+        "generic_id": "store_temp",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 7714117757135972556,
+              "debug_name": "NonZeroFelt252"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 3075775707538119114,
+        "debug_name": "felt252_const_minus_1"
       },
-      {
-        "id": {
-          "id": 3075775707538119114,
-          "debug_name": "felt252_const_minus_1"
-        },
-        "long_id": {
-          "generic_id": "felt252_const",
-          "generic_args": [
-            {
-              "Value": [
-                -1,
-                [
-                  1
-                ]
+      "long_id": {
+        "generic_id": "felt252_const",
+        "generic_args": [
+          {
+            "Value": [
+              -1,
+              [
+                1
               ]
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 5573091817713561949,
+        "debug_name": "felt252_add"
+      },
+      "long_id": {
+        "generic_id": "felt252_add",
+        "generic_args": []
+      }
+    },
+    {
+      "id": {
+        "id": 2468470103186650467,
+        "debug_name": "felt252_dup"
+      },
+      "long_id": {
+        "generic_id": "dup",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 6741348721511978627,
+        "debug_name": "felt252_drop"
       },
-      {
-        "id": {
-          "id": 5573091817713561949,
-          "debug_name": "felt252_add"
-        },
-        "long_id": {
-          "generic_id": "felt252_add",
-          "generic_args": []
-        }
-      },
-      {
-        "id": {
-          "id": 2468470103186650467,
-          "debug_name": "felt252_dup"
-        },
-        "long_id": {
-          "generic_id": "dup",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
+      "long_id": {
+        "generic_id": "drop",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 4730041110748051225,
+        "debug_name": "felt252_is_zero"
       },
-      {
-        "id": {
-          "id": 6741348721511978627,
-          "debug_name": "felt252_drop"
-        },
-        "long_id": {
-          "generic_id": "drop",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
+      "long_id": {
+        "generic_id": "felt252_is_zero",
+        "generic_args": []
+      }
+    },
+    {
+      "id": {
+        "id": 9547199891349871288,
+        "debug_name": "felt252_unwrap_non_zero"
+      },
+      "long_id": {
+        "generic_id": "unwrap_non_zero",
+        "generic_args": [
+          {
+            "Type": {
+              "id": 18197987107266074389,
+              "debug_name": "felt252"
             }
-          ]
-        }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 18361914643646105729,
+        "debug_name": "call_lib"
       },
-      {
-        "id": {
+      "long_id": {
+        "generic_id": "function_call",
+        "generic_args": [
+          {
+            "UserFunc": {
+              "id": 2313213558037562915,
+              "debug_name": "Fibonacci"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": {
+        "id": 14767329129431461243,
+        "debug_name": "disable_ap_tracking"
+      },
+      "long_id": {
+        "generic_id": "disable_ap_tracking",
+        "generic_args": []
+      }
+    }
+  ],
+  "statements": [
+    {
+      "Invocation": {
+        "libfunc_id": {
           "id": 4730041110748051225,
           "debug_name": "felt252_is_zero"
         },
-        "long_id": {
-          "generic_id": "felt252_is_zero",
-          "generic_args": []
-        }
-      },
-      {
-        "id": {
-          "id": 9547199891349871288,
-          "debug_name": "felt252_unwrap_non_zero"
-        },
-        "long_id": {
-          "generic_id": "unwrap_non_zero",
-          "generic_args": [
-            {
-              "Type": {
-                "id": 18197987107266074389,
-                "debug_name": "felt252"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": {
-          "id": 18361914643646105729,
-          "debug_name": "call_lib"
-        },
-        "long_id": {
-          "generic_id": "function_call",
-          "generic_args": [
-            {
-              "UserFunc": {
-                "id": 2313213558037562915,
-                "debug_name": "Fibonacci"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "id": {
-          "id": 14767329129431461243,
-          "debug_name": "disable_ap_tracking"
-        },
-        "long_id": {
-          "generic_id": "disable_ap_tracking",
-          "generic_args": []
-        }
-      }
-    ],
-    "statements": [
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 4730041110748051225,
-            "debug_name": "felt252_is_zero"
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
           },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
+          {
+            "target": {
+              "Statement": 6
             },
-            {
-              "target": {
-                "Statement": 6
-              },
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3328301606880823183,
-            "debug_name": "branch_align"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 6741348721511978627,
-            "debug_name": "felt252_drop"
-          },
-          "args": [
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638187200555641996,
-                  "debug_name": "a"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14767329129431461243,
-            "debug_name": "disable_ap_tracking"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Return": [
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3328301606880823183,
+          "debug_name": "branch_align"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 6741348721511978627,
+          "debug_name": "felt252_drop"
+        },
+        "args": [
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
           {
             "id": 12638187200555641996,
             "debug_name": "a"
           }
-        ]
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3328301606880823183,
-            "debug_name": "branch_align"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": []
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 9547199891349871288,
-            "debug_name": "felt252_unwrap_non_zero"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 3075775707538119114,
-            "debug_name": "felt252_const_minus_1"
-          },
-          "args": [],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 6610366976596557946,
-                  "debug_name": "minus1"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 5573091817713561949,
-            "debug_name": "felt252_add"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            },
-            {
-              "id": 6610366976596557946,
-              "debug_name": "minus1"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 2468470103186650467,
-            "debug_name": "felt252_dup"
-          },
-          "args": [
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638190499090526629,
-                  "debug_name": "b"
-                },
-                {
-                  "id": 623301080264879054,
-                  "debug_name": "b_"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 5573091817713561949,
-            "debug_name": "felt252_add"
-          },
-          "args": [
-            {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            },
-            {
-              "id": 623301080264879054,
-              "debug_name": "b_"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 11807312940536349088,
-                  "debug_name": "a_plus_b"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638190499090526629,
-                  "debug_name": "b"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 11807312940536349088,
-              "debug_name": "a_plus_b"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 11807312940536349088,
-                  "debug_name": "a_plus_b"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 14115798396771957644,
-            "debug_name": "store_temp_felt252"
-          },
-          "args": [
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638194897137039473,
-                  "debug_name": "n"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Invocation": {
-          "libfunc_id": {
-            "id": 18361914643646105729,
-            "debug_name": "call_lib"
-          },
-          "args": [
-            {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            },
-            {
-              "id": 11807312940536349088,
-              "debug_name": "a_plus_b"
-            },
-            {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            }
-          ],
-          "branches": [
-            {
-              "target": "Fallthrough",
-              "results": [
-                {
-                  "id": 12638208091276578005,
-                  "debug_name": "r"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "Return": [
+        ],
+        "branches": [
           {
-            "id": 12638208091276578005,
-            "debug_name": "r"
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638187200555641996,
+                "debug_name": "a"
+              }
+            ]
           }
         ]
       }
-    ],
-    "funcs": [
-      {
-        "id": {
-          "id": 2313213558037562915,
-          "debug_name": "Fibonacci"
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14767329129431461243,
+          "debug_name": "disable_ap_tracking"
         },
-        "signature": {
-          "param_types": [
-            {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            },
-            {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            },
-            {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            }
-          ],
-          "ret_types": [
-            {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            }
-          ]
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Return": [
+        {
+          "id": 12638187200555641996,
+          "debug_name": "a"
+        }
+      ]
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3328301606880823183,
+          "debug_name": "branch_align"
         },
-        "params": [
+        "args": [],
+        "branches": [
           {
-            "id": {
-              "id": 12638187200555641996,
-              "debug_name": "a"
-            },
-            "ty": {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            }
-          },
+            "target": "Fallthrough",
+            "results": []
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 9547199891349871288,
+          "debug_name": "felt252_unwrap_non_zero"
+        },
+        "args": [
           {
-            "id": {
-              "id": 12638190499090526629,
-              "debug_name": "b"
-            },
-            "ty": {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            }
-          },
-          {
-            "id": {
-              "id": 12638194897137039473,
-              "debug_name": "n"
-            },
-            "ty": {
-              "id": 18197987107266074389,
-              "debug_name": "felt252"
-            }
+            "id": 12638194897137039473,
+            "debug_name": "n"
           }
         ],
-        "entry_point": 0
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
       }
-    ]
-  }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 3075775707538119114,
+          "debug_name": "felt252_const_minus_1"
+        },
+        "args": [],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 6610366976596557946,
+                "debug_name": "minus1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 5573091817713561949,
+          "debug_name": "felt252_add"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          },
+          {
+            "id": 6610366976596557946,
+            "debug_name": "minus1"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 2468470103186650467,
+          "debug_name": "felt252_dup"
+        },
+        "args": [
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638190499090526629,
+                "debug_name": "b"
+              },
+              {
+                "id": 623301080264879054,
+                "debug_name": "b_"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 5573091817713561949,
+          "debug_name": "felt252_add"
+        },
+        "args": [
+          {
+            "id": 12638187200555641996,
+            "debug_name": "a"
+          },
+          {
+            "id": 623301080264879054,
+            "debug_name": "b_"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 11807312940536349088,
+                "debug_name": "a_plus_b"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638190499090526629,
+                "debug_name": "b"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 11807312940536349088,
+            "debug_name": "a_plus_b"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 11807312940536349088,
+                "debug_name": "a_plus_b"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 14115798396771957644,
+          "debug_name": "store_temp_felt252"
+        },
+        "args": [
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638194897137039473,
+                "debug_name": "n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Invocation": {
+        "libfunc_id": {
+          "id": 18361914643646105729,
+          "debug_name": "call_lib"
+        },
+        "args": [
+          {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          },
+          {
+            "id": 11807312940536349088,
+            "debug_name": "a_plus_b"
+          },
+          {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          }
+        ],
+        "branches": [
+          {
+            "target": "Fallthrough",
+            "results": [
+              {
+                "id": 12638208091276578005,
+                "debug_name": "r"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Return": [
+        {
+          "id": 12638208091276578005,
+          "debug_name": "r"
+        }
+      ]
+    }
+  ],
+  "funcs": [
+    {
+      "id": {
+        "id": 2313213558037562915,
+        "debug_name": "Fibonacci"
+      },
+      "signature": {
+        "param_types": [
+          {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          },
+          {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          },
+          {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          }
+        ],
+        "ret_types": [
+          {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          }
+        ]
+      },
+      "params": [
+        {
+          "id": {
+            "id": 12638187200555641996,
+            "debug_name": "a"
+          },
+          "ty": {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          }
+        },
+        {
+          "id": {
+            "id": 12638190499090526629,
+            "debug_name": "b"
+          },
+          "ty": {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          }
+        },
+        {
+          "id": {
+            "id": 12638194897137039473,
+            "debug_name": "n"
+          },
+          "ty": {
+            "id": 18197987107266074389,
+            "debug_name": "felt252"
+          }
+        }
+      ],
+      "entry_point": 0
+    }
+  ]
 }


### PR DESCRIPTION
This format gives much easier to consume representation, because now consumer just has to look at a well known `version` field value. It also aligns with other versioning cases, such as Scarb's contract artifacts file.

We can afford doing this breaking change **NOW** because VersionedProgram hasn't been released yet.