### PR TITLE
Re-use `Display` impl for diagnostics in formatter's `ParsingError`

### DIFF
--- a/crates/cairo-lang-diagnostics/src/diagnostics_test.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics_test.rs
@@ -8,6 +8,7 @@ use indoc::indoc;
 use test_log::test;
 
 use super::{DiagnosticEntry, DiagnosticLocation, DiagnosticsBuilder};
+use crate::{error_code, ErrorCode};
 
 // Test diagnostic.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -29,6 +30,10 @@ impl DiagnosticEntry for SimpleDiag {
                 end: TextOffset::default().add_width(TextWidth::new_for_testing(6)),
             },
         }
+    }
+
+    fn error_code(&self) -> Option<ErrorCode> {
+        Some(error_code!(E0001))
     }
 }
 
@@ -55,7 +60,7 @@ fn test_diagnostics() {
     assert_eq!(
         diagnostics.build().format(&db_val),
         indoc! { "
-            error: Simple diagnostic.
+            error[E0001]: Simple diagnostic.
              --> dummy_file.sierra:1:1
             abcd
             ^**^

--- a/crates/cairo-lang-diagnostics/src/error_code.rs
+++ b/crates/cairo-lang-diagnostics/src/error_code.rs
@@ -1,0 +1,76 @@
+use std::fmt;
+
+/// The unique and never-changing identifier of an error or warning.
+///
+/// For example: `E0001`, `W1234`.
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct ErrorCode(&'static str);
+
+impl ErrorCode {
+    /// Create a new error code.
+    ///
+    /// Valid error codes must start with capital `E` or `W` followed by 4 decimal digits.
+    /// For example: `E0001`, `W1234`.
+    ///
+    /// ## Panics
+    ///
+    /// This function will panic if the `code` does not match error code patter.
+    pub const fn new(code: &'static str) -> Self {
+        assert!(
+            matches!(
+                code.as_bytes(),
+                [b'E' | b'W', b'0'..=b'9', b'0'..=b'9', b'0'..=b'9', b'0'..=b'9']
+            ),
+            "Error codes must start with capital `E` or `W` followed by 4 decimal digits."
+        );
+        Self(code)
+    }
+
+    /// Format this error code in a way that is suitable for display in error message.
+    ///
+    /// ```
+    /// # use cairo_lang_diagnostics::error_code;
+    /// assert_eq!(error_code!(E0001).format_bracketed(), "[E0001]");
+    /// ```
+    pub fn format_bracketed(self) -> String {
+        format!("[{}]", self)
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.0, f)
+    }
+}
+
+/// Constructs an [`ErrorCode`].
+///
+/// ```
+/// # use cairo_lang_diagnostics::{error_code, ErrorCode};
+/// let code: ErrorCode = error_code!(E0001);
+/// # assert_eq!(format!("{code}"), "E0001");
+/// ```
+#[macro_export]
+macro_rules! error_code {
+    ($code:expr) => {
+        $crate::ErrorCode::new(stringify!($code))
+    };
+}
+
+/// Utilities for `Option<ErrorCode>`.
+pub trait OptionErrorCodeExt {
+    fn format_bracketed(self) -> String;
+}
+
+impl OptionErrorCodeExt for Option<ErrorCode> {
+    /// Format this error code in a way that is suitable for display in error message.
+    ///
+    /// ```
+    /// # use cairo_lang_diagnostics::{error_code, OptionErrorCodeExt};
+    /// assert_eq!(Some(error_code!(E0001)).format_bracketed(), "[E0001]");
+    /// assert_eq!(None.format_bracketed(), "");
+    /// ```
+    fn format_bracketed(self) -> String {
+        self.map(ErrorCode::format_bracketed).unwrap_or_default()
+    }
+}

--- a/crates/cairo-lang-diagnostics/src/lib.rs
+++ b/crates/cairo-lang-diagnostics/src/lib.rs
@@ -1,12 +1,14 @@
 //! Diagnostics hold error information from around the compiler, associated with a location to the
 //! source files.
 
-mod diagnostics;
-mod location_marks;
-
-pub use self::diagnostics::{
+pub use diagnostics::{
     format_diagnostics, skip_diagnostic, DiagnosticAdded, DiagnosticEntry, DiagnosticLocation,
     DiagnosticNote, Diagnostics, DiagnosticsBuilder, FormattedDiagnosticEntry, Maybe, Severity,
     ToMaybe, ToOption,
 };
-pub use self::location_marks::get_location_marks;
+pub use error_code::{ErrorCode, OptionErrorCodeExt};
+pub use location_marks::get_location_marks;
+
+mod diagnostics;
+mod error_code;
+mod location_marks;

--- a/crates/cairo-lang-formatter/src/cairo_formatter.rs
+++ b/crates/cairo-lang-formatter/src/cairo_formatter.rs
@@ -122,7 +122,7 @@ impl From<Vec<FormattedDiagnosticEntry>> for ParsingError {
 impl Display for ParsingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for entry in &self.0 {
-            writeln!(f, "{}: {}", entry.severity(), entry.message())?;
+            writeln!(f, "{entry}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
**Stack**:
- #5179
- #5178 ⬅
- #5177


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5178)
<!-- Reviewable:end -->
