### PR TITLE
LS: fix panic in `lsp_helper` and move its logic to `LsSemanticGroup`

### DIFF
--- a/crates/cairo-lang-language-server/src/ide/code_actions/add_missing_trait.rs
+++ b/crates/cairo-lang-language-server/src/ide/code_actions/add_missing_trait.rs
@@ -15,6 +15,7 @@ use tower_lsp::lsp_types::{CodeAction, CodeActionKind, Range, TextEdit, Url, Wor
 use tracing::debug;
 
 use crate::ide::utils::find_methods_for_type;
+use crate::lang::db::semantic_extension::LsSemanticGroupExtension;
 use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
 use crate::lang::lsp::{LsProtoGroup, ToLsp};
 
@@ -78,7 +79,7 @@ fn missing_traits_actions(
         module_start_offset.position_in_file(db.upcast(), file_id).unwrap().to_lsp();
     let relevant_methods = find_methods_for_type(db, resolver, ty, stable_ptr);
     let current_module = db.find_module_containing_node(node)?;
-    let module_visible_traits = db.visible_traits_from_module(current_module);
+    let module_visible_traits = db.visible_traits_from_module(current_module).ok()?;
     let mut code_actions = vec![];
     for method in relevant_methods {
         let method_name = method.name(db.upcast());

--- a/crates/cairo-lang-language-server/src/ide/completion/completions.rs
+++ b/crates/cairo-lang-language-server/src/ide/completion/completions.rs
@@ -24,6 +24,7 @@ use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Position, Range, 
 use tracing::debug;
 
 use crate::ide::utils::find_methods_for_type;
+use crate::lang::db::semantic_extension::LsSemanticGroupExtension;
 use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
 use crate::lang::lsp::ToLsp;
 
@@ -274,7 +275,7 @@ pub fn completion_for_method(
 
     // If the trait is not in scope, add a use statement.
     if !module_has_trait(db, module_id, trait_id)? {
-        if let Some(trait_path) = db.visible_traits_from_module(module_id).get(&trait_id) {
+        if let Some(trait_path) = db.visible_traits_from_module(module_id).ok()?.get(&trait_id) {
             additional_text_edits.push(TextEdit {
                 range: Range::new(position, position),
                 new_text: format!("use {};\n", trait_path),

--- a/crates/cairo-lang-language-server/src/ide/completion/mod.rs
+++ b/crates/cairo-lang-language-server/src/ide/completion/mod.rs
@@ -9,7 +9,8 @@ use tower_lsp::lsp_types::{CompletionParams, CompletionResponse, CompletionTrigg
 use tracing::debug;
 
 use self::completions::{colon_colon_completions, dot_completions, generic_completions};
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, LsSyntaxGroup};
+use crate::lang::db::semantic_extension::LsSemanticGroupExtension;
+use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
 use crate::lang::lsp::{LsProtoGroup, ToCairo};
 
 mod completions;

--- a/crates/cairo-lang-language-server/src/ide/hover/render/legacy.rs
+++ b/crates/cairo-lang-language-server/src/ide/hover/render/legacy.rs
@@ -11,7 +11,8 @@ use cairo_lang_utils::Upcast;
 use tower_lsp::lsp_types::Hover;
 
 use crate::ide::hover::markdown_contents;
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
+use crate::lang::db::semantic_extension::LsSemanticGroupExtension;
+use crate::lang::db::AnalysisDatabase;
 use crate::markdown::{fenced_code_block, RULE};
 
 /// Legacy hover rendering backported from Cairo 2.6.3 codebase.

--- a/crates/cairo-lang-language-server/src/ide/semantic_highlighting/token_kind.rs
+++ b/crates/cairo-lang-language-server/src/ide/semantic_highlighting/token_kind.rs
@@ -8,7 +8,8 @@ use cairo_lang_syntax::node::{ast, SyntaxNode, Terminal, TypedSyntaxNode};
 use cairo_lang_utils::Upcast;
 use tower_lsp::lsp_types::SemanticTokenType;
 
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
+use crate::lang::db::semantic_extension::LsSemanticGroupExtension;
+use crate::lang::db::AnalysisDatabase;
 
 #[allow(dead_code)]
 pub enum SemanticTokenKind {

--- a/crates/cairo-lang-language-server/src/ide/utils.rs
+++ b/crates/cairo-lang-language-server/src/ide/utils.rs
@@ -1,14 +1,12 @@
 use cairo_lang_defs::ids::TraitFunctionId;
 use cairo_lang_filesystem::db::FilesGroup;
-use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::expr::inference::infers::InferenceEmbeddings;
 use cairo_lang_semantic::expr::inference::solver::SolutionSet;
 use cairo_lang_semantic::expr::inference::InferenceId;
-use cairo_lang_semantic::lsp_helpers::TypeFilter;
 use cairo_lang_semantic::resolve::Resolver;
 use tracing::debug;
 
-use crate::lang::db::AnalysisDatabase;
+use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, TypeFilter};
 
 /// Finds all methods that can be called on a type.
 #[tracing::instrument(level = "trace", skip_all)]

--- a/crates/cairo-lang-language-server/src/lang/db/mod.rs
+++ b/crates/cairo-lang-language-server/src/lang/db/mod.rs
@@ -28,7 +28,8 @@ mod syntax;
     ParserDatabase,
     SemanticDatabase,
     SyntaxDatabase,
-    DocDatabase
+    DocDatabase,
+    LsSemanticDatabase
 )]
 pub struct AnalysisDatabase {
     storage: salsa::Storage<Self>,

--- a/crates/cairo-lang-language-server/src/lang/db/semantic/semantic_extension.rs
+++ b/crates/cairo-lang-language-server/src/lang/db/semantic/semantic_extension.rs
@@ -17,7 +17,7 @@ use cairo_lang_utils::{Intern, Upcast};
 
 // TODO(mkaput): Make this a real Salsa query group with sensible LRU.
 /// Language server-specific extensions to the semantic group.
-pub trait LsSemanticGroup: Upcast<dyn SemanticGroup> {
+pub trait LsSemanticGroupExtension: Upcast<dyn SemanticGroup> {
     /// Returns a [`LookupItemId`] corresponding to the node or its first parent all the way up to
     /// syntax root in the file.
     ///
@@ -117,7 +117,7 @@ pub trait LsSemanticGroup: Upcast<dyn SemanticGroup> {
     }
 }
 
-impl<T> LsSemanticGroup for T where T: Upcast<dyn SemanticGroup> + ?Sized {}
+impl<T> LsSemanticGroupExtension for T where T: Upcast<dyn SemanticGroup> + ?Sized {}
 
 /// If the ast node is a lookup item, return corresponding ids. Otherwise, returns `None`.
 /// See [LookupItemId].

--- a/crates/cairo-lang-language-server/src/lang/inspect/defs.rs
+++ b/crates/cairo-lang-language-server/src/lang/inspect/defs.rs
@@ -19,7 +19,8 @@ use itertools::Itertools;
 use smol_str::SmolStr;
 use tracing::error;
 
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
+use crate::lang::db::semantic_extension::LsSemanticGroupExtension;
+use crate::lang::db::AnalysisDatabase;
 use crate::lang::inspect::defs::SymbolDef::Member;
 use crate::{find_definition, ResolvedItem};
 

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -86,7 +86,8 @@ use tracing::{debug, error, info, trace_span, warn, Instrument};
 
 use crate::config::Config;
 use crate::ide::semantic_highlighting::SemanticTokenKind;
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, LsSyntaxGroup};
+use crate::lang::db::semantic_extension::LsSemanticGroupExtension;
+use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
 use crate::lang::diagnostics::lsp::map_cairo_diagnostics_to_lsp;
 use crate::lang::lsp::LsProtoGroup;
 use crate::lsp::client_capabilities::ClientCapabilitiesExt;

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -40,9 +40,7 @@ use crate::plugin::AnalyzerPlugin;
 use crate::resolve::{ResolvedConcreteItem, ResolvedGenericItem, ResolverData};
 use crate::substitution::GenericSubstitution;
 use crate::types::{ImplTypeId, TypeSizeInformation};
-use crate::{
-    corelib, items, lsp_helpers, semantic, types, FunctionId, Parameter, SemanticDiagnostic, TypeId,
-};
+use crate::{corelib, items, semantic, types, FunctionId, Parameter, SemanticDiagnostic, TypeId};
 
 /// Helper trait to make sure we can always get a `dyn SemanticGroup + 'static` from a
 /// SemanticGroup.
@@ -1492,47 +1490,6 @@ pub trait SemanticGroup:
     // ========
     #[salsa::input]
     fn analyzer_plugins(&self) -> Vec<Arc<dyn AnalyzerPlugin>>;
-
-    // Helpers for language server.
-    // ============================
-    /// Returns all methods in a module that match the given type filter.
-    #[salsa::invoke(lsp_helpers::methods_in_module)]
-    fn methods_in_module(
-        &self,
-        module_id: ModuleId,
-        type_filter: lsp_helpers::TypeFilter,
-    ) -> Arc<[TraitFunctionId]>;
-    /// Returns all methods in a crate that match the given type filter.
-    #[salsa::invoke(lsp_helpers::methods_in_crate)]
-    fn methods_in_crate(
-        &self,
-        crate_id: CrateId,
-        type_filter: lsp_helpers::TypeFilter,
-    ) -> Arc<[TraitFunctionId]>;
-    /// Returns all the traits visible from a module, alongside a visible use path to the trait.
-    #[salsa::invoke(lsp_helpers::visible_traits_from_module)]
-    fn visible_traits_from_module(
-        &self,
-        module_id: ModuleId,
-    ) -> Arc<OrderedHashMap<TraitId, String>>;
-    /// Returns all visible traits in a module, alongside a visible use path to the trait.
-    /// `user_module_id` is the module from which the traits are should be visible. If
-    /// `include_parent` is true, the parent module of `module_id` is also considered.
-    #[salsa::invoke(lsp_helpers::visible_traits_in_module)]
-    fn visible_traits_in_module(
-        &self,
-        module_id: ModuleId,
-        user_module_id: ModuleId,
-        include_parent: bool,
-    ) -> Arc<[(TraitId, String)]>;
-    /// Returns all visible traits in a crate, alongside a visible use path to the trait.
-    /// `user_module_id` is the module from which the traits are should be visible.
-    #[salsa::invoke(lsp_helpers::visible_traits_in_crate)]
-    fn visible_traits_in_crate(
-        &self,
-        crate_id: CrateId,
-        user_module_id: ModuleId,
-    ) -> Arc<[(TraitId, String)]>;
 }
 
 impl<T: Upcast<dyn SemanticGroup + 'static>> Elongate for T {

--- a/crates/cairo-lang-semantic/src/lib.rs
+++ b/crates/cairo-lang-semantic/src/lib.rs
@@ -2,6 +2,11 @@
 //! The semantic model represents the Cairo program after type resolution and some syntax
 //! desugaring.
 
+pub use diagnostic::SemanticDiagnostic;
+pub use substitution::SemanticObject;
+
+pub use self::semantic::*;
+
 pub mod corelib;
 pub mod db;
 pub mod diagnostic;
@@ -10,7 +15,6 @@ pub mod inline_macros;
 pub mod items;
 pub mod literals;
 pub mod lookup_item;
-pub mod lsp_helpers;
 pub mod plugin;
 pub mod resolve;
 pub mod substitution;
@@ -18,11 +22,6 @@ pub mod types;
 pub mod usage;
 
 mod semantic;
-
-pub use diagnostic::SemanticDiagnostic;
-pub use substitution::SemanticObject;
-
-pub use self::semantic::*;
 
 #[cfg(any(feature = "testing", test))]
 pub mod test_utils;


### PR DESCRIPTION
Code in `semantic/semantic_extension.rs` is the same as in previous `semantic.rs` besides trait name change `LsSemanticGroup` -> `LsSemanticGroupExtension`. Code in `semantic/mod.rs` is code from `lsp_helper.rs` + some code from trait definition `crates/cairo-lang-semantic/src/db.rs` wrapped into new salsa query group

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6159)
<!-- Reviewable:end -->
