### PR TITLE
Coupons: Add a compiler error test for coupon_buy and coupon_refund.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/compiler_test.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler_test.rs
@@ -792,9 +792,23 @@ fn compiler_errors(
     _args: &OrderedHashMap<String, String>,
 ) -> TestRunnerResult {
     let program = ProgramParser::new().parse(inputs["sierra_code"].as_str()).unwrap();
-    let error_str =
-        compile(&program, &calc_metadata_ap_change_only(&program).unwrap_or_default(), false)
+
+    let metadata = match inputs.get("metadata").map(|x| x.as_str()) {
+        Some("gas") => calc_metadata(&program, Default::default()),
+        Some("none") | None => {
+            // In this case, metadata errors are ignored.
+            Ok(calc_metadata_ap_change_only(&program).unwrap_or_default())
+        }
+        Some(metadata) => {
+            panic!("Invalid value for metadata argument: '{metadata}'.");
+        }
+    };
+
+    let error_str = match metadata {
+        Ok(metadata) => compile(&program, &metadata, false)
             .expect_err("Compilation is expected to fail.")
-            .to_string();
+            .to_string(),
+        Err(err) => err.to_string(),
+    };
     TestRunnerResult::success(OrderedHashMap::from([("error".into(), error_str)]))
 }

--- a/crates/cairo-lang-sierra-to-casm/src/test_data/errors
+++ b/crates/cairo-lang-sierra-to-casm/src/test_data/errors
@@ -779,3 +779,58 @@ foo@0() -> ();
 
 //! > error
 Error from program registry: Error during type specialization
+
+//! > ==========================================================================
+
+//! > Recursively buy coupon
+
+//! > test_runner_name
+compiler_errors
+
+//! > sierra_code
+type Coupon = Coupon<user@test::recursive_buy>;
+type Unit = Struct<ut@Tuple>;
+
+libfunc coupon_buy = coupon_buy<Coupon>;
+libfunc drop_coupon = drop<Coupon>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+
+coupon_buy() -> ([0]);
+drop_coupon([0]) -> ();
+struct_construct<Unit>() -> ([1]);
+return([1]);
+
+test::recursive_buy@0() -> (Unit);
+
+//! > metadata
+gas
+
+//! > error
+found an unexpected cycle during cost computation
+
+//! > ==========================================================================
+
+//! > Recursively refund coupon
+
+//! > test_runner_name
+compiler_errors
+
+//! > sierra_code
+type Coupon = Coupon<user@test::recursive_refund>;
+type Unit = Struct<ut@Tuple>;
+
+libfunc coupon_refund = coupon_refund<Coupon>;
+libfunc drop_coupon = drop<Coupon>;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+
+coupon_refund([0]) -> ();
+struct_construct<Unit>() -> ([1]);
+return([1]);
+
+test::recursive_refund@0([0]: Coupon) -> (Unit);
+
+//! > metadata
+gas
+
+//! > error
+found an unexpected cycle during cost computation


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4787)
<!-- Reviewable:end -->
