### PR TITLE
Modularize SierraCasmRunner and casm_run

### DIFF
--- a/crates/cairo-lang-casm/src/instructions.rs
+++ b/crates/cairo-lang-casm/src/instructions.rs
@@ -10,7 +10,7 @@ use crate::operand::{CellRef, DerefOrImmediate, ResOperand};
 mod test;
 
 // An enum of Cairo instructions.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum InstructionBody {
     AddAp(AddApInstruction),
     AssertEq(AssertEqInstruction),
@@ -46,7 +46,7 @@ impl Display for InstructionBody {
 }
 
 /// Represents an instruction, including the ap++ flag (inc_ap).
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Instruction {
     pub body: InstructionBody,
     pub inc_ap: bool,
@@ -79,7 +79,7 @@ impl Display for Instruction {
 }
 
 /// Represents a call instruction "call rel/abs target".
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct CallInstruction {
     pub target: DerefOrImmediate,
     pub relative: bool,
@@ -99,7 +99,7 @@ impl CallInstruction {
 }
 
 /// Represents the InstructionBody "jmp rel/abs target".
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct JumpInstruction {
     pub target: DerefOrImmediate,
     pub relative: bool,
@@ -119,7 +119,7 @@ impl Display for JumpInstruction {
 }
 
 /// Represents the InstructionBody "jmp rel <jump_offset> if condition != 0".
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct JnzInstruction {
     pub jump_offset: DerefOrImmediate,
     pub condition: CellRef,
@@ -152,7 +152,7 @@ pub fn op_size_based_on_res_operands(operand: &ResOperand) -> usize {
 }
 
 /// Represents the InstructionBody "a = b" for two operands a, b.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct AssertEqInstruction {
     pub a: CellRef,
     pub b: ResOperand,
@@ -169,7 +169,7 @@ impl Display for AssertEqInstruction {
 }
 
 /// Represents a return instruction, "ret".
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct RetInstruction {}
 impl Display for RetInstruction {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -184,7 +184,7 @@ impl RetInstruction {
 }
 
 /// Represents the InstructionBody "ap += op" for a given operand op.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct AddApInstruction {
     pub operand: ResOperand,
 }

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -2131,23 +2131,20 @@ pub fn build_cairo_runner(
     CairoRunner::new(&program, "all_cairo", false).map_err(CairoRunError::from).map_err(Box::new)
 }
 
-/// Runs `instructions` on layout with prime, and returns the memory layout and ap value.
+/// Runs `bytecode` on layout with prime, and returns the memory layout and ap value.
 /// Allows injecting custom HintProcessor.
-pub fn run_function<'a, 'b: 'a, Instructions>(
+pub fn run_function<'a, 'b: 'a>(
     vm: &mut VirtualMachine,
-    instructions: Instructions,
+    bytecode: impl Iterator<Item = &'a BigInt> + Clone,
     builtins: Vec<BuiltinName>,
     additional_initialization: fn(
         context: RunFunctionContext<'_>,
     ) -> Result<(), Box<CairoRunError>>,
     hint_processor: &mut dyn HintProcessor,
     hints_dict: HashMap<usize, Vec<HintParams>>,
-) -> Result<RunFunctionRes, Box<CairoRunError>>
-where
-    Instructions: Iterator<Item = &'a BigInt> + Clone,
-{
+) -> Result<RunFunctionRes, Box<CairoRunError>> {
     let data: Vec<MaybeRelocatable> =
-        instructions.map(Felt252::from).map(MaybeRelocatable::from).collect();
+        bytecode.map(Felt252::from).map(MaybeRelocatable::from).collect();
     let data_len = data.len();
     let mut runner = build_cairo_runner(data, builtins, hints_dict)?;
 

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -2190,11 +2190,7 @@ impl FormattedItem {
     }
     /// Wraps the formatted item with quote, if it's a string. Otherwise returns it as is.
     pub fn quote_if_string(self) -> String {
-        if self.is_string {
-            format!("\"{}\"", self.item)
-        } else {
-            self.item
-        }
+        if self.is_string { format!("\"{}\"", self.item) } else { self.item }
     }
 }
 

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -2090,6 +2090,8 @@ pub struct RunFunctionContext<'a> {
 
 type RunFunctionRes = (Vec<Option<Felt252>>, usize);
 
+/// Runs CairoRunner on layout with prime.
+/// Allows injecting custom CairoRunner.
 pub fn run_function_with_runner(
     vm: &mut VirtualMachine,
     data_len: usize,
@@ -2109,6 +2111,7 @@ pub fn run_function_with_runner(
     Ok(())
 }
 
+/// Creates CairoRunner for `program`.
 pub fn build_cairo_runner(
     data: Vec<MaybeRelocatable>,
     builtins: Vec<BuiltinName>,
@@ -2128,7 +2131,7 @@ pub fn build_cairo_runner(
     CairoRunner::new(&program, "all_cairo", false).map_err(CairoRunError::from).map_err(Box::new)
 }
 
-/// Runs `program` on layout with prime, and returns the memory layout and ap value.
+/// Runs `instructions` on layout with prime, and returns the memory layout and ap value.
 /// Allows injecting custom HintProcessor.
 pub fn run_function<'a, 'b: 'a, Instructions>(
     vm: &mut VirtualMachine,

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -13,7 +13,7 @@ use super::format_for_debug;
 use crate::casm_run::contract_address::calculate_contract_address;
 use crate::casm_run::run_function;
 use crate::short_string::{as_cairo_short_string, as_cairo_short_string_ex};
-use crate::{build_hints_dict, CairoHintProcessor, StarknetState};
+use crate::{assemble_instructions, build_hints_dict, CairoHintProcessor, StarknetState};
 
 #[test_case(
     casm! {
@@ -119,7 +119,7 @@ fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
 
     let (cells, ap) = run_function(
         &mut VirtualMachine::new(true),
-        function.instructions.iter(),
+        assemble_instructions(function.instructions.iter()).iter(),
         vec![],
         |_| Ok(()),
         &mut hint_processor,
@@ -152,7 +152,7 @@ fn test_allocate_segment() {
 
     let (memory, ap) = run_function(
         &mut VirtualMachine::new(true),
-        casm.instructions.iter(),
+        assemble_instructions(casm.instructions.iter()).iter(),
         vec![],
         |_| Ok(()),
         &mut hint_processor,

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -1,6 +1,5 @@
 use cairo_felt::{felt_str, Felt252};
 use cairo_lang_casm::inline::CasmContext;
-use cairo_lang_casm::instructions::Instruction;
 use cairo_lang_casm::{casm, deref};
 use cairo_lang_utils::byte_array::BYTE_ARRAY_MAGIC;
 use cairo_vm::vm::runners::cairo_runner::RunResources;
@@ -16,12 +15,6 @@ use crate::casm_run::contract_address::calculate_contract_address;
 use crate::casm_run::run_function;
 use crate::short_string::{as_cairo_short_string, as_cairo_short_string_ex};
 use crate::{build_hints_dict, CairoHintProcessor, StarknetState};
-
-pub fn assemble_instructions<'b>(
-    instructions: impl Iterator<Item = &'b Instruction>,
-) -> Vec<BigInt> {
-    instructions.into_iter().flat_map(|is| is.assemble().encode()).collect()
-}
 
 #[test_case(
     casm! {
@@ -124,10 +117,12 @@ fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
         starknet_state: StarknetState::default(),
         run_resources: RunResources::default(),
     };
+    let instructions: Vec<BigInt> =
+        function.instructions.iter().flat_map(|is| is.assemble().encode()).collect();
 
     let (cells, ap) = run_function(
         &mut VirtualMachine::new(true),
-        assemble_instructions(function.instructions.iter()).iter(),
+        instructions.iter(),
         vec![],
         |_| Ok(()),
         &mut hint_processor,
@@ -157,10 +152,12 @@ fn test_allocate_segment() {
         starknet_state: StarknetState::default(),
         run_resources: RunResources::default(),
     };
+    let instructions: Vec<BigInt> =
+        casm.instructions.iter().flat_map(|is| is.assemble().encode()).collect();
 
     let (memory, ap) = run_function(
         &mut VirtualMachine::new(true),
-        assemble_instructions(casm.instructions.iter()).iter(),
+        instructions.iter(),
         vec![],
         |_| Ok(()),
         &mut hint_processor,

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -1,11 +1,13 @@
 use cairo_felt::{felt_str, Felt252};
 use cairo_lang_casm::inline::CasmContext;
+use cairo_lang_casm::instructions::Instruction;
 use cairo_lang_casm::{casm, deref};
 use cairo_lang_utils::byte_array::BYTE_ARRAY_MAGIC;
 use cairo_vm::vm::runners::cairo_runner::RunResources;
 use cairo_vm::vm::vm_core::VirtualMachine;
 use indoc::indoc;
 use itertools::Itertools;
+use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use test_case::test_case;
 
@@ -13,7 +15,13 @@ use super::format_for_debug;
 use crate::casm_run::contract_address::calculate_contract_address;
 use crate::casm_run::run_function;
 use crate::short_string::{as_cairo_short_string, as_cairo_short_string_ex};
-use crate::{assemble_instructions, build_hints_dict, CairoHintProcessor, StarknetState};
+use crate::{build_hints_dict, CairoHintProcessor, StarknetState};
+
+pub fn assemble_instructions<'b>(
+    instructions: impl Iterator<Item = &'b Instruction>,
+) -> Vec<BigInt> {
+    instructions.into_iter().flat_map(|is| is.assemble().encode()).collect()
+}
 
 #[test_case(
     casm! {

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -117,12 +117,15 @@ fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
         starknet_state: StarknetState::default(),
         run_resources: RunResources::default(),
     };
-    let instructions: Vec<BigInt> =
-        function.instructions.iter().flat_map(|is| is.assemble().encode()).collect();
+    let bytecode: Vec<BigInt> = function
+        .instructions
+        .iter()
+        .flat_map(|instruction| instruction.assemble().encode())
+        .collect();
 
     let (cells, ap) = run_function(
         &mut VirtualMachine::new(true),
-        instructions.iter(),
+        bytecode.iter(),
         vec![],
         |_| Ok(()),
         &mut hint_processor,
@@ -152,12 +155,12 @@ fn test_allocate_segment() {
         starknet_state: StarknetState::default(),
         run_resources: RunResources::default(),
     };
-    let instructions: Vec<BigInt> =
-        casm.instructions.iter().flat_map(|is| is.assemble().encode()).collect();
+    let bytecode: Vec<BigInt> =
+        casm.instructions.iter().flat_map(|instruction| instruction.assemble().encode()).collect();
 
     let (memory, ap) = run_function(
         &mut VirtualMachine::new(true),
-        instructions.iter(),
+        bytecode.iter(),
         vec![],
         |_| Ok(()),
         &mut hint_processor,

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -17,6 +17,7 @@ use cairo_lang_sierra::extensions::range_check::RangeCheckType;
 use cairo_lang_sierra::extensions::segment_arena::SegmentArenaType;
 use cairo_lang_sierra::extensions::starknet::syscalls::SystemType;
 use cairo_lang_sierra::extensions::{ConcreteType, NamedType};
+use cairo_lang_sierra::ids::{ConcreteTypeId, GenericTypeId};
 use cairo_lang_sierra::program::{Function, GenericArg, StatementIdx};
 use cairo_lang_sierra::program_registry::{ProgramRegistry, ProgramRegistryError};
 use cairo_lang_sierra_ap_change::ApChangeError;
@@ -42,6 +43,8 @@ use itertools::chain;
 use num_traits::ToPrimitive;
 use profiling::ProfilingInfo;
 use thiserror::Error;
+
+use crate::casm_run::RunFunctionContext;
 
 pub mod casm_run;
 pub mod profiling;
@@ -245,58 +248,27 @@ impl SierraCasmRunner {
     where
         Instructions: Iterator<Item = &'a Instruction> + Clone,
     {
+        let return_types = self.generic_id_and_size_from_concrete(&func.signature.ret_types);
+
         let (cells, ap) = casm_run::run_function(
             vm,
             instructions.clone(),
             builtins,
-            |context| {
-                let vm = context.vm;
-                // Create the builtin cost segment, with dummy values.
-                let builtin_cost_segment = vm.add_memory_segment();
-                for token_type in CostTokenType::iter_precost() {
-                    vm.insert_value(
-                        (builtin_cost_segment + (token_type.offset_in_builtin_costs() as usize))
-                            .unwrap(),
-                        Felt252::from(token_gas_cost(*token_type)),
-                    )
-                    .map_err(|e| Box::new(e.into()))?;
-                }
-                // Put a pointer to the builtin cost segment at the end of the program (after the
-                // additional `ret` statement).
-                vm.insert_value((vm.get_pc() + context.data_len).unwrap(), builtin_cost_segment)
-                    .map_err(|e| Box::new(e.into()))?;
-                Ok(())
-            },
+            initialize_vm,
             hint_processor,
             hints_dict,
         )?;
-        let mut results_data = self.get_results_data(func, &cells, ap)?;
-        // Handling implicits.
-        let mut gas_counter = None;
-        results_data.retain_mut(|(ty, values)| {
-            let info = self.get_info(ty);
-            let generic_ty = &info.long_id.generic_id;
-            if *generic_ty == GasBuiltinType::ID {
-                gas_counter = Some(values.remove(0));
-                assert!(values.is_empty());
-                false
-            } else {
-                *generic_ty != RangeCheckType::ID
-                    && *generic_ty != BitwiseType::ID
-                    && *generic_ty != EcOpType::ID
-                    && *generic_ty != PedersenType::ID
-                    && *generic_ty != PoseidonType::ID
-                    && *generic_ty != SystemType::ID
-                    && *generic_ty != SegmentArenaType::ID
-            }
-        });
+        let (results_data, gas_counter) = Self::get_results_data(&return_types, &cells, ap);
         assert!(results_data.len() <= 1);
+
         let value = if results_data.is_empty() {
             // No result type - no panic.
             RunResultValue::Success(vec![])
         } else {
-            let [(ty, values)] = <[_; 1]>::try_from(results_data).ok().unwrap();
-            self.handle_main_return_value(ty, values, &cells)?
+            let (ty, values) = results_data[0].clone();
+            let inner_ty =
+                self.inner_type_from_panic_wrapper(&ty, func).map(|it| self.type_sizes[&it]);
+            Self::handle_main_return_value(inner_ty, values, &cells)
         };
 
         let profiling_info = if self.run_profiler {
@@ -354,6 +326,35 @@ impl SierraCasmRunner {
         ProfilingInfo { sierra_statements_weights }
     }
 
+    /// Extract inner type if `ty` is a panic wrapper
+    fn inner_type_from_panic_wrapper(
+        &self,
+        ty: &GenericTypeId,
+        func: &Function,
+    ) -> Option<ConcreteTypeId> {
+        let info = func
+            .signature
+            .ret_types
+            .iter()
+            .find_map(|rt| {
+                let info = self.get_info(rt);
+                if info.long_id.generic_id == *ty {
+                    Some(info)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        if *ty == EnumType::ID
+            && matches!(&info.long_id.generic_args[0], GenericArg::UserType(ut)
+                if ut.debug_name.as_ref().unwrap().starts_with("core::panics::PanicResult::"))
+        {
+            return Some(extract_matches!(&info.long_id.generic_args[1], GenericArg::Type).clone());
+        }
+        None
+    }
+
     /// Runs the vm starting from a function with custom hint processor. Function may have
     /// implicits, but no other ref params. The cost of the function is deducted from
     /// available_gas before the execution begins.
@@ -373,61 +374,71 @@ impl SierraCasmRunner {
     }
 
     /// Handling the main return value to create a `RunResultValue`.
-    fn handle_main_return_value(
-        &self,
-        ty: cairo_lang_sierra::ids::ConcreteTypeId,
+    pub fn handle_main_return_value(
+        inner_type_size: Option<i16>,
         values: Vec<Felt252>,
         cells: &[Option<Felt252>],
-    ) -> Result<RunResultValue, RunnerError> {
-        let info = self.get_info(&ty);
-        let long_id = &info.long_id;
-        Ok(
-            if long_id.generic_id == EnumType::ID
-                && matches!(&long_id.generic_args[0], GenericArg::UserType(ut)
-                if ut.debug_name.as_ref().unwrap().starts_with("core::panics::PanicResult::"))
-            {
-                // The function includes a panic wrapper.
-                if values[0] != Felt252::from(0) {
-                    // The run resulted in a panic, returning the error data.
-                    let err_data_start = values[values.len() - 2].to_usize().unwrap();
-                    let err_data_end = values[values.len() - 1].to_usize().unwrap();
-                    RunResultValue::Panic(
-                        cells[err_data_start..err_data_end]
-                            .iter()
-                            .cloned()
-                            .map(|cell| cell.unwrap())
-                            .collect(),
-                    )
-                } else {
-                    // The run resulted successfully, returning the inner value.
-                    let inner_ty = extract_matches!(&long_id.generic_args[1], GenericArg::Type);
-                    let inner_ty_size = self.type_sizes[inner_ty] as usize;
-                    let skip_size = values.len() - inner_ty_size;
-                    RunResultValue::Success(values.into_iter().skip(skip_size).collect())
-                }
+    ) -> RunResultValue {
+        if let Some(inner_type_size) = inner_type_size {
+            // The function includes a panic wrapper.
+            if values[0] == Felt252::from(0) {
+                // The run resulted successfully, returning the inner value.
+                let inner_ty_size = inner_type_size as usize;
+                let skip_size = values.len() - inner_ty_size;
+                RunResultValue::Success(values.into_iter().skip(skip_size).collect())
             } else {
-                // No panic wrap - so always successful.
-                RunResultValue::Success(values)
-            },
-        )
+                // The run resulted in a panic, returning the error data.
+                let err_data_start = values[values.len() - 2].to_usize().unwrap();
+                let err_data_end = values[values.len() - 1].to_usize().unwrap();
+                RunResultValue::Panic(
+                    cells[err_data_start..err_data_end]
+                        .iter()
+                        .cloned()
+                        .map(Option::unwrap)
+                        .collect(),
+                )
+            }
+        } else {
+            // No panic wrap - so always successful.
+            RunResultValue::Success(values)
+        }
     }
 
     /// Returns the final values and type of all `func`s returning variables.
-    fn get_results_data(
-        &self,
-        func: &Function,
+    pub fn get_results_data(
+        return_types: &[(GenericTypeId, i16)],
         cells: &[Option<Felt252>],
         mut ap: usize,
-    ) -> Result<Vec<(cairo_lang_sierra::ids::ConcreteTypeId, Vec<Felt252>)>, RunnerError> {
+    ) -> (Vec<(GenericTypeId, Vec<Felt252>)>, Option<Felt252>) {
         let mut results_data = vec![];
-        for ty in func.signature.ret_types.iter().rev() {
-            let size = self.type_sizes[ty] as usize;
+        for (ty, ty_size) in return_types.iter().rev() {
+            let size = *ty_size as usize;
             let values: Vec<Felt252> =
                 ((ap - size)..ap).map(|index| cells[index].clone().unwrap()).collect();
             ap -= size;
             results_data.push((ty.clone(), values));
         }
-        Ok(results_data)
+
+        // Handling implicits.
+        let mut gas_counter = None;
+        results_data.retain_mut(|(ty, values)| {
+            let generic_ty = ty;
+            if *generic_ty == GasBuiltinType::ID {
+                gas_counter = Some(values.remove(0));
+                assert!(values.is_empty());
+                false
+            } else {
+                *generic_ty != RangeCheckType::ID
+                    && *generic_ty != BitwiseType::ID
+                    && *generic_ty != EcOpType::ID
+                    && *generic_ty != PedersenType::ID
+                    && *generic_ty != PoseidonType::ID
+                    && *generic_ty != SystemType::ID
+                    && *generic_ty != SegmentArenaType::ID
+            }
+        });
+
+        (results_data, gas_counter)
     }
 
     /// Finds first function ending with `name_suffix`.
@@ -436,9 +447,28 @@ impl SierraCasmRunner {
             .funcs
             .iter()
             .find(|f| {
-                if let Some(name) = &f.id.debug_name { name.ends_with(name_suffix) } else { false }
+                if let Some(name) = &f.id.debug_name {
+                    name.ends_with(name_suffix)
+                } else {
+                    false
+                }
             })
             .ok_or_else(|| RunnerError::MissingFunction { suffix: name_suffix.to_owned() })
+    }
+
+    fn generic_id_and_size_from_concrete(
+        &self,
+        types: &[ConcreteTypeId],
+    ) -> Vec<(GenericTypeId, i16)> {
+        types
+            .iter()
+            .map(|pt| {
+                let info = self.get_info(pt);
+                let generic_id = &info.long_id.generic_id;
+                let size = self.type_sizes[pt];
+                (generic_id.clone(), size)
+            })
+            .collect()
     }
 
     fn get_info(
@@ -448,13 +478,11 @@ impl SierraCasmRunner {
         self.sierra_program_registry.get_type(ty).unwrap().info()
     }
 
-    /// Returns the instructions to add to the beginning of the code to successfully call the main
-    /// function, as well as the builtins required to execute the program.
-    pub fn create_entry_code(
-        &self,
-        func: &Function,
+    pub fn create_entry_code_from_params(
+        param_types: &[(GenericTypeId, i16)],
         args: &[Arg],
         initial_gas: usize,
+        code_offset: usize,
     ) -> Result<(Vec<Instruction>, Vec<BuiltinName>), RunnerError> {
         let mut ctx = casm! {};
         // The builtins in the formatting expected by the runner.
@@ -466,7 +494,7 @@ impl SierraCasmRunner {
             BuiltinName::poseidon,
         ];
         // The offset [fp - i] for each of this builtins in this configuration.
-        let builtin_offset: HashMap<cairo_lang_sierra::ids::GenericTypeId, i16> = HashMap::from([
+        let builtin_offset: HashMap<GenericTypeId, i16> = HashMap::from([
             (PedersenType::ID, 7),
             (RangeCheckType::ID, 6),
             (BitwiseType::ID, 5),
@@ -484,22 +512,17 @@ impl SierraCasmRunner {
                 ap += 1;
             }
             for (i, v) in values.iter().enumerate() {
-                let arr_at = (i + 1) as i16;
+                let arr_at = i16::try_from(i + 1).unwrap();
                 casm_extend! {ctx,
                     [ap + 0] = (v.to_bigint());
-                    [ap + 0] = [[ap - arr_at] + (i as i16)], ap++;
-                };
+                    [ap + 0] = [[ap - arr_at] + i16::try_from(i).unwrap()], ap++;
+                }
             }
-            ap_offset += (1 + values.len()) as i16;
+            ap_offset += i16::try_from(1 + values.len()).unwrap();
         }
         let mut array_args_data_iter = array_args_data.iter();
         let after_arrays_data_offset = ap_offset;
-        if func
-            .signature
-            .param_types
-            .iter()
-            .any(|ty| self.get_info(ty).long_id.generic_id == SegmentArenaType::ID)
-        {
+        if param_types.iter().any(|(ty, _)| ty == &SegmentArenaType::ID) {
             casm_extend! {ctx,
                 // SegmentArena segment.
                 %{ memory[ap + 0] = segments.add() %}
@@ -517,9 +540,8 @@ impl SierraCasmRunner {
         let mut expected_arguments_size = 0;
         let mut param_index = 0;
         let mut arg_iter = args.iter().enumerate();
-        for ty in func.signature.param_types.iter() {
-            let info = self.get_info(ty);
-            let generic_ty = &info.long_id.generic_id;
+        for ty in param_types {
+            let (generic_ty, ty_size) = ty;
             if let Some(offset) = builtin_offset.get(generic_ty) {
                 casm_extend! {ctx,
                     [ap + 0] = [fp - offset], ap++;
@@ -543,9 +565,9 @@ impl SierraCasmRunner {
                 }
                 ap_offset += 1;
             } else {
-                let ty_size = self.type_sizes[ty];
-                let param_ap_offset_end = ap_offset + ty_size;
-                expected_arguments_size += ty_size.into_or_panic::<usize>();
+                let arg_size = *ty_size;
+                let param_ap_offset_end = ap_offset + arg_size;
+                expected_arguments_size += arg_size.into_or_panic::<usize>();
                 while ap_offset < param_ap_offset_end {
                     let Some((arg_index, arg)) = arg_iter.next() else {
                         break;
@@ -591,14 +613,30 @@ impl SierraCasmRunner {
         }
         let before_final_call = ctx.current_code_offset;
         let final_call_size = 3;
-        let offset = final_call_size
-            + self.casm_program.debug_info.sierra_statement_info[func.entry_point.0].code_offset;
+        let offset = final_call_size + code_offset;
         casm_extend! {ctx,
             call rel offset;
             ret;
         }
         assert_eq!(before_final_call + final_call_size, ctx.current_code_offset);
         Ok((ctx.instructions, builtins))
+    }
+
+    /// Returns the instructions to add to the beginning of the code to successfully call the main
+    /// function, as well as the builtins required to execute the program.
+    pub fn create_entry_code(
+        &self,
+        func: &Function,
+        args: &[Arg],
+        initial_gas: usize,
+    ) -> Result<(Vec<Instruction>, Vec<BuiltinName>), RunnerError> {
+        let params = self.generic_id_and_size_from_concrete(&func.signature.param_types);
+
+        let entry_point = func.entry_point.0;
+        let code_offset =
+            self.casm_program.debug_info.sierra_statement_info[entry_point].code_offset;
+
+        Self::create_entry_code_from_params(&params, args, initial_gas, code_offset)
     }
 
     /// Returns the initial value for the gas counter.
@@ -647,6 +685,24 @@ impl SierraCasmRunner {
     pub fn get_casm_program(&self) -> &CairoProgram {
         &self.casm_program
     }
+}
+
+pub fn initialize_vm(context: RunFunctionContext<'_>) -> Result<(), Box<CairoRunError>> {
+    let vm = context.vm;
+    // Create the builtin cost segment, with dummy values.
+    let builtin_cost_segment = vm.add_memory_segment();
+    for token_type in CostTokenType::iter_precost() {
+        vm.insert_value(
+            (builtin_cost_segment + (token_type.offset_in_builtin_costs() as usize)).unwrap(),
+            Felt252::from(token_gas_cost(*token_type)),
+        )
+        .map_err(|e| Box::new(e.into()))?;
+    }
+    // Put a pointer to the builtin cost segment at the end of the program (after the
+    // additional `ret` statement).
+    vm.insert_value((vm.get_pc() + context.data_len).unwrap(), builtin_cost_segment)
+        .map_err(|e| Box::new(e.into()))?;
+    Ok(())
 }
 
 /// Creates the metadata required for a Sierra program lowering to casm.

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -519,7 +519,7 @@ impl SierraCasmRunner {
                     [ap + 0] = [[ap - arr_at] + i.into_or_panic()], ap++;
                 }
             }
-            ap_offset += (1 + values.len()).into_or_panic();
+            ap_offset += (1 + values.len()).into_or_panic::<i16>();
         }
         let mut array_args_data_iter = array_args_data.iter();
         let after_arrays_data_offset = ap_offset;

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -40,7 +40,7 @@ use cairo_vm::vm::trace::trace_entry::TraceEntry;
 use cairo_vm::vm::vm_core::VirtualMachine;
 use casm_run::hint_to_hint_params;
 pub use casm_run::{CairoHintProcessor, StarknetState};
-use itertools::{chain, Itertools};
+use itertools::chain;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use profiling::ProfilingInfo;

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -456,6 +456,7 @@ impl SierraCasmRunner {
             .ok_or_else(|| RunnerError::MissingFunction { suffix: name_suffix.to_owned() })
     }
 
+    /// Converts array of `ConcreteTypeId`s into corresponding `GenericTypeId`s and their sizes
     fn generic_id_and_size_from_concrete(
         &self,
         types: &[ConcreteTypeId],
@@ -687,6 +688,7 @@ impl SierraCasmRunner {
     }
 }
 
+/// Initializes a vm by adding a new segment with builtins cost and a necessary pointer at the end of the program
 pub fn initialize_vm(context: RunFunctionContext<'_>) -> Result<(), Box<CairoRunError>> {
     let vm = context.vm;
     // Create the builtin cost segment, with dummy values.

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 
 use ark_std::iterable::Iterable;
 use cairo_felt::Felt252;
-use cairo_lang_casm::assembler::AssembledCairoProgram;
 use cairo_lang_casm::hints::Hint;
 use cairo_lang_casm::instructions::Instruction;
 use cairo_lang_casm::{casm, casm_extend};
@@ -347,11 +346,7 @@ impl SierraCasmRunner {
             .iter()
             .find_map(|rt| {
                 let info = self.get_info(rt);
-                if info.long_id.generic_id == *ty {
-                    Some(info)
-                } else {
-                    None
-                }
+                (info.long_id.generic_id == *ty).then_some(info)
             })
             .unwrap();
 

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -154,20 +154,6 @@ pub fn build_hints_dict<'b>(
     (hints_dict, string_to_hint)
 }
 
-/// Inserts hints from AssembledCairoProgram into `hints_dict` and `string_to_hint`.
-pub fn hints_from_assembled_program(
-    casm_program: &AssembledCairoProgram,
-    hints_dict: &mut HashMap<usize, Vec<HintParams>>,
-    string_to_hint: &mut HashMap<String, Hint>,
-) {
-    for (offset, hints) in &casm_program.hints {
-        hints_dict.insert(*offset, hints.iter().map(hint_to_hint_params).collect());
-        for hint in hints {
-            string_to_hint.insert(hint.representing_string(), hint.clone());
-        }
-    }
-}
-
 /// Runner enabling running a Sierra program on the vm.
 pub struct SierraCasmRunner {
     /// The sierra program.
@@ -238,8 +224,13 @@ impl SierraCasmRunner {
             string_to_hint,
             run_resources: RunResources::default(),
         };
-        let RunResult { gas_counter, memory, value, profiling_info } =
-            self.run_function(func, &mut hint_processor, hints_dict, assembled_program.bytecode.iter(), builtins)?;
+        let RunResult { gas_counter, memory, value, profiling_info } = self.run_function(
+            func,
+            &mut hint_processor,
+            hints_dict,
+            assembled_program.bytecode.iter(),
+            builtins,
+        )?;
         Ok(RunResultStarknet {
             gas_counter,
             memory,

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -688,7 +688,8 @@ impl SierraCasmRunner {
     }
 }
 
-/// Initializes a vm by adding a new segment with builtins cost and a necessary pointer at the end of the program
+/// Initializes a vm by adding a new segment with builtins cost and a necessary pointer at the end
+/// of the program
 pub fn initialize_vm(context: RunFunctionContext<'_>) -> Result<(), Box<CairoRunError>> {
     let vm = context.vm;
     // Create the builtin cost segment, with dummy values.

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -40,6 +40,7 @@ use cairo_vm::vm::vm_core::VirtualMachine;
 use casm_run::hint_to_hint_params;
 pub use casm_run::{CairoHintProcessor, StarknetState};
 use itertools::chain;
+use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use profiling::ProfilingInfo;
 use thiserror::Error;
@@ -249,10 +250,11 @@ impl SierraCasmRunner {
         Instructions: Iterator<Item = &'a Instruction> + Clone,
     {
         let return_types = self.generic_id_and_size_from_concrete(&func.signature.ret_types);
+        let instructions = assemble_instructions(instructions);
 
         let (cells, ap) = casm_run::run_function(
             vm,
-            instructions.clone(),
+            instructions.iter(),
             builtins,
             initialize_vm,
             hint_processor,
@@ -706,6 +708,12 @@ pub fn initialize_vm(context: RunFunctionContext<'_>) -> Result<(), Box<CairoRun
     vm.insert_value((vm.get_pc() + context.data_len).unwrap(), builtin_cost_segment)
         .map_err(|e| Box::new(e.into()))?;
     Ok(())
+}
+
+pub fn assemble_instructions<'b>(
+    instructions: impl Iterator<Item = &'b Instruction>,
+) -> Vec<BigInt> {
+    instructions.into_iter().flat_map(|is| is.assemble().encode()).collect()
 }
 
 /// Creates the metadata required for a Sierra program lowering to casm.

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -230,8 +230,7 @@ impl SierraCasmRunner {
         let instructions =
             chain!(entry_code.iter(), self.casm_program.instructions.iter(), footer.iter());
         let (hints_dict, string_to_hint) = build_hints_dict(instructions.clone());
-        let assembled_program =
-            assemble_program(instructions.cloned().collect(), self.casm_program.clone());
+        let assembled_program = self.casm_program.clone().assemble_ex(entry_code, footer);
 
         let mut hint_processor = CairoHintProcessor {
             runner: Some(self),
@@ -725,14 +724,6 @@ pub fn initialize_vm(context: RunFunctionContext<'_>) -> Result<(), Box<CairoRun
     vm.insert_value((vm.get_pc() + context.data_len).unwrap(), builtin_cost_segment)
         .map_err(|e| Box::new(e.into()))?;
     Ok(())
-}
-
-pub fn assemble_program(
-    instructions: Vec<Instruction>,
-    mut new_program: CairoProgram,
-) -> AssembledCairoProgram {
-    new_program.instructions = instructions;
-    new_program.assemble()
 }
 
 /// Creates the metadata required for a Sierra program lowering to casm.

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -451,11 +451,7 @@ impl SierraCasmRunner {
             .funcs
             .iter()
             .find(|f| {
-                if let Some(name) = &f.id.debug_name {
-                    name.ends_with(name_suffix)
-                } else {
-                    false
-                }
+                if let Some(name) = &f.id.debug_name { name.ends_with(name_suffix) } else { false }
             })
             .ok_or_else(|| RunnerError::MissingFunction { suffix: name_suffix.to_owned() })
     }

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -154,6 +154,7 @@ pub fn build_hints_dict<'b>(
     (hints_dict, string_to_hint)
 }
 
+/// Inserts hints from AssembledCairoProgram into `hints_dict` and `string_to_hint`.
 pub fn hints_from_assembled_program(
     casm_program: &AssembledCairoProgram,
     hints_dict: &mut HashMap<usize, Vec<HintParams>>,

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -512,13 +512,13 @@ impl SierraCasmRunner {
                 ap += 1;
             }
             for (i, v) in values.iter().enumerate() {
-                let arr_at = i16::try_from(i + 1).unwrap();
+                let arr_at: i16 = (i + 1).into_or_panic();
                 casm_extend! {ctx,
                     [ap + 0] = (v.to_bigint());
-                    [ap + 0] = [[ap - arr_at] + i16::try_from(i).unwrap()], ap++;
+                    [ap + 0] = [[ap - arr_at] + i.into_or_panic()], ap++;
                 }
             }
-            ap_offset += i16::try_from(1 + values.len()).unwrap();
+            ap_offset += (1 + values.len()).into_or_panic();
         }
         let mut array_args_data_iter = array_args_data.iter();
         let after_arrays_data_offset = ap_offset;

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -233,9 +233,9 @@ impl SierraCasmRunner {
 
     /// Runs the vm starting from a function with custom hint processor. Function may have
     /// implicits, but no other ref params. The cost of the function is deducted from
-    /// available_gas before the execution begins.
+    /// `available_gas` before the execution begins.
     ///
-    /// Allows injecting Cairo VirtualMachine
+    /// Allows injecting Cairo `VirtualMachine`
     pub fn run_function_with_vm<'a, Instructions>(
         &self,
         func: &Function,
@@ -357,7 +357,7 @@ impl SierraCasmRunner {
 
     /// Runs the vm starting from a function with custom hint processor. Function may have
     /// implicits, but no other ref params. The cost of the function is deducted from
-    /// available_gas before the execution begins.
+    /// `available_gas` before the execution begins.
     pub fn run_function<'a, Instructions>(
         &self,
         func: &Function,
@@ -641,7 +641,7 @@ impl SierraCasmRunner {
     }
 
     /// Returns the initial value for the gas counter.
-    /// If available_gas is None returns 0.
+    /// If `available_gas` is None returns 0.
     pub fn get_initial_available_gas(
         &self,
         func: &Function,

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -211,7 +211,7 @@ impl SierraCasmRunner {
     ) -> Result<RunResultStarknet, RunnerError> {
         let initial_gas = self.get_initial_available_gas(func, available_gas)?;
         let (entry_code, builtins) = self.create_entry_code(func, args, initial_gas)?;
-        let footer = self.create_code_footer();
+        let footer = Self::create_code_footer();
         let instructions =
             chain!(entry_code.iter(), self.casm_program.instructions.iter(), footer.iter());
         let (hints_dict, string_to_hint) = build_hints_dict(instructions.clone());
@@ -678,7 +678,7 @@ impl SierraCasmRunner {
     }
 
     /// Creates a list of instructions that will be appended to the program's bytecode.
-    pub fn create_code_footer(&self) -> Vec<Instruction> {
+    pub fn create_code_footer() -> Vec<Instruction> {
         casm! {
             // Add a `ret` instruction used in libfuncs that retrieve the current value of the `fp`
             // and `pc` registers.

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use ark_std::iterable::Iterable;
 use cairo_felt::Felt252;
+use cairo_lang_casm::assembler::AssembledCairoProgram;
 use cairo_lang_casm::hints::Hint;
 use cairo_lang_casm::instructions::Instruction;
 use cairo_lang_casm::{casm, casm_extend};
@@ -39,7 +40,7 @@ use cairo_vm::vm::trace::trace_entry::TraceEntry;
 use cairo_vm::vm::vm_core::VirtualMachine;
 use casm_run::hint_to_hint_params;
 pub use casm_run::{CairoHintProcessor, StarknetState};
-use itertools::chain;
+use itertools::{chain, Itertools};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use profiling::ProfilingInfo;
@@ -153,6 +154,19 @@ pub fn build_hints_dict<'b>(
     (hints_dict, string_to_hint)
 }
 
+pub fn hints_from_assembled_program(
+    casm_program: &AssembledCairoProgram,
+    hints_dict: &mut HashMap<usize, Vec<HintParams>>,
+    string_to_hint: &mut HashMap<String, Hint>,
+) {
+    for (offset, hints) in &casm_program.hints {
+        hints_dict.insert(*offset, hints.iter().map(hint_to_hint_params).collect());
+        for hint in hints {
+            string_to_hint.insert(hint.representing_string(), hint.clone());
+        }
+    }
+}
+
 /// Runner enabling running a Sierra program on the vm.
 pub struct SierraCasmRunner {
     /// The sierra program.
@@ -215,6 +229,9 @@ impl SierraCasmRunner {
         let instructions =
             chain!(entry_code.iter(), self.casm_program.instructions.iter(), footer.iter());
         let (hints_dict, string_to_hint) = build_hints_dict(instructions.clone());
+        let assembled_program =
+            assemble_program(instructions.cloned().collect(), self.casm_program.clone());
+
         let mut hint_processor = CairoHintProcessor {
             runner: Some(self),
             starknet_state,
@@ -222,7 +239,7 @@ impl SierraCasmRunner {
             run_resources: RunResources::default(),
         };
         let RunResult { gas_counter, memory, value, profiling_info } =
-            self.run_function(func, &mut hint_processor, hints_dict, instructions, builtins)?;
+            self.run_function(func, &mut hint_processor, hints_dict, assembled_program.bytecode.iter(), builtins)?;
         Ok(RunResultStarknet {
             gas_counter,
             memory,
@@ -247,14 +264,13 @@ impl SierraCasmRunner {
         builtins: Vec<BuiltinName>,
     ) -> Result<RunResult, RunnerError>
     where
-        Instructions: Iterator<Item = &'a Instruction> + Clone,
+        Instructions: Iterator<Item = &'a BigInt> + Clone,
     {
         let return_types = self.generic_id_and_size_from_concrete(&func.signature.ret_types);
-        let instructions = assemble_instructions(instructions);
 
         let (cells, ap) = casm_run::run_function(
             vm,
-            instructions.iter(),
+            instructions,
             builtins,
             initialize_vm,
             hint_processor,
@@ -369,7 +385,7 @@ impl SierraCasmRunner {
         builtins: Vec<BuiltinName>,
     ) -> Result<RunResult, RunnerError>
     where
-        Instructions: Iterator<Item = &'a Instruction> + Clone,
+        Instructions: Iterator<Item = &'a BigInt> + Clone,
     {
         let mut vm = VirtualMachine::new(true);
         self.run_function_with_vm(func, &mut vm, hint_processor, hints_dict, instructions, builtins)
@@ -710,10 +726,12 @@ pub fn initialize_vm(context: RunFunctionContext<'_>) -> Result<(), Box<CairoRun
     Ok(())
 }
 
-pub fn assemble_instructions<'b>(
-    instructions: impl Iterator<Item = &'b Instruction>,
-) -> Vec<BigInt> {
-    instructions.into_iter().flat_map(|is| is.assemble().encode()).collect()
+pub fn assemble_program(
+    instructions: Vec<Instruction>,
+    mut new_program: CairoProgram,
+) -> AssembledCairoProgram {
+    new_program.instructions = instructions;
+    new_program.assemble()
 }
 
 /// Creates the metadata required for a Sierra program lowering to casm.

--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -104,7 +104,8 @@ impl CairoProgram {
         AssembledCairoProgram { bytecode, hints }
     }
 
-    /// Creates an assembled representation of the program preceded by `header` and followed by `footer`.
+    /// Creates an assembled representation of the program preceded by `header` and followed by
+    /// `footer`.
     pub fn assemble_ex(
         &mut self,
         header: Vec<Instruction>,

--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -13,7 +13,7 @@ use cairo_lang_sierra::program_registry::{ProgramRegistry, ProgramRegistryError}
 use cairo_lang_sierra_type_size::get_type_size_map;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
-use itertools::zip_eq;
+use itertools::{chain, zip_eq};
 use num_bigint::BigInt;
 use thiserror::Error;
 
@@ -102,6 +102,17 @@ impl CairoProgram {
             bytecode.extend(const_allocation.values.clone());
         }
         AssembledCairoProgram { bytecode, hints }
+    }
+
+    /// Creates an assembled representation of the program preceded by `header` and followed by `footer`.
+    pub fn assemble_ex(
+        &mut self,
+        header: Vec<Instruction>,
+        footer: Vec<Instruction>,
+    ) -> AssembledCairoProgram {
+        self.instructions =
+            chain!(header.iter(), self.instructions.iter(), footer.iter()).cloned().collect();
+        self.assemble()
     }
 }
 

--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -59,7 +59,7 @@ pub enum CompilationError {
 }
 
 /// The casm program representation.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct CairoProgram {
     pub instructions: Vec<Instruction>,
     pub debug_info: CairoProgramDebugInfo,
@@ -106,7 +106,7 @@ impl CairoProgram {
 }
 
 /// The debug information of a compilation from Sierra to casm.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct SierraStatementDebugInfo {
     /// The offset of the sierra statement within the bytecode.
     pub code_offset: usize,
@@ -115,7 +115,7 @@ pub struct SierraStatementDebugInfo {
 }
 
 /// The debug information of a compilation from Sierra to casm.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct CairoProgramDebugInfo {
     /// The debug information per Sierra statement.
     pub sierra_statement_info: Vec<SierraStatementDebugInfo>,
@@ -152,7 +152,7 @@ impl ConstSegmentInfoBuilder {
 }
 
 /// The data of a single const in the const segment.
-#[derive(Debug, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
 pub struct ConstAllocation {
     /// The offset of the const within the constants segment.
     pub offset: CodeOffset,
@@ -161,7 +161,7 @@ pub struct ConstAllocation {
 }
 
 /// The information about the constants used in the program.
-#[derive(Debug, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
 pub struct ConstSegmentInfo {
     /// A map between the const type and the data of the const.
     pub const_allocations: OrderedHashMap<ConcreteTypeId, ConstAllocation>,


### PR DESCRIPTION
We want to use some functionalities of SierraCasmRunner in Starknet Foundry but need access to some lower-level functionalities. This PR exposes some parts of SierraCasmRunner as static methods so they can be used directly while preserving top-level APIs. It also introduces similar changes to casm_run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4644)
<!-- Reviewable:end -->
