### PR TITLE
LS: Move all LS startup logic to its library main function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,9 +1046,6 @@ name = "cairo-language-server"
 version = "2.5.3"
 dependencies = [
  "cairo-lang-language-server",
- "cairo-lang-utils",
- "log",
- "tokio",
 ]
 
 [[package]]

--- a/crates/bin/cairo-language-server/Cargo.toml
+++ b/crates/bin/cairo-language-server/Cargo.toml
@@ -7,10 +7,4 @@ license-file.workspace = true
 description = "Language server executable for the Cairo programming language"
 
 [dependencies]
-tokio.workspace = true
-log.workspace = true
-
 cairo-lang-language-server = { path = "../../cairo-lang-language-server", version = "2.5.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "2.5.3", features = [
-    "env_logger",
-] }

--- a/crates/bin/cairo-language-server/src/main.rs
+++ b/crates/bin/cairo-language-server/src/main.rs
@@ -1,8 +1,3 @@
-use cairo_lang_language_server::serve_language_service;
-use cairo_lang_utils::logging::init_logging;
-
-#[tokio::main]
-async fn main() {
-    init_logging(log::LevelFilter::Warn);
-    serve_language_service().await;
+fn main() {
+    cairo_lang_language_server::start()
 }

--- a/crates/cairo-lang-language-server/Cargo.toml
+++ b/crates/cairo-lang-language-server/Cargo.toml
@@ -20,7 +20,7 @@ cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "2.5.3" }
 cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "2.5.3" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "2.5.3" }
 cairo-lang-test-plugin = { path = "../cairo-lang-test-plugin", version = "2.5.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.5.3" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.5.3", features = ["env_logger"] }
 log.workspace = true
 salsa.workspace = true
 scarb-metadata.workspace = true

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -52,6 +52,7 @@ use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::utils::is_grandparent_of_kind;
 use cairo_lang_syntax::node::{ast, SyntaxNode, TypedSyntaxNode};
 use cairo_lang_test_plugin::test_plugin_suite;
+use cairo_lang_utils::logging::init_logging;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::{try_extract_matches, OptionHelper, Upcast};
@@ -79,7 +80,10 @@ pub mod vfs;
 const MAX_CRATE_DETECTION_DEPTH: usize = 20;
 const DEFAULT_CAIRO_LSP_DB_REPLACE_INTERVAL: u64 = 300;
 
-pub async fn serve_language_service() {
+#[tokio::main]
+pub async fn start() {
+    init_logging(log::LevelFilter::Warn);
+
     let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
 
     let db = configured_db();


### PR DESCRIPTION
This change gives the LS crate exclusive control on its running
environment and behaviours, like Tokio runtime or logging.

---

**Stack**:
- #5060
- #5059
- #5058 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5058)
<!-- Reviewable:end -->
