### PR TITLE
Adding reduced contract call gas.

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -334,7 +334,7 @@ mod gas_costs {
 
     /// Entry point initial gas cost enforced by the compiler.
     /// Should match `ENTRY_POINT_COST` at `crates/cairo-lang-starknet/src/casm_contract_class.rs`.
-    const ENTRY_POINT_INITIAL_BUDGET: usize = 100 * STEP;
+    pub const ENTRY_POINT_INITIAL_BUDGET: usize = 100 * STEP;
     /// OS gas costs.
     const ENTRY_POINT: usize = ENTRY_POINT_INITIAL_BUDGET + 500 * STEP;
     // The required gas for each syscall minus the base amount that was pre-charged (by the
@@ -1139,7 +1139,7 @@ impl<'a> CairoHintProcessor<'a> {
             .run_function_with_starknet_context(
                 function,
                 &[Arg::Array(calldata.into_iter().map(Arg::Value).collect())],
-                Some(*gas_counter),
+                Some(*gas_counter + gas_costs::ENTRY_POINT_INITIAL_BUDGET),
                 self.starknet_state.clone(),
             )
             .expect("Internal runner error.");

--- a/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo
@@ -91,7 +91,7 @@ fn test_flow_safe_dispatcher() {
 // If the test is failing do to gas usage changes, update the gas limit by taking `test_flow` test
 // gas usage and add about 110000.
 #[test]
-#[available_gas(890000)]
+#[available_gas(820000)]
 #[should_panic(expected: ('Out of gas', 'ENTRYPOINT_FAILED',))]
 fn test_flow_out_of_gas() {
     // Calling the `test_flow` test but a low gas limit.


### PR DESCRIPTION
Prevents out of gas failure caused by the double reduction of base cost.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5437)
<!-- Reviewable:end -->
