### PR TITLE
LS: Move all go to definition logic into the `ide::navigation` module

### DIFF
--- a/crates/cairo-lang-language-server/src/ide/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/mod.rs
@@ -1,4 +1,5 @@
 pub mod completion;
 pub mod formatter;
 pub mod hover;
+pub mod navigation;
 pub mod semantic_highlighting;

--- a/crates/cairo-lang-language-server/src/ide/navigation/goto_definition.rs
+++ b/crates/cairo-lang-language-server/src/ide/navigation/goto_definition.rs
@@ -1,0 +1,26 @@
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_utils::Upcast;
+use tower_lsp::lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, Range};
+
+use crate::{from_pos, get_definition_location, get_uri};
+
+/// Get the definition location of a symbol at a given text document position.
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(uri = %params.text_document_position_params.text_document.uri)
+)]
+pub fn goto_definition(
+    params: GotoDefinitionParams,
+    db: &RootDatabase,
+) -> Option<GotoDefinitionResponse> {
+    let file_uri = params.text_document_position_params.text_document.uri;
+    let position = params.text_document_position_params.position;
+    let (found_file, span) =
+        get_definition_location(db, crate::file(db.upcast(), file_uri), position)?;
+    let found_uri = get_uri(db, found_file);
+
+    let start = from_pos(span.start.position_in_file(db.upcast(), found_file).unwrap());
+    let end = from_pos(span.end.position_in_file(db.upcast(), found_file).unwrap());
+    Some(GotoDefinitionResponse::Scalar(Location { uri: found_uri, range: Range { start, end } }))
+}

--- a/crates/cairo-lang-language-server/src/ide/navigation/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/navigation/mod.rs
@@ -1,0 +1,1 @@
+pub mod goto_definition;

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -815,26 +815,12 @@ impl LanguageServer for Backend {
         self.with_db(|db| ide::hover::hover(params, db)).await
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(uri = %params.text_document_position_params.text_document.uri))]
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn goto_definition(
         &self,
         params: GotoDefinitionParams,
     ) -> LSPResult<Option<GotoDefinitionResponse>> {
-        self.with_db(|db| {
-            let file_uri = params.text_document_position_params.text_document.uri;
-            let position = params.text_document_position_params.position;
-            let (found_file, span) =
-                get_definition_location(db, file(db.upcast(), file_uri), position)?;
-            let found_uri = get_uri(db, found_file);
-
-            let start = from_pos(span.start.position_in_file(db.upcast(), found_file).unwrap());
-            let end = from_pos(span.end.position_in_file(db.upcast(), found_file).unwrap());
-            Some(GotoDefinitionResponse::Scalar(Location {
-                uri: found_uri,
-                range: Range { start, end },
-            }))
-        })
-        .await
+        self.with_db(|db| ide::navigation::goto_definition::goto_definition(params, db)).await
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(uri = %params.text_document.uri))]


### PR DESCRIPTION
**Stack**:
- #5302
- #5301 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5301)
<!-- Reviewable:end -->
