### PR TITLE
Explicitly set resolver to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 overflow-checks = true     # Enable integer overflow checks.
 
 [workspace]
-
+resolver = "2"
 members = [
     "crates/cairo-lang-casm",
     "crates/cairo-lang-compiler",


### PR DESCRIPTION
Get rid of Cargo resolver version warning. 
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4061)
<!-- Reviewable:end -->
