### PR TITLE
LS: Rewrite project file searching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_fs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +578,7 @@ name = "cairo-lang-language-server"
 version = "2.6.3"
 dependencies = [
  "anyhow",
+ "assert_fs",
  "cairo-lang-compiler",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1336,6 +1352,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "diffy"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1397,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
@@ -1431,6 +1459,22 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fixedbitset"
@@ -1649,6 +1693,17 @@ dependencies = [
  "log",
  "regex-automata 0.4.6",
  "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.5.0",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -1953,6 +2008,12 @@ dependencies = [
  "bitflags 2.5.0",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -2409,6 +2470,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +2732,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3074,6 +3175,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,6 +3196,12 @@ dependencies = [
  "rustversion",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-case"

--- a/crates/cairo-lang-language-server/Cargo.toml
+++ b/crates/cairo-lang-language-server/Cargo.toml
@@ -32,3 +32,4 @@ tracing-chrome = "0.7.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+assert_fs = "1.1"

--- a/crates/cairo-lang-language-server/src/project/mod.rs
+++ b/crates/cairo-lang-language-server/src/project/mod.rs
@@ -1,0 +1,3 @@
+pub use self::project_manifest_path::*;
+
+mod project_manifest_path;

--- a/crates/cairo-lang-language-server/src/project/project_manifest_path.rs
+++ b/crates/cairo-lang-language-server/src/project/project_manifest_path.rs
@@ -1,0 +1,67 @@
+use std::path::{Path, PathBuf};
+use std::{fmt, fs};
+
+use cairo_lang_project::PROJECT_FILE_NAME;
+
+#[cfg(test)]
+#[path = "project_manifest_path_test.rs"]
+mod project_manifest_path_test;
+
+const MAX_CRATE_DETECTION_DEPTH: usize = 20;
+const SCARB_TOML: &str = "Scarb.toml";
+
+/// An absolute path to a manifest file of a single Cairo project.
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum ProjectManifestPath {
+    /// `cairo_project.toml` file.
+    CairoProject(PathBuf),
+
+    /// `Scarb.toml` file.
+    ///
+    /// This could either be a single package or a workspace manifest.
+    Scarb(PathBuf),
+}
+
+impl ProjectManifestPath {
+    /// Look for a project manifest that **can** include source files at the given path.
+    ///
+    /// Returns `None` if the file at `path` is detached from any Cairo project.
+    ///
+    /// ## Precedence
+    ///
+    /// The following files are searched for in order:
+    /// 1. `cairo_project.toml`
+    /// 2. `Scarb.toml`
+    pub fn discover(path: &Path) -> Option<ProjectManifestPath> {
+        return find_in_parent_dirs(path.to_path_buf(), PROJECT_FILE_NAME)
+            .map(ProjectManifestPath::CairoProject)
+            .or_else(|| {
+                find_in_parent_dirs(path.to_path_buf(), SCARB_TOML).map(ProjectManifestPath::Scarb)
+            });
+
+        fn find_in_parent_dirs(mut path: PathBuf, target_file_name: &str) -> Option<PathBuf> {
+            for _ in 0..MAX_CRATE_DETECTION_DEPTH {
+                if !path.pop() {
+                    return None;
+                }
+
+                let manifest_path = path.join(target_file_name);
+                // Check if the file exists and we can actually access it.
+                if fs::metadata(&manifest_path).is_ok() {
+                    return Some(manifest_path);
+                };
+            }
+            None
+        }
+    }
+}
+
+impl fmt::Display for ProjectManifestPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProjectManifestPath::CairoProject(path) | ProjectManifestPath::Scarb(path) => {
+                fmt::Display::fmt(&path.display(), f)
+            }
+        }
+    }
+}

--- a/crates/cairo-lang-language-server/src/project/project_manifest_path_test.rs
+++ b/crates/cairo-lang-language-server/src/project/project_manifest_path_test.rs
@@ -1,0 +1,60 @@
+use assert_fs::prelude::*;
+use assert_fs::TempDir;
+
+use super::*;
+
+#[test]
+fn discover_cairo_project_toml() {
+    let t = TempDir::new().unwrap();
+
+    let manifest = t.child("cairo_project.toml");
+    manifest.touch().unwrap();
+
+    let source_path = t.child("src/lib.cairo");
+    source_path.touch().unwrap();
+
+    let actual = ProjectManifestPath::discover(source_path.path());
+    assert_eq!(actual, Some(ProjectManifestPath::CairoProject(manifest.to_path_buf())));
+}
+
+#[test]
+fn discover_scarb_toml() {
+    let t = TempDir::new().unwrap();
+
+    let manifest = t.child("Scarb.toml");
+    manifest.touch().unwrap();
+
+    let source_path = t.child("src/lib.cairo");
+    source_path.touch().unwrap();
+
+    let actual = ProjectManifestPath::discover(source_path.path());
+    assert_eq!(actual, Some(ProjectManifestPath::Scarb(manifest.to_path_buf())));
+}
+
+#[test]
+fn discover_no_manifest() {
+    let t = TempDir::new().unwrap();
+
+    let source_path = t.child("src/lib.cairo");
+    source_path.touch().unwrap();
+
+    let actual = ProjectManifestPath::discover(source_path.path());
+    assert_eq!(actual, None);
+}
+
+#[test]
+fn discover_precedence() {
+    let t = TempDir::new().unwrap();
+
+    let scarb_manifest = t.child("Scarb.toml");
+    scarb_manifest.touch().unwrap();
+
+    let cairo_manifest = t.child("cairo_project.toml");
+    cairo_manifest.touch().unwrap();
+
+    let source_path = t.child("src/lib.cairo");
+    source_path.touch().unwrap();
+
+    let actual = ProjectManifestPath::discover(source_path.path());
+    assert_eq!(actual, Some(ProjectManifestPath::CairoProject(cairo_manifest.to_path_buf())));
+}

--- a/crates/cairo-lang-language-server/src/scarb_service.rs
+++ b/crates/cairo-lang-language-server/src/scarb_service.rs
@@ -7,7 +7,6 @@ use tower_lsp::lsp_types::Url;
 
 use crate::toolchain::scarb::ScarbToolchain;
 
-const MAX_CRATE_DETECTION_DEPTH: usize = 20;
 const SCARB_PROJECT_FILE_NAME: &str = "Scarb.toml";
 
 #[derive(Clone)]
@@ -18,19 +17,6 @@ pub struct ScarbService {
 impl ScarbService {
     pub fn new(scarb: &ScarbToolchain) -> Self {
         ScarbService { scarb: scarb.clone() }
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub fn scarb_manifest_path(&self, root_path: PathBuf) -> Option<PathBuf> {
-        let mut path = root_path;
-        for _ in 0..MAX_CRATE_DETECTION_DEPTH {
-            path.pop();
-            let manifest_path = path.join(SCARB_PROJECT_FILE_NAME);
-            if manifest_path.exists() {
-                return Some(manifest_path);
-            };
-        }
-        None
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/crates/cairo-lang-project/src/lib.rs
+++ b/crates/cairo-lang-project/src/lib.rs
@@ -19,7 +19,7 @@ pub enum DeserializationError {
     #[error("PathError")]
     PathError,
 }
-const PROJECT_FILE_NAME: &str = "cairo_project.toml";
+pub const PROJECT_FILE_NAME: &str = "cairo_project.toml";
 
 /// Cairo project config, including its file content and metadata about the file.
 /// This file is expected to be at a root of a crate and specify the crate name and location and


### PR DESCRIPTION
The logic for looking for the project file is not encapsulated as a
`ProjectManifestPath` struct.

This change swaps the precedence, now `cairo_project.toml` will be
recognized before `Scarb.toml` in case both files exist. This reflects
the notion that `cairo_project.toml` is something "custom" and Cairo
lang developer oriented, while Scarb is meant for regular scenarios.

---

**Stack**:
- #5434
- #5433
- #5423
- #5415 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5415)
<!-- Reviewable:end -->
