### PR TITLE
LS: Degrade gracefully on most quirks in File<>URL conversion

### DIFF
--- a/crates/cairo-lang-language-server/src/ide/code_actions/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/code_actions/mod.rs
@@ -21,7 +21,7 @@ mod rename_unused_variable;
 )]
 pub fn code_actions(params: CodeActionParams, db: &RootDatabase) -> Option<CodeActionResponse> {
     let mut actions = Vec::with_capacity(params.context.diagnostics.len());
-    let file_id = db.file_for_url(&params.text_document.uri);
+    let file_id = db.file_for_url(&params.text_document.uri)?;
     let node = db.find_syntax_node_at_position(file_id, params.range.start.to_cairo())?;
     for diagnostic in params.context.diagnostics.iter() {
         actions.extend(

--- a/crates/cairo-lang-language-server/src/ide/completion/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/completion/mod.rs
@@ -24,7 +24,7 @@ mod completions;
 )]
 pub fn complete(params: CompletionParams, db: &RootDatabase) -> Option<CompletionResponse> {
     let text_document_position = params.text_document_position;
-    let file_id = db.file_for_url(&text_document_position.text_document.uri);
+    let file_id = db.file_for_url(&text_document_position.text_document.uri)?;
     let mut position = text_document_position.position;
     position.character = position.character.saturating_sub(1);
 

--- a/crates/cairo-lang-language-server/src/ide/formatter.rs
+++ b/crates/cairo-lang-language-server/src/ide/formatter.rs
@@ -16,7 +16,7 @@ use crate::lang::lsp::LsProtoGroup;
 )]
 pub fn format(params: DocumentFormattingParams, db: &RootDatabase) -> Option<Vec<TextEdit>> {
     let file_uri = params.text_document.uri;
-    let file = db.file_for_url(&file_uri);
+    let file = db.file_for_url(&file_uri)?;
 
     let Ok(node) = db.file_syntax(file) else {
         error!("formatting failed: file '{file_uri}' does not exist");

--- a/crates/cairo-lang-language-server/src/ide/hover.rs
+++ b/crates/cairo-lang-language-server/src/ide/hover.rs
@@ -17,7 +17,7 @@ use crate::lang::syntax::LsSyntaxGroup;
     fields(uri = %params.text_document_position_params.text_document.uri)
 )]
 pub fn hover(params: HoverParams, db: &RootDatabase) -> Option<Hover> {
-    let file_id = db.file_for_url(&params.text_document_position_params.text_document.uri);
+    let file_id = db.file_for_url(&params.text_document_position_params.text_document.uri)?;
     let position = params.text_document_position_params.position.to_cairo();
     // Get the syntax node of the definition.
     let definition_node = {

--- a/crates/cairo-lang-language-server/src/ide/navigation/goto_definition.rs
+++ b/crates/cairo-lang-language-server/src/ide/navigation/goto_definition.rs
@@ -15,7 +15,7 @@ pub fn goto_definition(
     params: GotoDefinitionParams,
     db: &RootDatabase,
 ) -> Option<GotoDefinitionResponse> {
-    let file = db.file_for_url(&params.text_document_position_params.text_document.uri);
+    let file = db.file_for_url(&params.text_document_position_params.text_document.uri)?;
     let position = params.text_document_position_params.position.to_cairo();
     let (found_file, span) = get_definition_location(db, file, position)?;
     let found_uri = db.url_for_file(found_file);

--- a/crates/cairo-lang-language-server/src/ide/semantic_highlighting/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/semantic_highlighting/mod.rs
@@ -29,7 +29,7 @@ pub fn semantic_highlight_full(
     db: &RootDatabase,
 ) -> Option<SemanticTokensResult> {
     let file_uri = params.text_document.uri;
-    let file = db.file_for_url(&file_uri);
+    let file = db.file_for_url(&file_uri)?;
     let Ok(node) = db.file_syntax(file) else {
         error!("semantic analysis failed: file '{file_uri}' does not exist");
         return None;

--- a/crates/cairo-lang-language-server/src/lang/lsp/ls_proto_group.rs
+++ b/crates/cairo-lang-language-server/src/lang/lsp/ls_proto_group.rs
@@ -3,44 +3,54 @@ use cairo_lang_filesystem::ids::{FileId, FileLongId};
 use cairo_lang_utils::Upcast;
 use salsa::InternKey;
 use tower_lsp::lsp_types::Url;
+use tracing::error;
+
+#[cfg(test)]
+#[path = "ls_proto_group_test.rs"]
+mod test;
 
 pub trait LsProtoGroup: Upcast<dyn FilesGroup> {
     /// Get a [`FileId`] from an [`Url`].
     ///
-    /// ## Safety
-    /// This function assumes the `url` was produced by this language server. It panics for unknown
-    /// url schemes or parse failures.
-    fn file_for_url(&self, uri: &Url) -> FileId {
+    /// Returns `None` on failure, and errors are logged.
+    fn file_for_url(&self, uri: &Url) -> Option<FileId> {
         match uri.scheme() {
-            "file" => {
-                let path = uri.to_file_path().expect("Invalid file URL.");
-                FileId::new(self.upcast(), path)
+            "file" => uri
+                .to_file_path()
+                .inspect_err(|()| error!("invalid file url: {uri}"))
+                .ok()
+                .map(|path| FileId::new(self.upcast(), path)),
+            "vfs" => uri
+                .host_str()
+                .or_else(|| {
+                    error!("invalid vfs url, missing host string: {uri}");
+                    None
+                })?
+                .parse::<usize>()
+                .inspect_err(|e| {
+                    error!("invalid vfs url, host string is not a valid integer, {e}: {uri}")
+                })
+                .ok()
+                .map(Into::into)
+                .map(FileId::from_intern_id),
+            _ => {
+                error!("invalid url, scheme is not supported by this language server: {uri}");
+                None
             }
-            "vfs" => {
-                let id = uri
-                    .host_str()
-                    .expect("Invalid VFS URL: missing host string.")
-                    .parse::<usize>()
-                    .expect("Invalid VFS URL: host string is not a valid integer.");
-                FileId::from_intern_id(id.into())
-            }
-            _ => panic!("Invalid URL: scheme is not supported by this language server."),
         }
     }
 
     /// Get the canonical [`Url`] for a [`FileId`].
     fn url_for_file(&self, file_id: FileId) -> Url {
         match self.upcast().lookup_intern_file(file_id) {
-            FileLongId::OnDisk(path) => {
-                Url::from_file_path(path).expect("Salsa is expected to store absolute paths.")
-            }
+            FileLongId::OnDisk(path) => Url::from_file_path(path).unwrap(),
             FileLongId::Virtual(virtual_file) => {
-                let url = format!(
-                    "vfs://{}/{}.cairo",
-                    file_id.as_intern_id().as_usize(),
-                    virtual_file.name
-                );
-                Url::parse(&url).unwrap()
+                // NOTE: The URL is constructed using setters and path segments in order to
+                //   url-encode any funky characters in parts that LS is not controlling.
+                let mut url = Url::parse("vfs://").unwrap();
+                url.set_host(Some(&file_id.as_intern_id().to_string())).unwrap();
+                url.path_segments_mut().unwrap().push(&format!("{}.cairo", virtual_file.name));
+                url
             }
         }
     }

--- a/crates/cairo-lang-language-server/src/lang/lsp/ls_proto_group_test.rs
+++ b/crates/cairo-lang-language-server/src/lang/lsp/ls_proto_group_test.rs
@@ -1,0 +1,45 @@
+use cairo_lang_filesystem::db::FilesGroup;
+use cairo_lang_filesystem::ids::{FileKind, FileLongId, VirtualFile};
+use cairo_lang_filesystem::test_utils::FilesDatabaseForTesting;
+use tower_lsp::lsp_types::Url;
+
+use super::LsProtoGroup;
+
+#[test]
+fn file_url() {
+    let db = FilesDatabaseForTesting::default();
+
+    let check = |expected_url: &str, expected_file_long: FileLongId| {
+        let expected_url = Url::parse(expected_url).unwrap();
+        let expected_file = db.intern_file(expected_file_long);
+
+        assert_eq!(db.file_for_url(&expected_url), Some(expected_file));
+        assert_eq!(db.url_for_file(expected_file), expected_url);
+    };
+
+    check("file:///foo/bar", FileLongId::OnDisk("/foo/bar".into()));
+    check("file:///", FileLongId::OnDisk("/".into()));
+
+    // NOTE: We expect that Salsa is assigning sequential numeric ids to files,
+    //   hence numbers 2 and 3 appear further down.
+    check(
+        "vfs://2/foo.cairo",
+        FileLongId::Virtual(VirtualFile {
+            parent: None,
+            name: "foo".into(),
+            content: Default::default(),
+            code_mappings: Default::default(),
+            kind: FileKind::Module,
+        }),
+    );
+    check(
+        "vfs://3/foo%2Fbar.cairo",
+        FileLongId::Virtual(VirtualFile {
+            parent: None,
+            name: "foo/bar".into(),
+            content: Default::default(),
+            code_mappings: Default::default(),
+            kind: FileKind::Module,
+        }),
+    );
+}


### PR DESCRIPTION
One quirk left: `Url::from_file_path(path).unwrap()` happens to panic on
user machines, but fixing it requires more systematic change in
cairo-lang-filesystem, which will be done in separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5624)
<!-- Reviewable:end -->
