### PR TITLE
Relaxed solver equality to not fail on branch align mismatches.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/gas_info.rs
+++ b/crates/cairo-lang-sierra-gas/src/gas_info.rs
@@ -1,8 +1,10 @@
 use std::fmt::Display;
 
+use cairo_lang_sierra::extensions::branch_align::BranchAlignLibfunc;
 use cairo_lang_sierra::extensions::gas::CostTokenType;
+use cairo_lang_sierra::extensions::NamedLibfunc;
 use cairo_lang_sierra::ids::FunctionId;
-use cairo_lang_sierra::program::StatementIdx;
+use cairo_lang_sierra::program::{Program, Statement, StatementIdx};
 use cairo_lang_utils::collection_arithmetics::sub_maps;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use itertools::{chain, Itertools};
@@ -56,16 +58,28 @@ impl GasInfo {
         GasInfo { variable_values, function_costs }
     }
 
-    /// Asserts that all the values in `self.variable_values` are equal to the values in
-    /// `other.variable_values`. Panics otherwise, printing the differences.
-    pub fn assert_eq_variables(&self, other: &GasInfo) {
+    /// Asserts that all non-branch align values in `self.variable_values` are equal to the values
+    /// in `other.variable_values`. Panics otherwise, printing the differences.
+    /// We allow branch align values to be different, as they do not affect generated code directly.
+    pub fn assert_eq_variables(&self, other: &GasInfo, program: &Program) {
+        let branch_align_id: Option<_> = program.libfunc_declarations.iter().find_map(|fd| {
+            (fd.long_id.generic_id.0 == BranchAlignLibfunc::STR_ID).then_some(&fd.id)
+        });
         let mut fail = false;
-        for (key, val) in sub_maps(self.variable_values.clone(), other.variable_values.clone()) {
-            if val != 0 {
+        for ((idx, token), val) in
+            sub_maps(self.variable_values.clone(), other.variable_values.clone())
+        {
+            if val != 0
+                && !matches!(
+                    program.get_statement(&idx),
+                    Some(Statement::Invocation(x))
+                    if Some(&x.libfunc_id) == branch_align_id
+                )
+            {
                 println!(
-                    "Difference in {key:?}: {:?} != {:?}.",
-                    self.variable_values.get(&key),
-                    other.variable_values.get(&key)
+                    "Difference in ({idx:?}, {token:?}): {:?} != {:?}.",
+                    self.variable_values.get(&(idx, token)),
+                    other.variable_values.get(&(idx, token))
                 );
                 fail = true;
             }

--- a/crates/cairo-lang-sierra-to-casm/src/metadata.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/metadata.rs
@@ -99,7 +99,7 @@ pub fn calc_metadata(
     } else {
         let pre_gas_info_old = calc_gas_precost_info(program, pre_function_set_costs)?;
         if !config.skip_non_linear_solver_comparisons {
-            pre_gas_info_old.assert_eq_variables(&pre_gas_info_new);
+            pre_gas_info_old.assert_eq_variables(&pre_gas_info_new, program);
             pre_gas_info_old.assert_eq_functions(&pre_gas_info_new);
         }
         pre_gas_info_old


### PR DESCRIPTION
Required since the linear solver pushes excess to earliest branch align.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4893)
<!-- Reviewable:end -->
