### PR TITLE
Feat: support format!("{:x}") notation for hexadecimal formatting

### DIFF
--- a/corelib/src/fmt.cairo
+++ b/corelib/src/fmt.cairo
@@ -289,15 +289,44 @@ impl SpanTDebug<T, +Debug<T>> of Debug<Span<T>> {
     }
 }
 
-/// Impls for `Debug` for types that can be converted into `felt252` using the `Into` trait.
+/// Impls for `Debug` and `LowerHex` for types that can be converted into `felt252` using the `Into`
+/// trait.
 /// Usage example:
 /// ```ignore
 /// impl MyTypeDebug = crate::fmt::into_felt252_based::DebugImpl<MyType>;`
+/// impl MyTypeLowerHex = crate::fmt::into_felt252_based::LowerHexImpl<MyType>;
 /// ```
 pub mod into_felt252_based {
     pub impl DebugImpl<T, +Into<T, felt252>, +Copy<T>> of crate::fmt::Debug<T> {
         fn fmt(self: @T, ref f: crate::fmt::Formatter) -> Result<(), crate::fmt::Error> {
             crate::fmt::DebugInteger::<felt252>::fmt(@(*self).into(), ref f)
         }
+    }
+    pub impl LowerHexImpl<T, +Into<T, felt252>, +Copy<T>> of core::fmt::LowerHex<T> {
+        fn fmt(self: @T, ref f: core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+            core::fmt::LowerHexInteger::<felt252>::fmt(@(*self).into(), ref f)
+        }
+    }
+}
+
+/// A trait for hex formatting in lower case, using the empty format ("{:x}").
+pub trait LowerHex<T> {
+    fn fmt(self: @T, ref f: Formatter) -> Result<(), Error>;
+}
+
+impl LowerHexInteger<
+    T, +crate::to_byte_array::AppendFormattedToByteArray<T>, +Into<u8, T>, +TryInto<T, NonZero<T>>
+> of LowerHex<T> {
+    fn fmt(self: @T, ref f: Formatter) -> Result<(), Error> {
+        let base: T = 16_u8.into();
+        self.append_formatted_to_byte_array(ref f.buffer, base.try_into().unwrap());
+        Result::Ok(())
+    }
+}
+
+impl LowerHexNonZero<T, +LowerHex<T>, +Copy<T>, +Drop<T>> of LowerHex<NonZero<T>> {
+    fn fmt(self: @NonZero<T>, ref f: Formatter) -> Result<(), Error> {
+        let value: T = (*self).into();
+        write!(f, "{value:x}")
     }
 }

--- a/corelib/src/starknet/class_hash.cairo
+++ b/corelib/src/starknet/class_hash.cairo
@@ -63,3 +63,4 @@ impl HashClassHash<S, +HashStateTrait<S>, +Drop<S>> =
     core::hash::into_felt252_based::HashImpl<ClassHash, S>;
 
 impl DebugClassHash = core::fmt::into_felt252_based::DebugImpl<ClassHash>;
+impl LowerHexClassHash = core::fmt::into_felt252_based::LowerHexImpl<ClassHash>;

--- a/corelib/src/starknet/contract_address.cairo
+++ b/corelib/src/starknet/contract_address.cairo
@@ -77,3 +77,4 @@ impl HashContractAddress<S, +HashStateTrait<S>, +Drop<S>> =
     core::hash::into_felt252_based::HashImpl<ContractAddress, S>;
 
 impl DebugContractAddress = core::fmt::into_felt252_based::DebugImpl<ContractAddress>;
+impl LowerHexContractAddress = core::fmt::into_felt252_based::LowerHexImpl<ContractAddress>;

--- a/corelib/src/starknet/eth_address.cairo
+++ b/corelib/src/starknet/eth_address.cairo
@@ -78,3 +78,4 @@ pub(crate) impl EthAddressPrintImpl of PrintTrait<EthAddress> {
 }
 
 impl DebugEthAddress = core::fmt::into_felt252_based::DebugImpl<EthAddress>;
+impl LowerHexEthAddress = core::fmt::into_felt252_based::LowerHexImpl<EthAddress>;

