### PR TITLE
Make deref lookup stop early if member is found.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -2377,7 +2377,7 @@ fn member_access_expr(
     match &long_ty {
         TypeLongId::Concrete(_) | TypeLongId::Tuple(_) | TypeLongId::FixedSizeArray { .. } => {
             let EnrichedMembers { members, deref_functions } =
-                enriched_members(ctx, lexpr.clone(), stable_ptr)?;
+                enriched_members(ctx, lexpr.clone(), stable_ptr, Some(member_name.clone()))?;
             let Some((member, n_derefs)) = members.get(&member_name) else {
                 return Err(ctx.diagnostics.report(
                     &rhs_syntax,
@@ -2473,10 +2473,14 @@ struct EnrichedMembers {
 /// Enriched members include both direct members (in case of a struct), and members of derefed types
 /// if the type implements the Deref trait into a struct. Returns a map from member names to the
 /// semantic representation, and the number of deref operations needed for each member.
+/// `accessed_member_name` is an optional parameter that can be used to stop the search for members
+/// once the desired member is found. A `None` value means that all members should be returned, this
+/// is useful for completions in the language server.
 fn enriched_members(
     ctx: &mut ComputationContext<'_>,
     mut expr: ExprAndId,
     stable_ptr: ast::ExprPtr,
+    accessed_member_name: Option<SmolStr>,
 ) -> Maybe<EnrichedMembers> {
     // TODO(Gil): Use this function for LS completions.
     let mut ty = expr.ty();
@@ -2496,6 +2500,11 @@ fn enriched_members(
         let members = ctx.db.concrete_struct_members(concrete_struct_id)?;
         for (member_name, member) in members.iter() {
             res.insert(member_name.clone(), (member.clone(), 0));
+            if let Some(ref accessed_member_name) = accessed_member_name {
+                if *member_name == *accessed_member_name {
+                    return Ok(EnrichedMembers { members: res, deref_functions });
+                }
+            }
         }
     }
     // Add members of derefed types.
@@ -2529,16 +2538,21 @@ fn enriched_members(
             break;
         }
         expr = ExprAndId { expr: derefed_expr.clone(), id: ctx.exprs.alloc(derefed_expr) };
+        deref_functions.push(function_id);
         if let TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)) = long_ty {
             let members = ctx.db.concrete_struct_members(concrete_struct_id)?;
             for (member_name, member) in members.iter() {
                 // Insert member if there is not already a member with the same name.
                 if res.get(&member_name.clone()).is_none() {
                     res.insert(member_name.clone(), (member.clone(), n_deref));
+                    if let Some(ref accessed_member_name) = accessed_member_name {
+                        if *member_name == *accessed_member_name {
+                            return Ok(EnrichedMembers { members: res, deref_functions });
+                        }
+                    }
                 }
             }
         }
-        deref_functions.push(function_id);
         if !visited_types.insert(long_ty.intern(ctx.db)) {
             // Break if we have a cycle. A diagnostic will be reported from the impl and not from
             // member access.


### PR DESCRIPTION
**Stack**:
- #5830
- #5841
- #5834 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5834)
<!-- Reviewable:end -->
