### PR TITLE
Pass entries severity to DiagnosticReporter callback

### DIFF
--- a/crates/cairo-lang-compiler/src/diagnostics_test.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics_test.rs
@@ -14,5 +14,5 @@ fn test_diagnostics() {
         Some(CrateConfiguration::default_for_root(Directory::Real("no/such/path".into()))),
     );
 
-    assert_eq!(get_diagnostics_as_string(&db, &[]), "no/such/path/lib.cairo not found\n");
+    assert_eq!(get_diagnostics_as_string(&db, &[]), "error: no/such/path/lib.cairo not found\n");
 }

--- a/crates/cairo-lang-diagnostics/src/diagnostics.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics.rs
@@ -199,11 +199,36 @@ impl<TEntry: DiagnosticEntry> Default for DiagnosticsBuilder<TEntry> {
 
 pub fn format_diagnostics(
     db: &(dyn FilesGroup + 'static),
-    severity: Severity,
     message: &str,
     location: DiagnosticLocation,
 ) -> String {
-    format!("{severity}: {message}\n --> {:?}\n", location.debug(db))
+    format!("{message}\n --> {:?}\n", location.debug(db))
+}
+
+pub struct FormattedDiagnosticEntry((Severity, String));
+
+impl FormattedDiagnosticEntry {
+    pub fn new(severity: Severity, message: String) -> Self {
+        Self((severity, message))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.message().is_empty()
+    }
+
+    pub fn severity(&self) -> Severity {
+        self.0.0
+    }
+
+    pub fn message(&self) -> &str {
+        &self.0.1
+    }
+}
+
+impl From<(Severity, String)> for FormattedDiagnosticEntry {
+    fn from((severity, message): (Severity, String)) -> Self {
+        Self::new(severity, message)
+    }
 }
 
 /// A set of diagnostic entries that arose during a computation.
@@ -219,26 +244,32 @@ impl<TEntry: DiagnosticEntry> Diagnostics<TEntry> {
         if self.0.error_count == 0 { Ok(()) } else { Err(DiagnosticAdded) }
     }
 
-    pub fn format(&self, db: &TEntry::DbType) -> String {
-        let mut res = String::new();
+    /// Format entries to pairs of severity and message.
+    pub fn format_with_severity(&self, db: &TEntry::DbType) -> Vec<FormattedDiagnosticEntry> {
+        let mut res: Vec<FormattedDiagnosticEntry> = Vec::new();
 
         let files_db = db.upcast();
         // Format leaves.
         for entry in &self.0.leaves {
-            res += &format_diagnostics(
-                files_db,
-                entry.severity(),
-                &entry.format(db),
-                entry.location(db),
-            );
+            let mut msg = String::new();
+            msg += &format_diagnostics(files_db, &entry.format(db), entry.location(db));
             for note in entry.notes(db) {
-                res += &format!("note: {:?}\n", note.debug(files_db))
+                msg += &format!("note: {:?}\n", note.debug(files_db))
             }
-            res += "\n";
+            msg += "\n";
+            res.push((entry.severity(), msg).into());
         }
         // Format subtrees.
-        res += &self.0.subtrees.iter().map(|subtree| subtree.format(db)).join("");
+        res.extend(self.0.subtrees.iter().flat_map(|subtree| subtree.format_with_severity(db)));
         res
+    }
+
+    /// Format entries to a String with messages prefixed by severity.
+    pub fn format(&self, db: &TEntry::DbType) -> String {
+        self.format_with_severity(db)
+            .iter()
+            .map(|entry| format!("{}: {}", entry.severity(), entry.message()))
+            .join("")
     }
 
     /// Asserts that no diagnostic has occurred, panicking with an error message on failure.

--- a/crates/cairo-lang-plugins/src/test_utils.rs
+++ b/crates/cairo-lang-plugins/src/test_utils.rs
@@ -23,7 +23,11 @@ pub fn expand_module_text(
             file_id: file_id.file_id(db.upcast()).unwrap(),
             span: syntax_node.span_without_trivia(syntax_db),
         };
-        diagnostics.push(format_diagnostics(db.upcast(), Severity::Error, &diag.message, location));
+        diagnostics.push(format!(
+            "{}: {}",
+            Severity::Error,
+            format_diagnostics(db.upcast(), &diag.message, location)
+        ));
     }
     for item_id in db.module_items(module_id).unwrap().iter() {
         if let ModuleItemId::Submodule(item) = item_id {


### PR DESCRIPTION
This PR suggests making diagnostic reporter callback aware of entry severity. The overall aim is to enable callback to make better ui distinction between types, and implement possible features like filtering on severity level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4503)
<!-- Reviewable:end -->
