### PR TITLE
Test-runner:  separate build run, make compiled tests serializable 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,8 @@ dependencies = [
  "num-traits 0.2.15",
  "rayon",
  "salsa",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/crates/bin/cairo-test/src/main.rs
+++ b/crates/bin/cairo-test/src/main.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use anyhow::Ok;
 use cairo_lang_compiler::project::check_compiler_path;
-use cairo_lang_test_runner::TestRunner;
+use cairo_lang_test_runner::{TestRunConfig, TestRunner};
 use clap::Parser;
 
 /// Command line args parser.
@@ -37,13 +37,13 @@ fn main() -> anyhow::Result<()> {
     // Check if args.path is a file or a directory.
     check_compiler_path(args.single_file, &args.path)?;
 
-    let runner = TestRunner::new(
-        &args.path,
-        &args.filter,
-        args.include_ignored,
-        args.ignored,
-        args.starknet,
-    )?;
+    let config = TestRunConfig {
+        filter: args.filter,
+        ignored: args.ignored,
+        include_ignored: args.include_ignored,
+    };
+
+    let runner = TestRunner::new(&args.path, args.starknet, config)?;
     runner.run()?;
 
     Ok(())

--- a/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
@@ -1,5 +1,6 @@
 use convert_case::Casing;
 use itertools::chain;
+use serde::{Deserialize, Serialize};
 
 use super::int::unsigned128::Uint128Type;
 // Module providing the gas related extensions.
@@ -135,7 +136,7 @@ impl NoGenericArgsGenericLibfunc for GetAvailableGasLibfunc {
 
 /// Represents different type of costs.
 /// Note that if you add a type here you should update 'iter_precost'
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CostTokenType {
     /// A compile time known cost unit.
     Const,

--- a/crates/cairo-lang-starknet/src/contract.rs
+++ b/crates/cairo-lang-starknet/src/contract.rs
@@ -23,9 +23,12 @@ use cairo_lang_sierra_generator::replace_ids::SierraIdReplacer;
 use cairo_lang_syntax::node::helpers::{GetIdentifier, PathSegmentEx, QueryAttrs};
 use cairo_lang_syntax::node::TypedSyntaxNode;
 use cairo_lang_utils::extract_matches;
-use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::ordered_hash_map::{
+    deserialize_ordered_hashmap_vec, serialize_ordered_hashmap_vec, OrderedHashMap,
+};
 use itertools::chain;
 use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use {cairo_lang_lowering as lowering, cairo_lang_semantic as semantic};
 
@@ -289,12 +292,21 @@ fn get_submodule_id(
 }
 
 /// Sierra information of a contract.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct ContractInfo {
     /// Sierra function of the constructor.
     pub constructor: Option<FunctionId>,
     /// Sierra functions of the external functions.
+    #[serde(
+        serialize_with = "serialize_ordered_hashmap_vec",
+        deserialize_with = "deserialize_ordered_hashmap_vec"
+    )]
     pub externals: OrderedHashMap<Felt252, FunctionId>,
     /// Sierra functions of the l1 handler functions.
+    #[serde(
+        serialize_with = "serialize_ordered_hashmap_vec",
+        deserialize_with = "deserialize_ordered_hashmap_vec"
+    )]
     pub l1_handlers: OrderedHashMap<Felt252, FunctionId>,
 }
 

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -33,4 +33,8 @@ num-bigint.workspace = true
 num-traits.workspace = true
 rayon.workspace = true
 salsa.workspace = true
+serde.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -19,6 +19,7 @@ use cairo_lang_semantic::items::functions::GenericFunctionId;
 use cairo_lang_semantic::{ConcreteFunction, FunctionLongId};
 use cairo_lang_sierra::extensions::gas::CostTokenType;
 use cairo_lang_sierra::ids::FunctionId;
+use cairo_lang_sierra::program::Program;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_sierra_generator::replace_ids::{DebugReplacer, SierraIdReplacer};
 use cairo_lang_sierra_to_casm::metadata::MetadataComputationConfig;
