### PR TITLE
build: cairo-lang-casm support no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
     strategy:
       matrix:
         cmd:
-          - test --profile=ci-dev -p cairo-lang-casm
+          - test --profile=ci-dev -p cairo-lang-casm --features=serde,parity-scale-codec,schemars
+          - test --profile=ci-dev -p cairo-lang-casm --no-default-features --features=serde,parity-scale-codec
           - test --profile=ci-dev -p cairo-lang-compiler
           - test --profile=ci-dev -p cairo-lang-debug
           - test --profile=ci-dev -p cairo-lang-defs
@@ -52,8 +53,8 @@ jobs:
           - test --profile=ci-dev -p cairo-lang-syntax-codegen
           - test --profile=ci-dev -p cairo-lang-test-runner
           - test --profile=ci-dev -p cairo-lang-test-utils
-          - test --profile=ci-dev -p cairo-lang-utils
-          - test --profile=ci-dev -p cairo-lang-utils --no-default-features --features=serde
+          - test --profile=ci-dev -p cairo-lang-utils --features=serde,parity-scale-codec,schemars,testing,env_logger
+          - test --profile=ci-dev -p cairo-lang-utils --no-default-features --features=serde,parity-scale-codec
           - test --profile=ci-dev -p tests
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,18 +435,17 @@ version = "2.4.1"
 dependencies = [
  "cairo-lang-utils",
  "env_logger",
+ "hashbrown 0.14.3",
  "indoc",
  "itertools 0.11.0",
  "num-bigint",
  "num-traits 0.2.17",
  "parity-scale-codec",
- "parity-scale-codec-derive",
  "pretty_assertions",
  "schemars",
  "serde",
  "test-case",
  "test-log",
- "thiserror",
 ]
 
 [[package]]
@@ -2205,8 +2204,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,7 @@ num-bigint = { version = "0.4", default-features = false }
 num-integer = "0.1"
 num-traits = { version = "0.2", default-features = false }
 once_cell = "1.18.0"
-parity-scale-codec = { version = "3.6.5", default-features = false }
-parity-scale-codec-derive = "3.6.5"
+parity-scale-codec = { version = "3.6.5", default-features = false, features = ["derive"] }
 path-clean = "1.0.1"
 pretty_assertions = "1.4.0"
 proc-macro2 = "1.0"

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -7,15 +7,16 @@ license-file.workspace = true
 description = "Cairo assembly encoding."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1", features = ["serde", "schemars"] }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.4.1", default-features = false }
 indoc.workspace = true
-num-bigint = { workspace = true, default-features = true }
-num-traits = { workspace = true, default-features = true }
-parity-scale-codec.workspace = true
-parity-scale-codec-derive.workspace = true
-schemars = { workspace = true, features = ["preserve_order"] }
-serde = { workspace = true, default-features = true }
-thiserror.workspace = true
+num-bigint = { workspace = true }
+num-traits = { workspace = true }
+hashbrown = { workspace = true }
+
+# Optional
+serde = { workspace = true, optional = true }
+schemars = { workspace = true, features = ["preserve_order"], optional = true }
+parity-scale-codec = { workspace = true, optional = true }
 
 [dev-dependencies]
 env_logger.workspace = true
@@ -23,3 +24,10 @@ itertools = { workspace = true, default-features = true }
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+
+[features]
+default = ["std"]
+std = ["cairo-lang-utils/std", "num-bigint/std", "num-traits/std", "serde?/std", "parity-scale-codec?/std"]
+serde = ["dep:serde", "cairo-lang-utils/serde" ]
+schemars = [ "std", "dep:schemars", "cairo-lang-utils/schemars"]
+parity-scale-codec = ["dep:parity-scale-codec", "cairo-lang-utils/parity-scale-codec"]

--- a/crates/cairo-lang-casm/src/ap_change.rs
+++ b/crates/cairo-lang-casm/src/ap_change.rs
@@ -1,7 +1,6 @@
-use std::fmt::Display;
+use core::fmt::Display;
 
 use cairo_lang_utils::casts::IntoOrPanic;
-use thiserror::Error;
 
 use crate::operand::{BinOpOperand, CellRef, DerefOrImmediate, Register, ResOperand};
 
@@ -15,7 +14,7 @@ pub enum ApChange {
     Unknown,
 }
 impl Display for ApChange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ApChange::Known(change) => write!(f, "ApChange::Known({change})"),
             ApChange::Unknown => write!(f, "ApChange::Unknown"),
@@ -23,13 +22,23 @@ impl Display for ApChange {
     }
 }
 
-#[derive(Debug, Error, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ApChangeError {
-    #[error("Unknown ap change")]
     UnknownApChange,
-    #[error("Offset overflow")]
     OffsetOverflow,
 }
