### PR TITLE
feat: store bytes31

### DIFF
--- a/corelib/src/starknet/storage_access.cairo
+++ b/corelib/src/starknet/storage_access.cairo
@@ -420,6 +420,40 @@ impl StoreClassHash of Store<ClassHash> {
     }
 }
 
+impl StoreBytes31 of Store<bytes31> {
+    fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<bytes31> {
+        Result::Ok(
+            Store::<felt252>::read(address_domain, base)?
+                .try_into()
+                .expect('StoreBytes31 - non bytes31')
+        )
+    }
+    #[inline(always)]
+    fn write(address_domain: u32, base: StorageBaseAddress, value: bytes31) -> SyscallResult<()> {
+        Store::<felt252>::write(address_domain, base, value.into())
+    }
+    #[inline(always)]
+    fn read_at_offset(
+        address_domain: u32, base: StorageBaseAddress, offset: u8
+    ) -> SyscallResult<bytes31> {
+        Result::Ok(
+            Store::<felt252>::read_at_offset(address_domain, base, offset)?
+                .try_into()
+                .expect('StoreBytes31 - non bytes31')
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(
+        address_domain: u32, base: StorageBaseAddress, offset: u8, value: bytes31
+    ) -> SyscallResult<()> {
+        Store::<felt252>::write_at_offset(address_domain, base, offset, value.into())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        1_u8
+    }
+}
+
 impl TupleSize0Store of Store<()> {
     #[inline(always)]
     fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<()> {


### PR DESCRIPTION
Resolves #4256

- Implements the `Store` trait for the `bytes31` type by using conversion from/to `felt252`

I was thinking that all these impls could be refactored into a single generic impl, similar to what is done for Serde. What do you think? The only downside is the lack of custom error messages for each type.

```rust
mod into_felt252_based {
    use traits::{Into, TryInto};
    use core::array::ArrayTrait;
    impl SerdeImpl<T, +Copy<T>, +Into<T, felt252>, +TryInto<felt252, T>> of super::Serde<T> {
        #[inline(always)]
        fn serialize(self: @T, ref output: Array<felt252>) {
            output.append((*self).into());
        }
        #[inline(always)]
        fn deserialize(ref serialized: Span<felt252>) -> Option<T> {
            Option::Some((*serialized.pop_front()?).try_into()?)
        }
    }
}

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4283)
<!-- Reviewable:end -->
