### PR TITLE
VSCode: add status bar

### DIFF
--- a/vscode-cairo/package.json
+++ b/vscode-cairo/package.json
@@ -136,10 +136,10 @@
             "default": {},
             "markdownDescription": "Extra environment variables that will be passed to the `cairo-language-server` executable.\nUseful for passing e.g. `CAIRO_LS_LOG` for debugging."
           },
-          "cairo1.enableStatusBar": {
+          "cairo1.showInStatusBar": {
             "type": "boolean",
             "default": true,
-            "description": "Show Cairo Language Server information",
+            "description": "Show CairoLS information in the status bar.",
             "scope": "window"
           }
         }

--- a/vscode-cairo/package.json
+++ b/vscode-cairo/package.json
@@ -136,7 +136,7 @@
             "default": {},
             "markdownDescription": "Extra environment variables that will be passed to the `cairo-language-server` executable.\nUseful for passing e.g. `CAIRO_LS_LOG` for debugging."
           },
-          "cairo1.showStatusBar": {
+          "cairo1.enableStatusBar": {
             "type": "boolean",
             "default": true,
             "description": "Show Cairo Language Server information"

--- a/vscode-cairo/package.json
+++ b/vscode-cairo/package.json
@@ -139,7 +139,8 @@
           "cairo1.enableStatusBar": {
             "type": "boolean",
             "default": true,
-            "description": "Show Cairo Language Server information"
+            "description": "Show Cairo Language Server information",
+            "scope": "window"
           }
         }
       }

--- a/vscode-cairo/package.json
+++ b/vscode-cairo/package.json
@@ -135,6 +135,11 @@
             },
             "default": {},
             "markdownDescription": "Extra environment variables that will be passed to the `cairo-language-server` executable.\nUseful for passing e.g. `CAIRO_LS_LOG` for debugging."
+          },
+          "cairo1.showStatusBar": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show Cairo Language Server information"
           }
         }
       }

--- a/vscode-cairo/src/config.ts
+++ b/vscode-cairo/src/config.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 
 interface ConfigProps {
   enableLanguageServer: boolean;
+  enableStatusBar: boolean;
   languageServerPath: string;
   enableScarb: boolean;
   preferScarbLanguageServer: boolean;

--- a/vscode-cairo/src/config.ts
+++ b/vscode-cairo/src/config.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 
 interface ConfigProps {
   enableLanguageServer: boolean;
-  enableStatusBar: boolean;
+  showInStatusBar: boolean;
   languageServerPath: string;
   enableScarb: boolean;
   preferScarbLanguageServer: boolean;

--- a/vscode-cairo/src/context.ts
+++ b/vscode-cairo/src/context.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { Config } from "./config";
 import { RootLogOutputChannel } from "./logging";
+import { StatusBar } from "./statusBar";
 
 export class Context {
   public static create(extensionContext: vscode.ExtensionContext): Context {
@@ -9,19 +10,20 @@ export class Context {
         log: true,
       }),
     );
-    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
 
     extensionContext.subscriptions.push(log);
-    extensionContext.subscriptions.push(statusBarItem);
 
-    return new Context(extensionContext, log, statusBarItem);
+    const context = new Context(extensionContext, log);
+    context.statusBar = new StatusBar(context);
+
+    return context;
   }
 
   public readonly config: Config = new Config();
+  public statusBar!: StatusBar;
 
   private constructor(
     public readonly extension: vscode.ExtensionContext,
     public readonly log: RootLogOutputChannel,
-    public readonly statusBarItem: vscode.StatusBarItem,
   ) {}
 }

--- a/vscode-cairo/src/context.ts
+++ b/vscode-cairo/src/context.ts
@@ -13,17 +13,16 @@ export class Context {
 
     extensionContext.subscriptions.push(log);
 
-    const context = new Context(extensionContext, log);
-    context.statusBar = new StatusBar(context);
-
-    return context;
+    return new Context(extensionContext, log);
   }
 
   public readonly config: Config = new Config();
-  public statusBar!: StatusBar;
+  public readonly statusBar: StatusBar;
 
   private constructor(
     public readonly extension: vscode.ExtensionContext,
     public readonly log: RootLogOutputChannel,
-  ) {}
+  ) {
+    this.statusBar = new StatusBar(this);
+  }
 }