+
+impl Display for ApChangeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ApChangeError::UnknownApChange => write!(f, "Unknown ap change"),
+            ApChangeError::OffsetOverflow => write!(f, "Offset overflow"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ApChangeError {}
 
 /// Trait for applying ap changes.
 pub trait ApplyApChange: Sized {

--- a/crates/cairo-lang-casm/src/ap_change_test.rs
+++ b/crates/cairo-lang-casm/src/ap_change_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use test_log::test;
 
 use super::{BinOpOperand, DerefOrImmediate};

--- a/crates/cairo-lang-casm/src/assembler.rs
+++ b/crates/cairo-lang-casm/src/assembler.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use num_bigint::{BigInt, ToBigInt};
 
 use crate::hints::Hint;

--- a/crates/cairo-lang-casm/src/builder.rs
+++ b/crates/cairo-lang-casm/src/builder.rs
@@ -1,8 +1,16 @@
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+#[cfg(not(feature = "std"))]
+pub use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec, vec::Vec};
+#[cfg(feature = "std")]
+pub use std::borrow::ToOwned;
+#[cfg(feature = "std")]
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::extract_matches;
+#[cfg(not(feature = "std"))]
+use hashbrown::{hash_map::Entry, HashMap, HashSet};
 use num_bigint::BigInt;
 use num_traits::One;
 
@@ -414,7 +422,7 @@ impl CasmBuilder {
         );
         self.statements.push(Statement::Jump(label.clone(), instruction));
         let mut state = State::default();
-        std::mem::swap(&mut state, &mut self.main_state);
+        core::mem::swap(&mut state, &mut self.main_state);
         self.set_or_test_label_state(label, state);
         self.reachable = false;
     }
@@ -621,7 +629,7 @@ impl CasmBuilder {
         }
         self.main_state.steps += 1;
         let mut hints = vec![];
-        std::mem::swap(&mut hints, &mut self.current_hints);
+        core::mem::swap(&mut hints, &mut self.current_hints);
         Instruction { body, inc_ap, hints }
     }
 }
