### PR TITLE
feat: wrapping traits

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -3008,3 +3008,27 @@ impl U256OverflowingMul of core::num::traits::OverflowingMul<u256> {
         u256_overflow_mul(self, v)
     }
 }
+
+/// WrappingAdd implementations
+impl TWrappingAdd<T, +core::num::traits::OverflowingAdd<T>> of core::num::traits::WrappingAdd<T> {
+    fn wrapping_add(self: T, v: T) -> T {
+        let (result, _) = self.overflowing_add(v);
+        result
+    }
+}
+
+/// WrappingSub implementations
+impl TWrappingSub<T, +core::num::traits::OverflowingSub<T>> of core::num::traits::WrappingSub<T> {
+    fn wrapping_sub(self: T, v: T) -> T {
+        let (result, _) = self.overflowing_sub(v);
+        result
+    }
+}
+
+/// WrappingMul implementations
+impl TWrappingMul<T, +core::num::traits::OverflowingMul<T>> of core::num::traits::WrappingMul<T> {
+    fn wrapping_mul(self: T, v: T) -> T {
+        let (result, _) = self.overflowing_mul(v);
+        result
+    }
+}

--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -3010,25 +3010,35 @@ impl U256OverflowingMul of core::num::traits::OverflowingMul<u256> {
 }
 
 /// WrappingAdd implementations
-impl TWrappingAdd<T, +core::num::traits::OverflowingAdd<T>> of core::num::traits::WrappingAdd<T> {
-    fn wrapping_add(self: T, v: T) -> T {
-        let (result, _) = self.overflowing_add(v);
-        result
-    }
-}
+impl U8WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<u8>;
+impl U16WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<u16>;
+impl U32WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<u32>;
+impl U64WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<u64>;
+impl U128WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<u128>;
+impl U256WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<u256>;
+impl I8WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<i8>;
+impl I16WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<i16>;
+impl I32WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<i32>;
+impl I64WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<i64>;
+impl I128WrappingAdd = core::num::traits::ops::wrapping::overflow_based::TWrappingAdd<i128>;
 
 /// WrappingSub implementations
-impl TWrappingSub<T, +core::num::traits::OverflowingSub<T>> of core::num::traits::WrappingSub<T> {
-    fn wrapping_sub(self: T, v: T) -> T {
-        let (result, _) = self.overflowing_sub(v);
-        result
-    }
-}
+impl U8WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<u8>;
+impl U16WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<u16>;
+impl U32WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<u32>;
+impl U64WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<u64>;
+impl U128WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<u128>;
+impl U256WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<u256>;
+impl I8WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<i8>;
+impl I16WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<i16>;
+impl I32WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<i32>;
+impl I64WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<i64>;
+impl I128WrappingSub = core::num::traits::ops::wrapping::overflow_based::TWrappingSub<i128>;
 
 /// WrappingMul implementations
-impl TWrappingMul<T, +core::num::traits::OverflowingMul<T>> of core::num::traits::WrappingMul<T> {
-    fn wrapping_mul(self: T, v: T) -> T {
-        let (result, _) = self.overflowing_mul(v);
-        result
-    }
-}
+impl U8WrappingMul = core::num::traits::ops::wrapping::overflow_based::TWrappingMul<u8>;
+impl U16WrappingMul = core::num::traits::ops::wrapping::overflow_based::TWrappingMul<u16>;
+impl U32WrappingMul = core::num::traits::ops::wrapping::overflow_based::TWrappingMul<u32>;
+impl U64WrappingMul = core::num::traits::ops::wrapping::overflow_based::TWrappingMul<u64>;
+impl U128WrappingMul = core::num::traits::ops::wrapping::overflow_based::TWrappingMul<u128>;
+impl U256WrappingMul = core::num::traits::ops::wrapping::overflow_based::TWrappingMul<u256>;

