### PR TITLE
feat: replace the cairo-vm felt type by the starknet-types-core one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -105,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "ark-ec"
@@ -260,13 +271,13 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -277,20 +288,20 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -300,6 +311,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bimap"
@@ -339,9 +356,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
@@ -376,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byte-slice-cast"
@@ -387,10 +404,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
-name = "bytes"
+name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cairo-compile"
@@ -401,19 +445,6 @@ dependencies = [
  "cairo-lang-utils",
  "clap",
  "log",
-]
-
-[[package]]
-name = "cairo-felt"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae932292b9ba497a4e892b56aa4e0c6f329a455180fdbdc132700dfe68d9b153"
-dependencies = [
- "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits 0.2.18",
- "serde",
 ]
 
 [[package]]
@@ -666,7 +697,7 @@ version = "2.6.3"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -691,7 +722,6 @@ dependencies = [
  "ark-secp256k1",
  "ark-secp256r1",
  "ark-std",
- "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-compiler",
  "cairo-lang-lowering",
@@ -715,6 +745,7 @@ dependencies = [
  "sha2",
  "smol_str",
  "starknet-crypto",
+ "starknet-types-core",
  "test-case",
  "test-log",
  "thiserror",
@@ -755,7 +786,6 @@ version = "2.6.3"
 dependencies = [
  "anyhow",
  "bimap",
- "cairo-felt",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
  "const-fnv1a-hash",
@@ -775,6 +805,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
+ "starknet-types-core",
  "test-case",
  "test-log",
  "thiserror",
@@ -849,7 +880,6 @@ name = "cairo-lang-sierra-to-casm"
 version = "2.6.3"
 dependencies = [
  "assert_matches",
- "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-sierra",
  "cairo-lang-sierra-ap-change",
@@ -863,6 +893,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.18",
  "pretty_assertions",
+ "starknet-types-core",
  "test-case",
  "test-log",
  "thiserror",
@@ -881,7 +912,6 @@ name = "cairo-lang-starknet"
 version = "2.6.3"
 dependencies = [
  "anyhow",
- "cairo-felt",
  "cairo-lang-compiler",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -905,6 +935,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
+ "starknet-types-core",
  "test-case",
  "test-log",
  "thiserror",
@@ -914,7 +945,6 @@ dependencies = [
 name = "cairo-lang-starknet-classes"
 version = "2.6.3"
 dependencies = [
- "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-sierra",
  "cairo-lang-sierra-generator",
@@ -935,6 +965,7 @@ dependencies = [
  "sha3",
  "smol_str",
  "starknet-crypto",
+ "starknet-types-core",
  "test-case",
  "test-log",
  "thiserror",
@@ -972,7 +1003,6 @@ name = "cairo-lang-test-plugin"
 version = "2.6.3"
 dependencies = [
  "anyhow",
- "cairo-felt",
  "cairo-lang-compiler",
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -991,6 +1021,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.18",
  "serde",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -998,7 +1029,6 @@ name = "cairo-lang-test-runner"
 version = "2.6.3"
 dependencies = [
  "anyhow",
- "cairo-felt",
  "cairo-lang-compiler",
  "cairo-lang-filesystem",
  "cairo-lang-runner",
@@ -1013,6 +1043,7 @@ dependencies = [
  "num-traits 0.2.18",
  "rayon",
  "serde_json",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -1034,7 +1065,7 @@ version = "2.6.3"
 dependencies = [
  "env_logger 0.10.2",
  "hashbrown 0.14.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itertools 0.11.0",
  "log",
  "num-bigint",
@@ -1043,6 +1074,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "starknet-types-core",
  "test-case",
  "test-log",
  "time",
@@ -1081,14 +1113,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "0.9.2"
+version = "1.0.0-rc1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd569684da80d747273613d5c809e4f81bf6f6b1b64d0301b12bac8f2fb8ffb1"
+checksum = "4cf3ee3e7c38d7d69f2710dcf82159f447f8b410bbad4cec12009e434338f5ab"
 dependencies = [
  "anyhow",
  "bincode",
  "bitvec",
- "cairo-felt",
  "generic-array",
  "hashbrown 0.14.3",
  "hex",
@@ -1106,8 +1137,9 @@ dependencies = [
  "sha2",
  "sha3",
  "starknet-crypto",
- "starknet-curve",
+ "starknet-types-core",
  "thiserror-no-std",
+ "zip",
 ]
 
 [[package]]
@@ -1121,9 +1153,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1132,10 +1168,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "4.5.1"
+name = "cipher"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1143,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1155,14 +1201,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1227,6 +1273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1448,6 +1509,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,7 +1595,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1582,7 +1653,7 @@ checksum = "d4cf186fea4af17825116f72932fe52cce9a13bae39ff63b4dc0cfdb3fb4bde1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1657,14 +1728,14 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
 name = "good_lp"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa124423ded10046a849fa0ae9747c541895557f1af177e0890b09879e7e9e7d"
+checksum = "ef62372af3ab5b335ee1fca8ae7fb08da1c4aee777d9b6b740fa49cb74d905ac"
 dependencies = [
  "fnv",
  "minilp",
@@ -1710,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1809,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1833,9 +1904,18 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "instant"
@@ -1877,9 +1957,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1913,7 +2002,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1928,6 +2017,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
  "regex-automata 0.4.6",
+]
+
+[[package]]
+name = "lambdaworks-crypto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4c222d5b2fdc0faf702d3ab361d14589b097f40eac9dc550e27083483edc65"
+dependencies = [
+ "lambdaworks-math",
+ "serde",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
+name = "lambdaworks-math"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee7dcab3968c71896b8ee4dc829147acc918cffe897af6265b1894527fe3add"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1957,13 +2068,12 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
- "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -2024,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mimalloc"
@@ -2088,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "new_debug_unreachable"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -2322,6 +2432,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2453,18 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2346,7 +2479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -2381,20 +2514,26 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "portable-atomic"
@@ -2441,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2501,9 +2640,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -2539,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
  "libredox",
@@ -2550,14 +2689,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2577,7 +2716,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2588,9 +2727,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "relative-path"
@@ -2633,7 +2772,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.52",
+ "syn 2.0.57",
  "unicode-ident",
 ]
 
@@ -2778,7 +2917,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2794,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2811,7 +2950,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2821,6 +2960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2892,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol_str"
@@ -2945,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c03f5ac70f9b067f48db7d2d70bdf18ee0f731e8192b6cfa679136becfcdb0"
+checksum = "2e2c30c01e8eb0fc913c4ee3cf676389fffc1d1182bfe5bb9670e4e72e968064"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -2965,29 +3115,29 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto-codegen"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
+checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "starknet-curve"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c454fecadfb3fe56ee82c405439d663c8a037667cc9d8e4acb1fb17e15b1af"
+checksum = "d1c383518bb312751e4be80f53e8644034aa99a0afb29d7ac41b89a997db875b"
 dependencies = [
  "starknet-ff",
 ]
 
 [[package]]
 name = "starknet-ff"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067419451efdea1ee968df8438369960c167e0e905c05b84afd074f50e1d6f3d"
+checksum = "7abf1b44ec5b18d87c1ae5f54590ca9d0699ef4dd5b2ffa66fc97f24613ec585"
 dependencies = [
  "ark-ff",
  "crypto-bigint",
@@ -3033,6 +3183,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet-types-core"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d53160556d1f23425100f42b3230df747ea05763efee685a2cd939dfb640701"
+dependencies = [
+ "bitvec",
+ "lambdaworks-crypto",
+ "lambdaworks-math",
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.18",
+ "serde",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3123,7 +3289,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3134,7 +3300,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
  "test-case-core",
 ]
 
@@ -3156,7 +3322,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3164,7 +3330,6 @@ name = "tests"
 version = "2.6.3"
 dependencies = [
  "assert_matches",
- "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-compiler",
  "cairo-lang-defs",
@@ -3190,27 +3355,28 @@ dependencies = [
  "pretty_assertions",
  "rstest",
  "salsa",
+ "starknet-types-core",
  "test-log",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3302,9 +3468,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3327,7 +3493,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3346,14 +3512,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.6",
+ "toml_edit 0.22.9",
 ]
 
 [[package]]
@@ -3371,18 +3537,18 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3440,7 +3606,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3468,14 +3634,14 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "tracing-chrome"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496b3cd5447f7ff527bbbf19b071ad542a000adf297d4127078b4dfdb931f41a"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
 dependencies = [
  "serde_json",
  "tracing-core",
@@ -3642,7 +3808,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
  "wasm-bindgen-shared",
 ]
 
@@ -3664,7 +3830,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3867,18 +4033,18 @@ dependencies = [
 
 [[package]]
 name = "xshell"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2107fe03e558353b4c71ad7626d58ed82efaf56c54134228608893c77023ad"
+checksum = "6db0ab86eae739efd1b054a8d3d16041914030ac4e01cd1dca0cf252fd8b6437"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
+checksum = "9d422e8e38ec76e2f06ee439ccc765e9c6a9638b9e7c9f2e8255e4d41e8bd852"
 
 [[package]]
 name = "yansi"
@@ -3903,7 +4069,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3923,5 +4089,54 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.57",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.10+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ opt-level = 1
 opt-level = 3
 [profile.ci-dev.package."bimap"]
 opt-level = 3
-[profile.ci-dev.package."cairo-felt"]
+[profile.ci-dev.package."starknet-types-core"]
 opt-level = 3
 [profile.ci-dev.package."salsa"]
 opt-level = 3
@@ -85,8 +85,7 @@ ark-secp256r1 = "0.4.0"
 ark-std = "0.4.0"
 assert_matches = "1.5"
 bimap = "0.6.3"
-cairo-felt = "0.9.1"
-cairo-vm = "0.9.1"
+cairo-vm = "1.0.0-rc1"
 clap = { version = "4.4", features = ["derive"] }
 colored = "2"
 const-fnv1a-hash = "1.1.0"
@@ -126,6 +125,9 @@ sha2 = "0.10.8"
 sha3 = "0.10.8"
 smol_str = { version = "0.2.0", features = ["serde"] }
 starknet-crypto = "0.6.1"
+starknet-types-core = { version = "0.0.9", features = [
+    "hash",
+], default-features = false }
 syn = { version = "2.0.39", features = ["full", "extra-traits"] }
 test-case = "3.2.1"
 test-case-macros = "3.2.1"

--- a/crates/cairo-lang-runner/Cargo.toml
+++ b/crates/cairo-lang-runner/Cargo.toml
@@ -11,7 +11,6 @@ ark-ff.workspace = true
 ark-secp256k1.workspace = true
 ark-secp256r1.workspace = true
 ark-std.workspace = true
-cairo-felt.workspace = true
 cairo-lang-casm = { path = "../cairo-lang-casm", version = "~2.6.3" }
 cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "~2.6.3" }
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "~2.6.3" }
@@ -30,6 +29,7 @@ num-traits = { workspace = true, default-features = true }
 sha2.workspace = true
 smol_str.workspace = true
 starknet-crypto.workspace = true
+starknet-types-core = { workspace = true, default-features = true }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-runner/src/casm_run/contract_address.rs
+++ b/crates/cairo-lang-runner/src/casm_run/contract_address.rs
@@ -1,5 +1,5 @@
-use cairo_felt::Felt252;
 use starknet_crypto::{pedersen_hash, FieldElement};
+use starknet_types_core::felt::Felt as Felt252;
 
 /// Computes Pedersen hash using STARK curve on an array of elements, as defined
 /// in <https://docs.starknet.io/documentation/architecture_and_concepts/Hashing/hash-functions/#array_hashing.>
@@ -30,7 +30,7 @@ const CONTRACT_ADDRESS_PREFIX: FieldElement = FieldElement::from_mont([
 
 /// Converts a Felt252 to the FieldElement type used in starknet-crypto.
 fn felt252_to_field_element(input: &Felt252) -> FieldElement {
-    FieldElement::from_bytes_be(&input.to_be_bytes()).unwrap()
+    FieldElement::from_bytes_be(&input.to_bytes_be()).unwrap()
 }
 
 /// Calculates the address of a starknet contract, as defined in

--- a/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
+++ b/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use cairo_felt::Felt252;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::vm_core::VirtualMachine;
+use starknet_types_core::felt::Felt as Felt252;
 
 /// Stores the data of a specific dictionary.
 pub struct DictTrackerExecScope {

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -642,7 +642,7 @@ impl<'a> CairoHintProcessor<'a> {
         let mut system_buffer = MemBuffer::new(vm, system_ptr);
 
         let selector = system_buffer.next_felt252()?.to_bytes_be();
-        let first_selector_non_zero_byte =
+        let first_selector_non_zero_byte_pos =
             selector.iter().position(|b| *b != 0).expect("'selector' should not be an empty value");
 
         let mut gas_counter = system_buffer.next_usize()?;
@@ -667,7 +667,7 @@ impl<'a> CairoHintProcessor<'a> {
                 }
                 Ok(())
             };
-        let selector = std::str::from_utf8(&selector[first_selector_non_zero_byte..]).unwrap();
+        let selector = std::str::from_utf8(&selector[first_selector_non_zero_byte_pos..]).unwrap();
         *self.syscalls_used_resources.syscalls.entry(selector.into()).or_default() += 1;
         match selector {
             "StorageWrite" => execute_handle_helper(&mut |system_buffer, gas_counter| {
@@ -2267,11 +2267,7 @@ impl FormattedItem {
     }
     /// Wraps the formatted item with quote, if it's a string. Otherwise returns it as is.
     pub fn quote_if_string(self) -> String {
-        if self.is_string {
-            format!("\"{}\"", self.item)
-        } else {
-            self.item
-        }
+        if self.is_string { format!("\"{}\"", self.item) } else { self.item }
     }
 }
 

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -1,4 +1,3 @@
-use cairo_felt::{felt_str, Felt252};
 use cairo_lang_casm::inline::CasmContext;
 use cairo_lang_casm::{casm, deref};
 use cairo_lang_utils::byte_array::BYTE_ARRAY_MAGIC;
@@ -8,6 +7,7 @@ use indoc::indoc;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
+use starknet_types_core::felt::Felt as Felt252;
 use test_case::test_case;
 
 use super::format_for_debug;
@@ -124,7 +124,7 @@ fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
         .flat_map(|instruction| instruction.assemble().encode())
         .collect();
 
-    let RunFunctionResult { memory, ap, .. } = run_function(
+    let RunFunctionResult { memory, trace, .. } = run_function(
         &mut VirtualMachine::new(true),
         bytecode.iter(),
         vec![],
@@ -133,6 +133,7 @@ fn test_runner(function: CasmContext, n_returns: usize, expected: &[i128]) {
         hints_dict,
     )
     .expect("Running code failed.");
+    let ap = trace.last().unwrap().ap;
     let ret_memory = memory.into_iter().skip(ap - n_returns);
     assert_eq!(
         ret_memory.take(n_returns).map(|cell| cell.unwrap()).collect_vec(),
@@ -160,7 +161,7 @@ fn test_allocate_segment() {
     let bytecode: Vec<BigInt> =
         casm.instructions.iter().flat_map(|instruction| instruction.assemble().encode()).collect();
 
-    let RunFunctionResult { memory, ap, .. } = run_function(
+    let RunFunctionResult { memory, trace, .. } = run_function(
         &mut VirtualMachine::new(true),
         bytecode.iter(),
         vec![],
@@ -169,7 +170,8 @@ fn test_allocate_segment() {
         hints_dict,
     )
     .expect("Running code failed.");
-    let ptr = memory[ap]
+    let last_ap = trace.last().unwrap().ap;
+    let ptr = memory[last_ap]
         .as_ref()
         .expect("Uninitialized value.")
         .to_usize()
@@ -183,9 +185,8 @@ fn test_as_cairo_short_string() {
     assert_eq!(as_cairo_short_string(&Felt252::from(0)), Some("".to_string()));
     assert_eq!(as_cairo_short_string(&Felt252::from(0x61)), Some("a".to_string()));
     assert_eq!(
-        as_cairo_short_string(&felt_str!(
-            "30313233343536373839303132333435363738393031323334353637383930",
-            16
+        as_cairo_short_string(&Felt252::from_hex_unchecked(
+            "30313233343536373839303132333435363738393031323334353637383930"
         )),
         Some("0123456789012345678901234567890".to_string())
     );
@@ -212,7 +213,9 @@ fn test_as_cairo_short_string_ex() {
     assert_eq!(as_cairo_short_string_ex(&Felt252::from(0x61), 1), Some("a".to_string()));
     assert_eq!(
         as_cairo_short_string_ex(
-            &felt_str!("30313233343536373839303132333435363738393031323334353637383930", 16),
+            &Felt252::from_hex_unchecked(
+                "30313233343536373839303132333435363738393031323334353637383930"
+            ),
             31
         ),
         Some("0123456789012345678901234567890".to_string())
@@ -236,7 +239,9 @@ fn test_as_cairo_short_string_ex() {
     // length > 31.
     assert_eq!(
         as_cairo_short_string_ex(
-            &felt_str!("100000000000000000000000000000000000000000000000000000000000000", 16),
+            &Felt252::from_hex_unchecked(
+                "100000000000000000000000000000000000000000000000000000000000000"
+            ),
             32
         ),
         None
@@ -246,7 +251,7 @@ fn test_as_cairo_short_string_ex() {
 #[test]
 fn test_format_for_debug() {
     // Valid short string.
-    let felts = vec![felt_str!("68656c6c6f", 16)];
+    let felts = vec![Felt252::from_hex_unchecked("68656c6c6f")];
     assert_eq!(format_for_debug(felts.into_iter()), "[DEBUG]\t0x68656c6c6f ('hello')\n");
 
     // felt252
@@ -255,22 +260,24 @@ fn test_format_for_debug() {
 
     // Valid string with < 31 characters (no full words).
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
-        Felt252::from(0),                                    // No full words.
-        felt_str!("73686f72742c2062757420737472696e67", 16), // 'short, but string'
-        Felt252::from(17),                                   // pending word length
+        BYTE_ARRAY_MAGIC,
+        Felt252::from(0), // No full words.
+        Felt252::from_hex_unchecked("73686f72742c2062757420737472696e67"), // 'short, but string'
+        Felt252::from(17), // pending word length
     ];
     assert_eq!(format_for_debug(felts.into_iter()), "short, but string");
 
     // Valid string with > 31 characters (with a full word).
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // A single full word.
         Felt252::from(1),
         // full word: 'This is a long string with more'
-        felt_str!("546869732069732061206c6f6e6720737472696e672077697468206d6f7265", 16),
+        Felt252::from_hex_unchecked(
+            "546869732069732061206c6f6e6720737472696e672077697468206d6f7265",
+        ),
         // pending word: ' than 31 characters.'
-        felt_str!("207468616e20333120636861726163746572732e", 16),
+        Felt252::from_hex_unchecked("207468616e20333120636861726163746572732e"),
         // pending word length
         Felt252::from(20),
     ];
@@ -280,14 +287,14 @@ fn test_format_for_debug() {
     );
 
     // Only magic.
-    let felts = vec![felt_str!(BYTE_ARRAY_MAGIC, 16)];
+    let felts = vec![BYTE_ARRAY_MAGIC];
     assert_eq!(
         format_for_debug(felts.into_iter()),
         "[DEBUG]\t0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3\n"
     );
 
     // num_full_words > usize.
-    let felts = vec![felt_str!(BYTE_ARRAY_MAGIC, 16), felt_str!("100000000", 16)];
+    let felts = vec![BYTE_ARRAY_MAGIC, Felt252::from_hex_unchecked("100000000")];
     assert_eq!(
         format_for_debug(felts.into_iter()),
         indoc!(
@@ -298,7 +305,7 @@ fn test_format_for_debug() {
     );
 
     // Not enough data after num_full_words.
-    let felts = vec![felt_str!(BYTE_ARRAY_MAGIC, 16), Felt252::from(0)];
+    let felts = vec![BYTE_ARRAY_MAGIC, Felt252::from(0)];
     assert_eq!(
         format_for_debug(felts.into_iter()),
         "[DEBUG]\t0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3\n[DEBUG]\t0x0 \
@@ -306,8 +313,7 @@ fn test_format_for_debug() {
     );
 
     // Not enough full words.
-    let felts =
-        vec![felt_str!(BYTE_ARRAY_MAGIC, 16), Felt252::from(1), Felt252::from(0), Felt252::from(0)];
+    let felts = vec![BYTE_ARRAY_MAGIC, Felt252::from(1), Felt252::from(0), Felt252::from(0)];
     assert_eq!(
         format_for_debug(felts.into_iter()),
         indoc!(
@@ -320,9 +326,11 @@ fn test_format_for_debug() {
 
     // Too much data in full word.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         Felt252::from(1),
-        felt_str!("161616161616161616161616161616161616161616161616161616161616161", 16),
+        Felt252::from_hex_unchecked(
+            "161616161616161616161616161616161616161616161616161616161616161",
+        ),
         Felt252::from(0),
         Felt252::from(0),
     ];
@@ -340,10 +348,10 @@ fn test_format_for_debug() {
 
     // num_pending_bytes > usize.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         Felt252::from(0),
         Felt252::from(0),
-        felt_str!("100000000", 16),
+        Felt252::from_hex_unchecked("100000000"),
     ];
     assert_eq!(
         format_for_debug(felts.into_iter()),
@@ -358,11 +366,11 @@ fn test_format_for_debug() {
 
     // "Not enough" data in pending_word (nulls in the beginning).
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full words.
         Felt252::from(0),
         // 'a'
-        felt_str!("61", 16),
+        Felt252::from_hex_unchecked("61"),
         // pending word length. Bigger than the actual data in the pending word.
         Felt252::from(2),
     ];
@@ -370,11 +378,11 @@ fn test_format_for_debug() {
 
     // Too much data in pending_word.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full words.
         Felt252::from(0),
         // 'aa'
-        felt_str!("6161", 16),
+        Felt252::from_hex_unchecked("6161"),
         // pending word length. Smaller than the actual data in the pending word.
         Felt252::from(1),
     ];
@@ -391,11 +399,11 @@ fn test_format_for_debug() {
 
     // Valid string with Null.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full word.
         Felt252::from(0),
         // pending word: 'Hello\0world'
-        felt_str!("48656c6c6f00776f726c64", 16),
+        Felt252::from_hex_unchecked("48656c6c6f00776f726c64"),
         // pending word length
         Felt252::from(11),
     ];
@@ -403,11 +411,11 @@ fn test_format_for_debug() {
 
     // Valid string with a non printable character.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full word.
         Felt252::from(0),
         // pending word: 'Hello\x11world'
-        felt_str!("48656c6c6f11776f726c64", 16),
+        Felt252::from_hex_unchecked("48656c6c6f11776f726c64"),
         // pending word length
         Felt252::from(11),
     ];
@@ -415,11 +423,11 @@ fn test_format_for_debug() {
 
     // Valid string with a newline.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full word.
         Felt252::from(0),
         // pending word: 'Hello\nworld'
-        felt_str!("48656c6c6f0a776f726c64", 16),
+        Felt252::from_hex_unchecked("48656c6c6f0a776f726c64"),
         // pending word length
         Felt252::from(11),
     ];
@@ -430,12 +438,12 @@ fn test_format_for_debug() {
         // felt: 0x9999
         Felt252::from(0x9999),
         // String: "hello"
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         Felt252::from(0),
-        felt_str!("68656c6c6f", 16),
+        Felt252::from_hex_unchecked("68656c6c6f"),
         Felt252::from(5),
         // Short string: 'world'
-        felt_str!("776f726c64", 16),
+        Felt252::from_hex_unchecked("776f726c64"),
         // felt: 0x8888
         Felt252::from(0x8888),
     ];
@@ -453,16 +461,21 @@ fn test_format_for_debug() {
 
 #[test]
 fn test_calculate_contract_address() {
-    let salt = felt_str!("122660764594045088044512115");
+    let salt = Felt252::from_dec_str("122660764594045088044512115").unwrap();
     let deployer_address = Felt252::from(0x01);
-    let class_hash =
-        felt_str!("1779576919126046589190499439779938629977579841313883525093195577363779864274");
-    let calldata = vec![deployer_address.clone(), salt.clone()];
+    let class_hash = Felt252::from_dec_str(
+        "1779576919126046589190499439779938629977579841313883525093195577363779864274",
+    )
+    .unwrap();
+    let calldata = vec![deployer_address, salt];
     let deployed_contract_address =
         calculate_contract_address(&salt, &class_hash, &calldata, &deployer_address);
 
     assert_eq!(
-        felt_str!("2288343933438457476985546536845198482236255384896285993520343604559094835567"),
+        Felt252::from_dec_str(
+            "2288343933438457476985546536845198482236255384896285993520343604559094835567"
+        )
+        .unwrap(),
         deployed_contract_address
     );
 }

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -566,11 +566,7 @@ impl SierraCasmRunner {
             .funcs
             .iter()
             .find(|f| {
-                if let Some(name) = &f.id.debug_name {
-                    name.ends_with(name_suffix)
-                } else {
-                    false
-                }
+                if let Some(name) = &f.id.debug_name { name.ends_with(name_suffix) } else { false }
             })
             .ok_or_else(|| RunnerError::MissingFunction { suffix: name_suffix.to_owned() })
     }

--- a/crates/cairo-lang-sierra-to-casm/Cargo.toml
+++ b/crates/cairo-lang-sierra-to-casm/Cargo.toml
@@ -8,7 +8,6 @@ description = "Emitting of CASM instructions from Sierra code."
 
 [dependencies]
 assert_matches.workspace = true
-cairo-felt.workspace = true
 cairo-lang-casm = { path = "../cairo-lang-casm", version = "~2.6.3" }
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "~2.6.3" }
 cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "~2.6.3" }
@@ -19,6 +18,7 @@ indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
+starknet-types-core = { workspace = true, default-features = true }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 
-use cairo_felt::Felt252;
 use cairo_lang_casm::builder::{CasmBuilder, Var};
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_sierra::extensions::ec::EcConcreteLibfunc;
-use num_bigint::{BigInt, ToBigInt};
+use num_bigint::BigInt;
+use starknet_types_core::felt::{Felt, NonZeroFelt};
 
 use super::{CompiledInvocation, CompiledInvocationBuilder, InvocationError};
 use crate::invocations::misc::validate_under_limit;
@@ -218,7 +218,7 @@ fn build_ec_point_from_x_nz(
         &mut casm_builder,
         // Note that `1/2 (mod PRIME) = (PRIME + 1) / 2 = ceil(PRIME / 2)`.
         // Thus, `y < 1/2 (mod PRIME)` if and only if `y < PRIME / 2`.
-        &(Felt252::from(1) / Felt252::from(2)).to_biguint().to_bigint().unwrap(),
+        &(Felt::ONE.field_div(&NonZeroFelt::try_from(Felt::TWO).unwrap())).to_bigint(),
         y,
         range_check,
         &auxiliary_vars,

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -1,4 +1,3 @@
-use cairo_felt::Felt252;
 use cairo_lang_casm::builder::CasmBuilder;
 use cairo_lang_casm::cell_expression::CellExpression;
 use cairo_lang_casm::operand::CellRef;
@@ -10,6 +9,7 @@ use cairo_lang_sierra::program::{BranchInfo, BranchTarget};
 use cairo_lang_utils::try_extract_matches;
 use itertools::{chain, repeat_n};
 use num_bigint::BigInt;
+use starknet_types_core::felt::{Felt, NonZeroFelt};
 
 use super::{
     CompiledInvocation, CompiledInvocationBuilder, InvocationError, ReferenceExpressionView,
@@ -135,7 +135,8 @@ fn build_enum_from_bounded_int(
     // Define `(2*n - 1) / 2` as `m` - which is known in compilation time.
     // Hence the variant selector is `2 * (m - k)` or  alternatively `-2 * (k - m)`
 
-    let m = (Felt252::from(n_variants * 2 - 1) / Felt252::from(2)).to_bigint();
+    let m = (Felt::from(n_variants * 2 - 1).field_div(&NonZeroFelt::try_from(Felt::TWO).unwrap()))
+        .to_bigint();
     casm_build_extend! {casm_builder,
         const m = m;
         const negative_two = -2;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs
@@ -1,6 +1,5 @@
 use std::ops::Shl;
 
-use cairo_felt::Felt252;
 use cairo_lang_casm::builder::CasmBuilder;
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_sierra::extensions::int::unsigned::{UintConcrete, UintTraits};
@@ -8,6 +7,7 @@ use cairo_lang_sierra::extensions::int::{IntMulTraits, IntOperator};
 use cairo_lang_sierra::extensions::is_zero::IsZeroTraits;
 use cairo_lang_sierra::extensions::utils::Range;
 use num_bigint::{BigInt, ToBigInt};
+use starknet_types_core::felt::Felt as Felt252;
 
 use super::{build_const, build_small_diff, build_small_wide_mul};
 use crate::invocations::range_reduction::build_felt252_range_reduction;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs
@@ -1,4 +1,3 @@
-use cairo_felt::Felt252;
 use cairo_lang_casm::builder::{CasmBuilder, Var};
 use cairo_lang_casm::cell_expression::CellExpression;
 use cairo_lang_casm::{casm, casm_build_extend};
@@ -6,6 +5,7 @@ use cairo_lang_sierra::program::{BranchInfo, BranchTarget};
 use cairo_lang_sierra_gas::objects::ConstCost;
 use itertools::Itertools;
 use num_bigint::{BigInt, ToBigInt};
+use starknet_types_core::felt::Felt as Felt252;
 
 use super::{
     get_non_fallthrough_statement_id, CompiledInvocation, CompiledInvocationBuilder,

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs
@@ -1,10 +1,10 @@
 use std::ops::Shl;
 
-use cairo_felt::Felt252;
 use cairo_lang_casm::builder::CasmBuilder;
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_sierra::extensions::utils::Range;
 use num_bigint::BigInt;
+use starknet_types_core::felt::Felt as Felt252;
 
 use super::{
     get_non_fallthrough_statement_id, CompiledInvocation, CompiledInvocationBuilder,

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/storage.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/storage.rs
@@ -1,7 +1,7 @@
-use cairo_felt::Felt252;
 use cairo_lang_casm::builder::CasmBuilder;
 use cairo_lang_casm::casm_build_extend;
 use num_bigint::{BigInt, ToBigInt};
+use starknet_types_core::felt::Felt as Felt252;
 
 use super::{CompiledInvocation, CompiledInvocationBuilder, InvocationError};
 use crate::invocations::misc::validate_under_limit;

--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -13,7 +13,6 @@ regex = "1"
 
 [dependencies]
 anyhow.workspace = true
-cairo-felt.workspace = true
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "~2.6.3", features = ["serde", "schemars"] }
 const-fnv1a-hash.workspace = true
 convert_case.workspace = true
@@ -27,6 +26,7 @@ serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 sha3.workspace = true
 smol_str.workspace = true
+starknet-types-core.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
@@ -1,5 +1,5 @@
-use cairo_felt::Felt252;
 use num_bigint::BigInt;
+use starknet_types_core::felt::Felt as Felt252;
 
 use super::utils::Range;
 use crate::extensions::type_specialization_context::TypeSpecializationContext;

--- a/crates/cairo-lang-sierra/src/extensions/modules/casts.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/casts.rs
@@ -1,5 +1,5 @@
-use cairo_felt::Felt252;
 use num_traits::Zero;
+use starknet_types_core::felt::Felt as Felt252;
 
 use super::range_check::RangeCheckType;
 use super::utils::{reinterpret_cast_signature, Range};

--- a/crates/cairo-lang-sierra/src/extensions/modules/utils.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/utils.rs
@@ -1,8 +1,8 @@
 use std::ops::Shl;
 
-use cairo_felt::Felt252;
 use num_bigint::BigInt;
 use num_traits::One;
+use starknet_types_core::felt::Felt as Felt252;
 
 use super::bounded_int::BoundedIntType;
 use super::bytes31::Bytes31Type;

--- a/crates/cairo-lang-sierra/src/test_utils.rs
+++ b/crates/cairo-lang-sierra/src/test_utils.rs
@@ -1,7 +1,7 @@
 use bimap::BiMap;
-use cairo_felt::Felt252;
 use itertools::chain;
 use num_bigint::BigInt;
+use starknet_types_core::felt::Felt as Felt252;
 
 use crate::ids::ConcreteTypeId;
 use crate::program::{ConcreteTypeLongId, GenericArg};

--- a/crates/cairo-lang-starknet-classes/Cargo.toml
+++ b/crates/cairo-lang-starknet-classes/Cargo.toml
@@ -7,7 +7,6 @@ license-file.workspace = true
 description = "Starknet definitions for contract classes."
 
 [dependencies]
-cairo-felt.workspace = true
 cairo-lang-casm = { path = "../cairo-lang-casm", version = "~2.6.3", default-features = true, features = ["serde"] }
 cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "~2.6.3" }
 cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "~2.6.3" }
@@ -23,6 +22,7 @@ serde_json.workspace = true
 sha3.workspace = true
 smol_str.workspace = true
 starknet-crypto.workspace = true
+starknet-types-core = { workspace = true, default-features = true }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 
-use cairo_felt::Felt252;
 use cairo_lang_casm::assembler::AssembledCairoProgram;
 use cairo_lang_casm::hints::{Hint, PythonicHint};
 use cairo_lang_sierra::extensions::array::ArrayType;
@@ -35,6 +34,7 @@ use num_traits::Signed;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use starknet_crypto::{poseidon_hash_many, FieldElement};
+use starknet_types_core::felt::Felt as Felt252;
 use thiserror::Error;
 
 use crate::allowed_libfuncs::AllowedLibfuncsError;

--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::io::BufReader;
 
-use cairo_felt::Felt252;
 use cairo_lang_test_utils::compare_contents_or_fix_with_path;
+use starknet_types_core::felt::Felt as Felt252;
 use test_case::test_case;
 
 use crate::casm_contract_class::{BigUintAsHex, CasmContractClass, StarknetSierraCompilationError};

--- a/crates/cairo-lang-starknet-classes/src/felt252_vec_compression.rs
+++ b/crates/cairo-lang-starknet-classes/src/felt252_vec_compression.rs
@@ -1,9 +1,9 @@
-use cairo_felt::Felt252;
 use cairo_lang_utils::bigint::BigUintAsHex;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::ToPrimitive;
+use starknet_types_core::felt::Felt as Felt252;
 
 /// Compresses a vector of `BigUintAsHex` representing felts into `result`, by creating a code
 /// mapping, and then compressing several original code words into the given felts.

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -8,7 +8,6 @@ description = "Starknet capabilities and utilities on top of Cairo."
 
 [dependencies]
 anyhow.workspace = true
-cairo-felt.workspace = true
 cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "~2.6.3" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "~2.6.3" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "~2.6.3" }
@@ -28,6 +27,7 @@ once_cell.workspace = true
 serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 smol_str.workspace = true
+starknet-types-core = { workspace = true, default-features = true }
 thiserror.workspace = true
 indent.workspace = true
 

--- a/crates/cairo-lang-starknet/src/contract.rs
+++ b/crates/cairo-lang-starknet/src/contract.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Context};
-use cairo_felt::Felt252;
 use cairo_lang_defs::ids::{
     FileIndex, FreeFunctionId, LanguageElementId, LookupItemId, ModuleFileId, ModuleId,
     ModuleItemId, NamedLanguageElementId, SubmoduleId,
@@ -29,6 +28,7 @@ use cairo_lang_utils::ordered_hash_map::{
 };
 use itertools::chain;
 use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt as Felt252;
 use {cairo_lang_lowering as lowering, cairo_lang_semantic as semantic};
 
 use crate::aliased::Aliased;
@@ -311,7 +311,7 @@ fn analyze_contract<T: SierraIdReplacer>(
     db: &dyn SierraGenGroup,
     contract: &ContractDeclaration,
     replacer: &T,
-) -> anyhow::Result<(cairo_felt::Felt252, ContractInfo)> {
+) -> anyhow::Result<(Felt252, ContractInfo)> {
     // Extract class hash.
     let item =
         db.module_item_by_name(contract.module_id(), "TEST_CLASS_HASH".into()).unwrap().unwrap();

--- a/crates/cairo-lang-test-plugin/Cargo.toml
+++ b/crates/cairo-lang-test-plugin/Cargo.toml
@@ -8,7 +8,6 @@ description = "Cairo test compilation plugin."
 
 [dependencies]
 anyhow.workspace = true
-cairo-felt.workspace = true
 cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "~2.6.3" }
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "~2.6.3" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "~2.6.3" }
@@ -27,3 +26,4 @@ itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
+starknet-types-core = { workspace = true, default-features = true }

--- a/crates/cairo-lang-test-plugin/src/lib.rs
+++ b/crates/cairo-lang-test-plugin/src/lib.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use cairo_felt::Felt252;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{FreeFunctionId, FunctionWithBodyId, ModuleItemId};
@@ -30,6 +29,7 @@ use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::{chain, Itertools};
 pub use plugin::TestPlugin;
 use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt as Felt252;
 pub use test_config::{try_extract_test_config, TestConfig};
 
 mod inline_macros;

--- a/crates/cairo-lang-test-plugin/src/test_config.rs
+++ b/crates/cairo-lang-test-plugin/src/test_config.rs
@@ -1,4 +1,3 @@
-use cairo_felt::{felt_str, Felt252};
 use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_syntax::attribute::structured::{Attribute, AttributeArg, AttributeArgVariant};
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -9,6 +8,7 @@ use itertools::chain;
 use num_bigint::{BigInt, Sign};
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt as Felt252;
 
 use super::{AVAILABLE_GAS_ATTR, IGNORE_ATTR, SHOULD_PANIC_ATTR, STATIC_GAS_ARG, TEST_ATTR};
 
@@ -214,7 +214,7 @@ fn extract_string_panic_bytes(
     let pending_word = BigInt::from_bytes_be(Sign::Plus, remainder).into();
 
     chain!(
-        [felt_str!(BYTE_ARRAY_MAGIC, 16), num_full_words],
+        [BYTE_ARRAY_MAGIC, num_full_words],
         full_words.into_iter(),
         [pending_word, pending_word_len]
     )

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -8,7 +8,6 @@ description = "Cairo tests runner. Used to run tests written in Cairo."
 
 [dependencies]
 anyhow.workspace = true
-cairo-felt.workspace = true
 cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "~2.6.3" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "~2.6.3" }
 cairo-lang-runner = { path = "../cairo-lang-runner", version = "~2.6.3" }
@@ -22,6 +21,7 @@ colored.workspace = true
 itertools = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
 rayon.workspace = true
+starknet-types-core = { workspace = true, default-features = true }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, Mutex};
 use std::vec::IntoIter;
 
 use anyhow::{bail, Context, Result};
-use cairo_felt::Felt252;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::setup_project;
@@ -37,6 +36,7 @@ use colored::Colorize;
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use starknet_types_core::felt::Felt as Felt252;
 
 #[cfg(test)]
 mod test;

--- a/crates/cairo-lang-test-runner/src/test.rs
+++ b/crates/cairo-lang-test-runner/src/test.rs
@@ -1,6 +1,6 @@
-use cairo_felt::{felt_str, Felt252};
 use cairo_lang_utils::byte_array::BYTE_ARRAY_MAGIC;
 use itertools::Itertools;
+use starknet_types_core::felt::Felt as Felt252;
 
 use crate::{format_for_panic, TestCompilation, TestCompiler};
 
@@ -26,7 +26,7 @@ fn test_compiled_serialization() {
 #[test]
 fn test_format_for_panic() {
     // Valid short string.
-    let felts = vec![felt_str!("68656c6c6f", 16)];
+    let felts = vec![Felt252::from_hex_unchecked("68656c6c6f")];
     assert_eq!(format_for_panic(felts.into_iter()), "Panicked with 0x68656c6c6f ('hello').");
 
     // felt252
@@ -35,22 +35,24 @@ fn test_format_for_panic() {
 
     // Valid string with < 31 characters (no full words).
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
-        Felt252::from(0),                                    // No full words.
-        felt_str!("73686f72742c2062757420737472696e67", 16), // 'short, but string'
-        Felt252::from(17),                                   // pending word length
+        BYTE_ARRAY_MAGIC,
+        Felt252::from(0), // No full words.
+        Felt252::from_hex_unchecked("73686f72742c2062757420737472696e67"), // 'short, but string'
+        Felt252::from(17), // pending word length
     ];
     assert_eq!(format_for_panic(felts.into_iter()), "Panicked with \"short, but string\".");
 
     // Valid string with > 31 characters (with a full word).
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // A single full word.
         Felt252::from(1),
         // full word: 'This is a long string with more'
-        felt_str!("546869732069732061206c6f6e6720737472696e672077697468206d6f7265", 16),
+        Felt252::from_hex_unchecked(
+            "546869732069732061206c6f6e6720737472696e672077697468206d6f7265",
+        ),
         // pending word: ' than 31 characters.'
-        felt_str!("207468616e20333120636861726163746572732e", 16),
+        Felt252::from_hex_unchecked("207468616e20333120636861726163746572732e"),
         // pending word length
         Felt252::from(20),
     ];
@@ -60,14 +62,14 @@ fn test_format_for_panic() {
     );
 
     // Only magic.
-    let felts = vec![felt_str!(BYTE_ARRAY_MAGIC, 16)];
+    let felts = vec![BYTE_ARRAY_MAGIC];
     assert_eq!(
         format_for_panic(felts.into_iter()),
         "Panicked with 0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3."
     );
 
     // num_full_words > usize.
-    let felts = vec![felt_str!(BYTE_ARRAY_MAGIC, 16), felt_str!("100000000", 16)];
+    let felts = vec![BYTE_ARRAY_MAGIC, Felt252::from_hex_unchecked("100000000")];
     assert_eq!(
         format_for_panic(felts.into_iter()),
         "Panicked with (0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, \
@@ -75,7 +77,7 @@ fn test_format_for_panic() {
     );
 
     // Not enough data after num_full_words.
-    let felts = vec![felt_str!(BYTE_ARRAY_MAGIC, 16), Felt252::from(0)];
+    let felts = vec![BYTE_ARRAY_MAGIC, Felt252::from(0)];
     assert_eq!(
         format_for_panic(felts.into_iter()),
         "Panicked with (0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x0 \
@@ -83,8 +85,7 @@ fn test_format_for_panic() {
     );
 
     // Not enough full words.
-    let felts =
-        vec![felt_str!(BYTE_ARRAY_MAGIC, 16), Felt252::from(1), Felt252::from(0), Felt252::from(0)];
+    let felts = vec![BYTE_ARRAY_MAGIC, Felt252::from(1), Felt252::from(0), Felt252::from(0)];
     assert_eq!(
         format_for_panic(felts.into_iter()),
         "Panicked with (0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x1, \
@@ -93,9 +94,11 @@ fn test_format_for_panic() {
 
     // Too much data in full word.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         Felt252::from(1),
-        felt_str!("161616161616161616161616161616161616161616161616161616161616161", 16),
+        Felt252::from_hex_unchecked(
+            "161616161616161616161616161616161616161616161616161616161616161",
+        ),
         Felt252::from(0),
         Felt252::from(0),
     ];
@@ -107,10 +110,10 @@ fn test_format_for_panic() {
 
     // num_pending_bytes > usize.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         Felt252::from(0),
         Felt252::from(0),
-        felt_str!("100000000", 16),
+        Felt252::from_hex_unchecked("100000000"),
     ];
     assert_eq!(
         format_for_panic(felts.into_iter()),
@@ -120,11 +123,11 @@ fn test_format_for_panic() {
 
     // "Not enough" data in pending_word (nulls in the beginning).
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full words.
         Felt252::from(0),
         // 'a'
-        felt_str!("61", 16),
+        Felt252::from_hex_unchecked("61"),
         // pending word length. Bigger than the actual data in the pending word.
         Felt252::from(2),
     ];
@@ -132,11 +135,11 @@ fn test_format_for_panic() {
 
     // Too much data in pending_word.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full words.
         Felt252::from(0),
         // 'aa'
-        felt_str!("6161", 16),
+        Felt252::from_hex_unchecked("6161"),
         // pending word length. Smaller than the actual data in the pending word.
         Felt252::from(1),
     ];
@@ -148,11 +151,11 @@ fn test_format_for_panic() {
 
     // Valid string with Null.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full word.
         Felt252::from(0),
         // pending word: 'Hello\0world'
-        felt_str!("48656c6c6f00776f726c64", 16),
+        Felt252::from_hex_unchecked("48656c6c6f00776f726c64"),
         // pending word length
         Felt252::from(11),
     ];
@@ -160,11 +163,11 @@ fn test_format_for_panic() {
 
     // Valid string with a non printable character.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full word.
         Felt252::from(0),
         // pending word: 'Hello\x11world'
-        felt_str!("48656c6c6f11776f726c64", 16),
+        Felt252::from_hex_unchecked("48656c6c6f11776f726c64"),
         // pending word length
         Felt252::from(11),
     ];
@@ -172,11 +175,11 @@ fn test_format_for_panic() {
 
     // Valid string with a newline.
     let felts = vec![
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         // No full word.
         Felt252::from(0),
         // pending word: 'Hello\nworld'
-        felt_str!("48656c6c6f0a776f726c64", 16),
+        Felt252::from_hex_unchecked("48656c6c6f0a776f726c64"),
         // pending word length
         Felt252::from(11),
     ];
@@ -187,12 +190,12 @@ fn test_format_for_panic() {
         // felt: 0x9999
         Felt252::from(0x9999),
         // String: "hello"
-        felt_str!(BYTE_ARRAY_MAGIC, 16),
+        BYTE_ARRAY_MAGIC,
         Felt252::from(0),
-        felt_str!("68656c6c6f", 16),
+        Felt252::from_hex_unchecked("68656c6c6f"),
         Felt252::from(5),
         // Short string: 'world'
-        felt_str!("776f726c64", 16),
+        Felt252::from_hex_unchecked("776f726c64"),
         // felt: 0x8888
         Felt252::from(0x8888),
     ];

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -12,6 +12,8 @@ itertools = { workspace = true, features = ["use_alloc"] }
 num-bigint.workspace = true
 num-traits.workspace = true
 hashbrown = { workspace = true, features = ["serde"] }
+starknet-types-core = { workspace = true }
+
 
 # Optional
 serde = { workspace = true, features = ["alloc"], optional = true }
@@ -33,6 +35,7 @@ std = [
   "indexmap/std",
   "num-bigint/std",
   "num-traits/std",
+  "starknet-types-core/std",
   "serde?/std"
 ]
 serde = ["dep:serde", "num-bigint/serde", "indexmap/serde"]

--- a/crates/cairo-lang-utils/src/byte_array.rs
+++ b/crates/cairo-lang-utils/src/byte_array.rs
@@ -1,3 +1,5 @@
-pub const BYTE_ARRAY_MAGIC: &str =
-    "46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3";
+use starknet_types_core::felt::Felt as Felt252;
+
+pub const BYTE_ARRAY_MAGIC: Felt252 =
+    Felt252::from_hex_unchecked("46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3");
 pub const BYTES_IN_WORD: usize = 31;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,7 +8,7 @@ description = ""
 
 [dev-dependencies]
 assert_matches.workspace = true
-cairo-felt.workspace = true
+starknet-types-core = { workspace = true, default-features = true }
 cairo-lang-casm = { path = "../crates/cairo-lang-casm" }
 cairo-lang-compiler = { path = "../crates/cairo-lang-compiler" }
 cairo-lang-defs = { path = "../crates/cairo-lang-defs" }

--- a/tests/examples_test.rs
+++ b/tests/examples_test.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use assert_matches::assert_matches;
-use cairo_felt::{felt_str as felt252_str, Felt252};
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::setup_project;
@@ -22,6 +21,7 @@ use cairo_lang_test_utils::compare_contents_or_fix_with_path;
 use cairo_lang_utils::{extract_matches, Upcast};
 use itertools::Itertools;
 use rstest::{fixture, rstest};
+use starknet_types_core::felt::Felt as Felt252;
 
 type ExampleDirData = (Mutex<RootDatabase>, Vec<CrateId>);
 
@@ -212,7 +212,7 @@ fn run_function(
         .expect("Failed running the function.");
     if let Some(expected_cost) = expected_cost {
         assert_eq!(
-            available_gas.unwrap() - result.gas_counter.as_ref().unwrap(),
+            Felt252::from(available_gas.unwrap()) - result.gas_counter.as_ref().unwrap(),
             Felt252::from(expected_cost)
         );
     }
@@ -263,7 +263,7 @@ fn run_function(
 #[case::fib_u128_fail(
     "fib_u128",
     &[1, 1, 200].map(Felt252::from), None, None,
-    RunResultValue::Panic(vec![Felt252::from_bytes_be(b"u128_add Overflow")])
+    RunResultValue::Panic(vec![Felt252::from_bytes_be_slice(b"u128_add Overflow")])
 )]
 #[case::fib_local(
     "fib_local",
@@ -278,13 +278,13 @@ fn run_function(
 #[case::hash_chain(
     "hash_chain",
     &[3].map(Felt252::from), None, None,
-    RunResultValue::Success(vec![felt252_str!(
-        "2dca1ad81a6107a9ef68c69f791bcdbda1df257aab76bd43ded73d96ed6227d", 16)]))]
+    RunResultValue::Success(vec![Felt252::from_hex_unchecked(
+        "2dca1ad81a6107a9ef68c69f791bcdbda1df257aab76bd43ded73d96ed6227d")]))]
 #[case::hash_chain_gas(
     "hash_chain_gas",
     &[3].map(Felt252::from), Some(100000), Some(9880 + 3 * token_gas_cost(CostTokenType::Pedersen)),
-    RunResultValue::Success(vec![felt252_str!(
-        "2dca1ad81a6107a9ef68c69f791bcdbda1df257aab76bd43ded73d96ed6227d", 16)]))]
+    RunResultValue::Success(vec![Felt252::from_hex_unchecked(
+        "2dca1ad81a6107a9ef68c69f791bcdbda1df257aab76bd43ded73d96ed6227d")]))]
 fn run_function_test(
     #[case] name: &str,
     #[case] params: &[Felt252],
@@ -308,7 +308,7 @@ fn run_function_test(
 #[case::fib_fail(
     "fib",
     &[1, 1, 10].map(Felt252::from), Some(10000), None,
-    RunResultValue::Panic(vec![Felt252::from_bytes_be(b"Out of gas")])
+    RunResultValue::Panic(vec![Felt252::from_bytes_be_slice(b"Out of gas")])
 )]
 fn run_function_auto_gas_test(
     #[case] name: &str,


### PR DESCRIPTION
In the effort to homogenize the `Felt` type used across the Starknet rust ecosystem, this PR replaces the uses of the `cairo_felt::Felt252` type with the `starknet-types-cores::felt::Felt` type.

It is already used in the cairo-vm, and after this PR is merged, it will be in starknet-api and blockifier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5150)
<!-- Reviewable:end -->
