### PR TITLE
Disabled inline macro expansion on parser errors.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -396,6 +396,13 @@ fn compute_expr_inline_macro_semantic(
     let Some(macro_plugin) = ctx.db.inline_macro_plugins().get(&macro_name).cloned() else {
         return Err(ctx.diagnostics.report(syntax, InlineMacroNotFound(macro_name.into())));
     };
+    if matches!(syntax.arguments(syntax_db), ast::WrappedArgList::Missing(_)) {
+        return Ok(Expr::Missing(ExprMissing {
+            ty: TypeId::missing(ctx.db, skip_diagnostic()),
+            stable_ptr: ast::Expr::InlineMacro(syntax.clone()).stable_ptr(),
+            diag_added: skip_diagnostic(),
+        }));
+    }
 
     let result = macro_plugin.generate_code(
         syntax_db,

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -611,16 +611,6 @@ error: Plugin diagnostic: Unused argument.
     format!("{2}{0}", ba, 2, 1);
                           ^
 
-error: Plugin diagnostic: Macro `write` does not support this bracket type.
- --> lib.cairo:32:12
-    format!;
-           ^
-
-error: Wrong number of arguments. Expected 1, found: 2
- --> lib.cairo:32:5
-    format!;
-    ^*****^
-
 warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
  --> lib.cairo:2:9
     let ba: ByteArray = "hello";
@@ -724,16 +714,6 @@ error: Plugin diagnostic: Unused argument.
     print!("{2}{0}", ba, 2, 1);
                          ^
 
-error: Plugin diagnostic: Macro `write` does not support this bracket type.
- --> lib.cairo:32:11
-    print!;
-          ^
-
-error: Wrong number of arguments. Expected 1, found: 2
- --> lib.cairo:32:5
-    print!;
-    ^****^
-
 warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
  --> lib.cairo:2:9
     let ba: ByteArray = "hello";
@@ -836,16 +816,6 @@ error: Plugin diagnostic: Unused argument.
  --> lib.cairo:29:28
     println!("{2}{0}", ba, 2, 1);
                            ^
-
-error: Plugin diagnostic: Macro `writeln` does not support this bracket type.
- --> lib.cairo:32:13
-    println!;
-            ^
-
-error: Wrong number of arguments. Expected 1, found: 2
- --> lib.cairo:32:5
-    println!;
-    ^******^
 
 warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
  --> lib.cairo:2:9

--- a/crates/cairo-lang-semantic/src/inline_macros/panic.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/panic.rs
@@ -23,7 +23,7 @@ fn try_handle_simple_panic(
         [] => {
             // Trivial panic!() with no arguments case.
             builder.add_str(
-                "core::panics::panic(array![core::byte_array::BYTE_ARRAY_MAGIC, 0, 0, 0]);",
+                "core::panics::panic(array![core::byte_array::BYTE_ARRAY_MAGIC, 0, 0, 0])",
             );
             return true;
         }
@@ -60,7 +60,7 @@ fn try_handle_simple_panic(
         // Adding the empty remainder word.
         builder.add_str("0, ");
     }
-    builder.add_str(&format!("{remainder_size}]))"));
+    builder.add_str(&format!("{remainder_size}])"));
 
     true
 }


### PR DESCRIPTION
Additionally removed extra `)` and `;` from panic!.