### PR TITLE
feat: faster append_formatted_to_byte_array

### DIFF
--- a/corelib/src/to_byte_array.cairo
+++ b/corelib/src/to_byte_array.cairo
@@ -83,39 +83,39 @@ fn append_formatted_to_byte_array<
     let base: T = base_nz.into();
     let base: u8 = base.try_into().unwrap();
     assert(base > 1, 'base must be > 1');
-    assert(base <= 36, 'base must be <= 36');
-
-    let mut reversed_digits = array![];
 
     if base <= 10 {
-        loop {
-            let (new_value, digit) = DivRem::div_rem(*value, base_nz);
-            value = @new_value;
-            let digit_as_u8: u8 = digit.try_into().unwrap();
-            reversed_digits.append(digit_as_u8 + '0');
-            if (*value).is_zero() {
-                break;
-            };
-        }
+        append_small_digits_util(value, ref byte_array, base_nz);
     } else {
-        loop {
-            let (new_value, digit) = DivRem::div_rem(*value, base_nz);
-            value = @new_value;
-            let digit_as_u8: u8 = digit.try_into().unwrap();
-            reversed_digits.append(get_big_base_digit_representation(:digit_as_u8));
-            if (*value).is_zero() {
-                break;
-            };
-        };
+        assert(base <= 36, 'base must be <= 36');
+        append_big_digits_util(value, ref byte_array, base_nz);
     }
+}
 
-    let mut span = reversed_digits.span();
-    loop {
-        match span.pop_back() {
-            Option::Some(byte) => { byte_array.append_byte(*byte); },
-            Option::None => { break; },
-        };
+#[inline]
+fn append_small_digits_util<T, +Drop<T>, +Copy<T>, +DivRem<T>, +TryInto<T, u8>, +Zeroable<T>,>(
+    mut value: @T, ref byte_array: ByteArray, base_nz: NonZero<T>,
+) {
+    if (*value).is_zero() {
+        return;
     };
+    let (new_value, digit) = DivRem::div_rem(*value, base_nz);
+    let digit_as_u8: u8 = digit.try_into().unwrap();
+    append_big_digits_util(@new_value, ref byte_array, base_nz);
+    byte_array.append_byte(digit_as_u8 + '0');
+}
+
+#[inline]
+fn append_big_digits_util<T, +Drop<T>, +Copy<T>, +DivRem<T>, +TryInto<T, u8>, +Zeroable<T>,>(
+    mut value: @T, ref byte_array: ByteArray, base_nz: NonZero<T>,
+) {
+    if (*value).is_zero() {
+        return;
+    };
+    let (new_value, digit) = DivRem::div_rem(*value, base_nz);
+    let digit_as_u8: u8 = digit.try_into().unwrap();
+    append_big_digits_util(@new_value, ref byte_array, base_nz);
+    byte_array.append_byte(get_big_base_digit_representation(:digit_as_u8));
 }
 
 /// Converts a digit (0-9, A-Z) to its Ascii representation in a base > 10.


### PR DESCRIPTION
This pull request makes bytes_array formatting slightly faster. I think it also makes the code cleaner.

`cargo run --bin cairo-test -- --single-file ./corelib/src/test/fmt_test.cairo`

### Before changes:
```
running 3 tests
test fmt_test::fmt_test::test_array_debug ... ok (gas usage est.: 181390)
test fmt_test::fmt_test::test_format ... ok (gas usage est.: 1201900)
test fmt_test::fmt_test::test_format_debug ... ok (gas usage est.: 1644520)
test result: ok. 3 passed; 0 failed; 0 ignored; 0 filtered out;
```

### After changes:
```
running 3 tests
test fmt_test::fmt_test::test_array_debug ... ok (gas usage est.: 166690)
test fmt_test::fmt_test::test_format ... ok (gas usage est.: 1071540)
test fmt_test::fmt_test::test_format_debug ... ok (gas usage est.: 1547670)
test result: ok. 3 passed; 0 failed; 0 ignored; 0 filtered out;
```

The previous code used to first append digits to an array via a first loop and loop again over it to reverse this array. This code avoids the second iteration by using recursion to reorder the append calls.