@@ -790,15 +798,15 @@ macro_rules! casm_build_extend {
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, jump $target:ident; $($tok:tt)*) => {
-        $builder.jump(std::stringify!($target).to_owned());
+        $builder.jump($crate::builder::ToOwned::to_owned(core::stringify!($target)));
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, jump $target:ident if $condition:ident != 0; $($tok:tt)*) => {
-        $builder.jump_nz($condition, std::stringify!($target).to_owned());
+        $builder.jump_nz($condition, $crate::builder::ToOwned::to_owned(core::stringify!($target)));
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, let ($($var_name:ident),*) = call $target:ident; $($tok:tt)*) => {
-        $builder.call(std::stringify!($target).to_owned());
+        $builder.call($crate::builder::ToOwned::to_owned(core::stringify!($target)));
 
         let __var_count = {0i16 $(+ (stringify!($var_name), 1i16).1)*};
         let mut __var_index = 0;
@@ -816,7 +824,7 @@ macro_rules! casm_build_extend {
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, $label:ident: $($tok:tt)*) => {
-        $builder.label(std::stringify!($label).to_owned());
+        $builder.label($crate::builder::ToOwned::to_owned(core::stringify!($label)));
         $crate::casm_build_extend!($builder, $($tok)*)
     };
     ($builder:ident, fail; $($tok:tt)*) => {

--- a/crates/cairo-lang-casm/src/builder_test.rs
+++ b/crates/cairo-lang-casm/src/builder_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::format;
+
 use indoc::indoc;
 use itertools::join;
 use pretty_assertions::assert_eq;

--- a/crates/cairo-lang-casm/src/encoder.rs
+++ b/crates/cairo-lang-casm/src/encoder.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 use num_bigint::BigInt;
 
 use crate::assembler::{ApUpdate, FpUpdate, InstructionRepr, Op1Addr, Opcode, PcUpdate, Res};

--- a/crates/cairo-lang-casm/src/encoder_test.rs
+++ b/crates/cairo-lang-casm/src/encoder_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 use num_bigint::BigInt;
 use pretty_assertions::assert_eq;
 use test_case::test_case;

--- a/crates/cairo-lang-casm/src/hints/mod.rs
+++ b/crates/cairo-lang-casm/src/hints/mod.rs
@@ -1,10 +1,12 @@
-use std::fmt::{Display, Formatter};
+#[cfg(not(feature = "std"))]
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+use core::fmt::{Display, Formatter};
 
 use cairo_lang_utils::bigint::BigIntAsHex;
 use indoc::formatdoc;
-use parity_scale_codec_derive::{Decode, Encode};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::operand::{CellRef, DerefOrImmediate, ResOperand};
 
@@ -14,12 +16,17 @@ mod test;
 // Represents a cairo hint.
 // Note: Hint encoding should be backwards-compatible. This is an API guarantee.
 // For example, new variants should have new `index`.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Encode, Decode, JsonSchema)]
-#[serde(untagged)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(untagged))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub enum Hint {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Core(CoreHintBase),
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     Starknet(StarknetHint),
 }
 
@@ -56,12 +63,18 @@ impl PythonicHint for Hint {
 }
 
 /// Represents a hint that triggers a system call.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Encode, Decode, JsonSchema)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub enum StarknetHint {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     SystemCall { system: ResOperand },
-    #[codec(index = 1)]
-    #[schemars(skip)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
     Cheatcode {
         selector: BigIntAsHex,
         input_start: ResOperand,
@@ -72,12 +85,17 @@ pub enum StarknetHint {
 }
 
 // Represents a cairo core hint.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Encode, Decode, JsonSchema)]
-#[serde(untagged)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(untagged))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub enum CoreHintBase {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Core(CoreHint),
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     Deprecated(DeprecatedHint),
 }
 
@@ -92,27 +110,33 @@ impl From<DeprecatedHint> for CoreHintBase {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Encode, Decode, JsonSchema)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub enum CoreHint {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     AllocSegment { dst: CellRef },
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     TestLessThan { lhs: ResOperand, rhs: ResOperand, dst: CellRef },
-    #[codec(index = 2)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 2))]
     TestLessThanOrEqual { lhs: ResOperand, rhs: ResOperand, dst: CellRef },
     /// Multiplies two 128-bit integers and returns two 128-bit integers: the high and low parts of
     /// the product.
-    #[codec(index = 3)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 3))]
     WideMul128 { lhs: ResOperand, rhs: ResOperand, high: CellRef, low: CellRef },
     /// Computes lhs/rhs and returns the quotient and remainder.
     ///
     /// Note: the hint may be used to write an already assigned memory cell.
-    #[codec(index = 4)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 4))]
     DivMod { lhs: ResOperand, rhs: ResOperand, quotient: CellRef, remainder: CellRef },
     /// Divides dividend (represented by 2 128bit limbs) by divisor (represented by 2 128bit
     /// limbs). Returns the quotient (represented by 2 128bit limbs) and remainder (represented by
     /// 2 128bit limbs). In all cases - `name`0 is the least significant limb.
-    #[codec(index = 5)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 5))]
     Uint256DivMod {
         dividend0: ResOperand,
         dividend1: ResOperand,
@@ -127,7 +151,7 @@ pub enum CoreHint {
     /// limbs). Returns the quotient (represented by 4 128bit limbs) and remainder (represented
     /// by 2 128bit limbs).
     /// In all cases - `name`0 is the least significant limb.
-    #[codec(index = 6)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 6))]
     Uint512DivModByUint256 {
         dividend0: ResOperand,
         dividend1: ResOperand,
@@ -142,13 +166,13 @@ pub enum CoreHint {
         remainder0: CellRef,
         remainder1: CellRef,
     },
-    #[codec(index = 7)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 7))]
     SquareRoot { value: ResOperand, dst: CellRef },
     /// Computes the square root of value_low<<128+value_high, stores the 64bit limbs of the result
     /// in sqrt0 and sqrt1 as well as the 128bit limbs of the remainder in remainder_low and
     /// remainder_high. The remainder is defined as `value - sqrt**2`.
     /// Lastly it checks weather `2*sqrt - remainder >= 2**128`.
-    #[codec(index = 8)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 8))]
     Uint256SquareRoot {
         value_low: ResOperand,
         value_high: ResOperand,
@@ -159,23 +183,23 @@ pub enum CoreHint {
         sqrt_mul_2_minus_remainder_ge_u128: CellRef,
     },
     /// Finds some `x` and `y` such that `x * scalar + y = value` and `x <= max_x`.
-    #[codec(index = 9)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 9))]
     LinearSplit { value: ResOperand, scalar: ResOperand, max_x: ResOperand, x: CellRef, y: CellRef },
     /// Allocates a new dict segment, and write its start address into the dict_infos segment.
-    #[codec(index = 10)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 10))]
     AllocFelt252Dict { segment_arena_ptr: ResOperand },
     /// Fetch the previous value of a key in a dict, and write it in a new dict access.
-    #[codec(index = 11)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 11))]
     Felt252DictEntryInit { dict_ptr: ResOperand, key: ResOperand },
     /// Similar to Felt252DictWrite, but updates an existing entry and does not write the previous
     /// value to the stack.
-    #[codec(index = 12)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 12))]
     Felt252DictEntryUpdate { dict_ptr: ResOperand, value: ResOperand },
     /// Retrieves the index of the given dict in the dict_infos segment.
-    #[codec(index = 13)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 13))]
     GetSegmentArenaIndex { dict_end_ptr: ResOperand, dict_index: CellRef },
     /// Initialized the lists of accesses of each key of a dict as a preparation of squash_dict.
-    #[codec(index = 14)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 14))]
     InitSquashData {
         dict_accesses: ResOperand,
         ptr_diff: ResOperand,
@@ -184,46 +208,46 @@ pub enum CoreHint {
         first_key: CellRef,
     },
     /// Retrieves the current index of a dict access to process.
-    #[codec(index = 15)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 15))]
     GetCurrentAccessIndex { range_check_ptr: ResOperand },
     /// Writes if the squash_dict loop should be skipped.
-    #[codec(index = 16)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 16))]
     ShouldSkipSquashLoop { should_skip_loop: CellRef },
     /// Writes the delta from the current access index to the next one.
-    #[codec(index = 17)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 17))]
     GetCurrentAccessDelta { index_delta_minus1: CellRef },
     /// Writes if the squash_dict loop should be continued.
-    #[codec(index = 18)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 18))]
     ShouldContinueSquashLoop { should_continue: CellRef },
     /// Writes the next dict key to process.
-    #[codec(index = 19)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 19))]
     GetNextDictKey { next_key: CellRef },
     /// Finds the two small arcs from within [(0,a),(a,b),(b,PRIME)] and writes it to the
     /// range_check segment.
-    #[codec(index = 20)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 20))]
     AssertLeFindSmallArcs { range_check_ptr: ResOperand, a: ResOperand, b: ResOperand },
     /// Writes if the arc (0,a) was excluded.
-    #[codec(index = 21)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 21))]
     AssertLeIsFirstArcExcluded { skip_exclude_a_flag: CellRef },
     /// Writes if the arc (a,b) was excluded.
-    #[codec(index = 22)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 22))]
     AssertLeIsSecondArcExcluded { skip_exclude_b_minus_a: CellRef },
     /// Samples a random point on the EC.
-    #[codec(index = 23)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 23))]
     RandomEcPoint { x: CellRef, y: CellRef },
     /// Computes the square root of `val`, if `val` is a quadratic residue, and of `3 * val`
     /// otherwise.
     ///
     /// Since 3 is not a quadratic residue, exactly one of `val` and `3 * val` is a quadratic
     /// residue (unless `val` is 0). This allows proving that `val` is not a quadratic residue.
-    #[codec(index = 24)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 24))]
     FieldSqrt { val: ResOperand, sqrt: CellRef },
     /// Prints the values from start to end.
     /// Both must be pointers.
-    #[codec(index = 25)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 25))]
     DebugPrint { start: ResOperand, end: ResOperand },
     /// Returns an address with `size` free locations afterwards.
-    #[codec(index = 26)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 26))]
     AllocConstantSize { size: ResOperand, dst: CellRef },
     /// Provides the inverse of b (represented by 2 128-bit limbs) modulo n (represented by 2
     /// 128-bit limbs), or a proof that b has no inverse.
@@ -244,7 +268,7 @@ pub enum CoreHint {
     /// All no-inverse requirements are satisfied, except for `g > 1`.
     ///
     /// In all cases - `name`0 is the least significant limb.
-    #[codec(index = 27)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 27))]
     U256InvModN {
         b0: ResOperand,
         b1: ResOperand,
@@ -261,36 +285,42 @@ pub enum CoreHint {
 
 /// Represents a deprecated hint which is kept for backward compatibility of previously deployed
 /// contracts.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Encode, Decode, JsonSchema)]
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub enum DeprecatedHint {
     /// Asserts that the current access indices list is empty (after the loop).
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     AssertCurrentAccessIndicesIsEmpty,
     /// Asserts that the number of used accesses is equal to the length of the original accesses
     /// list.
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     AssertAllAccessesUsed { n_used_accesses: CellRef },
     /// Asserts that the keys list is empty.
-    #[codec(index = 2)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 2))]
     AssertAllKeysUsed,
     /// Asserts that the arc (b, PRIME) was excluded.
-    #[codec(index = 3)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 3))]
     AssertLeAssertThirdArcExcluded,
     /// Asserts that the input represents integers and that a<b.
-    #[codec(index = 4)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 4))]
     AssertLtAssertValidInput { a: ResOperand, b: ResOperand },
     /// Retrieves and writes the value corresponding to the given dict and key from the vm
     /// dict_manager.
-    #[codec(index = 5)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 5))]
     Felt252DictRead { dict_ptr: ResOperand, key: ResOperand, value_dst: CellRef },
     /// Sets the value corresponding to the key in the vm dict_manager.
-    #[codec(index = 6)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 6))]
     Felt252DictWrite { dict_ptr: ResOperand, key: ResOperand, value: ResOperand },
 }
 
 struct DerefOrImmediateFormatter<'a>(&'a DerefOrImmediate);
 impl<'a> Display for DerefOrImmediateFormatter<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self.0 {
             DerefOrImmediate::Deref(d) => write!(f, "memory{d}"),
             DerefOrImmediate::Immediate(i) => write!(f, "{}", i.value),
@@ -300,7 +330,7 @@ impl<'a> Display for DerefOrImmediateFormatter<'a> {
 
 struct ResOperandAsIntegerFormatter<'a>(&'a ResOperand);
 impl<'a> Display for ResOperandAsIntegerFormatter<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self.0 {
             ResOperand::Deref(d) => write!(f, "memory{d}"),
             ResOperand::DoubleDeref(d, i) => write!(f, "memory[memory{d} + {i}]"),
@@ -320,7 +350,7 @@ impl<'a> Display for ResOperandAsIntegerFormatter<'a> {
 
 struct ResOperandAsAddressFormatter<'a>(&'a ResOperand);
 impl<'a> Display for ResOperandAsAddressFormatter<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self.0 {
             ResOperand::Deref(d) => write!(f, "memory{d}"),
             ResOperand::DoubleDeref(d, i) => write!(f, "memory[memory{d} + {i}]"),

--- a/crates/cairo-lang-casm/src/hints/test.rs
+++ b/crates/cairo-lang-casm/src/hints/test.rs
@@ -1,11 +1,7 @@
-use std::str::FromStr;
-
-use cairo_lang_utils::bigint::BigIntAsHex;
 use indoc::indoc;
-use parity_scale_codec::{Decode, Encode};
 use test_log::test;
 
-use crate::hints::{CoreHint, CoreHintBase, Hint, PythonicHint, StarknetHint};
+use crate::hints::{CoreHint, PythonicHint, StarknetHint};
 use crate::operand::{BinOpOperand, CellRef, DerefOrImmediate, Operation, Register, ResOperand};
 use crate::res;
 
@@ -117,7 +113,15 @@ fn test_debug_hint_format() {
 }
 
 #[test]
+#[cfg(feature = "parity-scale-codec")]
 fn encode_hint() {
+    use core::str::FromStr;
+
+    use cairo_lang_utils::bigint::BigIntAsHex;
+    use parity_scale_codec::{Decode, Encode};
+
+    use crate::hints::{CoreHintBase, Hint};
+
     let hint = Hint::Core(CoreHintBase::Core(CoreHint::TestLessThan {
         lhs: ResOperand::Deref(CellRef { register: Register::FP, offset: -3 }),
         rhs: ResOperand::Immediate(BigIntAsHex {

--- a/crates/cairo-lang-casm/src/inline.rs
+++ b/crates/cairo-lang-casm/src/inline.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::hints::Hint;
 use crate::instructions::Instruction;
 
@@ -215,7 +218,7 @@ macro_rules! casm_extend {
 #[macro_export]
 macro_rules! append_instruction {
     ($ctx:ident, $body:ident $(,$ap:ident++)?) => {
-        let current_hints = std::mem::take(&mut $ctx.current_hints);
+        let current_hints = core::mem::take(&mut $ctx.current_hints);
         let instr = $crate::instructions::Instruction {
             body: $body,
             inc_ap: $crate::is_inc_ap!($($ap++)?),

--- a/crates/cairo-lang-casm/src/inline_test.rs
+++ b/crates/cairo-lang-casm/src/inline_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use indoc::indoc;
 use itertools::join;
 use pretty_assertions::assert_eq;

--- a/crates/cairo-lang-casm/src/instructions.rs
+++ b/crates/cairo-lang-casm/src/instructions.rs
@@ -1,5 +1,6 @@
-use std::fmt::Display;
-use std::vec;
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+use core::fmt::Display;
 
 use crate::hints::{Hint, PythonicHint};
 use crate::operand::{CellRef, DerefOrImmediate, ResOperand};
@@ -32,7 +33,7 @@ impl InstructionBody {
     }
 }
 impl Display for InstructionBody {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             InstructionBody::AddAp(insn) => write!(f, "{insn}",),
             InstructionBody::AssertEq(insn) => write!(f, "{insn}",),
@@ -58,7 +59,7 @@ impl Instruction {
 }
 
 impl Display for Instruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for hint in &self.hints {
             let hint_str = hint.get_pythonic_hint();
             // Skip leading and trailing space if hint starts with `\n`.
@@ -84,7 +85,7 @@ pub struct CallInstruction {
     pub relative: bool,
 }
 impl Display for CallInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "call {} {}", if self.relative { "rel" } else { "abs" }, self.target,)
     }
 }
@@ -112,7 +113,7 @@ impl JumpInstruction {
     }
 }
 impl Display for JumpInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "jmp {} {}", if self.relative { "rel" } else { "abs" }, self.target,)
     }
 }
@@ -132,7 +133,7 @@ impl JnzInstruction {
     }
 }
 impl Display for JnzInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "jmp rel {} if {} != 0", self.jump_offset, self.condition)
     }
 }
@@ -162,7 +163,7 @@ impl AssertEqInstruction {
     }
 }
 impl Display for AssertEqInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} = {}", self.a, self.b)
     }
 }
@@ -171,7 +172,7 @@ impl Display for AssertEqInstruction {
 #[derive(Debug, Eq, PartialEq)]
 pub struct RetInstruction {}
 impl Display for RetInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ret")
     }
 }
@@ -193,7 +194,7 @@ impl AddApInstruction {
     }
 }
 impl Display for AddApInstruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "ap += {}", self.operand)
     }
 }