--- a/vscode-cairo/src/context.ts
+++ b/vscode-cairo/src/context.ts
@@ -9,9 +9,12 @@ export class Context {
         log: true,
       }),
     );
-    extensionContext.subscriptions.push(log);
+    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
 
-    return new Context(extensionContext, log);
+    extensionContext.subscriptions.push(log);
+    extensionContext.subscriptions.push(statusBarItem);
+
+    return new Context(extensionContext, log, statusBarItem);
   }
 
   public readonly config: Config = new Config();
@@ -19,5 +22,6 @@ export class Context {
   private constructor(
     public readonly extension: vscode.ExtensionContext,
     public readonly log: RootLogOutputChannel,
+    public readonly statusBarItem: vscode.StatusBarItem,
   ) {}
 }

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -17,7 +17,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   }
 
   if (ctx.config.get("enableStatusBar")) {
-    await setupStatusBar(ctx);
+    await setupStatusBar(ctx, client);
   } else {
     ctx.log.warn("status bar is disabled");
     ctx.log.warn("note: set `cairo1.enableStatusBar` to `true` to enable it");

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -15,7 +15,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     ctx.log.warn("note: set `cairo1.enableLanguageServer` to `true` to enable it");
   }
 
-  ctx.statusBar.setup(client);
+  await ctx.statusBar.setup(client);
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -15,9 +15,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     ctx.log.warn("note: set `cairo1.enableLanguageServer` to `true` to enable it");
   }
 
-  if (ctx.config.get("showInStatusBar")) {
-    ctx.statusBar.setupStatusBar(client);
-  }
+  ctx.statusBar.setupStatusBar(client);
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -2,10 +2,9 @@ import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
 import { setupLanguageServer } from "./cairols";
 import { Context } from "./context";
-import { Scarb } from "./scarb";
+import { setupStatusBar } from "./statusBar";
 
 let client: lc.LanguageClient | undefined;
-let statusBarItem: vscode.StatusBarItem;
 
 export async function activate(extensionContext: vscode.ExtensionContext) {
   const ctx = Context.create(extensionContext);
@@ -17,56 +16,17 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     ctx.log.warn("note: set `cairo1.enableLanguageServer` to `true` to enable it");
   }
 
-  statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
-  extensionContext.subscriptions.push(statusBarItem);
-
-  updateStatusBar(ctx);
-
-  extensionContext.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("cairo1.showStatusBar")) {
-        updateStatusBar(ctx);
-      }
-    }),
-  );
-}
-
-async function updateStatusBar(ctx: Context) {
-  const config = vscode.workspace.getConfiguration("cairo1");
-  const showStatusBar = config.get<boolean>("showStatusBar", true);
-
-  if (showStatusBar) {
-    const editor = vscode.window.activeTextEditor;
-    if (editor && editor.document.languageId === "cairo") {
-      statusBarItem.text = "Cairo";
-      statusBarItem.tooltip = "Cairo Language";
-
-      // Get Scarb version
-      try {
-        const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], ctx);
-        if (scarb) {
-          const version = await scarb.getVersion(ctx);
-          statusBarItem.tooltip = `Cairo Language\n${version}`;
-        }
-      } catch (error) {
-        ctx.log.error(`Error getting Scarb version: ${error}`);
-      }
-
-      statusBarItem.show();
-    } else {
-      statusBarItem.hide();
-    }
+  if (ctx.config.get("enableStatusBar")) {
+    await setupStatusBar(ctx);
   } else {
-    statusBarItem.hide();
+    ctx.log.warn("status bar is disabled");
+    ctx.log.warn("note: set `cairo1.enableStatusBar` to `true` to enable it");
   }
 }
 
 export function deactivate(): Thenable<void> | undefined {
   if (!client) {
     return undefined;
-  }
-  if (statusBarItem) {
-    statusBarItem.dispose();
   }
 
   return client.stop();

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -15,7 +15,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     ctx.log.warn("note: set `cairo1.enableLanguageServer` to `true` to enable it");
   }
 
