### PR TITLE
Serde for AssembledCairoProgram

### DIFF
--- a/crates/cairo-lang-casm/src/assembler.rs
+++ b/crates/cairo-lang-casm/src/assembler.rs
@@ -2,6 +2,7 @@
 use alloc::vec::Vec;
 
 use num_bigint::{BigInt, ToBigInt};
+use serde::{Deserialize, Serialize};
 
 use crate::hints::Hint;
 use crate::instructions::{Instruction, InstructionBody};
@@ -76,6 +77,7 @@ pub struct InstructionRepr {
 }
 
 /// An assembled representation of a cairo program.
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AssembledCairoProgram {
     /// The bytecode of the program.
     pub bytecode: Vec<BigInt>,


### PR DESCRIPTION
This PR adds `serialize`, `deserialize` and `clone` methods for `AssembledCairoProgram` because they are needed in Starknet-Foundry (currently we had to copy this struct)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5057)
<!-- Reviewable:end -->
