### PR TITLE
chore: impl partial order for version id

### DIFF
--- a/crates/cairo-lang-starknet-classes/src/compiler_version.rs
+++ b/crates/cairo-lang-starknet-classes/src/compiler_version.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub struct VersionId {
     pub major: usize,
     pub minor: usize,


### PR DESCRIPTION
We use the VersionId struct in the gateway-mempool.
We use `less_then` (`<`) comparisons on such objects to validate that a given contract should be compiled.

We would like to put this code closer to the implementation, as we believe this functionality should be shared.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5996)
<!-- Reviewable:end -->
