### PR TITLE
Rename CostTokenType::iter to iter_casm_tokens.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost.rs
@@ -68,7 +68,7 @@ pub fn core_libfunc_cost<InfoProvider: InvocationCostInfoProvider>(
             let precost = precost?;
             let postcost = postcost?;
             Some(
-                CostTokenType::iter()
+                CostTokenType::iter_casm_tokens()
                     .map(|token| {
                         (
                             *token,

--- a/crates/cairo-lang-sierra-gas/src/generate_equations.rs
+++ b/crates/cairo-lang-sierra-gas/src/generate_equations.rs
@@ -68,7 +68,7 @@ impl EquationGenerator {
         Self {
             future_costs,
             equations: OrderedHashMap::from_iter(
-                CostTokenType::iter().map(|token_type| (*token_type, vec![])),
+                CostTokenType::iter_casm_tokens().map(|token_type| (*token_type, vec![])),
             ),
         }
     }
@@ -93,9 +93,11 @@ impl StatementFutureCost for EquationGenerator {
         if let Some(other) = entry {
             other
         } else {
-            entry.insert(CostExprMap::from_iter(CostTokenType::iter().map(|token_type| {
-                (*token_type, CostExpr::from_var(Var::StatementFuture(*idx, *token_type)))
-            })))
+            entry.insert(CostExprMap::from_iter(CostTokenType::iter_casm_tokens().map(
+                |token_type| {
+                    (*token_type, CostExpr::from_var(Var::StatementFuture(*idx, *token_type)))
+                },
+            )))
         }
     }
 }

--- a/crates/cairo-lang-sierra-gas/src/lib.rs
+++ b/crates/cairo-lang-sierra-gas/src/lib.rs
@@ -216,7 +216,7 @@ fn calc_gas_info_inner<
         .map(|f| f.entry_point)
         .collect();
     for (func_id, cost_terms) in function_set_costs {
-        for token_type in CostTokenType::iter() {
+        for token_type in CostTokenType::iter_casm_tokens() {
             equations[token_type].push(
                 Expr::from_var(Var::StatementFuture(
                     registry.get_function(&func_id)?.entry_point,

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs
@@ -121,7 +121,9 @@ fn build_redeposit_gas(
             .into_iter(),
         ));
     }
-    if !CostTokenType::iter().all(|token| variable_values.contains_key(&(builder.idx, *token))) {
+    if !CostTokenType::iter_casm_tokens()
+        .all(|token| variable_values.contains_key(&(builder.idx, *token)))
+    {
         return Err(InvocationError::UnknownVariableData);
     }
     let mut casm_builder = CasmBuilder::default();
@@ -218,7 +220,9 @@ fn add_get_total_requested_count_code(
     builtin_cost: Var,
 ) -> Result<(i64, Var), InvocationError> {
     let variable_values = &builder.program_info.metadata.gas_info.variable_values;
-    if !CostTokenType::iter().all(|token| variable_values.contains_key(&(builder.idx, *token))) {
+    if !CostTokenType::iter_casm_tokens()
+        .all(|token| variable_values.contains_key(&(builder.idx, *token)))
+    {
         return Err(InvocationError::UnknownVariableData);
     }
     let requested_count: i64 = variable_values[&(builder.idx, CostTokenType::Const)];

--- a/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
@@ -150,11 +150,7 @@ pub enum CostTokenType {
     EcOp,
 }
 impl CostTokenType {
-    pub fn iter()
-    -> std::iter::Chain<std::slice::Iter<'static, Self>, std::slice::Iter<'static, Self>> {
-        chain!(Self::iter_precost(), [CostTokenType::Const].iter())
-    }
-
+    /// Iterates over the pre-cost token types.
     pub fn iter_precost() -> std::slice::Iter<'static, Self> {
         [
             CostTokenType::Pedersen,
@@ -163,6 +159,13 @@ impl CostTokenType {
             CostTokenType::EcOp,
         ]
         .iter()
+    }
+
+    /// Iterates over the tokens that are used in the Sierra->Casm compilation (pre-cost token types
+    /// and [CostTokenType::Const]).
+    pub fn iter_casm_tokens()
+    -> std::iter::Chain<std::slice::Iter<'static, Self>, std::slice::Iter<'static, Self>> {
+        chain!(Self::iter_precost(), [CostTokenType::Const].iter())
     }
 
     /// Returns the name of the token type, in snake_case.


### PR DESCRIPTION
**Stack**:
- #4845
- #4844
- #4843
- #4842
- #4841 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4841)
<!-- Reviewable:end -->
