### PR TITLE
VSCode: Refactor cairols.ts to use `Context` and levelled logging

### DIFF
--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -9,11 +9,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   const ctx = Context.create(extensionContext);
 
   if (ctx.config.get<boolean>("enableLanguageServer")) {
-    client = await setupLanguageServer(
-      vscode.workspace.getConfiguration(),
-      ctx.extension,
-      ctx.log,
-    );
+    client = await setupLanguageServer(ctx);
   } else {
     ctx.log.warn("language server is disabled");
     ctx.log.warn(


### PR DESCRIPTION
**Stack**:
- #5015
- #5014
- #5013
- #5012
- #5011
- #4976
- #4975
- #4974
- #4973
- #4959 ⬅
- #4935
- #4934


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4959)
<!-- Reviewable:end -->
