### PR TITLE
better usage of `default` for `PluginSuite`

### DIFF
--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -90,6 +90,7 @@ impl RootDatabaseBuilder {
     fn new() -> Self {
         Self {
             plugin_suite: get_default_plugin_suite(),
+            detect_corelib: false,
             auto_withdraw_gas: true,
             project_config: None,
             cfg_set: None,

--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -91,7 +91,8 @@ impl RootDatabaseBuilder {
         Self {
             plugin_suite: get_default_plugin_suite(),
             auto_withdraw_gas: true,
-            ..Default::default()
+            project_config: None,
+            cfg_set: None,
         }
     }
 

--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -77,7 +77,7 @@ impl Default for RootDatabase {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct RootDatabaseBuilder {
     plugin_suite: PluginSuite,
     detect_corelib: bool,
@@ -90,10 +90,8 @@ impl RootDatabaseBuilder {
     fn new() -> Self {
         Self {
             plugin_suite: get_default_plugin_suite(),
-            detect_corelib: false,
             auto_withdraw_gas: true,
-            project_config: None,
-            cfg_set: None,
+            ..Default::default()
         }
     }
 

--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -77,7 +77,7 @@ impl Default for RootDatabase {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct RootDatabaseBuilder {
     plugin_suite: PluginSuite,
     detect_corelib: bool,

--- a/crates/cairo-lang-semantic/src/inline_macros/mod.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/mod.rs
@@ -19,11 +19,7 @@ use crate::plugin::PluginSuite;
 
 /// Gets the default plugin suite to load into the Cairo compiler.
 pub fn get_default_plugin_suite() -> PluginSuite {
-    let mut suite = PluginSuite {
-        plugins: get_base_plugins(),
-        inline_macro_plugins: Default::default(),
-        analyzer_plugins: Default::default(),
-    };
+    let mut suite = PluginSuite { plugins: get_base_plugins(), ..Default::default() };
     suite
         .add_inline_macro_plugin::<ArrayMacro>()
         .add_inline_macro_plugin::<AssertMacro>()


### PR DESCRIPTION
A better usage of `Default` implementation is made for the following structure:
- `PluginSuite`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5537)
<!-- Reviewable:end -->
