### PR TITLE
LS: Move all formatter logic into `ide` module

### DIFF
--- a/crates/cairo-lang-language-server/src/ide/formatter.rs
+++ b/crates/cairo-lang-language-server/src/ide/formatter.rs
@@ -1,0 +1,48 @@
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_filesystem::db::FilesGroup;
+use cairo_lang_formatter::{get_formatted_file, FormatterConfig};
+use cairo_lang_parser::db::ParserGroup;
+use cairo_lang_utils::Upcast;
+use tower_lsp::lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
+use tracing::error;
+
+/// Format a whole document.
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(uri = %params.text_document.uri)
+)]
+pub fn format(params: DocumentFormattingParams, db: &RootDatabase) -> Option<Vec<TextEdit>> {
+    let file_uri = params.text_document.uri;
+    let file = crate::file(db, file_uri.clone());
+
+    let Ok(node) = db.file_syntax(file) else {
+        error!("formatting failed: file '{file_uri}' does not exist");
+        return None;
+    };
+
+    if db.file_syntax_diagnostics(file).check_error_free().is_err() {
+        error!("formatting failed: cannot properly parse '{file_uri}' exist");
+        return None;
+    }
+
+    let new_text = get_formatted_file(db.upcast(), &node, FormatterConfig::default());
+
+    let Some(file_summary) = db.file_summary(file) else {
+        error!("formatting failed: cannot get summary for file '{file_uri}'");
+        return None;
+    };
+
+    let Ok(old_line_count) = file_summary.line_count().try_into() else {
+        error!("formatting failed: line count out of bound in file '{file_uri}'");
+        return None;
+    };
+
+    Some(vec![TextEdit {
+        range: Range {
+            start: Position { line: 0, character: 0 },
+            end: Position { line: old_line_count, character: 0 },
+        },
+        new_text,
+    }])
+}

--- a/crates/cairo-lang-language-server/src/ide/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/mod.rs
@@ -1,2 +1,3 @@
 pub mod completion;
+pub mod formatter;
 pub mod semantic_highlighting;


### PR DESCRIPTION
**Stack**:
- #5301
- #5300
- #5296 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5296)
<!-- Reviewable:end -->
