### PR TITLE
LS: Fix duplicated and misplaced diagnostics

### DIFF
--- a/crates/cairo-lang-diagnostics/src/diagnostics.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics.rs
@@ -331,10 +331,10 @@ impl<TEntry: DiagnosticEntry> Diagnostics<TEntry> {
             return diagnostic_with_dup;
         }
         let files_db = db.upcast();
-        let mut indexed_dup_diagnostic = diagnostic_with_dup
-            .iter()
-            .enumerate()
-            .sorted_by_key(|(idx, diag)| (diag.location(db).user_location(files_db).span, *idx));
+        let mut indexed_dup_diagnostic =
+            diagnostic_with_dup.iter().enumerate().sorted_by_cached_key(|(idx, diag)| {
+                (diag.location(db).user_location(files_db).span, diag.format(db), *idx)
+            });
         let mut prev_diagnostic_indexed = indexed_dup_diagnostic.next().unwrap();
         let mut diagnostic_without_dup = vec![prev_diagnostic_indexed];
 

--- a/crates/cairo-lang-language-server/src/lang/diagnostics/lsp.rs
+++ b/crates/cairo-lang-language-server/src/lang/diagnostics/lsp.rs
@@ -15,6 +15,7 @@ pub fn map_cairo_diagnostics_to_lsp<T: DiagnosticEntry>(
     db: &T::DbType,
     diags: &mut Vec<Diagnostic>,
     diagnostics: &Diagnostics<T>,
+    processed_file_id: &FileId,
     trace_macro_diagnostics: bool,
 ) {
     for diagnostic in if trace_macro_diagnostics {
@@ -43,7 +44,7 @@ pub fn map_cairo_diagnostics_to_lsp<T: DiagnosticEntry>(
             }
         }
 
-        let Some((range, _)) = get_mapped_range_and_add_mapping_note(
+        let Some((range, mapped_file_id)) = get_mapped_range_and_add_mapping_note(
             db,
             &diagnostic.location(db),
             trace_macro_diagnostics.then_some(&mut related_information),
@@ -51,6 +52,10 @@ pub fn map_cairo_diagnostics_to_lsp<T: DiagnosticEntry>(
         ) else {
             continue;
         };
+
+        if mapped_file_id != *processed_file_id {
+            continue;
+        }
         diags.push(Diagnostic {
             range,
             message,

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -534,18 +534,21 @@ impl Backend {
             (*db).upcast(),
             &mut diags,
             &new_file_diagnostics.parser,
+            file,
             trace_macro_diagnostics,
         );
         map_cairo_diagnostics_to_lsp(
             (*db).upcast(),
             &mut diags,
             &new_file_diagnostics.semantic,
+            file,
             trace_macro_diagnostics,
         );
         map_cairo_diagnostics_to_lsp(
             (*db).upcast(),
             &mut diags,
             &new_file_diagnostics.lowering,
+            file,
             trace_macro_diagnostics,
         );
 


### PR DESCRIPTION
The diagnostics were not sorted properly, because of lack of including their kind in sorting before deduplication
(`.format()` is a derivative of that)

Also added a check for file relevance, so that vfs-based diagnostics aren't included in the mapping phase

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6446)
<!-- Reviewable:end -->
