### PR TITLE
Removed `use` of EventEmitter in contract generated code

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/events.rs
+++ b/crates/cairo-lang-starknet/src/plugin/events.rs
@@ -417,10 +417,9 @@ pub fn generate_event_code(
 
     data.event_code = RewriteNode::interpolate_patched(
         formatdoc!(
-            "use starknet::event::EventEmitter;
-            $empty_event_code$
+            "$empty_event_code$
                 impl {state_struct_name}EventEmitter{generic_arg_str} of \
-             EventEmitter<{full_state_struct_name}, {EVENT_TYPE_NAME}> {{
+             starknet::event::EventEmitter<{full_state_struct_name}, {EVENT_TYPE_NAME}> {{
                     fn emit<S, impl IntoImp: traits::Into<S, {EVENT_TYPE_NAME}>>(ref self: \
              {full_state_struct_name}, event: S) {{
                         let event: {EVENT_TYPE_NAME} = traits::Into::into(event);

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
@@ -134,22 +134,21 @@ impl StoreMyType of starknet::Store::<MyType> {
 
 component:
 
-use starknet::event::EventEmitter;
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/diagnostics
@@ -43,23 +43,22 @@ trait MyTrait<T> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }
@@ -162,23 +161,22 @@ trait MyTrait<T> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }
@@ -281,23 +279,22 @@ trait MyTrait<T> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }
@@ -398,23 +395,22 @@ trait MyTrait<T> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }
@@ -515,23 +511,22 @@ trait MyTrait<T> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }
@@ -632,23 +627,22 @@ trait MyTrait<T> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }
@@ -749,23 +743,22 @@ trait MyTrait<T> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }
@@ -858,23 +851,22 @@ trait MyTrait<T>;
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }
@@ -979,23 +971,22 @@ trait MyTrait<T> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
@@ -105,22 +105,21 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -33,23 +33,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -145,23 +144,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -269,23 +267,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         mapping: mapping::ContractMemberState,
@@ -353,7 +350,7 @@ error: Plugin diagnostic: Identifier not found.
         ^*****^
 
 error: Invalid drop trait implementation, Candidate impl core::traits::SnapshotDrop::<?0> has an unused generic parameter..
- --> contract:22:5
+ --> contract:21:5
     impl ContractStateDrop of Drop<ContractState> {}
     ^**********************************************^
 
@@ -405,23 +402,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -583,23 +579,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -708,23 +703,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -835,23 +829,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -934,7 +927,7 @@ error: Plugin diagnostic: Contract entry points cannot have generic arguments
           ^*^
 
 error: Type not found.
- --> contract:42:24
+ --> contract:41:24
         serde::Serde::<T>::deserialize(ref data),
                        ^
 
@@ -981,23 +974,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -1125,23 +1117,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -1352,23 +1343,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -1493,23 +1483,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         same_name: same_name::ContractMemberState,
@@ -1717,23 +1706,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -1896,23 +1884,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -2085,22 +2072,21 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -2197,23 +2183,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
@@ -127,23 +127,22 @@ mod __constructor_OutsideImpl {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         value: value::ContractMemberState,
@@ -427,23 +426,22 @@ mod __constructor_OutsideImplWithPanicDestruct {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/external_event
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/external_event
@@ -152,22 +152,21 @@ impl BestEventEverIsEvent of starknet::Event<BestEventEver> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/hello_starknet
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/hello_starknet
@@ -45,23 +45,22 @@ mod hello_starknet {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         balance: balance::ContractMemberState,

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/l1_handler
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/l1_handler
@@ -33,23 +33,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/raw_output
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/raw_output
@@ -45,23 +45,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage
@@ -127,23 +127,22 @@ impl StoreOuterType of starknet::Store::<OuterType> {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         var_felt252: var_felt252::ContractMemberState,

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/user_defined_types
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/user_defined_types
@@ -93,23 +93,22 @@ mod test_contract {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         var: var::ContractMemberState,

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
@@ -73,23 +73,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -182,22 +181,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         test_component_storage: super::test_component::ComponentState<ContractState>,
@@ -449,23 +447,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -558,23 +555,22 @@ impl EventIsEvent of starknet::Event<Event> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -667,22 +663,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         component1_storage: super::component1::ComponentState<ContractState>,

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
@@ -57,23 +57,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -166,22 +165,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -340,23 +338,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -449,22 +446,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -611,23 +607,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -720,22 +715,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -891,23 +885,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -1000,22 +993,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -1178,23 +1170,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -1287,22 +1278,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         test_component_storage: super::test_component::ComponentState<ContractState>,
@@ -1476,23 +1466,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -1585,22 +1574,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
     }
@@ -1734,7 +1722,7 @@ error: Plugin diagnostic: Type not found.
                                                        ^*****^
 
 error: Cannot infer trait core::starknet::storage_access::StorePacking::<?0, ?1>. First generic argument must be known.
- --> contract:53:79
+ --> contract:52:79
                     starknet::Store::<super::super::test_component::Storage>::read(
                                                                               ^**^
 
@@ -1749,7 +1737,7 @@ error: Plugin diagnostic: Type not found.
                                                        ^*****^
 
 error: Cannot infer trait core::starknet::storage_access::StorePacking::<?0, ?1>. First generic argument must be known.
- --> contract:63:79
+ --> contract:62:79
                     starknet::Store::<super::super::test_component::Storage>::write(
                                                                               ^***^
 
@@ -1781,23 +1769,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -1890,22 +1877,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         test_component_storage: test_component_storage::ContractMemberState,
@@ -2088,23 +2074,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -2197,23 +2182,22 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         test_component_storage: super::test_component::ComponentState<ContractState>,
@@ -2419,23 +2403,22 @@ impl EventABCIntoEvent of Into<test_component::Event, Event> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -2528,22 +2511,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         test_component_storage: super::test_component::ComponentState<ContractState>,
@@ -2706,23 +2688,22 @@ mod test_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -2815,23 +2796,22 @@ impl EventIsEvent of starknet::Event<Event> {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         data: data::ComponentMemberState,
@@ -2924,22 +2904,21 @@ impl EventIsEvent of starknet::Event<Event> {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         component1_storage: super::component1::ComponentState<ContractState>,

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_ownable
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_ownable
@@ -157,23 +157,22 @@ mod my_contract {
 
 component:
 
-use starknet::event::EventEmitter;
 #[event] #[derive(Drop, starknet::Event)] enum Event {}
 
-    impl ComponentStateEventEmitter<TContractState> of EventEmitter<ComponentState<TContractState>, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ComponentStateEventEmitter<TContractState> of starknet::event::EventEmitter<ComponentState<TContractState>, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ComponentState<TContractState>, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ComponentState<TContractState> {
         owner: owner::ComponentMemberState,
@@ -376,22 +375,21 @@ mod __constructor_Transfer {
 
 contract:
 
-use starknet::event::EventEmitter;
 
-    impl ContractStateEventEmitter of EventEmitter<ContractState, Event> {
-        fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
-            let event: Event = traits::Into::into(event);
-            let mut keys = Default::<array::Array>::default();
-            let mut data = Default::<array::Array>::default();
-            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
-            starknet::SyscallResultTraitImpl::unwrap_syscall(
-                starknet::syscalls::emit_event_syscall(
-                    array::ArrayTrait::span(@keys),
-                    array::ArrayTrait::span(@data),
-                )
-            )
-        }
-    }
+   impl ContractStateEventEmitter of starknet::event::EventEmitter<ContractState, Event> {
+       fn emit<S, impl IntoImp: traits::Into<S, Event>>(ref self: ContractState, event: S) {
+           let event: Event = traits::Into::into(event);
+           let mut keys = Default::<array::Array>::default();
+           let mut data = Default::<array::Array>::default();
+           starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+           starknet::SyscallResultTraitImpl::unwrap_syscall(
+               starknet::syscalls::emit_event_syscall(
+                   array::ArrayTrait::span(@keys),
+                   array::ArrayTrait::span(@data),
+               )
+           )
+       }
+   }
 
     struct ContractState {
         ownable: super::ownable::ComponentState<ContractState>,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4012)
<!-- Reviewable:end -->
