### PR TITLE
Using default implementations for `PartialOrd::{gt,le,ge}`.

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -183,20 +183,12 @@ impl U128PartialEq of PartialEq<u128> {
 
 impl U128PartialOrd of PartialOrd<u128> {
     #[inline(always)]
-    fn le(lhs: u128, rhs: u128) -> bool {
-        u128_overflowing_sub(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
     fn ge(lhs: u128, rhs: u128) -> bool {
         u128_overflowing_sub(lhs, rhs).into_is_ok()
     }
     #[inline(always)]
     fn lt(lhs: u128, rhs: u128) -> bool {
         u128_overflowing_sub(lhs, rhs).into_is_err()
-    }
-    #[inline(always)]
-    fn gt(lhs: u128, rhs: u128) -> bool {
-        u128_overflowing_sub(rhs, lhs).into_is_err()
     }
 }
 
@@ -261,20 +253,12 @@ impl U8PartialEq of PartialEq<u8> {
 
 impl U8PartialOrd of PartialOrd<u8> {
     #[inline(always)]
-    fn le(lhs: u8, rhs: u8) -> bool {
-        u8_overflowing_sub(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: u8, rhs: u8) -> bool {
-        u8_overflowing_sub(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: u8, rhs: u8) -> bool {
         u8_overflowing_sub(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: u8, rhs: u8) -> bool {
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+    fn ge(lhs: u8, rhs: u8) -> bool {
+        u8_overflowing_sub(lhs, rhs).into_is_ok()
     }
 }
 
@@ -418,20 +402,12 @@ impl U16PartialEq of PartialEq<u16> {
 
 impl U16PartialOrd of PartialOrd<u16> {
     #[inline(always)]
-    fn le(lhs: u16, rhs: u16) -> bool {
-        u16_overflowing_sub(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: u16, rhs: u16) -> bool {
-        u16_overflowing_sub(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: u16, rhs: u16) -> bool {
         u16_overflowing_sub(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: u16, rhs: u16) -> bool {
-        u16_overflowing_sub(rhs, lhs).into_is_err()
+    fn ge(lhs: u16, rhs: u16) -> bool {
+        u16_overflowing_sub(lhs, rhs).into_is_ok()
     }
 }
 
@@ -581,20 +557,12 @@ impl U32PartialEq of PartialEq<u32> {
 
 impl U32PartialOrd of PartialOrd<u32> {
     #[inline(always)]
-    fn le(lhs: u32, rhs: u32) -> bool {
-        u32_overflowing_sub(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: u32, rhs: u32) -> bool {
-        u32_overflowing_sub(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: u32, rhs: u32) -> bool {
         u32_overflowing_sub(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: u32, rhs: u32) -> bool {
-        u32_overflowing_sub(rhs, lhs).into_is_err()
+    fn ge(lhs: u32, rhs: u32) -> bool {
+        u32_overflowing_sub(lhs, rhs).into_is_ok()
     }
 }
 
@@ -744,20 +712,12 @@ impl U64PartialEq of PartialEq<u64> {
 
 impl U64PartialOrd of PartialOrd<u64> {
     #[inline(always)]
-    fn le(lhs: u64, rhs: u64) -> bool {
-        u64_overflowing_sub(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: u64, rhs: u64) -> bool {
-        u64_overflowing_sub(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: u64, rhs: u64) -> bool {
         u64_overflowing_sub(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: u64, rhs: u64) -> bool {
-        u64_overflowing_sub(rhs, lhs).into_is_err()
+    fn ge(lhs: u64, rhs: u64) -> bool {
+        u64_overflowing_sub(lhs, rhs).into_is_ok()
     }
 }
 
@@ -1017,14 +977,6 @@ impl U256Mul of Mul<u256> {
 }
 
 impl U256PartialOrd of PartialOrd<u256> {
-    #[inline(always)]
-    fn le(lhs: u256, rhs: u256) -> bool {
-        !(rhs < lhs)
-    }
-    #[inline(always)]
-    fn ge(lhs: u256, rhs: u256) -> bool {
-        !(lhs < rhs)
-    }
     fn lt(lhs: u256, rhs: u256) -> bool {
         if lhs.high < rhs.high {
             true
@@ -1033,10 +985,6 @@ impl U256PartialOrd of PartialOrd<u256> {
         } else {
             false
         }
-    }
-    #[inline(always)]
-    fn gt(lhs: u256, rhs: u256) -> bool {
-        rhs < lhs
     }
 }
 
@@ -1705,20 +1653,12 @@ impl I8Mul of Mul<i8> {
 pub extern fn i8_diff(lhs: i8, rhs: i8) -> Result<u8, u8> implicits(RangeCheck) nopanic;
 impl I8PartialOrd of PartialOrd<i8> {
     #[inline(always)]
-    fn le(lhs: i8, rhs: i8) -> bool {
-        i8_diff(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: i8, rhs: i8) -> bool {
-        i8_diff(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: i8, rhs: i8) -> bool {
         i8_diff(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: i8, rhs: i8) -> bool {
-        i8_diff(rhs, lhs).into_is_err()
+    fn ge(lhs: i8, rhs: i8) -> bool {
+        i8_diff(lhs, rhs).into_is_ok()
     }
 }
 
@@ -1790,20 +1730,12 @@ impl I16Mul of Mul<i16> {
 pub extern fn i16_diff(lhs: i16, rhs: i16) -> Result<u16, u16> implicits(RangeCheck) nopanic;
 impl I16PartialOrd of PartialOrd<i16> {
     #[inline(always)]
-    fn le(lhs: i16, rhs: i16) -> bool {
-        i16_diff(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: i16, rhs: i16) -> bool {
-        i16_diff(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: i16, rhs: i16) -> bool {
         i16_diff(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: i16, rhs: i16) -> bool {
-        i16_diff(rhs, lhs).into_is_err()
+    fn ge(lhs: i16, rhs: i16) -> bool {
+        i16_diff(lhs, rhs).into_is_ok()
     }
 }
 
@@ -1875,20 +1807,12 @@ impl I32Mul of Mul<i32> {
 pub extern fn i32_diff(lhs: i32, rhs: i32) -> Result<u32, u32> implicits(RangeCheck) nopanic;
 impl I32PartialOrd of PartialOrd<i32> {
     #[inline(always)]
-    fn le(lhs: i32, rhs: i32) -> bool {
-        i32_diff(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: i32, rhs: i32) -> bool {
-        i32_diff(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: i32, rhs: i32) -> bool {
         i32_diff(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: i32, rhs: i32) -> bool {
-        i32_diff(rhs, lhs).into_is_err()
+    fn ge(lhs: i32, rhs: i32) -> bool {
+        i32_diff(lhs, rhs).into_is_ok()
     }
 }
 
@@ -1960,20 +1884,12 @@ impl I64Mul of Mul<i64> {
 pub extern fn i64_diff(lhs: i64, rhs: i64) -> Result<u64, u64> implicits(RangeCheck) nopanic;
 impl I64PartialOrd of PartialOrd<i64> {
     #[inline(always)]
-    fn le(lhs: i64, rhs: i64) -> bool {
-        i64_diff(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: i64, rhs: i64) -> bool {
-        i64_diff(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: i64, rhs: i64) -> bool {
         i64_diff(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: i64, rhs: i64) -> bool {
-        i64_diff(rhs, lhs).into_is_err()
+    fn ge(lhs: i64, rhs: i64) -> bool {
+        i64_diff(lhs, rhs).into_is_ok()
     }
 }
 
@@ -2058,20 +1974,12 @@ impl I128Mul of Mul<i128> {
 pub extern fn i128_diff(lhs: i128, rhs: i128) -> Result<u128, u128> implicits(RangeCheck) nopanic;
 impl I128PartialOrd of PartialOrd<i128> {
     #[inline(always)]
-    fn le(lhs: i128, rhs: i128) -> bool {
-        i128_diff(rhs, lhs).into_is_ok()
-    }
-    #[inline(always)]
-    fn ge(lhs: i128, rhs: i128) -> bool {
-        i128_diff(lhs, rhs).into_is_ok()
-    }
-    #[inline(always)]
     fn lt(lhs: i128, rhs: i128) -> bool {
         i128_diff(lhs, rhs).into_is_err()
     }
     #[inline(always)]
-    fn gt(lhs: i128, rhs: i128) -> bool {
-        i128_diff(rhs, lhs).into_is_err()
+    fn ge(lhs: i128, rhs: i128) -> bool {
+        i128_diff(lhs, rhs).into_is_ok()
     }
 }
 

--- a/corelib/src/starknet/contract_address.cairo
+++ b/corelib/src/starknet/contract_address.cairo
@@ -71,18 +71,6 @@ impl ContractAddressPartialOrd of PartialOrd<ContractAddress> {
         let lhs: u256 = contract_address_to_felt252(lhs).into();
         lhs < contract_address_to_felt252(rhs).into()
     }
-    #[inline(always)]
-    fn le(lhs: ContractAddress, rhs: ContractAddress) -> bool {
-        !(rhs < lhs)
-    }
-    #[inline(always)]
-    fn gt(lhs: ContractAddress, rhs: ContractAddress) -> bool {
-        rhs < lhs
-    }
-    #[inline(always)]
-    fn ge(lhs: ContractAddress, rhs: ContractAddress) -> bool {
-        !(lhs < rhs)
-    }
 }
 
 impl HashContractAddress<S, +HashStateTrait<S>, +Drop<S>> =

--- a/corelib/src/traits.cairo
+++ b/corelib/src/traits.cairo
@@ -99,10 +99,16 @@ pub trait BitNot<T> {
 }
 
 pub trait PartialOrd<T> {
-    fn le(lhs: T, rhs: T) -> bool;
-    fn ge(lhs: T, rhs: T) -> bool;
     fn lt(lhs: T, rhs: T) -> bool;
-    fn gt(lhs: T, rhs: T) -> bool;
+    fn ge(lhs: T, rhs: T) -> bool {
+        !Self::lt(lhs, rhs)
+    }
+    fn gt(lhs: T, rhs: T) -> bool {
+        Self::lt(rhs, lhs)
+    }
+    fn le(lhs: T, rhs: T) -> bool {
+        Self::ge(rhs, lhs)
+    }
 }
 
 impl PartialOrdSnap<T, +PartialOrd<T>, +Copy<T>> of PartialOrd<@T> {

--- a/crates/cairo-lang-sierra-generator/src/statement_location_test_data/simple
+++ b/crates/cairo-lang-sierra-generator/src/statement_location_test_data/simple
@@ -189,45 +189,60 @@ Originating location:
 In function: lib.cairo::foo
 dup<u8>([9]) -> ([9], [10])
 Originating location:
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+        u8_overflowing_sub(lhs, rhs).into_is_err()
         ^**************************^
-In function: core::integer::U8PartialOrd::gt
+In function: core::integer::U8PartialOrd::lt
+Inlined at:
+        Self::lt(rhs, lhs)
+        ^****************^
 Inlined at:
         MyEnum::C((c1, c2)) => { if c1 > c2 {
                                     ^*****^
 In function: lib.cairo::foo
 dup<u8>([8]) -> ([8], [11])
 Originating location:
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+        u8_overflowing_sub(lhs, rhs).into_is_err()
         ^**************************^
-In function: core::integer::U8PartialOrd::gt
+In function: core::integer::U8PartialOrd::lt
+Inlined at:
+        Self::lt(rhs, lhs)
+        ^****************^
 Inlined at:
         MyEnum::C((c1, c2)) => { if c1 > c2 {
                                     ^*****^
 In function: lib.cairo::foo
 u8_overflowing_sub([0], [10], [11]) { fallthrough([12], [13]) label_test::foo::5([14], [15]) }
 Originating location:
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+        u8_overflowing_sub(lhs, rhs).into_is_err()
         ^**************************^
-In function: core::integer::U8PartialOrd::gt
+In function: core::integer::U8PartialOrd::lt
+Inlined at:
+        Self::lt(rhs, lhs)
+        ^****************^
 Inlined at:
         MyEnum::C((c1, c2)) => { if c1 > c2 {
                                     ^*****^
 In function: lib.cairo::foo
 branch_align() -> ()
 Originating location:
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+        u8_overflowing_sub(lhs, rhs).into_is_err()
         ^**************************^
-In function: core::integer::U8PartialOrd::gt
+In function: core::integer::U8PartialOrd::lt
+Inlined at:
+        Self::lt(rhs, lhs)
+        ^****************^
 Inlined at:
         MyEnum::C((c1, c2)) => { if c1 > c2 {
                                     ^*****^
 In function: lib.cairo::foo
 drop<u8>([13]) -> ()
 Originating location:
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+        u8_overflowing_sub(lhs, rhs).into_is_err()
         ^**************************^
-In function: core::integer::U8PartialOrd::gt
+In function: core::integer::U8PartialOrd::lt
+Inlined at:
+        Self::lt(rhs, lhs)
+        ^****************^
 Inlined at:
         MyEnum::C((c1, c2)) => { if c1 > c2 {
                                     ^*****^
@@ -564,27 +579,36 @@ Inlined at:
 In function: lib.cairo::foo
 label_test::foo::5:
 Originating location:
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+        u8_overflowing_sub(lhs, rhs).into_is_err()
         ^**************************^
-In function: core::integer::U8PartialOrd::gt
+In function: core::integer::U8PartialOrd::lt
+Inlined at:
+        Self::lt(rhs, lhs)
+        ^****************^
 Inlined at:
         MyEnum::C((c1, c2)) => { if c1 > c2 {
                                     ^*****^
 In function: lib.cairo::foo
 branch_align() -> ()
 Originating location:
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+        u8_overflowing_sub(lhs, rhs).into_is_err()
         ^**************************^
-In function: core::integer::U8PartialOrd::gt
+In function: core::integer::U8PartialOrd::lt
+Inlined at:
+        Self::lt(rhs, lhs)
+        ^****************^
 Inlined at:
         MyEnum::C((c1, c2)) => { if c1 > c2 {
                                     ^*****^
 In function: lib.cairo::foo
 drop<u8>([15]) -> ()
 Originating location:
-        u8_overflowing_sub(rhs, lhs).into_is_err()
+        u8_overflowing_sub(lhs, rhs).into_is_err()
         ^**************************^
-In function: core::integer::U8PartialOrd::gt
+In function: core::integer::U8PartialOrd::lt
+Inlined at:
+        Self::lt(rhs, lhs)
+        ^****************^
 Inlined at:
         MyEnum::C((c1, c2)) => { if c1 > c2 {
                                     ^*****^


### PR DESCRIPTION
commit-id:8f9766c2

---

**Stack**:
- #6195 ⬅
- #6194


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6195)
<!-- Reviewable:end -->
