### PR TITLE
Add compiler flag to disable inlining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ version = "2.6.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
+ "cairo-lang-lowering",
  "cairo-lang-utils",
  "clap",
  "log",
@@ -688,6 +689,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
+ "clap",
  "env_logger",
  "id-arena",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,6 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "clap",
  "env_logger",
  "id-arena",
  "indoc",

--- a/crates/bin/cairo-compile/Cargo.toml
+++ b/crates/bin/cairo-compile/Cargo.toml
@@ -12,6 +12,7 @@ clap.workspace = true
 log.workspace = true
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "~2.6.4" }
+cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "~2.6.4" }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.6.4", features = [
     "env_logger",
 ] }

--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -38,9 +38,11 @@ fn main() -> anyhow::Result<()> {
 
     let sierra_program = compile_cairo_project_at_path(
         &args.path,
-        CompilerConfig { replace_ids: args.replace_ids,
+        CompilerConfig {
+            replace_ids: args.replace_ids,
             disable_inlining: args.disable_inlining,
-            ..CompilerConfig::default() },
+            ..CompilerConfig::default()
+        },
     )?;
 
     match args.output {

--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use cairo_lang_compiler::project::check_compiler_path;
 use cairo_lang_compiler::{compile_cairo_project_at_path, CompilerConfig};
+use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_utils::logging::init_logging;
 use clap::Parser;
 
@@ -22,9 +23,9 @@ struct Args {
     /// Replaces sierra ids with human-readable ones.
     #[arg(short, long, default_value_t = false)]
     replace_ids: bool,
-    /// Disables inlining functions
-    #[arg(short, long, default_value_t = false)]
-    disable_inlining: bool,
+    /// Overrides inlining behavior
+    #[arg(short, long)]
+    inlining_strategy: InliningStrategy,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -40,7 +41,7 @@ fn main() -> anyhow::Result<()> {
         &args.path,
         CompilerConfig {
             replace_ids: args.replace_ids,
-            disable_inlining: args.disable_inlining,
+            inlining_strategy: args.inlining_strategy,
             ..CompilerConfig::default()
         },
     )?;

--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -22,6 +22,9 @@ struct Args {
     /// Replaces sierra ids with human-readable ones.
     #[arg(short, long, default_value_t = false)]
     replace_ids: bool,
+    /// Disables inlining functions
+    #[arg(short, long, default_value_t = false)]
+    disable_inlining: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -35,7 +38,9 @@ fn main() -> anyhow::Result<()> {
 
     let sierra_program = compile_cairo_project_at_path(
         &args.path,
-        CompilerConfig { replace_ids: args.replace_ids, ..CompilerConfig::default() },
+        CompilerConfig { replace_ids: args.replace_ids,
+            disable_inlining: args.disable_inlining,
+            ..CompilerConfig::default() },
     )?;
 
     match args.output {

--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -7,13 +7,13 @@ use cairo_lang_compiler::{compile_cairo_project_at_path, CompilerConfig};
 use cairo_lang_utils::logging::init_logging;
 use clap::Parser;
 
-/// Options for the `inlining` arguments
+/// Options for the `inlining-strategy` arguments.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum InliningStrategy {
-    /// Do not override inlining strategy
+    /// Do not override inlining strategy.
     #[default]
     Default,
-    /// Inline only in the case of a `inline(always)` annotation
+    /// Inline only in the case of an `inline(always)` annotation.
     Avoid,
 }
 
@@ -41,7 +41,7 @@ struct Args {
     /// Replaces sierra ids with human-readable ones.
     #[arg(short, long, default_value_t = false)]
     replace_ids: bool,
-    /// Overrides inlining behavior
+    /// Overrides inlining behavior.
     #[arg(short, long, default_value = "default")]
     inlining_strategy: InliningStrategy,
 }

--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -42,7 +42,7 @@ struct Args {
     #[arg(short, long, default_value_t = false)]
     replace_ids: bool,
     /// Overrides inlining behavior
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "default")]
     inlining_strategy: InliningStrategy,
 }
 

--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -4,9 +4,27 @@ use std::path::PathBuf;
 use anyhow::Context;
 use cairo_lang_compiler::project::check_compiler_path;
 use cairo_lang_compiler::{compile_cairo_project_at_path, CompilerConfig};
-use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_utils::logging::init_logging;
 use clap::Parser;
+
+/// Options for the `inlining` arguments
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum InliningStrategy {
+    /// Do not override inlining strategy
+    #[default]
+    Default,
+    /// Inline only in the case of a `inline(always)` annotation
+    Avoid,
+}
+
+impl From<crate::InliningStrategy> for cairo_lang_lowering::utils::InliningStrategy {
+    fn from(value: crate::InliningStrategy) -> Self {
+        match value {
+            InliningStrategy::Default => cairo_lang_lowering::utils::InliningStrategy::Default,
+            InliningStrategy::Avoid => cairo_lang_lowering::utils::InliningStrategy::Avoid,
+        }
+    }
+}
 
 /// Compiles a Cairo project to Sierra.
 /// Exits with 0/1 if the compilation succeeds/fails.
@@ -41,7 +59,7 @@ fn main() -> anyhow::Result<()> {
         &args.path,
         CompilerConfig {
             replace_ids: args.replace_ids,
-            inlining_strategy: args.inlining_strategy,
+            inlining_strategy: args.inlining_strategy.into(),
             ..CompilerConfig::default()
         },
     )?;

--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -47,10 +47,11 @@ impl RootDatabase {
         plugins: Vec<Arc<dyn MacroPlugin>>,
         inline_macro_plugins: OrderedHashMap<String, Arc<dyn InlineMacroExprPlugin>>,
         analyzer_plugins: Vec<Arc<dyn AnalyzerPlugin>>,
+        disable_inlining: bool
     ) -> Self {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
-        init_lowering_group(&mut res);
+        init_lowering_group(&mut res, disable_inlining);
         res.set_macro_plugins(plugins);
         res.set_inline_macro_plugins(inline_macro_plugins.into());
         res.set_analyzer_plugins(analyzer_plugins);
@@ -84,6 +85,7 @@ pub struct RootDatabaseBuilder {
     auto_withdraw_gas: bool,
     project_config: Option<Box<ProjectConfig>>,
     cfg_set: Option<CfgSet>,
+    disable_inlining: bool
 }
 
 impl RootDatabaseBuilder {
@@ -94,6 +96,7 @@ impl RootDatabaseBuilder {
             auto_withdraw_gas: true,
             project_config: None,
             cfg_set: None,
+            disable_inlining: false,
         }
     }
 
@@ -104,6 +107,11 @@ impl RootDatabaseBuilder {
 
     pub fn clear_plugins(&mut self) -> &mut Self {
         self.plugin_suite = get_default_plugin_suite();
+        self
+    }
+
+    pub fn disable_inlining(&mut self) -> &mut Self {
+        self.disable_inlining = true;
         self
     }
 
@@ -136,6 +144,7 @@ impl RootDatabaseBuilder {
             self.plugin_suite.plugins.clone(),
             self.plugin_suite.inline_macro_plugins.clone(),
             self.plugin_suite.analyzer_plugins.clone(),
+            self.disable_inlining
         );
 
         if let Some(cfg_set) = &self.cfg_set {

--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -47,7 +47,7 @@ impl RootDatabase {
         plugins: Vec<Arc<dyn MacroPlugin>>,
         inline_macro_plugins: OrderedHashMap<String, Arc<dyn InlineMacroExprPlugin>>,
         analyzer_plugins: Vec<Arc<dyn AnalyzerPlugin>>,
-        disable_inlining: bool
+        disable_inlining: bool,
     ) -> Self {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
@@ -85,7 +85,7 @@ pub struct RootDatabaseBuilder {
     auto_withdraw_gas: bool,
     project_config: Option<Box<ProjectConfig>>,
     cfg_set: Option<CfgSet>,
-    disable_inlining: bool
+    disable_inlining: bool,
 }
 
 impl RootDatabaseBuilder {
@@ -144,7 +144,7 @@ impl RootDatabaseBuilder {
             self.plugin_suite.plugins.clone(),
             self.plugin_suite.inline_macro_plugins.clone(),
             self.plugin_suite.analyzer_plugins.clone(),
-            self.disable_inlining
+            self.disable_inlining,
         );
 
         if let Some(cfg_set) = &self.cfg_set {

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use ::cairo_lang_diagnostics::ToOption;
 use anyhow::{Context, Result};
 use cairo_lang_filesystem::ids::CrateId;
+use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_sierra::debug_info::{Annotations, DebugInfo};
 use cairo_lang_sierra::program::{Program, ProgramArtifact};
 use cairo_lang_sierra_generator::db::SierraGenGroup;
@@ -35,7 +36,7 @@ pub struct CompilerConfig<'c> {
     pub replace_ids: bool,
 
     /// Disables inlining functions.
-    pub disable_inlining: bool,
+    pub inlining_strategy: InliningStrategy,
 
     /// The name of the allowed libfuncs list to use in compilation.
     /// If None the default list of audited libfuncs will be used.
@@ -60,11 +61,10 @@ pub fn compile_cairo_project_at_path(
     path: &Path,
     compiler_config: CompilerConfig<'_>,
 ) -> Result<Program> {
-    let mut builder = RootDatabase::builder();
-    if compiler_config.disable_inlining {
-        builder.disable_inlining();
-    }
-    let mut db = builder.detect_corelib().build()?;
+    let mut db = RootDatabase::builder()
+        .with_inlining_strategy(compiler_config.inlining_strategy)
+        .detect_corelib()
+        .build()?;
     let main_crate_ids = setup_project(&mut db, path)?;
     compile_prepared_db_program(&mut db, main_crate_ids, compiler_config)
 }

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -34,6 +34,9 @@ pub struct CompilerConfig<'c> {
     /// Replaces sierra ids with human-readable ones.
     pub replace_ids: bool,
 
+    /// Disables inlining functions.
+    pub disable_inlining: bool,
+
     /// The name of the allowed libfuncs list to use in compilation.
     /// If None the default list of audited libfuncs will be used.
     pub allowed_libfuncs_list_name: Option<String>,
@@ -57,7 +60,11 @@ pub fn compile_cairo_project_at_path(
     path: &Path,
     compiler_config: CompilerConfig<'_>,
 ) -> Result<Program> {
-    let mut db = RootDatabase::builder().detect_corelib().build()?;
+    let mut builder = RootDatabase::builder();
+    if compiler_config.disable_inlining {
+        builder.disable_inlining();
+    }
+    let mut db = builder.detect_corelib().build()?;
     let main_crate_ids = setup_project(&mut db, path)?;
     compile_prepared_db_program(&mut db, main_crate_ids, compiler_config)
 }

--- a/crates/cairo-lang-language-server/src/lang/db/mod.rs
+++ b/crates/cairo-lang-language-server/src/lang/db/mod.rs
@@ -3,6 +3,7 @@ use cairo_lang_doc::db::DocDatabase;
 use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
 use cairo_lang_filesystem::db::{init_files_group, AsFilesGroupMut, FilesDatabase, FilesGroup};
 use cairo_lang_lowering::db::{init_lowering_group, LoweringDatabase, LoweringGroup};
+use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_parser::db::{ParserDatabase, ParserGroup};
 use cairo_lang_semantic::db::{SemanticDatabase, SemanticGroup};
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
@@ -39,7 +40,7 @@ impl AnalysisDatabase {
         let mut db = Self { storage: Default::default() };
 
         init_files_group(&mut db);
-        init_lowering_group(&mut db);
+        init_lowering_group(&mut db, InliningStrategy::Default);
 
         db.set_cfg_set(Self::initial_cfg_set().into());
 

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -16,7 +16,6 @@ cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "~2.6.4
 cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "~2.6.4" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "~2.6.4" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "~2.6.4" }
-clap.workspace = true
 id-arena.workspace = true
 itertools = { workspace = true, default-features = true }
 log.workspace = true

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -16,6 +16,7 @@ cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "~2.6.4
 cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "~2.6.4" }
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "~2.6.4" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "~2.6.4" }
+clap.workspace = true
 id-arena.workspace = true
 itertools = { workspace = true, default-features = true }
 log.workspace = true

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -29,6 +29,7 @@ use crate::optimizations::config::OptimizationConfig;
 use crate::optimizations::scrub_units::scrub_units;
 use crate::optimizations::strategy::{OptimizationStrategy, OptimizationStrategyId};
 use crate::panic::lower_panics;
+use crate::utils::InliningStrategy;
 use crate::{
     ids, BlockId, DependencyType, FlatBlockEnd, FlatLowered, Location, MatchInfo, Statement,
 };
@@ -334,7 +335,10 @@ pub trait LoweringGroup: SemanticGroup + Upcast<dyn SemanticGroup> {
     fn type_size(&self, ty: TypeId) -> usize;
 }
 
-pub fn init_lowering_group(db: &mut (dyn LoweringGroup + 'static), disable_inlining: bool) {
+pub fn init_lowering_group(
+    db: &mut (dyn LoweringGroup + 'static),
+    inlining_strategy: InliningStrategy,
+) {
     let mut moveable_functions: Vec<String> =
         ["bool_not_impl", "felt252_add", "felt252_sub", "felt252_mul", "felt252_div"]
             .into_iter()
@@ -348,7 +352,7 @@ pub fn init_lowering_group(db: &mut (dyn LoweringGroup + 'static), disable_inlin
     db.set_optimization_config(Arc::new(
         OptimizationConfig::default()
             .with_moveable_functions(moveable_functions)
-            .with_disable_inlining(disable_inlining),
+            .with_inlining_strategy(inlining_strategy),
     ));
 }
 

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -334,7 +334,7 @@ pub trait LoweringGroup: SemanticGroup + Upcast<dyn SemanticGroup> {
     fn type_size(&self, ty: TypeId) -> usize;
 }
 
-pub fn init_lowering_group(db: &mut (dyn LoweringGroup + 'static)) {
+pub fn init_lowering_group(db: &mut (dyn LoweringGroup + 'static), disable_inlining: bool) {
     let mut moveable_functions: Vec<String> =
         ["bool_not_impl", "felt252_add", "felt252_sub", "felt252_mul", "felt252_div"]
             .into_iter()
@@ -346,7 +346,7 @@ pub fn init_lowering_group(db: &mut (dyn LoweringGroup + 'static)) {
     }
 
     db.set_optimization_config(Arc::new(
-        OptimizationConfig::default().with_moveable_functions(moveable_functions),
+        OptimizationConfig::default().with_moveable_functions(moveable_functions).with_disable_inlining(disable_inlining)
     ));
 }
 

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -346,7 +346,9 @@ pub fn init_lowering_group(db: &mut (dyn LoweringGroup + 'static), disable_inlin
     }
 
     db.set_optimization_config(Arc::new(
-        OptimizationConfig::default().with_moveable_functions(moveable_functions).with_disable_inlining(disable_inlining)
+        OptimizationConfig::default()
+            .with_moveable_functions(moveable_functions)
+            .with_disable_inlining(disable_inlining),
     ));
 }
 

--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -67,9 +67,10 @@ pub fn priv_should_inline(
 
     Ok(match config {
         InlineConfiguration::Never(_) => false,
-        InlineConfiguration::Should(_) => true,
+        InlineConfiguration::Should(_) => !db.optimization_config().disable_inlining,
         InlineConfiguration::Always(_) => true,
-        InlineConfiguration::None => should_inline_lowered(db, function_id)?,
+        InlineConfiguration::None => !db.optimization_config().disable_inlining
+          && should_inline_lowered(db, function_id)?,
     })
 }
 

--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -69,8 +69,9 @@ pub fn priv_should_inline(
         InlineConfiguration::Never(_) => false,
         InlineConfiguration::Should(_) => !db.optimization_config().disable_inlining,
         InlineConfiguration::Always(_) => true,
-        InlineConfiguration::None => !db.optimization_config().disable_inlining
-          && should_inline_lowered(db, function_id)?,
+        InlineConfiguration::None => {
+            !db.optimization_config().disable_inlining && should_inline_lowered(db, function_id)?
+        }
     })
 }
 

--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -72,7 +72,7 @@ pub fn priv_should_inline(
             InlineConfiguration::Always(_) => true,
             InlineConfiguration::None => should_inline_lowered(db, function_id)?,
         },
-        InliningStrategy::Avoid => !matches!(config, InlineConfiguration::Always(_))
+        InliningStrategy::Avoid => !matches!(config, InlineConfiguration::Always(_)),
     })
 }
 

--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -72,8 +72,7 @@ pub fn priv_should_inline(
             InlineConfiguration::Always(_) => true,
             InlineConfiguration::None => should_inline_lowered(db, function_id)?,
         },
-        InliningStrategy::Avoid => !matches!(config, InlineConfiguration::Always(_)),
-        InliningStrategy::Forbid => false,
+        InliningStrategy::Avoid => !matches!(config, InlineConfiguration::Always(_))
     })
 }
 

--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -23,7 +23,7 @@ use crate::diagnostic::{
 };
 use crate::ids::{ConcreteFunctionWithBodyId, FunctionWithBodyId, LocationId};
 use crate::lower::context::{VarRequest, VariableAllocator};
-use crate::utils::{Rebuilder, RebuilderEx};
+use crate::utils::{InliningStrategy, Rebuilder, RebuilderEx};
 use crate::{
     BlockId, FlatBlock, FlatBlockEnd, FlatLowered, Statement, StatementCall, VarRemapping,
     VariableId,
@@ -65,13 +65,15 @@ pub fn priv_should_inline(
         function_id.function_with_body_id(db).base_semantic_function(db),
     )?;
 
-    Ok(match config {
-        InlineConfiguration::Never(_) => false,
-        InlineConfiguration::Should(_) => !db.optimization_config().disable_inlining,
-        InlineConfiguration::Always(_) => true,
-        InlineConfiguration::None => {
-            !db.optimization_config().disable_inlining && should_inline_lowered(db, function_id)?
-        }
+    Ok(match db.optimization_config().inlining_strategy {
+        InliningStrategy::Default => match config {
+            InlineConfiguration::Never(_) => false,
+            InlineConfiguration::Should(_) => true,
+            InlineConfiguration::Always(_) => true,
+            InlineConfiguration::None => should_inline_lowered(db, function_id)?,
+        },
+        InliningStrategy::Avoid => !matches!(config, InlineConfiguration::Always(_)),
+        InliningStrategy::Forbid => false,
     })
 }
 

--- a/crates/cairo-lang-lowering/src/optimizations/config.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/config.rs
@@ -21,6 +21,8 @@ pub struct OptimizationConfig {
     /// The size of functions (in lowering statements) below which they are marked as
     /// `should_inline`.
     pub inline_small_functions_threshold: usize,
+    /// Determines whether inlining is disabled.
+    pub disable_inlining: bool,
 }
 
 impl OptimizationConfig {
@@ -41,6 +43,11 @@ impl OptimizationConfig {
         self.inline_small_functions_threshold = inline_small_functions_threshold;
         self
     }
+    /// Sets the `disable_inlining` flag
+    pub fn with_disable_inlining(mut self, disable_inlining: bool) -> Self {
+        self.disable_inlining = disable_inlining;
+        self
+    }
 }
 
 impl Default for OptimizationConfig {
@@ -48,6 +55,7 @@ impl Default for OptimizationConfig {
         Self {
             moveable_functions: vec![],
             inline_small_functions_threshold: DEFAULT_INLINE_SMALL_FUNCTIONS_THRESHOLD,
+            disable_inlining: false
         }
     }
 }

--- a/crates/cairo-lang-lowering/src/optimizations/config.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/config.rs
@@ -7,6 +7,7 @@ use cairo_lang_utils::Intern;
 
 use crate::db::LoweringGroup;
 use crate::ids::{FunctionId, FunctionLongId};
+use crate::utils::InliningStrategy;
 
 /// The default threshold for inlining small functions. Decided according to sample contracts
 /// profiling.
@@ -22,7 +23,7 @@ pub struct OptimizationConfig {
     /// `should_inline`.
     pub inline_small_functions_threshold: usize,
     /// Determines whether inlining is disabled.
-    pub disable_inlining: bool,
+    pub inlining_strategy: InliningStrategy,
 }
 
 impl OptimizationConfig {
@@ -43,9 +44,9 @@ impl OptimizationConfig {
         self.inline_small_functions_threshold = inline_small_functions_threshold;
         self
     }
-    /// Sets the `disable_inlining` flag
-    pub fn with_disable_inlining(mut self, disable_inlining: bool) -> Self {
-        self.disable_inlining = disable_inlining;
+    /// Sets the `inlining_strategy` flag
+    pub fn with_inlining_strategy(mut self, inlining_strategy: InliningStrategy) -> Self {
+        self.inlining_strategy = inlining_strategy;
         self
     }
 }
@@ -55,7 +56,7 @@ impl Default for OptimizationConfig {
         Self {
             moveable_functions: vec![],
             inline_small_functions_threshold: DEFAULT_INLINE_SMALL_FUNCTIONS_THRESHOLD,
-            disable_inlining: false,
+            inlining_strategy: InliningStrategy::Default,
         }
     }
 }

--- a/crates/cairo-lang-lowering/src/optimizations/config.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/config.rs
@@ -55,7 +55,7 @@ impl Default for OptimizationConfig {
         Self {
             moveable_functions: vec![],
             inline_small_functions_threshold: DEFAULT_INLINE_SMALL_FUNCTIONS_THRESHOLD,
-            disable_inlining: false
+            disable_inlining: false,
         }
     }
 }

--- a/crates/cairo-lang-lowering/src/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/test_utils.rs
@@ -13,6 +13,7 @@ use cairo_lang_utils::Upcast;
 use once_cell::sync::Lazy;
 
 use crate::db::{init_lowering_group, LoweringDatabase, LoweringGroup};
+use crate::utils::InliningStrategy;
 
 #[salsa::database(
     LoweringDatabase,
@@ -47,7 +48,7 @@ pub static SHARED_DB: Lazy<Mutex<LoweringDatabaseForTesting>> = Lazy::new(|| {
 
     let corelib_path = detect_corelib().expect("Corelib not found in default location.");
     init_dev_corelib(&mut res, corelib_path);
-    init_lowering_group(&mut res, false);
+    init_lowering_group(&mut res, InliningStrategy::Default);
     Mutex::new(res)
 });
 impl Default for LoweringDatabaseForTesting {

--- a/crates/cairo-lang-lowering/src/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/test_utils.rs
@@ -47,7 +47,7 @@ pub static SHARED_DB: Lazy<Mutex<LoweringDatabaseForTesting>> = Lazy::new(|| {
 
     let corelib_path = detect_corelib().expect("Corelib not found in default location.");
     init_dev_corelib(&mut res, corelib_path);
-    init_lowering_group(&mut res);
+    init_lowering_group(&mut res, false);
     Mutex::new(res)
 });
 impl Default for LoweringDatabaseForTesting {

--- a/crates/cairo-lang-lowering/src/utils.rs
+++ b/crates/cairo-lang-lowering/src/utils.rs
@@ -1,4 +1,5 @@
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use clap;
 
 use crate::ids::LocationId;
 use crate::{
@@ -7,6 +8,18 @@ use crate::{
     StatementSnapshot, StatementStructConstruct, StatementStructDestructure, VarRemapping,
     VarUsage, VariableId,
 };
+
+/// Options for the `inlining` arguments
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum InliningStrategy {
+    /// Do not override inlining strategy
+    #[default]
+    Default,
+    /// Inline only in the case of a `inline(always)` annotation
+    Avoid,
+    /// Never inline
+    Forbid,
+}
 
 /// A rebuilder trait for rebuilding lowered representation.
 pub trait Rebuilder {

--- a/crates/cairo-lang-lowering/src/utils.rs
+++ b/crates/cairo-lang-lowering/src/utils.rs
@@ -9,15 +9,13 @@ use crate::{
 };
 
 /// Options for the `inlining` arguments
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum InliningStrategy {
     /// Do not override inlining strategy
     #[default]
     Default,
     /// Inline only in the case of a `inline(always)` annotation
     Avoid,
-    /// Never inline
-    Forbid,
 }
 
 /// A rebuilder trait for rebuilding lowered representation.

--- a/crates/cairo-lang-lowering/src/utils.rs
+++ b/crates/cairo-lang-lowering/src/utils.rs
@@ -8,13 +8,13 @@ use crate::{
     VarUsage, VariableId,
 };
 
-/// Options for the `inlining` arguments
+/// Options for the `inlining-strategy` arguments.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum InliningStrategy {
-    /// Do not override inlining strategy
+    /// Do not override inlining strategy.
     #[default]
     Default,
-    /// Inline only in the case of a `inline(always)` annotation
+    /// Inline only in the case of an `inline(always)` annotation.
     Avoid,
 }
 

--- a/crates/cairo-lang-lowering/src/utils.rs
+++ b/crates/cairo-lang-lowering/src/utils.rs
@@ -1,5 +1,4 @@
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use clap;
 
 use crate::ids::LocationId;
 use crate::{

--- a/crates/cairo-lang-starknet/src/test_utils.rs
+++ b/crates/cairo-lang-starknet/src/test_utils.rs
@@ -84,6 +84,7 @@ pub fn get_test_contract(example_file_name: &str) -> ContractClass {
             allowed_libfuncs_list_name: Some(BUILTIN_ALL_LIBFUNCS_LIST.to_string()),
             diagnostics_reporter,
             add_statements_functions: false,
+            disable_inlining: false
         },
     )
     .expect("compile_path failed")

--- a/crates/cairo-lang-starknet/src/test_utils.rs
+++ b/crates/cairo-lang-starknet/src/test_utils.rs
@@ -7,6 +7,7 @@ use cairo_lang_compiler::project::ProjectConfig;
 use cairo_lang_compiler::CompilerConfig;
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::Directory;
+use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_starknet_classes::allowed_libfuncs::BUILTIN_ALL_LIBFUNCS_LIST;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use cairo_lang_test_utils::test_lock;
@@ -84,7 +85,7 @@ pub fn get_test_contract(example_file_name: &str) -> ContractClass {
             allowed_libfuncs_list_name: Some(BUILTIN_ALL_LIBFUNCS_LIST.to_string()),
             diagnostics_reporter,
             add_statements_functions: false,
-            disable_inlining: false,
+            inlining_strategy: InliningStrategy::Default,
         },
     )
     .expect("compile_path failed")

--- a/crates/cairo-lang-starknet/src/test_utils.rs
+++ b/crates/cairo-lang-starknet/src/test_utils.rs
@@ -84,7 +84,7 @@ pub fn get_test_contract(example_file_name: &str) -> ContractClass {
             allowed_libfuncs_list_name: Some(BUILTIN_ALL_LIBFUNCS_LIST.to_string()),
             diagnostics_reporter,
             add_statements_functions: false,
-            disable_inlining: false
+            disable_inlining: false,
         },
     )
     .expect("compile_path failed")


### PR DESCRIPTION
For the discussion see the issue. Adds fields `disable_inlining` to `CompilerConfig`, `RootDatabaseBuilder` and `OptimizationConfig`. I don't know if there is any slicker way of adding the option.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5911)
<!-- Reviewable:end -->
