### PR TITLE
feat(lsp): add better hint for function

### DIFF
--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -798,7 +798,7 @@ impl LanguageServer for Backend {
             if let Some(hint) = get_pattern_hint(db, function_id, node.clone()) {
                 hints.push(MarkedString::String(hint));
             } else if let Some(hint) = get_expr_hint(db, function_id, node.clone()) {
-                hints.push(MarkedString::String(hint));
+                hints.push(hint);
             };
             if let Some(hint) = get_identifier_hint(db, lookup_item_id, node) {
                 hints.push(MarkedString::String(hint));
@@ -1276,7 +1276,7 @@ fn get_expr_hint(
     db: &(dyn SemanticGroup + 'static),
     function_id: FunctionWithBodyId,
     node: SyntaxNode,
-) -> Option<String> {
+) -> Option<MarkedString> {
     let semantic_expr = nearest_semantic_expr(db, node, function_id)?;
     let text = match semantic_expr {
         cairo_lang_semantic::Expr::FunctionCall(call) => {
@@ -1301,7 +1301,7 @@ fn get_expr_hint(
             };
             let mut s = format!(
                 "fn {}({}) -> {}",
-                call.function.name(db.upcast()).as_str(),
+                call.function.name(db.upcast()),
                 args,
                 call.ty.format(db.upcast())
             );
@@ -1311,7 +1311,7 @@ fn get_expr_hint(
         _ => semantic_expr.ty().format(db),
     };
     // Format the hover text.
-    Some(format!("rs\n{}\n", text))
+    Some(MarkedString::from_language_code("cairo".to_owned(), text))
 }
 
 /// Returns the semantic expression for the current node.


### PR DESCRIPTION
Example hover hint for the starknet deploy syscall:
```cairo
fn deploy_syscall(class_hash: core::starknet::class_hash::ClassHash, contract_address_salt: core::felt252, calldata: core::array::Span::<core::felt252>, deploy_from_zero: core::bool) -> core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5130)
<!-- Reviewable:end -->
