### PR TITLE
[fix] Fixing Antora build errors

### DIFF
--- a/docs/reference/src/components/cairo/antora.yml
+++ b/docs/reference/src/components/cairo/antora.yml
@@ -1,4 +1,4 @@
-name: documentation
+name: ROOT
 title: Cairo docs
 version: ~
 nav:

--- a/docs/reference/src/components/cairo/antora.yml
+++ b/docs/reference/src/components/cairo/antora.yml
@@ -1,5 +1,5 @@
+name: documentation
 title: Cairo docs
-name: ROOT
 version: ~
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/notation.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/notation.adoc
@@ -15,8 +15,8 @@ The following notational convention is used in grammar snippets:
 | `x?`                    | `pub?`                        | An optional item
 | `x*`                    | `item*`                       | 0 or more of `x`
 | `x+`                    | `item+`                       | 1 or more of `x`
-| `x{a}`                  | `[0-9a-fA-F]{2}`              | Exactly `a` repetitions of `x`
-| `x{a,b}`                | `[0-9a-fA-F]{1,6}`            | `a` to `b` repetitions of `x`
+| `x\{a}`                  | `[0-9a-fA-F]\{2}`              | Exactly `a` repetitions of `x`
+| `x\{a,b}`                | `[0-9a-fA-F]\{1,6}`            | `a` to `b` repetitions of `x`
 | `&#124;`                | `felt &#124; int`             | Either one or another
 | `[ ]`                   | `[bB]`                        | Any of the characters listed
 | `[ - ]`                 | `[a-z]`                       | Any of the characters in the range

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/tuple-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/tuple-expressions.adoc
@@ -15,3 +15,4 @@ Examples:
 | (1_u32,)                      | (u32,)
 | (1_u32, Option::Some(3_u8))   | (u32, Option<u8>)
 | (True, False, 'abc')          | (bool, bool, felt252)
+|===


### PR DESCRIPTION
Fixing these build errors:

[15:32:08.754] WARN (asciidoctor): skipping reference to missing attribute: a
    file: docs/reference/src/components/cairo/modules/language_constructs/pages/notation.adoc
    source: https://github.com/starkware-libs/cairo.git (branch: main | start path: docs/reference/src/components/cairo)
[15:32:08.757] WARN (asciidoctor): skipping reference to missing attribute: 2
    file: docs/reference/src/components/cairo/modules/language_constructs/pages/notation.adoc
    source: https://github.com/starkware-libs/cairo.git (branch: main | start path: docs/reference/src/components/cairo)
[15:32:08.811] WARN (asciidoctor): unterminated table block
    file: docs/reference/src/components/cairo/modules/language_constructs/pages/tuple-expressions.adoc:12
    source: https://github.com/starkware-libs/cairo.git (branch: main | start path: docs/reference/src/components/cairo)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4755)
<!-- Reviewable:end -->