-  ctx.statusBar.setupStatusBar(client);
+  ctx.statusBar.setup(client);
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -18,9 +18,6 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
 
   if (ctx.config.get("showInStatusBar")) {
     await setupStatusBar(ctx, client);
-  } else {
-    ctx.log.warn("status bar is disabled");
-    ctx.log.warn("note: set `cairo1.showInStatusBar` to `true` to enable it");
   }
 }
 

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -2,7 +2,6 @@ import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
 import { setupLanguageServer } from "./cairols";
 import { Context } from "./context";
-import { setupStatusBar } from "./statusBar";
 
 let client: lc.LanguageClient | undefined;
 
@@ -17,7 +16,7 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
   }
 
   if (ctx.config.get("showInStatusBar")) {
-    await setupStatusBar(ctx, client);
+    ctx.statusBar.setupStatusBar(client);
   }
 }
 

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -2,8 +2,10 @@ import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
 import { setupLanguageServer } from "./cairols";
 import { Context } from "./context";
+import { Scarb } from "./scarb";
 
 let client: lc.LanguageClient | undefined;
+let statusBarItem: vscode.StatusBarItem;
 
 export async function activate(extensionContext: vscode.ExtensionContext) {
   const ctx = Context.create(extensionContext);
@@ -14,11 +16,58 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     ctx.log.warn("language server is disabled");
     ctx.log.warn("note: set `cairo1.enableLanguageServer` to `true` to enable it");
   }
+
+  statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+  extensionContext.subscriptions.push(statusBarItem);
+
+  updateStatusBar(ctx);
+
+  extensionContext.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("cairo1.showStatusBar")) {
+        updateStatusBar(ctx);
+      }
+    }),
+  );
+}
+
+async function updateStatusBar(ctx: Context) {
+  const config = vscode.workspace.getConfiguration("cairo1");
+  const showStatusBar = config.get<boolean>("showStatusBar", true);
+
+  if (showStatusBar) {
+    const editor = vscode.window.activeTextEditor;
+    if (editor && editor.document.languageId === "cairo") {
+      statusBarItem.text = "Cairo";
+      statusBarItem.tooltip = "Cairo Language";
+
+      // Get Scarb version
+      try {
+        const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], ctx);
+        if (scarb) {
+          const version = await scarb.getVersion(ctx);
+          statusBarItem.tooltip = `Cairo Language\n${version}`;
+        }
+      } catch (error) {
+        ctx.log.error(`Error getting Scarb version: ${error}`);
+      }
+
+      statusBarItem.show();
+    } else {
+      statusBarItem.hide();
+    }
+  } else {
+    statusBarItem.hide();
+  }
 }
 
 export function deactivate(): Thenable<void> | undefined {
   if (!client) {
     return undefined;
   }
+  if (statusBarItem) {
+    statusBarItem.dispose();
+  }
+
   return client.stop();
 }

--- a/vscode-cairo/src/extension.ts
+++ b/vscode-cairo/src/extension.ts
@@ -16,11 +16,11 @@ export async function activate(extensionContext: vscode.ExtensionContext) {
     ctx.log.warn("note: set `cairo1.enableLanguageServer` to `true` to enable it");
   }
 
-  if (ctx.config.get("enableStatusBar")) {
+  if (ctx.config.get("showInStatusBar")) {
     await setupStatusBar(ctx, client);
   } else {
     ctx.log.warn("status bar is disabled");
-    ctx.log.warn("note: set `cairo1.enableStatusBar` to `true` to enable it");
+    ctx.log.warn("note: set `cairo1.showInStatusBar` to `true` to enable it");
   }
 }
 

--- a/vscode-cairo/src/scarb.ts
+++ b/vscode-cairo/src/scarb.ts
@@ -87,6 +87,11 @@ export class Scarb implements LanguageServerExecutableProvider {
     return this.hasCommand("cairo-language-server", ctx);
   }
 
