### PR TITLE
Allow storing arbitrary strings to differentiate crate instances

### DIFF
--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -10,7 +10,7 @@ use cairo_lang_filesystem::db::{
 };
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::flag::Flag;
-use cairo_lang_filesystem::ids::{CrateLongId, FlagId, VirtualFile};
+use cairo_lang_filesystem::ids::{CrateId, FlagId, VirtualFile};
 use cairo_lang_lowering::db::{init_lowering_group, LoweringDatabase, LoweringGroup};
 use cairo_lang_parser::db::{ParserDatabase, ParserGroup};
 use cairo_lang_project::ProjectConfig;
@@ -20,7 +20,7 @@ use cairo_lang_semantic::plugin::{AnalyzerPlugin, PluginSuite};
 use cairo_lang_sierra_generator::db::SierraGenDatabase;
 use cairo_lang_syntax::node::db::{SyntaxDatabase, SyntaxGroup};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{Intern, Upcast};
+use cairo_lang_utils::Upcast;
 
 use crate::project::{update_crate_root, update_crate_roots_from_project_config};
 use crate::InliningStrategy;
@@ -182,10 +182,8 @@ impl RootDatabaseBuilder {
 }
 
 /// Validates that the corelib version matches the expected one.
-pub fn validate_corelib(db: &dyn FilesGroup) -> Result<()> {
-    let core_crate =
-        CrateLongId::Real { name: CORELIB_CRATE_NAME.into(), version: None }.intern(db);
-    let Some(config) = db.crate_config(core_crate) else {
+pub fn validate_corelib(db: &(dyn FilesGroup + 'static)) -> Result<()> {
+    let Some(config) = db.crate_config(CrateId::core(db)) else {
         return Ok(());
     };
     let Some(found) = config.settings.version else {

--- a/crates/cairo-lang-compiler/src/diagnostics_test.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics_test.rs
@@ -8,7 +8,7 @@ use crate::diagnostics::get_diagnostics_as_string;
 fn test_diagnostics() {
     let mut db = RootDatabase::default();
 
-    let crate_id = CrateId::unversioned(&db, "bad_create");
+    let crate_id = CrateId::plain(&db, "bad_create");
     db.set_crate_config(
         crate_id,
         Some(CrateConfiguration::default_for_root(Directory::Real("no/such/path".into()))),

--- a/crates/cairo-lang-compiler/src/project.rs
+++ b/crates/cairo-lang-compiler/src/project.rs
@@ -2,12 +2,14 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use cairo_lang_defs::ids::ModuleId;
-use cairo_lang_filesystem::db::{CrateConfiguration, FilesGroupEx, CORELIB_CRATE_NAME};
+use cairo_lang_filesystem::db::{
+    CrateConfiguration, CrateSettings, FilesGroupEx, CORELIB_CRATE_NAME,
+};
 use cairo_lang_filesystem::ids::{CrateId, CrateLongId, Directory};
 pub use cairo_lang_project::*;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_utils::Intern;
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ProjectError {
@@ -42,7 +44,7 @@ pub fn setup_single_file_project(
     let file_stem = path.file_stem().and_then(OsStr::to_str).ok_or_else(bad_path_err)?;
     if file_stem == "lib" {
         let crate_name = file_dir.to_str().ok_or_else(bad_path_err)?;
-        let crate_id = CrateId::unversioned(db, crate_name);
+        let crate_id = CrateId::plain(db, crate_name);
         db.set_crate_config(
             crate_id,
             Some(CrateConfiguration::default_for_root(Directory::Real(file_dir.to_path_buf()))),
@@ -50,7 +52,7 @@ pub fn setup_single_file_project(
         Ok(crate_id)
     } else {
         // If file_stem is not lib, create a fake lib file.
-        let crate_id = CrateId::unversioned(db, file_stem);
+        let crate_id = CrateId::plain(db, file_stem);
         db.set_crate_config(
             crate_id,
             Some(CrateConfiguration::default_for_root(Directory::Real(file_dir.to_path_buf()))),
@@ -81,10 +83,7 @@ pub fn update_crate_root(
     crate_name: SmolStr,
     root: Directory,
 ) {
-    let crate_settings = config.content.crates_config.get(&crate_name);
-    let version =
-        if crate_name == CORELIB_CRATE_NAME { None } else { crate_settings.version.clone() };
-    let crate_id = CrateLongId::Real { name: crate_name, version }.intern(db);
+    let (crate_id, crate_settings) = get_crate_id_and_settings(db, crate_name, config);
     db.set_crate_config(
         crate_id,
         Some(CrateConfiguration { root, settings: crate_settings.clone() }),
@@ -136,11 +135,21 @@ pub fn get_main_crate_ids_from_project(
         .content
         .crate_roots
         .keys()
-        .map(|name| {
-            let crate_settings = config.content.crates_config.get(name);
-            let version =
-                if name == CORELIB_CRATE_NAME { None } else { crate_settings.version.clone() };
-            CrateLongId::Real { name: name.clone(), version }.intern(db)
-        })
+        .map(|name| get_crate_id_and_settings(db, name.clone(), config).0)
         .collect()
+}
+
+fn get_crate_id_and_settings<'a>(
+    db: &mut dyn SemanticGroup,
+    name: SmolStr,
+    config: &'a ProjectConfig,
+) -> (CrateId, &'a CrateSettings) {
+    let crate_settings = config.content.crates_config.get(&name);
+    let discriminator = if name == CORELIB_CRATE_NAME {
+        None
+    } else {
+        crate_settings.version.as_ref().map(ToSmolStr::to_smolstr)
+    };
+    let crate_id = CrateLongId::Real { name, discriminator }.intern(db);
+    (crate_id, crate_settings)
 }

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -129,7 +129,7 @@ pub fn setup_test_module<T: DefsGroup + AsFilesGroupMut + ?Sized>(
     db: &mut T,
     content: &str,
 ) -> ModuleId {
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let directory = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(directory)));
     let file = db.module_main_file(ModuleId::CrateRoot(crate_id)).unwrap();
@@ -174,7 +174,7 @@ fn test_submodules() {
     let mut db_val = DatabaseForTesting::default();
     let db = &mut db_val;
 
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 
@@ -257,7 +257,7 @@ fn test_plugin() {
     let mut db_val = DatabaseForTesting::default();
     let db = &mut db_val;
 
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 
@@ -281,7 +281,7 @@ fn test_plugin_remove_original() {
     let mut db_val = DatabaseForTesting::default();
     let db = &mut db_val;
 
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 
@@ -369,7 +369,7 @@ impl MacroPlugin for FooToBarPlugin {
 fn test_foo_to_bar() {
     let mut db_val = DatabaseForTesting::default();
     let db = &mut db_val;
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 
@@ -395,7 +395,7 @@ fn test_foo_to_bar() {
 fn test_first_plugin_removes() {
     let mut db_val = DatabaseForTesting::default();
     let db = &mut db_val;
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 
@@ -419,7 +419,7 @@ fn test_first_plugin_removes() {
 fn test_first_plugin_generates() {
     let mut db_val = DatabaseForTesting::default();
     let db = &mut db_val;
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 
@@ -443,7 +443,7 @@ fn test_first_plugin_generates() {
 fn test_plugin_chain() {
     let mut db_val = DatabaseForTesting::default();
     let db = &mut db_val;
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 
@@ -469,7 +469,7 @@ fn test_plugin_chain() {
 fn test_unknown_item_macro() {
     let mut db_val = DatabaseForTesting::default();
     let db = &mut db_val;
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 

--- a/crates/cairo-lang-doc/src/tests/test_utils.rs
+++ b/crates/cairo-lang-doc/src/tests/test_utils.rs
@@ -87,7 +87,7 @@ pub fn setup_test_module<T: DefsGroup + AsFilesGroupMut + ?Sized>(
     db: &mut T,
     content: &str,
 ) -> CrateId {
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let directory = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(directory)));
     let file = db.module_main_file(ModuleId::CrateRoot(crate_id)).unwrap();

--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{Intern, LookupIntern, Upcast};
+use cairo_lang_utils::{LookupIntern, Upcast};
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 
 use crate::cfg::CfgSet;
 use crate::flag::Flag;
@@ -104,8 +105,11 @@ impl Edition {
 /// The settings for a dependency.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DependencySettings {
-    /// The version of the dependency.
-    pub version: Option<Version>,
+    /// A unique string allowing identifying different copies of the same dependency
+    /// in the compilation unit.
+    ///
+    /// Usually such copies differ by their versions or sources (or both).
+    pub discriminator: Option<SmolStr>,
 }
 
 /// Configuration per crate.
@@ -182,16 +186,13 @@ pub fn init_files_group(db: &mut (dyn FilesGroup + 'static)) {
 }
 
 pub fn init_dev_corelib(db: &mut (dyn FilesGroup + 'static), core_lib_dir: PathBuf) {
-    let core_crate =
-        CrateLongId::Real { name: CORELIB_CRATE_NAME.into(), version: None }.intern(db);
-    let version = Version::parse(CORELIB_VERSION).ok();
     db.set_crate_config(
-        core_crate,
+        CrateId::core(db),
         Some(CrateConfiguration {
             root: Directory::Real(core_lib_dir),
             settings: CrateSettings {
                 edition: Edition::V2024_07,
-                version: version.clone(),
+                version: Version::parse(CORELIB_VERSION).ok(),
                 cfg_set: Default::default(),
                 dependencies: Default::default(),
                 experimental_features: ExperimentalFeaturesConfig {

--- a/crates/cairo-lang-filesystem/src/db_test.rs
+++ b/crates/cairo-lang-filesystem/src/db_test.rs
@@ -14,8 +14,8 @@ use crate::test_utils::FilesDatabaseForTesting;
 fn test_filesystem() {
     let mut db = FilesDatabaseForTesting::default();
 
-    let crt = CrateId::unversioned(&db, "my_crate");
-    let crt2 = CrateId::unversioned(&db, "my_crate2");
+    let crt = CrateId::plain(&db, "my_crate");
+    let crt2 = CrateId::plain(&db, "my_crate2");
     let directory = Directory::Real("src".into());
     let file_id = directory.file(&db, "child.cairo".into());
     let config = CrateConfiguration::default_for_root(directory);

--- a/crates/cairo-lang-language-server/src/project/crate_data.rs
+++ b/crates/cairo-lang-language-server/src/project/crate_data.rs
@@ -8,7 +8,7 @@ use cairo_lang_filesystem::db::{
 };
 use cairo_lang_filesystem::ids::{CrateId, CrateLongId, Directory};
 use cairo_lang_utils::{Intern, LookupIntern};
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr};
 
 use crate::lang::db::AnalysisDatabase;
 
@@ -36,9 +36,11 @@ pub struct Crate {
 impl Crate {
     /// Applies this crate to the [`AnalysisDatabase`].
     pub fn apply(&self, db: &mut AnalysisDatabase) {
-        let crate_id =
-            CrateLongId::Real { name: self.name.clone(), version: self.settings.version.clone() }
-                .intern(db);
+        let crate_id = CrateLongId::Real {
+            name: self.name.clone(),
+            discriminator: self.settings.version.as_ref().map(ToSmolStr::to_smolstr),
+        }
+        .intern(db);
 
         let crate_configuration = CrateConfiguration {
             root: Directory::Real(self.root.clone()),

--- a/crates/cairo-lang-language-server/src/project/scarb.rs
+++ b/crates/cairo-lang-language-server/src/project/scarb.rs
@@ -97,7 +97,7 @@ pub fn update_crate_roots(metadata: &Metadata, db: &mut AnalysisDatabase) {
                 .map(|p| {
                     p.dependencies
                         .iter()
-                        .map(|d| (d.name.clone(), DependencySettings { version: None }))
+                        .map(|d| (d.name.clone(), DependencySettings { discriminator: None }))
                         .collect()
                 })
                 .unwrap_or_default();

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -120,7 +120,7 @@ pub fn test_expand_plugin_inner(
 
     let cairo_code = &inputs["cairo_code"];
 
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("test_src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 

--- a/crates/cairo-lang-semantic/src/corelib.rs
+++ b/crates/cairo-lang-semantic/src/corelib.rs
@@ -3,7 +3,6 @@ use cairo_lang_defs::ids::{
     TraitFunctionId, TraitId,
 };
 use cairo_lang_diagnostics::{Maybe, ToOption};
-use cairo_lang_filesystem::db::CORELIB_CRATE_NAME;
 use cairo_lang_filesystem::ids::CrateId;
 use cairo_lang_syntax::node::ast::{self, BinaryOperator, UnaryOperator};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
@@ -64,7 +63,7 @@ pub fn core_submodule(db: &dyn SemanticGroup, submodule_name: &str) -> ModuleId 
 }
 
 pub fn core_crate(db: &dyn SemanticGroup) -> CrateId {
-    CrateId::unversioned(db, CORELIB_CRATE_NAME)
+    CrateId::core(db)
 }
 
 pub fn core_felt252_ty(db: &dyn SemanticGroup) -> TypeId {

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -25,7 +25,7 @@ use syntax::node::db::SyntaxGroup;
 use syntax::node::helpers::QueryAttrs;
 use syntax::node::TypedStablePtr;
 
-use crate::corelib::{core_crate, core_submodule, get_submodule};
+use crate::corelib::{core_submodule, get_submodule};
 use crate::db::SemanticGroup;
 use crate::diagnostic::SemanticDiagnosticKind::{self, *};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
@@ -996,12 +996,13 @@ impl<'db> Resolver<'db> {
         // module.
         if let Some(dep) = self.settings.dependencies.get(ident.as_str()) {
             return ResolvedBase::Crate(
-                CrateLongId::Real { name: ident, version: dep.version.clone() }.intern(self.db),
+                CrateLongId::Real { name: ident, discriminator: dep.discriminator.clone() }
+                    .intern(self.db),
             );
         }
         // If the first segment is `core` - and it was not overridden by a dependency - using it.
         if ident == CORELIB_CRATE_NAME {
-            return ResolvedBase::Crate(core_crate(self.db));
+            return ResolvedBase::Crate(CrateId::core(self.db));
         }
         ResolvedBase::Module(self.prelude_submodule())
     }

--- a/crates/cairo-lang-semantic/src/resolve/test.rs
+++ b/crates/cairo-lang-semantic/src/resolve/test.rs
@@ -58,7 +58,7 @@ fn test_resolve_path_super() {
     let mut db_val = SemanticDatabaseForTesting::new_empty();
     let db = &mut db_val;
 
-    let crate_id = CrateId::unversioned(db, "test");
+    let crate_id = CrateId::plain(db, "test");
     let root = Directory::Real("src".into());
     db.set_crate_config(crate_id, Some(CrateConfiguration::default_for_root(root)));
 


### PR DESCRIPTION
This PR renames the `Dependency.version` field to
`Dependency.discriminator` and the same for `CrateLongId`.
The type is being changed to `Option<SmolStr>`.
Alongside these changes, some minor refactorings are done to reduce code
duplication, primarily `CrateId::core` is introduced as this pattern
happened several times.

---

**Stack**:
- #6451
- #6450 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo/6450)
<!-- Reviewable:end -->
