### PR TITLE
Adjust `ProjectConfig` to remove implicit assumption that `discriminator == version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,6 @@ dependencies = [
  "indoc",
  "pretty_assertions",
  "serde",
- "smol_str",
  "thiserror",
  "toml",
 ]

--- a/crates/cairo-lang-compiler/src/project.rs
+++ b/crates/cairo-lang-compiler/src/project.rs
@@ -3,13 +3,12 @@ use std::path::Path;
 
 use cairo_lang_defs::ids::ModuleId;
 use cairo_lang_filesystem::db::{
-    CORELIB_CRATE_NAME, CrateConfiguration, CrateSettings, FilesGroupEx,
+    CORELIB_CRATE_NAME, CrateConfiguration, CrateIdentifier, CrateSettings, FilesGroupEx,
 };
 use cairo_lang_filesystem::ids::{CrateId, CrateLongId, Directory};
 pub use cairo_lang_project::*;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_utils::Intern;
-use smol_str::{SmolStr, ToSmolStr};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ProjectError {
@@ -68,9 +67,9 @@ pub fn setup_single_file_project(
 
 /// Updates the crate roots from a ProjectConfig object.
 pub fn update_crate_roots_from_project_config(db: &mut dyn SemanticGroup, config: &ProjectConfig) {
-    for (crate_name, directory_path) in config.content.crate_roots.iter() {
+    for (crate_identifier, directory_path) in config.content.crate_roots.iter() {
         let root = Directory::Real(config.absolute_crate_root(directory_path));
-        update_crate_root(db, config, crate_name.clone(), root);
+        update_crate_root(db, config, crate_identifier, root);
     }
 }
 
@@ -80,10 +79,10 @@ pub fn update_crate_roots_from_project_config(db: &mut dyn SemanticGroup, config
 pub fn update_crate_root(
     db: &mut dyn SemanticGroup,
     config: &ProjectConfig,
-    crate_name: SmolStr,
+    crate_identifier: &CrateIdentifier,
     root: Directory,
 ) {
-    let (crate_id, crate_settings) = get_crate_id_and_settings(db, crate_name, config);
+    let (crate_id, crate_settings) = get_crate_id_and_settings(db, crate_identifier, config);
     db.set_crate_config(
         crate_id,
         Some(CrateConfiguration { root, settings: crate_settings.clone() }),
@@ -135,21 +134,22 @@ pub fn get_main_crate_ids_from_project(
         .content
         .crate_roots
         .keys()
-        .map(|name| get_crate_id_and_settings(db, name.clone(), config).0)
+        .map(|crate_identifier| get_crate_id_and_settings(db, crate_identifier, config).0)
         .collect()
 }
 
 fn get_crate_id_and_settings<'a>(
     db: &mut dyn SemanticGroup,
-    name: SmolStr,
+    crate_identifier: &CrateIdentifier,
     config: &'a ProjectConfig,
 ) -> (CrateId, &'a CrateSettings) {
-    let crate_settings = config.content.crates_config.get(&name);
-    let discriminator = if name == CORELIB_CRATE_NAME {
-        None
-    } else {
-        crate_settings.version.as_ref().map(ToSmolStr::to_smolstr)
-    };
+    let crate_settings = config.content.crates_config.get(crate_identifier);
+    let name = crate_settings.name.clone().unwrap_or_else(|| crate_identifier.clone().into());
+    // It has to be done due to how `CrateId::core` works.
+    let discriminator =
+        if name == CORELIB_CRATE_NAME { None } else { Some(crate_identifier.clone().into()) };
+
     let crate_id = CrateLongId::Real { name, discriminator }.intern(db);
+
     (crate_id, crate_settings)
 }

--- a/crates/cairo-lang-language-server/src/project/scarb.rs
+++ b/crates/cairo-lang-language-server/src/project/scarb.rs
@@ -142,8 +142,14 @@ pub fn update_crate_roots(metadata: &Metadata, db: &mut AnalysisDatabase) {
                     .collect()
             };
 
-            let settings =
-                CrateSettings { edition, version, dependencies, cfg_set, experimental_features };
+            let settings = CrateSettings {
+                name: Some(crate_name.into()),
+                edition,
+                version,
+                dependencies,
+                cfg_set,
+                experimental_features,
+            };
 
             let custom_main_file_stems = (file_stem != "lib").then_some(vec![file_stem.into()]);
 

--- a/crates/cairo-lang-language-server/tests/e2e/analysis.rs
+++ b/crates/cairo-lang-language-server/tests/e2e/analysis.rs
@@ -42,6 +42,7 @@ fn cairo_projects() {
             - `core`: `["[CAIRO_SOURCE]/corelib/src/lib.cairo"]`
                 ```rust
                 CrateSettings {
+                    name: None,
                     edition: V2024_07,
                     version: Some(
                         Version {
@@ -61,6 +62,7 @@ fn cairo_projects() {
             - `project1`: `["[ROOT]/project1/src/lib.cairo"]`
                 ```rust
                 CrateSettings {
+                    name: None,
                     edition: V2023_01,
                     version: None,
                     cfg_set: None,
@@ -74,6 +76,7 @@ fn cairo_projects() {
             - `project2`: `["[ROOT]/project2/src/lib.cairo"]`
                 ```rust
                 CrateSettings {
+                    name: None,
                     edition: V2023_01,
                     version: None,
                     cfg_set: None,
@@ -87,6 +90,7 @@ fn cairo_projects() {
             - `subproject`: `["[ROOT]/project2/subproject/src/lib.cairo"]`
                 ```rust
                 CrateSettings {
+                    name: None,
                     edition: V2023_01,
                     version: None,
                     cfg_set: None,

--- a/crates/cairo-lang-project/Cargo.toml
+++ b/crates/cairo-lang-project/Cargo.toml
@@ -10,7 +10,6 @@ description = "Cairo project specification. For example, crates and flags used f
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "~2.8.4" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "~2.8.4" }
 serde = { workspace = true, default-features = true }
-smol_str.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 

--- a/crates/cairo-lang-project/src/lib.rs
+++ b/crates/cairo-lang-project/src/lib.rs
@@ -4,10 +4,9 @@ mod test;
 
 use std::path::{Path, PathBuf};
 
-use cairo_lang_filesystem::db::CrateSettings;
+use cairo_lang_filesystem::db::{CrateIdentifier, CrateSettings};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use serde::{Deserialize, Serialize};
-use smol_str::SmolStr;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DeserializationError {
@@ -32,7 +31,7 @@ pub struct ProjectConfig {
 /// Contents of a Cairo project config file.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProjectConfigContent {
-    pub crate_roots: OrderedHashMap<SmolStr, PathBuf>,
+    pub crate_roots: OrderedHashMap<CrateIdentifier, PathBuf>,
     /// Additional configurations for the crates.
     #[serde(default)]
     #[serde(rename = "config")]
@@ -48,12 +47,13 @@ pub struct AllCratesConfig {
     /// Configuration override per crate.
     #[serde(default)]
     #[serde(rename = "override")]
-    pub override_map: OrderedHashMap<SmolStr, CrateSettings>,
+    pub override_map: OrderedHashMap<CrateIdentifier, CrateSettings>,
 }
+
 impl AllCratesConfig {
     /// Returns the configuration for the given crate.
-    pub fn get(&self, crate_name: &str) -> &CrateSettings {
-        self.override_map.get(crate_name).unwrap_or(&self.global)
+    pub fn get(&self, crate_identifier: &CrateIdentifier) -> &CrateSettings {
+        self.override_map.get(crate_identifier).unwrap_or(&self.global)
     }
 }
 

--- a/crates/cairo-lang-project/src/test.rs
+++ b/crates/cairo-lang-project/src/test.rs
@@ -16,6 +16,7 @@ fn test_serde() {
         .collect(),
         crates_config: AllCratesConfig {
             global: CrateSettings {
+                name: None,
                 edition: Default::default(),
                 version: Default::default(),
                 dependencies: Default::default(),
@@ -24,6 +25,7 @@ fn test_serde() {
             },
             override_map: [
                 ("crate1".into(), CrateSettings {
+                    name: None,
                     edition: Edition::V2023_10,
                     version: Default::default(),
                     dependencies: Default::default(),
@@ -31,6 +33,7 @@ fn test_serde() {
                     cfg_set: Default::default(),
                 }),
                 ("crate3".into(), CrateSettings {
+                    name: None,
                     edition: Default::default(),
                     version: Default::default(),
                     dependencies: Default::default(),

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -139,6 +139,7 @@ pub fn setup_test_crate_ex(
         toml::from_str(crate_settings).expect("Invalid config.")
     } else {
         CrateSettings {
+            name: None,
             edition: Edition::default(),
             version: None,
             dependencies: Default::default(),


### PR DESCRIPTION
Currently there is no way to specify the discriminator for a crate itself, so we do a wild guess and assume that it is equal to version.