### PR TITLE
Made basic tuple and fixed array impls work up to size 10.

### DIFF
--- a/corelib/src/hash.cairo
+++ b/corelib/src/hash.cairo
@@ -88,63 +88,26 @@ impl TupleSize0Hash<S, +HashStateTrait<S>> of Hash<(), S> {
     }
 }
 
-impl TupleSize1Hash<E0, S, +Hash<E0, S>, +HashStateTrait<S>> of Hash<(E0,), S> {
+impl FixedSizedArray0Hash<T, S, +HashStateTrait<S>, +Drop<T>> of Hash<[T; 0], S> {
     #[inline(always)]
-    fn update_state(state: S, value: (E0,)) -> S {
-        let (e0,) = value;
-        state.update_with(e0)
+    fn update_state(state: S, value: [T; 0]) -> S {
+        state
     }
 }
 
-impl TupleSize2Hash<
-    E0, E1, S, +HashStateTrait<S>, +Hash<E0, S>, +Hash<E1, S>, +Drop<E0>, +Drop<E1>,
-> of Hash<(E0, E1), S> {
-    #[inline(always)]
-    fn update_state(state: S, value: (E0, E1,)) -> S {
-        let (e0, e1) = value;
-        state.update_with(e0).update_with(e1)
-    }
-}
-
-impl TupleSize3Hash<
-    E0,
-    E1,
-    E2,
+impl TupleNextHash<
+    T,
     S,
     +HashStateTrait<S>,
-    +Hash<E0, S>,
-    +Hash<E1, S>,
-    +Hash<E2, S>,
-    +Drop<E0>,
-    +Drop<E1>,
-    +Drop<E2>,
-> of Hash<(E0, E1, E2), S> {
+    const IS_TUPLE: bool,
+    impl TH: core::metaprogramming::TupleHelper<T, IS_TUPLE>,
+    +Hash<TH::Head, S>,
+    +Hash<TH::Rest, S>,
+    +Drop<TH::Rest>,
+> of Hash<T, S> {
     #[inline(always)]
-    fn update_state(state: S, value: (E0, E1, E2)) -> S {
-        let (e0, e1, e2) = value;
-        state.update_with(e0).update_with(e1).update_with(e2)
-    }
-}
-
-impl TupleSize4Hash<
-    E0,
-    E1,
-    E2,
-    E3,
-    S,
-    +HashStateTrait<S>,
-    +Hash<E0, S>,
-    +Hash<E1, S>,
-    +Hash<E2, S>,
-    +Hash<E3, S>,
-    +Drop<E0>,
-    +Drop<E1>,
-    +Drop<E2>,
-    +Drop<E3>,
-> of Hash<(E0, E1, E2, E3), S> {
-    #[inline(always)]
-    fn update_state(state: S, value: (E0, E1, E2, E3)) -> S {
-        let (e0, e1, e2, e3) = value;
-        state.update_with(e0).update_with(e1).update_with(e2).update_with(e3)
+    fn update_state(state: S, value: T) -> S {
+        let (head, rest) = TH::split_head(value);
+        state.update_with(head).update_with(rest)
     }
 }

--- a/corelib/src/metaprogramming.cairo
+++ b/corelib/src/metaprogramming.cairo
@@ -3,3 +3,278 @@
 pub trait TypeEqual<S, T> {}
 
 impl TypeEqualImpl<T> of TypeEqual<T, T>;
+
+/// A trait to help with implementation for traits of tuple like objects.
+pub(crate) trait TupleHelper<T, const IS_TUPLE: bool> {
+    /// The type of the first element of the tuple.
+    type Head;
+    /// The type of the rest of the tuple.
+    type Rest;
+    /// Splits the tuple into the head and the rest.
+    fn split_head(self: T) -> (Self::Head, Self::Rest) nopanic;
+    /// Reconstructs the tuple from the head and the rest.
+    fn reconstruct(head: Self::Head, rest: Self::Rest) -> T nopanic;
+}
+impl TupleHelperForTupleSize1<E0> of TupleHelper<(E0,), { true }> {
+    type Head = E0;
+    type Rest = ();
+    fn split_head(self: (E0,)) -> (E0, ()) nopanic {
+        let (e0,) = self;
+        (e0, ())
+    }
+    fn reconstruct(head: E0, rest: ()) -> (E0,) nopanic {
+        (head,)
+    }
+}
+impl TupleHelperForTupleSize2<E0, E1> of TupleHelper<(E0, E1), { true }> {
+    type Head = E0;
+    type Rest = (E1,);
+    fn split_head(self: (E0, E1)) -> (E0, (E1,)) nopanic {
+        let (e0, e1) = self;
+        (e0, (e1,))
+    }
+    fn reconstruct(head: E0, rest: (E1,)) -> (E0, E1) nopanic {
+        let (e1,) = rest;
+        (head, e1)
+    }
+}
+impl TupleHelperForTupleSize3<E0, E1, E2> of TupleHelper<(E0, E1, E2), { true }> {
+    type Head = E0;
+    type Rest = (E1, E2);
+    fn split_head(self: (E0, E1, E2)) -> (E0, (E1, E2)) nopanic {
+        let (e0, e1, e2) = self;
+        (e0, (e1, e2))
+    }
+    fn reconstruct(head: E0, rest: (E1, E2)) -> (E0, E1, E2) nopanic {
+        let (e1, e2) = rest;
+        (head, e1, e2)
+    }
+}
+impl TupleHelperForTupleSize4<E0, E1, E2, E3> of TupleHelper<(E0, E1, E2, E3), { true }> {
+    type Head = E0;
+    type Rest = (E1, E2, E3);
+    fn split_head(self: (E0, E1, E2, E3)) -> (E0, (E1, E2, E3)) nopanic {
+        let (e0, e1, e2, e3) = self;
+        (e0, (e1, e2, e3))
+    }
+    fn reconstruct(head: E0, rest: (E1, E2, E3)) -> (E0, E1, E2, E3) nopanic {
+        let (e1, e2, e3) = rest;
+        (head, e1, e2, e3)
+    }
+}
+impl TupleHelperForTupleSize5<E0, E1, E2, E3, E4> of TupleHelper<(E0, E1, E2, E3, E4), { true }> {
+    type Head = E0;
+    type Rest = (E1, E2, E3, E4);
+    fn split_head(self: (E0, E1, E2, E3, E4)) -> (E0, (E1, E2, E3, E4)) nopanic {
+        let (e0, e1, e2, e3, e4) = self;
+        (e0, (e1, e2, e3, e4))
+    }
+    fn reconstruct(head: E0, rest: (E1, E2, E3, E4)) -> (E0, E1, E2, E3, E4) nopanic {
+        let (e1, e2, e3, e4) = rest;
+        (head, e1, e2, e3, e4)
+    }
+}
+impl TupleHelperForTupleSize6<
+    E0, E1, E2, E3, E4, E5
+> of TupleHelper<(E0, E1, E2, E3, E4, E5), { true }> {
+    type Head = E0;
+    type Rest = (E1, E2, E3, E4, E5);
+    fn split_head(self: (E0, E1, E2, E3, E4, E5)) -> (E0, (E1, E2, E3, E4, E5)) nopanic {
+        let (e0, e1, e2, e3, e4, e5) = self;
+        (e0, (e1, e2, e3, e4, e5))
+    }
+    fn reconstruct(head: E0, rest: (E1, E2, E3, E4, E5)) -> (E0, E1, E2, E3, E4, E5) nopanic {
+        let (e1, e2, e3, e4, e5) = rest;
+        (head, e1, e2, e3, e4, e5)
+    }
+}
+impl TupleHelperForTupleSize7<
+    E0, E1, E2, E3, E4, E5, E6
+> of TupleHelper<(E0, E1, E2, E3, E4, E5, E6), { true }> {
+    type Head = E0;
+    type Rest = (E1, E2, E3, E4, E5, E6);
+    fn split_head(self: (E0, E1, E2, E3, E4, E5, E6)) -> (E0, (E1, E2, E3, E4, E5, E6)) nopanic {
+        let (e0, e1, e2, e3, e4, e5, e6) = self;
+        (e0, (e1, e2, e3, e4, e5, e6))
+    }
+    fn reconstruct(
+        head: E0, rest: (E1, E2, E3, E4, E5, E6)
+    ) -> (E0, E1, E2, E3, E4, E5, E6) nopanic {
+        let (e1, e2, e3, e4, e5, e6) = rest;
+        (head, e1, e2, e3, e4, e5, e6)
+    }
+}
+impl TupleHelperForTupleSize8<
+    E0, E1, E2, E3, E4, E5, E6, E7
+> of TupleHelper<(E0, E1, E2, E3, E4, E5, E6, E7), { true }> {
+    type Head = E0;
+    type Rest = (E1, E2, E3, E4, E5, E6, E7);
+    fn split_head(
+        self: (E0, E1, E2, E3, E4, E5, E6, E7)
+    ) -> (E0, (E1, E2, E3, E4, E5, E6, E7)) nopanic {
+        let (e0, e1, e2, e3, e4, e5, e6, e7) = self;
+        (e0, (e1, e2, e3, e4, e5, e6, e7))
+    }
+    fn reconstruct(
+        head: E0, rest: (E1, E2, E3, E4, E5, E6, E7)
+    ) -> (E0, E1, E2, E3, E4, E5, E6, E7) nopanic {
+        let (e1, e2, e3, e4, e5, e6, e7) = rest;
+        (head, e1, e2, e3, e4, e5, e6, e7)
+    }
+}
+impl TupleHelperForTupleSize9<
+    E0, E1, E2, E3, E4, E5, E6, E7, E8
+> of TupleHelper<(E0, E1, E2, E3, E4, E5, E6, E7, E8), { true }> {
+    type Head = E0;
+    type Rest = (E1, E2, E3, E4, E5, E6, E7, E8);
+    fn split_head(
+        self: (E0, E1, E2, E3, E4, E5, E6, E7, E8)
+    ) -> (E0, (E1, E2, E3, E4, E5, E6, E7, E8)) nopanic {
+        let (e0, e1, e2, e3, e4, e5, e6, e7, e8) = self;
+        (e0, (e1, e2, e3, e4, e5, e6, e7, e8))
+    }
+    fn reconstruct(
+        head: E0, rest: (E1, E2, E3, E4, E5, E6, E7, E8)
+    ) -> (E0, E1, E2, E3, E4, E5, E6, E7, E8) nopanic {
+        let (e1, e2, e3, e4, e5, e6, e7, e8) = rest;
+        (head, e1, e2, e3, e4, e5, e6, e7, e8)
+    }
+}
+impl TupleHelperForTupleSize10<
+    E0, E1, E2, E3, E4, E5, E6, E7, E8, E9
+> of TupleHelper<(E0, E1, E2, E3, E4, E5, E6, E7, E8, E9), { true }> {
+    type Head = E0;
+    type Rest = (E1, E2, E3, E4, E5, E6, E7, E8, E9);
+    fn split_head(
+        self: (E0, E1, E2, E3, E4, E5, E6, E7, E8, E9)
+    ) -> (E0, (E1, E2, E3, E4, E5, E6, E7, E8, E9)) nopanic {
+        let (e0, e1, e2, e3, e4, e5, e6, e7, e8, e9) = self;
+        (e0, (e1, e2, e3, e4, e5, e6, e7, e8, e9))
+    }
+    fn reconstruct(
+        head: E0, rest: (E1, E2, E3, E4, E5, E6, E7, E8, E9)
+    ) -> (E0, E1, E2, E3, E4, E5, E6, E7, E8, E9) nopanic {
+        let (e1, e2, e3, e4, e5, e6, e7, e8, e9) = rest;
+        (head, e1, e2, e3, e4, e5, e6, e7, e8, e9)
+    }
+}
+impl TupleHelperForFixedSizedArraySized1<T> of TupleHelper<[T; 1], { false }> {
+    type Head = T;
+    type Rest = [T; 0];
+    fn split_head(self: [T; 1]) -> (T, [T; 0]) nopanic {
+        let [e0] = self;
+        (e0, [])
+    }
+    fn reconstruct(head: T, rest: [T; 0]) -> [T; 1] nopanic {
+        let [] = rest;
+        [head]
+    }
+}
+impl TupleHelperForFixedSizedArraySized2<T> of TupleHelper<[T; 2], { false }> {
+    type Head = T;
+    type Rest = [T; 1];
+    fn split_head(self: [T; 2]) -> (T, [T; 1]) nopanic {
+        let [e0, e1] = self;
+        (e0, [e1])
+    }
+    fn reconstruct(head: T, rest: [T; 1]) -> [T; 2] nopanic {
+        let [e1] = rest;
+        [head, e1]
+    }
+}
+impl TupleHelperForFixedSizedArraySized3<T> of TupleHelper<[T; 3], { false }> {
+    type Head = T;
+    type Rest = [T; 2];
+    fn split_head(self: [T; 3]) -> (T, [T; 2]) nopanic {
+        let [e0, e1, e2] = self;
+        (e0, [e1, e2])
+    }
+    fn reconstruct(head: T, rest: [T; 2]) -> [T; 3] nopanic {
+        let [e1, e2] = rest;
+        [head, e1, e2]
+    }
+}
+impl TupleHelperForFixedSizedArraySized4<T> of TupleHelper<[T; 4], { false }> {
+    type Head = T;
+    type Rest = [T; 3];
+    fn split_head(self: [T; 4]) -> (T, [T; 3]) nopanic {
+        let [e0, e1, e2, e3] = self;
+        (e0, [e1, e2, e3])
+    }
+    fn reconstruct(head: T, rest: [T; 3]) -> [T; 4] nopanic {
+        let [e1, e2, e3] = rest;
+        [head, e1, e2, e3]
+    }
+}
+impl TupleHelperForFixedSizedArraySized5<T> of TupleHelper<[T; 5], { false }> {
+    type Head = T;
+    type Rest = [T; 4];
+    fn split_head(self: [T; 5]) -> (T, [T; 4]) nopanic {
+        let [e0, e1, e2, e3, e4] = self;
+        (e0, [e1, e2, e3, e4])
+    }
+    fn reconstruct(head: T, rest: [T; 4]) -> [T; 5] nopanic {
+        let [e1, e2, e3, e4] = rest;
+        [head, e1, e2, e3, e4]
+    }
+}
+impl TupleHelperForFixedSizedArraySized6<T> of TupleHelper<[T; 6], { false }> {
+    type Head = T;
+    type Rest = [T; 5];
+    fn split_head(self: [T; 6]) -> (T, [T; 5]) nopanic {
+        let [e0, e1, e2, e3, e4, e5] = self;
+        (e0, [e1, e2, e3, e4, e5])
+    }
+    fn reconstruct(head: T, rest: [T; 5]) -> [T; 6] nopanic {
+        let [e1, e2, e3, e4, e5] = rest;
+        [head, e1, e2, e3, e4, e5]
+    }
+}
+impl TupleHelperForFixedSizedArraySized7<T> of TupleHelper<[T; 7], { false }> {
+    type Head = T;
+    type Rest = [T; 6];
+    fn split_head(self: [T; 7]) -> (T, [T; 6]) nopanic {
+        let [e0, e1, e2, e3, e4, e5, e6] = self;
+        (e0, [e1, e2, e3, e4, e5, e6])
+    }
+    fn reconstruct(head: T, rest: [T; 6]) -> [T; 7] nopanic {
+        let [e1, e2, e3, e4, e5, e6] = rest;
+        [head, e1, e2, e3, e4, e5, e6]
+    }
+}
+impl TupleHelperForFixedSizedArraySized8<T> of TupleHelper<[T; 8], { false }> {
+    type Head = T;
+    type Rest = [T; 7];
+    fn split_head(self: [T; 8]) -> (T, [T; 7]) nopanic {
+        let [e0, e1, e2, e3, e4, e5, e6, e7] = self;
+        (e0, [e1, e2, e3, e4, e5, e6, e7])
+    }
+    fn reconstruct(head: T, rest: [T; 7]) -> [T; 8] nopanic {
+        let [e1, e2, e3, e4, e5, e6, e7] = rest;
+        [head, e1, e2, e3, e4, e5, e6, e7]
+    }
+}
+impl TupleHelperForFixedSizedArraySized9<T> of TupleHelper<[T; 9], { false }> {
+    type Head = T;
+    type Rest = [T; 8];
+    fn split_head(self: [T; 9]) -> (T, [T; 8]) nopanic {
+        let [e0, e1, e2, e3, e4, e5, e6, e7, e8] = self;
+        (e0, [e1, e2, e3, e4, e5, e6, e7, e8])
+    }
+    fn reconstruct(head: T, rest: [T; 8]) -> [T; 9] nopanic {
+        let [e1, e2, e3, e4, e5, e6, e7, e8] = rest;
+        [head, e1, e2, e3, e4, e5, e6, e7, e8]
+    }
+}
+impl TupleHelperForFixedSizedArraySized10<T> of TupleHelper<[T; 10], { false }> {
+    type Head = T;
+    type Rest = [T; 9];
+    fn split_head(self: [T; 10]) -> (T, [T; 9]) nopanic {
+        let [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9] = self;
+        (e0, [e1, e2, e3, e4, e5, e6, e7, e8, e9])
+    }
+    fn reconstruct(head: T, rest: [T; 9]) -> [T; 10] nopanic {
+        let [e1, e2, e3, e4, e5, e6, e7, e8, e9] = rest;
+        [head, e1, e2, e3, e4, e5, e6, e7, e8, e9]
+    }
+}

--- a/corelib/src/traits.cairo
+++ b/corelib/src/traits.cairo
@@ -207,31 +207,15 @@ pub trait Felt252DictValue<T> {
     fn zero_default() -> T nopanic;
 }
 
-// Tuple Copy impls.
+// Tuple Copy and Drop impls.
 pub(crate) impl TupleSize0Copy of Copy<()>;
-
-impl TupleSize1Copy<E0, +Copy<E0>> of Copy<(E0,)>;
-
-impl TupleSize2Copy<E0, E1, +Copy<E0>, +Copy<E1>> of Copy<(E0, E1)>;
-
-impl TupleSize3Copy<E0, E1, E2, +Copy<E0>, +Copy<E1>, +Copy<E2>> of Copy<(E0, E1, E2)>;
-
-impl TupleSize4Copy<
-    E0, E1, E2, E3, +Copy<E0>, +Copy<E1>, +Copy<E2>, +Copy<E3>
-> of Copy<(E0, E1, E2, E3)>;
-
-// Tuple Drop impls.
 pub(crate) impl TupleSize0Drop of Drop<()>;
-
-impl TupleSize1Drop<E0, +Drop<E0>> of Drop<(E0,)>;
-
-impl TupleSize2Drop<E0, E1, +Drop<E0>, +Drop<E1>> of Drop<(E0, E1)>;
-
-impl TupleSize3Drop<E0, E1, E2, +Drop<E0>, +Drop<E1>, +Drop<E2>> of Drop<(E0, E1, E2)>;
-
-impl TupleSize4Drop<
-    E0, E1, E2, E3, +Drop<E0>, +Drop<E1>, +Drop<E2>, +Drop<E3>
-> of Drop<(E0, E1, E2, E3)>;
+impl TupleNextDrop<
+    T, impl TH: core::metaprogramming::TupleHelper<T, { true }>, +Drop<TH::Head>, +Drop<TH::Rest>
+> of Drop<T>;
+impl TupleNextCopy<
+    T, impl TH: core::metaprogramming::TupleHelper<T, { true }>, +Copy<TH::Head>, +Copy<TH::Rest>
+> of Copy<T>;
 
 // Tuple PartialEq impls.
 impl TupleSize0PartialEq of PartialEq<()> {


### PR DESCRIPTION
* Works for Copy, Drop, Hash and starknet::Store.
* Based on a tuple split implementation.

---

**Stack**:
- #5761
- #5760
- #5759
- #5753
- #5752 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5752)
<!-- Reviewable:end -->
