### PR TITLE
Removed redundant v0 in #[embeddable] attributes

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
@@ -4,7 +4,7 @@
 ExpandContractTestRunner(expect_diagnostics: false)
 
 //! > cairo_code
-#[starknet::embeddable(v0)]
+#[starknet::embeddable]
 #[generate_trait]
 impl OutsideImpl<TContractState> of OutsideTrait<TContractState> {
     #[external]
@@ -29,7 +29,7 @@ mod empty_contract {
 //! > generated_cairo_code
 lib.cairo:
 
-#[starknet::embeddable(v0)]
+#[starknet::embeddable]
 #[generate_trait]
 impl OutsideImpl<TContractState> of OutsideTrait<TContractState> {
     #[external]

--- a/crates/cairo-lang-starknet/test_data/test_contract.cairo
+++ b/crates/cairo-lang-starknet/test_data/test_contract.cairo
@@ -7,7 +7,7 @@ trait IAnotherContract<T> {
 trait OutsideTrait<TContractState> {
     fn ret_3(self: @TContractState) -> felt252;
 }
-#[starknet::embeddable(v0)]
+#[starknet::embeddable]
 impl OutsideImpl<TContractState, +Drop<TContractState>> of OutsideTrait<TContractState> {
     #[external]
     fn ret_3(self: @TContractState) -> felt252 {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4102)
<!-- Reviewable:end -->