--- a/crates/cairo-lang-casm/src/instructions_test.rs
+++ b/crates/cairo-lang-casm/src/instructions_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::{string::ToString, vec};
+
 use indoc::indoc;
 use test_log::test;
 

--- a/crates/cairo-lang-casm/src/lib.rs
+++ b/crates/cairo-lang-casm/src/lib.rs
@@ -1,5 +1,10 @@
 //! Cairo assembly representation, formatting and construction utilities.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 pub mod ap_change;
 pub mod assembler;
 pub mod builder;

--- a/crates/cairo-lang-casm/src/operand.rs
+++ b/crates/cairo-lang-casm/src/operand.rs
@@ -1,25 +1,26 @@
-use std::fmt::Display;
+use core::fmt::Display;
 
 use cairo_lang_utils::bigint::BigIntAsHex;
-use parity_scale_codec_derive::{Decode, Encode};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 #[path = "operand_test.rs"]
 mod test;
 
-#[derive(
-    Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, JsonSchema,
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
 )]
 pub enum Register {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     AP,
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     FP,
 }
 impl Display for Register {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Register::AP => write!(f, "ap"),
             Register::FP => write!(f, "fp"),
@@ -28,19 +29,25 @@ impl Display for Register {
 }
 
 // Represents the rhs operand of an assert equal InstructionBody.
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub enum ResOperand {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Deref(CellRef),
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     DoubleDeref(CellRef, i16),
-    #[codec(index = 2)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 2))]
     Immediate(BigIntAsHex),
-    #[codec(index = 3)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 3))]
     BinOp(BinOpOperand),
 }
 impl Display for ResOperand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ResOperand::Deref(operand) => write!(f, "{operand}"),
             ResOperand::DoubleDeref(operand, offset) => write!(f, "[{operand} + {offset}]"),
@@ -65,13 +72,19 @@ impl<T: Into<BigIntAsHex>> From<T> for ResOperand {
 }
 
 /// Represents an operand of the form [reg + offset].
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub struct CellRef {
     pub register: Register,
     pub offset: i16,
 }
 impl Display for CellRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "[{} + {}]", self.register, self.offset)
     }
 }
