### PR TITLE
LS: Fix hover definition lookup logic

### DIFF
--- a/crates/cairo-lang-language-server/tests/e2e/hover.rs
+++ b/crates/cairo-lang-language-server/tests/e2e/hover.rs
@@ -121,7 +121,7 @@ fn starknet() {
 
                 #[constructor]
                 fn constructor(ref se<caret>lf: Cont<caret>ractState, value_: u128) {
-                    self.va<caret>lue.write(value_);
+                    self.va<caret>lue.write(<caret>value_);
                 }
 
                 #[abi(embed_v0)]
@@ -130,7 +130,7 @@ fn starknet() {
                         self.value.r<caret>ead()
                     }
                     fn increase(ref self: ContractState, a: u128)  {
-                        self.value.wr<caret>ite( self.value.read() + a );
+                        self.value.wr<caret>ite( self.value.read() + <caret>a );
                     }
                 }
             }

--- a/crates/cairo-lang-language-server/tests/test_data/hover/starknet.txt
+++ b/crates/cairo-lang-language-server/tests/test_data/hover/starknet.txt
@@ -5,8 +5,9 @@ use Balance::contract_state_for_testing;
                   ↑
 
 //! > popover
-No hover information.
-
+```cairo
+pub fn contract_state_for_testing() -> ContractState
+```
 =========
 
 //! > hover at Position { line: 23, character: 25 }
@@ -27,8 +28,14 @@ No hover information.
                                  ↑
 
 //! > popover
-No hover information.
+```cairo
 
+
+    pub struct ContractState {
+        pub value: __member_module_value::ContractMemberState,
+    }
+
+```
 =========
 
 //! > hover at Position { line: 24, character: 15 }
@@ -40,6 +47,18 @@ No hover information.
 //! > popover
 No hover information.
 
+=========
+
+//! > hover at Position { line: 24, character: 25 }
+
+//! > source context
+        self.value.write(value_);
+                         ↑
+
+//! > popover
+```cairo
+fn constructor(ref self: ContractState, value_: u128)
+```
 =========
 
 //! > hover at Position { line: 28, character: 30 }
@@ -64,8 +83,14 @@ No hover information.
                                        ↑
 
 //! > popover
-No hover information.
+```cairo
 
+
+    pub struct ContractState {
+        pub value: __member_module_value::ContractMemberState,
+    }
+
+```
 =========
 
 //! > hover at Position { line: 30, character: 24 }
@@ -89,6 +114,18 @@ fn read(self: @TMemberState) -> Self::Value;
 //! > popover
 ```cairo
 fn write(ref self: TMemberState, value: Self::Value);
+```
+=========
+
+//! > hover at Position { line: 33, character: 50 }
+
+//! > source context
+            self.value.write( self.value.read() + a );
+                                                  ↑
+
+//! > popover
+```cairo
+fn increase(ref self: ContractState, a: u128)
 ```
 =========
 


### PR DESCRIPTION
Since ba74ab11b8c678f97bf3e12d7145f7e01abd1eb1 the hover logic wrongly
tried to find definition lookup item by inspecting originating location
within `get_definition_location`. The bug was introduced by making an
attempt to share the definition lookup logic with _goto definition_,
where actually both features need different results.

---

**Stack**:
- #5605
- #5603 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5603)
<!-- Reviewable:end -->
