### PR TITLE
feat: cairo-lang-utils supports no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,18 @@ on:
     types: [checks_requested]
 
 jobs:
+  ensure-no_std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2023-07-05
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          cd ensure-no_std && cargo build
+  
   parallel-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - test -p cairo-lang-test-runner
           - test -p cairo-lang-test-utils
           - test -p cairo-lang-utils
+          - test -p cairo-lang-utils --no-default-features --features=serde 
           - test -p tests
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           - test -p cairo-lang-test-runner
           - test -p cairo-lang-test-utils
           - test -p cairo-lang-utils
-          - test -p cairo-lang-utils --no-default-features --features=serde 
+          - test -p cairo-lang-utils --no-default-features --features=serde
           - test -p tests
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules
 .DS_Store
 perf.data*
 flamegraph.svg
+
+ensure-no_std/Cargo.lock
+ensure-no_std/target/
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ name = "cairo-lang-utils"
 version = "2.4.1"
 dependencies = [
  "env_logger",
+ "hashbrown 0.14.3",
  "indexmap 2.1.0",
  "itertools 0.11.0",
  "log",
@@ -1053,7 +1054,7 @@ dependencies = [
  "bitvec",
  "cairo-felt",
  "generic-array",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "hex",
  "keccak",
  "lazy_static",
@@ -1277,7 +1278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.9",
@@ -1637,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash 0.8.6",
  "allocator-api2",
@@ -1762,7 +1763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -2204,10 +2205,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
- "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "crates/bin/starknet-sierra-upgrade-validate",
     "tests",
 ]
+exclude = ["ensure-no_std"]
 
 [workspace.package]
 version = "2.4.1"
@@ -77,21 +78,22 @@ diffy = "0.3.0"
 env_logger = "0.10.0"
 genco = "0.17.8"
 good_lp = { version = "1.7.0", features = ["minilp"], default-features = false }
+hashbrown = "0.14.3" 
 id-arena = "2.2.1"
 ignore = "0.4.20"
 indent = "0.1.1"
-indexmap = { version = "2.1.0", features = ["serde"] }
+indexmap = { version = "2.1.0", default-features = false }
 indoc = "2.0.4"
-itertools = "0.11.0"
+itertools = {version = "0.11.0", default-features = false }
 keccak = "0.1.4"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 log = "0.4"
 lsp = { version = "0.94", package = "lsp-types" }
-num-bigint = { version = "0.4", features = ["serde"] }
+num-bigint = { version = "0.4", default-features = false }
 num-integer = "0.1"
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 once_cell = "1.18.0"
-parity-scale-codec = "3.6.5"
+parity-scale-codec = { version = "3.6.5", default-features = false }
 parity-scale-codec-derive = "3.6.5"
 path-clean = "1.0.1"
 pretty_assertions = "1.4.0"
@@ -102,7 +104,7 @@ rstest = "0.18.2"
 salsa = "0.16.1"
 scarb-metadata = "1"
 schemars = { version = "0.8.15", features = ["preserve_order"] }
-serde = { version = "1.0.192", features = ["derive"] }
+serde = { version = "1.0.192", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.10.8"
 smol_str = { version = "0.2.0", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ ignore = "0.4.20"
 indent = "0.1.1"
 indexmap = { version = "2.1.0", default-features = false }
 indoc = "2.0.4"
-itertools = {version = "0.11.0", default-features = false }
+itertools = { version = "0.11.0", default-features = false }
 keccak = "0.1.4"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 log = "0.4"

--- a/crates/bin/generate-syntax/Cargo.toml
+++ b/crates/bin/generate-syntax/Cargo.toml
@@ -8,7 +8,7 @@ license-file.workspace = true
 [dependencies]
 log.workspace = true
 
-cairo-lang-utils = { path = "../../cairo-lang-utils", features = [
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.4.1", features = [
     "env_logger",
 ] }
-cairo-lang-syntax-codegen = { path = "../../cairo-lang-syntax-codegen" }
+cairo-lang-syntax-codegen = { path = "../../cairo-lang-syntax-codegen", version = "2.4.1" }

--- a/crates/bin/starknet-sierra-compile/Cargo.toml
+++ b/crates/bin/starknet-sierra-compile/Cargo.toml
@@ -9,7 +9,7 @@ description = "Compiler executable for the Sierra intemediate representation wit
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 
 cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "2.4.1" }

--- a/crates/bin/starknet-sierra-compile/Cargo.toml
+++ b/crates/bin/starknet-sierra-compile/Cargo.toml
@@ -12,6 +12,6 @@ clap.workspace = true
 serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 
-cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "2.4.1" }
-cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.4.1" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.4.1" }
+cairo-lang-sierra = { path = "../../cairo-lang-sierra" }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", features = ["serde"] }

--- a/crates/bin/starknet-sierra-compile/Cargo.toml
+++ b/crates/bin/starknet-sierra-compile/Cargo.toml
@@ -12,6 +12,6 @@ clap.workspace = true
 serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 
-cairo-lang-sierra = { path = "../../cairo-lang-sierra" }
-cairo-lang-starknet = { path = "../../cairo-lang-starknet" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", features = ["serde"] }
+cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "2.4.1" }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.4.1" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.4.1", features = ["serde"] }

--- a/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
+++ b/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
@@ -9,7 +9,7 @@ description = "Compiler executable for validating a Sierra upgrade is valid"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 rayon.workspace = true
 indicatif = "0.17.7"

--- a/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
+++ b/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
@@ -14,5 +14,5 @@ serde_json.workspace = true
 rayon.workspace = true
 indicatif = "0.17.7"
 
-cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.4.1" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.4.1" }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", features = ["serde"] }

--- a/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
+++ b/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
@@ -14,5 +14,5 @@ serde_json.workspace = true
 rayon.workspace = true
 indicatif = "0.17.7"
 
-cairo-lang-starknet = { path = "../../cairo-lang-starknet" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", features = ["serde"] }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "2.4.1" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.4.1", features = ["serde"] }

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -9,17 +9,17 @@ description = "Cairo assembly encoding."
 [dependencies]
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 indoc.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
 parity-scale-codec.workspace = true
 parity-scale-codec-derive.workspace = true
 schemars = { workspace = true, features = ["preserve_order"] }
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 thiserror.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Cairo assembly encoding."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
+cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde"] }
 indoc.workspace = true
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Cairo assembly encoding."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde"] }
+cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde", "schemars"] }
 indoc.workspace = true
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Cairo assembly encoding."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde", "schemars"] }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1", features = ["serde", "schemars"] }
 indoc.workspace = true
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }

--- a/crates/cairo-lang-defs/Cargo.toml
+++ b/crates/cairo-lang-defs/Cargo.toml
@@ -13,7 +13,7 @@ cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.4.1" }
 cairo-lang-parser = { path = "../cairo-lang-parser", version = "2.4.1" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 salsa.workspace = true
 smol_str.workspace = true
 

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -194,7 +194,7 @@ pub trait DefsGroup:
         module_id: ModuleId,
     ) -> Maybe<Arc<OrderedHashMap<ExternFunctionId, ast::ItemExternFunction>>>;
     fn module_extern_functions_ids(&self, module_id: ModuleId)