@@ -81,15 +94,21 @@ pub fn ap_cell_ref(offset: i16) -> CellRef {
     CellRef { register: Register::AP, offset }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub enum DerefOrImmediate {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Deref(CellRef),
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     Immediate(BigIntAsHex),
 }
 impl Display for DerefOrImmediate {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             DerefOrImmediate::Deref(operand) => write!(f, "{operand}"),
             DerefOrImmediate::Immediate(operand) => write!(f, "{}", operand.value),
@@ -107,15 +126,21 @@ impl From<CellRef> for DerefOrImmediate {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub enum Operation {
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 0))]
     Add,
-    #[codec(index = 1)]
+    #[cfg_attr(feature = "parity-scale-codec", codec(index = 1))]
     Mul,
 }
 impl Display for Operation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Operation::Add => write!(f, "+"),
             Operation::Mul => write!(f, "*"),
@@ -123,14 +148,20 @@ impl Display for Operation {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Encode, Decode, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub struct BinOpOperand {
     pub op: Operation,
     pub a: CellRef,
     pub b: DerefOrImmediate,
 }
 impl Display for BinOpOperand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} {} {}", self.a, self.op, self.b)
     }
 }

--- a/crates/cairo-lang-casm/src/operand_test.rs
+++ b/crates/cairo-lang-casm/src/operand_test.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use test_log::test;
 
 use super::{BinOpOperand, DerefOrImmediate, Operation};

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -9,7 +9,7 @@ description = "Starknet capabilities and utilities on top of Cairo."
 [dependencies]
 anyhow.workspace = true
 cairo-felt.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.4.1" }
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "2.4.1", features = ["serde"] }
 cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "2.4.1" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "2.4.1" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "2.4.1" }

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -11,7 +11,6 @@ indexmap = { workspace = true }
 itertools = { workspace = true, features = ["use_alloc"] }
 num-bigint.workspace = true
 num-traits.workspace = true
