### PR TITLE
Re-use `Display` impl for diagnostics in formatter's `ParsingError`

### DIFF
--- a/crates/cairo-lang-formatter/src/cairo_formatter.rs
+++ b/crates/cairo-lang-formatter/src/cairo_formatter.rs
@@ -122,7 +122,7 @@ impl From<Vec<FormattedDiagnosticEntry>> for ParsingError {
 impl Display for ParsingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for entry in &self.0 {
-            writeln!(f, "{}: {}", entry.severity(), entry.message())?;
+            writeln!(f, "{entry}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
**Stack**:
- #5196
- #5181 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5181)
<!-- Reviewable:end -->
