### PR TITLE
LS: Make `crate::server::schedule::thread` accessible in codebase

### DIFF
--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -69,7 +69,8 @@ use crate::project::scarb::update_crate_roots;
 use crate::project::unmanaged_core_crate::try_to_init_unmanaged_core;
 use crate::server::client::{Client, Notifier, Requester, Responder};
 use crate::server::connection::{Connection, ConnectionInitializer};
-use crate::server::schedule::{JoinHandle, Scheduler, Task, event_loop_thread};
+use crate::server::schedule::thread::JoinHandle;
+use crate::server::schedule::{Scheduler, Task, event_loop_thread};
 use crate::state::State;
 use crate::toolchain::scarb::ScarbToolchain;
 

--- a/crates/cairo-lang-language-server/src/server/schedule/mod.rs
+++ b/crates/cairo-lang-language-server/src/server/schedule/mod.rs
@@ -6,19 +6,18 @@
 // +---------------------------------------------------+
 
 use anyhow::Result;
-use task::BackgroundTaskBuilder;
-use thread::ThreadPriority;
 
+use self::task::BackgroundTaskBuilder;
+use self::thread::{JoinHandle, ThreadPriority};
 use crate::server::client::{Client, Notifier, Requester, Responder};
 use crate::server::connection::ClientSender;
 use crate::state::State;
 
 mod task;
-mod thread;
+pub mod thread;
 
-pub(super) use task::BackgroundSchedule;
-pub use task::{SyncTask, Task};
-pub use thread::JoinHandle;
+pub(super) use self::task::BackgroundSchedule;
+pub use self::task::{SyncTask, Task};
 
 /// The event loop thread is actually a secondary thread that we spawn from the
 /// _actual_ main thread. This secondary thread has a larger stack size

--- a/crates/cairo-lang-language-server/src/server/schedule/thread/mod.rs
+++ b/crates/cairo-lang-language-server/src/server/schedule/thread/mod.rs
@@ -39,7 +39,7 @@ mod pool;
 mod priority;
 
 pub(super) use pool::Pool;
-pub(super) use priority::ThreadPriority;
+pub use priority::ThreadPriority;
 
 pub struct Builder {
     priority: ThreadPriority,


### PR DESCRIPTION
**Stack**:
- #6508
- #6507 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*