### PR TITLE
Add coupons to corelib's Scarb manifest features list

### DIFF
--- a/corelib/Scarb.toml
+++ b/corelib/Scarb.toml
@@ -2,7 +2,7 @@
 name = "core"
 version = "2.6.0-rc.0"
 edition = "2023_11"
-experimental-features = ["negative_impls"]
+experimental-features = ["coupons", "negative_impls"]
 
 # NOTE: This is non-public, unstable Scarb's field, which instructs resolver that this package does not
 #   depend on `core`, which is only true for this particular package. Nobody else should use it.


### PR DESCRIPTION
Motivation: keep Scarb manifest and cairo_project.toml equivalent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5027)
<!-- Reviewable:end -->
