### PR TITLE
fix: format fail even if not check mode

### DIFF
--- a/crates/bin/cairo-format/src/main.rs
+++ b/crates/bin/cairo-format/src/main.rs
@@ -201,5 +201,5 @@ fn main() -> ExitCode {
         // Input comes from walk of listed locations
         args.files.iter().all(|file| format_path(file, &args, &fmt))
     };
-    if !all_correct && args.check { ExitCode::FAILURE } else { ExitCode::SUCCESS }
+    if !all_correct { ExitCode::FAILURE } else { ExitCode::SUCCESS }
 }


### PR DESCRIPTION
Currently the formatter doesn't fail if the file is not formatted and we are not in check mode. But we expect an error status if we didn't manage to format even if we are not in check mode