### PR TITLE
Do not pass empty diagnostics to callback

### DIFF
--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -145,10 +145,12 @@ impl<'a> DiagnosticsReporter<'a> {
         group: Diagnostics<TEntry>,
     ) -> bool {
         let text = group.format(db);
-        let found_diagnostics =
-            !text.is_empty() && (!self.allow_warnings || group.check_error_free().is_err());
-        self.callback.on_diagnostic(text);
-        found_diagnostics
+        if !text.is_empty() {
+            self.callback.on_diagnostic(text);
+            !self.allow_warnings || group.check_error_free().is_err()
+        } else {
+            false
+        }
     }
 
     /// Checks if there are diagnostics and reports them to the provided callback as strings.


### PR DESCRIPTION
Sorry for second in a row 😅  
The callback should not be called at all for empty message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4487)
<!-- Reviewable:end -->