--- a/corelib/src/num/traits.cairo
+++ b/corelib/src/num/traits.cairo
@@ -8,4 +8,5 @@ pub mod bit_size;
 pub use bit_size::BitSize;
 
 pub mod ops;
-pub use ops::{OverflowingAdd, OverflowingSub, OverflowingMul};
+pub use ops::overflowing::{OverflowingAdd, OverflowingSub, OverflowingMul};
+pub use ops::wrapping::{WrappingAdd, WrappingSub, WrappingMul};

--- a/corelib/src/num/traits/ops.cairo
+++ b/corelib/src/num/traits/ops.cairo
@@ -1,2 +1,2 @@
 pub mod overflowing;
-pub use overflowing::{OverflowingAdd, OverflowingSub, OverflowingMul};
+pub mod wrapping;

--- a/corelib/src/num/traits/ops/wrapping.cairo
+++ b/corelib/src/num/traits/ops/wrapping.cairo
@@ -18,3 +18,32 @@ pub trait WrappingMul<T> {
     /// of the type.
     fn wrapping_mul(self: T, v: T) -> T;
 }
+
+pub(crate) mod overflow_based {
+    pub(crate) impl TWrappingAdd<
+        T, +core::num::traits::OverflowingAdd<T>
+    > of core::num::traits::WrappingAdd<T> {
+        fn wrapping_add(self: T, v: T) -> T {
+            let (result, _) = self.overflowing_add(v);
+            result
+        }
+    }
+
+    pub(crate) impl TWrappingSub<
+        T, +core::num::traits::OverflowingSub<T>
+    > of core::num::traits::WrappingSub<T> {
+        fn wrapping_sub(self: T, v: T) -> T {
+            let (result, _) = self.overflowing_sub(v);
+            result
+        }
+    }
+
+    pub(crate) impl TWrappingMul<
+        T, +core::num::traits::OverflowingMul<T>
+    > of core::num::traits::WrappingMul<T> {
+        fn wrapping_mul(self: T, v: T) -> T {
+            let (result, _) = self.overflowing_mul(v);
+            result
+        }
+    }
+}

--- a/corelib/src/num/traits/ops/wrapping.cairo
+++ b/corelib/src/num/traits/ops/wrapping.cairo
@@ -1,0 +1,20 @@
+/// Performs addition that wraps around on overflow.
+pub trait WrappingAdd<T> {
+    /// Wrapping (modular) addition. Computes `self + other`, wrapping around at the boundary of the
+    /// type.
+    fn wrapping_add(self: T, v: T) -> T;
+}
+
+/// Performs subtraction that wraps around on overflow.
+pub trait WrappingSub<T> {
+    /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary of
+    /// the type.
+    fn wrapping_sub(self: T, v: T) -> T;
+}
+
+/// Performs multiplication that wraps around on overflow.
+pub trait WrappingMul<T> {
+    /// Wrapping (modular) multiplication. Computes `self * other`, wrapping around at the boundary
+    /// of the type.
+    fn wrapping_mul(self: T, v: T) -> T;
+}

--- a/corelib/src/test/num_test.cairo
+++ b/corelib/src/test/num_test.cairo
@@ -1,5 +1,7 @@
 use core::num::traits::BitSize;
-use core::num::traits::{OverflowingAdd, OverflowingSub, OverflowingMul};
+use core::num::traits::{
+    OverflowingAdd, OverflowingSub, OverflowingMul, WrappingAdd, WrappingSub, WrappingMul
+};
 use core::integer::BoundedInt;
 
 
@@ -18,6 +20,8 @@ fn test_bit_size() {
     assert!(BitSize::<i128>::bits() == 128);
     assert!(BitSize::<bytes31>::bits() == 248);
 }
