### PR TITLE
Added option for documentation of inline macros.

### DIFF
--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -146,6 +146,11 @@ pub trait InlineMacroExprPlugin: std::fmt::Debug + Sync + Send {
         item_ast: &ast::ExprInlineMacro,
         metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult;
+
+    /// Allows for the plugin to provide documentation for an inline macro.
+    fn documentation(&self) -> Option<String> {
+        None
+    }
 }
 
 /// A trait for easier addition of macro plugins.

--- a/crates/cairo-lang-language-server/src/ide/hover/render/definition.rs
+++ b/crates/cairo-lang-language-server/src/ide/hover/render/definition.rs
@@ -1,3 +1,4 @@
+use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_syntax::node::ast::TerminalIdentifier;
 use cairo_lang_syntax::node::TypedSyntaxNode;
@@ -32,6 +33,14 @@ pub fn definition(
         }
 
         SymbolDef::Variable(var) => fenced_code_block(&var.signature(db)),
+        SymbolDef::ExprInlineMacro(macro_name) => {
+            let mut md = fenced_code_block(macro_name);
+            if let Some(doc) = db.inline_macro_plugins().get(macro_name)?.documentation() {
+                md += RULE;
+                md += &doc;
+            }
+            md
+        }
     };
 
     Some(Hover {

--- a/crates/cairo-lang-language-server/tests/test_data/hover/basic.txt
+++ b/crates/cairo-lang-language-server/tests/test_data/hover/basic.txt
@@ -87,11 +87,13 @@ Type: `core::integer::u32`
 // = source context
     p<caret>rintln!("The value of x is: {}", x);
 // = highlight
-No highlight information.
+    <sel>println</sel>!("The value of x is: {}", x);
 // = popover
 ```cairo
-()
+println
 ```
+---
+Prints the format string, with the injected arguments, followed by a new line.
 
 //! > hover #2
 // = source context

--- a/crates/cairo-lang-semantic/src/inline_macros/print.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/print.rs
@@ -25,6 +25,10 @@ impl InlineMacroExprPlugin for PrintMacro {
     ) -> InlinePluginResult {
         generate_code_inner(syntax, db, false)
     }
+
+    fn documentation(&self) -> Option<String> {
+        Some("Prints the format string, with the injected arguments.".to_string())
+    }
 }
 
 /// Macro for printing with a new line.
@@ -41,6 +45,13 @@ impl InlineMacroExprPlugin for PrintlnMacro {
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult {
         generate_code_inner(syntax, db, true)
+    }
+
+    fn documentation(&self) -> Option<String> {
+        Some(
+            "Prints the format string, with the injected arguments, followed by a new line."
+                .to_string(),
+        )
     }
 }
 


### PR DESCRIPTION
Including adding doc for `print` and `println`.
Closes #5824

---

**Stack**:
- #5955
- #5954 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5954)
<!-- Reviewable:end -->
