### PR TITLE
Remove redundent diagnostics for inline macros.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -291,14 +291,17 @@ fn compute_expr_inline_macro_semantic(
     };
 
     let result = macro_plugin.generate_code(syntax_db, syntax);
+    let mut diag_added = None;
     for diagnostic in result.diagnostics {
-        ctx.diagnostics.report_by_ptr(diagnostic.stable_ptr, PluginDiagnostic(diagnostic));
+        diag_added = Some(
+            ctx.diagnostics.report_by_ptr(diagnostic.stable_ptr, PluginDiagnostic(diagnostic)),
+        );
     }
 
     let Some(code) = result.code else {
-        return Err(ctx
-            .diagnostics
-            .report(syntax, InlineMacroFailed { macro_name: macro_name.into() }));
+        return Err(diag_added.unwrap_or_else(|| {
+            ctx.diagnostics.report(syntax, InlineMacroFailed { macro_name: macro_name.into() })
+        }));
     };
 
     // Create a file

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -37,11 +37,6 @@ error: Plugin diagnostic: Unsupported expression in consteval_int macro
 const a: felt252 = consteval_int!(func_call(24));
                                   ^***********^
 
-error: Inline macro `consteval_int` failed.
- --> lib.cairo:1:20
-const a: felt252 = consteval_int!(func_call(24));
-                   ^***************************^
-
 error: Only literal constants are currently supported.
  --> lib.cairo:1:20
 const a: felt252 = consteval_int!(func_call(24));
@@ -51,11 +46,6 @@ error: Plugin diagnostic: Unsupported expression in consteval_int macro
  --> lib.cairo:3:35
 const b: felt252 = consteval_int!('some string');
                                   ^***********^
-
-error: Inline macro `consteval_int` failed.
- --> lib.cairo:3:20
-const b: felt252 = consteval_int!('some string');
-                   ^***************************^
 
 error: Only literal constants are currently supported.
  --> lib.cairo:3:20
@@ -67,11 +57,6 @@ error: Plugin diagnostic: Unsupported unary operator in consteval_int macro
 const c: felt252 = consteval_int!(*24);
                                   ^*^
 
-error: Inline macro `consteval_int` failed.
- --> lib.cairo:5:20
-const c: felt252 = consteval_int!(*24);
-                   ^*****************^
-
 error: Only literal constants are currently supported.
  --> lib.cairo:5:20
 const c: felt252 = consteval_int!(*24);
@@ -81,11 +66,6 @@ error: Plugin diagnostic: Unsupported unary operator in consteval_int macro
  --> lib.cairo:7:35
 const d: felt252 = consteval_int!(~24);
                                   ^*^
-
-error: Inline macro `consteval_int` failed.
- --> lib.cairo:7:20
-const d: felt252 = consteval_int!(~24);
-                   ^*****************^
 
 error: Only literal constants are currently supported.
  --> lib.cairo:7:20
@@ -97,11 +77,6 @@ error: Plugin diagnostic: Unsupported binary operator in consteval_int macro
 const e: felt252 = consteval_int!(234 < 5);
                                   ^*****^
 
-error: Inline macro `consteval_int` failed.
- --> lib.cairo:9:20
-const e: felt252 = consteval_int!(234 < 5);
-                   ^*********************^
-
 error: Only literal constants are currently supported.
  --> lib.cairo:9:20
 const e: felt252 = consteval_int!(234 < 5);
@@ -112,11 +87,6 @@ error: Plugin diagnostic: Macro `consteval_int` does not support this bracket ty
 const e: felt252 = consteval_int![4 + 5];
                                  ^
 
-error: Inline macro `consteval_int` failed.
- --> lib.cairo:11:20
-const e: felt252 = consteval_int![4 + 5];
-                   ^*******************^
-
 error: Only literal constants are currently supported.
  --> lib.cairo:11:20
 const e: felt252 = consteval_int![4 + 5];
@@ -126,11 +96,6 @@ error: Plugin diagnostic: Macro `consteval_int` does not support this bracket ty
  --> lib.cairo:13:34
 const f: felt252 = consteval_int!{4 + 5};
                                  ^
-
-error: Inline macro `consteval_int` failed.
- --> lib.cairo:13:20
-const f: felt252 = consteval_int!{4 + 5};
-                   ^*******************^
 
 error: Only literal constants are currently supported.
  --> lib.cairo:13:20
@@ -165,11 +130,6 @@ error: Plugin diagnostic: Macro `array` does not support this bracket type.
  --> lib.cairo:2:19
     let x = array!(0);
                   ^
-
-error: Inline macro `array` failed.
- --> lib.cairo:2:13
-    let x = array!(0);
-            ^*******^
 
 error: Plugin diagnostic: Unexpected argument type. Expected: "core::felt252", found: "core::integer::u8".
  --> lib.cairo:3:31
@@ -211,37 +171,17 @@ error: Plugin diagnostic: Macro `format` does not support this bracket type.
    format!["{}", ba];
           ^
 
-error: Inline macro `format` failed.
- --> lib.cairo:5:4
-   format!["{}", ba];
-   ^***************^
-
 error: Plugin diagnostic: Macro `format` must have exactly 2 unnamed arguments.
  --> lib.cairo:8:4
    format!(ba);
    ^*********^
 
-error: Inline macro `format` failed.
- --> lib.cairo:8:4
-   format!(ba);
-   ^*********^
-
 error: Plugin diagnostic: Macro `format` must have exactly 2 unnamed arguments.
