### PR TITLE
Made reorder statements use a clone for the first received info.

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/reorder_statements.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/reorder_statements.rs
@@ -155,10 +155,10 @@ impl Analyzer<'_> for ReorderStatementsContext<'_> {
         &'b mut self,
         statement_location: StatementLocation,
         match_info: &MatchInfo,
-        infos: Infos,
+        mut infos: Infos,
     ) -> Self::Info {
-        let mut info = Self::Info::default();
-
+        let mut info =
+            if let Some(first) = infos.next() { first.clone() } else { Self::Info::default() };
         for arm_info in infos {
             info.next_use.merge(&arm_info.next_use, |v, _| {
                 *v = statement_location;


### PR DESCRIPTION
**Stack**:
- #5271 ⬅
- #5266


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5271)
<!-- Reviewable:end -->