+  public async getVersion(ctx: Context): Promise<string> {
+    const output = await this.execWithOutput(["--version"], ctx);
+    return output.trim();
+  }
+
   public async cacheClean(ctx: Context): Promise<void> {
     await this.execWithOutput(["cache", "clean"], ctx);
   }

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -43,7 +43,6 @@ export class StatusBar {
   }
 
   private async updateScarbVersion(): Promise<void> {
-    this.context.log.info("Updating Scarb version");
     try {
       // TODO(mkaput): Support multi-root workspaces.
       const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], this.context);

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -19,26 +19,20 @@ async function updateStatusBar(ctx: Context) {
   const enableStatusBar = config.get<boolean>("enableStatusBar", true);
 
   if (enableStatusBar) {
-    const editor = vscode.window.activeTextEditor;
-    if (editor && editor.document.languageId === "cairo") {
-      ctx.statusBarItem.text = "Cairo";
-      ctx.statusBarItem.tooltip = "Cairo Language";
+    ctx.statusBarItem.text = "Cairo";
+    ctx.statusBarItem.tooltip = "Cairo Language";
 
-      // Get Scarb version
-      try {
-        const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], ctx);
-        if (scarb) {
-          const version = await scarb.getVersion(ctx);
-          ctx.statusBarItem.tooltip = `Cairo Language\n${version}`;
-        }
-      } catch (error) {
-        ctx.log.error(`Error getting Scarb version: ${error}`);
+    try {
+      const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], ctx);
+      if (scarb) {
+        const version = await scarb.getVersion(ctx);
+        ctx.statusBarItem.tooltip = `Cairo Language\n${version}`;
       }
-
-      ctx.statusBarItem.show();
-    } else {
-      ctx.statusBarItem.hide();
+    } catch (error) {
+      ctx.log.error(`Error getting Scarb version: ${error}`);
     }
+
+    ctx.statusBarItem.show();
   } else {
     ctx.statusBarItem.hide();
   }

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -1,6 +1,6 @@
-import type { Context } from "./context";
 import * as vscode from "vscode";
 import * as lc from "vscode-languageclient/node";
+import type { Context } from "./context";
 import { Scarb } from "./scarb";
 
 const CAIRO_STATUS_BAR_COMMAND = "cairo1.statusBar.clicked";
@@ -16,10 +16,8 @@ export class StatusBar {
     this.context.extension.subscriptions.push(this.statusBarItem);
 
     this.context.extension.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration((e) => {
-        if (e.affectsConfiguration("cairo1.showInStatusBar")) {
-          this.update();
-        }
+      vscode.workspace.onDidChangeConfiguration(() => {
+        this.update();
       }),
     );
 
@@ -57,6 +55,9 @@ export class StatusBar {
     }
   }
 
+  /**
+   * Updates the status bar item based on the current workspace configuration.
+   */
   private async update(): Promise<void> {
     const config = vscode.workspace.getConfiguration("cairo1");
     const showInStatusBar = config.get<boolean>("showInStatusBar", true);

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -1,0 +1,45 @@
+import * as vscode from "vscode";
+import { Context } from "./context";
+import { Scarb } from "./scarb";
+
+export async function setupStatusBar(ctx: Context) {
+  ctx.extension.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("cairo1.enableStatusBar")) {
+        updateStatusBar(ctx);
+      }
+    }),
+  );
+
+  updateStatusBar(ctx);
+}
+
+async function updateStatusBar(ctx: Context) {
+  const config = vscode.workspace.getConfiguration("cairo1");
+  const enableStatusBar = config.get<boolean>("enableStatusBar", true);
+
+  if (enableStatusBar) {
+    const editor = vscode.window.activeTextEditor;
+    if (editor && editor.document.languageId === "cairo") {
+      ctx.statusBarItem.text = "Cairo";
+      ctx.statusBarItem.tooltip = "Cairo Language";
+
+      // Get Scarb version
+      try {
+        const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], ctx);
+        if (scarb) {
+          const version = await scarb.getVersion(ctx);
+          ctx.statusBarItem.tooltip = `Cairo Language\n${version}`;
+        }
+      } catch (error) {
+        ctx.log.error(`Error getting Scarb version: ${error}`);
+      }
+
+      ctx.statusBarItem.show();
+    } else {
+      ctx.statusBarItem.hide();
+    }
+  } else {
+    ctx.statusBarItem.hide();
+  }
+}

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -1,53 +1,71 @@
+import type { Context } from "./context";
 import * as vscode from "vscode";
-import { Context } from "./context";
-import { Scarb } from "./scarb";
 import * as lc from "vscode-languageclient/node";
