### PR TITLE
Pass plugin env variable to LS subprocess

### DIFF
--- a/vscode-cairo/src/cairols.ts
+++ b/vscode-cairo/src/cairols.ts
@@ -184,11 +184,13 @@ function setupEnv(serverExecutable: lc.Executable, ctx: Context) {
   const extraEnv = ctx.config.get("languageServerExtraEnv");
 
   serverExecutable.options ??= {};
-  serverExecutable.options.env ??= {};
-
-  // By default, the server environment variables are not inherited from the parent process.
-  serverExecutable.options.env = process.env;
-  Object.assign(serverExecutable.options.env, logEnv, extraEnv);
+  serverExecutable.options.env = {
+    // Inherit env from parent process.
+    ...process.env,
+    ...(serverExecutable.options.env ?? {}),
+    ...logEnv,
+    ...extraEnv,
+  };
 }
 
 function buildEnvFilter(ctx: Context): string {

--- a/vscode-cairo/src/cairols.ts
+++ b/vscode-cairo/src/cairols.ts
@@ -175,7 +175,6 @@ async function determineLanguageServerExecutableProvider(
   }
 }
 
-// By default, the server environment variables are not from the parent process
 function setupEnv(serverExecutable: lc.Executable, ctx: Context) {
   const logEnv = {
     CAIRO_LS_LOG: buildEnvFilter(ctx),
@@ -187,6 +186,7 @@ function setupEnv(serverExecutable: lc.Executable, ctx: Context) {
   serverExecutable.options ??= {};
   serverExecutable.options.env ??= {};
 
+  // By default, the server environment variables are not inherited from the parent process.
   serverExecutable.options.env.PATH = process.env["PATH"];
   Object.assign(serverExecutable.options.env, logEnv, extraEnv);
 }

--- a/vscode-cairo/src/cairols.ts
+++ b/vscode-cairo/src/cairols.ts
@@ -187,7 +187,7 @@ function setupEnv(serverExecutable: lc.Executable, ctx: Context) {
   serverExecutable.options.env ??= {};
 
   // By default, the server environment variables are not inherited from the parent process.
-  serverExecutable.options.env.PATH = process.env["PATH"];
+  serverExecutable.options.env = process.env;
   Object.assign(serverExecutable.options.env, logEnv, extraEnv);
 }
 

--- a/vscode-cairo/src/cairols.ts
+++ b/vscode-cairo/src/cairols.ts
@@ -175,6 +175,7 @@ async function determineLanguageServerExecutableProvider(
   }
 }
 
+// By default, the server environment variables are not from the parent process
 function setupEnv(serverExecutable: lc.Executable, ctx: Context) {
   const logEnv = {
     CAIRO_LS_LOG: buildEnvFilter(ctx),
@@ -185,6 +186,8 @@ function setupEnv(serverExecutable: lc.Executable, ctx: Context) {
 
   serverExecutable.options ??= {};
   serverExecutable.options.env ??= {};
+
+  serverExecutable.options.env.PATH = process.env["PATH"];
   Object.assign(serverExecutable.options.env, logEnv, extraEnv);
 }
 


### PR DESCRIPTION
This fixes the issue with the crashes, envs are not inherited by default in the server process, so path is ambiguous for the scarb process invoked by server

Closes #6164

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6176)
<!-- Reviewable:end -->
