### PR TITLE
Extract CfgSet from crate config in ConfigPlugin

### DIFF
--- a/crates/cairo-lang-compiler/src/project.rs
+++ b/crates/cairo-lang-compiler/src/project.rs
@@ -82,6 +82,7 @@ pub fn update_crate_roots_from_project_config(db: &mut dyn SemanticGroup, config
                 root,
                 settings: CrateSettings {
                     edition: crates_config.edition,
+                    cfg_set: Default::default(),
                     experimental_features: crates_config.experimental_features.clone(),
                 },
             }),

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -404,8 +404,11 @@ fn priv_module_data(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<ModuleData
     let mut files = Vec::new();
     let mut plugin_diagnostics = Vec::new();
 
-    let metadata =
-        MacroPluginMetadata { crate_config: db.crate_config(module_id.owning_crate(db)) };
+    let cfg_set = db
+        .crate_config(module_id.owning_crate(db))
+        .and_then(|cfg| cfg.settings.cfg_set.map(Arc::new))
+        .unwrap_or(db.cfg_set());
+    let metadata = MacroPluginMetadata { cfg_set: &cfg_set };
 
     let mut items = vec![];
     generated_file_infos.push(main_file_info);

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -21,7 +21,8 @@ use cairo_lang_utils::Upcast;
 
 use crate::ids::*;
 use crate::plugin::{
-    DynGeneratedFileAuxData, InlineMacroExprPlugin, MacroPlugin, PluginDiagnostic,
+    DynGeneratedFileAuxData, InlineMacroExprPlugin, MacroPlugin, MacroPluginMetadata,
+    PluginDiagnostic,
 };
 
 /// Salsa database interface.
@@ -403,6 +404,9 @@ fn priv_module_data(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<ModuleData
     let mut files = Vec::new();
     let mut plugin_diagnostics = Vec::new();
 
+    let metadata =
+        MacroPluginMetadata { crate_config: db.crate_config(module_id.owning_crate(db)) };
+
     let mut items = vec![];
     generated_file_infos.push(main_file_info);
     while let Some((module_file, item_asts)) = module_queue.pop_front() {
@@ -416,7 +420,7 @@ fn priv_module_data(db: &dyn DefsGroup, module_id: ModuleId) -> Maybe<ModuleData
             // generate new code, remove the original code, or both), breaks the loop. If more
             // plugins might have act on the item, they can do it on the generated code.
             for plugin in db.macro_plugins() {
-                let result = plugin.generate_code(db.upcast(), item_ast.clone());
+                let result = plugin.generate_code(db.upcast(), item_ast.clone(), &metadata);
                 for plugin_diag in result.diagnostics {
                     plugin_diagnostics.push((module_file_id, plugin_diag));
                 }

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -93,7 +93,7 @@ pub trait MacroPlugin: std::fmt::Debug + Sync + Send {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        metadata: &MacroPluginMetadata,
+        metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult;
 
     /// Attributes this plugin uses.

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use cairo_lang_diagnostics::Severity;
+use cairo_lang_filesystem::db::CrateConfiguration;
 use cairo_lang_filesystem::ids::CodeMapping;
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -75,13 +76,22 @@ impl PluginDiagnostic {
     }
 }
 
+pub struct MacroPluginMetadata {
+    pub crate_config: Option<CrateConfiguration>,
+}
+
 // TOD(spapini): Move to another place.
 /// A trait for a macro plugin: external plugin that generates additional code for items.
 pub trait MacroPlugin: std::fmt::Debug + Sync + Send {
     /// Generates code for an item. If no code should be generated returns None.
     /// Otherwise, returns (virtual_module_name, module_content), and a virtual submodule
     /// with that name and content should be created.
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult;
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        metadata: &MacroPluginMetadata,
+    ) -> PluginResult;
 
     /// Attributes this plugin uses.
     /// Attributes the plugin uses without declaring here are likely to cause a compilation error

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use cairo_lang_diagnostics::Severity;
+use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::db::CrateConfiguration;
 use cairo_lang_filesystem::ids::CodeMapping;
 use cairo_lang_syntax::node::ast;
@@ -76,8 +77,8 @@ impl PluginDiagnostic {
     }
 }
 
-pub struct MacroPluginMetadata {
-    pub crate_config: Option<CrateConfiguration>,
+pub struct MacroPluginMetadata<'a> {
+    pub cfg_set: &'a CfgSet,
 }
 
 // TOD(spapini): Move to another place.

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use cairo_lang_diagnostics::Severity;
 use cairo_lang_filesystem::cfg::CfgSet;
-use cairo_lang_filesystem::db::CrateConfiguration;
 use cairo_lang_filesystem::ids::CodeMapping;
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -77,7 +76,10 @@ impl PluginDiagnostic {
     }
 }
 
+/// A structure containing additional info about
+/// the current module item on which macro plugin operates.
 pub struct MacroPluginMetadata<'a> {
+    /// Config set of a crate to which the current item belongs.
     pub cfg_set: &'a CfgSet,
 }
 

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -76,8 +76,8 @@ impl PluginDiagnostic {
     }
 }
 
