### PR TITLE
Add `get_starknet_inline_macro_plugins` and `RootDatabaseBuilder::with_inline_macro_plugins`

### DIFF
--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -107,6 +107,16 @@ impl RootDatabaseBuilder {
         self
     }
 
+    pub fn with_inline_macro_plugins(
+        &mut self,
+        plugins: impl IntoIterator<Item = (impl AsRef<str>, Arc<dyn InlineMacroExprPlugin>)>,
+    ) -> &mut Self {
+        for (name, plugin) in plugins {
+            self.with_inline_macro_plugin(name.as_ref(), plugin);
+        }
+        self
+    }
+
     pub fn clear_plugins(&mut self) -> &mut Self {
         self.plugins.clear();
         self

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -38,10 +38,7 @@ use cairo_lang_semantic::items::imp::ImplId;
 use cairo_lang_semantic::items::us::get_use_segments;
 use cairo_lang_semantic::resolve::{AsSegments, ResolvedConcreteItem, ResolvedGenericItem};
 use cairo_lang_semantic::{SemanticDiagnostic, TypeLongId};
-use cairo_lang_starknet::inline_macros::get_dep_component::{
-    GetDepComponentMacro, GetDepComponentMutMacro,
-};
-use cairo_lang_starknet::inline_macros::selector::SelectorMacro;
+use cairo_lang_starknet::inline_macros::get_starknet_inline_macro_plugins;
 use cairo_lang_starknet::plugin::StarkNetPlugin;
 use cairo_lang_syntax::node::ast::PathSegment;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -88,9 +85,7 @@ pub async fn serve_language_service() {
         .with_cfg(CfgSet::from_iter([Cfg::name("test")]))
         .with_macro_plugin(Arc::new(StarkNetPlugin::default()))
         .with_macro_plugin(Arc::new(TestPlugin::default()))
-        .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro))
-        .with_inline_macro_plugin(GetDepComponentMacro::NAME, Arc::new(GetDepComponentMacro))
-        .with_inline_macro_plugin(GetDepComponentMutMacro::NAME, Arc::new(GetDepComponentMutMacro))
+        .with_inline_macro_plugins(get_starknet_inline_macro_plugins())
         .build()
         .expect("Failed to initialize Cairo compiler database.");
 

--- a/crates/cairo-lang-starknet/src/abi_test.rs
+++ b/crates/cairo-lang-starknet/src/abi_test.rs
@@ -9,8 +9,7 @@ use cairo_lang_test_utils::{get_direct_or_file_content, verify_diagnostics_expec
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 
 use crate::abi::AbiBuilder;
-use crate::inline_macros::get_dep_component::{GetDepComponentMacro, GetDepComponentMutMacro};
-use crate::inline_macros::selector::SelectorMacro;
+use crate::inline_macros::get_starknet_inline_macro_plugins;
 use crate::plugin::StarkNetPlugin;
 
 /// Helper function for testing ABI failures.
@@ -21,9 +20,7 @@ pub fn test_abi_failure(
     let db = &mut RootDatabase::builder()
         .detect_corelib()
         .with_macro_plugin(Arc::new(StarkNetPlugin::default()))
-        .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro))
-        .with_inline_macro_plugin(GetDepComponentMacro::NAME, Arc::new(GetDepComponentMacro))
-        .with_inline_macro_plugin(GetDepComponentMutMacro::NAME, Arc::new(GetDepComponentMutMacro))
+        .with_inline_macro_plugins(get_starknet_inline_macro_plugins())
         .build()
         .unwrap();
     let (_, cairo_code) = get_direct_or_file_content(&inputs["cairo_code"]);

--- a/crates/cairo-lang-starknet/src/contract_class.rs
+++ b/crates/cairo-lang-starknet/src/contract_class.rs
@@ -31,8 +31,7 @@ use crate::contract::{
     ContractDeclaration,
 };
 use crate::felt252_serde::{sierra_from_felt252s, sierra_to_felt252s, Felt252SerdeError};
-use crate::inline_macros::get_dep_component::{GetDepComponentMacro, GetDepComponentMutMacro};
-use crate::inline_macros::selector::SelectorMacro;
+use crate::inline_macros::get_starknet_inline_macro_plugins;
 use crate::plugin::consts::{CONSTRUCTOR_MODULE, EXTERNAL_MODULE, L1_HANDLER_MODULE};
 use crate::plugin::StarkNetPlugin;
 
@@ -112,9 +111,7 @@ pub fn compile_path(
     let mut db = RootDatabase::builder()
         .detect_corelib()
         .with_macro_plugin(Arc::new(StarkNetPlugin::default()))
-        .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro))
-        .with_inline_macro_plugin(GetDepComponentMacro::NAME, Arc::new(GetDepComponentMacro))
-        .with_inline_macro_plugin(GetDepComponentMutMacro::NAME, Arc::new(GetDepComponentMutMacro))
+        .with_inline_macro_plugins(get_starknet_inline_macro_plugins())
         .build()?;
 
     let main_crate_ids = setup_project(&mut db, Path::new(&path))?;

