### PR TITLE
VSCode: Minor improvements in LS setup logic

### DIFF
--- a/vscode-cairo/src/cairols.ts
+++ b/vscode-cairo/src/cairols.ts
@@ -7,8 +7,6 @@ import { Scarb } from "./scarb";
 import { isScarbProject } from "./scarbProject";
 import { StandaloneLS } from "./standalonels";
 import { registerMacroExpandProvider, registerVfsProvider } from "./textDocumentProviders";
-import { NotificationType } from "vscode-jsonrpc/lib/common/messages";
-import * as cp from "node:child_process";
 
 export interface LanguageServerExecutableProvider {
   languageServerExecutable(): lc.Executable;
@@ -24,7 +22,12 @@ function notifyScarbMissing(ctx: Context) {
 }
 
 export async function setupLanguageServer(ctx: Context): Promise<lc.LanguageClient> {
-  const serverOptions = await getServerOptions(ctx);
+  // TODO(mkaput): Support multi-root workspaces.
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+  const scarb = await findScarbForWorkspaceFolder(workspaceFolder, ctx);
+
+  const serverOptions = await getServerOptions(workspaceFolder, scarb, ctx);
 
   const clientOptions: lc.LanguageClientOptions = {
     documentSelector: [
@@ -40,9 +43,9 @@ export async function setupLanguageServer(ctx: Context): Promise<lc.LanguageClie
     clientOptions,
   );
 
-  // Notify the server when client configuration changes.
+  // Notify the server when the client configuration changes.
   // CairoLS pulls configuration properties it is interested in by itself, so it
-  // is not needed to attach any details in the notification payload.
+  // is unnecessary to attach any details in the notification payload.
   const weakClient = new WeakRef(client);
 
   ctx.extension.subscriptions.push(
@@ -85,12 +88,10 @@ export async function setupLanguageServer(ctx: Context): Promise<lc.LanguageClie
   });
 
   client.onNotification(
-    new NotificationType<string>("cairo/corelib-version-mismatch"),
+    new lc.NotificationType<string>("cairo/corelib-version-mismatch"),
     async (errorMessage) => {
-      ctx.log.error(errorMessage);
-
       const reloadWindow = "Reload window";
-      const cleanScarbCache = "Clean Scarb's cache";
+      const cleanScarbCache = "Clean Scarb cache and reload";
 
       const selectedValue = await vscode.window.showErrorMessage(
         errorMessage,
@@ -98,16 +99,14 @@ export async function setupLanguageServer(ctx: Context): Promise<lc.LanguageClie
         cleanScarbCache,
       );
 
-      if (selectedValue === reloadWindow) {
-        await vscode.commands.executeCommand("workbench.action.reloadWindow");
-      } else if (selectedValue === cleanScarbCache) {
-        cp.exec("scarb cache clean", (err, stdout, stderr) => {
-          ctx.log.trace("`scarb cache clean` stdout: " + stdout);
-          ctx.log.trace("`scarb cache clean` stderr: " + stderr);
-          if (err) {
-            ctx.log.warn("error: " + err);
-          }
-        });
+      switch (selectedValue) {
+        case reloadWindow:
+          await vscode.commands.executeCommand("workbench.action.reloadWindow");
+          break;
+        case cleanScarbCache:
+          await scarb?.cacheClean(ctx);
+          await vscode.commands.executeCommand("workbench.action.reloadWindow");
+          break;
       }
     },
   );
@@ -117,24 +116,31 @@ export async function setupLanguageServer(ctx: Context): Promise<lc.LanguageClie
   return client;
 }
 
-async function getServerOptions(ctx: Context): Promise<lc.ServerOptions> {
-  // TODO(mkaput): Support multi-root workspaces.
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-
+async function findScarbForWorkspaceFolder(
+  workspaceFolder: vscode.WorkspaceFolder | undefined,
+  ctx: Context,
+): Promise<Scarb | undefined> {
   const isScarbEnabled = ctx.config.get("enableScarb", false);
-  let scarb: Scarb | undefined;
   if (!isScarbEnabled) {
     ctx.log.warn("Scarb integration is disabled");
     ctx.log.warn("note: set `cairo1.enableScarb` to `true` to enable it");
+    return undefined;
   } else {
     try {
-      scarb = await Scarb.find(workspaceFolder, ctx);
+      return await Scarb.find(workspaceFolder, ctx);
     } catch (e) {
       ctx.log.error(`${e}`);
       ctx.log.error("note: Scarb integration is disabled due to this error");
+      return undefined;
     }
   }
+}
 
+async function getServerOptions(
+  workspaceFolder: vscode.WorkspaceFolder | undefined,
+  scarb: Scarb | undefined,
+  ctx: Context,
+): Promise<lc.ServerOptions> {
   let serverExecutableProvider: LanguageServerExecutableProvider | undefined;
   try {
     serverExecutableProvider = await determineLanguageServerExecutableProvider(

--- a/vscode-cairo/src/scarb.ts
+++ b/vscode-cairo/src/scarb.ts
@@ -87,6 +87,10 @@ export class Scarb implements LanguageServerExecutableProvider {
     return this.hasCommand("cairo-language-server", ctx);
   }
 
+  public async cacheClean(ctx: Context): Promise<void> {
+    await this.execWithOutput(["cache", "clean"], ctx);
+  }
+
   private async hasCommand(command: string, ctx: Context): Promise<boolean> {
     const output = await this.execWithOutput(["--json", "commands"], ctx);
 


### PR DESCRIPTION
1. Moved `scarb cache clean` invocation into `Scarb` class and started
using its `execWithOutput` method for starting process
2. Moved `workspaceFolder` and `scarb`
initialization out of `getServerOptions`.
3. In the `cairo/corelib-version-mismatch ` notification,
changed the _clean scarb cache_ action to also reload the window
(as cleaning the cache itself is not causing immediate effects).
4. Various cosmetic changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6253)
<!-- Reviewable:end -->
