### PR TITLE
Create api for diagnostics ensure with no need for lowering group

### DIFF
--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -207,7 +207,7 @@ impl<'a> DiagnosticsReporter<'a> {
             let ignore_warnings_in_crate = self.ignore_warnings_crate_ids.contains(crate_id);
             let modules = db.crate_modules(*crate_id);
             for module_id in modules.iter() {
-                if let Ok(group) = db.module_semantic_diagnostics(*module_id) {
+                if let Ok(group) = db.module_lowering_diagnostics(*module_id) {
                     found_diagnostics |=
                         self.check_diag_group(db.upcast(), group, ignore_warnings_in_crate);
                 }


### PR DESCRIPTION
We decided to create a diagnostics' api, that doesn't require a LoweringGroup db, as without it, the diagnostic performence is much more better. For more information, [click here](https://github.com/software-mansion/scarb/pull/1590).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6440)
<!-- Reviewable:end -->
