### PR TITLE
feat: add Nullable `deref_or` method

### DIFF
--- a/corelib/src/nullable.cairo
+++ b/corelib/src/nullable.cairo
@@ -14,15 +14,17 @@ extern fn null<T>() -> Nullable<T> nopanic;
 extern fn nullable_from_box<T>(value: Box<T>) -> Nullable<T> nopanic;
 extern fn match_nullable<T>(value: Nullable<T>) -> FromNullableResult<T> nopanic;
 
-trait NullableTrait<T> {
-    fn deref(self: Nullable<T>) -> T;
-    fn new(value: T) -> Nullable<T>;
-}
-
+#[generate_trait]
 impl NullableImpl<T> of NullableTrait<T> {
     fn deref(self: Nullable<T>) -> T {
         match match_nullable(self) {
             FromNullableResult::Null => panic_with_felt252('Attempted to deref null value'),
+            FromNullableResult::NotNull(value) => value.unbox(),
+        }
+    }
+    fn deref_or<+Drop<T>>(self: Nullable<T>, default: T) -> T {
+        match match_nullable(self) {
+            FromNullableResult::Null => default,
             FromNullableResult::NotNull(value) => value.unbox(),
         }
     }


### PR DESCRIPTION
- Adds a `deref_or` method to `Nullable`

Closes #3854

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4037)
<!-- Reviewable:end -->
