### PR TITLE
Added option (by env-var) to print bytecode offsets in CASM

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -67,13 +67,29 @@ pub struct CairoProgram {
 }
 impl Display for CairoProgram {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for instruction in &self.instructions {
-            writeln!(f, "{instruction};")?
-        }
-        for const_allocation in self.const_segment_info.const_allocations.values() {
-            writeln!(f, "ret;")?;
-            for value in &const_allocation.values {
-                writeln!(f, "dw {};", value)?;
+        if std::env::var("PRINT_CASM_BYTECODE_OFFSETS").is_ok() {
+            let mut bytecode_offset = 0;
+            for instruction in &self.instructions {
+                writeln!(f, "{instruction}; // {bytecode_offset}")?;
+                bytecode_offset += instruction.body.op_size();
+            }
+            for const_allocation in self.const_segment_info.const_allocations.values() {
+                writeln!(f, "ret; // {bytecode_offset}")?;
+                bytecode_offset += 1;
+                for value in &const_allocation.values {
+                    writeln!(f, "dw {value}; // {bytecode_offset}")?;
+                }
+                bytecode_offset += 1;
+            }
+        } else {
+            for instruction in &self.instructions {
+                writeln!(f, "{instruction};")?;
+            }
+            for const_allocation in self.const_segment_info.const_allocations.values() {
+                writeln!(f, "ret;")?;
+                for value in &const_allocation.values {
+                    writeln!(f, "dw {value};")?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4927)
<!-- Reviewable:end -->
