### PR TITLE
LS: Make all paths at input absolute

### DIFF
--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -581,6 +581,10 @@ impl Backend {
             }
 
             Some(ProjectManifestPath::CairoProject(config_path)) => {
+                // The base path of ProjectConfig must be absolute to ensure that all paths in Salsa
+                // DB will also be absolute.
+                assert!(config_path.is_absolute());
+
                 try_to_init_unmanaged_core(&*self.config.read().await, db);
 
                 if let Ok(config) = ProjectConfig::from_file(&config_path) {

--- a/crates/cairo-lang-language-server/src/project/scarb/db.rs
+++ b/crates/cairo-lang-language-server/src/project/scarb/db.rs
@@ -112,6 +112,12 @@ fn validate_and_chop_source_path<'a>(
         );
     };
 
+    ensure!(
+        root.is_absolute(),
+        "source path must be absolute: {source_path}",
+        source_path = source_path.display()
+    );
+
     let Some(file_stem) = source_path.file_stem() else {
         bail!(
             "failed to get file stem for component `{crate_name}`: {source_path}",


### PR DESCRIPTION
Language server's Salsa **must** use absolute paths for `FileLongId`s
**exclusively**, as panics would happen when trying to generate
`file://` URLs for LSP use.

This is something LS-specific. It doesn't matter for the compiler itself
because none of its interfaces are sensitive to this problem, hence the
fix is applied at call sites instead of enforcing this within
`FileLongId`. And probably such enforcement would not be desired, as
diagnostics output etc. would have to be able to relativize such
absolute paths for clean look.

In the ideal world, a proper VFS abstraction in
`cairo-lang-filesystem` should provide a mean to enforce absolute
paths if needed, but this is very much TBD yet.

---

**Stack**:
- #5671
- #5670
- #5632 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5632)
<!-- Reviewable:end -->
