### PR TITLE
upgrade checkout action to version with node20

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,7 +4,7 @@ jobs:
   create_artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
Node16 is deprecated and Actions using it will stop being used 3rd of June
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

`checkout@v2` uses `node12` but is currently forced to use `node16`

Remove warnings here
https://github.com/starkware-libs/cairo/actions/runs/8630792026

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5554)
<!-- Reviewable:end -->
