### PR TITLE
enable disallowing lists to end with a trailing with seperator

### DIFF
--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -36,6 +36,7 @@ pub enum ParserDiagnosticKind {
     AttributesWithoutTraitItem,
     AttributesWithoutImplItem,
     AttributesWithoutStatement,
+    DisallowedTrailingSeparatorOr,
 }
 impl DiagnosticEntry for ParserDiagnostic {
     type DbType = dyn FilesGroup;
@@ -111,6 +112,9 @@ Did you mean to write `{identifier}!{left}...{right}'?",
             }
             ParserDiagnosticKind::AttributesWithoutStatement => {
                 "Missing tokens. Expected a statement after attributes.".to_string()
+            }
+            ParserDiagnosticKind::DisallowedTrailingSeparatorOr => {
+                "A trailing `|` is not allowed in an or-pattern.".to_string()
             }
         }
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4452)
<!-- Reviewable:end -->