--- a/crates/cairo-lang-starknet/src/inline_macros/mod.rs
+++ b/crates/cairo-lang-starknet/src/inline_macros/mod.rs
@@ -1,2 +1,20 @@
+use std::sync::Arc;
+
+use cairo_lang_defs::plugin::InlineMacroExprPlugin;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use selector::SelectorMacro;
+
+use crate::inline_macros::get_dep_component::{GetDepComponentMacro, GetDepComponentMutMacro};
+
 pub mod get_dep_component;
 pub mod selector;
+
+/// Gets the default plugins to load into the Cairo compiler in Starknet context.
+pub fn get_starknet_inline_macro_plugins() -> OrderedHashMap<String, Arc<dyn InlineMacroExprPlugin>>
+{
+    let mut res = OrderedHashMap::<String, Arc<dyn InlineMacroExprPlugin>>::default();
+    res.insert(SelectorMacro::NAME.into(), Arc::new(SelectorMacro));
+    res.insert(GetDepComponentMacro::NAME.into(), Arc::new(GetDepComponentMacro));
+    res.insert(GetDepComponentMutMacro::NAME.into(), Arc::new(GetDepComponentMutMacro));
+    res
+}

--- a/crates/cairo-lang-starknet/src/test_utils.rs
+++ b/crates/cairo-lang-starknet/src/test_utils.rs
@@ -13,8 +13,7 @@ use once_cell::sync::Lazy;
 
 use crate::allowed_libfuncs::BUILTIN_ALL_LIBFUNCS_LIST;
 use crate::contract_class::compile_contract_in_prepared_db;
-use crate::inline_macros::get_dep_component::{GetDepComponentMacro, GetDepComponentMutMacro};
-use crate::inline_macros::selector::SelectorMacro;
+use crate::inline_macros::get_starknet_inline_macro_plugins;
 use crate::plugin::StarkNetPlugin;
 
 /// Returns a path to example contract that matches `name`.
@@ -31,12 +30,7 @@ pub static SHARED_DB: Lazy<Mutex<RootDatabase>> = Lazy::new(|| {
         RootDatabase::builder()
             .detect_corelib()
             .with_macro_plugin(Arc::new(StarkNetPlugin::default()))
-            .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro))
-            .with_inline_macro_plugin(GetDepComponentMacro::NAME, Arc::new(GetDepComponentMacro))
-            .with_inline_macro_plugin(
-                GetDepComponentMutMacro::NAME,
-                Arc::new(GetDepComponentMutMacro),
-            )
+            .with_inline_macro_plugins(get_starknet_inline_macro_plugins())
             .build()
             .unwrap(),
     )
@@ -55,12 +49,7 @@ pub static SHARED_DB_WITH_CONTRACTS: Lazy<Mutex<RootDatabase>> = Lazy::new(|| {
                 ProjectConfig::from_directory(Path::new(CONTRACTS_CRATE_DIR)).unwrap(),
             )
             .with_macro_plugin(Arc::new(StarkNetPlugin::default()))
-            .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro))
-            .with_inline_macro_plugin(GetDepComponentMacro::NAME, Arc::new(GetDepComponentMacro))
-            .with_inline_macro_plugin(
-                GetDepComponentMutMacro::NAME,
-                Arc::new(GetDepComponentMutMacro),
-            )
+            .with_inline_macro_plugins(get_starknet_inline_macro_plugins())
             .build()
             .unwrap(),
     )

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -16,10 +16,7 @@ use cairo_lang_sierra::ids::FunctionId;
 use cairo_lang_sierra::program::Program;
 use cairo_lang_sierra_to_casm::metadata::MetadataComputationConfig;
 use cairo_lang_starknet::contract::ContractInfo;
-use cairo_lang_starknet::inline_macros::get_dep_component::{
-    GetDepComponentMacro, GetDepComponentMutMacro,
-};
-use cairo_lang_starknet::inline_macros::selector::SelectorMacro;
+use cairo_lang_starknet::inline_macros::get_starknet_inline_macro_plugins;
 use cairo_lang_starknet::plugin::StarkNetPlugin;
 use cairo_lang_test_plugin::test_config::{PanicExpectation, TestExpectation};
 use cairo_lang_test_plugin::{compile_test_prepared_db, TestCompilation, TestConfig, TestPlugin};
@@ -221,15 +218,7 @@ impl TestCompiler {
 
             if starknet {
                 b.with_macro_plugin(Arc::new(StarkNetPlugin::default()))
-                    .with_inline_macro_plugin(SelectorMacro::NAME, Arc::new(SelectorMacro))
-                    .with_inline_macro_plugin(
-                        GetDepComponentMacro::NAME,
-                        Arc::new(GetDepComponentMacro),
-                    )
-                    .with_inline_macro_plugin(
-                        GetDepComponentMutMacro::NAME,
-                        Arc::new(GetDepComponentMutMacro),
-                    );
+                    .with_inline_macro_plugins(get_starknet_inline_macro_plugins());
             }
 
             b.build()?


### PR DESCRIPTION
Add centralized source of information about Starknet-relevant plugins, instead of smearing this list everywhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4313)
<!-- Reviewable:end -->
