### PR TITLE
Removed full id replacer from runners.

### DIFF
--- a/crates/bin/cairo-run/src/main.rs
+++ b/crates/bin/cairo-run/src/main.rs
@@ -64,12 +64,13 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("failed to compile: {}", args.path.display());
     }
 
-    let SierraProgramWithDebug { program: sierra_program, debug_info } = Arc::unwrap_or_clone(
+    let SierraProgramWithDebug { program: mut sierra_program, debug_info } = Arc::unwrap_or_clone(
         db.get_sierra_program(main_crate_ids.clone())
             .to_option()
             .with_context(|| "Compilation failed without any diagnostics.")?,
     );
     let replacer = DebugReplacer { db };
+    replacer.enrich_function_names(&mut sierra_program);
     if args.available_gas.is_none() && sierra_program.requires_gas_counter() {
         anyhow::bail!("Program requires gas counter, please provide `--available-gas` argument.");
     }

--- a/crates/cairo-lang-sierra-generator/src/replace_ids.rs
+++ b/crates/cairo-lang-sierra-generator/src/replace_ids.rs
@@ -147,6 +147,16 @@ impl SierraIdReplacer for DebugReplacer<'_> {
     }
 }
 
+impl DebugReplacer<'_> {
+    /// Enriches the function entries with their full function name. Required for tests and cairo
+    /// running.
+    pub fn enrich_function_names(&self, program: &mut cairo_lang_sierra::program::Program) {
+        for function in &mut program.funcs {
+            function.id = self.replace_function_id(&function.id);
+        }
+    }
+}
+
 pub fn replace_sierra_ids(
     db: &dyn SierraGenGroup,
     statement: &pre_sierra::StatementWithLocation,


### PR DESCRIPTION
Only adding full function names as these are required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5790)
<!-- Reviewable:end -->