-/// A structure containing additional info about
-/// the current module item on which macro plugin operates.
+/// A structure containing additional info about the current module item on which macro plugin
+/// operates.
 pub struct MacroPluginMetadata<'a> {
     /// Config set of a crate to which the current item belongs.
     pub cfg_set: &'a CfgSet,

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -21,7 +21,8 @@ use crate::ids::{
     FileIndex, GenericParamLongId, ModuleFileId, ModuleId, ModuleItemId, SubmoduleLongId,
 };
 use crate::plugin::{
-    GeneratedFileAuxData, MacroPlugin, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+    GeneratedFileAuxData, MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile,
+    PluginResult,
 };
 
 #[salsa::database(DefsDatabase, ParserDatabase, SyntaxDatabase, FilesDatabase)]
@@ -220,7 +221,12 @@ impl GeneratedFileAuxData for DummyAuxData {
 #[derive(Debug)]
 struct DummyPlugin;
 impl MacroPlugin for DummyPlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::Struct(struct_ast) => {
                 let remove_original_item = struct_ast.has_attr(db, "remove_original");
@@ -310,7 +316,12 @@ fn test_plugin_remove_original() {
 #[derive(Debug)]
 struct RemoveOrigPlugin;
 impl MacroPlugin for RemoveOrigPlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         let Some(free_function_ast) = try_extract_matches!(item_ast, ast::ModuleItem::FreeFunction)
         else {
             return PluginResult::default();
@@ -331,7 +342,12 @@ impl MacroPlugin for RemoveOrigPlugin {
 #[derive(Debug)]
 struct FooToBarPlugin;
 impl MacroPlugin for FooToBarPlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         let Some(free_function_ast) = try_extract_matches!(item_ast, ast::ModuleItem::FreeFunction)
         else {
             return PluginResult::default();

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -225,7 +225,7 @@ impl MacroPlugin for DummyPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::Struct(struct_ast) => {
@@ -320,7 +320,7 @@ impl MacroPlugin for RemoveOrigPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         let Some(free_function_ast) = try_extract_matches!(item_ast, ast::ModuleItem::FreeFunction)
         else {
@@ -346,7 +346,7 @@ impl MacroPlugin for FooToBarPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         let Some(free_function_ast) = try_extract_matches!(item_ast, ast::ModuleItem::FreeFunction)
         else {

--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -39,6 +39,8 @@ pub struct CrateSettings {
     /// The crate's Cairo edition.
     pub edition: Edition,
 
+    pub cfg_set: Option<CfgSet>,
+
     #[serde(default)]
     pub experimental_features: ExperimentalFeaturesConfig,
 }
@@ -156,6 +158,7 @@ pub fn init_dev_corelib_from_directory(
             root: core_lib_dir,
             settings: CrateSettings {
                 edition: Edition::V2023_11,
+                cfg_set: Default::default(),
                 experimental_features: ExperimentalFeaturesConfig { negative_impls: true },
             },
         }),

--- a/crates/cairo-lang-language-server/src/scarb_service.rs
+++ b/crates/cairo-lang-language-server/src/scarb_service.rs
@@ -101,7 +101,11 @@ impl ScarbService {
                         crate_id,
                         source_path,
                         // TODO(ilya): Get experimental features from Scarb.
-                        CrateSettings { edition, experimental_features: Default::default() },
+                        CrateSettings {
+                            edition,
+                            cfg_set: Default::default(),
+                            experimental_features: Default::default(),
+                        },
                     ))
                 } else {
                     None

--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -27,7 +27,7 @@ impl MacroPlugin for ConfigPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        metadata: &MacroPluginMetadata,
+        metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         let mut diagnostics = vec![];
 

--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -29,18 +29,12 @@ impl MacroPlugin for ConfigPlugin {
         item_ast: ast::ModuleItem,
         metadata: &MacroPluginMetadata,
     ) -> PluginResult {
-        let db_cfg_set = db.cfg_set();
-        let cfg_set = metadata
-            .crate_config
-            .as_ref()
-            .and_then(|cfg| cfg.settings.cfg_set.as_ref())
-            .unwrap_or(db_cfg_set.as_ref());
-
         let mut diagnostics = vec![];
 
-        if should_drop(db, cfg_set, &item_ast, &mut diagnostics) {
+        if should_drop(db, metadata.cfg_set, &item_ast, &mut diagnostics) {
             PluginResult { code: None, diagnostics, remove_original_item: true }
-        } else if let Some(builder) = handle_undropped_item(db, cfg_set, item_ast, &mut diagnostics)
+        } else if let Some(builder) =
+            handle_undropped_item(db, metadata.cfg_set, item_ast, &mut diagnostics)
         {
             PluginResult {
                 code: Some(PluginGeneratedFile {

--- a/crates/cairo-lang-plugins/src/plugins/derive/mod.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/mod.rs
@@ -1,4 +1,6 @@
-use cairo_lang_defs::plugin::{MacroPlugin, PluginDiagnostic, PluginGeneratedFile, PluginResult};
+use cairo_lang_defs::plugin::{
+    MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+};
 use cairo_lang_syntax::attribute::structured::{
     AttributeArg, AttributeArgVariant, AttributeStructurize,
 };
@@ -28,7 +30,12 @@ pub struct DerivePlugin;
 const DERIVE_ATTR: &str = "derive";
 
 impl MacroPlugin for DerivePlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         generate_derive_code_for_type(
             db,
             match item_ast {

--- a/crates/cairo-lang-plugins/src/plugins/derive/mod.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/mod.rs
@@ -34,7 +34,7 @@ impl MacroPlugin for DerivePlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         generate_derive_code_for_type(
             db,

--- a/crates/cairo-lang-plugins/src/plugins/generate_trait.rs
+++ b/crates/cairo-lang-plugins/src/plugins/generate_trait.rs
@@ -21,7 +21,7 @@ impl MacroPlugin for GenerateTraitPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::Impl(impl_ast) => generate_trait_for_impl(db, impl_ast),

--- a/crates/cairo-lang-plugins/src/plugins/generate_trait.rs
+++ b/crates/cairo-lang-plugins/src/plugins/generate_trait.rs
@@ -1,7 +1,9 @@
 use std::iter::zip;
 
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
-use cairo_lang_defs::plugin::{MacroPlugin, PluginDiagnostic, PluginGeneratedFile, PluginResult};
+use cairo_lang_defs::plugin::{
+    MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+};
 use cairo_lang_syntax::attribute::structured::{AttributeArgVariant, AttributeStructurize};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::{GenericParamEx, QueryAttrs};
@@ -15,7 +17,12 @@ pub struct GenerateTraitPlugin;
 const GENERATE_TRAIT_ATTR: &str = "generate_trait";
 
 impl MacroPlugin for GenerateTraitPlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::Impl(impl_ast) => generate_trait_for_impl(db, impl_ast),
             _ => PluginResult::default(),

--- a/crates/cairo-lang-plugins/src/plugins/panicable.rs
+++ b/crates/cairo-lang-plugins/src/plugins/panicable.rs
@@ -1,5 +1,7 @@
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
-use cairo_lang_defs::plugin::{MacroPlugin, PluginDiagnostic, PluginGeneratedFile, PluginResult};
+use cairo_lang_defs::plugin::{
+    MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+};
 use cairo_lang_syntax::attribute::structured::{
     Attribute, AttributeArg, AttributeArgVariant, AttributeStructurize,
 };
@@ -17,7 +19,12 @@ pub struct PanicablePlugin;
 const PANIC_WITH_ATTR: &str = "panic_with";
 
 impl MacroPlugin for PanicablePlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         let (declaration, attributes, visibility) = match item_ast {
             ast::ModuleItem::ExternFunction(extern_func_ast) => (
                 extern_func_ast.declaration(db),

--- a/crates/cairo-lang-plugins/src/plugins/panicable.rs
+++ b/crates/cairo-lang-plugins/src/plugins/panicable.rs
@@ -23,7 +23,7 @@ impl MacroPlugin for PanicablePlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         let (declaration, attributes, visibility) = match item_ast {
             ast::ModuleItem::ExternFunction(extern_func_ast) => (

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -143,7 +143,7 @@ impl MacroPlugin for DoubleIndirectionPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::Struct(struct_ast) => {

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use cairo_lang_defs::db::{DefsDatabase, DefsGroup};
 use cairo_lang_defs::ids::ModuleId;
-use cairo_lang_defs::plugin::{MacroPlugin, PluginDiagnostic, PluginGeneratedFile, PluginResult};
+use cairo_lang_defs::plugin::{
+    MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+};
 use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::db::{
     init_files_group, AsFilesGroupMut, CrateConfiguration, FilesDatabase, FilesGroup, FilesGroupEx,
@@ -137,7 +139,12 @@ pub fn test_expand_plugin_inner(
 #[derive(Debug)]
 struct DoubleIndirectionPlugin;
 impl MacroPlugin for DoubleIndirectionPlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::Struct(struct_ast) => {
                 if struct_ast.has_attr(db, "first") {

--- a/crates/cairo-lang-project/src/test.rs
+++ b/crates/cairo-lang-project/src/test.rs
@@ -18,6 +18,7 @@ fn test_serde() {
             global: CrateSettings {
                 edition: Default::default(),
                 experimental_features: ExperimentalFeaturesConfig::default(),
+                cfg_set: Default::default(),
             },
             override_map: [
                 (
@@ -25,6 +26,7 @@ fn test_serde() {
                     CrateSettings {
                         edition: Edition::V2023_10,
                         experimental_features: ExperimentalFeaturesConfig::default(),
+                        cfg_set: Default::default(),
                     },
                 ),
                 (
@@ -32,6 +34,7 @@ fn test_serde() {
                     CrateSettings {
                         edition: Default::default(),
                         experimental_features: ExperimentalFeaturesConfig { negative_impls: true },
+                        cfg_set: Default::default(),
                     },
                 ),
             ]

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{GenericTypeId, ModuleId, TopLevelLanguageElementId};
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
-use cairo_lang_defs::plugin::{MacroPlugin, PluginDiagnostic, PluginGeneratedFile, PluginResult};
+use cairo_lang_defs::plugin::{
+    MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+};
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
@@ -69,7 +71,12 @@ fn test_missing_module_file() {
 struct AddInlineModuleDummyPlugin;
 
 impl MacroPlugin for AddInlineModuleDummyPlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::FreeFunction(func) if func.has_attr(db, "test_change_return_type") => {
                 let mut builder = PatchBuilder::new(db);

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -75,7 +75,7 @@ impl MacroPlugin for AddInlineModuleDummyPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::FreeFunction(func) if func.has_attr(db, "test_change_return_type") => {

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -134,6 +134,7 @@ pub fn setup_test_crate(db: &dyn SemanticGroup, content: &str) -> CrateId {
             settings: CrateSettings {
                 edition: Edition::default(),
                 experimental_features: ExperimentalFeaturesConfig { negative_impls: true },
+                cfg_set: Default::default(),
             },
         },
     })

--- a/crates/cairo-lang-starknet/src/plugin/mod.rs
+++ b/crates/cairo-lang-starknet/src/plugin/mod.rs
@@ -34,7 +34,7 @@ impl MacroPlugin for StarkNetPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::Module(module_ast) => handle_module(db, module_ast),

--- a/crates/cairo-lang-starknet/src/plugin/mod.rs
+++ b/crates/cairo-lang-starknet/src/plugin/mod.rs
@@ -3,7 +3,7 @@ mod test;
 
 pub mod consts;
 
-use cairo_lang_defs::plugin::{MacroPlugin, PluginResult};
+use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginResult};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{ast, Terminal};
@@ -30,7 +30,12 @@ use self::starknet_module::{handle_module, handle_module_by_storage};
 pub struct StarkNetPlugin;
 
 impl MacroPlugin for StarkNetPlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         match item_ast {
             ast::ModuleItem::Module(module_ast) => handle_module(db, module_ast),
             ast::ModuleItem::Trait(trait_ast) => handle_trait(db, trait_ast),

--- a/crates/cairo-lang-test-plugin/src/plugin.rs
+++ b/crates/cairo-lang-test-plugin/src/plugin.rs
@@ -1,4 +1,4 @@
-use cairo_lang_defs::plugin::{MacroPlugin, PluginResult};
+use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginResult};
 use cairo_lang_syntax::attribute::structured::AttributeListStructurize;
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -12,7 +12,12 @@ use crate::test_config::try_extract_test_config;
 pub struct TestPlugin;
 
 impl MacroPlugin for TestPlugin {
-    fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::ModuleItem) -> PluginResult {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata,
+    ) -> PluginResult {
         PluginResult {
             code: None,
             diagnostics: if let ast::ModuleItem::FreeFunction(free_func_ast) = item_ast {

--- a/crates/cairo-lang-test-plugin/src/plugin.rs
+++ b/crates/cairo-lang-test-plugin/src/plugin.rs
@@ -16,7 +16,7 @@ impl MacroPlugin for TestPlugin {
         &self,
         db: &dyn SyntaxGroup,
         item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata,
+        _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         PluginResult {
             code: None,


### PR DESCRIPTION
There is an ongoing process of supporting dev dependencies in Scarb. 
Currently, when a project is compiled with the test config, all deps are compiled as such as well. This results in the compilation of tests within those dependencies. Apart from slowing down the overall compilation process (corelib tests are compiled unnecessarily), it is also a problem for dev dependencies. Test suites within dev dependencies may rely on other dev dependencies, which are not propagated when the package is used in the root project.

This PR introduces an extra parameter to the `MacroPlugin::generate_code` function.
This allows the passage of additional metadata to each node within macro plugins. Specifically, crate configuration is used to determine `CfgSet` for each node, rather than uniformly applying `db.cfg_set()` to all nodes. To achieve that `CrateSettings` struct was expanded with a new property: `cfg_set`.

Adding `CfgSet` prop to hashable `CrateSettings` would not be possible without changing implementation of the `CfgSet` itself, so now it is using `Vec` instead of `OrderedHashSet` thanks to the @murek suggestion.

This change allows setting "test" config to the root crate and "lib" for every other crate for example, which will result in compiling tests in the root crate only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4831)
<!-- Reviewable:end -->
