### PR TITLE
Add support for editions to Language Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "scarb-metadata"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1939d4a36ba77bc4a23024f42e16e307b74fe451d8efa23aff8916fdde6a83"
+checksum = "cf294b35e5abed4510b98150fbdfad402111cb05532b38d8569a1c3edea6d1a6"
 dependencies = [
  "camino",
  "semver",

--- a/crates/cairo-lang-language-server/src/scarb_service.rs
+++ b/crates/cairo-lang-language-server/src/scarb_service.rs
@@ -2,7 +2,8 @@ use std::env;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use cairo_lang_filesystem::{db::Edition, ids::CrateLongId};
+use cairo_lang_filesystem::db::Edition;
+use cairo_lang_filesystem::ids::CrateLongId;
 use lsp::Url;
 use scarb_metadata::Metadata;
 
@@ -87,13 +88,12 @@ impl ScarbService {
                     .packages
                     .iter()
                     .find(|package| package.id == component.package)
-                    .map(|package| {
+                    .and_then(|package| {
                         package
                             .edition
                             .clone()
                             .map(|edition| serde_json::from_value(edition.into()).unwrap())
                     })
-                    .flatten()
                     .unwrap_or_default();
                 if source_path.exists() {
                     let crate_id = CrateLongId::Real(component.name.as_str().into());

--- a/crates/cairo-lang-language-server/src/scarb_service.rs
+++ b/crates/cairo-lang-language-server/src/scarb_service.rs
@@ -84,19 +84,19 @@ impl ScarbService {
             .flat_map(|unit| unit.components)
             .filter_map(|component| {
                 let source_path: PathBuf = component.source_path.into();
-                let edition = metadata
-                    .packages
-                    .iter()
-                    .find(|package| package.id == component.package)
-                    .and_then(|package| {
-                        package
-                            .edition
-                            .clone()
-                            .map(|edition| serde_json::from_value(edition.into()).unwrap())
-                    })
-                    .unwrap_or_default();
                 if source_path.exists() {
                     let crate_id = CrateLongId::Real(component.name.as_str().into());
+                    let edition = metadata
+                        .packages
+                        .iter()
+                        .find(|package| package.id == component.package)
+                        .and_then(|package| {
+                            package
+                                .edition
+                                .clone()
+                                .map(|edition| serde_json::from_value(edition.into()).unwrap())
+                        })
+                        .unwrap_or_default();
                     Some((crate_id, source_path, edition))
                 } else {
                     None


### PR DESCRIPTION
This PR bumps `scarb-metadata` to `1.9` and adds support for loading correct edition per compilation unit from scarb metadata info.

Before, the edition for LS was always `2023_01` as per `CrateConfiguration::default` which failed when newer edition was specified in `Scarb.toml` - the LS didn't report any errors but compilation wasn't possible. After the changes edition is correctly loaded and reflected in LS.

Tested with the following snippet:
```rust
fn example() -> Nullable<felt252> {
    null()
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4448)
<!-- Reviewable:end -->
