### PR TITLE
VSCode: Drop word `Extension` from output panel title

### DIFF
--- a/vscode-cairo/src/context.ts
+++ b/vscode-cairo/src/context.ts
@@ -5,7 +5,7 @@ import { RootLogOutputChannel } from "./logging";
 export class Context {
   public static create(extensionContext: vscode.ExtensionContext): Context {
     const log = new RootLogOutputChannel(
-      vscode.window.createOutputChannel("Cairo Extension", {
+      vscode.window.createOutputChannel("Cairo", {
         log: true,
       }),
     );


### PR DESCRIPTION
**Stack**:
- #5687
- #5686 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5686)
<!-- Reviewable:end -->
