### PR TITLE
chore: Remove negation in the behaviour of the inlining flag

### DIFF
--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -72,7 +72,7 @@ pub fn priv_should_inline(
             InlineConfiguration::Always(_) => true,
             InlineConfiguration::None => should_inline_lowered(db, function_id)?,
         },
-        InliningStrategy::Avoid => !matches!(config, InlineConfiguration::Always(_)),
+        InliningStrategy::Avoid => matches!(config, InlineConfiguration::Always(_)),
     })
 }
 


### PR DESCRIPTION
I managed to mangle the behavior of  `InliningStrategy::Avoid` during all of the style changes during the last review process, I'm terribly sorry :flushed: :grimacing:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/5998)
<!-- Reviewable:end -->
