### PR TITLE
docs: fix broken link to documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/ROOT/pages/index.adoc
+++ b/docs/reference/src/components/cairo/modules/ROOT/pages/index.adoc
@@ -16,7 +16,7 @@ resistance. You can
 read
 more about Sierra link:https://medium.com/starkware/cairo-1-0-aa96eefb19a0[here].
 
-If you are looking for Cairo 0 documentation, please see link:https://www.cairo-lang.org/docs/0.12.0/hello_cairo/index.html[here].
+If you are looking for Cairo 0 documentation, please see link:https://docs.cairo-lang.org/hello_cairo/index.html[here].
 
 ## Help us to improve this documentation
 This documentation site is a work in progress. You are very welcome to contribute to this


### PR DESCRIPTION
Description:
the link to documentation mentioned in the doc was broken, therefore updated now with correct link.

Test:
no test is required because only doc modification

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6400)
<!-- Reviewable:end -->
