### PR TITLE
feat: ok_or

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -13,6 +13,8 @@ trait OptionTrait<T> {
     fn expect(self: Option<T>, err: felt252) -> T;
     /// If `val` is `Option::Some(x)`, returns `x`. Otherwise, panics.
     fn unwrap(self: Option<T>) -> T;
+    /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Option::Some(v)` to `Result::Ok(v)` and `Option::None` to Result::Err(err)`.
+    fn ok_or<+Drop<E>>(self: Option<T>, err: E) -> Result<T, E>;
     /// Returns `true` if the `Option` is `Option::Some`.
     fn is_some(self: @Option<T>) -> bool;
     /// Returns `true` if the `Option` is `Option::None`.
@@ -26,10 +28,20 @@ impl OptionTraitImpl<T> of OptionTrait<T> {
             Option::None => panic_with_felt252(err),
         }
     }
+
     #[inline(always)]
     fn unwrap(self: Option<T>) -> T {
         self.expect('Option::unwrap failed.')
     }
+
+    #[inline(always)]
+    fn ok_or<+Drop<E>>(self: Option<T>, err: E) -> Result<T, E> {
+        match self {
+            Option::Some(v) => Result::Ok(v),
+            Option::None => Result::Err(err),
+        }
+    }
+
     #[inline(always)]
     fn is_some(self: @Option<T>) -> bool {
         match self {
@@ -37,6 +49,7 @@ impl OptionTraitImpl<T> of OptionTrait<T> {
             Option::None => false,
         }
     }
+
     #[inline(always)]
     fn is_none(self: @Option<T>) -> bool {
         match self {

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -13,8 +13,9 @@ trait OptionTrait<T> {
     fn expect(self: Option<T>, err: felt252) -> T;
     /// If `val` is `Option::Some(x)`, returns `x`. Otherwise, panics.
     fn unwrap(self: Option<T>) -> T;
-    /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Option::Some(v)` to `Result::Ok(v)` and `Option::None` to Result::Err(err)`.
-    fn ok_or<+Drop<E>>(self: Option<T>, err: E) -> Result<T, E>;
+    /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Option::Some(v)` to
+    /// `Result::Ok(v)` and `Option::None` to `Result::Err(err)`.
+    fn ok_or<E, +Drop<E>>(self: Option<T>, err: E) -> Result<T, E>;
     /// Returns `true` if the `Option` is `Option::Some`.
     fn is_some(self: @Option<T>) -> bool;
     /// Returns `true` if the `Option` is `Option::None`.
@@ -35,7 +36,7 @@ impl OptionTraitImpl<T> of OptionTrait<T> {
     }
 
     #[inline(always)]
-    fn ok_or<+Drop<E>>(self: Option<T>, err: E) -> Result<T, E> {
+    fn ok_or<E, +Drop<E>>(self: Option<T>, err: E) -> Result<T, E> {
         match self {
             Option::Some(v) => Result::Ok(v),
             Option::None => Result::Err(err),

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -35,7 +35,7 @@ impl OptionTraitImpl<T> of OptionTrait<T> {
         self.expect('Option::unwrap failed.')
     }
 
-    #[inline(always)]
+    #[inline]
     fn ok_or<E, +Drop<E>>(self: Option<T>, err: E) -> Result<T, E> {
         match self {
             Option::Some(v) => Result::Ok(v),


### PR DESCRIPTION
Closes #4063 

Implements an `ok_or` method that transforms an Option<T> to Result<T, E>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4066)
<!-- Reviewable:end -->
