### PR TITLE
chore: remove outdated snippet

### DIFF
--- a/vscode-cairo/snippets/cairo.json
+++ b/vscode-cairo/snippets/cairo.json
@@ -160,11 +160,6 @@
     ],
     "description": "Create a generate trait impl"
   },
-  "Print the selected item": {
-    "prefix": "print",
-    "body": ["use debug::PrintTrait;", "$TM_SELECTED_TEXT$1.print();"],
-    "description": "Print the selected item"
-  },
   "Creates an Enum object": {
     "prefix": "enum",
     "body": ["#[derive(Copy, Drop, $1)]", "enum $2 {", "\t$3: ${4},", "}"],


### PR DESCRIPTION
removes outdated `print` vs-code snippet. Replaced by `println!`, it doesn't make sense to keep it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5414)
<!-- Reviewable:end -->
