### PR TITLE
Added support for minus literals in const items.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1878,22 +1878,32 @@ fn expr_function_call(
     let expr_function_call =
         ExprFunctionCall { function: function_id, args, ty: signature.return_type, stable_ptr };
     // Check panicable.
-    if signature.panicable
-        && !ctx
-            .get_signature(
-                stable_ptr.untyped(),
-                UnsupportedOutsideOfFunctionFeatureName::FunctionCall,
-            )?
-            .panicable
-        // Minus literals are a special case, since we know these cannot panic, as they would fail
-        // on value in illegal bounds.
-        && try_extract_minus_literal(ctx.db, &ctx.exprs, &expr_function_call).is_none()
-    {
+    if signature.panicable && has_panic_incompatiblity(ctx, &expr_function_call)? {
         // TODO(spapini): Delay this check until after inference, to allow resolving specific
         //   impls first.
         return Err(ctx.diagnostics.report_by_ptr(stable_ptr.untyped(), PanicableFromNonPanicable));
     }
     Ok(Expr::FunctionCall(expr_function_call))
+}
+
+/// Checks if a panicable function is called from a disallowed context.
+fn has_panic_incompatiblity(
+    ctx: &mut ComputationContext<'_>,
+    expr_function_call: &ExprFunctionCall,
+) -> Maybe<bool> {
+    // If this is not an actual function call, but actually a minus literal (e.g. -1), then this is
+    // the same as nopanic.
+    if try_extract_minus_literal(ctx.db, &ctx.exprs, expr_function_call).is_some() {
+        return Ok(false);
+    }
+    // If this is not from within a context of a function - e.g. a const item, we will exit with an
+    // error here, as this is a call with bad context.
+    let caller_signature = ctx.get_signature(
+        expr_function_call.stable_ptr.untyped(),
+        UnsupportedOutsideOfFunctionFeatureName::FunctionCall,
+    )?;
+    // If the caller is nopanic, then this is a panic incompatibility.
+    Ok(!caller_signature.panicable)
 }
 
 /// Checks the correctness of the named arguments, and outputs diagnostics on errors.

--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -1,7 +1,7 @@
 //! > Const
 
 //! > test_runner_name
-test_function_diagnostics
+test_function_diagnostics(allow_diagnostics: false)
 
 //! > function
 fn foo() {
@@ -25,7 +25,7 @@ mod my_module {
 //! > Const diagnostics
 
 //! > test_runner_name
-test_function_diagnostics
+test_function_diagnostics(allow_diagnostics: true)
 
 //! > function
 fn foo() { }
@@ -82,7 +82,7 @@ const WRONG_TYPE_AND_NOT_LITERAL: bool = 1 + 2;
 //! > Const of wrong type.
 
 //! > test_runner_name
-test_function_diagnostics
+test_function_diagnostics(allow_diagnostics: true)
 
 //! > function
 fn foo() { }
@@ -106,10 +106,10 @@ const DEFAULT_VAR: bool = 1;
 
 //! > ==========================================================================
 
-//! > Const of out of range value.
+//! > Const of positive values out of range.
 
 //! > test_runner_name
-test_function_diagnostics
+test_function_diagnostics(allow_diagnostics: true)
 
 //! > function
 fn foo() { }
@@ -118,10 +118,74 @@ fn foo() { }
 foo
 
 //! > module_code
-const DEFAULT_VAR: u8 = 256;
+const UNSIGNED_VAR: u8 = 256;
+const SIGNED_VAR: i8 = 128;
 
 //! > expected_diagnostics
 error: The value does not fit within the range of type core::integer::u8.
- --> lib.cairo:1:25
-const DEFAULT_VAR: u8 = 256;
-                        ^*^
+ --> lib.cairo:1:26
+const UNSIGNED_VAR: u8 = 256;
+                         ^*^
+
+error: The value does not fit within the range of type core::integer::i8.
+ --> lib.cairo:2:24
+const SIGNED_VAR: i8 = 128;
+                       ^*^
+
+//! > ==========================================================================
+
+//! > Const of negative values in range.
+
+//! > test_runner_name
+test_function_diagnostics(allow_diagnostics: false)
+
+//! > function
+fn foo() -> i8 nopanic { A }
+
+//! > function_name
+foo
+
+//! > module_code
+const A: i8 = -0x80;
+const B: i16 = -5;
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Const of negative values out of range.
+
+//! > test_runner_name
+test_function_diagnostics(allow_diagnostics: true)
+
+//! > function
+fn foo() { }
+
+//! > function_name
+foo
+
+//! > module_code
+const A: i8 = -0x81;
+const B: u8 = -1;
+const C: i16 = -0x8001;
+
+//! > expected_diagnostics
+error: The value does not fit within the range of type core::integer::i8.
+ --> lib.cairo:1:15
+const A: i8 = -0x81;
+              ^***^
+
+error: The value does not fit within the range of type core::integer::u8.
+ --> lib.cairo:2:15
+const B: u8 = -1;
+              ^^
+
+error: Trait has no implementation in context: core::traits::Neg::<core::integer::u8>
+ --> lib.cairo:2:15
+const B: u8 = -1;
+              ^^
+
+error: The value does not fit within the range of type core::integer::i16.
+ --> lib.cairo:3:16
+const C: i16 = -0x8001;
+               ^*****^

--- a/crates/cairo-lang-semantic/src/items/constant_test.rs
+++ b/crates/cairo-lang-semantic/src/items/constant_test.rs
@@ -1,1 +1,0 @@
-// TODO(lior): Add semantic tests for constant definitions.


### PR DESCRIPTION
**Stack**:
- #4013
- #4027 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4027)
<!-- Reviewable:end -->
