### PR TITLE
Update match-expressions.adoc

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
@@ -57,5 +57,5 @@ match felt_var {
 }
 ----
 
-Where `felt_var` is a xref:felt252-type.adoc[felt252] and the match patters are the
+Where `felt_var` is a xref:felt252-type.adoc[felt252] and the match patterns are the
 xref:literal-expressions.adoc[literal] '0' and wildcard '_' (which matches any value).


### PR DESCRIPTION
fix a typo in` docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc:60`: patters ==> patterns

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4607)
<!-- Reviewable:end -->
