### PR TITLE
VSCode: Move Scarb searching logic to the `Scarb` class

### DIFF
--- a/vscode-cairo/src/scarb.ts
+++ b/vscode-cairo/src/scarb.ts
@@ -2,6 +2,7 @@ import { spawn } from "child_process";
 import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
 import type { Context } from "./context";
+import { checkTool, findToolInAsdf, findToolInPath } from "./toolchain";
 
 let globalExecId = 0;
 
@@ -17,6 +18,55 @@ export class Scarb {
      */
     public readonly workspaceFolder?: vscode.WorkspaceFolder | undefined,
   ) {}
+
+  /**
+   * Tries to find Scarb on the host in context of the given workspace folder.
+   */
+  public static async find(
+    workspaceFolder: vscode.WorkspaceFolder | undefined,
+    ctx: Context,
+  ): Promise<Scarb> {
+    const path =
+      (await fromConfig()) || (await fromPath()) || (await fromAsdf());
+    if (!path) {
+      throw new Error("could not find Scarb executable on this machine");
+    }
+    return new Scarb(path, workspaceFolder);
+
+    async function fromConfig(): Promise<string | undefined> {
+      // TODO(mkaput): Config should probably be scoped to workspace folder.
+      let configPath = ctx.config.get("scarbPath");
+      if (configPath) {
+        configPath = await checkTool(configPath);
+        if (configPath) {
+          ctx.log.debug(`using Scarb from config: ${configPath}`);
+          return configPath;
+        }
+        throw new Error(`configured Scarb path does not exist: ${configPath}`);
+      }
+      return undefined;
+    }
+
+    async function fromPath(): Promise<string | undefined> {
+      const envPath = await findToolInPath("scarb");
+      if (envPath) {
+        ctx.log.debug(`using Scarb from PATH: ${envPath}`);
+        return envPath;
+      }
+      return undefined;
+    }
+
+    async function fromAsdf(): Promise<string | undefined> {
+      // Usually asdf scarb shim is already in PATH, but some users happened
+      // not to have it there.
+      const asdfPath = await findToolInAsdf("scarb");
+      if (asdfPath) {
+        ctx.log.debug(`using Scarb from asdf: ${asdfPath}`);
+        return asdfPath;
+      }
+      return undefined;
+    }
+  }
 
   public languageServerExecutable(): lc.Executable {
     const exec: lc.Executable = {


### PR DESCRIPTION
**Stack**:
- #5015
- #5014
- #5013
- #5012 ⬅
- #4976
- #4975
- #4974
- #4973


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5012)
<!-- Reviewable:end -->
