### PR TITLE
Add `Copy` trait to `Call`

### DIFF
--- a/corelib/src/starknet/account.cairo
+++ b/corelib/src/starknet/account.cairo
@@ -1,6 +1,6 @@
 use starknet::ContractAddress;
 
-#[derive(Drop, Serde, Debug)]
+#[derive(Drop, Copy, Serde, Debug)]
 pub struct Call {
     pub to: ContractAddress,
     pub selector: felt252,


### PR DESCRIPTION
Allows desnapping of call structs