### PR TITLE
feat(profiler): allow to preserve original stack trace order

### DIFF
--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -316,7 +316,7 @@ impl SierraCasmRunner {
         // function).
         // The value is the weight of the stack trace so far, not including the pending weight being
         // tracked at the time.
-        let mut stack_trace_weights = UnorderedHashMap::default();
+        let mut stack_trace_weights = OrderedHashMap::default();
         let mut end_of_program_reached = false;
         // The total weight of each Sierra statement.
         // Note the header and footer (CASM instructions added for running the program by the

--- a/crates/cairo-lang-runner/src/profiling.rs
+++ b/crates/cairo-lang-runner/src/profiling.rs
@@ -7,6 +7,7 @@ use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::{require, LookupIntern};
+use itertools::Itertools;
 use smol_str::SmolStr;
 
 #[cfg(test)]
@@ -25,7 +26,8 @@ pub struct ProfilingInfo {
     /// as a vector of indices of the functions in the stack (indices of the functions according to
     /// the list in the sierra program).
     /// The value is the weight of the stack trace.
-    pub stack_trace_weights: UnorderedHashMap<Vec<usize>, usize>,
+    /// The stack trace entries are sorted in the order they occur.
+    pub stack_trace_weights: OrderedHashMap<Vec<usize>, usize>,
 }
 
 /// Weights per libfunc.
@@ -309,21 +311,16 @@ impl<'a> ProfilingInfoProcessor<'a> {
         raw_profiling_info: &ProfilingInfo,
         params: &ProfilingInfoProcessorParams,
     ) -> StackTraceWeights {
+        let resolve_names = |(idx_stack_trace, weight): (&Vec<usize>, &usize)| {
+            (index_stack_trace_to_name_stack_trace(&self.sierra_program, idx_stack_trace), *weight)
+        };
+
         let sierra_stack_trace_weights = params.process_by_stack_trace.then(|| {
             raw_profiling_info
                 .stack_trace_weights
-                .iter_sorted_by_key(|(idx_stack_trace, weight)| {
-                    (usize::MAX - **weight, (*idx_stack_trace).clone())
-                })
-                .map(|(idx_stack_trace, weight)| {
-                    (
-                        index_stack_trace_to_name_stack_trace(
-                            &self.sierra_program,
-                            idx_stack_trace,
-                        ),
-                        *weight,
-                    )
-                })
+                .iter()
+                .sorted_by_key(|&(trace, weight)| (usize::MAX - *weight, trace.clone()))
+                .map(resolve_names)
                 .collect()
         });
 
@@ -331,17 +328,10 @@ impl<'a> ProfilingInfoProcessor<'a> {
             let db = self.db.expect("DB must be set with `process_by_cairo_stack_trace=true`.");
             raw_profiling_info
                 .stack_trace_weights
-                .filter_cloned(|trace, _| is_cairo_trace(db, &self.sierra_program, trace))
-                .into_iter_sorted_by_key(|(trace, weight)| (usize::MAX - *weight, trace.clone()))
-                .map(|(idx_stack_trace, weight)| {
-                    (
-                        index_stack_trace_to_name_stack_trace(
-                            &self.sierra_program,
-                            &idx_stack_trace,
-                        ),
-                        weight,
-                    )
-                })
+                .iter()
+                .filter(|(trace, _)| is_cairo_trace(db, &self.sierra_program, trace))
+                .sorted_by_key(|&(trace, weight)| (usize::MAX - *weight, trace.clone()))
+                .map(resolve_names)
                 .collect()
         });
 


### PR DESCRIPTION
This PR allows to preserve the original order of the stack trace as opposed to the current approach when items are sorted by weight (and stack entry).

Backwards compatible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6441)
<!-- Reviewable:end -->