-    -> Maybe<Arc<Vec<ExternFunctionId>>>;
+        -> Maybe<Arc<Vec<ExternFunctionId>>>;
     fn module_extern_function_by_id(
         &self,
         extern_function_id: ExternFunctionId,
@@ -237,7 +237,7 @@ fn module_main_file(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<FileId> {
         }
         ModuleId::Submodule(submodule_id) => {
             let parent = submodule_id.parent_module(db);
-            let item_module_ast = &db.priv_module_data(parent)?.submodules[submodule_id];
+            let item_module_ast = &db.priv_module_data(parent)?.submodules[&submodule_id];
             match item_module_ast.body(db.upcast()) {
                 MaybeModuleBody::Some(_) => {
                     // This is an inline module, we return the file where the inline module was
@@ -259,7 +259,7 @@ fn module_files(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<Arc<Vec<FileId
 }
 
 fn module_file(db: &dyn DefsGroup, module_file_id: ModuleFileId) -> Maybe<FileId> {
-    Ok(db.module_files(module_file_id.0)?[module_file_id.1.0])
+    Ok(db.module_files(module_file_id.0)?[module_file_id.1 .0])
 }
 
 fn module_dir(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<Directory> {
@@ -361,7 +361,7 @@ fn priv_module_data(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<ModuleData
         ModuleId::CrateRoot(_) => file_syntax.items(syntax_db),
         ModuleId::Submodule(submodule_id) => {
             let parent_module_data = db.priv_module_data(submodule_id.parent_module(db))?;
-            let item_module_ast = &parent_module_data.submodules[submodule_id];
+            let item_module_ast = &parent_module_data.submodules[&submodule_id];
 
             match item_module_ast.body(syntax_db) {
                 MaybeModuleBody::Some(body) => {
@@ -956,7 +956,7 @@ fn module_item_name_stable_ptr(
 ) -> Maybe<SyntaxStablePtrId> {
     let data = db.priv_module_data(module_id)?;
     let db = db.upcast();
-    Ok(match item_id {
+    Ok(match &item_id {
         ModuleItemId::Constant(id) => data.constants[id].name(db).stable_ptr().untyped(),
         ModuleItemId::Submodule(id) => data.submodules[id].name(db).stable_ptr().untyped(),
         ModuleItemId::Use(id) => {

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -194,7 +194,7 @@ pub trait DefsGroup:
         module_id: ModuleId,
     ) -> Maybe<Arc<OrderedHashMap<ExternFunctionId, ast::ItemExternFunction>>>;
     fn module_extern_functions_ids(&self, module_id: ModuleId)
-        -> Maybe<Arc<Vec<ExternFunctionId>>>;
+    -> Maybe<Arc<Vec<ExternFunctionId>>>;
     fn module_extern_function_by_id(
         &self,
         extern_function_id: ExternFunctionId,
@@ -259,7 +259,7 @@ fn module_files(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<Arc<Vec<FileId
 }
 
 fn module_file(db: &dyn DefsGroup, module_file_id: ModuleFileId) -> Maybe<FileId> {
-    Ok(db.module_files(module_file_id.0)?[module_file_id.1 .0])
+    Ok(db.module_files(module_file_id.0)?[module_file_id.1.0])
 }
 
 fn module_dir(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<Directory> {

--- a/crates/cairo-lang-diagnostics/Cargo.toml
+++ b/crates/cairo-lang-diagnostics/Cargo.toml
@@ -10,7 +10,7 @@ description = "Diagnostic utilities."
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.4.1" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/cairo-lang-eq-solver/Cargo.toml
+++ b/crates/cairo-lang-eq-solver/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Equation solving for Sierra generation."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
+cairo-lang-utils = { path = "../cairo-lang-utils" }
 good_lp.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-eq-solver/Cargo.toml
+++ b/crates/cairo-lang-eq-solver/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Equation solving for Sierra generation."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 good_lp.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-eq-solver/src/lib.rs
+++ b/crates/cairo-lang-eq-solver/src/lib.rs
@@ -70,7 +70,7 @@ fn try_solve_equations_iteration<Var: Clone + Debug + PartialEq + Eq + Hash>(
     target_vars: &[Var],
 ) -> Option<OrderedHashMap<Var, i64>> {
     let mut vars = variables!();
-    let mut orig_to_solver_var = OrderedHashMap::default();
+    let mut orig_to_solver_var = OrderedHashMap::new();
     // Add all variables to structure and map.
     for eq in equations {
         for var in eq.var_to_coef.keys() {

--- a/crates/cairo-lang-filesystem/Cargo.toml
+++ b/crates/cairo-lang-filesystem/Cargo.toml
@@ -7,11 +7,11 @@ license-file.workspace = true
 description = "Virtual filesystem for the compiler."
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.4.1" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
+cairo-lang-debug = { path = "../cairo-lang-debug" }
+cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde"] }
 path-clean.workspace = true
 salsa.workspace = true
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 smol_str.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-filesystem/Cargo.toml
+++ b/crates/cairo-lang-filesystem/Cargo.toml
@@ -7,8 +7,8 @@ license-file.workspace = true
 description = "Virtual filesystem for the compiler."
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug" }
-cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde"] }
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.4.1" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1", features = ["serde"] }
 path-clean.workspace = true
 salsa.workspace = true
 serde = { workspace = true, default-features = true }

--- a/crates/cairo-lang-formatter/Cargo.toml
+++ b/crates/cairo-lang-formatter/Cargo.toml
@@ -15,9 +15,9 @@ cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 diffy.workspace = true
 ignore.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 salsa.workspace = true
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 smol_str.workspace = true
 thiserror.workspace = true
 

--- a/crates/cairo-lang-language-server/Cargo.toml
+++ b/crates/cairo-lang-language-server/Cargo.toml
@@ -25,7 +25,7 @@ log.workspace = true
 lsp.workspace = true
 salsa.workspace = true
 scarb-metadata.workspace = true
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 tokio.workspace = true
 tower-lsp.workspace = true

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -17,10 +17,10 @@ cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "2.4.1" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 id-arena.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 log.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
 once_cell.workspace = true
 salsa.workspace = true
 smol_str.workspace = true

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -320,7 +320,7 @@ fn priv_function_with_body_lowering(
 ) -> Maybe<Arc<FlatLowered>> {
     let semantic_function_id = function_id.base_semantic_function(db);
     let multi_lowering = db.priv_function_with_body_multi_lowering(semantic_function_id)?;
-    let lowered = match db.lookup_intern_lowering_function_with_body(function_id) {
+    let lowered = match &db.lookup_intern_lowering_function_with_body(function_id) {
         ids::FunctionWithBodyLongId::Semantic(_) => multi_lowering.main_lowering.clone(),
         ids::FunctionWithBodyLongId::Generated { element, .. } => {
             multi_lowering.generated_lowerings[element].clone()

--- a/crates/cairo-lang-lowering/src/graph_algorithms/strongly_connected_components.rs
+++ b/crates/cairo-lang-lowering/src/graph_algorithms/strongly_connected_components.rs
@@ -1,5 +1,3 @@
-use std::collections::hash_map::RandomState;
-
 use cairo_lang_defs::ids::UnstableSalsaId;
 use cairo_lang_utils::graph_algos::strongly_connected_components::compute_scc;
 
@@ -28,10 +26,7 @@ pub fn concrete_function_with_body_scc(
     db: &dyn LoweringGroup,
     function_id: ConcreteFunctionWithBodyId,
 ) -> Vec<ConcreteFunctionWithBodyId> {
-    compute_scc::<_, RandomState>(&ConcreteFunctionWithBodyPostInlineNode {
-        function_id,
-        db: db.upcast(),
-    })
+    compute_scc(&ConcreteFunctionWithBodyPostInlineNode { function_id, db: db.upcast() })
 }
 
 /// Query implementation of
@@ -53,8 +48,5 @@ pub fn concrete_function_with_body_postpanic_scc(
     db: &dyn LoweringGroup,
     function_id: ConcreteFunctionWithBodyId,
 ) -> Vec<ConcreteFunctionWithBodyId> {
-    compute_scc::<_, RandomState>(&ConcreteFunctionWithBodyPostPanicNode {
-        function_id,
-        db: db.upcast(),
-    })
+    compute_scc(&ConcreteFunctionWithBodyPostPanicNode { function_id, db: db.upcast() })
 }

--- a/crates/cairo-lang-lowering/src/graph_algorithms/strongly_connected_components.rs
+++ b/crates/cairo-lang-lowering/src/graph_algorithms/strongly_connected_components.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::RandomState;
+
 use cairo_lang_defs::ids::UnstableSalsaId;
 use cairo_lang_utils::graph_algos::strongly_connected_components::compute_scc;
 
@@ -26,7 +28,10 @@ pub fn concrete_function_with_body_scc(
     db: &dyn LoweringGroup,
     function_id: ConcreteFunctionWithBodyId,
 ) -> Vec<ConcreteFunctionWithBodyId> {
-    compute_scc(&ConcreteFunctionWithBodyPostInlineNode { function_id, db: db.upcast() })
+    compute_scc::<_, RandomState>(&ConcreteFunctionWithBodyPostInlineNode {
+        function_id,
+        db: db.upcast(),
+    })
 }
 
 /// Query implementation of
@@ -48,5 +53,8 @@ pub fn concrete_function_with_body_postpanic_scc(
     db: &dyn LoweringGroup,
     function_id: ConcreteFunctionWithBodyId,
 ) -> Vec<ConcreteFunctionWithBodyId> {
-    compute_scc(&ConcreteFunctionWithBodyPostPanicNode { function_id, db: db.upcast() })
+    compute_scc::<_, RandomState>(&ConcreteFunctionWithBodyPostPanicNode {
+        function_id,
+        db: db.upcast(),
+    })
 }

--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -329,9 +329,14 @@ impl SealedBlockBuilder {
             let mut remapping = VarRemapping::default();
             // Since SemanticRemapping should have unique variable ids, these asserts will pass.
             for (semantic, remapped_var) in semantic_remapping.member_path_value.iter() {
-                assert!(remapping
-                    .insert(*remapped_var, builder.get_ref_raw(ctx, semantic, location).unwrap())
-                    .is_none());
+                assert!(
+                    remapping
+                        .insert(
+                            *remapped_var,
+                            builder.get_ref_raw(ctx, semantic, location).unwrap()
+                        )
+                        .is_none()
+                );
             }
             if let Some(remapped_var) = semantic_remapping.expr {
                 let var_usage = expr.unwrap_or_else(|| {

--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -127,8 +127,8 @@ impl BlockBuilder {
             MemberPath::Var(var) => ctx.semantic_defs[var].ty(),
             MemberPath::Member { member_id, concrete_struct_id, .. } => {
                 ctx.db.concrete_struct_members(*concrete_struct_id).unwrap()
-                    [member_id.name(ctx.db.upcast())]
-                .ty
+                    [&member_id.name(ctx.db.upcast())]
+                    .ty
             }
         }
     }
@@ -329,14 +329,9 @@ impl SealedBlockBuilder {
             let mut remapping = VarRemapping::default();
             // Since SemanticRemapping should have unique variable ids, these asserts will pass.
             for (semantic, remapped_var) in semantic_remapping.member_path_value.iter() {
-                assert!(
-                    remapping
-                        .insert(
-                            *remapped_var,
-                            builder.get_ref_raw(ctx, semantic, location).unwrap()
-                        )
-                        .is_none()
-                );
+                assert!(remapping
+                    .insert(*remapped_var, builder.get_ref_raw(ctx, semantic, location).unwrap())
+                    .is_none());
             }
             if let Some(remapped_var) = semantic_remapping.expr {
                 let var_usage = expr.unwrap_or_else(|| {

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::RandomState;
+
 use block_builder::BlockBuilder;
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_diagnostics::Maybe;
@@ -481,7 +483,7 @@ fn lower_single_pattern(
                 .db
                 .concrete_struct_members(structure.concrete_struct_id)
                 .map_err(LoweringFlowError::Failed)?;
-            let mut required_members = UnorderedHashMap::from_iter(
+            let mut required_members = UnorderedHashMap::<_, _, RandomState>::from_iter(
                 structure.field_patterns.iter().map(|(member, pattern)| (member.id, pattern)),
             );
             let generator = generators::StructDestructure {
@@ -1016,7 +1018,7 @@ fn lower_expr_loop(
         _ => unreachable!("Loop expression must be either loop or while."),
     };
 
-    let usage = &ctx.block_usages.block_usages[loop_expr_id];
+    let usage = &ctx.block_usages.block_usages[&loop_expr_id];
 
     // Determine signature.
     let params = usage.usage.iter().map(|(_, expr)| expr.clone()).collect_vec();
@@ -1682,7 +1684,8 @@ fn lower_expr_struct_ctor(
         .db
         .concrete_struct_members(expr.concrete_struct_id)
         .map_err(LoweringFlowError::Failed)?;
-    let member_expr = UnorderedHashMap::from_iter(expr.members.iter().cloned());
+    let member_expr =
+        UnorderedHashMap::<_, _, RandomState>::from_iter(expr.members.iter().cloned());
     Ok(LoweredExpr::AtVariable(
         generators::StructConstruct {
             inputs: members

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::hash_map::RandomState;
-
 use block_builder::BlockBuilder;
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_diagnostics::Maybe;
@@ -483,7 +481,7 @@ fn lower_single_pattern(
                 .db
                 .concrete_struct_members(structure.concrete_struct_id)
                 .map_err(LoweringFlowError::Failed)?;
-            let mut required_members = UnorderedHashMap::<_, _, RandomState>::from_iter(
+            let mut required_members = UnorderedHashMap::<_, _>::from_iter(
                 structure.field_patterns.iter().map(|(member, pattern)| (member.id, pattern)),
             );
             let generator = generators::StructDestructure {
@@ -1684,8 +1682,7 @@ fn lower_expr_struct_ctor(
         .db
         .concrete_struct_members(expr.concrete_struct_id)
         .map_err(LoweringFlowError::Failed)?;
-    let member_expr =
-        UnorderedHashMap::<_, _, RandomState>::from_iter(expr.members.iter().cloned());
+    let member_expr = UnorderedHashMap::<_, _>::from_iter(expr.members.iter().cloned());
     Ok(LoweredExpr::AtVariable(
         generators::StructConstruct {
             inputs: members

--- a/crates/cairo-lang-lowering/src/lower/usage.rs
+++ b/crates/cairo-lang-lowering/src/lower/usage.rs
@@ -177,7 +177,7 @@ impl BlockUsages {
             Expr::Loop(expr) => {
                 self.handle_expr(function_body, expr.body, current);
                 // Copy body usage to loop usage.
-                self.block_usages.insert(expr_id, self.block_usages[expr.body].clone());
+                self.block_usages.insert(expr_id, self.block_usages[&expr.body].clone());
             }
             Expr::While(expr) => {
                 let mut usage = Default::default();

--- a/crates/cairo-lang-lowering/src/optimizations/match_optimizer.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/match_optimizer.rs
@@ -25,7 +25,7 @@ pub fn optimize_matches(lowered: &mut FlatLowered) {
         analysis.get_root_info();
         let ctx = analysis.analyzer;
 
-        let mut target_blocks = UnorderedHashSet::default();
+        let mut target_blocks = UnorderedHashSet::new();
         for FixInfo { statement_location, target_block, remapping } in ctx.fixes.into_iter() {
             let block = &mut lowered.blocks[statement_location.0];
 

--- a/crates/cairo-lang-lowering/src/scc/mod.rs
+++ b/crates/cairo-lang-lowering/src/scc/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::RandomState;
+
 use cairo_lang_utils::graph_algos::graph_node::GraphNode;
 use cairo_lang_utils::graph_algos::strongly_connected_components::compute_scc;
 
@@ -9,7 +11,10 @@ pub fn function_with_body_scc(
     db: &dyn LoweringGroup,
     function_id: FunctionWithBodyId,
 ) -> Vec<FunctionWithBodyId> {
-    compute_scc(&FunctionWithBodyNode { function_with_body_id: function_id, db: db.upcast() })
+    compute_scc::<_, RandomState>(&FunctionWithBodyNode {
+        function_with_body_id: function_id,
+        db: db.upcast(),
+    })
 }
 
 /// A node to use in the SCC computation.

--- a/crates/cairo-lang-lowering/src/scc/mod.rs
+++ b/crates/cairo-lang-lowering/src/scc/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::hash_map::RandomState;
-
 use cairo_lang_utils::graph_algos::graph_node::GraphNode;
 use cairo_lang_utils::graph_algos::strongly_connected_components::compute_scc;
 
@@ -11,10 +9,7 @@ pub fn function_with_body_scc(
     db: &dyn LoweringGroup,
     function_id: FunctionWithBodyId,
 ) -> Vec<FunctionWithBodyId> {
-    compute_scc::<_, RandomState>(&FunctionWithBodyNode {
-        function_with_body_id: function_id,
-        db: db.upcast(),
-    })
+    compute_scc(&FunctionWithBodyNode { function_with_body_id: function_id, db: db.upcast() })
 }
 
 /// A node to use in the SCC computation.

--- a/crates/cairo-lang-parser/Cargo.toml
+++ b/crates/cairo-lang-parser/Cargo.toml
@@ -13,9 +13,9 @@ cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
 cairo-lang-syntax-codegen = { path = "../cairo-lang-syntax-codegen", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 colored.workspace = true
-itertools.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+itertools = { workspace = true, default-features = true }
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
 smol_str.workspace = true
 unescaper.workspace = true

--- a/crates/cairo-lang-plugins/Cargo.toml
+++ b/crates/cairo-lang-plugins/Cargo.toml
@@ -18,7 +18,7 @@ cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 indent.workspace = true
 indoc.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 salsa.workspace = true
 smol_str.workspace = true
 

--- a/crates/cairo-lang-plugins/src/test_utils.rs
+++ b/crates/cairo-lang-plugins/src/test_utils.rs
@@ -14,7 +14,7 @@ pub fn expand_module_text(
 ) -> String {
     let mut output = String::new();
     // A collection of all the use statements in the module.
-    let mut uses_list = UnorderedHashSet::default();
+    let mut uses_list = UnorderedHashSet::new();
     let syntax_db = db.upcast();
     // Collect the module diagnostics.
     for (file_id, diag) in db.module_plugin_diagnostics(module_id).unwrap().iter() {

--- a/crates/cairo-lang-project/Cargo.toml
+++ b/crates/cairo-lang-project/Cargo.toml
@@ -9,7 +9,7 @@ description = "Cairo project specification. For example, crates and flags used f
 [dependencies]
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 smol_str.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cairo-lang-runner/Cargo.toml
+++ b/crates/cairo-lang-runner/Cargo.toml
@@ -20,11 +20,11 @@ cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version
 cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 cairo-vm.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 keccak.workspace = true
-num-bigint.workspace = true
+num-bigint = { workspace = true, default-features = true }
 num-integer.workspace = true
-num-traits.workspace = true
+num-traits = { workspace = true, default-features = true }
 thiserror.workspace = true
 starknet-crypto.workspace = true
 

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -367,7 +367,11 @@ impl SierraCasmRunner {
             .funcs
             .iter()
             .find(|f| {
-                if let Some(name) = &f.id.debug_name { name.ends_with(name_suffix) } else { false }
+                if let Some(name) = &f.id.debug_name {
+                    name.ends_with(name_suffix)
+                } else {
+                    false
+                }
             })
             .ok_or_else(|| RunnerError::MissingFunction { suffix: name_suffix.to_owned() })
     }
@@ -534,7 +538,7 @@ impl SierraCasmRunner {
             return None;
         }
         Some(
-            self.metadata.gas_info.function_costs[func.id.clone()]
+            self.metadata.gas_info.function_costs[&func.id]
                 .iter()
                 .map(|(token_type, val)| val.into_or_panic::<usize>() * token_gas_cost(*token_type))
                 .sum(),

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -367,11 +367,7 @@ impl SierraCasmRunner {
             .funcs
             .iter()
             .find(|f| {
-                if let Some(name) = &f.id.debug_name {
-                    name.ends_with(name_suffix)
-                } else {
-                    false
-                }
+                if let Some(name) = &f.id.debug_name { name.ends_with(name_suffix) } else { false }
             })
             .ok_or_else(|| RunnerError::MissingFunction { suffix: name_suffix.to_owned() })
     }

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -22,9 +22,9 @@ cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", optional = true, features = ["testing"], version = "2.4.1" }
 id-arena.workspace = true
 indoc.workspace = true
-itertools.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+itertools = { workspace = true, default-features = true }
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
 once_cell.workspace = true
 salsa.workspace = true
 smol_str.workspace = true

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -19,7 +19,7 @@ cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "2.4.1" }
 cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "2.4.1" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
-cairo-lang-test-utils = { path = "../cairo-lang-test-utils", optional = true, features = ["testing"], version = "2.4.1" }
+cairo-lang-test-utils = { path = "../cairo-lang-test-utils", version = "2.4.1", optional = true, features = ["testing"] }
 id-arena.workspace = true
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1330,7 +1330,7 @@ fn maybe_compute_pattern_semantic(
             let pattern_param_asts = pattern_struct.params(syntax_db).elements(syntax_db);
             let struct_id = concrete_struct_id.struct_id(ctx.db);
             let mut members = ctx.db.concrete_struct_members(concrete_struct_id)?;
-            let mut used_members = UnorderedHashSet::default();
+            let mut used_members = UnorderedHashSet::new();
             let mut get_member = |ctx: &mut ComputationContext<'_>,
                                   member_name: SmolStr,
                                   stable_ptr: SyntaxStablePtrId| {

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -564,9 +564,9 @@ pub fn priv_impl_definition_data(
 
     // TODO(yuval): verify that all functions of `concrete_trait` appear in this impl.
 
-    let mut function_asts = OrderedHashMap::default();
-    let mut item_type_asts = OrderedHashMap::default();
-    let mut impl_item_names = OrderedHashSet::default();
+    let mut function_asts = OrderedHashMap::new();
+    let mut item_type_asts = OrderedHashMap::new();
+    let mut impl_item_names = OrderedHashSet::new();
 
     if let MaybeImplBody::Some(body) = impl_ast.body(syntax_db) {
         for item in body.items(syntax_db).elements(syntax_db) {
@@ -1362,7 +1362,7 @@ pub fn priv_impl_function_generic_params_data(
     let mut diagnostics = SemanticDiagnostics::new(module_file_id.file_id(db.upcast())?);
     let impl_def_id = impl_function_id.impl_def_id(db.upcast());
     let data = db.priv_impl_definition_data(impl_def_id)?;
-    let function_syntax = &data.function_asts[impl_function_id];
+    let function_syntax = &data.function_asts[&impl_function_id];
     let syntax_db = db.upcast();
     let declaration = function_syntax.declaration(syntax_db);
     let inference_id = InferenceId::LookupItemGenerics(LookupItemId::ImplItem(
@@ -1461,7 +1461,7 @@ pub fn priv_impl_function_declaration_data(
     let mut diagnostics = SemanticDiagnostics::new(module_file_id.file_id(db.upcast())?);
     let impl_def_id = impl_function_id.impl_def_id(db.upcast());
     let data = db.priv_impl_definition_data(impl_def_id)?;
-    let function_syntax = &data.function_asts[impl_function_id];
+    let function_syntax = &data.function_asts[&impl_function_id];
     let syntax_db = db.upcast();
     let declaration = function_syntax.declaration(syntax_db);
 
@@ -1724,7 +1724,7 @@ pub fn priv_impl_function_body_data(
     let mut diagnostics = SemanticDiagnostics::new(module_file_id.file_id(db.upcast())?);
     let impl_def_id = impl_function_id.impl_def_id(defs_db);
     let data = db.priv_impl_definition_data(impl_def_id)?;
-    let function_syntax = &data.function_asts[impl_function_id];
+    let function_syntax = &data.function_asts[&impl_function_id];
     // Compute declaration semantic.
     let declaration = db.priv_impl_function_declaration_data(impl_function_id)?;
     let parent_resolver_data = declaration.function_declaration_data.resolver_data;

--- a/crates/cairo-lang-semantic/src/items/module.rs
+++ b/crates/cairo-lang-semantic/src/items/module.rs
@@ -47,7 +47,7 @@ pub fn priv_module_semantic_data(
     let mut items = OrderedHashMap::default();
     let visibility_extractor = VisibilityExtractor { db: def_db, module_id };
     for item_id in db.module_items(module_id)?.iter().copied() {
-        let (name, visibility) = match item_id {
+        let (name, visibility) = match &item_id {
             ModuleItemId::Constant(item_id) => {
                 (item_id.name(def_db), visibility_extractor.constant(item_id))
             }
@@ -107,40 +107,40 @@ struct VisibilityExtractor<'a> {
     module_id: ModuleId,
 }
 impl<'a> VisibilityExtractor<'a> {
-    fn submodule(&self, item_id: SubmoduleId) -> Maybe<ast::Visibility> {
+    fn submodule(&self, item_id: &SubmoduleId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_submodules(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn constant(&self, item_id: ConstantId) -> Maybe<ast::Visibility> {
+    fn constant(&self, item_id: &ConstantId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_constants(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn free_function(&self, item_id: FreeFunctionId) -> Maybe<ast::Visibility> {
+    fn free_function(&self, item_id: &FreeFunctionId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_free_functions(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn enum_(&self, item_id: EnumId) -> Maybe<ast::Visibility> {
+    fn enum_(&self, item_id: &EnumId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_enums(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn struct_(&self, item_id: StructId) -> Maybe<ast::Visibility> {
+    fn struct_(&self, item_id: &StructId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_structs(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn extern_function(&self, item_id: ExternFunctionId) -> Maybe<ast::Visibility> {
+    fn extern_function(&self, item_id: &ExternFunctionId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_extern_functions(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn extern_type(&self, item_id: ExternTypeId) -> Maybe<ast::Visibility> {
+    fn extern_type(&self, item_id: &ExternTypeId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_extern_types(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn type_alias(&self, item_id: ModuleTypeAliasId) -> Maybe<ast::Visibility> {
+    fn type_alias(&self, item_id: &ModuleTypeAliasId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_type_aliases(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn impl_alias(&self, item_id: ImplAliasId) -> Maybe<ast::Visibility> {
+    fn impl_alias(&self, item_id: &ImplAliasId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_impl_aliases(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn trait_(&self, item_id: TraitId) -> Maybe<ast::Visibility> {
+    fn trait_(&self, item_id: &TraitId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_traits(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn impl_def(&self, item_id: ImplDefId) -> Maybe<ast::Visibility> {
+    fn impl_def(&self, item_id: &ImplDefId) -> Maybe<ast::Visibility> {
         Ok(self.db.module_impls(self.module_id)?[item_id].visibility(self.db.upcast()))
     }
-    fn use_(&self, item_id: UseId) -> Maybe<ast::Visibility> {
+    fn use_(&self, item_id: &UseId) -> Maybe<ast::Visibility> {
         let use_ast = &self.db.module_uses(self.module_id)?[item_id];
         let use_path = ast::UsePath::Leaf(use_ast.clone());
         let mut node = use_path.as_syntax_node();
@@ -179,7 +179,7 @@ pub fn module_item_info_by_name(
 
 /// Query implementation of [SemanticGroup::module_attributes].
 pub fn module_attributes(db: &dyn SemanticGroup, module_id: ModuleId) -> Maybe<Vec<Attribute>> {
-    Ok(match module_id {
+    Ok(match &module_id {
         ModuleId::CrateRoot(_) => vec![],
         ModuleId::Submodule(submodule_id) => {
             let module_ast =

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -381,9 +381,9 @@ pub fn priv_trait_semantic_definition_data(
     // the item instead of all the module data.
     let trait_ast = db.module_trait_by_id(trait_id)?.to_maybe()?;
 
-    let mut function_asts = OrderedHashMap::default();
-    let mut item_type_asts = OrderedHashMap::default();
-    let mut trait_item_names = OrderedHashSet::default();
+    let mut function_asts = OrderedHashMap::new();
+    let mut item_type_asts = OrderedHashMap::new();
+    let mut trait_item_names = OrderedHashSet::new();
     if let ast::MaybeTraitBody::Some(body) = trait_ast.body(syntax_db) {
         for item in body.items(syntax_db).elements(syntax_db) {
             match item {
@@ -488,7 +488,7 @@ pub fn priv_trait_type_generic_params_data(
     let mut diagnostics = SemanticDiagnostics::new(module_file_id.file_id(db.upcast())?);
     let trait_id = trait_type_id.trait_id(db.upcast());
     let data = db.priv_trait_semantic_definition_data(trait_id)?;
-    let trait_type_ast = &data.item_type_asts[trait_type_id];
+    let trait_type_ast = &data.item_type_asts[&trait_type_id];
     let inference_id =
         InferenceId::LookupItemGenerics(LookupItemId::TraitItem(TraitItemId::Type(trait_type_id)));
     let parent_resolver_data = db.trait_resolver_data(trait_id)?;
@@ -534,7 +534,7 @@ pub fn priv_trait_type_data(
     let mut diagnostics = SemanticDiagnostics::new(module_file_id.file_id(db.upcast())?);
     let trait_id = trait_type_id.trait_id(db.upcast());
     let data = db.priv_trait_semantic_definition_data(trait_id)?;
-    let type_syntax = &data.item_type_asts[trait_type_id];
+    let type_syntax = &data.item_type_asts[&trait_type_id];
 
     let type_generic_params_data = db.priv_trait_type_generic_params_data(trait_type_id)?;
     let type_generic_params = type_generic_params_data.generic_params;
@@ -598,7 +598,7 @@ pub fn priv_trait_function_generic_params_data(
     let mut diagnostics = SemanticDiagnostics::new(module_file_id.file_id(db.upcast())?);
     let trait_id = trait_function_id.trait_id(db.upcast());
     let data = db.priv_trait_semantic_definition_data(trait_id)?;
-    let function_syntax = &data.function_asts[trait_function_id];
+    let function_syntax = &data.function_asts[&trait_function_id];
     let declaration = function_syntax.declaration(syntax_db);
     let inference_id = InferenceId::LookupItemGenerics(LookupItemId::TraitItem(
         TraitItemId::Function(trait_function_id),
@@ -678,7 +678,7 @@ pub fn priv_trait_function_declaration_data(
     let mut diagnostics = SemanticDiagnostics::new(module_file_id.file_id(db.upcast())?);
     let trait_id = trait_function_id.trait_id(db.upcast());
     let data = db.priv_trait_semantic_definition_data(trait_id)?;
-    let function_syntax = &data.function_asts[trait_function_id];
+    let function_syntax = &data.function_asts[&trait_function_id];
     let declaration = function_syntax.declaration(syntax_db);
     let function_generic_params_data =
         db.priv_trait_function_generic_params_data(trait_function_id)?;
@@ -832,7 +832,7 @@ pub fn priv_trait_function_body_data(
     let mut diagnostics = SemanticDiagnostics::new(module_file_id.file_id(db.upcast())?);
     let trait_id = trait_function_id.trait_id(defs_db);
     let data = db.priv_trait_semantic_definition_data(trait_id)?;
-    let function_syntax = &data.function_asts[trait_function_id];
+    let function_syntax = &data.function_asts[&trait_function_id];
     // Compute declaration semantic.
     let trait_function_declaration_data =
         db.priv_trait_function_declaration_data(trait_function_id)?;

--- a/crates/cairo-lang-sierra-ap-change/Cargo.toml
+++ b/crates/cairo-lang-sierra-ap-change/Cargo.toml
@@ -11,9 +11,9 @@ cairo-lang-eq-solver = { path = "../cairo-lang-eq-solver", version = "2.4.1" }
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.4.1" }
 cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 thiserror.workspace = true
-num-traits.workspace = true
+num-traits = { workspace = true, default-features = true }
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/cairo-lang-sierra-gas/Cargo.toml
+++ b/crates/cairo-lang-sierra-gas/Cargo.toml
@@ -11,9 +11,9 @@ cairo-lang-eq-solver = { path = "../cairo-lang-eq-solver", version = "2.4.1" }
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.4.1" }
 cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 thiserror.workspace = true
-num-traits.workspace = true
+num-traits = { workspace = true, default-features = true }
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }

--- a/crates/cairo-lang-sierra-gas/src/compute_costs.rs
+++ b/crates/cairo-lang-sierra-gas/src/compute_costs.rs
@@ -707,7 +707,11 @@ impl<'a> SpecificCostContextTrait<i32> for PostcostContext<'a> {
     }
 
     fn to_cost_map(cost: i32) -> OrderedHashMap<CostTokenType, i64> {
-        if cost == 0 { Default::default() } else { Self::to_full_cost_map(cost) }
+        if cost == 0 {
+            Default::default()
+        } else {
+            Self::to_full_cost_map(cost)
+        }
     }
 
     fn to_full_cost_map(cost: i32) -> OrderedHashMap<CostTokenType, i64> {
@@ -780,7 +784,7 @@ impl<'a> PostcostContext<'a> {
 
         if with_builtin_costs {
             let steps = BuiltinCostWithdrawGasLibfunc::cost_computation_steps(|token_type| {
-                self.precost_gas_info.variable_values[(*idx, token_type)].into_or_panic()
+                self.precost_gas_info.variable_values[&(*idx, token_type)].into_or_panic()
             })
             .into_or_panic::<i32>();
             amount += ConstCost { steps, ..Default::default() }.cost();

--- a/crates/cairo-lang-sierra-gas/src/compute_costs.rs
+++ b/crates/cairo-lang-sierra-gas/src/compute_costs.rs
@@ -707,11 +707,7 @@ impl<'a> SpecificCostContextTrait<i32> for PostcostContext<'a> {
     }
 
     fn to_cost_map(cost: i32) -> OrderedHashMap<CostTokenType, i64> {
-        if cost == 0 {
-            Default::default()
-        } else {
-            Self::to_full_cost_map(cost)
-        }
+        if cost == 0 { Default::default() } else { Self::to_full_cost_map(cost) }
     }
 
     fn to_full_cost_map(cost: i32) -> OrderedHashMap<CostTokenType, i64> {

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_expr.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_expr.rs
@@ -31,7 +31,7 @@ impl CostOperations for Ops<'_> {
     ) -> Self::CostType {
         Self::CostType::from_iter([(
             token_type,
-            self.statement_future_cost.get_future_cost(&function.entry_point)[token_type].clone(),
+            self.statement_future_cost.get_future_cost(&function.entry_point)[&token_type].clone(),
         )])
     }
 

--- a/crates/cairo-lang-sierra-gas/src/gas_info.rs
+++ b/crates/cairo-lang-sierra-gas/src/gas_info.rs
@@ -108,7 +108,7 @@ impl Display for GasInfo {
         }
 
         for statement_idx in var_values.keys().sorted_by(|a, b| a.0.cmp(&b.0)) {
-            writeln!(f, "#{statement_idx}: {:?}", var_values[*statement_idx])?;
+            writeln!(f, "#{statement_idx}: {:?}", var_values[statement_idx])?;
         }
         writeln!(f)?;
         for (function_id, costs) in self.function_costs.iter() {

--- a/crates/cairo-lang-sierra-gas/src/generate_equations.rs
+++ b/crates/cairo-lang-sierra-gas/src/generate_equations.rs
@@ -78,7 +78,7 @@ impl EquationGenerator {
         let entry = &mut self.future_costs[idx.0];
         if let Some(other) = entry {
             for (token_type, val) in sub_maps(other.clone(), cost) {
-                self.equations[token_type].push(val);
+                self.equations[&token_type].push(val);
             }
         } else {
             *entry = Some(cost);

--- a/crates/cairo-lang-sierra-gas/src/generate_equations_test.rs
+++ b/crates/cairo-lang-sierra-gas/src/generate_equations_test.rs
@@ -111,7 +111,7 @@ fn generate(
                 .map(|x| CostExprMap::from_iter([(CostTokenType::Const, x.clone())]))
                 .collect()
         },
-    )?[CostTokenType::Const]
+    )?[&CostTokenType::Const]
         .clone())
 }
 

--- a/crates/cairo-lang-sierra-gas/src/lib.rs
+++ b/crates/cairo-lang-sierra-gas/src/lib.rs
@@ -150,7 +150,7 @@ pub fn calc_gas_postcost_info<ApChangeVarValue: Fn(StatementIdx) -> usize>(
                 &InvocationCostInfoProviderForEqGen {
                     type_sizes: &type_sizes,
                     token_usages: |token_type| {
-                        precost_gas_info.variable_values[(*idx, token_type)].into_or_panic()
+                        precost_gas_info.variable_values[&(*idx, token_type)].into_or_panic()
                     },
                     ap_change_var_value: || ap_change_var_value(*idx),
                 },
@@ -179,7 +179,7 @@ fn calc_gas_info_inner<
         .collect();
     for (func_id, cost_terms) in function_set_costs {
         for token_type in CostTokenType::iter() {
-            equations[*token_type].push(
+            equations[token_type].push(
                 Expr::from_var(Var::StatementFuture(
                     registry.get_function(&func_id)?.entry_point,
                     *token_type,
@@ -246,7 +246,7 @@ fn calc_gas_info_inner<
             if !function_costs.contains_key(id) {
                 function_costs.insert(id.clone(), OrderedHashMap::default());
             }
-            let value = solution[Var::StatementFuture(func.entry_point, token_type)];
+            let value = solution[&Var::StatementFuture(func.entry_point, token_type)];
             if value != 0 {
                 function_costs.get_mut(id).unwrap().insert(token_type, value);
             }

--- a/crates/cairo-lang-sierra-generator/Cargo.toml
+++ b/crates/cairo-lang-sierra-generator/Cargo.toml
@@ -21,8 +21,8 @@ cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.4.1" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", optional = true, features = ["testing"], version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
-itertools.workspace = true
-num-bigint.workspace = true
+itertools = { workspace = true, default-features = true }
+num-bigint = { workspace = true, default-features = true }
 once_cell.workspace = true
 salsa.workspace = true
 smol_str.workspace = true

--- a/crates/cairo-lang-sierra-generator/Cargo.toml
+++ b/crates/cairo-lang-sierra-generator/Cargo.toml
@@ -19,7 +19,7 @@ cairo-lang-parser = { path = "../cairo-lang-parser", version = "2.4.1" }
 cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "2.4.1" }
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.4.1" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
-cairo-lang-test-utils = { path = "../cairo-lang-test-utils", optional = true, features = ["testing"], version = "2.4.1" }
+cairo-lang-test-utils = { path = "../cairo-lang-test-utils", version = "2.4.1", optional = true, features = ["testing"] }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }

--- a/crates/cairo-lang-sierra-generator/src/store_variables/known_stack_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/known_stack_test.rs
@@ -21,7 +21,7 @@ fn assert_eq_stacks(a: &KnownStack, b: &KnownStack) {
     for (var, a_index) in a.variables_on_stack.iter() {
         assert_eq!(
             a.offset - *a_index,
-            b.offset - b.variables_on_stack[var.clone()],
+            b.offset - b.variables_on_stack[var],
             "Wrong value found for {var}.\na: {a:?}\nb: {b:?}"
         );
     }

--- a/crates/cairo-lang-sierra-to-casm/Cargo.toml
+++ b/crates/cairo-lang-sierra-to-casm/Cargo.toml
@@ -16,9 +16,9 @@ cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "2.4.1" }
 cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 indoc.workspace = true
-itertools.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+itertools = { workspace = true, default-features = true }
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-sierra-to-casm/Cargo.toml
+++ b/crates/cairo-lang-sierra-to-casm/Cargo.toml
@@ -9,12 +9,12 @@ description = "Emitting of CASM instructions from Sierra code."
 [dependencies]
 assert_matches.workspace = true
 cairo-felt.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra" }
-cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change" }
-cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas" }
-cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size" }
-cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde"] }
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.4.1" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.4.1" }
+cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "2.4.1" }
+cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "2.4.1" }
+cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.4.1" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1", features = ["serde"] }
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }

--- a/crates/cairo-lang-sierra-to-casm/Cargo.toml
+++ b/crates/cairo-lang-sierra-to-casm/Cargo.toml
@@ -9,12 +9,12 @@ description = "Emitting of CASM instructions from Sierra code."
 [dependencies]
 assert_matches.workspace = true
 cairo-felt.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.4.1" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.4.1" }
-cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "2.4.1" }
-cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "2.4.1" }
-cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "2.4.1" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
+cairo-lang-casm = { path = "../cairo-lang-casm" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra" }
+cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change" }
+cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas" }
+cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size" }
+cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde"] }
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }

--- a/crates/cairo-lang-sierra-to-casm/src/annotations.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/annotations.rs
@@ -134,7 +134,7 @@ impl ProgramAnnotations {
                     function_id: func.id.clone(),
                     convergence_allowed: false,
                     environment: Environment::new(if gas_usage_check {
-                        GasWallet::Value(metadata.gas_info.function_costs[func.id.clone()].clone())
+                        GasWallet::Value(metadata.gas_info.function_costs[&func.id].clone())
                     } else {
                         GasWallet::Disabled
                     }),

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs
@@ -144,11 +144,11 @@ fn build_builtin_withdraw_gas(
         deref gas_counter;
         deref builtin_cost;
     };
-    let requested_count: i64 = variable_values[(builder.idx, CostTokenType::Const)];
+    let requested_count: i64 = variable_values[&(builder.idx, CostTokenType::Const)];
     let mut total_requested_count =
         casm_builder.add_var(CellExpression::Immediate(BigInt::from(requested_count)));
     for token_type in CostTokenType::iter_precost() {
-        let requested_count = variable_values[(builder.idx, *token_type)];
+        let requested_count = variable_values[&(builder.idx, *token_type)];
         if requested_count == 0 {
             continue;
         }

--- a/crates/cairo-lang-sierra-to-casm/src/metadata.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/metadata.rs
@@ -97,7 +97,7 @@ pub fn calc_metadata(
     let ap_change_info =
         if config.linear_ap_change_solver { linear_calc_ap_changes } else { calc_ap_changes }(
             program,
-            |idx, token_type| pre_gas_info.variable_values[(idx, token_type)] as usize,
+            |idx, token_type| pre_gas_info.variable_values[&(idx, token_type)] as usize,
         )?;
 
     let post_function_set_costs = config
@@ -122,7 +122,7 @@ pub fn calc_metadata(
         let enforced_function_costs: OrderedHashMap<FunctionId, i32> = config
             .function_set_costs
             .iter()
-            .map(|(func, costs)| (func.clone(), costs[CostTokenType::Const]))
+            .map(|(func, costs)| (func.clone(), costs[&CostTokenType::Const]))
             .collect();
         let post_gas_info2 = compute_postcost_info(
             program,

--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -14,16 +14,16 @@ regex = "1"
 [dependencies]
 anyhow.workspace = true
 cairo-felt.workspace = true
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
+cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde", "schemars"] }
 const-fnv1a-hash.workspace = true
 convert_case.workspace = true
 derivative.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 lalrpop-util.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 sha3.workspace = true
 smol_str.workspace = true

--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -14,7 +14,7 @@ regex = "1"
 [dependencies]
 anyhow.workspace = true
 cairo-felt.workspace = true
-cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde", "schemars"] }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1", features = ["serde", "schemars"] }
 const-fnv1a-hash.workspace = true
 convert_case.workspace = true
 derivative.workspace = true

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -24,12 +24,12 @@ cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 const_format.workspace = true
 convert_case.workspace = true
 indoc.workspace = true
-itertools.workspace = true
-num-bigint.workspace = true
+itertools = { workspace = true, default-features = true }
+num-bigint = { workspace = true, default-features = true }
 num-integer.workspace = true
-num-traits.workspace = true
+num-traits = { workspace = true, default-features = true }
 once_cell.workspace = true
-serde.workspace = true
+serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 sha3.workspace = true
 smol_str.workspace = true

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -9,18 +9,18 @@ description = "Starknet capabilities and utilities on top of Cairo."
 [dependencies]
 anyhow.workspace = true
 cairo-felt.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm" }
-cairo-lang-compiler = { path = "../cairo-lang-compiler" }
-cairo-lang-defs = { path = "../cairo-lang-defs" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem" }
-cairo-lang-lowering = { path = "../cairo-lang-lowering" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra" }
-cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator" }
-cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax" }
-cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde"] }
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.4.1" }
+cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "2.4.1" }
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "2.4.1" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "2.4.1" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.4.1" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "2.4.1" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "2.4.1" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.4.1" }
+cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "2.4.1" }
+cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "2.4.1" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1", features = ["serde"] }
 const_format.workspace = true
 convert_case.workspace = true
 indoc.workspace = true

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -9,18 +9,18 @@ description = "Starknet capabilities and utilities on top of Cairo."
 [dependencies]
 anyhow.workspace = true
 cairo-felt.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.4.1" }
-cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "2.4.1" }
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "2.4.1" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "2.4.1" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.4.1" }
-cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "2.4.1" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "2.4.1" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "2.4.1" }
-cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "2.4.1" }
-cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "2.4.1" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
+cairo-lang-casm = { path = "../cairo-lang-casm" }
+cairo-lang-compiler = { path = "../cairo-lang-compiler" }
+cairo-lang-defs = { path = "../cairo-lang-defs" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra" }
+cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator" }
+cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax" }
+cairo-lang-utils = { path = "../cairo-lang-utils", features = ["serde"] }
 const_format.workspace = true
 convert_case.workspace = true
 indoc.workspace = true

--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -194,11 +194,7 @@ impl<'a> AbiBuilder<'a> {
 
     /// Returns the finalized ABI.
     pub fn finalize(self) -> Result<Contract, ABIError> {
-        if let Some(err) = self.errors.into_iter().next() {
-            Err(err)
-        } else {
-            Ok(self.abi)
-        }
+        if let Some(err) = self.errors.into_iter().next() { Err(err) } else { Ok(self.abi) }
     }
 
     /// Returns the errors accumulated by the builder.
@@ -862,7 +858,7 @@ fn fetch_event_data(db: &dyn SemanticGroup, event_type_id: TypeId) -> Option<Eve
     // Attempt to extract the event data from the aux data from the impl generation.
     let module_file = impl_def_id.module_file_id(db.upcast());
     let file_infos = db.module_generated_file_infos(module_file.0).ok()?;
-    let aux_data = file_infos.get(module_file.1 .0)?.as_ref()?.aux_data.as_ref()?;
+    let aux_data = file_infos.get(module_file.1.0)?.as_ref()?.aux_data.as_ref()?;
     Some(aux_data.0.as_any().downcast_ref::<StarkNetEventAuxData>()?.event_data.clone())
 }
 

--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -194,7 +194,11 @@ impl<'a> AbiBuilder<'a> {
 
     /// Returns the finalized ABI.
     pub fn finalize(self) -> Result<Contract, ABIError> {
-        if let Some(err) = self.errors.into_iter().next() { Err(err) } else { Ok(self.abi) }
+        if let Some(err) = self.errors.into_iter().next() {
+            Err(err)
+        } else {
+            Ok(self.abi)
+        }
     }
 
     /// Returns the errors accumulated by the builder.
@@ -611,7 +615,7 @@ impl<'a> AbiBuilder<'a> {
                 let event_fields = members
                     .into_iter()
                     .map(|(name, kind)| {
-                        let concrete_member = &concrete_members[name.clone()];
+                        let concrete_member = &concrete_members[&name];
                         let ty = concrete_member.ty;
                         self.add_event_field(kind, ty, name, Source::Member(concrete_member.id))
                     })
@@ -858,7 +862,7 @@ fn fetch_event_data(db: &dyn SemanticGroup, event_type_id: TypeId) -> Option<Eve
     // Attempt to extract the event data from the aux data from the impl generation.
     let module_file = impl_def_id.module_file_id(db.upcast());
     let file_infos = db.module_generated_file_infos(module_file.0).ok()?;
-    let aux_data = file_infos.get(module_file.1.0)?.as_ref()?.aux_data.as_ref()?;
+    let aux_data = file_infos.get(module_file.1 .0)?.as_ref()?.aux_data.as_ref()?;
     Some(aux_data.0.as_any().downcast_ref::<StarkNetEventAuxData>()?.event_data.clone())
 }
 

--- a/crates/cairo-lang-starknet/src/casm_contract_class.rs
+++ b/crates/cairo-lang-starknet/src/casm_contract_class.rs
@@ -430,7 +430,7 @@ impl CasmContractClass {
                 .ok_or(StarknetSierraCompilationError::EntryPointError)?
                 .code_offset;
             assert_eq!(
-                metadata.gas_info.function_costs[function.id.clone()],
+                metadata.gas_info.function_costs[&function.id],
                 OrderedHashMap::from_iter([(CostTokenType::Const, ENTRY_POINT_COST as i64)]),
                 "Unexpected entry point cost."
             );

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -10,8 +10,8 @@ description = "Cairo syntax representation."
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.4.1" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
-num-bigint.workspace = true
-num-traits.workspace = true
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
 smol_str.workspace = true
 unescaper.workspace = true

--- a/crates/cairo-lang-test-plugin/Cargo.toml
+++ b/crates/cairo-lang-test-plugin/Cargo.toml
@@ -22,7 +22,7 @@ cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "2.4.1" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 indoc.workspace = true
-itertools.workspace = true
-num-bigint.workspace = true
-num-traits.workspace = true
-serde.workspace = true
+itertools = { workspace = true, default-features = true }
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
+serde = { workspace = true, default-features = true }

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -18,8 +18,8 @@ cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "2.4.1" }
 cairo-lang-test-plugin = { path = "../cairo-lang-test-plugin", version = "2.4.1" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1" }
 colored.workspace = true
-itertools.workspace = true
-num-traits.workspace = true
+itertools = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
 rayon.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -7,15 +7,16 @@ license-file.workspace = true
 description = "General utilities for the Cairo compiler project."
 
 [dependencies]
-indexmap.workspace = true
-itertools.workspace = true
+indexmap = { workspace = true }
+itertools = { workspace = true, features = ["use_alloc"] }
 num-bigint.workspace = true
 num-traits.workspace = true
 parity-scale-codec.workspace = true
-schemars = { workspace = true, features = ["preserve_order"] }
-serde.workspace = true
+hashbrown = { workspace = true, features = ["serde"] }
 
 # Optional
+serde = { workspace = true, features = ["alloc"], optional = true }
+schemars = { workspace = true, features = ["preserve_order"], optional = true }
 env_logger = { workspace = true, optional = true }
 time = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
@@ -27,5 +28,14 @@ test-log.workspace = true
 env_logger.workspace = true
 
 [features]
+default = ["std"]
+std = [
+  "indexmap/std",
+  "num-bigint/std",
+  "num-traits/std",
+  "serde?/std"
+]
+serde = ["dep:serde", "num-bigint/serde", "indexmap/serde"]
+schemars = ["std", "serde", "dep:schemars"]
 testing = []
-env_logger = ["dep:env_logger", "dep:time", "dep:log"]
+env_logger = ["std", "dep:env_logger", "dep:time", "dep:log"]

--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -4,7 +4,6 @@ mod test;
 
 #[cfg(not(feature = "std"))]
 use alloc::{format, string::String, vec};
-
 use core::ops::Neg;
 
 use num_bigint::{BigInt, BigUint, ToBigInt};

--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -2,12 +2,14 @@
 #[path = "bigint_test.rs"]
 mod test;
 
-use std::ops::Neg;
+#[cfg(not(feature = "std"))]
+use alloc::{format, string::String, vec};
+
+use core::ops::Neg;
 
 use num_bigint::{BigInt, BigUint, ToBigInt};
 use num_traits::{Num, Signed};
 use parity_scale_codec::{Decode, Encode};
-use schemars::JsonSchema;
 use serde::ser::Serializer;
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -47,17 +49,21 @@ where
 }
 
 // A wrapper for BigInt that serializes as hex.
-#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct BigIntAsHex {
     /// A field element that encodes the signature of the called function.
     #[serde(serialize_with = "serialize_big_int", deserialize_with = "deserialize_big_int")]
-    #[schemars(schema_with = "big_int_schema")]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "big_int_schema"))]
     pub value: BigInt,
 }
 
 // BigInt doesn't implement JsonSchema, so we need to manually define it.
+#[cfg(feature = "schemars")]
 fn big_int_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    use schemars::JsonSchema;
+
     #[allow(dead_code)]
     #[allow(clippy::enum_variant_names)]
     #[derive(JsonSchema)]

--- a/crates/cairo-lang-utils/src/bigint_test.rs
+++ b/crates/cairo-lang-utils/src/bigint_test.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use alloc::format;
 use core::ops::Neg;
 use core::str::FromStr;
 

--- a/crates/cairo-lang-utils/src/bigint_test.rs
+++ b/crates/cairo-lang-utils/src/bigint_test.rs
@@ -1,5 +1,5 @@
-use std::ops::Neg;
-use std::str::FromStr;
+use core::ops::Neg;
+use core::str::FromStr;
 
 use num_bigint::BigInt;
 use num_traits::Num;

--- a/crates/cairo-lang-utils/src/collection_arithmetics.rs
+++ b/crates/cairo-lang-utils/src/collection_arithmetics.rs
@@ -2,8 +2,8 @@
 #[path = "collection_arithmetics_test.rs"]
 mod test;
 
-use std::hash::Hash;
-use std::ops::{Add, Sub};
+use core::hash::{BuildHasher, Hash};
+use core::ops::{Add, Sub};
 
 use crate::ordered_hash_map::{Entry, OrderedHashMap};
 
@@ -33,10 +33,11 @@ pub fn add_maps<
     Key: Hash + Eq,
     Value: HasZero + Add<Output = Value> + Clone + Eq,
     Rhs: IntoIterator<Item = (Key, Value)>,
+    BH: BuildHasher,
 >(
-    lhs: OrderedHashMap<Key, Value>,
+    lhs: OrderedHashMap<Key, Value, BH>,
     rhs: Rhs,
-) -> OrderedHashMap<Key, Value> {
+) -> OrderedHashMap<Key, Value, BH> {
     merge_maps(lhs, rhs, |a, b| a + b)
 }
 
@@ -47,10 +48,11 @@ pub fn sub_maps<
     Key: Hash + Eq,
     Value: HasZero + Sub<Output = Value> + Clone + Eq,
     Rhs: IntoIterator<Item = (Key, Value)>,
+    BH: BuildHasher,
 >(
-    lhs: OrderedHashMap<Key, Value>,
+    lhs: OrderedHashMap<Key, Value, BH>,
     rhs: Rhs,
-) -> OrderedHashMap<Key, Value> {
+) -> OrderedHashMap<Key, Value, BH> {
     merge_maps(lhs, rhs, |a, b| a - b)
 }
 
@@ -63,11 +65,12 @@ fn merge_maps<
     Value: HasZero + Clone + Eq,
     Rhs: IntoIterator<Item = (Key, Value)>,
     Action: Fn(Value, Value) -> Value,
+    BH: BuildHasher,
 >(
-    lhs: OrderedHashMap<Key, Value>,
+    lhs: OrderedHashMap<Key, Value, BH>,
     rhs: Rhs,
     action: Action,
-) -> OrderedHashMap<Key, Value> {
+) -> OrderedHashMap<Key, Value, BH> {
     let mut res = lhs;
     for (key, rhs_val) in rhs {
         match res.entry(key) {

--- a/crates/cairo-lang-utils/src/collection_arithmetics_test.rs
+++ b/crates/cairo-lang-utils/src/collection_arithmetics_test.rs
@@ -3,17 +3,37 @@ use test_log::test;
 use crate::collection_arithmetics::{add_maps, sub_maps};
 use crate::ordered_hash_map::OrderedHashMap;
 
+#[cfg(not(feature = "std"))]
+use hashbrown::hash_map::DefaultHashBuilder as HashBuilderType;
+#[cfg(feature = "std")]
+use std::collections::hash_map::RandomState as HashBuilderType;
+
 #[test]
 fn test_add_map_and_sub_map() {
-    let x = OrderedHashMap::<i64, i64>::from_iter([(10, 3), (20, 7), (30, 3), (40, 3)]);
-    let y = OrderedHashMap::<i64, i64>::from_iter([(0, 2), (10, 5), (30, -3), (40, 3)]);
+    let x = OrderedHashMap::<i64, i64, HashBuilderType>::from_iter([
+        (10, 3),
+        (20, 7),
+        (30, 3),
+        (40, 3),
+    ]);
+    let y = OrderedHashMap::<i64, i64, HashBuilderType>::from_iter([
+        (0, 2),
+        (10, 5),
+        (30, -3),
+        (40, 3),
+    ]);
 
     assert_eq!(
         add_maps(x.clone(), y.iter().map(|(k, v)| (*k, *v))),
-        OrderedHashMap::<i64, i64>::from_iter([(10, 8), (20, 7), (0, 2), (40, 6)])
+        OrderedHashMap::<i64, i64, HashBuilderType>::from_iter([(10, 8), (20, 7), (0, 2), (40, 6)])
     );
     assert_eq!(
         sub_maps(x, y),
-        OrderedHashMap::<i64, i64>::from_iter([(10, -2), (20, 7), (30, 6), (0, -2)])
+        OrderedHashMap::<i64, i64, HashBuilderType>::from_iter([
+            (10, -2),
+            (20, 7),
+            (30, 6),
+            (0, -2)
+        ])
     );
 }

--- a/crates/cairo-lang-utils/src/collection_arithmetics_test.rs
+++ b/crates/cairo-lang-utils/src/collection_arithmetics_test.rs
@@ -1,12 +1,12 @@
+#[cfg(feature = "std")]
+use std::collections::hash_map::RandomState as HashBuilderType;
+
+#[cfg(not(feature = "std"))]
+use hashbrown::hash_map::DefaultHashBuilder as HashBuilderType;
 use test_log::test;
 
 use crate::collection_arithmetics::{add_maps, sub_maps};
 use crate::ordered_hash_map::OrderedHashMap;
-
-#[cfg(not(feature = "std"))]
-use hashbrown::hash_map::DefaultHashBuilder as HashBuilderType;
-#[cfg(feature = "std")]
-use std::collections::hash_map::RandomState as HashBuilderType;
 
 #[test]
 fn test_add_map_and_sub_map() {

--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set.rs
@@ -7,8 +7,6 @@
 //! so here we implement some straight-forward algorithm that guarantees to cover all the cycles in
 //! the graph, but doesn't necessarily produce the minimum size of such a set.
 
-use core::hash::BuildHasher;
-
 use super::graph_node::GraphNode;
 use super::scc_graph_node::SccGraphNode;
 use super::strongly_connected_components::ComputeScc;
@@ -20,35 +18,35 @@ use crate::unordered_hash_set::UnorderedHashSet;
 mod feedback_set_test;
 
 /// Context for the feedback-set algorithm.
-struct FeedbackSetAlgoContext<Node: GraphNode, BH: BuildHasher> {
+struct FeedbackSetAlgoContext<Node: GraphNode> {
     /// The accumulated feedback set so far in the process of the algorithm. In the end of the
     /// algorithm, this is also the result.
-    pub feedback_set: OrderedHashSet<Node::NodeId, BH>,
+    pub feedback_set: OrderedHashSet<Node::NodeId>,
     /// Nodes that are currently during the recursion call on them. That is - if one of these is
     /// reached, it indicates it's in some cycle that was not "resolved" yet.
-    pub in_flight: UnorderedHashSet<Node::NodeId, BH>,
+    pub in_flight: UnorderedHashSet<Node::NodeId>,
 }
-impl<Node: GraphNode, BH: BuildHasher + Default> FeedbackSetAlgoContext<Node, BH> {
+impl<Node: GraphNode> FeedbackSetAlgoContext<Node> {
     fn new() -> Self {
         FeedbackSetAlgoContext {
-            feedback_set: OrderedHashSet::default(),
-            in_flight: UnorderedHashSet::default(),
+            feedback_set: OrderedHashSet::new(),
+            in_flight: UnorderedHashSet::new(),
         }
     }
 }
 
 /// Calculates the feedback set of an SCC.
-pub fn calc_feedback_set<Node: GraphNode + ComputeScc, BH: BuildHasher + Default>(
+pub fn calc_feedback_set<Node: GraphNode + ComputeScc>(
     node: &SccGraphNode<Node>,
-) -> OrderedHashSet<Node::NodeId, BH> {
-    let mut ctx = FeedbackSetAlgoContext::<Node, BH>::new();
+) -> OrderedHashSet<Node::NodeId> {
+    let mut ctx = FeedbackSetAlgoContext::<Node>::new();
     calc_feedback_set_recursive(node, &mut ctx);
     ctx.feedback_set
 }
 
-fn calc_feedback_set_recursive<Node: GraphNode + ComputeScc, S: BuildHasher>(
+fn calc_feedback_set_recursive<Node: GraphNode + ComputeScc>(
     node: &SccGraphNode<Node>,
-    ctx: &mut FeedbackSetAlgoContext<Node, S>,
+    ctx: &mut FeedbackSetAlgoContext<Node>,
 ) {
     let cur_node_id = node.get_id();
     ctx.in_flight.insert(cur_node_id.clone());

--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
@@ -41,8 +41,7 @@ fn test_list() {
     let mut graph: Vec<Vec<usize>> = (0..10).map(|id| vec![id + 1]).collect();
     graph.push(vec![]);
 
-    let fset =
-        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
+    let fset = HashSet::<usize>::from_iter(calc_feedback_set(&IntegerNode { id: 0, graph }.into()));
     assert!(fset.is_empty());
 }
 
@@ -51,8 +50,7 @@ fn test_cycle() {
     // Each node has only one neighbor. i -> i + 1 for i = 0...8, and 9 -> 0.
     let graph: Vec<Vec<usize>> = (0..10).map(|id| vec![(id + 1) % 10]).collect();
 
-    let fset =
-        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
+    let fset = HashSet::<usize>::from_iter(calc_feedback_set(&IntegerNode { id: 0, graph }.into()));
     assert_eq!(fset, HashSet::from([0]));
 }
 
@@ -64,8 +62,7 @@ fn test_root_points_to_cycle() {
     graph.push(/* 10: */ vec![0]);
 
     // Note 10 is used as a root.
-    let fset =
-        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
+    let fset = HashSet::<usize>::from_iter(calc_feedback_set(&IntegerNode { id: 0, graph }.into()));
     assert_eq!(fset, HashSet::from([0]));
 }
 
@@ -80,8 +77,7 @@ fn test_connected_cycles() {
     graph[4].push(5);
 
     // Make sure the cycle that's not in the SCC of the root is not covered.
-    let fset =
-        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
+    let fset = HashSet::<usize>::from_iter(calc_feedback_set(&IntegerNode { id: 0, graph }.into()));
     assert_eq!(fset, HashSet::from([0]));
 }
 
@@ -90,8 +86,7 @@ fn test_mesh() {
     // Each node has edges to all other nodes.
     let graph = (0..5).map(|i| (0..5).filter(|j| *j != i).collect::<Vec<usize>>()).collect();
 
-    let fset =
-        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
+    let fset = HashSet::<usize>::from_iter(calc_feedback_set(&IntegerNode { id: 0, graph }.into()));
     assert_eq!(fset, HashSet::from_iter(0..4));
 }
 
@@ -110,9 +105,8 @@ fn test_tangent_cycles(root: usize, expected_fset: HashSet<usize>) {
     )
     .collect();
 
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_>(
-        &IntegerNode { id: root, graph }.into(),
-    ));
+    let fset =
+        HashSet::<usize>::from_iter(calc_feedback_set(&IntegerNode { id: root, graph }.into()));
     assert_eq!(fset, expected_fset);
 }
 
@@ -134,8 +128,7 @@ fn test_multiple_cycles(root: usize, expected_fset: HashSet<usize>) {
     )
     .collect();
 
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_>(
-        &IntegerNode { id: root, graph }.into(),
-    ));
+    let fset =
+        HashSet::<usize>::from_iter(calc_feedback_set(&IntegerNode { id: root, graph }.into()));
     assert_eq!(fset, expected_fset);
 }

--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
@@ -1,13 +1,12 @@
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
-#[cfg(not(feature = "std"))]
-use hashbrown::{hash_map::DefaultHashBuilder as HashBuilderType, HashSet};
-
 #[cfg(feature = "std")]
 use std::collections::hash_map::RandomState as HashBuilderType;
 #[cfg(feature = "std")]
 use std::collections::HashSet;
 
+#[cfg(not(feature = "std"))]
+use hashbrown::{hash_map::DefaultHashBuilder as HashBuilderType, HashSet};
 use itertools::chain;
 use test_case::test_case;
 use test_log::test;

--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
@@ -31,7 +31,7 @@ impl GraphNode for IntegerNode {
 }
 impl ComputeScc for IntegerNode {
     fn compute_scc(&self) -> Vec<Self::NodeId> {
-        compute_scc::<_>(self)
+        compute_scc(self)
     }
 }
 

--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
@@ -1,12 +1,5 @@
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
-#[cfg(feature = "std")]
-use std::collections::hash_map::RandomState as HashBuilderType;
-#[cfg(feature = "std")]
 use std::collections::HashSet;
 
-#[cfg(not(feature = "std"))]
-use hashbrown::{hash_map::DefaultHashBuilder as HashBuilderType, HashSet};
 use itertools::chain;
 use test_case::test_case;
 use test_log::test;
@@ -38,7 +31,7 @@ impl GraphNode for IntegerNode {
 }
 impl ComputeScc for IntegerNode {
     fn compute_scc(&self) -> Vec<Self::NodeId> {
-        compute_scc::<_, HashBuilderType>(self)
+        compute_scc::<_>(self)
     }
 }
 
@@ -48,9 +41,8 @@ fn test_list() {
     let mut graph: Vec<Vec<usize>> = (0..10).map(|id| vec![id + 1]).collect();
     graph.push(vec![]);
 
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_, HashBuilderType>(
-        &IntegerNode { id: 0, graph }.into(),
-    ));
+    let fset =
+        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
     assert!(fset.is_empty());
 }
 
@@ -59,9 +51,8 @@ fn test_cycle() {
     // Each node has only one neighbor. i -> i + 1 for i = 0...8, and 9 -> 0.
     let graph: Vec<Vec<usize>> = (0..10).map(|id| vec![(id + 1) % 10]).collect();
 
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_, HashBuilderType>(
-        &IntegerNode { id: 0, graph }.into(),
-    ));
+    let fset =
+        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
     assert_eq!(fset, HashSet::from([0]));
 }
 
@@ -73,9 +64,8 @@ fn test_root_points_to_cycle() {
     graph.push(/* 10: */ vec![0]);
 
     // Note 10 is used as a root.
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_, HashBuilderType>(
-        &IntegerNode { id: 0, graph }.into(),
-    ));
+    let fset =
+        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
     assert_eq!(fset, HashSet::from([0]));
 }
 
@@ -90,9 +80,8 @@ fn test_connected_cycles() {
     graph[4].push(5);
 
     // Make sure the cycle that's not in the SCC of the root is not covered.
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_, HashBuilderType>(
-        &IntegerNode { id: 0, graph }.into(),
-    ));
+    let fset =
+        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
     assert_eq!(fset, HashSet::from([0]));
 }
 
@@ -101,9 +90,8 @@ fn test_mesh() {
     // Each node has edges to all other nodes.
     let graph = (0..5).map(|i| (0..5).filter(|j| *j != i).collect::<Vec<usize>>()).collect();
 
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_, HashBuilderType>(
-        &IntegerNode { id: 0, graph }.into(),
-    ));
+    let fset =
+        HashSet::<usize>::from_iter(calc_feedback_set::<_>(&IntegerNode { id: 0, graph }.into()));
     assert_eq!(fset, HashSet::from_iter(0..4));
 }
 
@@ -122,7 +110,7 @@ fn test_tangent_cycles(root: usize, expected_fset: HashSet<usize>) {
     )
     .collect();
 
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_, HashBuilderType>(
+    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_>(
         &IntegerNode { id: root, graph }.into(),
     ));
     assert_eq!(fset, expected_fset);
@@ -146,7 +134,7 @@ fn test_multiple_cycles(root: usize, expected_fset: HashSet<usize>) {
     )
     .collect();
 
-    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_, HashBuilderType>(
+    let fset = HashSet::<usize>::from_iter(calc_feedback_set::<_>(
         &IntegerNode { id: root, graph }.into(),
     ));
     assert_eq!(fset, expected_fset);

--- a/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use core::hash::Hash;
 
 /// A trait for a node in a graph. Note that a GraphNode has to be able to provide its neighbors

--- a/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
@@ -1,6 +1,5 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-
 use core::hash::Hash;
 
 /// A trait for a node in a graph. Note that a GraphNode has to be able to provide its neighbors

--- a/crates/cairo-lang-utils/src/graph_algos/scc_graph_node.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/scc_graph_node.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use super::graph_node::GraphNode;
 use super::strongly_connected_components::ComputeScc;
 

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
@@ -59,7 +59,7 @@ impl<Node: GraphNode> SccAlgoContext<Node> {
 
 /// Computes the SCC (Strongly Connected Component) of the given node in its graph.
 pub fn compute_scc<Node: GraphNode>(root: &Node) -> Vec<Node::NodeId> {
-    let mut ctx = SccAlgoContext::<_>::new(root.get_id());
+    let mut ctx = SccAlgoContext::new(root.get_id());
     compute_scc_recursive(&mut ctx, root);
     ctx.result
 }

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
@@ -1,9 +1,8 @@
 //! Logic for computing the strongly connected component of a node in a graph.
 
-use core::hash::{BuildHasher, Hash};
-
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use core::hash::{BuildHasher, Hash};
 
 use super::graph_node::GraphNode;
 use crate::unordered_hash_map::UnorderedHashMap;

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
@@ -45,7 +45,6 @@ struct SccAlgoContext<Node: GraphNode> {
     /// The SCC of the `target_node_id`. Populated only at the end of the algorithm.
     result: Vec<Node::NodeId>,
 }
-
 impl<Node: GraphNode> SccAlgoContext<Node> {
     fn new(target_node_id: Node::NodeId) -> Self {
         SccAlgoContext::<Node> {

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
@@ -1,12 +1,10 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
 #[cfg(feature = "std")]
 use std::collections::{hash_map::RandomState as HashBuilderType, HashSet};
 
 #[cfg(not(feature = "std"))]
 use hashbrown::{hash_map::DefaultHashBuilder as HashBuilderType, HashSet};
-
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
-
 use itertools::chain;
 use test_case::test_case;
 use test_log::test;

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
@@ -1,10 +1,5 @@
-#[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
-#[cfg(feature = "std")]
-use std::collections::{hash_map::RandomState as HashBuilderType, HashSet};
+use std::collections::HashSet;
 
-#[cfg(not(feature = "std"))]
-use hashbrown::{hash_map::DefaultHashBuilder as HashBuilderType, HashSet};
 use itertools::chain;
 use test_case::test_case;
 use test_log::test;
@@ -37,10 +32,7 @@ impl GraphNode for IntegerNode {
 fn test_short_list() {
     let graph = vec![/* 0: */ vec![1], /* 1: */ vec![]];
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
-        id: 0,
-        graph,
-    }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from([0]));
 }
 
@@ -50,10 +42,7 @@ fn test_list() {
     let mut graph: Vec<Vec<usize>> = (0..10).map(|id| vec![id + 1]).collect();
     graph.push(vec![]);
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
-        id: 0,
-        graph,
-    }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from([0]));
 }
 
@@ -62,10 +51,7 @@ fn test_cycle() {
     // Each node has only one neighbor. i -> i + 1 for i = 0...8, and 9 -> 0.
     let graph: Vec<Vec<usize>> = (0..10).map(|id| vec![(id + 1) % 10]).collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
-        id: 0,
-        graph,
-    }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..10));
 }
 
@@ -74,10 +60,7 @@ fn test_mesh() {
     // Each node has edges to all other nodes.
     let graph = (0..5).map(|i| (0..5).filter(|j| *j != i).collect::<Vec<usize>>()).collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
-        id: 0,
-        graph,
-    }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..5));
 }
 
@@ -94,10 +77,7 @@ fn test_list_with_back_edges() {
         vec![1],
     ];
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
-        id: 0,
-        graph,
-    }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..4));
 }
 
@@ -109,10 +89,7 @@ fn test_root_points_to_cycle() {
     graph.push(/* 10: */ vec![0]);
 
     // Note 10 is used as a root.
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
-        id: 10,
-        graph,
-    }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 10, graph }));
     assert_eq!(scc, HashSet::from([10]));
 }
 
@@ -132,10 +109,7 @@ fn test_connected_cycles(root_in_first_cycle: bool) {
         graph[5].push(4);
     }
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
-        id: 0,
-        graph,
-    }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..5));
 }
 
@@ -152,9 +126,6 @@ fn test_tangent_cycles() {
     )
     .collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
-        id: 0,
-        graph,
-    }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..7));
 }

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
@@ -1,4 +1,11 @@
-use std::collections::HashSet;
+#[cfg(feature = "std")]
+use std::collections::{hash_map::RandomState as HashBuilderType, HashSet};
+
+#[cfg(not(feature = "std"))]
+use hashbrown::{hash_map::DefaultHashBuilder as HashBuilderType, HashSet};
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
 
 use itertools::chain;
 use test_case::test_case;
@@ -32,7 +39,10 @@ impl GraphNode for IntegerNode {
 fn test_short_list() {
     let graph = vec![/* 0: */ vec![1], /* 1: */ vec![]];
 
-    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
+        id: 0,
+        graph,
+    }));
     assert_eq!(scc, HashSet::from([0]));
 }
 
@@ -42,7 +52,10 @@ fn test_list() {
     let mut graph: Vec<Vec<usize>> = (0..10).map(|id| vec![id + 1]).collect();
     graph.push(vec![]);
 
-    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
+        id: 0,
+        graph,
+    }));
     assert_eq!(scc, HashSet::from([0]));
 }
 
@@ -51,7 +64,10 @@ fn test_cycle() {
     // Each node has only one neighbor. i -> i + 1 for i = 0...8, and 9 -> 0.
     let graph: Vec<Vec<usize>> = (0..10).map(|id| vec![(id + 1) % 10]).collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
+        id: 0,
+        graph,
+    }));
     assert_eq!(scc, HashSet::from_iter(0..10));
 }
 
@@ -60,7 +76,10 @@ fn test_mesh() {
     // Each node has edges to all other nodes.
     let graph = (0..5).map(|i| (0..5).filter(|j| *j != i).collect::<Vec<usize>>()).collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
+        id: 0,
+        graph,
+    }));
     assert_eq!(scc, HashSet::from_iter(0..5));
 }
 
@@ -77,7 +96,10 @@ fn test_list_with_back_edges() {
         vec![1],
     ];
 
-    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
+        id: 0,
+        graph,
+    }));
     assert_eq!(scc, HashSet::from_iter(0..4));
 }
 
@@ -89,7 +111,10 @@ fn test_root_points_to_cycle() {
     graph.push(/* 10: */ vec![0]);
 
     // Note 10 is used as a root.
-    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 10, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
+        id: 10,
+        graph,
+    }));
     assert_eq!(scc, HashSet::from([10]));
 }
 
@@ -109,7 +134,10 @@ fn test_connected_cycles(root_in_first_cycle: bool) {
         graph[5].push(4);
     }
 
-    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
+        id: 0,
+        graph,
+    }));
     assert_eq!(scc, HashSet::from_iter(0..5));
 }
 
@@ -126,6 +154,9 @@ fn test_tangent_cycles() {
     )
     .collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc::<_, HashBuilderType>(&IntegerNode {
+        id: 0,
+        graph,
+    }));
     assert_eq!(scc, HashSet::from_iter(0..7));
 }

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
@@ -32,7 +32,7 @@ impl GraphNode for IntegerNode {
 fn test_short_list() {
     let graph = vec![/* 0: */ vec![1], /* 1: */ vec![]];
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from([0]));
 }
 
@@ -42,7 +42,7 @@ fn test_list() {
     let mut graph: Vec<Vec<usize>> = (0..10).map(|id| vec![id + 1]).collect();
     graph.push(vec![]);
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from([0]));
 }
 
@@ -51,7 +51,7 @@ fn test_cycle() {
     // Each node has only one neighbor. i -> i + 1 for i = 0...8, and 9 -> 0.
     let graph: Vec<Vec<usize>> = (0..10).map(|id| vec![(id + 1) % 10]).collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..10));
 }
 
@@ -60,7 +60,7 @@ fn test_mesh() {
     // Each node has edges to all other nodes.
     let graph = (0..5).map(|i| (0..5).filter(|j| *j != i).collect::<Vec<usize>>()).collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..5));
 }
 
@@ -77,7 +77,7 @@ fn test_list_with_back_edges() {
         vec![1],
     ];
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..4));
 }
 
@@ -89,7 +89,7 @@ fn test_root_points_to_cycle() {
     graph.push(/* 10: */ vec![0]);
 
     // Note 10 is used as a root.
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 10, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 10, graph }));
     assert_eq!(scc, HashSet::from([10]));
 }
 
@@ -109,7 +109,7 @@ fn test_connected_cycles(root_in_first_cycle: bool) {
         graph[5].push(4);
     }
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..5));
 }
 
@@ -126,6 +126,6 @@ fn test_tangent_cycles() {
     )
     .collect();
 
-    let scc = HashSet::<usize>::from_iter(compute_scc::<_>(&IntegerNode { id: 0, graph }));
+    let scc = HashSet::<usize>::from_iter(compute_scc(&IntegerNode { id: 0, graph }));
     assert_eq!(scc, HashSet::from_iter(0..7));
 }

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -7,7 +7,6 @@ extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
-
 use core::fmt;
 
 #[cfg(feature = "serde")]

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -15,6 +15,7 @@ pub mod byte_array;
 pub mod casts;
 pub mod collection_arithmetics;
 pub mod extract_matches;
+#[cfg(feature = "std")]
 pub mod graph_algos;
 pub mod iterators;
 #[cfg(feature = "env_logger")]

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -1,6 +1,16 @@
 //! Cairo utilities.
-use std::fmt;
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
+use core::fmt;
+
+#[cfg(feature = "serde")]
 pub mod bigint;
 pub mod byte_array;
 pub mod casts;
@@ -23,7 +33,7 @@ where
     fn option_from(other: T) -> Option<Self>;
 }
 
-pub fn write_comma_separated<Iter: IntoIterator<Item = V>, V: std::fmt::Display>(
+pub fn write_comma_separated<Iter: IntoIterator<Item = V>, V: core::fmt::Display>(
     f: &mut fmt::Formatter<'_>,
     values: Iter,
 ) -> fmt::Result {
@@ -83,7 +93,7 @@ impl<T, E> ResultHelper<E> for Result<T, E> {
 pub fn borrow_as_box<T: Default, R, F: FnOnce(Box<T>) -> (R, Box<T>)>(ptr: &mut T, f: F) -> R {
     // TODO(spapini): Consider replacing take with something the leaves the memory dangling, instead
     // of filling with default().
-    let (res, boxed) = f(Box::new(std::mem::take(ptr)));
+    let (res, boxed) = f(Box::new(core::mem::take(ptr)));
     *ptr = *boxed;
     res
 }
@@ -115,7 +125,7 @@ macro_rules! define_short_id {
             cairo_lang_debug::DebugWithDb<T> for $short_id
         {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &T) -> std::fmt::Result {
-                use std::fmt::Debug;
+                use core::fmt::Debug;
 
                 use cairo_lang_debug::helper::Fallback;
                 let db = db.upcast();

--- a/crates/cairo-lang-utils/src/ordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_map.rs
@@ -1,36 +1,27 @@
-use std::hash::Hash;
-use std::ops::{Index, IndexMut};
+use core::hash::{BuildHasher, Hash};
+use core::ops::{Index, IndexMut};
 
 use indexmap::{Equivalent, IndexMap};
-use itertools::{zip_eq, Itertools};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use itertools::zip_eq;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct OrderedHashMap<Key: Hash + Eq, Value>(IndexMap<Key, Value>);
+#[cfg(feature = "std")]
+use std::collections::hash_map::RandomState;
 
-impl<Key: Hash + Eq, Value> OrderedHashMap<Key, Value> {
-    /// Returns a reference to the value stored for key, if it is present, else None.
-    ///
-    /// Computes in O(1) time (average).
-    pub fn get<Q: ?Sized + Hash + Equivalent<Key>>(&self, key: &Q) -> Option<&Value> {
-        self.0.get(key)
+#[cfg(feature = "std")]
+#[derive(Clone, Debug)]
+pub struct OrderedHashMap<Key, Value, BH = RandomState>(IndexMap<Key, Value, BH>);
+#[cfg(not(feature = "std"))]
+#[derive(Clone, Debug)]
+pub struct OrderedHashMap<Key, Value, BH>(IndexMap<Key, Value, BH>);
+
+#[cfg(feature = "std")]
+impl<K, V> OrderedHashMap<K, V> {
+    pub fn new() -> Self {
+        Self(IndexMap::new())
     }
+}
 
-    /// Returns a mutable reference to the value stored for key, if it is present, else None.
-    ///
-    /// Computes in O(1) time (average).
-    pub fn get_mut<Q: ?Sized + Hash + Equivalent<Key>>(&mut self, key: &Q) -> Option<&mut Value> {
-        self.0.get_mut(key)
-    }
-
-    /// Gets the given key’s corresponding entry in the map for insertion and/or in-place
-    /// manipulation.
-    ///
-    /// Computes in O(1) time (amortized average).
-    pub fn entry(&mut self, key: Key) -> Entry<'_, Key, Value> {
-        self.0.entry(key)
-    }
-
+impl<Key, Value, BH> OrderedHashMap<Key, Value, BH> {
     /// Returns an iterator over the key-value pairs of the map, in their order.
     pub fn iter(&self) -> indexmap::map::Iter<'_, Key, Value> {
         self.0.iter()
@@ -54,6 +45,52 @@ impl<Key: Hash + Eq, Value> OrderedHashMap<Key, Value> {
     /// Returns an iterator over the values of the map, in their order.
     pub fn values(&self) -> indexmap::map::Values<'_, Key, Value> {
         self.0.values()
+    }
+
+    /// Returns the number of key-value pairs in the map.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Removes all the entries for the map.
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+
+    /// Removes the entry at the given index.
+    ///
+    /// Returns the key-value pair at the given index (if present).
+    pub fn shift_remove_index(&mut self, index: usize) -> Option<(Key, Value)> {
+        self.0.shift_remove_index(index)
+    }
+}
+
+impl<Key: Eq + Hash, Value, BH: BuildHasher> OrderedHashMap<Key, Value, BH> {
+    /// Returns a reference to the value stored for key, if it is present, else None.
+    ///
+    /// Computes in O(1) time (average).
+    pub fn get<Q: ?Sized + Hash + Equivalent<Key>>(&self, key: &Q) -> Option<&Value> {
+        self.0.get(key)
+    }
+
+    /// Returns a mutable reference to the value stored for key, if it is present, else None.
+    ///
+    /// Computes in O(1) time (average).
+    pub fn get_mut<Q: ?Sized + Hash + Equivalent<Key>>(&mut self, key: &Q) -> Option<&mut Value> {
+        self.0.get_mut(key)
+    }
+
+    /// Gets the given key’s corresponding entry in the map for insertion and/or in-place
+    /// manipulation.
+    ///
+    /// Computes in O(1) time (amortized average).
+    pub fn entry(&mut self, key: Key) -> Entry<'_, Key, Value> {
+        self.0.entry(key)
     }
 
     /// Insert a key-value pair in the map.
@@ -83,21 +120,6 @@ impl<Key: Hash + Eq, Value> OrderedHashMap<Key, Value> {
         self.0.contains_key(key)
     }
 
-    /// Returns the number of key-value pairs in the map.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns true if the map contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Removes all the entries for the map.
-    pub fn clear(&mut self) {
-        self.0.clear()
-    }
-
     /// Removes the entry for the given key, preserving the order of entries.
     ///
     /// Returns the value associated with the key (if present).
@@ -111,13 +133,6 @@ impl<Key: Hash + Eq, Value> OrderedHashMap<Key, Value> {
     /// Returns the value associated with the key (if present).
     pub fn swap_remove<Q: ?Sized + Hash + Equivalent<Key>>(&mut self, key: &Q) -> Option<Value> {
         self.0.swap_remove(key)
-    }
-
-    /// Removes the entry at the given index.
-    ///
-    /// Returns the key-value pair at the given index (if present).
-    pub fn shift_remove_index(&mut self, index: usize) -> Option<(Key, Value)> {
-        self.0.shift_remove_index(index)
     }
 
     /// Returns true if the maps are equal, ignoring the order of the entries.
@@ -135,7 +150,7 @@ impl<Key: Hash + Eq, Value> OrderedHashMap<Key, Value> {
 /// Entry for an existing key-value pair or a vacant location to insert one.
 pub type Entry<'a, Key, Value> = indexmap::map::Entry<'a, Key, Value>;
 
-impl<Key: Hash + Eq, Value> IntoIterator for OrderedHashMap<Key, Value> {
+impl<Key, Value, BH> IntoIterator for OrderedHashMap<Key, Value, BH> {
     type Item = (Key, Value);
     type IntoIter = indexmap::map::IntoIter<Key, Value>;
     fn into_iter(self) -> Self::IntoIter {
@@ -144,23 +159,31 @@ impl<Key: Hash + Eq, Value> IntoIterator for OrderedHashMap<Key, Value> {
     }
 }
 
-impl<Key: Hash + Eq, IndexType: Into<Key>, Value> Index<IndexType> for OrderedHashMap<Key, Value> {
+impl<Key, Value, Q: ?Sized, BH> Index<&Q> for OrderedHashMap<Key, Value, BH>
+where
+    Q: Hash + Equivalent<Key>,
+    Key: Hash + Eq,
+    BH: BuildHasher,
+{
     type Output = Value;
 
-    fn index(&self, index: IndexType) -> &Self::Output {
-        &self.0[&index.into()]
+    fn index(&self, index: &Q) -> &Self::Output {
+        self.0.index(index)
     }
 }
 
-impl<Key: Hash + Eq, IndexType: Into<Key>, Value> IndexMut<IndexType>
-    for OrderedHashMap<Key, Value>
+impl<Key, Value, Q: ?Sized, BH> IndexMut<&Q> for OrderedHashMap<Key, Value, BH>
+where
+    Q: Hash + Equivalent<Key>,
+    Key: Hash + Eq,
+    BH: BuildHasher,
 {
-    fn index_mut(&mut self, index: IndexType) -> &mut Value {
-        self.0.index_mut(&index.into())
+    fn index_mut(&mut self, index: &Q) -> &mut Value {
+        self.0.index_mut(index)
     }
 }
 
-impl<Key: Hash + Eq, Value: Eq> PartialEq for OrderedHashMap<Key, Value> {
+impl<Key: Eq, Value: Eq, BH> PartialEq for OrderedHashMap<Key, Value, BH> {
     fn eq(&self, other: &Self) -> bool {
         if self.0.len() != other.0.len() {
             return false;
@@ -170,47 +193,81 @@ impl<Key: Hash + Eq, Value: Eq> PartialEq for OrderedHashMap<Key, Value> {
     }
 }
 
-impl<Key: Hash + Eq, Value: Eq> Eq for OrderedHashMap<Key, Value> {
-    fn assert_receiver_is_total_eq(&self) {}
-}
+impl<Key: Hash + Eq, Value: Eq, BH: BuildHasher> Eq for OrderedHashMap<Key, Value, BH> {}
 
-impl<Key: Hash + Eq, Value> Default for OrderedHashMap<Key, Value> {
+impl<Key, Value, BH: Default> Default for OrderedHashMap<Key, Value, BH> {
     fn default() -> Self {
-        Self(Default::default())
+        Self(IndexMap::default())
     }
 }
 
-impl<Key: Hash + Eq, Value> FromIterator<(Key, Value)> for OrderedHashMap<Key, Value> {
+impl<Key: Hash + Eq, Value, BH: BuildHasher + Default> FromIterator<(Key, Value)>
+    for OrderedHashMap<Key, Value, BH>
+{
     fn from_iter<T: IntoIterator<Item = (Key, Value)>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
     }
 }
 
-impl<Key: Hash + Eq, Value, const N: usize> From<[(Key, Value); N]> for OrderedHashMap<Key, Value> {
+impl<Key: Hash + Eq, Value, BH: BuildHasher + Default, const N: usize> From<[(Key, Value); N]>
+    for OrderedHashMap<Key, Value, BH>
+{
     fn from(init_map: [(Key, Value); N]) -> Self {
-        Self(init_map.into())
+        Self(IndexMap::from_iter(init_map))
     }
 }
 
-pub fn serialize_ordered_hashmap_vec<'de, K, V, S>(
-    v: &OrderedHashMap<K, V>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    K: Serialize + Deserialize<'de> + Hash + Eq,
-    V: Serialize + Deserialize<'de>,
-{
-    v.iter().collect_vec().serialize(serializer)
-}
+#[cfg(feature = "serde")]
+mod impl_serde {
+    use itertools::Itertools;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-pub fn deserialize_ordered_hashmap_vec<'de, K, V, D>(
-    deserializer: D,
-) -> Result<OrderedHashMap<K, V>, D::Error>
-where
-    D: Deserializer<'de>,
-    K: Serialize + Deserialize<'de> + Hash + Eq,
-    V: Serialize + Deserialize<'de>,
-{
-    Ok(Vec::<(K, V)>::deserialize(deserializer)?.into_iter().collect())
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    impl<K: Hash + Eq + Serialize, V: Serialize, BH: BuildHasher> Serialize
+        for OrderedHashMap<K, V, BH>
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.0.serialize(serializer)
+        }
+    }
+
+    impl<'de, K: Hash + Eq + Deserialize<'de>, V: Deserialize<'de>, BH: BuildHasher + Default>
+        Deserialize<'de> for OrderedHashMap<K, V, BH>
+    {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            IndexMap::<K, V, BH>::deserialize(deserializer).map(|s| OrderedHashMap(s))
+        }
+    }
+
+    pub fn serialize_ordered_hashmap_vec<'de, K, V, BH, S>(
+        v: &OrderedHashMap<K, V, BH>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        K: Serialize + Deserialize<'de> + Hash + Eq,
+        V: Serialize + Deserialize<'de>,
+    {
+        v.iter().collect_vec().serialize(serializer)
+    }
+
+    pub fn deserialize_ordered_hashmap_vec<'de, K, V, BH: BuildHasher + Default, D>(
+        deserializer: D,
+    ) -> Result<OrderedHashMap<K, V, BH>, D::Error>
+    where
+        D: Deserializer<'de>,
+        K: Serialize + Deserialize<'de> + Hash + Eq,
+        V: Serialize + Deserialize<'de>,
+    {
+        Ok(Vec::<(K, V)>::deserialize(deserializer)?.into_iter().collect())
+    }
 }
+#[cfg(feature = "serde")]
+pub use impl_serde::*;

--- a/crates/cairo-lang-utils/src/ordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_map.rs
@@ -1,11 +1,10 @@
 use core::hash::{BuildHasher, Hash};
 use core::ops::{Index, IndexMut};
+#[cfg(feature = "std")]
+use std::collections::hash_map::RandomState;
 
 use indexmap::{Equivalent, IndexMap};
 use itertools::zip_eq;
-
-#[cfg(feature = "std")]
-use std::collections::hash_map::RandomState;
 
 #[cfg(feature = "std")]
 #[derive(Clone, Debug)]
@@ -219,11 +218,11 @@ impl<Key: Hash + Eq, Value, BH: BuildHasher + Default, const N: usize> From<[(Ke
 
 #[cfg(feature = "serde")]
 mod impl_serde {
-    use itertools::Itertools;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
+
+    use itertools::Itertools;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     use super::*;
 

--- a/crates/cairo-lang-utils/src/ordered_hash_set.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_set.rs
@@ -1,17 +1,23 @@
+use core::hash::{BuildHasher, Hash};
+use core::ops::Sub;
+
+#[cfg(feature = "std")]
 use std::collections::hash_map::RandomState;
-use std::hash::{BuildHasher, Hash};
-use std::ops::Sub;
 
 use indexmap::{Equivalent, IndexSet};
 use itertools::zip_eq;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(feature = "std")]
 #[derive(Clone, Debug)]
-pub struct OrderedHashSet<Key: Hash + Eq, S = RandomState>(IndexSet<Key, S>);
+pub struct OrderedHashSet<Key, BH = RandomState>(IndexSet<Key, BH>);
+#[cfg(not(feature = "std"))]
+#[derive(Clone, Debug)]
+pub struct OrderedHashSet<Key, BH>(IndexSet<Key, BH>);
 
 pub type Iter<'a, Key> = indexmap::set::Iter<'a, Key>;
 
-impl<Key: Hash + Eq> OrderedHashSet<Key> {
+#[cfg(feature = "std")]
+impl<Key> OrderedHashSet<Key> {
     /// Creates an empty `OrderedHashSet`.
     ///
     /// The hash set is initially created with a capacity of 0, so it will not allocate until it
@@ -19,29 +25,16 @@ impl<Key: Hash + Eq> OrderedHashSet<Key> {
     pub fn new() -> Self {
         Self(IndexSet::new())
     }
+}
 
+impl<Key, BH> OrderedHashSet<Key, BH> {
     /// Returns an iterator over the values of the set, in their order.
     pub fn iter(&self) -> Iter<'_, Key> {
         self.0.iter()
     }
+}
 
-    /// Inserts the value into the set.
-    ///
-    /// If an equivalent item already exists in the set, returns `false`. Otherwise, returns `true`.
-    pub fn insert(&mut self, key: Key) -> bool {
-        self.0.insert(key)
-    }
-
-    /// Extends the set with the content of the given iterator.
-    pub fn extend<I: IntoIterator<Item = Key>>(&mut self, iter: I) {
-        self.0.extend(iter)
-    }
-
-    /// Returns true if an equivalent to value exists in the set.
-    pub fn contains<Q: ?Sized + Hash + Equivalent<Key>>(&self, value: &Q) -> bool {
-        self.0.contains(value)
-    }
-
+impl<Key: Hash + Eq, BH> OrderedHashSet<Key, BH> {
     /// Returns the number of elements in the set.
     pub fn len(&self) -> usize {
         self.0.len()
@@ -57,6 +50,25 @@ impl<Key: Hash + Eq> OrderedHashSet<Key> {
     /// Computes in O(n) time.
     pub fn clear(&mut self) {
         self.0.clear()
+    }
+}
+
+impl<Key: Hash + Eq, BH: BuildHasher> OrderedHashSet<Key, BH> {
+    /// Inserts the value into the set.
+    ///
+    /// If an equivalent item already exists in the set, returns `false`. Otherwise, returns `true`.
+    pub fn insert(&mut self, key: Key) -> bool {
+        self.0.insert(key)
+    }
+
+    /// Extends the set with the content of the given iterator.
+    pub fn extend<I: IntoIterator<Item = Key>>(&mut self, iter: I) {
+        self.0.extend(iter)
+    }
+
+    /// Returns true if an equivalent to value exists in the set.
+    pub fn contains<Q: ?Sized + Hash + Equivalent<Key>>(&self, value: &Q) -> bool {
+        self.0.contains(value)
     }
 
     /// Removes the value from the set, preserving the order of elements.
@@ -79,7 +91,7 @@ impl<Key: Hash + Eq> OrderedHashSet<Key> {
         other: &'a OrderedHashSet<Key, S2>,
     ) -> indexmap::set::Difference<'a, Key, S2>
     where
-        S2: std::hash::BuildHasher,
+        S2: core::hash::BuildHasher,
     {
         self.0.difference(&other.0)
     }
@@ -93,40 +105,38 @@ impl<Key: Hash + Eq> OrderedHashSet<Key> {
     pub fn is_superset<S2: BuildHasher>(&self, other: &OrderedHashSet<Key, S2>) -> bool {
         self.0.is_superset(&other.0)
     }
-}
 
-impl<Key: Hash + Eq, S: BuildHasher> OrderedHashSet<Key, S> {
     /// Return an iterator over all values that are either in `self` or `other`.
     ///
     /// Values from `self` are produced in their original order, followed by
     /// values that are unique to `other` in their original order.
-    pub fn union<'a, S2: BuildHasher>(
+    pub fn union<'a, BH2: BuildHasher>(
         &'a self,
-        other: &'a OrderedHashSet<Key, S2>,
-    ) -> indexmap::set::Union<'a, Key, S> {
+        other: &'a OrderedHashSet<Key, BH2>,
+    ) -> indexmap::set::Union<'a, Key, BH> {
         self.0.union(&other.0)
     }
 }
 
-impl<Key: Hash + Eq> IntoIterator for OrderedHashSet<Key> {
+impl<Key, BH> IntoIterator for OrderedHashSet<Key, BH> {
     type Item = Key;
-    type IntoIter = <IndexSet<Key> as IntoIterator>::IntoIter;
+    type IntoIter = <IndexSet<Key, BH> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl<'a, Key: Hash + Eq> IntoIterator for &'a OrderedHashSet<Key> {
+impl<'a, Key, BH> IntoIterator for &'a OrderedHashSet<Key, BH> {
     type Item = &'a Key;
-    type IntoIter = <&'a IndexSet<Key> as IntoIterator>::IntoIter;
+    type IntoIter = <&'a IndexSet<Key, BH> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<Key: Hash + Eq> PartialEq for OrderedHashSet<Key> {
+impl<Key: Eq, BH> PartialEq for OrderedHashSet<Key, BH> {
     fn eq(&self, other: &Self) -> bool {
         if self.0.len() != other.0.len() {
             return false;
@@ -136,37 +146,48 @@ impl<Key: Hash + Eq> PartialEq for OrderedHashSet<Key> {
     }
 }
 
-impl<Key: Hash + Eq> Eq for OrderedHashSet<Key> {
-    fn assert_receiver_is_total_eq(&self) {}
-}
+impl<Key: Eq, BH> Eq for OrderedHashSet<Key, BH> {}
 
-impl<Key: Hash + Eq> Default for OrderedHashSet<Key> {
+impl<Key, BH: Default> Default for OrderedHashSet<Key, BH> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<Key: Hash + Eq> FromIterator<Key> for OrderedHashSet<Key> {
+impl<Key: Hash + Eq, BH: BuildHasher + Default> FromIterator<Key> for OrderedHashSet<Key, BH> {
     fn from_iter<T: IntoIterator<Item = Key>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
     }
 }
 
-impl<'a, Key: Hash + Eq + Clone> Sub<&'a OrderedHashSet<Key>> for &'a OrderedHashSet<Key> {
-    type Output = OrderedHashSet<Key>;
+impl<'a, Key, BH> Sub<&'a OrderedHashSet<Key, BH>> for &'a OrderedHashSet<Key, BH>
+where
+    &'a IndexSet<Key, BH>: Sub<Output = IndexSet<Key, BH>>,
+{
+    type Output = OrderedHashSet<Key, BH>;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        OrderedHashSet::<Key>(&self.0 - &rhs.0)
+        OrderedHashSet::<Key, BH>(&self.0 - &rhs.0)
     }
 }
 
-impl<K: Hash + Eq + Serialize> Serialize for OrderedHashSet<K> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.serialize(serializer)
+#[cfg(feature = "serde")]
+mod impl_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::*;
+
+    impl<K: Hash + Eq + Serialize, BH: BuildHasher> Serialize for OrderedHashSet<K, BH> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            self.0.serialize(serializer)
+        }
     }
-}
-impl<'de, K: Hash + Eq + Deserialize<'de>> Deserialize<'de> for OrderedHashSet<K> {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        IndexSet::<K, RandomState>::deserialize(deserializer).map(|s| OrderedHashSet(s))
+
+    impl<'de, K: Hash + Eq + Deserialize<'de>, BH: BuildHasher + Default> Deserialize<'de>
+        for OrderedHashSet<K, BH>
+    {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            IndexSet::<K, BH>::deserialize(deserializer).map(|s| OrderedHashSet(s))
+        }
     }
 }

--- a/crates/cairo-lang-utils/src/ordered_hash_set.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_set.rs
@@ -1,6 +1,5 @@
 use core::hash::{BuildHasher, Hash};
 use core::ops::Sub;
-
 #[cfg(feature = "std")]
 use std::collections::hash_map::RandomState;
 

--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -1,14 +1,13 @@
-use core::hash::Hash;
+use core::borrow::Borrow;
+use core::hash::{BuildHasher, Hash};
 use core::ops::Index;
-use core::{borrow::Borrow, hash::BuildHasher};
-
 #[cfg(feature = "std")]
 use std::collections::hash_map::RandomState;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
 
 #[cfg(not(feature = "std"))]
 use hashbrown::HashMap;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
 
 /// A hash map that does not care about the order of insertion.
 /// In particular, it does not support iterating, in order to guarantee deterministic compilation.

--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -1,15 +1,64 @@
-use std::borrow::Borrow;
-use std::collections::{hash_map, HashMap};
-use std::hash::Hash;
-use std::ops::Index;
+use core::hash::Hash;
+use core::ops::Index;
+use core::{borrow::Borrow, hash::BuildHasher};
+
+#[cfg(feature = "std")]
+use std::collections::hash_map::RandomState;
+
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
 
 /// A hash map that does not care about the order of insertion.
 /// In particular, it does not support iterating, in order to guarantee deterministic compilation.
 /// For an iterable version see [OrderedHashMap](crate::ordered_hash_map::OrderedHashMap).
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UnorderedHashMap<Key: Hash + Eq, Value>(HashMap<Key, Value>);
+#[cfg(feature = "std")]
+#[derive(Clone, Debug)]
+pub struct UnorderedHashMap<Key, Value, BH = RandomState>(HashMap<Key, Value, BH>);
+#[cfg(not(feature = "std"))]
+#[derive(Clone, Debug)]
+pub struct UnorderedHashMap<Key, Value, BH>(HashMap<Key, Value, BH>);
 
-impl<Key: Hash + Eq, Value> UnorderedHashMap<Key, Value> {
+#[cfg(feature = "std")]
+impl<Key, Value> UnorderedHashMap<Key, Value> {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+impl<Key, Value, BH> PartialEq for UnorderedHashMap<Key, Value, BH>
+where
+    Key: Eq + Hash,
+    Value: PartialEq,
+    BH: BuildHasher,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<Key, Value, BH> Eq for UnorderedHashMap<Key, Value, BH>
+where
+    Key: Eq + Hash,
+    Value: Eq,
+    BH: BuildHasher,
+{
+}
+
+impl<Key, Value, BH> UnorderedHashMap<Key, Value, BH> {
+    /// Returns the number of elements in the map.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<Key: Eq + Hash, Value, BH: BuildHasher> UnorderedHashMap<Key, Value, BH> {
     /// Returns a reference to the value corresponding to the key.
     ///
     /// The key may be any borrowed form of the map's key type, but [`Hash`] and [`Eq`] on the
@@ -58,8 +107,15 @@ impl<Key: Hash + Eq, Value> UnorderedHashMap<Key, Value> {
         self.0.remove(key)
     }
 
+    #[cfg(feature = "std")]
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
-    pub fn entry(&mut self, key: Key) -> hash_map::Entry<'_, Key, Value> {
+    pub fn entry(&mut self, key: Key) -> std::collections::hash_map::Entry<'_, Key, Value> {
+        self.0.entry(key)
+    }
+
+    #[cfg(not(feature = "std"))]
+    /// Gets the given key's corresponding entry in the map for in-place manipulation.
+    pub fn entry(&mut self, key: Key) -> hashbrown::hash_map::Entry<'_, Key, Value, BH> {
         self.0.entry(key)
     }
 
@@ -72,19 +128,9 @@ impl<Key: Hash + Eq, Value> UnorderedHashMap<Key, Value> {
     {
         self.0.contains_key(key)
     }
-
-    /// Returns the number of elements in the map.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns true if the map contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
 }
 
-impl<Key, Q: ?Sized, Value> Index<&Q> for UnorderedHashMap<Key, Value>
+impl<Key, Q: ?Sized, Value, BH: BuildHasher> Index<&Q> for UnorderedHashMap<Key, Value, BH>
 where
     Key: Eq + Hash + Borrow<Q>,
     Q: Eq + Hash,
@@ -96,22 +142,24 @@ where
     }
 }
 
-impl<Key: Hash + Eq, Value> Default for UnorderedHashMap<Key, Value> {
+impl<Key, Value, BH: Default> Default for UnorderedHashMap<Key, Value, BH> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<Key: Hash + Eq, Value> FromIterator<(Key, Value)> for UnorderedHashMap<Key, Value> {
+impl<Key: Hash + Eq, Value, BH: BuildHasher + Default> FromIterator<(Key, Value)>
+    for UnorderedHashMap<Key, Value, BH>
+{
     fn from_iter<T: IntoIterator<Item = (Key, Value)>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
     }
 }
 
-impl<Key: Hash + Eq, Value, const N: usize> From<[(Key, Value); N]>
-    for UnorderedHashMap<Key, Value>
+impl<Key: Hash + Eq, Value, const N: usize, BH: BuildHasher + Default> From<[(Key, Value); N]>
+    for UnorderedHashMap<Key, Value, BH>
 {
     fn from(items: [(Key, Value); N]) -> Self {
-        Self(HashMap::from(items))
+        Self(HashMap::from_iter(items))
     }
 }

--- a/crates/cairo-lang-utils/src/unordered_hash_set.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_set.rs
@@ -1,14 +1,13 @@
 use core::borrow::Borrow;
 use core::hash::{BuildHasher, Hash};
 use core::ops::Sub;
-
 #[cfg(feature = "std")]
 use std::collections::hash_map::RandomState;
+#[cfg(feature = "std")]
+use std::collections::HashSet;
 
 #[cfg(not(feature = "std"))]
 use hashbrown::HashSet;
-#[cfg(feature = "std")]
-use std::collections::HashSet;
 
 /// A hash set that does not care about the order of insertion.
 /// In particular, it does not support iterating, in order to guarantee deterministic compilation.

--- a/crates/cairo-lang-utils/src/unordered_hash_set.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_set.rs
@@ -1,15 +1,67 @@
-use std::borrow::Borrow;
+use core::borrow::Borrow;
+use core::hash::{BuildHasher, Hash};
+use core::ops::Sub;
+
+#[cfg(feature = "std")]
+use std::collections::hash_map::RandomState;
+
+#[cfg(not(feature = "std"))]
+use hashbrown::HashSet;
+#[cfg(feature = "std")]
 use std::collections::HashSet;
-use std::hash::Hash;
-use std::ops::Sub;
 
 /// A hash set that does not care about the order of insertion.
 /// In particular, it does not support iterating, in order to guarantee deterministic compilation.
 /// For an iterable version see [OrderedHashSet](crate::ordered_hash_set::OrderedHashSet).
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UnorderedHashSet<Key: Hash + Eq>(HashSet<Key>);
+#[cfg(feature = "std")]
+#[derive(Clone, Debug)]
+pub struct UnorderedHashSet<Key, BH = RandomState>(HashSet<Key, BH>);
+#[cfg(not(feature = "std"))]
+#[derive(Clone, Debug)]
+pub struct UnorderedHashSet<Key, BH>(HashSet<Key, BH>);
 
-impl<Key: Hash + Eq> UnorderedHashSet<Key> {
+#[cfg(feature = "std")]
+impl<K> UnorderedHashSet<K> {
+    pub fn new() -> Self {
+        Self(HashSet::new())
+    }
+}
+
+impl<K, BH> PartialEq for UnorderedHashSet<K, BH>
+where
+    K: Eq + Hash,
+    BH: BuildHasher,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<K, BH> Eq for UnorderedHashSet<K, BH>
+where
+    K: Eq + Hash,
+    BH: BuildHasher,
+{
+}
+
+impl<Key, BH> UnorderedHashSet<Key, BH> {
+    /// Returns the number of elements in the set.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the set contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Clears the set, removing all values.
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+}
+
+impl<Key: Hash + Eq, BH: BuildHasher> UnorderedHashSet<Key, BH> {
     /// Inserts the value into the set.
     ///
     /// If an equivalent item already exists in the set, returns `false`. Otherwise, returns `true`.
@@ -42,39 +94,27 @@ impl<Key: Hash + Eq> UnorderedHashSet<Key> {
     {
         self.0.contains(value)
     }
-
-    /// Returns the number of elements in the set.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns true if the set contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Clears the set, removing all values.
-    pub fn clear(&mut self) {
-        self.0.clear()
-    }
 }
 
-impl<Key: Hash + Eq> Default for UnorderedHashSet<Key> {
+impl<Key, BH: Default> Default for UnorderedHashSet<Key, BH> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<Key: Hash + Eq> FromIterator<Key> for UnorderedHashSet<Key> {
+impl<Key: Hash + Eq, BH: BuildHasher + Default> FromIterator<Key> for UnorderedHashSet<Key, BH> {
     fn from_iter<T: IntoIterator<Item = Key>>(iter: T) -> Self {
         Self(iter.into_iter().collect())
     }
 }
 
-impl<'a, Key: Hash + Eq + Clone> Sub<&'a UnorderedHashSet<Key>> for &'a UnorderedHashSet<Key> {
-    type Output = UnorderedHashSet<Key>;
+impl<'a, Key, BH> Sub<&'a UnorderedHashSet<Key, BH>> for &'a UnorderedHashSet<Key, BH>
+where
+    &'a HashSet<Key, BH>: Sub<Output = HashSet<Key, BH>>,
+{
+    type Output = UnorderedHashSet<Key, BH>;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        UnorderedHashSet::<Key>(&self.0 - &rhs.0)
+        UnorderedHashSet::<Key, BH>(&self.0 - &rhs.0)
     }
 }

--- a/ensure-no_std/.cargo/config.toml
+++ b/ensure-no_std/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/ensure-no_std/Cargo.toml
+++ b/ensure-no_std/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ensure-no_std"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cairo-lang-utils = { path = "../crates/cairo-lang-utils", default-features = false, features = ["serde"] }
+
+esp-alloc = "0.3.0"

--- a/ensure-no_std/src/main.rs
+++ b/ensure-no_std/src/main.rs
@@ -1,0 +1,22 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+/// This function is called on panic.
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    loop {}
+}
+
+#[global_allocator]
+// NOTE: this should be initialized before use
+static ALLOC: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
+
+#[allow(unused_imports)]
+use cairo_lang_utils;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,9 +27,9 @@ cairo-lang-syntax = { path = "../crates/cairo-lang-syntax" }
 cairo-lang-test-utils = { path = "../crates/cairo-lang-test-utils", features = ["testing"] }
 cairo-lang-utils = { path = "../crates/cairo-lang-utils" }
 env_logger.workspace = true
-itertools.workspace = true
+itertools = { workspace = true, default-features = true }
 log.workspace = true
-num-bigint.workspace = true
+num-bigint = { workspace = true, default-features = true }
 once_cell.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true


### PR DESCRIPTION
supersede #3297 

In this PR:
- cairo-lang-utils can now be compiled to no_std
- add the crate `ensure-no_std` to workspace
- add a check for a correct build of `ensure-no_std` in the CI
- `Index` and `IndexMut` impl of `OrderedHashMap` is changed, arg is now a reference, to match the inner type signature and avoid unnecessary `clone`
- `<Un>OrderedHash<Map/Set>` types have no constraint over their generics. The constraint is only enforced at the `impl` code block level, where they are required
- add `new()` for `<Un>OrderedHash<Map/Set>` types behind a `std` flag. They uses`std::collections::hash_map::RandomState` as its `HashBuilder` types like it's implicitly done in `std` rust for their internal types.

Once this one is merged, I will do the follow up for `cairo-lang-casm`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4759)
<!-- Reviewable:end -->
