### PR TITLE
fix(vscode-cairo): fix compile build error

### DIFF
--- a/vscode-cairo/tsconfig.json
+++ b/vscode-cairo/tsconfig.json
@@ -12,7 +12,8 @@
     "noUnusedLocals": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "types": ["node"]
   },
   "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
try fix compile error: 

```
> cairo1@2.3.1 compile
> tsc -p ./

node_modules/@types/node/globals.d.ts:84:11 - error TS2300: Duplicate identifier 'AbortController'.

84 interface AbortController {
…

Found 55 errors in 18 files.

Errors  Files
     4  node_modules/@types/node/globals.d.ts:84
     4  node_modules/@types/node/url.d.ts:119
…
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4398)
<!-- Reviewable:end -->
