### PR TITLE
VSCode: Encapsulate all configuration magic into `Config` class

### DIFF
--- a/vscode-cairo/src/cairols.ts
+++ b/vscode-cairo/src/cairols.ts
@@ -51,21 +51,14 @@ function rootPath(ctx: Context): string {
   return rootPath;
 }
 
-function replacePathPlaceholders(path: string, root: string): string {
-  return path
-    .replace(/\${workspaceFolder}/g, root)
-    .replace(/\${userHome}/g, process.env["HOME"] ?? "");
-}
-
 async function findLanguageServerExecutable(ctx: Context) {
-  const root = rootPath(ctx);
-  const configPath = ctx.config.get<string>("languageServerPath");
+  const configPath = ctx.config.get("languageServerPath");
   if (configPath) {
-    const serverPath = replacePathPlaceholders(configPath, root);
-    return await checkTool(serverPath);
+    return await checkTool(configPath);
   }
 
   // TODO(spapini): Use a bundled language server.
+  const root = rootPath(ctx);
   return findDevLanguageServerAt(root);
 }
 
@@ -73,11 +66,9 @@ async function findScarbExecutablePath(
   ctx: Context,
 ): Promise<string | undefined> {
   // Check config for scarb path.
-  const root = rootPath(ctx);
-  const configPath = ctx.config.get<string>("scarbPath");
+  const configPath = ctx.config.get("scarbPath");
   if (configPath) {
-    const scarbPath = replacePathPlaceholders(configPath, root);
-    return await checkTool(scarbPath);
+    return await checkTool(configPath);
   }
 
   // Check PATH env var for scarb path.
@@ -213,9 +204,9 @@ export async function setupLanguageServer(
 }
 
 async function getServerOptions(ctx: Context): Promise<lc.ServerOptions> {
-  const isScarbEnabled = ctx.config.get<boolean>("enableScarb", false);
+  const isScarbEnabled = ctx.config.get("enableScarb", false);
   const scarbPath = await findScarbExecutablePath(ctx);
-  const configLanguageServerPath = ctx.config.get<string>("languageServerPath");
+  const configLanguageServerPath = ctx.config.get("languageServerPath");
 
   if (!isScarbEnabled) {
     ctx.log.warn("Scarb integration is disabled");

--- a/vscode-cairo/src/config.ts
+++ b/vscode-cairo/src/config.ts
@@ -1,0 +1,54 @@
+import * as os from "os";
+import * as vscode from "vscode";
+
+interface ConfigProps {
+  enableLanguageServer: boolean;
+  languageServerPath: string;
+  enableScarb: boolean;
+  scarbPath: string;
+  corelibPath: string;
+}
+
+export class Config {
+  public static ROOT: string = "cairo1";
+
+  // TODO(mkaput): Attach configs to workspace folders when we'll support
+  //  multi-root workspaces.
+
+  get<K extends keyof ConfigProps>(prop: K): ConfigProps[K] | undefined;
+  get<K extends keyof ConfigProps>(
+    prop: K,
+    defaultValue: ConfigProps[K],
+  ): ConfigProps[K];
+  public get(prop: keyof ConfigProps, defaultValue?: unknown): unknown {
+    const config = vscode.workspace.getConfiguration(Config.ROOT);
+    const value = config.get(prop, defaultValue);
+    if (typeof value === "string" && isPropWithPlaceholders(prop)) {
+      return replacePathPlaceholders(value, undefined);
+    }
+    return value;
+  }
+}
+
+function isPropWithPlaceholders(prop: keyof ConfigProps): boolean {
+  return prop === "languageServerPath" || prop === "scarbPath";
+}
+
+function replacePathPlaceholders(
+  path: string,
+  workspaceFolder: vscode.WorkspaceFolder | undefined,
+): string {
+  // 1. If there is known workspace folder, replace ${workspaceFolder} with it.
+  // 2. If it is undefined, assume the first folder in currently opened
+  //    workspace. We could use the currently opened document to detect
+  //    the correct workspace. However, that would be determined by the document
+  //    user has opened on Editor startup. This could lead to unpredictable
+  //    workspace selection in practice.
+  // 3. If no workspace is opened, replace ${workspaceFolder} with empty string.
+  const workspaceFolderPath =
+    (workspaceFolder ?? vscode.workspace.workspaceFolders?.[0])?.uri.path ?? "";
+
+  return path
+    .replace(/\${workspaceFolder}/g, workspaceFolderPath)
+    .replace(/\${userHome}/g, os.homedir());
+}

--- a/vscode-cairo/src/context.ts
+++ b/vscode-cairo/src/context.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { Config } from "./config";
 
 export class Context {
   public static create(extensionContext: vscode.ExtensionContext): Context {
@@ -10,21 +11,10 @@ export class Context {
     return new Context(extensionContext, log);
   }
 
+  public readonly config: Config = new Config();
+
   private constructor(
     public readonly extension: vscode.ExtensionContext,
     public readonly log: vscode.LogOutputChannel,
   ) {}
-
-  /**
-   * Get Cairo extension-specific configuration.
-   *
-   * @remarks
-   * This is equivalent to calling:
-   * ```
-   * vscode.workspace.getConfiguration("cairo1")
-   * ```
-   */
-  public get config(): vscode.WorkspaceConfiguration {
-    return vscode.workspace.getConfiguration("cairo1");
-  }
 }

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -8,7 +8,7 @@ let client: lc.LanguageClient | undefined;
 export async function activate(extensionContext: vscode.ExtensionContext) {
   const ctx = Context.create(extensionContext);
 
-  if (ctx.config.get<boolean>("enableLanguageServer")) {
+  if (ctx.config.get("enableLanguageServer")) {
     client = await setupLanguageServer(ctx);
   } else {
     ctx.log.warn("language server is disabled");


### PR DESCRIPTION
This commit also slightly changes the logic behind the
`${workspaceFolder}` placeholder. Now, it expands to empty string in
case there is no open workspace. This should not be a problem, because
it does not make sense to use this placeholder in global config.

---

**Stack**:
- #5015
- #5014
- #5013
- #5012
- #4976 ⬅
- #4975
- #4974
- #4973


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/4976)
<!-- Reviewable:end -->
