### PR TITLE
LS: Replace remaining `eprintln!` calls to logger incantations

### DIFF
--- a/crates/cairo-lang-language-server/src/completions.rs
+++ b/crates/cairo-lang-language-server/src/completions.rs
@@ -20,6 +20,7 @@ use cairo_lang_semantic::{ConcreteTypeId, Pattern, TypeLongId};
 use cairo_lang_syntax::node::ast::PathSegment;
 use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Position, Range, TextEdit};
+use tracing::debug;
 
 use crate::{find_node_module, from_pos};
 
@@ -208,7 +209,7 @@ pub fn dot_completions(
     // Get the type.
     let ty = semantic_expr.ty();
     if ty.is_missing(db) {
-        eprintln!("Type is missing");
+        debug!("type is missing");
         return None;
     }
 
@@ -337,7 +338,7 @@ fn find_methods_for_type(
                 Some(stable_ptr),
                 |_| {},
             ) else {
-                eprintln!("Can't fit");
+                debug!("can't fit");
                 continue;
             };
 


### PR DESCRIPTION
**Stack**:
- #5201
- #5200
- #5199 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5199)
<!-- Reviewable:end -->