- --> lib.cairo:11:4
-   format!("{}", ba, 1);
-   ^******************^
-
-error: Inline macro `format` failed.
  --> lib.cairo:11:4
    format!("{}", ba, 1);
    ^******************^
 
 error: Plugin diagnostic: Currently `format` macro only supports `"{}"` as the first argument (format string).
- --> lib.cairo:14:4
-   format!("{}{}", ba);
-   ^*****************^
-
-error: Inline macro `format` failed.
  --> lib.cairo:14:4
    format!("{}{}", ba);
    ^*****************^
@@ -281,37 +221,17 @@ error: Plugin diagnostic: Macro `print` does not support this bracket type.
    print!["{}", ba];
          ^
 
-error: Inline macro `print` failed.
- --> lib.cairo:5:4
-   print!["{}", ba];
-   ^**************^
-
 error: Plugin diagnostic: Macro `print` must have exactly 2 unnamed arguments.
  --> lib.cairo:8:4
    print!(ba);
    ^********^
 
-error: Inline macro `print` failed.
- --> lib.cairo:8:4
-   print!(ba);
-   ^********^
-
 error: Plugin diagnostic: Macro `print` must have exactly 2 unnamed arguments.
- --> lib.cairo:11:4
-   print!("{}", ba, 1);
-   ^*****************^
-
-error: Inline macro `print` failed.
  --> lib.cairo:11:4
    print!("{}", ba, 1);
    ^*****************^
 
 error: Plugin diagnostic: Currently, the `print` macro only supports `"{}"` as the first argument (format string).
- --> lib.cairo:14:4
-   print!("{}{}", ba);
-   ^****************^
-
-error: Inline macro `print` failed.
  --> lib.cairo:14:4
    print!("{}{}", ba);
    ^****************^
@@ -351,37 +271,17 @@ error: Plugin diagnostic: Macro `println` does not support this bracket type.
    println!["{}", ba];
            ^
 
-error: Inline macro `println` failed.
- --> lib.cairo:5:4
-   println!["{}", ba];
-   ^****************^
-
 error: Plugin diagnostic: Macro `println` must have exactly 2 unnamed arguments.
  --> lib.cairo:8:4
    println!(ba);
    ^**********^
 
-error: Inline macro `println` failed.
- --> lib.cairo:8:4
-   println!(ba);
-   ^**********^
-
 error: Plugin diagnostic: Macro `println` must have exactly 2 unnamed arguments.
- --> lib.cairo:11:4
-   println!("{}", ba, 1);
-   ^*******************^
-
-error: Inline macro `println` failed.
  --> lib.cairo:11:4
    println!("{}", ba, 1);
    ^*******************^
 
 error: Plugin diagnostic: Currently, the `println` macro only supports `"{}"` as the first argument (format string).
- --> lib.cairo:14:4
-   println!("{}{}", ba);
-   ^******************^
-
-error: Inline macro `println` failed.
  --> lib.cairo:14:4
    println!("{}{}", ba);
    ^******************^

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -6378,11 +6378,6 @@ error: Plugin diagnostic: The first argument of `get_dep_component_mut` macro mu
             get_dep_component_mut!(Comp1, self).foo1();
                                    ^***^
 
-error: Inline macro `get_dep_component_mut` failed.
- --> lib.cairo:53:13
-            get_dep_component_mut!(Comp1, self).foo1();
-            ^*********************************^
-
 error: Plugin diagnostic: Identifier not found.
  --> lib.cairo:54:46
             get_dep_component_mut!(ref self, self).foo1();
@@ -6408,40 +6403,20 @@ error: Plugin diagnostic: The first argument of `get_dep_component_mut` macro mu
             get_dep_component_mut!(self, Comp1).foo1();
                                    ^**^
 
-error: Inline macro `get_dep_component_mut` failed.
- --> lib.cairo:57:13
-            get_dep_component_mut!(self, Comp1).foo1();
-            ^*********************************^
-
 error: Plugin diagnostic: The first argument of `get_dep_component_mut` macro must have only a `ref` modifier.
  --> lib.cairo:58:40
             get_dep_component_mut!(mut self, Comp1).foo1();
                                        ^**^
-
-error: Inline macro `get_dep_component_mut` failed.
- --> lib.cairo:58:13
-            get_dep_component_mut!(mut self, Comp1).foo1();
-            ^*************************************^
 
 error: Plugin diagnostic: The first argument of `get_dep_component_mut` macro must have only a `ref` modifier.
  --> lib.cairo:59:44
             get_dep_component_mut!(ref ref self, Comp1).foo1();
                                            ^**^
 
-error: Inline macro `get_dep_component_mut` failed.
- --> lib.cairo:59:13
-            get_dep_component_mut!(ref ref self, Comp1).foo1();
-            ^*****************************************^
-
 error: Plugin diagnostic: The first argument of `get_dep_component_mut` macro must have only a `ref` modifier.
  --> lib.cairo:60:44
             get_dep_component_mut!(ref mut self, Comp1).foo1();
                                            ^**^
-
-error: Inline macro `get_dep_component_mut` failed.
- --> lib.cairo:60:13
-            get_dep_component_mut!(ref mut self, Comp1).foo1();
-            ^*****************************************^
 
 error: Type annotations needed. Failed to infer ?2
  --> lib.cairo:53:49


### PR DESCRIPTION
**Stack**:
- #4349
- #4348
- #4347
- #4346 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4346)
<!-- Reviewable:end -->
