### PR TITLE
dev: allow use starknet::get_block_number

### DIFF
--- a/corelib/src/starknet.cairo
+++ b/corelib/src/starknet.cairo
@@ -59,7 +59,8 @@ use class_hash::{
 mod info;
 pub use info::{
     v2::ExecutionInfo as ExecutionInfo, BlockInfo, v2::TxInfo as TxInfo, get_execution_info,
-    get_caller_address, get_contract_address, get_block_info, get_tx_info, get_block_timestamp
+    get_caller_address, get_contract_address, get_block_info, get_tx_info, get_block_timestamp,
+    get_block_number
 };
 
 pub mod event;


### PR DESCRIPTION
It's currently not possible to do `use starknet::get_block_number` because the fn is not reexported. This PR fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4914)
<!-- Reviewable:end -->