+import { Scarb } from "./scarb";
 
 const CAIRO_STATUS_BAR_COMMAND = "cairo1.statusBar.clicked";
 
-export async function setupStatusBar(ctx: Context, client?: lc.LanguageClient) {
-  ctx.extension.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("cairo1.showInStatusBar")) {
-        updateStatusBar(ctx);
+export class StatusBar {
+  private statusBarItem: vscode.StatusBarItem;
+
+  constructor(private readonly context: Context) {
+    this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+    this.context.extension.subscriptions.push(this.statusBarItem);
+  }
+
+  public setupStatusBar(client?: lc.LanguageClient): void {
+    this.context.extension.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration("cairo1.showInStatusBar")) {
+          this.updateStatusBar();
+        }
+      }),
+    );
+
+    this.context.extension.subscriptions.push(
+      vscode.commands.registerCommand(CAIRO_STATUS_BAR_COMMAND, () => {
+        if (client) {
+          client.outputChannel.show();
+        } else {
+          vscode.window.showWarningMessage("Cairo Language Server is not active");
+        }
+      }),
+    );
+    this.statusBarItem.command = CAIRO_STATUS_BAR_COMMAND;
+
+    this.updateStatusBar();
+  }
+
+  public async updateStatusBar(): Promise<void> {
+    const config = vscode.workspace.getConfiguration("cairo1");
+    const showInStatusBar = config.get<boolean>("showInStatusBar", true);
+
+    if (showInStatusBar) {
+      this.statusBarItem.text = "Cairo";
+      this.statusBarItem.tooltip = "Cairo Language";
+
+      try {
+        // TODO(mkaput): Support multi-root workspaces.
+        const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], this.context);
+        if (scarb) {
+          const version = await scarb.getVersion(this.context);
+          this.statusBarItem.tooltip = `Cairo Language\n${version}`;
+        }
+      } catch (error) {
+        this.context.log.error(`Error getting Scarb version: ${error}`);
       }
-    }),
-  );
 
-  ctx.extension.subscriptions.push(
-    vscode.commands.registerCommand(CAIRO_STATUS_BAR_COMMAND, () => {
-      if (client) {
-        client.outputChannel.show();
-      } else {
-        vscode.window.showWarningMessage("Cairo Language Server is not active");
-      }
-    }),
-  );
-  ctx.statusBarItem.command = CAIRO_STATUS_BAR_COMMAND;
-
-  updateStatusBar(ctx);
-}
-
-async function updateStatusBar(ctx: Context) {
-  const config = vscode.workspace.getConfiguration("cairo1");
-  const showInStatusBar = config.get<boolean>("showInStatusBar", true);
-
-  if (showInStatusBar) {
-    ctx.statusBarItem.text = "Cairo";
-    ctx.statusBarItem.tooltip = "Cairo Language";
-
-    try {
-      const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], ctx);
-      if (scarb) {
-        const version = await scarb.getVersion(ctx);
-        ctx.statusBarItem.tooltip = `Cairo Language\n${version}`;
-      }
-    } catch (error) {
-      ctx.log.error(`Error getting Scarb version: ${error}`);
+      this.statusBarItem.show();
+    } else {
+      this.statusBarItem.hide();
     }
+  }
 
