### PR TITLE
Port missing language configuration features from rust-analyzer

### DIFF
--- a/vscode-cairo/language-configuration.json
+++ b/vscode-cairo/language-configuration.json
@@ -1,27 +1,43 @@
 {
   "comments": {
-    // Symbol used for single line comment.
     "lineComment": "//"
   },
-  // Symbols used as brackets.
   "brackets": [
     ["{", "}"],
     ["[", "]"],
     ["(", ")"]
   ],
-  // Symbols that are auto closed when typing.
+  "colorizedBracketPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
   "autoClosingPairs": [
     { "open": "{", "close": "}" },
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
-    { "open": "'", "close": "'", "notIn": ["string"] }
+    { "open": "'", "close": "'", "notIn": ["string"] },
+    { "open": "`", "close": "`", "notIn": ["string"] }
   ],
+  "autoCloseBefore": ";:.,=}])> \n\t",
   "surroundingPairs": [
     ["{", "}"],
     ["[", "]"],
     ["(", ")"],
+    ["<", ">"],
     ["\"", "\""],
-    ["'", "'"]
-  ]
+    ["'", "'"],
+    ["`", "`"]
+  ],
+  "indentationRules": {
+    "increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$",
+    "decreaseIndentPattern": "^\\s*(\\s*\\/[*].*[*]\\/\\s*)*[})]"
+  },
+  "folding": {
+    "markers": {
+      "start": "^\\s*// region:\\b",
+      "end": "^\\s*// endregion\\b"
+    }
+  }
 }


### PR DESCRIPTION
Source: https://github.com/rust-lang/rust-analyzer/blob/d410d4a2baf9e99b37b03dd42f06238b14374bf7/editors/code/language-configuration.json

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4903)
<!-- Reviewable:end -->