-parity-scale-codec.workspace = true
 hashbrown = { workspace = true, features = ["serde"] }
 
 # Optional
@@ -20,6 +19,7 @@ schemars = { workspace = true, features = ["preserve_order"], optional = true }
 env_logger = { workspace = true, optional = true }
 time = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
+parity-scale-codec = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -37,5 +37,6 @@ std = [
 ]
 serde = ["dep:serde", "num-bigint/serde", "indexmap/serde"]
 schemars = ["std", "serde", "dep:schemars"]
+parity-scale-codec = ["dep:parity-scale-codec"]
 testing = []
 env_logger = ["std", "dep:env_logger", "dep:time", "dep:log"]

--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -1,29 +1,32 @@
 #[cfg(test)]
-#[path = "bigint_test.rs"]
+#[path = "bigint_tests/mod.rs"]
 mod test;
 
-#[cfg(not(feature = "std"))]
-use alloc::{format, string::String, vec};
-use core::ops::Neg;
+#[cfg(all(not(feature = "std"), feature = "serde"))]
+use alloc::{format, string::String};
 
-use num_bigint::{BigInt, BigUint, ToBigInt};
+#[cfg(feature = "serde")]
+use num_bigint::ToBigInt;
+use num_bigint::{BigInt, BigUint};
+#[cfg(feature = "serde")]
 use num_traits::{Num, Signed};
-use parity_scale_codec::{Decode, Encode};
-use serde::ser::Serializer;
-use serde::{Deserialize, Deserializer, Serialize};
 
 /// A wrapper for BigUint that serializes as hex.
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 pub struct BigUintAsHex {
     /// A field element that encodes the signature of the called function.
-    #[serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")
+    )]
     pub value: BigUint,
 }
 