@@ -44,13 +45,8 @@ pub mod plugin;
 mod test_config;
 
 pub struct TestRunner {
-    pub db: RootDatabase,
-    pub main_crate_ids: Vec<CrateId>,
-    pub test_crate_ids: Vec<CrateId>,
-    pub filter: String,
-    pub include_ignored: bool,
-    pub ignored: bool,
-    pub starknet: bool,
+    compiler: TestCompiler,
+    config: TestRunConfig,
 }
 
 impl TestRunner {
@@ -63,123 +59,52 @@ impl TestRunner {
     /// * `include_ignored` - Include ignored tests as well
     /// * `ignored` - Run ignored tests only
     /// * `starknet` - Add the starknet plugin to run the tests
-    pub fn new(
-        path: &Path,
-        filter: &str,
-        include_ignored: bool,
-        ignored: bool,
-        starknet: bool,
-    ) -> Result<Self> {
-        let db = &mut {
-            let mut b = RootDatabase::builder();
-            b.detect_corelib();
-            b.with_cfg(CfgSet::from_iter([Cfg::name("test")]));
-            b.with_macro_plugin(Arc::new(TestPlugin::default()));
-
-            if starknet {
-                b.with_macro_plugin(Arc::new(StarkNetPlugin::default()))
-                    .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro));
-            }
-
-            b.build()?
-        };
-
-        let main_crate_ids = setup_project(db, Path::new(&path))?;
-
-        if DiagnosticsReporter::stderr().with_extra_crates(&main_crate_ids).check(db) {
-            bail!("failed to compile: {}", path.display());
-        }
-
-        Ok(Self {
-            db: db.snapshot(),
-            test_crate_ids: main_crate_ids.clone(),
-            main_crate_ids,
-            filter: filter.into(),
-            include_ignored,
-            ignored,
-            starknet,
-        })
+    pub fn new(path: &Path, starknet: bool, config: TestRunConfig) -> Result<Self> {
+        let compiler = TestCompiler::try_new(path, starknet)?;
+        Ok(Self { compiler, config })
     }
 
     /// Runs the tests and process the results for a summary.
     pub fn run(&self) -> Result<Option<TestsSummary>> {
-        if !self.test_crate_ids.iter().all(|id| self.main_crate_ids.contains(id)) {
-            bail!("The test runner can only run tests from the main crates.");
-        }
+        let runner = CompiledTestRunner::new(self.compiler.build()?, self.config.clone());
+        runner.run()
+    }
+}
 
-        let db = &self.db;
+pub struct CompiledTestRunner {
+    pub compiled: TestCompilation,
+    pub config: TestRunConfig,
+}
 
