### PR TITLE
Restrict semantic tests in the CI to only one thread.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - test -p cairo-lang-proc-macros
           - test -p cairo-lang-project
           - test -p cairo-lang-runner
-          - test -p cairo-lang-semantic
+          - test -p cairo-lang-semantic -- --test-threads=1
           - test -p cairo-lang-sierra
           - test -p cairo-lang-sierra-ap-change
           - test -p cairo-lang-sierra-gas


### PR DESCRIPTION
A possible fix to the issue Tomer brought, the semantic tests are not the bottleneck anyway so it won't hurt, but I'm not sure that's how we want to handle it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4514)
<!-- Reviewable:end -->
