### PR TITLE
Replace `arc_unwrap_or_clone` with now stable `Arc::unwrap_or_clone`

### DIFF
--- a/crates/bin/cairo-run/src/main.rs
+++ b/crates/bin/cairo-run/src/main.rs
@@ -1,6 +1,7 @@
 //! Compiles and runs a Cairo program.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Ok};
 use cairo_lang_compiler::db::RootDatabase;
@@ -14,7 +15,6 @@ use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_sierra_generator::program_generator::SierraProgramWithDebug;
 use cairo_lang_sierra_generator::replace_ids::{DebugReplacer, SierraIdReplacer};
 use cairo_lang_starknet::contract::get_contracts_info;
-use cairo_lang_utils::arc_unwrap_or_clone;
 use clap::Parser;
 
 /// Compiles a Cairo project and runs the function `main`.
@@ -64,7 +64,7 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("failed to compile: {}", args.path.display());
     }
 
-    let SierraProgramWithDebug { program: sierra_program, debug_info } = arc_unwrap_or_clone(
+    let SierraProgramWithDebug { program: sierra_program, debug_info } = Arc::unwrap_or_clone(
         db.get_sierra_program(main_crate_ids.clone())
             .to_option()
             .with_context(|| "Compilation failed without any diagnostics.")?,

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate is responsible for compiling a Cairo project into a Sierra program.
 //! It is the main entry point for the compiler.
 use std::path::Path;
+use std::sync::Arc;
 
 use ::cairo_lang_diagnostics::ToOption;
 use anyhow::{Context, Result};
@@ -11,7 +12,6 @@ use cairo_lang_sierra::program::Program;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_sierra_generator::program_generator::SierraProgramWithDebug;
 use cairo_lang_sierra_generator::replace_ids::replace_sierra_ids_in_program;
-use cairo_lang_utils::arc_unwrap_or_clone;
 
 use crate::db::RootDatabase;
 use crate::diagnostics::DiagnosticsReporter;
@@ -100,7 +100,7 @@ pub fn compile_prepared_db(
 ) -> Result<Program> {
     compiler_config.diagnostics_reporter.ensure(db)?;
 
-    let SierraProgramWithDebug { program: mut sierra_program, .. } = arc_unwrap_or_clone(
+    let SierraProgramWithDebug { program: mut sierra_program, .. } = Arc::unwrap_or_clone(
         db.get_sierra_program(main_crate_ids)
             .to_option()
             .context("Compilation failed without any diagnostics")?,

--- a/crates/cairo-lang-runner/src/profiling_test.rs
+++ b/crates/cairo-lang-runner/src/profiling_test.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_semantic::test_utils::setup_test_module;
@@ -7,7 +9,6 @@ use cairo_lang_sierra_generator::replace_ids::replace_sierra_ids_in_program;
 use cairo_lang_starknet::starknet_plugin_suite;
 use cairo_lang_test_utils::get_direct_or_file_content;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
-use cairo_lang_utils::arc_unwrap_or_clone;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 
 use super::ProfilingInfoProcessor;
@@ -45,7 +46,7 @@ pub fn test_profiling(
 
     // Compile to Sierra.
     let SierraProgramWithDebug { program: sierra_program, debug_info } =
-        arc_unwrap_or_clone(db.get_sierra_program(vec![test_module.crate_id]).unwrap());
+        Arc::unwrap_or_clone(db.get_sierra_program(vec![test_module.crate_id]).unwrap());
     let sierra_program = replace_sierra_ids_in_program(&db, &sierra_program);
     let statements_functions = debug_info.statements_locations.get_statements_functions_map(&db);
     let runner = SierraCasmRunner::new(

--- a/crates/cairo-lang-sierra-generator/src/program_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator_test.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::ModuleItemId;
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{arc_unwrap_or_clone, try_extract_matches};
+use cairo_lang_utils::try_extract_matches;
 use indoc::indoc;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
@@ -82,7 +84,7 @@ fn test_only_include_dependencies(func_name: &str, sierra_used_funcs: &[&str]) {
     )
     .unwrap();
     let SierraProgramWithDebug { program, .. } =
-        arc_unwrap_or_clone(db.get_sierra_program_for_functions(vec![func_id]).unwrap());
+        Arc::unwrap_or_clone(db.get_sierra_program_for_functions(vec![func_id]).unwrap());
     assert_eq!(
         replace_sierra_ids_in_program(&db, &program)
             .funcs

--- a/crates/cairo-lang-sierra-generator/src/test_utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/test_utils.rs
@@ -15,7 +15,7 @@ use cairo_lang_semantic::test_utils::setup_test_crate;
 use cairo_lang_sierra::ids::{ConcreteLibfuncId, GenericLibfuncId};
 use cairo_lang_sierra::program;
 use cairo_lang_syntax::node::db::{SyntaxDatabase, SyntaxGroup};
-use cairo_lang_utils::{arc_unwrap_or_clone, Upcast, UpcastMut};
+use cairo_lang_utils::{Upcast, UpcastMut};
 use defs::ids::FreeFunctionId;
 use lowering::ids::ConcreteFunctionWithBodyLongId;
 use lowering::optimizations::config::OptimizationConfig;
@@ -127,7 +127,7 @@ pub fn checked_compile_to_sierra(content: &str) -> cairo_lang_sierra::program::P
     let (db, crate_id) = setup_db_and_get_crate_id(content);
 
     let SierraProgramWithDebug { program, .. } =
-        arc_unwrap_or_clone(db.get_sierra_program(vec![crate_id]).unwrap());
+        Arc::unwrap_or_clone(db.get_sierra_program(vec![crate_id]).unwrap());
     replace_sierra_ids_in_program(&db, &program)
 }
 

--- a/crates/cairo-lang-starknet/src/compile.rs
+++ b/crates/cairo-lang-starknet/src/compile.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use cairo_lang_compiler::db::RootDatabase;
@@ -17,7 +18,6 @@ use cairo_lang_starknet_classes::allowed_libfuncs::ListSelector;
 use cairo_lang_starknet_classes::contract_class::{
     ContractClass, ContractEntryPoint, ContractEntryPoints,
 };
-use cairo_lang_utils::arc_unwrap_or_clone;
 use itertools::{chain, Itertools};
 
 use crate::abi::AbiBuilder;
@@ -126,7 +126,7 @@ fn compile_contract_with_prepared_and_checked_db(
 ) -> Result<ContractClass> {
     let SemanticEntryPoints { external, l1_handler, constructor } =
         extract_semantic_entrypoints(db, contract)?;
-    let SierraProgramWithDebug { program: mut sierra_program, .. } = arc_unwrap_or_clone(
+    let SierraProgramWithDebug { program: mut sierra_program, .. } = Arc::unwrap_or_clone(
         db.get_sierra_program_for_functions(
             chain!(&external, &l1_handler, &constructor).map(|f| f.value).collect(),
         )

--- a/crates/cairo-lang-test-plugin/src/lib.rs
+++ b/crates/cairo-lang-test-plugin/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use cairo_felt::Felt252;
 use cairo_lang_compiler::db::RootDatabase;
@@ -21,19 +23,18 @@ use cairo_lang_starknet::contract::{
 };
 use cairo_lang_starknet::plugin::consts::{CONSTRUCTOR_MODULE, EXTERNAL_MODULE, L1_HANDLER_MODULE};
 use cairo_lang_starknet_classes::casm_contract_class::ENTRY_POINT_COST;
-use cairo_lang_utils::arc_unwrap_or_clone;
 use cairo_lang_utils::ordered_hash_map::{
     deserialize_ordered_hashmap_vec, serialize_ordered_hashmap_vec, OrderedHashMap,
 };
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::{chain, Itertools};
+pub use plugin::TestPlugin;
 use serde::{Deserialize, Serialize};
 pub use test_config::{try_extract_test_config, TestConfig};
 
 mod inline_macros;
 pub mod plugin;
 pub mod test_config;
-pub use plugin::TestPlugin;
 
 const TEST_ATTR: &str = "test";
 const SHOULD_PANIC_ATTR: &str = "should_panic";
@@ -84,7 +85,7 @@ pub fn compile_test_prepared_db(
             })
             .collect();
     let all_tests = find_all_tests(db, test_crate_ids.clone());
-    let SierraProgramWithDebug { program: sierra_program, debug_info } = arc_unwrap_or_clone(
+    let SierraProgramWithDebug { program: sierra_program, debug_info } = Arc::unwrap_or_clone(
         db.get_sierra_program_for_functions(
             chain!(
                 all_entry_points.into_iter(),

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -161,9 +161,3 @@ impl<T: ?Sized> UpcastMut<T> for T {
         self
     }
 }
-
-// TODO(yuval): use Arc::unwrap_or_clone once it's stable.
-/// Moves the content out of the Arc if possible, otherwise just clones it.
-pub fn arc_unwrap_or_clone<T: Clone>(arc: Arc<T>) -> T {
-    Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone())
-}

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -16,7 +16,6 @@ use cairo_lang_sierra_to_casm::compiler;
 use cairo_lang_sierra_to_casm::metadata::{calc_metadata, MetadataComputationConfig};
 use cairo_lang_test_utils::parse_test_file::{TestFileRunner, TestRunnerResult};
 use cairo_lang_test_utils::test_lock;
-use cairo_lang_utils::arc_unwrap_or_clone;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::Itertools;
@@ -187,7 +186,7 @@ fn run_e2e_test(
 
     // Compile to Sierra.
     let SierraProgramWithDebug { program: sierra_program, .. } =
-        arc_unwrap_or_clone(db.get_sierra_program(vec![test_module.crate_id]).unwrap());
+        Arc::unwrap_or_clone(db.get_sierra_program(vec![test_module.crate_id]).unwrap());
     let sierra_program = replace_sierra_ids_in_program(&db, &sierra_program);
     let sierra_program_str = sierra_program.to_string();
 

--- a/tests/examples_test.rs
+++ b/tests/examples_test.rs
@@ -19,7 +19,7 @@ use cairo_lang_sierra_generator::replace_ids::replace_sierra_ids_in_program;
 use cairo_lang_sierra_to_casm::compiler::SierraToCasmConfig;
 use cairo_lang_sierra_to_casm::metadata::{calc_metadata, calc_metadata_ap_change_only};
 use cairo_lang_test_utils::compare_contents_or_fix_with_path;
-use cairo_lang_utils::{arc_unwrap_or_clone, extract_matches, Upcast};
+use cairo_lang_utils::{extract_matches, Upcast};
 use itertools::Itertools;
 use rstest::{fixture, rstest};
 
@@ -84,7 +84,7 @@ fn checked_compile_to_sierra(
         }
     }
     let SierraProgramWithDebug { program: sierra_program, .. } =
-        arc_unwrap_or_clone(db.get_sierra_program_for_functions(requested_function_ids).unwrap());
+        Arc::unwrap_or_clone(db.get_sierra_program_for_functions(requested_function_ids).unwrap());
     replace_sierra_ids_in_program(&db, &sierra_program)
 }
 


### PR DESCRIPTION
The `Arc::unwrap_or_clone` function was stabilized in Rust 1.76