### PR TITLE
re-export syscalls publicly

### DIFF
--- a/corelib/src/starknet.cairo
+++ b/corelib/src/starknet.cairo
@@ -17,7 +17,7 @@ use storage_access::{
 
 // Module containing all the extern declaration of the syscalls.
 pub mod syscalls;
-use syscalls::{
+pub use syscalls::{
     call_contract_syscall, deploy_syscall, emit_event_syscall, get_block_hash_syscall,
     get_execution_info_syscall, library_call_syscall, send_message_to_l1_syscall,
     storage_read_syscall, storage_write_syscall, replace_class_syscall, keccak_syscall


### PR DESCRIPTION
Since the introduction of the `pub` keyword in Cairo 2.5, syscalls functions like `deploy_syscall` are no more reachable with `use starknet::deploy_syscall` but with `use starknet::syscalls::deploy_syscall`.

To fix that, syscalls functions should be exported publicly with `pub use`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5132)
<!-- Reviewable:end -->
