### PR TITLE
Added test for functions reporting wrong ap-tracking.

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/ap_change_test_data/tests
+++ b/crates/cairo-lang-sierra-generator/src/ap_change_test_data/tests
@@ -66,3 +66,32 @@ fn call_cycle_of_len2(x: felt252) -> felt252 {
 cycle_of_len2_a: ap_change=Ok(Unknown), has_cycles=Ok(true)
 cycle_of_len2_b: ap_change=Ok(Unknown), has_cycles=Ok(true)
 call_cycle_of_len2: ap_change=Ok(Unknown), has_cycles=Ok(true)
+
+//! > ==========================================================================
+
+//! > Cycle non-existent after optimizations.
+
+//! > test_runner_name
+contains_cycles_test
+
+//! > module_code
+fn not_cycle() {
+    cycle_if_some(Option::None)
+}
+
+#[inline(always)]
+fn cycle_if_some(x: Option<felt252>) {
+    match x {
+        Option::Some(x) => { cycle(x); },
+        Option::None => {},
+    }
+}
+
+fn cycle(x: felt252) -> felt252 {
+    cycle(x)
+}
+
+//! > result
+not_cycle: ap_change=Ok(Unknown), has_cycles=Ok(true)
+cycle_if_some: ap_change=Ok(Unknown), has_cycles=Ok(true)
+cycle: ap_change=Ok(Unknown), has_cycles=Ok(true)


### PR DESCRIPTION
**Stack**:
- #6259
- #6258
- #6257
- #6256 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6256)
<!-- Reviewable:end -->