--- a/corelib/src/starknet/storage_access.cairo
+++ b/corelib/src/starknet/storage_access.cairo
@@ -72,6 +72,13 @@ impl DebugStorageBaseAddress of core::fmt::Debug<StorageBaseAddress> {
     }
 }
 
+impl LowerHexStorageAddress = core::fmt::into_felt252_based::LowerHexImpl<StorageAddress>;
+impl LowerHexStorageBaseAddress of core::fmt::LowerHex<StorageBaseAddress> {
+    fn fmt(self: @StorageBaseAddress, ref f: core::fmt::Formatter) -> Result<(), core::fmt::Error> {
+        LowerHexStorageAddress::fmt(@storage_address_from_base(*self), ref f)
+    }
+}
+
 /// Trait for types that can be used as a value in Starknet storage variables.
 pub trait Store<T> {
     /// Reads a value from storage from domain `address_domain` and base address `base`.

--- a/corelib/src/test/fmt_test.cairo
+++ b/corelib/src/test/fmt_test.cairo
@@ -38,6 +38,20 @@ enum EnumExample {
     BoolValue: bool,
 }
 
+#[derive(Drop, Copy)]
+struct IntoFelt252Based {
+    felt_value: felt252
+}
+
+impl IntoFelt252BasedInto of Into<IntoFelt252Based, felt252> {
+    fn into(self: IntoFelt252Based) -> felt252 {
+        self.felt_value
+    }
+}
+
+impl IntoFelt252BasedDebug = core::fmt::into_felt252_based::DebugImpl<IntoFelt252Based>;
+impl IntoFelt252BasedLowerHex = core::fmt::into_felt252_based::LowerHexImpl<IntoFelt252Based>;
+
 #[test]
 fn test_format_debug() {
     let ba: ByteArray = "hello";
@@ -84,10 +98,49 @@ fn test_format_debug() {
         format!("{:?}", crate::nullable::NullableTrait::new(1)) == "&1", 'bad nullable value fmt'
     );
     assert(format!("{:?}", crate::nullable::null::<felt252>()) == "null", 'bad null fmt');
+
+    let s = IntoFelt252Based { felt_value: 42 };
+    assert(format!("{:?}", s) == "42", 'felt252 based bad formatting');
 }
 
 #[test]
 fn test_array_debug() {
     let arr = array![1, 2, 3];
     assert(format!("{:?}", arr) == "[1, 2, 3]", 'bad array fmt');
+}
+
+#[test]
+fn test_format_hex() {
+    assert(format!("{:x}", 42) == "2a", 'bad felt252 hex formatting');
+    assert(format!("{:x}", 42_u8) == "2a", 'bad u8 lower hex formatting');
+    assert(format!("{:x}", 42_u16) == "2a", 'bad u16 lower hex formatting');
+    assert(format!("{:x}", 48879_u16) == "beef", 'bad u16 lower hex formatting');
+    assert(format!("{:x}", 42_u32) == "2a", 'bad u32 lower hex formatting');
+    assert(format!("{:x}", 3735928559_u32) == "deadbeef", 'bad u32 lower hex formatting');
+    assert(format!("{:x}", 42_u64) == "2a", 'bad u64 lower hex formatting');
+    assert(
+        format!("{:x}", 16045690984833335023_u64) == "deadbeefdeadbeef",
+        'bad u64 lower hex formatting'
+    );
+    assert(format!("{:x}", 42_u128) == "2a", 'bad u128 lower hex formatting');
+    assert(
+        format!(
+            "{:x}", 295990755083049101712519384020072382191_u128
+        ) == "deadbeefdeadbeefdeadbeefdeadbeef",
+        'bad u128 lower hex formatting'
+    );
+    assert(format!("{:x}", 42_u256) == "2a", 'bad u256 lower hex formatting');
+    assert(
+        format!(
+            "{:x}",
+            100720434726375746010458024839911619878118703404436202866098422983289408962287_u256
+        ) == "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        'bad u256 lower hex formatting'
+    );
+
+    let nz_value: NonZero<felt252> = 42.try_into().unwrap();
+    assert(format!("{:x}", nz_value) == "2a", 'non zero bad formatting');
+
+    let s = IntoFelt252Based { felt_value: 42 };
+    assert(format!("{:x}", s) == "2a", 'felt252 based bad formatting');
 }

--- a/crates/cairo-lang-language-server/tests/test_data/completions/methods_text_edits.txt
+++ b/crates/cairo-lang-language-server/tests/test_data/completions/methods_text_edits.txt
@@ -87,6 +87,9 @@ Text edit: use core::fmt::Display;
 Completion: fmt()
 Text edit: use core::fmt::Debug;
 --------------------------
+Completion: fmt()
+Text edit: use core::fmt::LowerHex;
+--------------------------
 Completion: is_zero()
 --------------------------
 Completion: is_non_zero()
@@ -191,6 +194,9 @@ Text edit: use core::fmt::Display;
 --------------------------
 Completion: fmt()
 Text edit: use core::fmt::Debug;
+--------------------------
+Completion: fmt()
+Text edit: use core::fmt::LowerHex;
 --------------------------
 Completion: is_zero()
 --------------------------

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -302,7 +302,7 @@ error: Plugin diagnostic: Invalid format string: Unexpected character in placeho
     write!(f, "{:x ?}");
               ^******^
 
-error: Plugin diagnostic: Invalid format string: Unsupported formatting trait: only `Display` and `Debug` are supported.
+error: Plugin diagnostic: Invalid format string: Unsupported formatting trait: only `Display`, `Debug` and `LowerHex` are supported.
  --> lib.cairo:51:15
     write!(f, "{:??}");
               ^*****^
@@ -493,7 +493,7 @@ error: Plugin diagnostic: Invalid format string: Unexpected character in placeho
     writeln!(f, "{:x ?}");
                 ^******^
 
-error: Plugin diagnostic: Invalid format string: Unsupported formatting trait: only `Display` and `Debug` are supported.
+error: Plugin diagnostic: Invalid format string: Unsupported formatting trait: only `Display`, `Debug` and `LowerHex` are supported.
  --> lib.cairo:51:17
     writeln!(f, "{:??}");
                 ^*****^

--- a/crates/cairo-lang-semantic/src/inline_macros/write.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/write.rs
@@ -454,12 +454,15 @@ enum FormattingTrait {
     Display,
     /// Got `{:?}` and we should use the `Debug` trait.
     Debug,
+    /// Got `{:x}` and we should use the `LowerHex` trait.
+    LowerHex,
 }
 impl fmt::Display for FormattingTrait {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FormattingTrait::Display => write!(f, "Display"),
             FormattingTrait::Debug => write!(f, "Debug"),
+            FormattingTrait::LowerHex => write!(f, "LowerHex"),
         }
     }
 }
