### PR TITLE
Allow injecting vm to `SierraCasmRunner`

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -38,7 +38,7 @@ use {ark_secp256k1 as secp256k1, ark_secp256r1 as secp256r1};
 
 use self::dict_manager::DictSquashExecScope;
 use crate::short_string::as_cairo_short_string;
-use crate::{build_hints_dict, Arg, RunResultValue, SierraCasmRunner};
+use crate::{Arg, RunResultValue, SierraCasmRunner};
 
 #[cfg(test)]
 mod test;
@@ -1963,30 +1963,6 @@ pub struct RunFunctionContext<'a> {
 
 type RunFunctionRes = (Vec<Option<Felt252>>, usize);
 type RunFunctionResStarknet = (Vec<Option<Felt252>>, usize, StarknetState);
-
-/// Runs `program` on layout with prime, and returns the memory layout and ap value.
-/// Run used CairoHintProcessor and StarknetState to emulate Starknet behaviour.
-pub fn run_function_with_starknet_context<'a, 'b: 'a, Instructions>(
-    vm: &mut VirtualMachine,
-    instructions: Instructions,
-    builtins: Vec<BuiltinName>,
-    additional_initialization: fn(
-        context: RunFunctionContext<'_>,
-    ) -> Result<(), Box<CairoRunError>>,
-) -> Result<RunFunctionResStarknet, Box<CairoRunError>>
-where
-    Instructions: Iterator<Item = &'a Instruction> + Clone,
-{
-    let (hints_dict, string_to_hint) = build_hints_dict(instructions.clone());
-    let mut hint_processor = CairoHintProcessor {
-        runner: None,
-        string_to_hint,
-        starknet_state: StarknetState::default(),
-        run_resources: RunResources::default(),
-    };
-    run_function(vm, instructions, builtins, additional_initialization, &mut hint_processor, hints_dict)
-        .map(|(mem, val)| (mem, val, hint_processor.starknet_state))
-}
 
 /// Runs `program` on layout with prime, and returns the memory layout and ap value.
 /// Allows injecting custom HintProcessor.

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -582,7 +582,7 @@ impl<'a> MemBuffer<'a> {
 
     /// Writes an array into a new segment and writes the start and end pointers to the current
     /// position of the buffer. Advances the buffer by two.
-    pub fn write_arr<T: Into<MaybeRelocatable>, Data: Iterator<Item=T>>(
+    pub fn write_arr<T: Into<MaybeRelocatable>, Data: Iterator<Item = T>>(
         &mut self,
         data: Data,
     ) -> Result<(), MemoryError> {
@@ -1962,7 +1962,6 @@ pub struct RunFunctionContext<'a> {
 }
 
 type RunFunctionRes = (Vec<Option<Felt252>>, usize);
-type RunFunctionResStarknet = (Vec<Option<Felt252>>, usize, StarknetState);
 
 /// Runs `program` on layout with prime, and returns the memory layout and ap value.
 /// Allows injecting custom HintProcessor.

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -1,14 +1,14 @@
 use cairo_felt::Felt252;
-use cairo_vm::vm::runners::cairo_runner::RunResources;
-use cairo_vm::vm::vm_core::VirtualMachine;
 use cairo_lang_casm::inline::CasmContext;
 use cairo_lang_casm::{casm, deref};
+use cairo_vm::vm::runners::cairo_runner::RunResources;
+use cairo_vm::vm::vm_core::VirtualMachine;
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use test_case::test_case;
-use crate::{build_hints_dict, CairoHintProcessor, StarknetState};
 
 use crate::casm_run::run_function;
+use crate::{build_hints_dict, CairoHintProcessor, StarknetState};
 
 #[test_case(
     casm! {
@@ -112,9 +112,15 @@ fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
         run_resources: RunResources::default(),
     };
 
-    let (cells, ap) =
-        run_function(&mut VirtualMachine::new(true), function.instructions.iter(), vec![], |_| Ok(()), &mut hint_processor, hints_dict)
-            .expect("Running code failed.");
+    let (cells, ap) = run_function(
+        &mut VirtualMachine::new(true),
+        function.instructions.iter(),
+        vec![],
+        |_| Ok(()),
+        &mut hint_processor,
+        hints_dict,
+    )
+    .expect("Running code failed.");
     let cells = cells.into_iter().skip(ap - n_returns);
     assert_eq!(
         cells.take(n_returns).map(|cell| cell.unwrap()).collect_vec(),
@@ -125,11 +131,11 @@ fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
 #[test]
 fn test_allocate_segment() {
     let casm = casm! {
-            [ap] = 1337, ap++;
-            %{ memory[ap] = segments.add() %}
-            [ap - 1] = [[&deref!([ap])]];
-            ret;
-        };
+        [ap] = 1337, ap++;
+        %{ memory[ap] = segments.add() %}
+        [ap - 1] = [[&deref!([ap])]];
+        ret;
+    };
 
     let (hints_dict, string_to_hint) = build_hints_dict(casm.instructions.iter());
     let mut hint_processor = CairoHintProcessor {
@@ -139,7 +145,14 @@ fn test_allocate_segment() {
         run_resources: RunResources::default(),
     };
 
-    let (memory, ap) = run_function(&mut VirtualMachine::new(true), casm.instructions.iter() , vec![], |_| Ok(()), &mut hint_processor, hints_dict)
+    let (memory, ap) = run_function(
+        &mut VirtualMachine::new(true),
+        casm.instructions.iter(),
+        vec![],
+        |_| Ok(()),
+        &mut hint_processor,
+        hints_dict,
+    )
     .expect("Running code failed.");
     let ptr = memory[ap]
         .as_ref()

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -1,4 +1,5 @@
 use cairo_felt::Felt252;
+use cairo_vm::vm::vm_core::VirtualMachine;
 use cairo_lang_casm::inline::CasmContext;
 use cairo_lang_casm::{casm, deref};
 use itertools::Itertools;
@@ -102,7 +103,7 @@ use crate::casm_run::run_function_with_starknet_context;
 )]
 fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
     let (cells, ap, _) =
-        run_function_with_starknet_context(function.instructions.iter(), vec![], |_| Ok(()))
+        run_function_with_starknet_context(&mut VirtualMachine::new(true), function.instructions.iter(), vec![], |_| Ok(()))
             .expect("Running code failed.");
     let cells = cells.into_iter().skip(ap - n_returns);
     assert_eq!(
@@ -114,6 +115,7 @@ fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
 #[test]
 fn test_allocate_segment() {
     let (memory, ap, _) = run_function_with_starknet_context(
+        &mut VirtualMachine::new(true),
         casm! {
             [ap] = 1337, ap++;
             %{ memory[ap] = segments.add() %}


### PR DESCRIPTION
This PRs add an `run_function_with_vm` method to `SierraCasmRunner` that allows injecting a vm to be used for running. Previously, vm was deleted after each call to method so it was impossible to extract details about the run from it. This change is useful for Starknet Foundry.

Removed `casm_run::run_function_with_starknet_context`, because it was only used in tests - no external usages. This made more sense than updating the its' signature, but I'm open to any other approaches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4084)
<!-- Reviewable:end -->
