### PR TITLE
Add optional `annotations` field to `SierraProgram` and `ContractClass`

### DIFF
--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -23,16 +23,16 @@ num-bigint.workspace = true
 num-traits.workspace = true
 salsa.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sha3.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
 bimap.workspace = true
+cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
 env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
-serde_json.workspace = true
 test-case.workspace = true
 test-log.workspace = true

--- a/crates/cairo-lang-sierra/src/debug_info_test.rs
+++ b/crates/cairo-lang-sierra/src/debug_info_test.rs
@@ -35,6 +35,7 @@ fn test_extract_names() {
                 ("Func1".into(), "Func1".into()),
                 ("Func2".into(), "Func2".into())
             ]),
+            annotations: Default::default(),
         }
     );
 }
@@ -68,6 +69,7 @@ fn test_populate_names() {
             (1.into(), "rename_gb".into()),
         ]),
         user_func_names: HashMap::from([(0.into(), "Func1".into()), (1.into(), "Func2".into())]),
+        annotations: Default::default(),
     }
     .populate(&mut program);
 

--- a/crates/cairo-lang-sierra/tests/format_test.rs
+++ b/crates/cairo-lang-sierra/tests/format_test.rs
@@ -1,4 +1,3 @@
-use cairo_lang_sierra::program::VersionedProgram;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 use test_log::test;
@@ -107,7 +106,7 @@ fn versioned_program_display_test() {
             "};
     assert_eq!(
         parser.parse(sierra_code).map(|p| p.to_string()),
-        Ok(VersionedProgram::from(parser.parse(sierra_code).unwrap()).to_string())
+        Ok(parser.parse(sierra_code).unwrap().into_artifact().to_string())
     );
 }
 

--- a/crates/cairo-lang-sierra/tests/serde_test.rs
+++ b/crates/cairo-lang-sierra/tests/serde_test.rs
@@ -34,11 +34,10 @@ fn get_path(file_name: &str, ext: &str) -> PathBuf {
 fn get_test_program_from_sierra(example_file_name: &str) -> VersionedProgram {
     let path = get_path(example_file_name, "sierra");
     let parser = cairo_lang_sierra::ProgramParser::new();
-    VersionedProgram::from(
-        parser
-            .parse(&std::fs::read_to_string(path).expect("Could not read example program."))
-            .expect("Could not parse example program."),
-    )
+    parser
+        .parse(&std::fs::read_to_string(path).expect("Could not read example program."))
+        .expect("Could not parse example program.")
+        .into_artifact()
 }
 
 // Parse code, serialize, and then deserialize it, ensuring the original parsed code is retained.


### PR DESCRIPTION
This field adds an ability to store non-crucial information about the program, for use by external libraries and tool.

See `Annotations` type docs for more information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4076)
<!-- Reviewable:end -->
