### PR TITLE
Add option to include statements functions in artifacts from test compilation

### DIFF
--- a/crates/cairo-lang-test-plugin/src/lib.rs
+++ b/crates/cairo-lang-test-plugin/src/lib.rs
@@ -46,8 +46,12 @@ const AVAILABLE_GAS_ATTR: &str = "available_gas";
 const STATIC_GAS_ARG: &str = "static";
 
 /// Configuration for test compilation.
-pub struct TestCompilationConfig {
+pub struct TestsCompilationConfig {
+    /// Adds the starknet contracts to the compiled tests.
     pub starknet: bool,
+
+    /// Adds mapping used by [cairo-profiler](https://github.com/software-mansion/cairo-profiler) to
+    /// [Annotations] in [DebugInfo] in the compiled tests.
     pub add_statements_functions: bool,
 }
 
@@ -55,7 +59,7 @@ pub struct TestCompilationConfig {
 ///
 /// # Arguments
 /// * `db` - Preloaded compilation database.
-/// * `starknet` - Add the starknet contracts to the compiled tests.
+/// * `tests_compilation_config` - The compiler configuration for tests compilation.
 /// * `main_crate_ids` - [`CrateId`]s to compile. Use `CrateLongId::Real(name).intern(db)` in order
 ///   to obtain [`CrateId`] from its name.
 /// * `test_crate_ids` - [`CrateId`]s to find tests cases in. Must be a subset of `main_crate_ids`.
@@ -64,11 +68,11 @@ pub struct TestCompilationConfig {
 /// * `Err(anyhow::Error)` - Compilation failed.
 pub fn compile_test_prepared_db(
     db: &RootDatabase,
-    test_compilation_config: TestCompilationConfig,
+    tests_compilation_config: TestsCompilationConfig,
     main_crate_ids: Vec<CrateId>,
     test_crate_ids: Vec<CrateId>,
 ) -> Result<TestCompilation> {
-    let all_entry_points = if test_compilation_config.starknet {
+    let all_entry_points = if tests_compilation_config.starknet {
         find_contracts(db, &main_crate_ids)
             .iter()
             .flat_map(|contract| {
@@ -116,7 +120,7 @@ pub fn compile_test_prepared_db(
     let statements_functions_for_tests =
         debug_info.statements_locations.get_statements_functions_map_for_tests(db);
 
-    let annotations = if test_compilation_config.add_statements_functions {
+    let annotations = if tests_compilation_config.add_statements_functions {
         Annotations::from(debug_info.statements_locations.extract_statements_functions(db))
     } else {
         Annotations::default()

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -26,8 +26,8 @@ use cairo_lang_starknet::contract::ContractInfo;
 use cairo_lang_starknet::starknet_plugin_suite;
 use cairo_lang_test_plugin::test_config::{PanicExpectation, TestExpectation};
 use cairo_lang_test_plugin::{
-    compile_test_prepared_db, test_plugin_suite, TestCompilation, TestCompilationMetadata,
-    TestConfig,
+    compile_test_prepared_db, test_plugin_suite, TestCompilation, TestCompilationConfig,
+    TestCompilationMetadata, TestConfig,
 };
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -238,7 +238,7 @@ impl TestCompiler {
     pub fn build(&self) -> Result<TestCompilation> {
         compile_test_prepared_db(
             &self.db,
-            self.starknet,
+            TestCompilationConfig { starknet: self.starknet, add_statements_functions: false },
             self.main_crate_ids.clone(),
             self.test_crate_ids.clone(),
         )

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -26,8 +26,8 @@ use cairo_lang_starknet::contract::ContractInfo;
 use cairo_lang_starknet::starknet_plugin_suite;
 use cairo_lang_test_plugin::test_config::{PanicExpectation, TestExpectation};
 use cairo_lang_test_plugin::{
-    compile_test_prepared_db, test_plugin_suite, TestCompilation, TestCompilationConfig,
-    TestCompilationMetadata, TestConfig,
+    compile_test_prepared_db, test_plugin_suite, TestCompilation, TestCompilationMetadata,
+    TestConfig, TestsCompilationConfig,
 };
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -238,7 +238,7 @@ impl TestCompiler {
     pub fn build(&self) -> Result<TestCompilation> {
         compile_test_prepared_db(
             &self.db,
-            TestCompilationConfig { starknet: self.starknet, add_statements_functions: false },
+            TestsCompilationConfig { starknet: self.starknet, add_statements_functions: false },
             self.main_crate_ids.clone(),
             self.test_crate_ids.clone(),
         )


### PR DESCRIPTION
Needed for Scarb to be able to produce the mappings in test artifacts as well (for purposes of `cairo-profiler`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5913)
<!-- Reviewable:end -->
