### PR TITLE
VSCode: Add `cairo1.preferScarbLanguageServer` option

### DIFF
--- a/vscode-cairo/package.json
+++ b/vscode-cairo/package.json
@@ -60,6 +60,12 @@
             "description": "Enable the use of Scarb package manager.",
             "scope": "window"
           },
+          "cairo1.preferScarbLanguageServer": {
+            "type": "boolean",
+            "default": "true",
+            "description": "If the workspace contains a Scarb.toml file, prefer using `scarb cairo-language-server` over standalone `cairo-language-server` (e.g. one specified by `cairo1.languageServerPath`).",
+            "scope": "window"
+          },
           "cairo1.scarbPath": {
             "type": "string",
             "description": "Path to the Scarb package manager binary.",

--- a/vscode-cairo/src/config.ts
+++ b/vscode-cairo/src/config.ts
@@ -5,6 +5,7 @@ interface ConfigProps {
   enableLanguageServer: boolean;
   languageServerPath: string;
   enableScarb: boolean;
+  preferScarbLanguageServer: boolean;
   scarbPath: string;
   corelibPath: string;
   languageServerExtraEnv: null | Record<string, string | number>;
@@ -28,11 +29,6 @@ export class Config {
       return replacePathPlaceholders(value, undefined);
     }
     return value;
-  }
-
-  public has(prop: keyof ConfigProps): boolean {
-    const config = vscode.workspace.getConfiguration(Config.ROOT);
-    return config.has(prop);
   }
 }
 


### PR DESCRIPTION
This PR adds a possibility to allow VSC extension users to use Scarb
project recognition, but use their Cairo LS build, instead of the one
built-into Scarb.

The following configuration will now enable running standalone LS with
auto-detected Scarb installation passed via `SCARB` environment
variable:

```json
{
"cairo1.languageServerPath": "/path/to/cairo-language-server",
"cairo1.preferScarbLanguageServer": false
}
```

fix #4760

---

**Stack**:
- #5611
- #5607 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5607)
<!-- Reviewable:end -->