+#[cfg(feature = "serde")]
 fn deserialize_from_str<'a, D>(s: &str) -> Result<BigUint, D::Error>
 where
-    D: Deserializer<'a>,
+    D: serde::Deserializer<'a>,
 {
     match s.strip_prefix("0x") {
         Some(num_no_prefix) => BigUint::from_str_radix(num_no_prefix, 16)
@@ -32,28 +35,33 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 pub fn serialize_big_uint<S>(num: &BigUint, serializer: S) -> Result<S::Ok, S::Error>
 where
-    S: Serializer,
+    S: serde::Serializer,
 {
     serializer.serialize_str(&format!("{num:#x}"))
 }
 
+#[cfg(feature = "serde")]
 pub fn deserialize_big_uint<'a, D>(deserializer: D) -> Result<BigUint, D::Error>
 where
-    D: Deserializer<'a>,
+    D: serde::Deserializer<'a>,
 {
-    let s = &String::deserialize(deserializer)?;
+    let s = &<String as serde::Deserialize>::deserialize(deserializer)?;
     deserialize_from_str::<D>(s)
 }
 
 // A wrapper for BigInt that serializes as hex.
-#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[serde(transparent)]
 pub struct BigIntAsHex {
     /// A field element that encodes the signature of the called function.
-    #[serde(serialize_with = "serialize_big_int", deserialize_with = "deserialize_big_int")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "serialize_big_int", deserialize_with = "deserialize_big_int")
+    )]
     #[cfg_attr(feature = "schemars", schemars(schema_with = "big_int_schema"))]
     pub value: BigInt,
 }
@@ -94,9 +102,10 @@ impl<T: Into<BigInt>> From<T> for BigIntAsHex {
     }
 }
 
+#[cfg(feature = "serde")]
 pub fn serialize_big_int<S>(num: &BigInt, serializer: S) -> Result<S::Ok, S::Error>
 where
-    S: Serializer,
+    S: serde::ser::Serializer,
 {
     serializer.serialize_str(&format!(
         "{}{:#x}",
@@ -105,57 +114,70 @@ where
     ))
 }
 
+#[cfg(feature = "serde")]
 pub fn deserialize_big_int<'a, D>(deserializer: D) -> Result<BigInt, D::Error>
 where
-    D: Deserializer<'a>,
+    D: serde::de::Deserializer<'a>,
 {
-    let s = &String::deserialize(deserializer)?;
+    use core::ops::Neg;
+
+    let s = &<String as serde::Deserialize>::deserialize(deserializer)?;
     match s.strip_prefix('-') {
         Some(abs_value) => Ok(deserialize_from_str::<D>(abs_value)?.to_bigint().unwrap().neg()),
         None => Ok(deserialize_from_str::<D>(s)?.to_bigint().unwrap()),
     }
 }
 
-impl Encode for BigIntAsHex {
-    fn size_hint(&self) -> usize {
-        // sign + len packed in the same byte, it allows numbers of byte size up to 63 (2**504),
-        // data.
-        let bits = self.value.bits() as usize;
-        core::mem::size_of::<u8>() + bits / 8 + if bits % 8 != 0 { 1 } else { 0 }
+#[cfg(feature = "parity-scale-codec")]
+mod impl_parity_scale_codec {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
+    use parity_scale_codec::{Decode, Encode};
+
+    use super::*;
+
+    impl Encode for BigIntAsHex {
+        fn size_hint(&self) -> usize {
+            // sign + len packed in the same byte, it allows numbers of byte size up to 63 (2**504),
+            // data.
+            let bits = self.value.bits() as usize;
+            core::mem::size_of::<u8>() + bits / 8 + if bits % 8 != 0 { 1 } else { 0 }
+        }
+
+        /// /!\ Warning this function panics if the number encoded is too big (>= 2**504)
+        fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
+            let (sign, data) = self.value.to_bytes_le();
+            assert!(data.len() <= 63, "Can't encode numbers longer than 63 bytes");
+            // Pack sign + number byte size.
+            ((match sign {
+                num_bigint::Sign::Minus => 0u8,
+                num_bigint::Sign::NoSign => 1u8,
+                num_bigint::Sign::Plus => 2u8,
+            } << 6)
+                + data.len() as u8)
+                .encode_to(dest);
+            dest.write(&data);
+        }
     }
 
-    /// /!\ Warning this function panics if the number encoded is too big (>= 2**504)
-    fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
-        let (sign, data) = self.value.to_bytes_le();
-        assert!(data.len() <= 63, "Can't encode numbers longer than 63 bytes");
-        // Pack sign + number byte size.
-        ((match sign {
-            num_bigint::Sign::Minus => 0u8,
-            num_bigint::Sign::NoSign => 1u8,
-            num_bigint::Sign::Plus => 2u8,
-        } << 6)
-            + data.len() as u8)
-            .encode_to(dest);
-        dest.write(&data);
-    }
-}
-
-impl Decode for BigIntAsHex {
-    fn decode<I: parity_scale_codec::Input>(
-        input: &mut I,
-    ) -> Result<Self, parity_scale_codec::Error> {
-        let sign_and_len = input.read_byte()?;
-        let sign = match sign_and_len >> 6 {
-            0u8 => num_bigint::Sign::Minus,
-            1u8 => num_bigint::Sign::NoSign,
-            2u8 => num_bigint::Sign::Plus,
-            _ => {
-                return Err(parity_scale_codec::Error::from("Bad sign encoding."));
-            }
-        };
-        let len = sign_and_len & 0b00111111;
-        let mut buffer = vec![0; len as usize];
-        input.read(&mut buffer)?;
-        Ok(Self { value: BigInt::from_bytes_le(sign, buffer.as_slice()) })
+    impl Decode for BigIntAsHex {
+        fn decode<I: parity_scale_codec::Input>(
+            input: &mut I,
+        ) -> Result<Self, parity_scale_codec::Error> {
+            let sign_and_len = input.read_byte()?;
+            let sign = match sign_and_len >> 6 {
+                0u8 => num_bigint::Sign::Minus,
+                1u8 => num_bigint::Sign::NoSign,
+                2u8 => num_bigint::Sign::Plus,
+                _ => {
+                    return Err(parity_scale_codec::Error::from("Bad sign encoding."));
+                }
+            };
+            let len = sign_and_len & 0b00111111;
+            let mut buffer = vec![0; len as usize];
+            input.read(&mut buffer)?;
+            Ok(Self { value: BigInt::from_bytes_le(sign, buffer.as_slice()) })
+        }
     }
 }

--- a/crates/cairo-lang-utils/src/bigint_tests/mod.rs
+++ b/crates/cairo-lang-utils/src/bigint_tests/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "parity-scale-codec")]
+mod parity_scale_codec;
+#[cfg(feature = "serde")]
+mod serde;