+
+// Overflowing tests
 
 #[test]
 fn tests_overflowing_add_unsigned_integers() {
@@ -124,4 +128,110 @@ fn test_overflowing_mul_unsigned_integers() {
     assert_eq!(BoundedInt::<u128>::max().overflowing_mul(2), (BoundedInt::<u128>::max() - 1, true));
     assert_eq!(2_u256.overflowing_mul(3), (6, false));
     assert_eq!(BoundedInt::<u256>::max().overflowing_mul(2), (BoundedInt::<u256>::max() - 1, true));
+}
+
+// Wrapping tests
+
+#[test]
+fn tests_wrapping_add_unsigned_integers() {
+    assert_eq!(1_u8.wrapping_add(2), 3);
+    assert_eq!(BoundedInt::<u8>::max().wrapping_add(1), 0);
+    assert_eq!(1_u16.wrapping_add(2), 3);
+    assert_eq!(BoundedInt::<u16>::max().wrapping_add(1), 0);
+    assert_eq!(1_u32.wrapping_add(2), 3);
+    assert_eq!(BoundedInt::<u32>::max().wrapping_add(1), 0);
+    assert_eq!(1_u64.wrapping_add(2), 3);
+    assert_eq!(BoundedInt::<u64>::max().wrapping_add(1), 0);
+    assert_eq!(1_u128.wrapping_add(2), 3);
+    assert_eq!(BoundedInt::<u128>::max().wrapping_add(1), 0);
+    assert_eq!(1_u256.wrapping_add(2), 3);
+    assert_eq!(BoundedInt::<u256>::max().wrapping_add(1), 0);
+}
+
+#[test]
+fn test_wrapping_add_positive_signed_integers() {
+    assert!(1_i8.wrapping_add(2) == 3);
+    assert!(BoundedInt::<i8>::max().wrapping_add(1) == -0x80);
+    assert!(1_i16.wrapping_add(2) == 3);
+    assert!(BoundedInt::<i16>::max().wrapping_add(1) == -0x8000);
+    assert!(1_i32.wrapping_add(2) == 3);
+    assert!(BoundedInt::<i32>::max().wrapping_add(1) == -0x80000000);
+    assert!(1_i64.wrapping_add(2) == 3);
+    assert!(BoundedInt::<i64>::max().wrapping_add(1) == -0x8000000000000000);
+    assert!(1_i128.wrapping_add(2) == 3);
+    assert!(BoundedInt::<i128>::max().wrapping_add(1) == -0x80000000000000000000000000000000);
+}
+
+#[test]
+fn test_wrapping_add_negative_signed_integers() {
+    assert!((-1_i8).wrapping_add(-2) == -3);
+    assert!(BoundedInt::<i8>::min().wrapping_add(-1) == 0x7f);
+    assert!((-1_i16).wrapping_add(-2) == -3);
+    assert!(BoundedInt::<i16>::min().wrapping_add(-1) == 0x7fff);
+    assert!((-1_i32).wrapping_add(-2) == -3);
+    assert!(BoundedInt::<i32>::min().wrapping_add(-1) == 0x7fffffff);
+    assert!((-1_i64).wrapping_add(-2) == -3);
+    assert!(BoundedInt::<i64>::min().wrapping_add(-1) == 0x7fffffffffffffff);
+    assert!((-1_i128).wrapping_add(-2) == -3);
+    assert!(BoundedInt::<i128>::min().wrapping_add(-1) == 0x7fffffffffffffffffffffffffffffff);
+}
+
+#[test]
+fn test_wrapping_sub_unsigned_integers() {
+    assert_eq!(3_u8.wrapping_sub(2), 1);
+    assert_eq!(0_u8.wrapping_sub(1), BoundedInt::<u8>::max());
+    assert_eq!(3_u16.wrapping_sub(2), 1);
+    assert_eq!(0_u16.wrapping_sub(1), BoundedInt::<u16>::max());
+    assert_eq!(3_u32.wrapping_sub(2), 1);
+    assert_eq!(0_u32.wrapping_sub(1), BoundedInt::<u32>::max());
+    assert_eq!(3_u64.wrapping_sub(2), 1);
+    assert_eq!(0_u64.wrapping_sub(1), BoundedInt::<u64>::max());
+    assert_eq!(3_u128.wrapping_sub(2), 1);
+    assert_eq!(0_u128.wrapping_sub(1), BoundedInt::<u128>::max());
+    assert_eq!(3_u256.wrapping_sub(2), 1);
+    assert_eq!(0_u256.wrapping_sub(1), BoundedInt::<u256>::max());
+}
+
+#[test]
+fn test_wrapping_sub_positive_signed_integers() {
+    assert!(3_i8.wrapping_sub(2) == 1);
+    assert!(BoundedInt::<i8>::min().wrapping_sub(1) == BoundedInt::<i8>::max());
+    assert!(3_i16.wrapping_sub(2) == 1);
+    assert!(BoundedInt::<i16>::min().wrapping_sub(1) == BoundedInt::<i16>::max());
+    assert!(3_i32.wrapping_sub(2) == 1);
+    assert!(BoundedInt::<i32>::min().wrapping_sub(1) == BoundedInt::<i32>::max());
+    assert!(3_i64.wrapping_sub(2) == 1);
+    assert!(BoundedInt::<i64>::min().wrapping_sub(1) == BoundedInt::<i64>::max());
+    assert!(3_i128.wrapping_sub(2) == 1);
+    assert!(BoundedInt::<i128>::min().wrapping_sub(1) == BoundedInt::<i128>::max());
+}
+
+#[test]
+fn test_wrapping_sub_negative_signed_integers() {
+    assert!((-3_i8).wrapping_sub(-2) == -1);
+    assert!(BoundedInt::<i8>::max().wrapping_sub(-1) == BoundedInt::<i8>::min());
+    assert!((-3_i16).wrapping_sub(-2) == -1);
+    assert!(BoundedInt::<i16>::max().wrapping_sub(-1) == BoundedInt::<i16>::min());
+    assert!((-3_i32).wrapping_sub(-2) == -1);
+    assert!(BoundedInt::<i32>::max().wrapping_sub(-1) == BoundedInt::<i32>::min());
+    assert!((-3_i64).wrapping_sub(-2) == -1);
+    assert!(BoundedInt::<i64>::max().wrapping_sub(-1) == BoundedInt::<i64>::min());
+    assert!((-3_i128).wrapping_sub(-2) == -1);
+    assert!(BoundedInt::<i128>::max().wrapping_sub(-1) == BoundedInt::<i128>::min());
+}
+
+#[test]
+fn test_wrapping_mul_unsigned_integers() {
+    assert_eq!(2_u8.wrapping_mul(3), 6);
+    assert_eq!(BoundedInt::<u8>::max().wrapping_mul(2), BoundedInt::<u8>::max() - 1);
+    assert_eq!(2_u16.wrapping_mul(3), 6);
+    assert_eq!(BoundedInt::<u16>::max().wrapping_mul(2), BoundedInt::<u16>::max() - 1);
+    assert_eq!(2_u32.wrapping_mul(3), 6);
+    assert_eq!(BoundedInt::<u32>::max().wrapping_mul(2), BoundedInt::<u32>::max() - 1);
+    assert_eq!(2_u64.wrapping_mul(3), 6);
+    assert_eq!(BoundedInt::<u64>::max().wrapping_mul(2), BoundedInt::<u64>::max() - 1);
+    assert_eq!(2_u128.wrapping_mul(3), 6);
+    assert_eq!(BoundedInt::<u128>::max().wrapping_mul(2), BoundedInt::<u128>::max() - 1);
+    assert_eq!(2_u256.wrapping_mul(3), 6);
+    assert_eq!(BoundedInt::<u256>::max().wrapping_mul(2), BoundedInt::<u256>::max() - 1);
 }


### PR DESCRIPTION
Added traits for wrapping arithmetic operations, based on the overflowing operations.
Removed reexporting from the `ops` module, to only have it at the `num::traits` level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5175)
<!-- Reviewable:end -->