-        let all_entry_points = if self.starknet {
-            find_contracts(db, &self.main_crate_ids)
-                .iter()
-                .flat_map(|contract| {
-                    chain!(
-                        get_contract_abi_functions(db, contract, EXTERNAL_MODULE).unwrap(),
-                        get_contract_abi_functions(db, contract, CONSTRUCTOR_MODULE).unwrap(),
-                        get_contract_abi_functions(db, contract, L1_HANDLER_MODULE).unwrap(),
-                    )
-                })
-                .map(|func| ConcreteFunctionWithBodyId::from_semantic(db, func.value))
-                .collect()
-        } else {
-            vec![]
-        };
-        let function_set_costs: OrderedHashMap<FunctionId, OrderedHashMap<CostTokenType, i32>> =
-            all_entry_points
-                .iter()
-                .map(|func_id| {
-                    (
-                        db.function_with_body_sierra(*func_id).unwrap().id.clone(),
-                        [(CostTokenType::Const, ENTRY_POINT_COST)].into(),
-                    )
-                })
-                .collect();
-        let all_tests = find_all_tests(db, self.test_crate_ids.clone());
-        let sierra_program = self
-            .db
-            .get_sierra_program_for_functions(
-                chain!(
-                    all_entry_points.into_iter(),
-                    all_tests.iter().flat_map(|(func_id, _cfg)| {
-                        ConcreteFunctionWithBodyId::from_no_generics_free(db, *func_id)
-                    })
-                )
-                .collect(),
-            )
-            .to_option()
-            .with_context(|| "Compilation failed without any diagnostics.")?;
-        let replacer = DebugReplacer { db };
-        let sierra_program = replacer.apply(&sierra_program);
-        let total_tests_count = all_tests.len();
-        let named_tests = all_tests
-          .into_iter()
-          .map(|(func_id, mut test)| {
-              // Un-ignoring all the tests in `include-ignored` mode.
-              if self.include_ignored {
-                  test.ignored = false;
-              }
-              (
-                  format!(
-                      "{:?}",
-                      FunctionLongId {
-                          function: ConcreteFunction {
-                              generic_function: GenericFunctionId::Free(func_id),
-                              generic_args: vec![]
-                          }
-                      }
-                      .debug(db)
-                  ),
-                  test,
-              )
-          })
-          .filter(|(name, _)| name.contains(&self.filter))
-          // Filtering unignored tests in `ignored` mode.
-          .filter(|(_, test)| !self.ignored || test.ignored)
-          .collect_vec();
-        let filtered_out = total_tests_count - named_tests.len();
-        let contracts_info = get_contracts_info(db, self.main_crate_ids.clone(), &replacer)?;
-        let TestsSummary { passed, failed, ignored, failed_run_results } =
-            run_tests(named_tests, sierra_program, function_set_costs, contracts_info)?;
+impl CompiledTestRunner {
+    /// Configure a new compiled test runner
+    ///
+    /// # Arguments
+    ///
+    /// * `compiled` - The compiled tests to run
+    /// * `filter` - Run only tests containing the filter string
+    /// * `include_ignored` - Include ignored tests as well
+    /// * `ignored` - Run ignored tests only
+    pub fn new(compiled: TestCompilation, config: TestRunConfig) -> Self {
+        Self { compiled, config }
+    }
+
+    /// Execute preconfigured test execution.
+    pub fn run(self) -> Result<Option<TestsSummary>> {
+        let (compiled, filtered_out) = filter_test_cases(
+            self.compiled,
+            self.config.include_ignored,
+            self.config.ignored,
+            self.config.filter,
+        );
+
+        let TestsSummary { passed, failed, ignored, failed_run_results } = run_tests(
+            compiled.named_tests,
+            compiled.sierra_program,
+            compiled.function_set_costs,
+            compiled.contracts_info,
+        )?;
+
         if failed.is_empty() {
             println!(
                 "test result: {}. {} passed; {} failed; {} ignored; {filtered_out} filtered out;",
@@ -221,6 +146,171 @@ impl TestRunner {
     }
 }
 
+/// Configuration of compiled tests runner.
+#[derive(Clone, Debug)]
+pub struct TestRunConfig {
+    pub filter: String,
+    pub include_ignored: bool,
+    pub ignored: bool,
+}
+
+/// The test cases compiler.
+pub struct TestCompiler {
+    pub db: RootDatabase,
+    pub main_crate_ids: Vec<CrateId>,
+    pub test_crate_ids: Vec<CrateId>,
+    pub starknet: bool,
+}
+
+impl TestCompiler {
+    /// Configure a new test compiler
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to compile and run its tests
+    /// * `starknet` - Add the starknet plugin to run the tests
+    pub fn try_new(path: &Path, starknet: bool) -> Result<Self> {
+        let db = &mut {
+            let mut b = RootDatabase::builder();
+            b.detect_corelib();
+            b.with_cfg(CfgSet::from_iter([Cfg::name("test")]));
+            b.with_macro_plugin(Arc::new(TestPlugin::default()));
+
+            if starknet {
+                b.with_macro_plugin(Arc::new(StarkNetPlugin::default()))
+                    .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro));
+            }
+
+            b.build()?
+        };
+
+        let main_crate_ids = setup_project(db, Path::new(&path))?;
+
+        if DiagnosticsReporter::stderr().with_extra_crates(&main_crate_ids).check(db) {
+            bail!("failed to compile: {}", path.display());
+        }
+
+        Ok(Self {
+            db: db.snapshot(),
+            test_crate_ids: main_crate_ids.clone(),
+            main_crate_ids,
+            starknet,
+        })
+    }
+
+    /// Build the tests and collect metadata.
+    pub fn build(&self) -> Result<TestCompilation> {
+        compile_test_prepared_db(
+            &self.db,
+            self.starknet,
+            self.main_crate_ids.clone(),
+            self.test_crate_ids.clone(),
+        )
+    }
+}
+
+pub fn compile_test_prepared_db(
+    db: &RootDatabase,
+    starknet: bool,
+    main_crate_ids: Vec<CrateId>,
+    test_crate_ids: Vec<CrateId>,
+) -> Result<TestCompilation> {
+    let all_entry_points = if starknet {
+        find_contracts(db, &main_crate_ids)
+            .iter()
+            .flat_map(|contract| {
+                chain!(
+                    get_contract_abi_functions(db, contract, EXTERNAL_MODULE).unwrap(),
+                    get_contract_abi_functions(db, contract, CONSTRUCTOR_MODULE).unwrap(),
+                    get_contract_abi_functions(db, contract, L1_HANDLER_MODULE).unwrap(),
+                )
+            })
+            .map(|func| ConcreteFunctionWithBodyId::from_semantic(db, func.value))
+            .collect()
+    } else {
+        vec![]
+    };
+    let function_set_costs: OrderedHashMap<FunctionId, OrderedHashMap<CostTokenType, i32>> =
+        all_entry_points
+            .iter()
+            .map(|func_id| {
+                (
+                    db.function_with_body_sierra(*func_id).unwrap().id.clone(),
+                    [(CostTokenType::Const, ENTRY_POINT_COST)].into(),
+                )
+            })
+            .collect();
+    let all_tests = find_all_tests(db, test_crate_ids.clone());
+    let sierra_program = db
+        .get_sierra_program_for_functions(
+            chain!(
+                all_entry_points.into_iter(),
+                all_tests.iter().flat_map(|(func_id, _cfg)| {
+                    ConcreteFunctionWithBodyId::from_no_generics_free(db, *func_id)
+                })
+            )
+            .collect(),
+        )
+        .to_option()
+        .with_context(|| "Compilation failed without any diagnostics.")?;
+    let replacer = DebugReplacer { db };
+    let sierra_program = replacer.apply(&sierra_program);
+
+    let named_tests = all_tests
+        .into_iter()
+        .map(|(func_id, test)| {
+            (
+                format!(
+                    "{:?}",
+                    FunctionLongId {
+                        function: ConcreteFunction {
+                            generic_function: GenericFunctionId::Free(func_id),
+                            generic_args: vec![]
+                        }
+                    }
+                    .debug(db)
+                ),
+                test,
+            )
+        })
+        .collect_vec();
+    let contracts_info = get_contracts_info(db, main_crate_ids.clone(), &replacer)?;
+
+    Ok(TestCompilation { named_tests, sierra_program, function_set_costs, contracts_info })
+}
+
+pub struct TestCompilation {
+    named_tests: Vec<(String, TestConfig)>,
+    sierra_program: Program,
+    function_set_costs: OrderedHashMap<FunctionId, OrderedHashMap<CostTokenType, i32>>,
+    contracts_info: OrderedHashMap<Felt252, ContractInfo>,
+}
+
+pub fn filter_test_cases(
+    compiled: TestCompilation,
+    include_ignored: bool,
+    ignored: bool,
+    filter: String,
+) -> (TestCompilation, usize) {
+    let total_tests_count = compiled.named_tests.len();
+    let named_tests = compiled.named_tests
+        .into_iter()
+        .map(|(func, mut test)| {
+            // Un-ignoring all the tests in `include-ignored` mode.
+            if include_ignored {
+                test.ignored = false;
+            }
+            (func, test)
+        })
+        .filter(|(name, _)| name.contains(&filter))
+        // Filtering unignored tests in `ignored` mode
+        .filter(|(_, test)| !ignored || test.ignored)
+        .collect_vec();
+    let filtered_out = total_tests_count - named_tests.len();
+    let tests = TestCompilation { named_tests, ..compiled };
+    (tests, filtered_out)
+}
+
 /// The status of a ran test.
 enum TestStatus {
     Success,
@@ -246,10 +336,10 @@ pub struct TestsSummary {
 /// Runs the tests and process the results for a summary.
 pub fn run_tests(
     named_tests: Vec<(String, TestConfig)>,
-    sierra_program: cairo_lang_sierra::program::Program,
+    sierra_program: Program,
     function_set_costs: OrderedHashMap<FunctionId, OrderedHashMap<CostTokenType, i32>>,
     contracts_info: OrderedHashMap<Felt252, ContractInfo>,
-) -> anyhow::Result<TestsSummary> {
+) -> Result<TestsSummary> {
     let runner = SierraCasmRunner::new(
         sierra_program,
         Some(MetadataComputationConfig { function_set_costs }),

--- a/crates/cairo-lang-test-runner/src/test.rs
+++ b/crates/cairo-lang-test-runner/src/test.rs
@@ -1,0 +1,22 @@
+use itertools::Itertools;
+
+use crate::{TestCompilation, TestCompiler};
+
+#[test]
+fn test_compiled_serialization() {
+    use std::path::PathBuf;
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_data");
+
+    let compiler = TestCompiler::try_new(&path, true).unwrap();
+    let compiled = compiler.build().unwrap();
+    let serialized = serde_json::to_string_pretty(&compiled).unwrap();
+    let deserialized: TestCompilation = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(compiled.sierra_program, deserialized.sierra_program);
+    assert_eq!(compiled.function_set_costs, deserialized.function_set_costs);
+    assert_eq!(compiled.named_tests, deserialized.named_tests);
+    assert_eq!(
+        compiled.contracts_info.values().collect_vec(),
+        deserialized.contracts_info.values().collect_vec()
+    );
+}

--- a/crates/cairo-lang-test-runner/src/test_config.rs
+++ b/crates/cairo-lang-test-runner/src/test_config.rs
@@ -5,8 +5,10 @@ use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_utils::OptionHelper;
 use num_traits::ToPrimitive;
+use serde::{Deserialize, Serialize};
 
 /// Expectation for a panic case.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub enum PanicExpectation {
     /// Accept any panic value.
     Any,
@@ -15,6 +17,7 @@ pub enum PanicExpectation {
 }
 
 /// Expectation for a result of a test.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub enum TestExpectation {
     /// Running the test should not panic.
     Success,
@@ -23,6 +26,7 @@ pub enum TestExpectation {
 }
 
 /// The configuration for running a single test.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct TestConfig {
     /// The amount of gas the test requested.
     pub available_gas: Option<usize>,

--- a/crates/cairo-lang-test-runner/test_data/cairo_project.toml
+++ b/crates/cairo-lang-test-runner/test_data/cairo_project.toml
@@ -1,0 +1,2 @@
+[crate_roots]
+contracts = "."

--- a/crates/cairo-lang-test-runner/test_data/lib.cairo
+++ b/crates/cairo-lang-test-runner/test_data/lib.cairo
@@ -1,0 +1,70 @@
+#[starknet::interface]
+trait IBalance<T> {
+    // Returns the current balance.
+    fn get(self: @T) -> u128;
+    // Increases the balance by the given amount.
+    fn increase(ref self: T, a: u128);
+}
+
+#[starknet::contract]
+mod Balance {
+    use traits::Into;
+
+    #[storage]
+    struct Storage {
+        value: u128,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, value_: u128) {
+        self.value.write(value_);
+    }
+
+    #[external(v0)]
+    impl Balance of super::IBalance<ContractState> {
+        fn get(self: @ContractState) -> u128 {
+            self.value.read()
+        }
+        fn increase(ref self: ContractState, a: u128) {
+            self.value.write(self.value.read() + a);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use array::ArrayTrait;
+    use core::result::ResultTrait;
+    use core::traits::Into;
+    use option::OptionTrait;
+    use starknet::syscalls::deploy_syscall;
+    use traits::TryInto;
+
+    use test::test_utils::assert_eq;
+
+    use super::{Balance, IBalance, IBalanceDispatcher, IBalanceDispatcherTrait};
+
+    #[test]
+    #[available_gas(30000000)]
+    fn test_flow() {
+        let calldata = array![100];
+        let (address0, _) = deploy_syscall(
+            Balance::TEST_CLASS_HASH.try_into().unwrap(), 0, calldata.span(), false
+        )
+            .unwrap();
+        let mut contract0 = IBalanceDispatcher { contract_address: address0 };
+
+        let calldata = array![200];
+        let (address1, _) = deploy_syscall(
+            Balance::TEST_CLASS_HASH.try_into().unwrap(), 0, calldata.span(), false
+        )
+            .unwrap();
+        let mut contract1 = IBalanceDispatcher { contract_address: address1 };
+
+        assert_eq(@contract0.get(), @100, 'contract0.get() == 100');
+        assert_eq(@contract1.get(), @200, 'contract1.get() == 200');
+        @contract1.increase(200);
+        assert_eq(@contract0.get(), @100, 'contract0.get() == 100');
+        assert_eq(@contract1.get(), @400, 'contract1.get() == 400');
+    }
+}


### PR DESCRIPTION
Refactor `TestRunner` struct to separate compilation from test run. This will allow downstream test runner implementations to run precompiled tests without the compiler setup for `TestRunner` struct.   


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4015)
<!-- Reviewable:end -->
