### PR TITLE
bug: update `nullable_from_box` visibility to `pub`

### DIFF
--- a/corelib/src/nullable.cairo
+++ b/corelib/src/nullable.cairo
@@ -11,7 +11,7 @@ pub enum FromNullableResult<T> {
 }
 
 pub extern fn null<T>() -> Nullable<T> nopanic;
-pub(crate) extern fn nullable_from_box<T>(value: Box<T>) -> Nullable<T> nopanic;
+pub extern fn nullable_from_box<T>(value: Box<T>) -> Nullable<T> nopanic;
 pub extern fn match_nullable<T>(value: Nullable<T>) -> FromNullableResult<T> nopanic;
 extern fn nullable_forward_snapshot<T>(value: @Nullable<T>) -> Nullable<@T> nopanic;
 


### PR DESCRIPTION
Resolves #5412 

This PR addresses the visibility issue of the `nullable_from_box` function in _nullable.cairo_. Its visibility is currently `pub(crate)` while it should be `pub` to be useable in any crate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5413)
<!-- Reviewable:end -->
