### PR TITLE
LS: Consider empty strings in `workspace/configuration` as `None`

### DIFF
--- a/crates/cairo-lang-language-server/src/config.rs
+++ b/crates/cairo-lang-language-server/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::path::PathBuf;
 
 use anyhow::Context;
+use serde_json::Value;
 use tower_lsp::lsp_types::{ClientCapabilities, ConfigurationItem};
 use tower_lsp::Client;
 use tracing::{debug, error, warn};
@@ -64,8 +65,12 @@ impl Config {
             // This conversion is O(1), and makes popping from front also O(1).
             let mut response = VecDeque::from(response);
 
-            self.unmanaged_core_path =
-                response.pop_front().as_ref().and_then(|v| v.as_str()).map(Into::into);
+            self.unmanaged_core_path = response
+                .pop_front()
+                .as_ref()
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(Into::into);
 
             debug!("reloaded configuration: {self:#?}");
         }


### PR DESCRIPTION
It occurs that the `workspace/configuration`
request returns `Some("")` for the `cairo1.corelibPath`
field even if it is not set anywhere.
This fact blocked any logic that happened in the ` find_unmanaged_core `
function,
as it always assumed
that the user explicitly set the path in their config to `""`.
By nullifying empty configuration values, this change fixes
`find_unmanaged_core`.

---

**Stack**:
- #6248
- #6247 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6247)
<!-- Reviewable:end -->
