### PR TITLE
feat(lsp): show rust doc when hovering over things

### DIFF
--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -102,10 +102,10 @@ pub trait DefsGroup:
     /// Gets the directory of a module.
     fn module_dir(&self, module_id: ModuleId) -> Maybe<Directory>;
 
-    // TODO: test that
+    // TODO(Marek): test that
     /// Gets the documentation above an item definition.
     fn get_item_documentation(&self, item_id: LookupItemId) -> Option<String>;
-    // TODO: test that
+    // TODO(Marek): test that
     /// Gets the the definition of an item.
     fn get_item_definition(&self, item_id: LookupItemId) -> String;
 

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -312,7 +312,7 @@ fn get_item_definition(db: &dyn DefsGroup, item_id: LookupItemId) -> String {
         | SyntaxKind::TraitItemFunction
         | SyntaxKind::ItemTypeAlias
         | SyntaxKind::ItemImplAlias => syntax_node.clone().get_text_without_trivia(db.upcast()),
-        SyntaxKind::FunctionWithBody => {
+        SyntaxKind::FunctionWithBody | SyntaxKind::ItemExternFunction => {
             let children =
                 <dyn DefsGroup as Upcast<dyn SyntaxGroup>>::upcast(db).get_children(syntax_node);
             children[1..]
@@ -322,17 +322,21 @@ fn get_item_definition(db: &dyn DefsGroup, item_id: LookupItemId) -> String {
                     (kind != SyntaxKind::ExprBlock
                         && kind != SyntaxKind::ImplBody
                         && kind != SyntaxKind::TraitBody)
-                        .then_some(if kind == SyntaxKind::VisibilityPub {
-                            node.clone().get_text_without_trivia(db.upcast()).trim().to_owned()
-                                + " "
-                        } else {
-                            node.clone()
-                                .get_text_without_trivia(db.upcast())
-                                .lines()
-                                .map(|line| line.trim())
-                                .collect::<Vec<&str>>()
-                                .join("")
-                        })
+                        .then_some(
+                            if kind == SyntaxKind::VisibilityPub
+                                || kind == SyntaxKind::TerminalExtern
+                            {
+                                node.clone().get_text_without_trivia(db.upcast()).trim().to_owned()
+                                    + " "
+                            } else {
+                                node.clone()
+                                    .get_text_without_trivia(db.upcast())
+                                    .lines()
+                                    .map(|line| line.trim())
+                                    .collect::<Vec<&str>>()
+                                    .join("")
+                            },
+                        )
                 })
                 .collect::<Vec<String>>()
                 .join("")

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -102,8 +102,10 @@ pub trait DefsGroup:
     /// Gets the directory of a module.
     fn module_dir(&self, module_id: ModuleId) -> Maybe<Directory>;
 
+    // TODO: test that
     /// Gets the documentation above an item definition.
     fn get_item_documentation(&self, item_id: LookupItemId) -> Option<String>;
+    // TODO: test that
     /// Gets the the definition of an item.
     fn get_item_definition(&self, item_id: LookupItemId) -> String;
 

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -102,10 +102,10 @@ pub trait DefsGroup:
     /// Gets the directory of a module.
     fn module_dir(&self, module_id: ModuleId) -> Maybe<Directory>;
 
-    // TODO(Marek): test that
+    // TODO(mkaput): Add tests.
     /// Gets the documentation above an item definition.
     fn get_item_documentation(&self, item_id: LookupItemId) -> Option<String>;
-    // TODO(Marek): test that
+    // TODO(mkaput): Add tests.
     /// Gets the the definition of an item.
     fn get_item_definition(&self, item_id: LookupItemId) -> String;
 

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -1440,6 +1440,7 @@ fn get_identifier_hint(
     Some(format!("`{}`", item.full_path(db)))
 }
 
+// TODO: test this
 /// If the node is an expression, retrieves a hover hint for it.
 #[tracing::instrument(level = "trace", skip_all)]
 fn get_expr_hint(db: &dyn DefsGroup, lookup_item_id: LookupItemId) -> Option<Vec<MarkedString>> {

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -1727,6 +1727,17 @@ fn get_diagnostics<T: DiagnosticEntry>(
     }
 }
 
+/// Returns the file id and span of the definition of an expression from its position.
+///
+/// # Arguments
+///
+/// * `db` - Preloaded compilation database
+/// * `uri` - Uri of the expression position
+/// * `position` - Position of the expression
+///
+/// # Returns
+///
+/// The [FileId] and [TextSpan] of the expression definition if found.
 pub fn get_definition_location(
     db: &RootDatabase,
     uri: Url,

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -1440,7 +1440,6 @@ fn get_identifier_hint(
     Some(format!("`{}`", item.full_path(db)))
 }
 
-// TODO: test this
 /// If the node is an expression, retrieves a hover hint for it.
 #[tracing::instrument(level = "trace", skip_all)]
 fn get_expr_hint(db: &dyn DefsGroup, lookup_item_id: LookupItemId) -> Option<Vec<MarkedString>> {

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -877,7 +877,7 @@ impl LanguageServer for Backend {
     async fn hover(&self, params: HoverParams) -> LSPResult<Option<Hover>> {
         self.with_db(|db| {
             let file_uri = params.text_document_position_params.text_document.uri;
-            let file_id = file(db, file_uri.clone());
+            let file_id = file(db, file_uri);
             let position = params.text_document_position_params.position;
             let (node, lookup_items) = get_node_and_lookup_items(db, file_id, position)?;
             let lookup_item_id = lookup_items.into_iter().next()?;
@@ -893,11 +893,20 @@ impl LanguageServer for Backend {
                 }
             };
 
+            // Get the item id of the definition.
+            let (found_file, span) = get_definition_location(db, file_id, position)?;
+            // Get the documentation and declaration of the item.
+            let (_, lookup_items) = get_node_and_lookup_items(
+                db,
+                found_file,
+                from_pos(span.start.position_in_file(db.upcast(), found_file)?),
+            )?;
             // Build texts.
             let mut hints = Vec::new();
             if let Some(hint) = get_pattern_hint(db, function_id, node.clone()) {
                 hints.push(MarkedString::String(hint));
-            } else if let Some(hint) = get_expr_hint(db, file_id, position) {
+            } else if let Some(hint) = get_expr_hint(db.upcast(), lookup_items.into_iter().next()?)
+            {
                 hints.extend(hint);
             };
             if let Some(hint) = get_identifier_hint(db, lookup_item_id, node) {
@@ -1453,79 +1462,43 @@ fn get_identifier_hint(
 
 /// If the node is an expression, retrieves a hover hint for it.
 #[tracing::instrument(level = "trace", skip_all)]
-fn get_expr_hint(db: &RootDatabase, file: FileId, position: Position) -> Option<Vec<MarkedString>> {
+fn get_expr_hint(db: &dyn DefsGroup, lookup_item_id: LookupItemId) -> Option<Vec<MarkedString>> {
     let mut hints = vec![];
-    // We'll do the following. Let's consider this case:
-    // /// abc
-    // fn abc() {}
-    //
-    // let _ = abc();
-    // If we hover over the function call `abc()`
-    // we get the location of the `abc` function definition. The we get the first node of the
-    // definition (here `fn`) and we get the text with trivia from this node so `/// abc\n fn`
-    // And then we properly format it.
-
-    // Find the definition of the expression.
-    let (file_id, text_span) = get_definition_location(db, file, position)?;
-    // Get the content of the file where the expression is defined.
-    let file_content = db.file_content(file_id)?;
-    // Get the definition string and format it in a single line.
-    let func = text_span.take(&file_content);
-    let func = func
-        .find('{')
-        .map_or_else(|| func.trim().to_string(), |index| func[..index].trim_end().to_string())
-        .lines()
-        .skip_while(|line| !line.trim_start().chars().next().unwrap().is_alphabetic()) // Remove macros above definition
-        .map(|line| line.trim().to_string())
-        .collect::<String>();
-    // Format the definition as a cairo string.
-    hints.push(MarkedString::from_language_code("cairo".to_owned(), func.to_owned()));
+    let (definition, documentation) = db.documentation_with_definition(lookup_item_id);
+    hints.push(MarkedString::from_language_code("cairo".to_owned(), definition));
     // Add a separator.
     hints.push(MarkedString::String("\n---\n".to_string()));
-    // Get the position of the first node of the expression definition.
-    let first_node_pos = from_pos(text_span.start.position_in_file(db.upcast(), file_id).unwrap());
-    // Get the first node of the definition.
-    let (node, _lookup_items) = get_node_and_lookup_items(db, file_id, first_node_pos)?;
-    // Get its parent to get the trivia.
-    if let Some(parent_node) = node.parent() {
-        let mut is_cairo_string = false;
-        // Get the trivia and remove the node text.
-        let lines = if let Some(split) = parent_node.get_text(db.upcast()).rsplit_once('\n') {
-            split.0.to_string()
-        } else {
-            "".to_string()
-        };
-        let mut doc = "".to_string();
-        for line in lines.lines() {
-            // Skip everything else than doc
-            if !line.trim_start().starts_with("///") {
-                continue;
-            }
-            // Remove the leading whitespaces and `///`
-            let line = line.trim().trim_start_matches("///").trim_start().to_string();
-            // If we reach ``` it means that we either begin a code section or end a code section.
-            if line.starts_with("```") {
-                // If is_cairo_string is true it means that we end the code block so append the code
-                // in a cairo formatted string.
-                hints.push(if is_cairo_string {
-                    MarkedString::from_language_code("cairo".to_owned(), doc)
-                } else {
-                    // else append a regular string.
-                    MarkedString::from_markdown(doc)
-                });
-                // Switch the variable to properly format the following block.
-                is_cairo_string = !is_cairo_string;
-                // reset the string to start the next block.
-                doc = "".to_string();
-                continue;
-            }
-            // Append the current block string.
-            doc += line.as_str();
-            // add new line to have a proper formatting.
-            doc += "\n";
+    let mut doc = "".to_string();
+    let mut is_cairo_string = false;
+    for line in documentation.lines() {
+        if line.starts_with("```") {
+            // If is_cairo_string is true it means that we end the code block so append the code
+            // in a cairo formatted string.
+            hints.push(if is_cairo_string {
+                MarkedString::from_language_code("cairo".to_owned(), doc)
+            } else {
+                // else append a regular string.
+                MarkedString::from_markdown(doc)
+            });
+            // Switch the variable to properly format the following block.
+            is_cairo_string = !is_cairo_string;
+            // reset the string to start the next block.
+            doc = "".to_string();
+            continue;
         }
-        hints.push(MarkedString::from_markdown(doc));
+        // Append the current block string.
+        doc += if let Some(stripped) = line.strip_prefix("///") {
+            stripped
+        } else if let Some(stripped) = line.strip_prefix("//!") {
+            stripped
+        } else {
+            line
+        };
+        // add new line to have a proper formatting.
+        doc += "\n";
     }
+    hints.push(MarkedString::from_markdown(doc));
+
     Some(hints)
 }
 

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -1446,9 +1446,11 @@ fn get_expr_hint(db: &dyn DefsGroup, lookup_item_id: LookupItemId) -> Option<Vec
     let mut hints = vec![];
     let definition = db.get_item_definition(lookup_item_id);
     hints.push(MarkedString::from_language_code("cairo".to_owned(), definition));
+    let documentation = db.get_item_documentation(lookup_item_id).unwrap_or_default();
     // Add a separator.
-    hints.push(MarkedString::String("\n---\n".to_string()));
-    let documentation = db.get_item_documentation(lookup_item_id);
+    if !documentation.is_empty() {
+        hints.push(MarkedString::String("\n---\n".to_string()));
+    }
     let mut doc = "".to_string();
     let mut is_cairo_string = false;
     for line in documentation.lines() {

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -30,7 +30,7 @@ use cairo_lang_filesystem::db::{
 };
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::ids::{CrateId, CrateLongId, Directory, FileId, FileLongId};
-use cairo_lang_filesystem::span::{FileSummary, TextOffset, TextPosition, TextWidth};
+use cairo_lang_filesystem::span::{FileSummary, TextOffset, TextPosition, TextSpan, TextWidth};
 use cairo_lang_formatter::{get_formatted_file, FormatterConfig};
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::diagnostic::LoweringDiagnostic;
@@ -43,7 +43,7 @@ use cairo_lang_semantic::items::functions::GenericFunctionId;
 use cairo_lang_semantic::items::imp::ImplId;
 use cairo_lang_semantic::items::us::get_use_segments;
 use cairo_lang_semantic::resolve::{AsSegments, ResolvedConcreteItem, ResolvedGenericItem};
-use cairo_lang_semantic::{Mutability, SemanticDiagnostic, TypeLongId};
+use cairo_lang_semantic::{SemanticDiagnostic, TypeLongId};
 use cairo_lang_starknet::starknet_plugin_suite;
 use cairo_lang_syntax::node::ast::PathSegment;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -877,7 +877,7 @@ impl LanguageServer for Backend {
     async fn hover(&self, params: HoverParams) -> LSPResult<Option<Hover>> {
         self.with_db(|db| {
             let file_uri = params.text_document_position_params.text_document.uri;
-            let file_id = file(db, file_uri);
+            let file_id = file(db, file_uri.clone());
             let position = params.text_document_position_params.position;
             let (node, lookup_items) = get_node_and_lookup_items(db, file_id, position)?;
             let lookup_item_id = lookup_items.into_iter().next()?;
@@ -897,8 +897,8 @@ impl LanguageServer for Backend {
             let mut hints = Vec::new();
             if let Some(hint) = get_pattern_hint(db, function_id, node.clone()) {
                 hints.push(MarkedString::String(hint));
-            } else if let Some(hint) = get_expr_hint(db, function_id, node.clone()) {
-                hints.push(hint);
+            } else if let Some(hint) = get_expr_hint(db, file_uri, position) {
+                hints.extend(hint);
             };
             if let Some(hint) = get_identifier_hint(db, lookup_item_id, node) {
                 hints.push(MarkedString::String(hint));
@@ -915,29 +915,13 @@ impl LanguageServer for Backend {
         params: GotoDefinitionParams,
     ) -> LSPResult<Option<GotoDefinitionResponse>> {
         self.with_db(|db| {
-            let syntax_db = db.upcast();
             let file_uri = params.text_document_position_params.text_document.uri;
-            let file = file(db, file_uri.clone());
             let position = params.text_document_position_params.position;
-            let (node, lookup_items) = get_node_and_lookup_items(db, file, position)?;
-            if node.kind(syntax_db) != SyntaxKind::TokenIdentifier {
-                return None;
-            }
-            let identifier =
-                ast::TerminalIdentifier::from_syntax_node(syntax_db, node.parent().unwrap());
-            let stable_ptr = find_definition(db, file, &identifier, &lookup_items)?;
-            let node = stable_ptr.lookup(syntax_db);
-            let found_file = stable_ptr.file_id(syntax_db);
-            let span = node.span_without_trivia(syntax_db);
-            let width = span.width();
-            let (found_file, span) =
-                get_originating_location(db.upcast(), found_file, span.start_only());
+            let (found_file, span) = get_definition_location(db, file_uri, position)?;
             let found_uri = get_uri(db, found_file);
 
             let start = from_pos(span.start.position_in_file(db.upcast(), found_file).unwrap());
-            let end = from_pos(
-                span.end.add_width(width).position_in_file(db.upcast(), found_file).unwrap(),
-            );
+            let end = from_pos(span.end.position_in_file(db.upcast(), found_file).unwrap());
             Some(GotoDefinitionResponse::Scalar(Location {
                 uri: found_uri,
                 range: Range { start, end },
@@ -1469,45 +1453,83 @@ fn get_identifier_hint(
 /// If the node is an expression, retrieves a hover hint for it.
 #[tracing::instrument(level = "trace", skip_all)]
 fn get_expr_hint(
-    db: &(dyn SemanticGroup + 'static),
-    function_id: FunctionWithBodyId,
-    node: SyntaxNode,
-) -> Option<MarkedString> {
-    let semantic_expr = nearest_semantic_expr(db, node, function_id)?;
-    let text = match semantic_expr {
-        cairo_lang_semantic::Expr::FunctionCall(call) => {
-            let args = if let Ok(signature) =
-                call.function.get_concrete(db).generic_function.generic_signature(db.upcast())
-            {
-                signature
-                    .params
-                    .iter()
-                    .map(|arg| {
-                        let mutability = match arg.mutability {
-                            Mutability::Immutable => "",
-                            Mutability::Mutable => "mut ",
-                            Mutability::Reference => "ref ",
-                        };
-                        format!("{mutability}{}: {}", arg.name, arg.ty.format(db.upcast()))
-                    })
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            } else {
-                "".to_owned()
-            };
-            let mut s = format!(
-                "fn {}({}) -> {}",
-                call.function.name(db.upcast()),
-                args,
-                call.ty.format(db.upcast())
-            );
-            s.retain(|c| c != '"');
-            s
+    db: &RootDatabase,
+    file_uri: Url,
+    position: Position,
+) -> Option<Vec<MarkedString>> {
+    let mut hints = vec![];
+    // We'll do the following. Let's consider this case:
+    // /// abc
+    // fn abc() {}
+    //
+    // let _ = abc();
+    // If we hover over the function call `abc()`
+    // we get the location of the `abc` function definition. The we get the first node of the
+    // definition (here `fn`) and we get the text with trivia from this node so `/// abc\n fn`
+    // And then we properly format it.
+
+    // Find the definition of the expression.
+    let (file_id, text_span) = get_definition_location(db, file_uri, position)?;
+    // Get the content of the file where the expression is defined.
+    let file_content = db.file_content(file_id)?;
+    // Get the definition string and format it in a single line.
+    let func = text_span.take(&file_content);
+    let func = func
+        .find('{')
+        .map_or_else(|| func.trim().to_string(), |index| func[..index].trim_end().to_string())
+        .lines()
+        .skip_while(|line| !line.trim_start().chars().next().unwrap().is_alphabetic())
+        .map(|line| line.trim().to_string())
+        .collect::<String>();
+    // Format the definition as a cairo string.
+    hints.push(MarkedString::from_language_code("cairo".to_owned(), func.to_owned()));
+    // Add a separator.
+    hints.push(MarkedString::String("\n---\n".to_string()));
+    // Get the position of the first node of the expression definition.
+    let first_node_pos = from_pos(text_span.start.position_in_file(db.upcast(), file_id).unwrap());
+    // Get the first node of the definition.
+    let (node, _lookup_items) = get_node_and_lookup_items(db, file_id, first_node_pos)?;
+    // Get its parent to get the trivia.
+    if let Some(parent_node) = node.parent() {
+        let mut is_cairo_string = false;
+        // Get the trivia and remove the node text.
+        let lines = if let Some(split) = parent_node.get_text(db.upcast()).rsplit_once('\n') {
+            split.0.to_string()
+        } else {
+            "".to_string()
+        };
+        let mut doc = "".to_string();
+        for line in lines.lines() {
+            // Skip everything else than doc
+            if !line.trim_start().starts_with("///") {
+                continue;
+            }
+            // Remove the leading whitespaces and `///`
+            let line = line.trim().trim_start_matches("///").trim_start().to_string();
+            // If we reach ``` it means that we either begin a code section or end a code section.
+            if line.starts_with("```") {
+                // If is_cairo_string is true it means that we end the code block so append the code
+                // in a cairo formatted string.
+                hints.push(if is_cairo_string {
+                    MarkedString::from_language_code("cairo".to_owned(), doc)
+                } else {
+                    // else append a regular string.
+                    MarkedString::from_markdown(doc)
+                });
+                // Switch the variable to properly format the following block.
+                is_cairo_string = !is_cairo_string;
+                // reset the string to start the next block.
+                doc = "".to_string();
+                continue;
+            }
+            // Append the current block string.
+            doc += line.as_str();
+            // add new line to have a proper formatting.
+            doc += "\n";
         }
-        _ => semantic_expr.ty().format(db),
-    };
-    // Format the hover text.
-    Some(MarkedString::from_language_code("cairo".to_owned(), text))
+        hints.push(MarkedString::from_markdown(doc));
+    }
+    Some(hints)
 }
 
 /// Returns the semantic expression for the current node.
@@ -1703,4 +1725,26 @@ fn get_diagnostics<T: DiagnosticEntry>(
             ..Diagnostic::default()
         });
     }
+}
+
+pub fn get_definition_location(
+    db: &RootDatabase,
+    uri: Url,
+    position: Position,
+) -> Option<(FileId, TextSpan)> {
+    let file = file(db.upcast(), uri);
+    let syntax_db = db.upcast();
+    let (node, lookup_items) = get_node_and_lookup_items(db, file, position)?;
+    if node.kind(syntax_db) != SyntaxKind::TokenIdentifier {
+        return None;
+    }
+    let identifier = ast::TerminalIdentifier::from_syntax_node(syntax_db, node.parent().unwrap());
+    let stable_ptr = find_definition(db, file, &identifier, &lookup_items)?;
+    let node = stable_ptr.lookup(syntax_db);
+    let found_file = stable_ptr.file_id(syntax_db);
+    let span = node.span_without_trivia(syntax_db);
+    let width = span.width();
+    let (file_id, mut span) = get_originating_location(db.upcast(), found_file, span.start_only());
+    span.end = span.end.add_width(width);
+    Some((file_id, span))
 }


### PR DESCRIPTION
what's displayed for `then_some`

![Screenshot 2024-03-08 at 16 19 42](https://github.com/starkware-libs/cairo/assets/70894690/432fd153-b844-479b-a1e9-e7d7706cfb25)

And for `check_ecdsa_signature` (if it started with `///` instead of `//`)
![Screenshot 2024-03-08 at 16 32 03](https://github.com/starkware-libs/cairo/assets/70894690/d52b9a04-404d-4824-8c06-d146bcee2607)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5225)
<!-- Reviewable:end -->
