### PR TITLE
feat: Default impls for signed integer types

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -1738,6 +1738,40 @@ impl U256Default of Default<u256> {
     }
 }
 
+impl I8Default of Default<i8> {
+    #[inline(always)]
+    fn default() -> i8 nopanic {
+        0_i8
+    }
+}
+
+impl I16Default of Default<i16> {
+    #[inline(always)]
+    fn default() -> i16 nopanic {
+        0_i16
+    }
+}
+
+impl I32Default of Default<i32> {
+    #[inline(always)]
+    fn default() -> i32 nopanic {
+        0_i32
+    }
+}
+
+impl I64Default of Default<i64> {
+    #[inline(always)]
+    fn default() -> i64 nopanic {
+        0_i64
+    }
+}
+
+impl I128Default of Default<i128> {
+    #[inline(always)]
+    fn default() -> i128 nopanic {
+        0_i128
+    }
+}
 
 /// Default values for felt252_dict values.
 impl U8Felt252DictValue of Felt252DictValue<u8> {

--- a/corelib/src/test/integer_test.cairo
+++ b/corelib/src/test/integer_test.cairo
@@ -886,6 +886,11 @@ fn test_default_values() {
     assert_eq(@Default::default(), @0_u64, '0 == 0');
     assert_eq(@Default::default(), @0_u128, '0 == 0');
     assert_eq(@Default::default(), @0_u256, '0 == 0');
+    assert_eq(@Default::default(), @0_i8, '0 == 0');
+    assert_eq(@Default::default(), @0_i16, '0 == 0');
+    assert_eq(@Default::default(), @0_i32, '0 == 0');
+    assert_eq(@Default::default(), @0_i64, '0 == 0');
+    assert_eq(@Default::default(), @0_i128, '0 == 0');
 }
 
 #[test]


### PR DESCRIPTION
Signed integer types are missing `Default`. This PR adds it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5312)
<!-- Reviewable:end -->
