### PR TITLE
Replace `ResultHelper::on_err` with `std::Result::inspect_err`

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -8,7 +8,7 @@ use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::TypedStablePtr;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::unordered_hash_map::{Entry, UnorderedHashMap};
-use cairo_lang_utils::{extract_matches, try_extract_matches, Intern, LookupIntern, ResultHelper};
+use cairo_lang_utils::{extract_matches, try_extract_matches, Intern, LookupIntern};
 use defs::ids::TopLevelLanguageElementId;
 use itertools::{chain, izip, zip_eq, Itertools};
 use num_bigint::{BigInt, Sign};
@@ -1645,7 +1645,7 @@ fn check_error_free_or_warn(
     diagnostics_description: &str,
 ) -> Maybe<()> {
     let declaration_error_free = diagnostics.check_error_free();
-    declaration_error_free.on_err(|_| {
+    declaration_error_free.inspect_err(|_| {
         log::warn!(
             "Function `{function_path}` has semantic diagnostics in its \
              {diagnostics_description}:\n{diagnostics_format}",

--- a/crates/cairo-lang-test-utils/src/parse_test_file.rs
+++ b/crates/cairo-lang-test-utils/src/parse_test_file.rs
@@ -9,7 +9,6 @@ use std::path::Path;
 
 use cairo_lang_formatter::CairoFormatter;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::ResultHelper;
 use colored::Colorize;
 
 const TAG_PREFIX: &str = "//! > ";
@@ -71,7 +70,8 @@ struct TestBuilder {
 }
 
 pub fn parse_test_file(filename: &Path) -> io::Result<OrderedHashMap<String, Test>> {
-    let file = fs::File::open(filename).on_err(|_| log::error!("File not found: {filename:?}"))?;
+    let file =
+        fs::File::open(filename).inspect_err(|_| log::error!("File not found: {filename:?}"))?;
     let mut lines = io::BufReader::new(file).lines();
     let mut builder = TestBuilder::default();
     let mut line_num: usize = 0;

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -59,22 +59,6 @@ impl<T> OptionHelper for Option<T> {
     }
 }
 
-/// Helper operations on `Option<T>`.
-pub trait ResultHelper<E> {
-    fn on_err<F: FnOnce(&E)>(self, f: F) -> Self;
-}
-impl<T, E> ResultHelper<E> for Result<T, E> {
-    fn on_err<F: FnOnce(&E)>(self, f: F) -> Self {
-        match &self {
-            Ok(_) => self,
-            Err(e) => {
-                f(e);
-                self
-            }
-        }
-    }
-}
-
 /// Borrows a mutable reference as Box for the lifespan of this function. Runs the given closure
 /// with the boxed value as a parameter.
 /// The closure is expected to return a boxed value, whose changes will be reflected on the mutable


### PR DESCRIPTION
**Stack**:
- #5624
- #5623 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5623)
<!-- Reviewable:end -->