@@ -509,13 +512,17 @@ fn extract_placeholder_argument(
     if !placeholder_terminated {
         return Err("Unterminated placeholder: no matching '}' for '{'");
     }
-    let fmt_type = if formatting_spec.is_empty() {
-        FormattingTrait::Display
-    } else if formatting_spec == "?" {
-        FormattingTrait::Debug
-    } else {
-        return Err("Unsupported formatting trait: only `Display` and `Debug` are supported");
+
+    let fmt_type = match formatting_spec.as_str() {
+        "" => FormattingTrait::Display,
+        "?" => FormattingTrait::Debug,
+        "x" => FormattingTrait::LowerHex,
+        _ => {
+            return Err("Unsupported formatting trait: only `Display`, `Debug` and `LowerHex` \
+                        are supported");
+        }
     };
+
     let source = if parameter_name.is_empty() {
         PlaceholderArgumentSource::Next
     } else if let Ok(position) = parameter_name.parse::<usize>() {


### PR DESCRIPTION
Proposal for issue https://github.com/starkware-libs/cairo/issues/6261.

This PR adds a `LowerHex` trait as existing in Rust, to be able to format integer values to hexadecimal using the `{:x}` notation. Rust also provides a `UpperHex` trait to format the string in upper case but I don't know if it's really useful.

This PR also implements this trait for:
- unsigned integers (from `u8` to `u256`),
- felt252
- `NonZero`
- common Starknet types such as `ContractAddress` and `ClassHash` using the existing `into_felt252_based` module.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6297)
<!-- Reviewable:end -->
