### PR TITLE
Fixed `unsafe_*` and `*_for_testing` generic.

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
@@ -115,7 +115,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
     use data::InternalComponentMemberStateTrait as dataComponentMemberStateTrait;

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/diagnostics
@@ -72,7 +72,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 
@@ -191,7 +191,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 
@@ -310,7 +310,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 
@@ -427,7 +427,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 
@@ -544,7 +544,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 
@@ -661,7 +661,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 
@@ -778,7 +778,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 
@@ -887,7 +887,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 
@@ -1008,7 +1008,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
@@ -104,7 +104,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
     use data::InternalComponentMemberStateTrait as dataComponentMemberStateTrait;

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
@@ -88,7 +88,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
     use data::InternalComponentMemberStateTrait as dataComponentMemberStateTrait;
@@ -371,7 +371,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
     use data::InternalComponentMemberStateTrait as dataComponentMemberStateTrait;
@@ -642,7 +642,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
     use data::InternalComponentMemberStateTrait as dataComponentMemberStateTrait;
@@ -922,7 +922,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
     use data::InternalComponentMemberStateTrait as dataComponentMemberStateTrait;
@@ -1209,7 +1209,7 @@ use starknet::event::EventEmitter;
     #[cfg(test)]
     #[inline(always)]
     fn component_state_for_testing<TCS>() -> ComponentState<TCS> {
-        unsafe_new_component_state<TCS>()
+        unsafe_new_component_state::<TCS>()
     }
     
     use data::InternalComponentMemberStateTrait as dataComponentMemberStateTrait;

--- a/crates/cairo-lang-starknet/src/plugin/storage.rs
+++ b/crates/cairo-lang-starknet/src/plugin/storage.rs
@@ -112,10 +112,8 @@ pub fn handle_storage_struct(
         }
     }
 
-    let unsafe_new_function_name =
-        format!("unsafe_new_{}_state{generic_arg_str}", starknet_module_kind.to_str_lower());
-    let for_testing_function_name =
-        format!("{}_state_for_testing{generic_arg_str}", starknet_module_kind.to_str_lower());
+    let module_kind = starknet_module_kind.to_str_lower();
+    let unsafe_new_function_name = format!("unsafe_new_{module_kind}_state");
     data.state_struct_code = RewriteNode::interpolate_patched(
         formatdoc!(
             "    struct {full_state_struct_name} {{$members_code$
@@ -123,14 +121,15 @@ pub fn handle_storage_struct(
                  impl {state_struct_name}Drop{generic_arg_str} of Drop<{full_state_struct_name}> \
              {{}}
                  #[inline(always)]
-                 fn {unsafe_new_function_name}() -> {full_state_struct_name} {{
+                 fn {unsafe_new_function_name}{generic_arg_str}() -> {full_state_struct_name} {{
                      {state_struct_name}{full_generic_arg_str} {{$member_init_code$
                      }}
                  }}
                  #[cfg(test)]
                  #[inline(always)]
-                 fn {for_testing_function_name}() -> {full_state_struct_name} {{
-                     {unsafe_new_function_name}()
+                 fn {module_kind}_state_for_testing{generic_arg_str}() -> {full_state_struct_name} \
+             {{
+                     {unsafe_new_function_name}{full_generic_arg_str}()
                  }}
                  $vars_code$",
         )


### PR DESCRIPTION
**Stack**:
- #3989
- #3986 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3986)
<!-- Reviewable:end -->
