### PR TITLE
fix: ByteArrayAdd impl name

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -356,7 +356,7 @@ impl ByteArrayImpl of ByteArrayTrait {
     }
 }
 
-impl U128Add of Add<ByteArray> {
+impl ByteArrayAdd of Add<ByteArray> {
     #[inline]
     fn add(lhs: ByteArray, rhs: ByteArray) -> ByteArray {
         ByteArrayTrait::concat(@lhs, @rhs)


### PR DESCRIPTION
A tiny fix of an impl name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4077)
<!-- Reviewable:end -->
