### PR TITLE
Allow defining const negative `NonZero`.

### DIFF
--- a/corelib/src/zeroable.cairo
+++ b/corelib/src/zeroable.cairo
@@ -76,6 +76,14 @@ pub(crate) impl Felt252Zeroable = zero_based::ZeroableImpl<felt252>;
 /// This type guarantees that the wrapped value is never zero.
 #[derive(Copy, Drop)]
 pub extern type NonZero<T>;
+impl NonZeroNeg<T, +Neg<T>, +TryInto<T, NonZero<T>>> of Neg<NonZero<T>> {
+    fn neg(a: NonZero<T>) -> NonZero<T> {
+        // TODO(orizi): Optimize using bounded integers.
+        let value: T = a.into();
+        let negated: T = -value;
+        negated.try_into().unwrap()
+    }
+}
 
 /// Represents the result of checking whether a value is zero.
 pub(crate) enum IsZeroResult<T> {


### PR DESCRIPTION
**Stack**:
- #6428
- #6427
- #6426
- #6425 ⬅
- #6424
- #6423


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6425)
<!-- Reviewable:end -->
