### PR TITLE
fix: several links pointing to legacy repository uri

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Cairo Community Support
-    url: https://github.com/starkware-libs-cairo/discussions
+    url: https://github.com/starkware-libs/cairo/discussions
     about: Please ask and answer questions here.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all project spaces, and it also applies when
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainer using any of the [private contact addresses](https://github.com/starkware-libs-cairo#support). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainer using any of the [private contact addresses](https://github.com/starkware-libs/cairo#support). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To set up a development environment, please follow these steps:
 1. Clone the repo
 
    ```sh
-   git clone https://github.com/starkware-libs-cairo
+   git clone https://github.com/starkware-libs/cairo
    ```
 
 2. Download and install [VSCode](https://code.visualstudio.com/).
@@ -39,9 +39,9 @@ Some tests should now be fixed.
 ## Issues and feature requests
 
 You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new
-feature? Take a look at [GitHub Discussions](https://github.com/starkware-libs-cairo/discussions)
+feature? Take a look at [GitHub Discussions](https://github.com/starkware-libs/cairo/discussions)
 to see if it's already being discussed. You can help us by
-[submitting an issue on GitHub](https://github.com/starkware-libs-cairo/issues).
+[submitting an issue on GitHub](https://github.com/starkware-libs/cairo/issues).
 Before you create an issue, make sure to search the issue archive -- your issue may have already
 been addressed!
 
@@ -57,7 +57,7 @@ Please try to create bug reports that are:
 ### How to submit a Pull Request
 
 1. Search our repository for open or closed
-   [Pull Requests](https://github.com/starkware-libs-cairo/pulls)
+   [Pull Requests](https://github.com/starkware-libs/cairo/pulls)
    that relate to your submission. You don't want to duplicate effort.
 2. Fork the project
 3. Create your feature branch (`git checkout -b feat/amazing_feature`)


### PR DESCRIPTION
I've found, that several links are pointing to (probably) legacy version of Cairo repository URI. This PR fixes them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4568)
<!-- Reviewable:end -->
