### PR TITLE
Feature suggestion to apply into() on non-optional and optional values

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -63,5 +63,5 @@ impl IntoOptionImpl<T> of Into<T, Option<T>> {
     #[inline]
     fn into(self: T) -> Option<T> {
         Option::<T>::Some(self)
-    } 
+    }
 }

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -74,9 +74,9 @@ impl IntoOptionFromOptionImpl<T, S, +Into<T, S>> of Into<Option<T>, Option<S>> {
         }
     }
 }
-impl TryIntoOptionFromOptionImpl<T, S, +TryInto<T, S>> of Into<Option<T>, Option<S>> {
+impl TryIntoOptionFromOptionImpl<T, S, +TryInto<T, S>> of TryInto<Option<T>, S> {
     #[inline]
-    fn into(self: Option<T>) -> Option<S> {
+    fn try_into(self: Option<T>) -> Option<S> {
         match self {
             Option::Some(t) => t.try_into(),
             Option::None => Option::None,

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -1,6 +1,7 @@
 use array::ArrayTrait;
 use serde::Serde;
 use array::SpanTrait;
+use traits::TryInto;
 
 #[derive(Copy, Drop, Serde, PartialEq)]
 enum Option<T> {
@@ -63,5 +64,23 @@ impl IntoOptionImpl<T> of Into<T, Option<T>> {
     #[inline]
     fn into(self: T) -> Option<T> {
         Option::<T>::Some(self)
+    }
+}
+impl IntoOptionFromOptionImpl<T, S, +Into<T, S>> of Into<Option<T>, Option<S>> {
+    #[inline]
+    fn into(self: Option<T>) -> Option<S> {
+        match self {
+            Option::Some(t) => Option::Some(t.into()),
+            Option::None => Option::None,
+        }
+    }
+}
+impl TryIntoOptionFromOptionImpl<T, S, +TryInto<T, S>> of Into<Option<T>, Option<S>> {
+    #[inline]
+    fn into(self: Option<T>) -> Option<S> {
+        match self {
+            Option::Some(t) => t.try_into(),
+            Option::None => Option::None,
+        }
     }
 }

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -1,7 +1,6 @@
 use array::ArrayTrait;
 use serde::Serde;
 use array::SpanTrait;
-use traits::TryInto;
 
 #[derive(Copy, Drop, Serde, PartialEq)]
 enum Option<T> {

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -59,3 +59,9 @@ impl OptionTraitImpl<T> of OptionTrait<T> {
         }
     }
 }
+impl IntoOptionImpl<T> of Into<T, Option<T>> {
+    #[inline]
+    fn into(self: T) -> Option<T> {
+        Option::<T>::Some(self)
+    } 
+}


### PR DESCRIPTION
This is a minimal feature request/suggestion to lessen the boilerplate of dealing with optionals. Consider this convoluted example
```
fn foo() -> Optional<bool> {
  some_optional_call()?.into()
}
```
instead of requiring the manual constructor `Optional::Some(some_optional_call()?)`, which to me loses some clarity of expression.

It broadens the use of `.into()` to either wrap a non-optional value into its expected optional result or, in the case where there is a clear type conversion such as an upcast (into) or downcast (try_into) between optional types, those cases can be considered as well.

Maybe the scope of `into()` is inappropriate for the suggested behavior here. In some languages, perhaps the more natural applications of dealing with optional type conversion is through (functor) maps.

N.b. that a type conversion between `Optional<A>` to `Optional<B>` where there exists `TryInto<A, B>`, is possible with an `.into()` as opposed to a `.try_into()` as well, but semantically it may cause more harm than good. Consider this in contrast to what was committed in the PR
```
impl TryIntoOptionFromOptionImpl<T, S, +TryInto<T, S>> of Into<Option<T>, Option<S>> {
    #[inline]
    fn into(self: Option<T>) -> Option<S> {
        match self {
            Option::Some(t) => t.try_into(),
            Option::None => Option::None,
        }
    }
}
```
