### PR TITLE
feat: Storage{Base}Address impls

### DIFF
--- a/corelib/src/starknet/storage_access.cairo
+++ b/corelib/src/starknet/storage_access.cairo
@@ -42,9 +42,23 @@ impl StorageAddressIntoFelt252 of Into<StorageAddress, felt252> {
     }
 }
 
+impl StorageAddressIntoU256 of Into<StorageAddress, u256> {
+    fn into(self: StorageAddress) -> u256 {
+        let self: felt252 = self.into();
+        self.into()
+    }
+}
+
 impl StorageBaseAddressIntoFelt252 of Into<StorageBaseAddress, felt252> {
     fn into(self: StorageBaseAddress) -> felt252 {
         storage_address_from_base(self).into()
+    }
+}
+
+impl StorageBaseAddressIntoU256 of Into<StorageBaseAddress, u256> {
+    fn into(self: StorageBaseAddress) -> u256 {
+        let self: felt252 = self.into();
+        self.into()
     }
 }
 

--- a/corelib/src/starknet/storage_access.cairo
+++ b/corelib/src/starknet/storage_access.cairo
@@ -64,7 +64,9 @@ impl StorageBaseAddressIntoU256 of Into<StorageBaseAddress, u256> {
 
 impl StorageAddressPartialEq of PartialEq<StorageAddress> {
     fn eq(lhs: @StorageAddress, rhs: @StorageAddress) -> bool {
-        *lhs.into() == *rhs.into()
+        let lhs: felt252 = (*lhs).into();
+        let rhs: felt252 = (*rhs).into();
+        lhs == rhs
     }
     fn ne(lhs: @StorageAddress, rhs: @StorageAddress) -> bool {
         !(*lhs == *rhs)
@@ -73,7 +75,9 @@ impl StorageAddressPartialEq of PartialEq<StorageAddress> {
 
 impl StorageBaseAddressPartialEq of PartialEq<StorageBaseAddress> {
     fn eq(lhs: @StorageBaseAddress, rhs: @StorageBaseAddress) -> bool {
-        *lhs.into() == *rhs.into()
+        let lhs: felt252 = (*lhs).into();
+        let rhs: felt252 = (*rhs).into();
+        lhs == rhs
     }
     fn ne(lhs: @StorageBaseAddress, rhs: @StorageBaseAddress) -> bool {
         !(*lhs == *rhs)

--- a/corelib/src/starknet/storage_access.cairo
+++ b/corelib/src/starknet/storage_access.cairo
@@ -48,6 +48,24 @@ impl StorageBaseAddressIntoFelt252 of Into<StorageBaseAddress, felt252> {
     }
 }
 
+impl StorageAddressPartialEq of PartialEq<StorageAddress> {
+    fn eq(lhs: @StorageAddress, rhs: @StorageAddress) -> bool {
+        *lhs.into() == *rhs.into()
+    }
+    fn ne(lhs: @StorageAddress, rhs: @StorageAddress) -> bool {
+        !(*lhs == *rhs)
+    }
+}
+
+impl StorageBaseAddressPartialEq of PartialEq<StorageBaseAddress> {
+    fn eq(lhs: @StorageBaseAddress, rhs: @StorageBaseAddress) -> bool {
+        *lhs.into() == *rhs.into()
+    }
+    fn ne(lhs: @StorageBaseAddress, rhs: @StorageBaseAddress) -> bool {
+        !(*lhs == *rhs)
+    }
+}
+
 impl StorageAddressSerde of serde::Serde<StorageAddress> {
     fn serialize(self: @StorageAddress, ref output: Array<felt252>) {
         storage_address_to_felt252(*self).serialize(ref output);

--- a/corelib/src/starknet/storage_access.cairo
+++ b/corelib/src/starknet/storage_access.cairo
@@ -42,6 +42,12 @@ impl StorageAddressIntoFelt252 of Into<StorageAddress, felt252> {
     }
 }
 
+impl StorageBaseAddressIntoFelt252 of Into<StorageBaseAddress, felt252> {
+    fn into(self: StorageBaseAddress) -> felt252 {
+        storage_address_from_base(self).into()
+    }
+}
+
 impl StorageAddressSerde of serde::Serde<StorageAddress> {
     fn serialize(self: @StorageAddress, ref output: Array<felt252>) {
         storage_address_to_felt252(*self).serialize(ref output);

--- a/corelib/src/test/cmp_test.cairo
+++ b/corelib/src/test/cmp_test.cairo
@@ -283,3 +283,37 @@ fn test_max_foo() {
     assert_eq(@max(a, a).val, @a.val, 'a == a');
     assert_eq(@max(b, b).val, @b.val, 'b == b');
 }
+
+// StorageAddress and StorageBaseAddress
+
+use starknet::{storage_address_try_from_felt252, storage_base_address_from_felt252};
+
+#[test]
+#[available_gas(200000)]
+fn test_eq_storage_address() {
+    let val_1 = storage_address_try_from_felt252(0x01).unwrap();
+    assert_eq(@val_1, @val_1, 'expected equality')
+}
+
+#[test]
+fn test_ne_storage_address() {
+    let val_1 = storage_address_try_from_felt252(0x01).unwrap();
+    let val_2 = storage_address_try_from_felt252(0x02).unwrap();
+
+    assert_ne(@val_1, @val_2, 'expected inequality')
+}
+
+#[test]
+fn test_eq_storage_base_address() {
+    let val_1 = storage_base_address_from_felt252(0x01);
+
+    assert_eq(@val_1, @val_1, 'expected equality')
+}
+
+#[test]
+fn test_ne_storage_base_address() {
+    let val_1 = storage_base_address_from_felt252(0x01);
+    let val_2 = storage_base_address_from_felt252(0x02);
+
+    assert_ne(@val_1, @val_2, 'expected inequality')
+}

--- a/crates/cairo-lang-starknet/cairo_level_tests/storage_access.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/storage_access.cairo
@@ -6,15 +6,6 @@ use test::test_utils::assert_eq;
 use super::utils::serialized;
 use integer::BoundedInt;
 
-impl StorageAddressPartialEq of PartialEq<StorageAddress> {
-    fn eq(lhs: @StorageAddress, rhs: @StorageAddress) -> bool {
-        storage_address_to_felt252(*lhs) == storage_address_to_felt252(*rhs)
-    }
-    fn ne(lhs: @StorageAddress, rhs: @StorageAddress) -> bool {
-        !(storage_address_to_felt252(*lhs) == storage_address_to_felt252(*rhs))
-    }
-}
-
 #[derive(Drop, Serde, PartialEq, Copy, starknet::Store)]
 struct Abc {
     a: u8,


### PR DESCRIPTION
- Implements the `Into` trait to convert a `Storage{Base}Address` into a `felt252`
- Implements the `Into` trait to convert a `Storage{Base}Address` into a `u256` 
- Implements `PartialEq` trait to allow comparison of `StorageBaseAddress` and `StorageAddress`

Resolves #4195
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4194)
<!-- Reviewable:end -->
