### PR TITLE
Serialize sierra version to int not string

### DIFF
--- a/crates/cairo-lang-sierra/src/program.rs
+++ b/crates/cairo-lang-sierra/src/program.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use anyhow::Result;
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::debug_info::DebugInfo;
 use crate::extensions::gas::{
@@ -18,22 +19,57 @@ use crate::ids::{
 ///
 /// Always prefer using this struct as saved artifacts instead of inner ones.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "version")]
+#[serde(untagged)]
 pub enum VersionedProgram {
-    #[serde(rename = "1")]
-    V1(ProgramArtifact),
+    V1 {
+        version: Version<1>,
+        #[serde(flatten)]
+        program: ProgramArtifact,
+    },
+}
+
+impl VersionedProgram {
+    pub fn v1(program: ProgramArtifact) -> Self {
+        Self::V1 { program, version: Version::<1> }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Version<const V: u8>;
+
+#[derive(Debug, Error)]
+#[error("Unsupported Sierra program version")]
+struct VersionError;
+
+impl<const V: u8> Serialize for Version<V> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u8(V)
+    }
+}
+
+impl<'de, const V: u8> Deserialize<'de> for Version<V> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u8::deserialize(deserializer)?;
+        if value == V { Ok(Version::<V>) } else { Err(serde::de::Error::custom(VersionError)) }
+    }
 }
 
 impl From<ProgramArtifact> for VersionedProgram {
     fn from(value: ProgramArtifact) -> Self {
-        VersionedProgram::V1(value)
+        VersionedProgram::v1(value)
     }
 }
 
 impl VersionedProgram {
     pub fn into_v1(self) -> Result<ProgramArtifact> {
         match self {
-            VersionedProgram::V1(program) => Ok(program),
+            VersionedProgram::V1 { program, .. } => Ok(program),
         }
     }
 }
@@ -41,7 +77,7 @@ impl VersionedProgram {
 impl fmt::Display for VersionedProgram {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            VersionedProgram::V1(program) => fmt::Display::fmt(program, f),
+            VersionedProgram::V1 { program, .. } => fmt::Display::fmt(program, f),
         }
     }
 }
@@ -96,7 +132,7 @@ impl Program {
 
     /// Create a new [`ProgramArtifact`] out of this [`Program`].
     pub fn into_artifact(self) -> VersionedProgram {
-        VersionedProgram::V1(ProgramArtifact::stripped(self))
+        ProgramArtifact::stripped(self).into()
     }
 }
 

--- a/crates/cairo-lang-sierra/src/test_data/fib_jumps
+++ b/crates/cairo-lang-sierra/src/test_data/fib_jumps
@@ -5,7 +5,7 @@ test_sierra_serde_json
 
 //! > pretty_json
 {
-  "version": "1",
+  "version": 1,
   "type_declarations": [
     {
       "id": {

--- a/crates/cairo-lang-sierra/src/test_data/fib_no_gas
+++ b/crates/cairo-lang-sierra/src/test_data/fib_no_gas
@@ -5,7 +5,7 @@ test_sierra_serde_json
 
 //! > pretty_json
 {
-  "version": "1",
+  "version": 1,
   "type_declarations": [
     {
       "id": {


### PR DESCRIPTION
Serialize sierra version field to int instead of string (i.e. `version = 1` instead of `version = "1"`. 
For context on serde side see: https://github.com/serde-rs/serde/issues/745


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4252)
<!-- Reviewable:end -->
