### PR TITLE
LS: Improve fixture format of hover tests

### DIFF
--- a/crates/cairo-lang-language-server/tests/e2e/hover.rs
+++ b/crates/cairo-lang-language-server/tests/e2e/hover.rs
@@ -2,9 +2,13 @@ use std::fmt::Write;
 
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use tower_lsp::lsp_types;
-use tower_lsp::lsp_types::lsp_request;
+use tower_lsp::lsp_types::{
+    lsp_request, ClientCapabilities, Hover, HoverClientCapabilities, HoverContents, HoverParams,
+    LanguageString, MarkedString, MarkupContent, MarkupKind, TextDocumentClientCapabilities,
+    TextDocumentPositionParams,
+};
 
+use crate::support::cursor::{peek_caret, peek_selection};
 use crate::support::{cursors, sandbox};
 
 cairo_lang_test_utils::test_file_test!(
@@ -17,8 +21,7 @@ cairo_lang_test_utils::test_file_test!(
     test_hover
 );
 
-fn caps(base: lsp_types::ClientCapabilities) -> lsp_types::ClientCapabilities {
-    use lsp_types::*;
+fn caps(base: ClientCapabilities) -> ClientCapabilities {
     ClientCapabilities {
         text_document: base.text_document.or_else(Default::default).map(|it| {
             TextDocumentClientCapabilities {
@@ -62,31 +65,28 @@ fn test_hover(
 
         let mut report = String::new();
 
-        let source_line = cairo.lines().nth(position.line as usize).unwrap();
-        writeln!(&mut report, "{:-^1$}", " source context ", source_line.len()).unwrap();
-        writeln!(&mut report, "{source_line}").unwrap();
-        writeln!(
-            &mut report,
-            "{caret:>width$}",
-            caret = "↑",
-            width = position.character as usize + 1
-        )
-        .unwrap();
+        report.push_str("// = source context\n");
+        report.push_str(&peek_caret(&cairo, position));
 
-        let hover = ls.send_request::<lsp_request!("textDocument/hover")>(lsp_types::HoverParams {
-            text_document_position_params: lsp_types::TextDocumentPositionParams {
+        let hover = ls.send_request::<lsp_request!("textDocument/hover")>(HoverParams {
+            text_document_position_params: TextDocumentPositionParams {
                 text_document: ls.doc_id("src/lib.cairo"),
                 position,
             },
             work_done_progress_params: Default::default(),
         });
 
-        let hover = match hover {
-            Some(hover) => render(hover),
-            None => "No hover information.\n".to_owned(),
-        };
-        writeln!(&mut report, "{:-^1$}", " popover ", source_line.len()).unwrap();
-        write!(&mut report, "{hover}").unwrap();
+        report.push_str("// = highlight\n");
+        if let Some(Hover { range: Some(range), .. }) = &hover {
+            report.push_str(&peek_selection(&cairo, range));
+        } else {
+            report.push_str("No highlight information.\n");
+        }
+
+        report.push_str("// = popover\n");
+        report.push_str(
+            &hover.as_ref().map(render).unwrap_or_else(|| "No hover information.\n".to_owned()),
+        );
 
         hovers.insert(hover_name, report);
     }
@@ -98,25 +98,20 @@ fn test_hover(
 /// in the text editor.
 ///
 /// Any additional hover metadata is rendered as HTML comments at the beginning of the output.
-fn render(h: lsp_types::Hover) -> String {
-    use lsp_types::*;
+fn render(h: &Hover) -> String {
     let mut buf = String::new();
 
-    if let Some(range) = h.range {
-        writeln!(&mut buf, "<!-- range: {range:?} -->").unwrap();
-    }
-
-    let mut write_marked_string = |content| match content {
-        MarkedString::String(contents) => buf.push_str(&contents),
+    let mut write_marked_string = |content: &MarkedString| match content {
+        MarkedString::String(contents) => buf.push_str(contents),
         MarkedString::LanguageString(LanguageString { language, value }) => {
             write!(&mut buf, "```{language}\n{value}\n```").unwrap();
         }
     };
 
-    match h.contents {
+    match &h.contents {
         HoverContents::Scalar(content) => write_marked_string(content),
         HoverContents::Markup(MarkupContent { value, .. }) => {
-            buf.push_str(&value);
+            buf.push_str(value);
         }
         HoverContents::Array(contents) => {
             for content in contents {

--- a/crates/cairo-lang-language-server/tests/test_data/hover/basic.txt
+++ b/crates/cairo-lang-language-server/tests/test_data/hover/basic.txt
@@ -73,26 +73,29 @@ pub mod front_of_house {
 }
 
 //! > hover 2:5
------------- source context -------------
-    println!("The value of x is: {}", x);
-     ↑
----------------- popover ----------------
+// = source context
+    p<caret>rintln!("The value of x is: {}", x);
+// = highlight
+No highlight information.
+// = popover
 No hover information.
 
 //! > hover 3:5
-- source context --
-    x = add_two(x);
-     ↑
------ popover -----
+// = source context
+    x<caret> = add_two(x);
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 fn main()
 ```
 
 //! > hover 3:8
-- source context --
-    x = add_two(x);
-        ↑
------ popover -----
+// = source context
+    x = <caret>add_two(x);
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 fn add_two(x: u32) -> u32
 ```
@@ -100,10 +103,11 @@ fn add_two(x: u32) -> u32
  `add_two` documentation.
 
 //! > hover 3:9
-- source context --
-    x = add_two(x);
-         ↑
------ popover -----
+// = source context
+    x = a<caret>dd_two(x);
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 fn add_two(x: u32) -> u32
 ```
@@ -111,10 +115,11 @@ fn add_two(x: u32) -> u32
  `add_two` documentation.
 
 //! > hover 3:15
-- source context --
-    x = add_two(x);
-               ↑
------ popover -----
+// = source context
+    x = add_two<caret>(x);
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 fn add_two(x: u32) -> u32
 ```
@@ -122,24 +127,27 @@ fn add_two(x: u32) -> u32
  `add_two` documentation.
 
 //! > hover 5:9
---------------- source context ----------------
-    front_of_house::hosting::add_to_waitlist();
-         ↑
-------------------- popover -------------------
+// = source context
+    front<caret>_of_house::hosting::add_to_waitlist();
+// = highlight
+No highlight information.
+// = popover
 No hover information.
 
 //! > hover 5:22
---------------- source context ----------------
-    front_of_house::hosting::add_to_waitlist();
-                      ↑
-------------------- popover -------------------
+// = source context
+    front_of_house::ho<caret>sting::add_to_waitlist();
+// = highlight
+No highlight information.
+// = popover
 No hover information.
 
 //! > hover 5:32
---------------- source context ----------------
-    front_of_house::hosting::add_to_waitlist();
-                                ↑
-------------------- popover -------------------
+// = source context
+    front_of_house::hosting::add<caret>_to_waitlist();
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 pub fn add_to_waitlist()
 ```
@@ -147,17 +155,19 @@ pub fn add_to_waitlist()
  Add to waitlist function.
 
 //! > hover 9:8
---------- source context ----------
-fn add_two(x: u32) -> u32 { x + 2 }
-        ↑
-------------- popover -------------
+// = source context
+fn add_t<caret>wo(x: u32) -> u32 { x + 2 }
+// = highlight
+No highlight information.
+// = popover
 No hover information.
 
 //! > hover 23:22
----------- source context -----------
-    fn area(self: @Rectangle) -> u64;
-                      ↑
--------------- popover --------------
+// = source context
+    fn area(self: @Rec<caret>tangle) -> u64;
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 struct Rectangle {
     /// Width of the rectangle.
@@ -171,10 +181,11 @@ struct Rectangle {
  Rectangle struct.
 
 //! > hover 28:22
------------ source context -----------
-    fn area(self: @Rectangle) -> u64 {
-                      ↑
--------------- popover ---------------
+// = source context
+    fn area(self: @Rec<caret>tangle) -> u64 {
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 struct Rectangle {
     /// Width of the rectangle.
@@ -188,17 +199,19 @@ struct Rectangle {
  Rectangle struct.
 
 //! > hover 29:17
------------ source context -----------
-        (*self.width) * (*self.height)
-                 ↑
--------------- popover ---------------
+// = source context
+        (*self.wi<caret>dth) * (*self.height)
+// = highlight
+No highlight information.
+// = popover
 No hover information.
 
 //! > hover 37:22
------------ source context -----------
-    fn area(self: @Rectangle) -> u64 {
-                      ↑
--------------- popover ---------------
+// = source context
+    fn area(self: @Rec<caret>tangle) -> u64 {
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 struct Rectangle {
     /// Width of the rectangle.
@@ -212,17 +225,19 @@ struct Rectangle {
  Rectangle struct.
 
 //! > hover 38:17
------------ source context -----------
-        (*self.width) * (*self.height)
-                 ↑
--------------- popover ---------------
+// = source context
+        (*self.wi<caret>dth) * (*self.height)
+// = highlight
+No highlight information.
+// = popover
 No hover information.
 
 //! > hover 46:25
-------------- source context -------------
-fn value_in_cents(coin: Coin) -> felt252 {
-                         ↑
----------------- popover -----------------
+// = source context
+fn value_in_cents(coin: C<caret>oin) -> felt252 {
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 
 enum Coin {
@@ -232,10 +247,11 @@ enum Coin {
 ```
 
 //! > hover 48:15
----- source context -----
-        Coin::Penny => 1,
-               ↑
--------- popover --------
+// = source context
+        Coin::P<caret>enny => 1,
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 
 enum Coin {

--- a/crates/cairo-lang-language-server/tests/test_data/hover/starknet.txt
+++ b/crates/cairo-lang-language-server/tests/test_data/hover/starknet.txt
@@ -50,26 +50,29 @@ mod Balance {
 }
 
 //! > hover 0:18
------------- source context ------------
-use Balance::contract_state_for_testing;
-                  ↑
---------------- popover ----------------
+// = source context
+use Balance::contr<caret>act_state_for_testing;
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 pub fn contract_state_for_testing() -> ContractState
 ```
 
 //! > hover 23:25
---------------------- source context ----------------------
-    fn constructor(ref self: ContractState, value_: u128) {
-                         ↑
-------------------------- popover -------------------------
+// = source context
+    fn constructor(ref se<caret>lf: ContractState, value_: u128) {
+// = highlight
+No highlight information.
+// = popover
 No hover information.
 
 //! > hover 23:33
---------------------- source context ----------------------
-    fn constructor(ref self: ContractState, value_: u128) {
-                                 ↑
-------------------------- popover -------------------------
+// = source context
+    fn constructor(ref self: Cont<caret>ractState, value_: u128) {
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 
 
@@ -80,26 +83,29 @@ No hover information.
 ```
 
 //! > hover 24:15
--------- source context ---------
-        self.value.write(value_);
-               ↑
------------- popover ------------
+// = source context
+        self.va<caret>lue.write(value_);
+// = highlight
+No highlight information.
+// = popover
 No hover information.
 
 //! > hover 24:25
--------- source context ---------
-        self.value.write(value_);
-                         ↑
------------- popover ------------
+// = source context
+        self.value.write(<caret>value_);
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 fn constructor(ref self: ContractState, value_: u128)
 ```
 
 //! > hover 28:30
------------------- source context ------------------
-    impl Balance of super::IBalance<ContractState> {
-                              ↑
---------------------- popover ----------------------
+// = source context
+    impl Balance of super::IBa<caret>lance<ContractState> {
+// = highlight
+No highlight information.
+// = popover
 ```cairo
  trait IBalance<T>
 ```
@@ -107,10 +113,11 @@ fn constructor(ref self: ContractState, value_: u128)
  The balance contract interface.
 
 //! > hover 28:39
------------------- source context ------------------
-    impl Balance of super::IBalance<ContractState> {
-                                       ↑
---------------------- popover ----------------------
+// = source context
+    impl Balance of super::IBalance<Con<caret>tractState> {
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 
 
@@ -121,28 +128,31 @@ fn constructor(ref self: ContractState, value_: u128)
 ```
 
 //! > hover 30:24
------- source context -------
-            self.value.read()
-                        ↑
----------- popover ----------
+// = source context
+            self.value.r<caret>ead()
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 fn read(self: @TMemberState) -> Self::Value;
 ```
 
 //! > hover 33:25
-------------------- source context -------------------
-            self.value.write( self.value.read() + a );
-                         ↑
----------------------- popover -----------------------
+// = source context
+            self.value.wr<caret>ite( self.value.read() + a );
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 fn write(ref self: TMemberState, value: Self::Value);
 ```
 
 //! > hover 33:50
-------------------- source context -------------------
-            self.value.write( self.value.read() + a );
-                                                  ↑
----------------------- popover -----------------------
+// = source context
+            self.value.write( self.value.read() + <caret>a );
+// = highlight
+No highlight information.
+// = popover
 ```cairo
 fn increase(ref self: ContractState, a: u128)
 ```


### PR DESCRIPTION
1. Caret is now represented as inline marker instead of underline of
character afterward.
2. Added information about highlighted selection.
This will start becoming noticeable in subsequent PRs.

---

**Stack**:
- #5784
- #5783
- #5782
- #5780
- #5779 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5779)
<!-- Reviewable:end -->
