### PR TITLE
Bump minimum VSC version to 1.84 and fix breaking changes

### DIFF
--- a/vscode-cairo/package-lock.json
+++ b/vscode-cairo/package-lock.json
@@ -8,22 +8,22 @@
       "name": "cairo1",
       "version": "2.5.0",
       "dependencies": {
-        "vscode-languageclient": "^7.0.0"
+        "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@tsconfig/node14": "^14.1.0",
+        "@tsconfig/node18": "^18.2.2",
         "@tsconfig/strictest": "^2.0.2",
-        "@types/node": "^14.0.0",
-        "@types/vscode": "^1.60.0",
+        "@types/node": "^18.15.3",
+        "@types/vscode": "^1.84.0",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
-        "@vscode/test-electron": "^2.3.1",
+        "@vscode/test-electron": "^2.3.9",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "prettier": "3.2.4",
         "typescript": "^5.3.3"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.84.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -168,10 +168,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node14": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.0.tgz",
-      "integrity": "sha512-VmsCG04YR58ciHBeJKBDNMWWfYbyP8FekWVuTlpstaUPlat1D0x/tXzkWP7yCMU0eSz9V4OZU0LBWTFJ3xZf6w==",
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
+      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
       "dev": true
     },
     "node_modules/@tsconfig/strictest": {
@@ -187,10 +187,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
+      "version": "18.19.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.10.tgz",
+      "integrity": "sha512-IZD8kAM02AW1HRDTPOlz3npFava678pr8Ie9Vp8uRhBROXAv8MXT2pCnGZZAKYdromsNQLHQcfWQ6EOatVLtqA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -199,9 +202,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
-      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -426,9 +429,9 @@
       "dev": true
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.6.tgz",
-      "integrity": "sha512-M31xGH0RgqNU6CZ4/9g39oUMJ99nLzfjA+4UbtIQ6TcXQ6+2qkjOOxedmPBDDCg26/3Al5ubjY80hIoaMwKYSw==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.9.tgz",
+      "integrity": "sha512-z3eiChaCQXMqBnk2aHHSEkobmC2VRalFQN0ApOAtydL172zXGxTwGrRtviT5HnUB+Q+G3vtEYFtuQkYqBzYgMA==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
@@ -537,6 +540,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -600,7 +604,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -1305,6 +1310,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1745,6 +1751,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1761,39 +1773,58 @@
       "dev": true
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "dependencies": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.4",
-        "vscode-languageserver-protocol": "3.16.0"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/vscode-cairo/package.json
+++ b/vscode-cairo/package.json
@@ -3,12 +3,6 @@
   "displayName": "Cairo 1.0",
   "description": "Support Cairo syntax",
   "version": "2.5.0",
-  "engines": {
-    "vscode": "^1.60.0"
-  },
-  "dependencies": {
-    "vscode-languageclient": "^7.0.0"
-  },
   "categories": [
     "Programming Languages"
   ],
@@ -100,13 +94,19 @@
     "fmt:check": "prettier --check .",
     "lint": "eslint . src --ext .ts,.tsx"
   },
+  "engines": {
+    "vscode": "^1.84.0"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  },
   "devDependencies": {
-    "@tsconfig/node14": "^14.1.0",
+    "@tsconfig/node18": "^18.2.2",
     "@tsconfig/strictest": "^2.0.2",
-    "@types/node": "^14.0.0",
-    "@types/vscode": "^1.60.0",
+    "@types/node": "^18.15.3",
+    "@types/vscode": "^1.84.0",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
-    "@vscode/test-electron": "^2.3.1",
+    "@vscode/test-electron": "^2.3.9",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "3.2.4",

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -349,50 +349,49 @@ async function setupLanguageServer(
     serverOptions,
     clientOptions,
   );
+
   client.registerFeature(new SemanticTokensFeature(client));
-  client.onReady().then(() => {
-    const myProvider = new (class
-      implements vscode.TextDocumentContentProvider
-    {
-      async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const res: any = await client.sendRequest("vfs/provide", {
-          uri: uri.toString(),
-        });
-        return res.content;
-      }
 
-      onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
-      onDidChange = this.onDidChangeEmitter.event;
-    })();
-    client.onNotification("vfs/update", (param) => {
-      myProvider.onDidChangeEmitter.fire(param.uri);
-    });
-    vscode.workspace.registerTextDocumentContentProvider("vfs", myProvider);
+  const myProvider = new (class implements vscode.TextDocumentContentProvider {
+    async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const res: any = await client.sendRequest("vfs/provide", {
+        uri: uri.toString(),
+      });
+      return res.content;
+    }
 
-    client.onNotification("scarb/could-not-find-scarb-executable", () =>
-      notifyScarbMissing(outputChannel),
-    );
-
-    client.onNotification("scarb/resolving-start", () => {
-      vscode.window.withProgress(
-        {
-          title: "Scarb is resolving the project...",
-          location: vscode.ProgressLocation.Notification,
-          cancellable: false,
-        },
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        async (_progress, _token) => {
-          return new Promise((resolve) => {
-            client.onNotification("scarb/resolving-finish", () => {
-              resolve(null);
-            });
-          });
-        },
-      );
-    });
+    onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+    onDidChange = this.onDidChangeEmitter.event;
+  })();
+  client.onNotification("vfs/update", (param) => {
+    myProvider.onDidChangeEmitter.fire(param.uri);
   });
-  client.start();
+  vscode.workspace.registerTextDocumentContentProvider("vfs", myProvider);
+
+  client.onNotification("scarb/could-not-find-scarb-executable", () =>
+    notifyScarbMissing(outputChannel),
+  );
+
+  client.onNotification("scarb/resolving-start", () => {
+    vscode.window.withProgress(
+      {
+        title: "Scarb is resolving the project...",
+        location: vscode.ProgressLocation.Notification,
+        cancellable: false,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      async (_progress, _token) => {
+        return new Promise((resolve) => {
+          client.onNotification("scarb/resolving-finish", () => {
+            resolve(null);
+          });
+        });
+      },
+    );
+  });
+
+  await client.start();
 }
 
 export async function activate(context: vscode.ExtensionContext) {

--- a/vscode-cairo/tsconfig.json
+++ b/vscode-cairo/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "@tsconfig/strictest/tsconfig.json",
-    "@tsconfig/node14/tsconfig.json",
+    "@tsconfig/node18/tsconfig.json",
   ],
   "compilerOptions": {
     "outDir": "out",


### PR DESCRIPTION
* `LanguageClient.onReady` is no longer existing, and feature
registration now happens before awaiting `client.start()` call.
* Upgraded to Node.js 18, as this is the version bundled with this VSC
release.
* Moved `engine` and `dependencies` section closer to `devDependencies`
in package.json

Why VSC 1.84? Because that's the oldest release that provides all
features I think I'd like to make use of in the near future:
1. Better logging from 1.73
2. Node.js upgrade to 18 in 1.82
3. 1.84 gives new testing facilities for extensions

Signed-off-by: Marek Kaput <marek.kaput@swmansion.com>

---

**Stack**:
- #4930
- #4929 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4929)
<!-- Reviewable:end -->
