### PR TITLE
Use serde on FormatterConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "log",
  "pretty_assertions",
  "salsa",
+ "serde",
  "smol_str",
  "test-case",
  "test-log",

--- a/crates/cairo-lang-formatter/Cargo.toml
+++ b/crates/cairo-lang-formatter/Cargo.toml
@@ -20,6 +20,7 @@ itertools.workspace = true
 log.workspace = true
 salsa.workspace = true
 smol_str.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/cairo-lang-formatter/src/lib.rs
+++ b/crates/cairo-lang-formatter/src/lib.rs
@@ -12,6 +12,7 @@ use cairo_lang_filesystem::ids::{FileKind, FileLongId, VirtualFile};
 use cairo_lang_parser::parser::Parser;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode};
+use serde::{Deserialize, Serialize};
 
 pub use crate::cairo_formatter::{CairoFormatter, FormatOutcome, StdinFmt};
 use crate::formatter_impl::FormatterImpl;
@@ -57,7 +58,8 @@ pub fn format_string(db: &dyn SyntaxGroup, content: String) -> String {
     get_formatted_file(db, &syntax_root, FormatterConfig::default())
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct FormatterConfig {
     tab_size: usize,
     max_line_length: usize,


### PR DESCRIPTION
In order to make it possible to utilize import sorting which is turned off by default, we need a way to override this default configuration.

This PR modifies FormatterConfig struct in order to make it possible to override default config using values from `tool.fmt` section in `Scarb.toml`, as shown in [here](https://github.com/software-mansion/scarb/pull/633#discussion_r1311354639).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/3999)
<!-- Reviewable:end -->
