### PR TITLE
Fix attribute parsing with only an identifier after.

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -204,6 +204,9 @@ impl<'a> Parser<'a> {
             Ok(attributes) => (true, attributes),
             Err(_) => (false, AttributeList::new_green(self.db, vec![])),
         };
+        // Save the current offset for reporting the diagnositc in case there is only an identifier
+        // after.
+        let after_attributes_offset = self.offset.add_width(self.current_width);
         match self.peek().kind {
             SyntaxKind::TerminalConst => Ok(self.expect_const(attributes).into()),
             SyntaxKind::TerminalModule => Ok(self.expect_module(attributes).into()),
@@ -255,6 +258,16 @@ impl<'a> Parser<'a> {
                             .into())
                     }
                     _ => {
+                        if has_attrs {
+                            self.skip_taken_node_with_offset(
+                                attributes,
+                                ParserDiagnosticKind::SkippedElement {
+                                    element_name: or_an_attribute!(TOP_LEVEL_ITEM_DESCRIPTION)
+                                        .into(),
+                                },
+                                after_attributes_offset,
+                            );
+                        }
                         // Complete the `skip`ping of the identifier.
                         self.append_skipped_token_to_pending_trivia(
                             ident,
@@ -2233,22 +2246,36 @@ impl<'a> Parser<'a> {
         });
     }
 
+    /// A wrapper for `skip_taken_node_with_offset` to report the skipped node diagnostic relative
+    /// to the current offset. Use this when the skipped node is the last node taken.
+    fn skip_taken_node_from_current_offset(
+        &mut self,
+        node_to_skip: impl Into<SkippedNodeGreen>,
+        diagnostic_kind: ParserDiagnosticKind,
+    ) {
+        self.skip_taken_node_with_offset(
+            node_to_skip,
+            diagnostic_kind,
+            self.offset.add_width(self.current_width),
+        )
+    }
+
     /// Skips the given node which is a variant of `SkippedNode` and is already taken. A skipped
     /// node is a node which is not expected where it is found. Skipping this node means
     /// reporting the given error (pointing to right after the node), appending the node to the
     /// current trivia as skipped, and continuing the compilation as if it wasn't there.
-    fn skip_taken_node(
+    /// `end_of_node_offset` is the offset of the end of the skipped node.
+    fn skip_taken_node_with_offset(
         &mut self,
         node_to_skip: impl Into<SkippedNodeGreen>,
         diagnostic_kind: ParserDiagnosticKind,
+        end_of_node_offset: TextOffset,
     ) {
         let trivium_green = TriviumSkippedNode::new_green(self.db, node_to_skip.into()).into();
 
         // Add to pending trivia.
         self.pending_trivia.push(trivium_green);
 
-        // Fix the offset for the last token not being considered in the current offset.
-        let end_of_node_offset = self.offset.add_width(self.current_width);
         let start_of_node_offset = end_of_node_offset.sub_width(trivium_green.0.width(self.db));
         let diag_pos =
             end_of_node_offset.sub_width(trailing_trivia_width(self.db, trivium_green.0));
@@ -2278,7 +2305,7 @@ impl<'a> Parser<'a> {
         node_to_skip: impl Into<SkippedNodeGreen>,
         diagnostic_kind: ParserDiagnosticKind,
     ) -> ExpectedNode::Green {
-        self.skip_taken_node(node_to_skip, diagnostic_kind);
+        self.skip_taken_node_from_current_offset(node_to_skip, diagnostic_kind);
         ExpectedNode::missing(self.db)
     }
 

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees_with_trivia/attribute_errors
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees_with_trivia/attribute_errors
@@ -1236,3 +1236,59 @@ error: Missing tokens. Expected a statement after attributes.
         │   └── child #3 (kind: TokenNewline).
         ├── token (kind: TokenRBrace): '}'
         └── trailing_trivia (kind: Trivia) []
+
+//! > ==========================================================================
+
+//! > Test an attribute with an identifier after.
+
+//! > test_runner_name
+test_partial_parser_tree_with_trivia(expect_diagnostics: *)
+
+//! > cairo_code
+// TODO(Gil): handle multiline diagnostics.
+#[bbb]
+macro
+
+//! > top_level_kind
+
+//! > ignored_kinds
+TerminalLBrace
+TerminalLet
+TerminalLBrack
+TerminalRBrack
+TerminalEq
+TerminalLiteralNumber
+TerminalSemicolon
+
+//! > expected_diagnostics
+error: Skipped tokens. Expected: Const/Module/Use/FreeFunction/ExternFunction/ExternType/Trait/Impl/Struct/Enum/TypeAlias/InlineMacro or an attribute.
+ --> dummy_file.cairo:2:7
+#[bbb]
+      ^
+
+//! > expected_tree
+└── root (kind: SyntaxFile)
+    ├── items (kind: ItemList) []
+    └── eof (kind: TerminalEndOfFile)
+        ├── leading_trivia (kind: Trivia)
+        │   ├── child #0 (kind: TriviumSkippedNode)
+        │   │   └── node (kind: AttributeList)
+        │   │       └── child #0 (kind: Attribute)
+        │   │           ├── hash (kind: TerminalHash)
+        │   │           │   ├── leading_trivia (kind: Trivia)
+        │   │           │   │   ├── child #0 (kind: TokenSingleLineComment): '// TODO(Gil): handle multiline diagnostics.'
+        │   │           │   │   └── child #1 (kind: TokenNewline).
+        │   │           │   ├── token (kind: TokenHash): '#'
+        │   │           │   └── trailing_trivia (kind: Trivia) []
+        │   │           ├── lbrack (kind: TerminalLBrack) <ignored>
+        │   │           ├── attr (kind: ExprPath)
+        │   │           │   └── item #0 (kind: PathSegmentSimple)
+        │   │           │       └── ident (kind: TerminalIdentifier)
+        │   │           │           ├── leading_trivia (kind: Trivia) []
+        │   │           │           ├── token (kind: TokenIdentifier): 'bbb'
+        │   │           │           └── trailing_trivia (kind: Trivia) []
+        │   │           ├── arguments (kind: OptionArgListParenthesizedEmpty) []
+        │   │           └── rbrack (kind: TerminalRBrack) <ignored>
+        │   └── child #1 (kind: TokenSkipped): 'macro'
+        ├── token (kind: TokenEndOfFile).
+        └── trailing_trivia (kind: Trivia) []


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4407)
<!-- Reviewable:end -->
