### PR TITLE
LS: Move LS-specific dependencies out of workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ quote = "1.0.33"
 rayon = "1.8.0"
 rstest = "0.18.2"
 salsa = "0.16.1"
-scarb-metadata = "1"
 schemars = { version = "0.8.15", features = ["preserve_order"] }
 serde = { version = "1.0.192", default-features = false, features = ["derive"] }
 serde_json = "1.0"
@@ -137,6 +136,5 @@ time = { version = "0.3.30", features = [
 ] }
 tokio = { version = "1.33.0", features = ["full", "sync"] }
 toml = "0.8.8"
-tower-lsp = "0.20.0"
 unescaper = "0.1.2"
 xshell = "0.2.5"

--- a/crates/cairo-lang-language-server/Cargo.toml
+++ b/crates/cairo-lang-language-server/Cargo.toml
@@ -23,10 +23,10 @@ cairo-lang-test-plugin = { path = "../cairo-lang-test-plugin", version = "2.5.4"
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.5.4", features = ["env_logger"] }
 log.workspace = true
 salsa.workspace = true
-scarb-metadata.workspace = true
+scarb-metadata = "1"
 serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 tokio.workspace = true
-tower-lsp.workspace = true
+tower-lsp = "0.20.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The language server is going to be maintained by a separate team from
now on, so it makes sense to give this new team a freedom to manage
their specific deps without influencing other crates. The more shared
deps, like `anyhow` or `serde` have not been moved, though they may be
in the future.

---

**Stack**:
- #5060
- #5059 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5059)
<!-- Reviewable:end -->
