### PR TITLE
feat: allow to access ByteArray fields

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -24,14 +24,14 @@ const BYTES_IN_BYTES31_MINUS_ONE: usize = BYTES_IN_BYTES31 - 1;
 pub struct ByteArray {
     // Full "words" of 31 bytes each. The first byte of each word in the byte array
     // is the most significant byte in the word.
-    pub(crate) data: Array<bytes31>,
+    pub data: Array<bytes31>,
     // This felt252 actually represents a bytes31, with < 31 bytes.
     // It is represented as a felt252 to improve performance of building the byte array.
     // The number of bytes in here is specified in `pending_word_len`.
     // The first byte is the most significant byte among the `pending_word_len` bytes in the word.
-    pub(crate) pending_word: felt252,
+    pub pending_word: felt252,
     // Should be in range [0, 30].
-    pub(crate) pending_word_len: usize,
+    pub pending_word_len: usize,
 }
 
 pub(crate) impl ByteArrayStringLiteral of core::string::StringLiteral<ByteArray>;


### PR DESCRIPTION
This makes `ByteArray` fields accessible outside of the crate.

A ByteArray is stored in memory at two locations: one storage slot receives its length, while other slots store the multiple elements (data + pending_word).

I use ByteArray to store Strings. In my use case, most of the time the stored String would fit in a single felt and my users end up paying twice the price. I would like to impl an alternative _storage optimized_ trait which only stores the data and pending_word and retrieves the String size by iterating until it finds an empty string. To do so efficiently I would need to be able to read the content of the struct. I could also add the alternative Store trait to a pr if you think that could be useful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6022)
<!-- Reviewable:end -->
