### PR TITLE
LS: Introduce `Config` and refactor logic around unmanaged `core` crate

### DIFF
--- a/crates/cairo-lang-language-server/src/config.rs
+++ b/crates/cairo-lang-language-server/src/config.rs
@@ -1,0 +1,65 @@
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use tower_lsp::lsp_types::ConfigurationItem;
+use tower_lsp::Client;
+use tracing::{debug, error, warn};
+
+// TODO(mkaput): Write a macro that will auto-generate this struct and the `reload` logic.
+// TODO(mkaput): Write a test that checks that fields in this struct are sorted alphabetically.
+// TODO(mkaput): Write a tool that syncs `configuration` in VSCode extension's `package.json`.
+// TODO(mkaput): Consider moving `SCARB` env var here. Env var must override client config,
+//  because env will be set in `scarb cairo-language-server` context.
+/// Runtime configuration for the language server.
+///
+/// The properties stored in this struct **may** change during LS lifetime (through the
+/// [`Self::reload`] method).
+/// Therefore, it is **forbidden** to hold any references or copies of this struct or its values for
+/// longer periods of time.
+#[derive(Debug, Default)]
+pub struct Config {
+    /// A user-provided fallback path to the `core` crate source code for use in projects where
+    /// `core` is unmanaged by the toolchain.
+    ///
+    /// This property is only used when the LS is unable to find unmanaged `core` automatically.
+    /// The path may omit the `corelib/src` or `src` suffix.
+    ///
+    /// The property is set by the user under the `cairo1.corelibPath` key in client configuration.
+    pub unmanaged_core_fallback_path: Option<PathBuf>,
+}
+
+impl Config {
+    /// Reloads the configuration from the language client.
+    #[tracing::instrument(name = "reload_config", level = "trace", skip_all)]
+    pub async fn reload(&mut self, client: &Client) {
+        let items = vec![ConfigurationItem {
+            scope_uri: None,
+            section: Some("cairo1.corelibPath".to_owned()),
+        }];
+        let expected_len = items.len();
+        if let Ok(response) = client
+            .configuration(items)
+            .await
+            .context("failed to query language client for configuration items")
+            .inspect_err(|e| warn!("{e:?}"))
+        {
+            let response_len = response.len();
+            if response_len != expected_len {
+                error!(
+                    "server returned unexpected number of configuration items, expected: \
+                     {expected_len}, got: {response_len}"
+                );
+                return;
+            }
+
+            // This conversion is O(1), and makes popping from front also O(1).
+            let mut response = VecDeque::from(response);
+
+            self.unmanaged_core_fallback_path =
+                response.pop_front().as_ref().and_then(|v| v.as_str()).map(Into::into);
+
+            debug!("reloaded configuration: {self:#?}");
+        }
+    }
+}

--- a/crates/cairo-lang-language-server/src/project/backends/cairo_project/corelib.rs
+++ b/crates/cairo-lang-language-server/src/project/backends/cairo_project/corelib.rs
@@ -1,0 +1,58 @@
+use std::path::{Path, PathBuf};
+
+use cairo_lang_filesystem::db::{init_dev_corelib, FilesGroup};
+use tracing::warn;
+
+use crate::config::Config;
+
+/// Try to find a Cairo `core` crate (see [`find_unmanaged_core`]) and initialize it in the
+/// provided database.
+pub fn try_to_init_unmanaged_core(config: &Config, db: &mut (dyn FilesGroup + 'static)) {
+    if let Some(path) = find_unmanaged_core(config) {
+        init_dev_corelib(db, path);
+    } else {
+        warn!("failed to find unmanaged core crate")
+    }
+}
+
+/// Try to find a Cairo `core` crate in various well-known places, for use in project backends that
+/// do not manage the `core` crate (i.e., anything non-Scarb).
+pub fn find_unmanaged_core(config: &Config) -> Option<PathBuf> {
+    // TODO(mkaput): First, try to find Scarb-managed `core` package if we have Scarb toolchain.
+    //   The most reliable way to do this is to create an empty Scarb package, and run
+    //   `scarb metadata` on it. The `core` package will be a component of this empty package.
+    //   For minimal packages, `scarb metadata` should be pretty fast.
+    // TODO(mkaput): Shouldn't `fallback` actually be an `override`?
+    cairo_lang_filesystem::detect::detect_corelib()
+        .or_else(|| find_core_at_path(config.unmanaged_core_fallback_path.as_ref()?.as_path()))
+}
+
+/// Attempts to find the `core` crate source root at a given path.
+///
+/// In the [starkware-libs/cairo] repository, the `core` crate sits in `./corelib/src`, this is the
+/// first place looked for.
+/// The `core` crate is a regular Scarb package, so it sounds obvious that the user may provide a
+/// path to the directory containing the manifest file, hence next this function looks for `./src`.
+/// Finally, the input path is considered as a candidate and is just checked for existence.
+///
+/// [starkware-libs/cairo]: https://github.com/starkware-libs/cairo
+fn find_core_at_path(root_path: &Path) -> Option<PathBuf> {
+    let mut path = root_path.to_owned();
+    path.push("corelib");
+    path.push("src");
+    if path.exists() {
+        return Some(path);
+    }
+
+    let mut path = root_path.to_owned();
+    path.push("src");
+    if path.exists() {
+        return Some(path);
+    }
+
+    if root_path.exists() {
+        return Some(root_path.to_owned());
+    }
+
+    None
+}

--- a/crates/cairo-lang-language-server/src/project/backends/cairo_project/mod.rs
+++ b/crates/cairo-lang-language-server/src/project/backends/cairo_project/mod.rs
@@ -1,0 +1,2 @@
+// TODO(mkaput): This is `pub` temporarily.
+pub(crate) mod corelib;

--- a/crates/cairo-lang-language-server/src/project/backends/mod.rs
+++ b/crates/cairo-lang-language-server/src/project/backends/mod.rs
@@ -1,2 +1,4 @@
 // TODO(mkaput): This is `pub` temporarily.
+pub(crate) mod cairo_project;
+// TODO(mkaput): This is `pub` temporarily.
 pub(crate) mod scarb;

--- a/vscode-cairo/src/cairols.ts
+++ b/vscode-cairo/src/cairols.ts
@@ -39,6 +39,26 @@ export async function setupLanguageServer(
     clientOptions,
   );
 
+  // Notify the server when client configuration changes.
+  // CairoLS pulls configuration properties it is interested in by itself, so it
+  // is not needed to attach any details in the notification payload.
+  const weakClient = new WeakRef(client);
+  vscode.workspace.onDidChangeConfiguration(
+    async () => {
+      const client = weakClient.deref();
+      if (client != undefined) {
+        await client.sendNotification(
+          lc.DidChangeConfigurationNotification.type,
+          {
+            settings: "",
+          },
+        );
+      }
+    },
+    null,
+    ctx.extension.subscriptions,
+  );
+
   client.registerFeature(new SemanticTokensFeature(client));
 
   const myProvider = new (class implements vscode.TextDocumentContentProvider {


### PR DESCRIPTION
This change changes the model of pulling configuration properties from
the client. Previously, LS queried config every time it needed, forcing
the code around to be async, and adding (negligible) latency in
encompassing operations. The new model separates concerns, and now
actual configuration reading is sync and instant. This did not come with
a cost though, because the new implementation is longer, and it
requires cooperation with the accompanying language client extension.
Mind that this setup gracefully degrades if the client does not
cooperate: users can force reloading manually.

---

**Stack**:
- #5434
- #5433 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5433)
<!-- Reviewable:end -->
