### PR TITLE
fix(profiler): ignore pc outside of function area

### DIFF
--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -330,7 +330,10 @@ impl SierraCasmRunner {
             }
             let real_pc: usize = step.pc.sub(real_pc_0);
             // Skip the footer.
-            if real_pc == bytecode_len {
+            // Also if pc is greater or equal the bytecode length it means that it is the outside
+            // ret used for e.g. getting pointer to builtins costs table, const segments
+            // etc.
+            if real_pc >= bytecode_len {
                 continue;
             }
 


### PR DESCRIPTION
Fixes the `End of program reached, but trace continues.` error which occurs when program counter is outside the function area. Can be reproduced on the program attached.
[sha256.cairo.txt](https://github.com/user-attachments/files/17190098/sha256.cairo.txt)

```
cargo run --bin cairo-run -- --single-file sha256.cairo --available-gas 100000000000 --run-profiler
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6439)
<!-- Reviewable:end -->
