### PR TITLE
fix typo: calosure -> closure

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test.rs
+++ b/crates/cairo-lang-semantic/src/expr/test.rs
@@ -68,7 +68,7 @@ cairo_lang_test_utils::test_file_test!(
         assignment: "assignment",
         block: "block",
         call: "call",
-        calosure: "closure",
+        closure: "closure",
         coupon: "coupon",
         inline_macros: "inline_macros",
         let_statement: "let_statement",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6179)
<!-- Reviewable:end -->
