### PR TITLE
Cleanup APIs for position/offset calculation

### DIFF
--- a/crates/cairo-lang-filesystem/src/span.rs
+++ b/crates/cairo-lang-filesystem/src/span.rs
@@ -1,15 +1,15 @@
-#[cfg(test)]
-#[path = "span_test.rs"]
-mod test;
-
 use std::iter::Sum;
 use std::ops::{Add, Sub};
 
 use crate::db::FilesGroup;
 use crate::ids::FileId;
 
-/// Byte length of a utf8 string.
-// Note: The wrapped value is private to make sure no one gets confused with non utf8 sizes.
+#[cfg(test)]
+#[path = "span_test.rs"]
+mod test;
+
+/// Byte length of an utf8 string.
+// This wrapper type is used to avoid confusion with non-utf8 sizes.
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TextWidth(u32);
 impl TextWidth {
@@ -48,13 +48,13 @@ impl Sum for TextWidth {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TextOffset(TextWidth);
 impl TextOffset {
-    pub fn add_width(&self, width: TextWidth) -> Self {
+    pub fn add_width(self, width: TextWidth) -> Self {
         TextOffset(self.0 + width)
     }
-    pub fn sub_width(&self, width: TextWidth) -> Self {
+    pub fn sub_width(self, width: TextWidth) -> Self {
         TextOffset(self.0 - width)
     }
-    pub fn take_from<'a>(&self, content: &'a str) -> &'a str {
+    pub fn take_from(self, content: &str) -> &str {
         &content[(self.0.0 as usize)..]
     }
 }
@@ -66,36 +66,37 @@ impl Sub for TextOffset {
     }
 }
 
+/// A range of text offsets that form a span (like text selection).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct TextSpan {
     pub start: TextOffset,
     pub end: TextOffset,
 }
 impl TextSpan {
-    pub fn width(&self) -> TextWidth {
+    pub fn width(self) -> TextWidth {
         self.end - self.start
     }
-    pub fn contains(&self, other: Self) -> bool {
+    pub fn contains(self, other: Self) -> bool {
         self.start <= other.start && self.end >= other.end
     }
-    pub fn take<'b>(&self, content: &'b str) -> &'b str {
+    pub fn take(self, content: &str) -> &str {
         &content[(self.start.0.0 as usize)..(self.end.0.0 as usize)]
     }
-    pub fn n_chars(&self, content: &str) -> usize {
+    pub fn n_chars(self, content: &str) -> usize {
         self.take(content).chars().count()
     }
     /// Get the span of width 0, located right after this span.
-    pub fn after(&self) -> Self {
+    pub fn after(self) -> Self {
         Self { start: self.end, end: self.end }
     }
     /// Get the span of width 0, located right at the beginning of this span.
-    pub fn start_only(&self) -> Self {
+    pub fn start_only(self) -> Self {
         Self { start: self.start, end: self.start }
     }
 }
 
-/// Human readable position inside a file, in lines and characters.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// Human-readable position inside a file, in lines and characters.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct TextPosition {
     /// Line index, 0 based.
     pub line: usize,
@@ -103,34 +104,55 @@ pub struct TextPosition {
     pub col: usize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FileSummary {
-    pub line_offsets: Vec<TextOffset>,
-    pub last_offset: TextOffset,
-}
-
 impl TextOffset {
-    pub fn get_line_number(&self, db: &dyn FilesGroup, file: FileId) -> Option<usize> {
+    fn get_line_number(self, db: &dyn FilesGroup, file: FileId) -> Option<usize> {
         let summary = db.file_summary(file)?;
         assert!(
-            *self <= summary.last_offset,
+            self <= summary.last_offset,
             "TextOffset out of range. {:?} > {:?}.",
             self.0,
             summary.last_offset.0
         );
-        Some(summary.line_offsets.binary_search(self).unwrap_or_else(|x| x - 1))
+        Some(summary.line_offsets.binary_search(&self).unwrap_or_else(|x| x - 1))
     }
 
-    pub fn position_in_file(&self, db: &dyn FilesGroup, file: FileId) -> Option<TextPosition> {
+    /// Convert this offset to an equivalent [`TextPosition`] in the file.
+    pub fn position_in_file(self, db: &dyn FilesGroup, file: FileId) -> Option<TextPosition> {
         let summary = db.file_summary(file)?;
         let line_number = self.get_line_number(db, file)?;
         let line_offset = summary.line_offsets[line_number];
         let content = db.file_content(file)?;
-        let col = TextSpan { start: line_offset, end: *self }.n_chars(&content);
+        let col = TextSpan { start: line_offset, end: self }.n_chars(&content);
         Some(TextPosition { line: line_number, col })
     }
 }
 
+impl TextPosition {
+    /// Convert this position to an equivalent [`TextOffset`] in the file.
+    pub fn offset_in_file(self, db: &dyn FilesGroup, file: FileId) -> Option<TextOffset> {
+        let file_summary = db.file_summary(file)?;
+        let content = db.file_content(file)?;
+
+        let mut offset = *file_summary.line_offsets.get(self.line)?;
+
+        let mut chars_it = offset.take_from(&content).chars();
+        for _ in 0..self.col {
+            let c = chars_it.next()?;
+            offset = offset.add_width(TextWidth::from_char(c));
+        }
+
+        Some(offset)
+    }
+}
+
+/// A set of offset-related information about a file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FileSummary {
+    /// Starting offsets of all lines in this file.
+    pub line_offsets: Vec<TextOffset>,
+    /// Offset of the last character in the file.
+    pub last_offset: TextOffset,
+}
 impl FileSummary {
     /// Gets the number of lines
     pub fn line_count(&self) -> usize {

--- a/crates/cairo-lang-language-server/src/ide/code_actions/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/code_actions/mod.rs
@@ -8,7 +8,7 @@ use tower_lsp::lsp_types::{
 use tracing::debug;
 
 use crate::get_node_and_lookup_items;
-use crate::lang::lsp::LsProtoGroup;
+use crate::lang::lsp::{LsProtoGroup, ToCairo};
 
 mod rename_unused_variable;
 
@@ -22,7 +22,8 @@ mod rename_unused_variable;
 pub fn code_actions(params: CodeActionParams, db: &RootDatabase) -> Option<CodeActionResponse> {
     let mut actions = Vec::with_capacity(params.context.diagnostics.len());
     let file_id = db.file_for_url(&params.text_document.uri);
-    let (node, _lookup_items) = get_node_and_lookup_items(db, file_id, params.range.start)?;
+    let (node, _lookup_items) =
+        get_node_and_lookup_items(db, file_id, params.range.start.to_cairo())?;
     for diagnostic in params.context.diagnostics.iter() {
         actions.extend(
             get_code_actions_for_diagnostic(db, &node, diagnostic, &params)

--- a/crates/cairo-lang-language-server/src/ide/completion/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/completion/mod.rs
@@ -11,7 +11,7 @@ use tower_lsp::lsp_types::{CompletionParams, CompletionResponse, CompletionTrigg
 use tracing::{debug, error};
 
 use self::completions::{colon_colon_completions, dot_completions, generic_completions};
-use crate::lang::lsp::LsProtoGroup;
+use crate::lang::lsp::{LsProtoGroup, ToCairo};
 use crate::{find_node_module, get_node_and_lookup_items};
 
 mod completions;
@@ -28,7 +28,7 @@ pub fn complete(params: CompletionParams, db: &RootDatabase) -> Option<Completio
     let mut position = text_document_position.position;
     position.character = position.character.saturating_sub(1);
 
-    let (mut node, lookup_items) = get_node_and_lookup_items(db, file_id, position)?;
+    let (mut node, lookup_items) = get_node_and_lookup_items(db, file_id, position.to_cairo())?;
 
     // Find module.
     let Some(module_id) = find_node_module(db, file_id, node.clone()) else {

--- a/crates/cairo-lang-language-server/src/ide/hover.rs
+++ b/crates/cairo-lang-language-server/src/ide/hover.rs
@@ -4,7 +4,7 @@ use cairo_lang_defs::ids::LookupItemId;
 use cairo_lang_utils::Upcast;
 use tower_lsp::lsp_types::{Hover, HoverContents, HoverParams, MarkedString};
 
-use crate::lang::lsp::{LsProtoGroup, ToLsp};
+use crate::lang::lsp::{LsProtoGroup, ToCairo};
 use crate::{get_definition_location, get_node_and_lookup_items};
 
 /// Get hover information at a given text document position.
@@ -15,14 +15,14 @@ use crate::{get_definition_location, get_node_and_lookup_items};
 )]
 pub fn hover(params: HoverParams, db: &RootDatabase) -> Option<Hover> {
     let file_id = db.file_for_url(&params.text_document_position_params.text_document.uri);
-    let position = params.text_document_position_params.position;
+    let position = params.text_document_position_params.position.to_cairo();
     // Get the item id of the definition.
     let (found_file, span) = get_definition_location(db, file_id, position)?;
     // Get the documentation and declaration of the item.
     let (_, lookup_items) = get_node_and_lookup_items(
         db,
         found_file,
-        span.start.position_in_file(db.upcast(), found_file)?.to_lsp(),
+        span.start.position_in_file(db.upcast(), found_file)?,
     )?;
     // Build texts.
     let mut hints = Vec::new();

--- a/crates/cairo-lang-language-server/src/ide/navigation/goto_definition.rs
+++ b/crates/cairo-lang-language-server/src/ide/navigation/goto_definition.rs
@@ -3,7 +3,7 @@ use cairo_lang_utils::Upcast;
 use tower_lsp::lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, Range};
 
 use crate::get_definition_location;
-use crate::lang::lsp::{LsProtoGroup, ToLsp};
+use crate::lang::lsp::{LsProtoGroup, ToCairo, ToLsp};
 
 /// Get the definition location of a symbol at a given text document position.
 #[tracing::instrument(
@@ -16,7 +16,7 @@ pub fn goto_definition(
     db: &RootDatabase,
 ) -> Option<GotoDefinitionResponse> {
     let file = db.file_for_url(&params.text_document_position_params.text_document.uri);
-    let position = params.text_document_position_params.position;
+    let position = params.text_document_position_params.position.to_cairo();
     let (found_file, span) = get_definition_location(db, file, position)?;
     let found_uri = db.url_for_file(found_file);
 

--- a/crates/cairo-lang-language-server/src/lang/lsp/to_lsp.rs
+++ b/crates/cairo-lang-language-server/src/lang/lsp/to_lsp.rs
@@ -22,3 +22,25 @@ impl ToLsp for TextPosition {
         Position { line: self.line as u32, character: self.col as u32 }
     }
 }
+
+/// Convert an LSP type into its Cairo equivalent.
+///
+/// This trait should be used for conversions, where there is a direct mapping between the types,
+/// and no extra context is needed. Many conversions may need access to the compiler database,
+/// and such ones are mostly implemented in the [`LsProtoGroup`] extension trait.
+///
+/// [`LsProtoGroup`]: crate::lang::lsp::LsProtoGroup
+pub trait ToCairo {
+    /// Cairo equivalent type.
+    type Output;
+
+    /// Convert an LSP type into its Cairo equivalent.
+    fn to_cairo(&self) -> Self::Output;
+}
+
+impl ToCairo for Position {
+    type Output = TextPosition;
+    fn to_cairo(&self) -> Self::Output {
+        TextPosition { line: self.line as usize, col: self.character as usize }
+    }
+}


### PR DESCRIPTION
- Ensured all types are `Copy` and references are avoided.
- Moved position-to-offset here from LS code.
- Make `TextOffset::get_line_number` private as it was not used
anywhere, and it duplicated `TextOffset::position_in_file`.
- Added docs.

---

**Stack**:
- #5562
- #5561
- #5560 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5560)
<!-- Reviewable:end -->