-    ctx.statusBarItem.show();
-  } else {
-    ctx.statusBarItem.hide();
+  public showStatusBarItem(): void {
+    this.statusBarItem.show();
+  }
+
+  public hideStatusBarItem(): void {
+    this.statusBarItem.hide();
   }
 }

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -10,11 +10,11 @@ export class StatusBar {
 
   constructor(private readonly context: Context) {
     this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+
+    this.context.extension.subscriptions.push(this.statusBarItem);
   }
 
   public async setup(client?: lc.LanguageClient): Promise<void> {
-    this.context.extension.subscriptions.push(this.statusBarItem);
-
     this.context.extension.subscriptions.push(
       vscode.workspace.onDidChangeConfiguration(() => {
         this.update();
@@ -43,6 +43,7 @@ export class StatusBar {
   }
 
   private async updateScarbVersion(): Promise<void> {
+    this.context.log.info("Updating Scarb version");
     try {
       // TODO(mkaput): Support multi-root workspaces.
       const scarb = await Scarb.find(vscode.workspace.workspaceFolders?.[0], this.context);

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -8,7 +8,7 @@ const CAIRO_STATUS_BAR_COMMAND = "cairo1.statusBar.clicked";
 export async function setupStatusBar(ctx: Context, client?: lc.LanguageClient) {
   ctx.extension.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("cairo1.enableStatusBar")) {
+      if (e.affectsConfiguration("cairo1.showInStatusBar")) {
         updateStatusBar(ctx);
       }
     }),
@@ -30,9 +30,9 @@ export async function setupStatusBar(ctx: Context, client?: lc.LanguageClient) {
 
 async function updateStatusBar(ctx: Context) {
   const config = vscode.workspace.getConfiguration("cairo1");
-  const enableStatusBar = config.get<boolean>("enableStatusBar", true);
+  const showInStatusBar = config.get<boolean>("showInStatusBar", true);
 
-  if (enableStatusBar) {
+  if (showInStatusBar) {
     ctx.statusBarItem.text = "Cairo";
     ctx.statusBarItem.tooltip = "Cairo Language";
 

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -55,9 +55,9 @@ export class StatusBar {
         this.context.log.error(`Error getting Scarb version: ${error}`);
       }
 
-      this.statusBarItem.show();
+      this.showStatusBarItem();
     } else {
-      this.statusBarItem.hide();
+      this.hideStatusBarItem();
     }
   }
 

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -13,11 +13,11 @@ export class StatusBar {
     this.context.extension.subscriptions.push(this.statusBarItem);
   }
 
-  public setupStatusBar(client?: lc.LanguageClient): void {
+  public setup(client?: lc.LanguageClient): void {
     this.context.extension.subscriptions.push(
       vscode.workspace.onDidChangeConfiguration((e) => {
         if (e.affectsConfiguration("cairo1.showInStatusBar")) {
-          this.updateStatusBar();
+          this.update();
         }
       }),
     );
@@ -33,10 +33,10 @@ export class StatusBar {
     );
     this.statusBarItem.command = CAIRO_STATUS_BAR_COMMAND;
 
-    this.updateStatusBar();
+    this.update();
   }
 
-  public async updateStatusBar(): Promise<void> {
+  private async update(): Promise<void> {
     const config = vscode.workspace.getConfiguration("cairo1");
     const showInStatusBar = config.get<boolean>("showInStatusBar", true);
 

--- a/vscode-cairo/src/statusBar.ts
+++ b/vscode-cairo/src/statusBar.ts
@@ -1,8 +1,11 @@
 import * as vscode from "vscode";
 import { Context } from "./context";
 import { Scarb } from "./scarb";
+import * as lc from "vscode-languageclient/node";
 
-export async function setupStatusBar(ctx: Context) {
+const CAIRO_STATUS_BAR_COMMAND = "cairo1.statusBar.clicked";
+
+export async function setupStatusBar(ctx: Context, client?: lc.LanguageClient) {
   ctx.extension.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration("cairo1.enableStatusBar")) {
@@ -10,6 +13,17 @@ export async function setupStatusBar(ctx: Context) {
       }
     }),
   );
+
+  ctx.extension.subscriptions.push(
+    vscode.commands.registerCommand(CAIRO_STATUS_BAR_COMMAND, () => {
+      if (client) {
+        client.outputChannel.show();
+      } else {
+        vscode.window.showWarningMessage("Cairo Language Server is not active");
+      }
+    }),
+  );
+  ctx.statusBarItem.command = CAIRO_STATUS_BAR_COMMAND;
 
   updateStatusBar(ctx);
 }


### PR DESCRIPTION
Fixes: #6474

## Changes

- add status bar component
- add `cairo1.showInStatusBar` config item in vscode settings
- made status bar component clickable to LSP logs

Let me know if more info should be added to the UI.

## Screenshots

Hovering over the extension shows the following info:

![Screenshot 2024-10-17 at 14 47 08](https://github.com/user-attachments/assets/b7e5dd1c-a6bd-4008-93cf-afdef8ffee35)

Enabling/disabling the setting works:

https://github.com/user-attachments/assets/81cb9d37-6091-4e2a-b50a-5093da65a6b2

