### PR TITLE
Add standalone conditions

### DIFF
--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -245,6 +245,9 @@ async function getServerType(
   context: vscode.ExtensionContext
 ) {
   if (!isScarbEnabled) return ServerType.Standalone;
+  if (isScarbEnabled && !!configLanguageServerPath) {
+    return ServerType.Standalone
+  }
   if (!(await isScarbProject()) && !!configLanguageServerPath) {
     // If Scarb manifest is missing, and Cairo-LS path is explicit.
     return ServerType.Standalone;


### PR DESCRIPTION
In [dojo-starter](https://github.com/dojoengine/dojo-starter) template, dojo is configured as follows:

```json
{
    "cairo1.languageServerPath": "$HOME/.dojo/bin/dojo-language-server",
    "cairo1.enableLanguageServer": true,
    "cairo1.enableScarb": true
}
```

But this configuration will cause cairo-vscode to start the LSP inside the scarb. The following shows the Cairo extension log:

```
Using Scarb binary from: /root/.local/bin/scarb
Cairo language server running from Scarb at: /root/.local/bin/scarb
```

This is not in line with developer intuition. Generally speaking, the configuration specified by the developer should override the default configuration. So I modified the `getServerType` function to make vscode-cairo more intuitive to users. The following shows the modified cairo extension log:

```
Using Scarb binary from: /root/.local/bin/scarb
Cairo language server running from: /root/.dojo/bin/dojo-language-server
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4690)
<!-- Reviewable:end -->
