### PR TITLE
Profiling info processor: allow to specify non-default params

### DIFF
--- a/crates/bin/cairo-run/src/main.rs
+++ b/crates/bin/cairo-run/src/main.rs
@@ -101,6 +101,7 @@ fn main() -> anyhow::Result<()> {
             Some(db),
             sierra_program,
             debug_info.statements_locations.get_statements_functions_map_for_tests(db),
+            Default::default(),
         );
         match result.profiling_info {
             Some(raw_profiling_info) => {

--- a/crates/cairo-lang-runner/src/profiling.rs
+++ b/crates/cairo-lang-runner/src/profiling.rs
@@ -237,13 +237,9 @@ impl<'a> ProfilingInfoProcessor<'a> {
         db: Option<&'a dyn SierraGenGroup>,
         sierra_program: Program,
         statements_functions: UnorderedHashMap<StatementIdx, String>,
+        params: ProfilingInfoProcessorParams,
     ) -> Self {
-        Self {
-            db,
-            sierra_program,
-            statements_functions,
-            params: ProfilingInfoProcessorParams::default(),
-        }
+        Self { db, sierra_program, statements_functions, params }
     }
 
     /// Processes the raw profiling info according to the params set in the processor.

--- a/crates/cairo-lang-runner/src/profiling_test.rs
+++ b/crates/cairo-lang-runner/src/profiling_test.rs
@@ -68,8 +68,12 @@ pub fn test_profiling(
     let result = runner
         .run_function_with_starknet_context(func, &[], Some(u32::MAX as usize), Default::default())
         .unwrap();
-    let profiling_processor =
-        ProfilingInfoProcessor::new(Some(&db), sierra_program, statements_functions);
+    let profiling_processor = ProfilingInfoProcessor::new(
+        Some(&db),
+        sierra_program,
+        statements_functions,
+        Default::default(),
+    );
     let processed_profiling_info = profiling_processor.process(&result.profiling_info.unwrap());
 
     TestRunnerResult {

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -544,6 +544,7 @@ fn update_summary(
             Some(*db),
             sierra_program.clone(),
             statements_functions.clone(),
+            Default::default(),
         );
         let processed_profiling_info =
             profiling_processor.process_ex(&profiling_info, profiling_params);


### PR DESCRIPTION
Currently it is not possible to instantiate `ProfilingInfoProcessor` with non-default parameters.  
It might be handy though for cases where we need to disable `process_by_cairo_stack_trace` and allow profiling even if `SierraGenGroup` db is not initialized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6396)
<!-- Reviewable:end -->
