### PR TITLE
dev: Result unwrap_or, unwrap_or_default

### DIFF
--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -31,9 +31,13 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     }
     /// If `val` is `Result::Ok(x)`, returns `x`.
     /// Otherwise returns `Default::<T>::default()`.
-    fn unwrap_or_default<+Drop<T>, +Drop<E>, +Default<T>>(self: Result<T, E>) -> T {
-        self.unwrap_or(Default::default())
+    fn unwrap_or_default<+Drop<E>, +Default<T>>(self: Result<T, E>) -> T {
+        match self {
+            Result::Ok(x) => x,
+            Result::Err(_) => Default::default(),
+        }
     }
+
     /// If `val` is `Result::Err(x)`, returns `x`. Otherwise, panics with `err`.
     fn expect_err<+Drop<T>>(self: Result<T, E>, err: felt252) -> E {
         match self {

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -22,6 +22,18 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     fn unwrap<+Drop<E>>(self: Result<T, E>) -> T {
         self.expect('Result::unwrap failed.')
     }
+    /// If `val` is `Result::Ok(x)`, returns `x`. Otherwise, returns `default`.
+    fn unwrap_or<+Drop<T>, +Drop<E>>(self: Result<T, E>, default: T) -> T {
+        match self {
+            Result::Ok(x) => x,
+            Result::Err(_) => default,
+        }
+    }
+    /// If `val` is `Result::Ok(x)`, returns `x`.
+    /// Otherwise returns `Default::<T>::default()`.
+    fn unwrap_or_default<+Drop<T>, +Drop<E>, +Default<T>>(self: Result<T, E>) -> T {
+        self.unwrap_or(Default::default())
+    }
     /// If `val` is `Result::Err(x)`, returns `x`. Otherwise, panics with `err`.
     fn expect_err<+Drop<T>>(self: Result<T, E>, err: felt252) -> E {
         match self {

--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -17,6 +17,7 @@ mod nullable_test;
 mod panics_test;
 mod plugins_test;
 mod print_test;
+mod result_test;
 mod secp256k1_test;
 mod secp256r1_test;
 mod test_utils;

--- a/corelib/src/test/result_test.cairo
+++ b/corelib/src/test/result_test.cairo
@@ -1,0 +1,125 @@
+use core::result::{Result, ResultTraitImpl};
+
+#[test]
+fn test_result_ok_expect() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    assert(result.expect('') == 42, 'result_ok_expect');
+}
+
+#[test]
+#[should_panic(expected: ('err msg',))]
+fn test_result_err_expect() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    result.expect('err msg');
+}
+
+#[test]
+fn test_result_ok_unwrap() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    assert(result.unwrap() == 42, 'result_ok_unwrap');
+}
+
+#[test]
+#[should_panic(expected: ('Result::unwrap failed.',))]
+fn test_result_err_unwrap() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    result.unwrap();
+}
+
+#[test]
+fn test_result_ok_unwrap_or() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    assert(result.unwrap_or(0) == 42, 'result_ok_unwrap_or');
+}
+
+#[test]
+fn test_result_err_unwrap_or() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    assert(result.unwrap_or(0) == 0, 'result_err_unwrap_or');
+}
+
+#[test]
+fn test_result_ok_unwrap_or_default() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    assert(result.unwrap_or_default() == 42, 'result_ok_unwrap_or_default');
+}
+
+#[test]
+fn test_result_err_unwrap_or_default() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    assert(result.unwrap_or_default() == 0, 'result_err_unwrap_or_default');
+}
+
+#[test]
+#[should_panic(expected: ('err msg',))]
+fn test_result_ok_expect_err() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    result.expect_err('err msg');
+}
+
+#[test]
+fn test_result_err_expect_err() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    assert(result.expect_err('') == 'no', 'result_err_expect_err');
+}
+
+#[test]
+#[should_panic(expected: ('Result::unwrap_err failed.',))]
+fn test_result_ok_unwrap_err() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    result.unwrap_err();
+}
+
+#[test]
+fn test_result_err_unwrap_err() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    assert(result.unwrap_err() == 'no', 'result_err_unwrap_err');
+}
+
+#[test]
+fn test_result_ok_is_ok() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    assert(result.is_ok(), 'result_ok_is_ok');
+}
+
+#[test]
+fn test_result_err_is_ok() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    assert(!result.is_ok(), 'result_err_is_ok');
+}
+
+#[test]
+fn test_result_ok_is_err() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    assert(!result.is_err(), 'result_ok_is_err');
+}
+
+#[test]
+fn test_result_err_is_err() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    assert(result.is_err(), 'result_err_is_err');
+}
+
+#[test]
+fn test_result_ok_into_is_err() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    assert(!result.into_is_err(), 'result_ok_into_is_err');
+}
+
+#[test]
+fn test_result_err_into_is_err() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    assert(result.into_is_err(), 'result_err_into_is_err');
+}
+
+#[test]
+fn test_result_ok_into_is_ok() {
+    let result: Result<u32, felt252> = Result::Ok(42);
+    assert(result.into_is_ok(), 'result_ok_into_is_ok');
+}
+
+#[test]
+fn test_result_err_into_is_ok() {
+    let result: Result<u32, felt252> = Result::Err('no');
+    assert(!result.into_is_ok(), 'result_err_into_is_ok');
+}


### PR DESCRIPTION
Adds `unwrap_or` and `unwrap_or_default` to `Result`.

Also a full unit test suite for `Result`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4815)
<!-- Reviewable:end -->
