### PR TITLE
Modernize tsconfig.json

### DIFF
--- a/vscode-cairo/package-lock.json
+++ b/vscode-cairo/package-lock.json
@@ -11,6 +11,8 @@
         "vscode-languageclient": "^7.0.0"
       },
       "devDependencies": {
+        "@tsconfig/node14": "^14.1.0",
+        "@tsconfig/strictest": "^2.0.2",
         "@types/node": "^14.0.0",
         "@types/vscode": "^1.60.0",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
@@ -165,6 +167,18 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.0.tgz",
+      "integrity": "sha512-VmsCG04YR58ciHBeJKBDNMWWfYbyP8FekWVuTlpstaUPlat1D0x/tXzkWP7yCMU0eSz9V4OZU0LBWTFJ3xZf6w==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/strictest": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.2.tgz",
+      "integrity": "sha512-jt4jIsWKvUvuY6adJnQJlb/UR7DdjC8CjHI/OaSQruj2yX9/K6+KOvDt/vD6udqos/FUk5Op66CvYT7TBLYO5Q==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/vscode-cairo/package.json
+++ b/vscode-cairo/package.json
@@ -101,10 +101,12 @@
     "lint": "eslint . src --ext .ts,.tsx"
   },
   "devDependencies": {
+    "@tsconfig/node14": "^14.1.0",
+    "@tsconfig/strictest": "^2.0.2",
     "@types/node": "^14.0.0",
+    "@types/vscode": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@vscode/test-electron": "^2.3.1",
-    "@types/vscode": "^1.60.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "3.2.4",

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -56,7 +56,7 @@ function isExecutable(path: string): boolean {
 function replacePathPlaceholders(path: string, root: string): string {
   return path
     .replace(/\${workspaceFolder}/g, root)
-    .replace(/\${userHome}/g, process.env.HOME ?? "");
+    .replace(/\${userHome}/g, process.env["HOME"] ?? "");
 }
 
 function findLanguageServerExecutable(
@@ -78,8 +78,8 @@ function findLanguageServerExecutable(
 }
 
 async function findExecutableFromPathVar(name: string) {
-  const envPath = process.env.PATH || "";
-  const envExt = process.env.PATHEXT || "";
+  const envPath = process.env["PATH"] || "";
+  const envExt = process.env["PATHEXT"] || "";
   const pathDirs = envPath
     .replace(/["]+/g, "")
     .split(path.delimiter)
@@ -110,9 +110,9 @@ async function findScarbExecutablePathInAsdfDir() {
     return undefined;
   }
 
-  let asdfDataDir = process.env.ASDF_DATA_DIR;
+  let asdfDataDir = process.env["ASDF_DATA_DIR"];
   if (!asdfDataDir) {
-    const home = process.env.HOME;
+    const home = process.env["HOME"];
     if (!home) {
       return undefined;
     }

--- a/vscode-cairo/tsconfig.json
+++ b/vscode-cairo/tsconfig.json
@@ -1,18 +1,13 @@
 {
+  "extends": [
+    "@tsconfig/strictest/tsconfig.json",
+    "@tsconfig/node14/tsconfig.json",
+  ],
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
     "outDir": "out",
-    "lib": ["es6"],
     "sourceMap": true,
     "rootDir": "src",
-    // Enable all strict type-checking options.
-    "strict": true,
-    // Additional checks.
-    "noUnusedLocals": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedParameters": true,
   },
   "exclude": ["node_modules", ".vscode-test"],
+  "include": ["src", "tests"],
 }


### PR DESCRIPTION
* Use base configs for everything viable.
* Enabled the strictest checks available.
* Node 14 (the one supported to date) supports newer output targets. The `node14` preset therefore causes `tsc` to emit fewer polyfills and in general more modern JS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4921)
<!-- Reviewable:end -->