--- a/crates/cairo-lang-utils/src/bigint_tests/parity_scale_codec.rs
+++ b/crates/cairo-lang-utils/src/bigint_tests/parity_scale_codec.rs
@@ -1,0 +1,18 @@
+use crate::bigint::BigIntAsHex;
+
+#[test]
+fn encode_bigint() {
+    use core::str::FromStr;
+
+    use parity_scale_codec::{Decode, Encode};
+
+    let bigint = BigIntAsHex {
+        value: num_bigint::BigInt::from_str(
+            "3618502788666131106986593281521497120414687020801267626233049500247285301248",
+        )
+        .unwrap(),
+    };
+    let encoding = bigint.encode();
+    let decoded = BigIntAsHex::decode(&mut encoding.as_slice()).unwrap();
+    assert_eq!(bigint, decoded);
+}

--- a/crates/cairo-lang-utils/src/bigint_tests/serde.rs
+++ b/crates/cairo-lang-utils/src/bigint_tests/serde.rs
@@ -1,11 +1,9 @@
 #[cfg(not(feature = "std"))]
 use alloc::format;
 use core::ops::Neg;
-use core::str::FromStr;
 
 use num_bigint::BigInt;
 use num_traits::Num;
-use parity_scale_codec::{Decode, Encode};
 use test_case::test_case;
 
 use crate::bigint::BigIntAsHex;
@@ -23,17 +21,4 @@ fn test_bigint_serde(s: &str, is_negative: bool) {
     assert_eq!(serialized, format!("\"{}0x{}\"", if is_negative { "-" } else { "" }, s));
 
     assert_eq!(num, serde_json::from_str(&serialized).unwrap())
-}
-
-#[test]
-fn encode_bigint() {
-    let bigint = BigIntAsHex {
-        value: num_bigint::BigInt::from_str(
-            "3618502788666131106986593281521497120414687020801267626233049500247285301248",
-        )
-        .unwrap(),
-    };
-    let encoding = bigint.encode();
-    let decoded = BigIntAsHex::decode(&mut encoding.as_slice()).unwrap();
-    assert_eq!(bigint, decoded);
 }

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -9,7 +9,6 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::fmt;
 
-#[cfg(feature = "serde")]
 pub mod bigint;
 pub mod byte_array;
 pub mod casts;

--- a/ensure-no_std/Cargo.toml
+++ b/ensure-no_std/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cairo-lang-utils = { path = "../crates/cairo-lang-utils", default-features = false, features = ["serde"] }
+cairo-lang-utils = { path = "../crates/cairo-lang-utils", default-features = false, features = ["serde", "parity-scale-codec"] }
+cairo-lang-casm = { path = "../crates/cairo-lang-casm", default-features = false, features = ["serde", "parity-scale-codec"] }
 
 esp-alloc = "0.3.0"

--- a/ensure-no_std/src/main.rs
+++ b/ensure-no_std/src/main.rs
@@ -19,4 +19,6 @@ pub extern "C" fn _start() -> ! {
 static ALLOC: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 
 #[allow(unused_imports)]
+use cairo_lang_casm;
+#[allow(unused_imports)]
 use cairo_lang_utils;


### PR DESCRIPTION
In this PR:
- cairo-lang-casm can compile to no_std
- derive of encode/decode in cairo-lang-utils is behind a "parity-scale-codec" feature flag

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4780)
<!-- Reviewable:end -->
