### PR TITLE
Handle single-file crate roots in project config

### DIFF
--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -145,7 +145,7 @@ impl RootDatabaseBuilder {
         }
 
         if let Some(config) = self.project_config.clone() {
-            update_crate_roots_from_project_config(&mut db, *config.clone());
+            update_crate_roots_from_project_config(&mut db, *config.clone())?;
 
             if let Some(corelib) = config.corelib {
                 let core_crate = db.intern_crate(CrateLongId::Real(CORELIB_CRATE_NAME.into()));

--- a/crates/cairo-lang-compiler/src/project.rs
+++ b/crates/cairo-lang-compiler/src/project.rs
@@ -20,6 +20,14 @@ pub enum ProjectError {
     LoadProjectError,
 }
 
+impl From<CrateRootError> for ProjectError {
+    fn from(e: CrateRootError) -> Self {
+        match e {
+            CrateRootError::BadPath { path } => ProjectError::BadPath { path },
+        }
+    }
+}
+
 /// Setup to 'db' to compile the file at the given path.
 /// Returns the id of the generated crate.
 pub fn setup_single_file_project(
@@ -45,29 +53,48 @@ pub fn setup_single_file_project(
         db.set_crate_root(crate_id, Some(Directory::Real(file_dir.to_path_buf())));
         Ok(crate_id)
     } else {
-        // If file_stem is not lib, create a fake lib file.
+        // If file_stem is not lib, create a wrapper lib file.
         let crate_id = db.intern_crate(CrateLongId::Real(file_stem.into()));
         db.set_crate_root(crate_id, Some(Directory::Real(path.parent().unwrap().to_path_buf())));
-
-        let module_id = ModuleId::CrateRoot(crate_id);
-        let file_id = db.module_main_file(module_id).unwrap();
-        db.as_files_group_mut()
-            .override_file_content(file_id, Some(Arc::new(format!("mod {file_stem};"))));
+        virtual_wrapper_lib(db, crate_id, file_stem.to_string());
         Ok(crate_id)
     }
 }
 
 /// Updates the crate roots from a ProjectConfig object.
-pub fn update_crate_roots_from_project_config(db: &mut dyn SemanticGroup, config: ProjectConfig) {
-    for (crate_name, directory_path) in config.content.crate_roots {
+pub fn update_crate_roots_from_project_config(
+    db: &mut dyn SemanticGroup,
+    config: ProjectConfig,
+) -> Result<(), ProjectError> {
+    for (crate_name, crate_root) in config.content.crate_roots {
         let crate_id = db.intern_crate(CrateLongId::Real(crate_name));
-        let mut path = PathBuf::from(&directory_path);
+
+        let mut path = crate_root.root()?;
         if path.is_relative() {
             path = PathBuf::from(&config.base_path).join(path);
         }
-        let root = Directory::Real(path);
-        db.set_crate_root(crate_id, Some(root));
+        db.set_crate_root(crate_id, Some(Directory::Real(path.clone())));
+
+        if crate_root.inject_lib() {
+            let file_stem = crate_root.file_stem().ok_or_else(|| ProjectError::BadPath {
+                path: path.to_string_lossy().to_string(),
+            })?;
+            virtual_wrapper_lib(db, crate_id, file_stem);
+        }
     }
+    Ok(())
+}
+
+/// Generates a wrapper lib file for the given crate.
+///
+/// This approach allows compiling crates that do not define `lib.cairo` file.
+/// For example, single file crates can be created this way.
+/// The actual single file module is defined as `mod` item in created lib file.
+pub fn virtual_wrapper_lib(db: &mut dyn SemanticGroup, crate_id: CrateId, file_stem: String) {
+    let module_id = ModuleId::CrateRoot(crate_id);
+    let file_id = db.module_main_file(module_id).unwrap();
+    db.as_files_group_mut()
+        .override_file_content(file_id, Some(Arc::new(format!("mod {file_stem};"))));
 }
 
 /// Setup the 'db' to compile the project in the given path.
@@ -81,7 +108,7 @@ pub fn setup_project(
         match ProjectConfig::from_directory(path) {
             Ok(config) => {
                 let main_crate_ids = get_main_crate_ids_from_project(db, &config);
-                update_crate_roots_from_project_config(db, config);
+                update_crate_roots_from_project_config(db, config)?;
                 Ok(main_crate_ids)
             }
             _ => Err(ProjectError::LoadProjectError),

--- a/crates/cairo-lang-project/src/lib.rs
+++ b/crates/cairo-lang-project/src/lib.rs
@@ -18,6 +18,14 @@ pub enum DeserializationError {
     #[error("PathError")]
     PathError,
 }
+
+/// Error that can occur when parsing a crate root definition.
+#[derive(thiserror::Error, Debug)]
+pub enum CrateRootError {
+    #[error("Couldn't handle {path}: Not a legal path.")]
+    BadPath { path: String },
+}
+
 const PROJECT_FILE_NAME: &str = "cairo_project.toml";
 
 /// Cairo project config, including its file content and metadata about the file.
@@ -32,7 +40,77 @@ pub struct ProjectConfig {
 /// Contents of a Cairo project config file.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProjectConfigContent {
-    pub crate_roots: OrderedHashMap<SmolStr, PathBuf>,
+    pub crate_roots: OrderedHashMap<SmolStr, CrateSourcePath>,
+}
+
+/// A crate root specification.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CrateSourcePath {
+    /// Crate root specified as path, eg. `<crate_name> = "<crate_root>"`.
+    SimpleSourceRoot(PathBuf),
+    /// Detailed crate root specification as a table, eg. `<crate_name> = { path = "<crate_path>"
+    /// }`. Crate root must be a directory that contains a `lib.cairo` file.
+    SourceRoot(DetailedSourceRoot),
+    /// Crate entrypoint specification as a table, eg. `<crate_name> = { entrypoint =
+    /// "<entrypoint_path>" }`. Entrypoint must be a file.
+    SourcePath(DetailedSourcePath),
+}
+
+impl From<PathBuf> for CrateSourcePath {
+    fn from(path: PathBuf) -> Self {
+        CrateSourcePath::SimpleSourceRoot(path)
+    }
+}
+
+/// A detailed crate root specification.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetailedSourceRoot {
+    /// Crate root path.
+    pub source_root: PathBuf,
+}
+
+/// A detailed crate entrypoint specification.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetailedSourcePath {
+    /// Crate entrypoint file path.
+    pub source_path: PathBuf,
+}
+
+impl CrateSourcePath {
+    pub fn inject_lib(&self) -> bool {
+        matches!(self, CrateSourcePath::SourcePath(_))
+    }
+
+    pub fn file_stem(&self) -> Option<String> {
+        match self {
+            CrateSourcePath::SourcePath(detailed) => {
+                detailed.source_path.file_stem().map(|s| s.to_string_lossy().to_string())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn root(&self) -> Result<PathBuf, CrateRootError> {
+        match self {
+            CrateSourcePath::SimpleSourceRoot(path) => Ok(path.clone()),
+            CrateSourcePath::SourceRoot(detailed) => Ok(detailed.source_root.clone()),
+            CrateSourcePath::SourcePath(detailed) => detailed
+                .source_path
+                .clone()
+                .parent()
+                .ok_or_else(|| CrateRootError::BadPath {
+                    path: detailed.source_path.to_string_lossy().to_string(),
+                })
+                .map(|p| p.to_path_buf()),
+        }
+    }
+}
+
+impl From<&str> for CrateSourcePath {
+    fn from(path: &str) -> Self {
+        CrateSourcePath::SimpleSourceRoot(path.into())
+    }
 }
 
 impl ProjectConfig {


### PR DESCRIPTION
This changes allow usage of crates with user defined source paths (i.e. other than `src/lib.cairo`) via project config. It is achieved with an approach analogous to single file setup. This would make a powerful api for features like exposing source-path setting to user in scarb, or single file modules (e.g. `tests/module.cairo`).  

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4016)
<!-- Reviewable:end -->
