### PR TITLE
Remove redundant `Copy` requirement from `Debug` impls

### DIFF
--- a/corelib/src/fmt.cairo
+++ b/corelib/src/fmt.cairo
@@ -55,11 +55,7 @@ impl DebugByteArray of Debug<ByteArray> {
 }
 
 impl DebugInteger<
-    T,
-    +to_byte_array::AppendFormattedToByteArray<T>,
-    +Into<u8, T>,
-    +TryInto<T, NonZero<T>>,
-    +Copy<T>
+    T, +to_byte_array::AppendFormattedToByteArray<T>, +Into<u8, T>, +TryInto<T, NonZero<T>>
 > of Debug<T> {
     fn fmt(self: @T, ref f: Formatter) -> Result<(), Error> {
         Display::fmt(self, ref f)
@@ -144,13 +140,13 @@ impl DebugTuple4<
     }
 }
 
-impl ArrayTDebug<T, +Debug<T>, +Copy<T>> of Debug<Array<T>> {
+impl ArrayTDebug<T, +Debug<T>> of Debug<Array<T>> {
     fn fmt(self: @Array<T>, ref f: Formatter) -> Result<(), Error> {
         Debug::fmt(@self.span(), ref f)
     }
 }
 
-impl SpanTDebug<T, +Debug<T>, +Copy<T>> of Debug<Span<T>> {
+impl SpanTDebug<T, +Debug<T>> of Debug<Span<T>> {
     fn fmt(self: @Span<T>, ref f: Formatter) -> Result<(), Error> {
         let mut self = *self;
         write!(f, "[")?;


### PR DESCRIPTION
Those requirements doesn't seem necessary, correct me if I'm wrong

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4741)
<!-- Reviewable:end -->
