### PR TITLE
Remove `__validate_declare__` func

### DIFF
--- a/corelib/src/starknet/account.cairo
+++ b/corelib/src/starknet/account.cairo
@@ -9,7 +9,6 @@ pub struct Call {
 
 #[starknet::interface]
 pub trait AccountContract<TContractState> {
-    fn __validate_declare__(self: @TContractState, class_hash: felt252) -> felt252;
     fn __validate__(ref self: TContractState, calls: Array<Call>) -> felt252;
     fn __execute__(ref self: TContractState, calls: Array<Call>) -> Array<Span<felt252>>;
 }


### PR DESCRIPTION
The function is not required according to https://docs.starknet.io/architecture-and-concepts/accounts/account-functions/ and this is missleading.

It makes more sense to have the interface containing only the required functions that need to be implemented.