### PR TITLE
Added default-implementation for `map_block_id` in `Rebuilder`.

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/remappings.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/remappings.rs
@@ -82,10 +82,6 @@ impl Rebuilder for Context {
         }
     }
 
-    fn map_block_id(&mut self, block: BlockId) -> BlockId {
-        block
-    }
-
     fn transform_remapping(&mut self, remapping: &mut VarRemapping) {
         let mut new_remapping = VarRemapping::default();
         for (dst, src) in remapping.iter() {

--- a/crates/cairo-lang-lowering/src/reorganize_blocks.rs
+++ b/crates/cairo-lang-lowering/src/reorganize_blocks.rs
@@ -217,8 +217,4 @@ impl Rebuilder for VarReassigner<'_> {
     fn map_var_id(&mut self, var: VariableId) -> VariableId {
         *self.vars.entry(var).or_insert_with(|| self.new_vars.alloc(self.old_vars[var].clone()))
     }
-
-    fn map_block_id(&mut self, block: BlockId) -> BlockId {
-        block
-    }
 }

--- a/crates/cairo-lang-lowering/src/utils.rs
+++ b/crates/cairo-lang-lowering/src/utils.rs
@@ -30,7 +30,9 @@ pub trait Rebuilder {
     fn map_location(&mut self, location: LocationId) -> LocationId {
         location
     }
-    fn map_block_id(&mut self, block: BlockId) -> BlockId;
+    fn map_block_id(&mut self, block: BlockId) -> BlockId {
+        block
+    }
     fn transform_statement(&mut self, _statement: &mut Statement) {}
     fn transform_remapping(&mut self, _remapping: &mut VarRemapping) {}
     fn transform_end(&mut self, _end: &mut FlatBlockEnd) {}


### PR DESCRIPTION
**Stack**:
- #6352
- #6354 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6354)
<!-- Reviewable:end -->
