### PR TITLE
Remove inlining_strategy from CompilerConfig

### DIFF
--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -57,11 +57,8 @@ fn main() -> anyhow::Result<()> {
 
     let sierra_program = compile_cairo_project_at_path(
         &args.path,
-        CompilerConfig {
-            replace_ids: args.replace_ids,
-            inlining_strategy: args.inlining_strategy.into(),
-            ..CompilerConfig::default()
-        },
+        args.inlining_strategy.into(),
+        CompilerConfig { replace_ids: args.replace_ids, ..CompilerConfig::default() },
     )?;
 
     match args.output {

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -39,9 +39,6 @@ pub struct CompilerConfig<'c> {
     /// Replaces sierra ids with human-readable ones.
     pub replace_ids: bool,
 
-    /// Disables inlining functions.
-    pub inlining_strategy: InliningStrategy,
-
     /// The name of the allowed libfuncs list to use in compilation.
     /// If None the default list of audited libfuncs will be used.
     pub allowed_libfuncs_list_name: Option<String>,
@@ -63,10 +60,11 @@ pub struct CompilerConfig<'c> {
 /// * `Err(anyhow::Error)` - Compilation failed.
 pub fn compile_cairo_project_at_path(
     path: &Path,
+    inlining_strategy: InliningStrategy,
     compiler_config: CompilerConfig<'_>,
 ) -> Result<Program> {
     let mut db = RootDatabase::builder()
-        .with_inlining_strategy(compiler_config.inlining_strategy)
+        .with_inlining_strategy(inlining_strategy)
         .detect_corelib()
         .build()?;
     let main_crate_ids = setup_project(&mut db, path)?;
@@ -84,9 +82,13 @@ pub fn compile_cairo_project_at_path(
 /// * `Err(anyhow::Error)` - Compilation failed.
 pub fn compile(
     project_config: ProjectConfig,
+    inlining_strategy: InliningStrategy,
     compiler_config: CompilerConfig<'_>,
 ) -> Result<Program> {
-    let mut db = RootDatabase::builder().with_project_config(project_config.clone()).build()?;
+    let mut db = RootDatabase::builder()
+        .with_project_config(project_config.clone())
+        .with_inlining_strategy(inlining_strategy)
+        .build()?;
     let main_crate_ids = get_main_crate_ids_from_project(&mut db, &project_config);
 
     compile_prepared_db_program(&mut db, main_crate_ids, compiler_config)

--- a/crates/cairo-lang-starknet/src/test_utils.rs
+++ b/crates/cairo-lang-starknet/src/test_utils.rs
@@ -7,7 +7,6 @@ use cairo_lang_compiler::project::ProjectConfig;
 use cairo_lang_compiler::CompilerConfig;
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::Directory;
-use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_starknet_classes::allowed_libfuncs::BUILTIN_ALL_LIBFUNCS_LIST;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use cairo_lang_test_utils::test_lock;
@@ -85,7 +84,6 @@ pub fn get_test_contract(example_file_name: &str) -> ContractClass {
             allowed_libfuncs_list_name: Some(BUILTIN_ALL_LIBFUNCS_LIST.to_string()),
             diagnostics_reporter,
             add_statements_functions: false,
-            inlining_strategy: InliningStrategy::Default,
         },
     )
     .expect("compile_path failed")


### PR DESCRIPTION
I suggest we should not use `CompilerConfig` to store variables that are used during construction of compiler database, as APIs  that accept both `RootDatabase` and `CompilerConfig` become confusing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6081)
<!-- Reviewable:end -->
