### PR TITLE
feat(lsp): add code action for unused variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
  "cairo-lang-utils",
+ "downcast-rs",
  "env_logger",
  "indoc",
  "itertools 0.11.0",
@@ -1373,6 +1374,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dyn-clone"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [profile.release]
-overflow-checks = true     # Enable integer overflow checks.
+overflow-checks = true # Enable integer overflow checks.
 
 [profile.release-with-debug]
 inherits = "release"
@@ -94,10 +94,11 @@ const_format = "0.2.32"
 convert_case = "0.6.0"
 derivative = "2.2.0"
 diffy = "0.3.0"
+downcast-rs = "1.2.0"
 env_logger = "0.10.0"
 genco = "0.17.8"
 good_lp = { version = "1.7.0", features = ["minilp"], default-features = false }
-hashbrown = "0.14.3" 
+hashbrown = "0.14.3"
 id-arena = "2.2.1"
 ignore = "0.4.20"
 indent = "0.1.1"
@@ -111,7 +112,9 @@ num-bigint = { version = "0.4", default-features = false }
 num-integer = "0.1"
 num-traits = { version = "0.2", default-features = false }
 once_cell = "1.18.0"
-parity-scale-codec = { version = "3.6.5", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "3.6.5", default-features = false, features = [
+    "derive",
+] }
 path-clean = "1.0.1"
 pretty_assertions = "1.4.0"
 proc-macro2 = "1.0"

--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -140,7 +140,7 @@ impl<'a> DiagnosticsReporter<'a> {
 
     /// Checks if a diagnostics group contains any diagnostics and reports them to the provided
     /// callback as strings. Returns `true` if diagnostics were found.
-    fn check_diag_group<TEntry: DiagnosticEntry>(
+    fn check_diag_group<TEntry: DiagnosticEntry + Clone>(
         &mut self,
         db: &TEntry::DbType,
         group: Diagnostics<TEntry>,

--- a/crates/cairo-lang-diagnostics/Cargo.toml
+++ b/crates/cairo-lang-diagnostics/Cargo.toml
@@ -10,6 +10,7 @@ description = "Diagnostic utilities."
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "2.5.4" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "2.5.4" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "2.5.4" }
+downcast-rs.workspace = true
 itertools = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Implements the LSP protocol over stdin/out.
 
+use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
@@ -1533,6 +1534,12 @@ fn get_diagnostics<T: DiagnosticEntry>(
                 message += &format!("\nnote: {}", note.text);
             }
         }
+        let diagnostic: &&T = diagnostic.borrow();
+        let kind = if let Some(diag) = diagnostic.as_any().downcast_ref::<ParserDiagnostic>() {
+            format!("{:?}", diag.kind)
+        } else {
+            return;
+        };
 
         diags.push(Diagnostic {
             range: get_range(db.upcast(), &diagnostic.location(db)),
@@ -1546,6 +1553,7 @@ fn get_diagnostics<T: DiagnosticEntry>(
                 Severity::Error => DiagnosticSeverity::ERROR,
                 Severity::Warning => DiagnosticSeverity::WARNING,
             }),
+            code: Some(NumberOrString::String(kind)),
             ..Diagnostic::default()
         });
     }

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -879,10 +879,7 @@ fn unused_variable(
     uri: Url,
 ) -> CodeAction {
     CodeAction {
-        title: format!(
-            "if this is intentional, prefix it with an underscore: `_{}`",
-            node.get_text(db.upcast())
-        ),
+        title: format!("Rename to `_{}`", node.get_text(db.upcast())),
         edit: Some(WorkspaceEdit {
             changes: Some(HashMap::from_iter([(
                 uri,

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -39,6 +39,7 @@ pub enum ParserDiagnosticKind {
     AttributesWithoutStatement,
     DisallowedTrailingSeparatorOr,
 }
+
 impl DiagnosticEntry for ParserDiagnostic {
     type DbType = dyn FilesGroup;
 


### PR DESCRIPTION
When an unused variable diagnostic is generated it's possible to use a code action to prefix it with an `_`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5151)
<!-- Reviewable:end -->
