### PR TITLE
Preventing box values from being const-folded.

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -116,7 +116,8 @@ pub fn const_folding(db: &dyn LoweringGroup, lowered: &mut FlatLowered) {
                                     lowered.variables[inputs[0].var_id].ty,
                                     val.clone().into(),
                                 );
-                                var_info.insert(outputs[0], VarInfo::Const(value.clone()));
+                                // Not inserting the value into the `var_info` map because the
+                                // resulting box isn't an actual const at the Sierra level.
                                 *stmt =
                                     Statement::Const(StatementConst { value, output: outputs[0] });
                             }

--- a/tests/bug_samples/issue5411.cairo
+++ b/tests/bug_samples/issue5411.cairo
@@ -1,0 +1,6 @@
+use core::nullable::NullableTrait;
+
+#[test]
+fn box_of_box() -> Nullable<Box<u32>> {
+    NullableTrait::<Box<u32>>::new(BoxTrait::new(16))
+}

--- a/tests/bug_samples/lib.cairo
+++ b/tests/bug_samples/lib.cairo
@@ -40,6 +40,7 @@ mod issue4318;
 mod issue4380;
 mod issue4897;
 mod issue4937;
+mod issue5411;
 mod loop_break_in_match;
 mod loop_only_change;
 mod partial_param_local;


### PR DESCRIPTION
**Stack**:
- #5418
- #5417
- #5416 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5416)
<!-- Reviewable:end -->
