### PR TITLE
LS: Fix module members completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "scarb-metadata"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170ebce1774a85568646ba4096827f898306665187eebd9282fee313e316518d"
+checksum = "1a8b71f63999dbb6d269fbc6fd61310016ab3a160fb13e52a6511a2b904359f0"
 dependencies = [
  "camino",
  "semver",

--- a/crates/cairo-lang-language-server/Cargo.toml
+++ b/crates/cairo-lang-language-server/Cargo.toml
@@ -34,7 +34,7 @@ lsp-server = "0.7.7"
 lsp-types = "=0.95.0"
 rustc-hash = "1.1.0"
 salsa.workspace = true
-scarb-metadata = "1.12"
+scarb-metadata = "1.13"
 serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 smol_str.workspace = true

--- a/crates/cairo-lang-language-server/src/ide/completion/completions.rs
+++ b/crates/cairo-lang-language-server/src/ide/completion/completions.rs
@@ -12,6 +12,7 @@ use cairo_lang_semantic::diagnostic::{NotFoundItemType, SemanticDiagnostics};
 use cairo_lang_semantic::expr::inference::InferenceId;
 use cairo_lang_semantic::items::function_with_body::SemanticExprLookup;
 use cairo_lang_semantic::items::us::SemanticUseEx;
+use cairo_lang_semantic::items::visibility::peek_visible_in;
 use cairo_lang_semantic::lookup_item::{HasResolverData, LookupItemEx};
 use cairo_lang_semantic::resolve::{ResolvedConcreteItem, ResolvedGenericItem, Resolver};
 use cairo_lang_semantic::types::peel_snapshots;
@@ -125,17 +126,24 @@ pub fn colon_colon_completions(
         .resolve_concrete_path(&mut diagnostics, segments, NotFoundItemType::Identifier)
         .ok()?;
 
+    let current_module_id = module_file_id.0;
+
     Some(match item {
         ResolvedConcreteItem::Module(module_id) => db
             .module_items(module_id)
             .ok()?
             .iter()
-            .map(|item| CompletionItem {
-                label: item.name(db.upcast()).to_string(),
-                kind: ResolvedGenericItem::from_module_item(db, *item)
-                    .ok()
-                    .map(resolved_generic_item_completion_kind),
-                ..CompletionItem::default()
+            .filter_map(|item| {
+                let resolved_item = ResolvedGenericItem::from_module_item(db, *item).ok()?;
+                let item_info = db.module_item_info_by_name(module_id, item.name(db)).ok()??;
+
+                peek_visible_in(db, item_info.visibility, module_id, current_module_id).then(|| {
+                    CompletionItem {
+                        label: item.name(db.upcast()).to_string(),
+                        kind: Some(resolved_generic_item_completion_kind(resolved_item)),
+                        ..CompletionItem::default()
+                    }
+                })
             })
             .collect(),
         ResolvedConcreteItem::Trait(item) => db

--- a/crates/cairo-lang-language-server/src/project/scarb.rs
+++ b/crates/cairo-lang-language-server/src/project/scarb.rs
@@ -1,14 +1,14 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result, bail, ensure};
 use cairo_lang_filesystem::db::{
-    CORELIB_CRATE_NAME, CrateSettings, DependencySettings, Edition, ExperimentalFeaturesConfig,
+    CrateSettings, DependencySettings, Edition, ExperimentalFeaturesConfig,
 };
 use itertools::Itertools;
-use scarb_metadata::{CompilationUnitComponentMetadata, Metadata, PackageMetadata};
-use smol_str::{SmolStr, ToSmolStr};
+use scarb_metadata::{CompilationUnitComponentDependencyMetadata, Metadata, PackageMetadata};
+use smol_str::ToSmolStr;
 use tracing::{debug, error, warn};
 
 use crate::lang::db::AnalysisDatabase;
@@ -95,52 +95,36 @@ pub fn update_crate_roots(metadata: &Metadata, db: &mut AnalysisDatabase) {
                     .map(|cfg_set| cfg_set.union(&AnalysisDatabase::initial_cfg_set_for_deps()))
             };
 
-            let dependencies = {
-                let direct_dependencies = package
-                    .map(|p| p.dependencies.iter().map(|dep| &*dep.name).collect::<HashSet<_>>())
-                    .unwrap_or_default();
+            let dependencies = component
+                .dependencies
+                .as_deref()
+                .unwrap_or_else(|| {
+                    error!(
+                        "dependencies of component {crate_name} with id {:?} not found in metadata",
+                        component.id
+                    );
+                    &[]
+                })
+                .iter()
+                .filter_map(|CompilationUnitComponentDependencyMetadata { id, .. }| {
+                    let dependency_component = compilation_unit
+                        .components
+                        .iter()
+                        .find(|component| component.id.as_ref() == Some(id));
 
-                compilation_unit
-                    .components
-                    .iter()
-                    .filter(|component_as_dependency| {
-                        direct_dependencies.contains(&*component_as_dependency.name) || {
-                            // This is a hacky way of accommodating integration test components,
-                            // which need to depend on the tested package.
-                            if let Some(package) = metadata
-                                .packages
-                                .iter()
-                                .find(|package| package.id == component_as_dependency.package)
-                            {
-                                package.targets.iter().filter(|target| target.kind == "test").any(
-                                    |target| {
-                                        let group_name = target
-                                            .params
-                                            .get("group-id")
-                                            .and_then(|g| g.as_str())
-                                            .unwrap_or(&target.name);
-                                        group_name == component.name
-                                    },
-                                )
-                            } else {
-                                false
-                            }
-                        }
-                    })
-                    .map(|component| {
-                        let settings = DependencySettings {
-                            discriminator: component_discriminator(component),
-                        };
-                        (component.name.clone(), settings)
-                    })
-                    .chain([
-                        // Add the component itself to dependencies.
-                        (crate_name.into(), DependencySettings {
-                            discriminator: component_discriminator(component),
-                        }),
-                    ])
-                    .collect()
-            };
+                    if let Some(dependency_component) = dependency_component {
+                        Some((dependency_component.name.clone(), DependencySettings {
+                            discriminator: dependency_component
+                                .discriminator
+                                .as_ref()
+                                .map(ToSmolStr::to_smolstr),
+                        }))
+                    } else {
+                        error!("component not found in metadata");
+                        None
+                    }
+                })
+                .collect();
 
             let settings = CrateSettings {
                 name: Some(crate_name.into()),
@@ -155,7 +139,7 @@ pub fn update_crate_roots(metadata: &Metadata, db: &mut AnalysisDatabase) {
 
             let cr = Crate {
                 name: crate_name.into(),
-                discriminator: component_discriminator(component),
+                discriminator: component.discriminator.as_ref().map(ToSmolStr::to_smolstr),
                 root: root.into(),
                 custom_main_file_stems,
                 settings,
@@ -318,11 +302,4 @@ fn scarb_package_experimental_features(
         negative_impls: contains("negative_impls"),
         coupons: contains("coupons"),
     }
-}
-
-/// Get crate discriminator from component metadata.
-///
-/// This function properly handles the fact that the `core` crate cannot have a discriminator.
-fn component_discriminator(component: &CompilationUnitComponentMetadata) -> Option<SmolStr> {
-    (component.name != CORELIB_CRATE_NAME).then(|| component.package.to_smolstr())
 }

--- a/crates/cairo-lang-language-server/tests/e2e/completions.rs
+++ b/crates/cairo-lang-language-server/tests/e2e/completions.rs
@@ -10,6 +10,7 @@ cairo_lang_test_utils::test_file_test!(
     "tests/test_data/completions",
     {
         methods_text_edits: "methods_text_edits.txt",
+        module_items: "module_items.txt",
     },
     test_completions_text_edits
 

--- a/crates/cairo-lang-language-server/tests/test_data/completions/module_items.txt
+++ b/crates/cairo-lang-language-server/tests/test_data/completions/module_items.txt
@@ -1,0 +1,54 @@
+//! > Test completing public members of a module.
+
+//! > test_runner_name
+test_completions_text_edits
+
+//! > cairo_project.toml
+[crate_roots]
+hello = "src"
+
+[config.global]
+edition = "2024_07"
+
+//! > cairo_code
+mod helper_module {
+    pub trait Trait1<T> {
+        fn some_method(self: @T);
+    }
+    
+    pub const CONST: felt252 = 0x0;
+    
+    fn foo() {}
+    pub fn bar() {}
+}
+
+mod not_exporting_module {
+    const CONST: u32 = 0;
+    fn foo() {}
+    fn bar() {}
+}
+
+mod nested_module {
+    pub mod inner {}
+}
+
+use helper_module::<caret>
+use not_exporting_module::<caret>
+use nested_module::<caret>
+
+//! > Completions #0
+use helper_module::<caret>
+--------------------------
+Completion: Trait1
+--------------------------
+Completion: CONST
+--------------------------
+Completion: bar
+
+//! > Completions #1
+use not_exporting_module::<caret>
+
+//! > Completions #2
+use nested_module::<caret>
+--------------------------
+Completion: inner

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1800,7 +1800,7 @@ fn add_closure_call_function(
     let impl_id = ImplLongId::GeneratedImpl(
         GeneratedImplLongId {
             concrete_trait,
-            generic_args: vec![],
+            generic_params: vec![],
             impl_items: GeneratedImplItems(iter::once((ret_ty, closure_ty.ret_ty)).collect()),
         }
         .intern(semantic_db),

--- a/crates/cairo-lang-lowering/src/lower/test_data/closure
+++ b/crates/cairo-lang-lowering/src/lower/test_data/closure
@@ -256,6 +256,27 @@ End:
   Return()
 
 
+Generated core::traits::Destruct::destruct lowering for source location:
+    let c =  || a;
+             ^^
+
+Parameters: v0: {closure@lib.cairo:6:14: 6:16}
+blk0 (root):
+Statements:
+  (v1: core::integer::u32) <- struct_destructure(v0)
+  (v2: ()) <- struct_construct()
+End:
+  Return(v2)
+
+
+Final lowering:
+Parameters: v0: {closure@lib.cairo:6:14: 6:16}
+blk0 (root):
+Statements:
+End:
+  Return()
+
+
 Generated core::ops::function::FnOnce::call lowering for source location:
     let c =  || a;
              ^^

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -12,11 +12,13 @@ use cairo_lang_defs::ids::{
     LookupItemId, MemberId, ParamId, StructId, TraitConstantId, TraitFunctionId, TraitId,
     TraitImplId, TraitTypeId, VarId, VariantId,
 };
-use cairo_lang_diagnostics::{DiagnosticAdded, skip_diagnostic};
+use cairo_lang_diagnostics::{DiagnosticAdded, Maybe, skip_diagnostic};
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_utils::ordered_hash_map::{Entry, OrderedHashMap};
-use cairo_lang_utils::{Intern, LookupIntern, define_short_id, extract_matches};
+use cairo_lang_utils::{
+    Intern, LookupIntern, define_short_id, extract_matches, try_extract_matches,
+};
 
 use self::canonic::{CanonicalImpl, CanonicalMapping, CanonicalTrait, NoError};
 use self::solver::{Ambiguity, SolutionSet, enrich_lookup_context};
@@ -930,63 +932,93 @@ impl<'db> Inference<'db> {
         lookup_context: &ImplLookupContext,
         canonical_impl: CanonicalImpl,
     ) -> InferenceResult<SolutionSet<CanonicalImpl>> {
-        let ImplLongId::Concrete(concrete_impl) = canonical_impl.0.lookup_intern(self.db) else {
-            return Ok(SolutionSet::Unique(canonical_impl));
-        };
-        let mut rewriter = SubstitutionRewriter {
-            db: self.db,
-            substitution: &concrete_impl
-                .substitution(self.db)
-                .map_err(|diag_added| self.set_error(InferenceError::Reported(diag_added)))?,
-        };
+        /// Validates that no solution set is found for the negative impls.
+        fn validate_no_solution_set(
+            inference: &mut Inference<'_>,
+            canonical_impl: CanonicalImpl,
+            lookup_context: &ImplLookupContext,
+            negative_impls_concrete_traits: impl Iterator<Item = Maybe<ConcreteTraitId>>,
+        ) -> InferenceResult<SolutionSet<CanonicalImpl>> {
+            for concrete_trait_id in negative_impls_concrete_traits {
+                let concrete_trait_id = concrete_trait_id.map_err(|diag_added| {
+                    inference.set_error(InferenceError::Reported(diag_added))
+                })?;
+                for garg in concrete_trait_id.generic_args(inference.db) {
+                    let GenericArgumentId::Type(ty) = garg else {
+                        continue;
+                    };
 
-        for garg in self
-            .db
-            .impl_def_generic_params(concrete_impl.impl_def_id(self.db))
-            .map_err(|diag_added| self.set_error(InferenceError::Reported(diag_added)))?
-        {
-            let GenericParam::NegImpl(neg_impl) = garg else {
-                continue;
-            };
+                    // If the negative impl has a generic argument that is not fully
+                    // concrete we can't tell if we should rule out the candidate impl.
+                    // For example if we have -TypeEqual<S, T> we can't tell if S and
+                    // T are going to be assigned the same concrete type.
+                    // We return `SolutionSet::Ambiguous` here to indicate that more
+                    // information is needed.
+                    if !ty.is_fully_concrete(inference.db) {
+                        // TODO(ilya): Try to detect the ambiguity earlier in the
+                        // inference process.
+                        return Ok(SolutionSet::Ambiguous(
+                            Ambiguity::NegativeImplWithUnresolvedGenericArgs {
+                                impl_id: canonical_impl.0,
+                                ty,
+                            },
+                        ));
+                    }
+                }
 
-            let concrete_trait_id = rewriter
-                .rewrite(neg_impl)
-                .map_err(|diag_added| self.set_error(InferenceError::Reported(diag_added)))?
-                .concrete_trait
-                .map_err(|diag_added| self.set_error(InferenceError::Reported(diag_added)))?;
-            for garg in concrete_trait_id.generic_args(self.db) {
-                let GenericArgumentId::Type(ty) = garg else {
-                    continue;
-                };
-
-                // If the negative impl has a generic argument that is not fully
-                // concrete we can't tell if we should rule out the candidate impl.
-                // For example if we have -TypeEqual<S, T> we can't tell if S and
-                // T are going to be assigned the same concrete type.
-                // We return `SolutionSet::Ambiguous` here to indicate that more
-                // information is needed.
-                if !ty.is_fully_concrete(self.db) {
-                    // TODO(ilya): Try to detect the ambiguity earlier in the
-                    // inference process.
-                    return Ok(SolutionSet::Ambiguous(
-                        Ambiguity::NegativeImplWithUnresolvedGenericArgs {
-                            impl_id: ImplLongId::Concrete(concrete_impl).intern(self.db),
-                            ty,
-                        },
-                    ));
+                if !matches!(
+                    inference.trait_solution_set(concrete_trait_id, lookup_context.clone())?,
+                    SolutionSet::None
+                ) {
+                    // If a negative impl has an impl, then we should skip it.
+                    return Ok(SolutionSet::None);
                 }
             }
 
-            if !matches!(
-                self.trait_solution_set(concrete_trait_id, lookup_context.clone())?,
-                SolutionSet::None
-            ) {
-                // If a negative impl has an impl, then we should skip it.
-                return Ok(SolutionSet::None);
-            }
+            Ok(SolutionSet::Unique(canonical_impl))
         }
-
-        Ok(SolutionSet::Unique(canonical_impl))
+        match canonical_impl.0.lookup_intern(self.db) {
+            ImplLongId::Concrete(concrete_impl) => {
+                let mut rewriter = SubstitutionRewriter {
+                    db: self.db,
+                    substitution: &concrete_impl.substitution(self.db).map_err(|diag_added| {
+                        self.set_error(InferenceError::Reported(diag_added))
+                    })?,
+                };
+                let generic_params = self
+                    .db
+                    .impl_def_generic_params(concrete_impl.impl_def_id(self.db))
+                    .map_err(|diag_added| self.set_error(InferenceError::Reported(diag_added)))?;
+                let concrete_traits = generic_params
+                    .iter()
+                    .filter_map(|generic_param| {
+                        try_extract_matches!(generic_param, GenericParam::NegImpl)
+                    })
+                    .map(|generic_param| {
+                        rewriter
+                            .rewrite(*generic_param)
+                            .and_then(|generic_param| generic_param.concrete_trait)
+                    });
+                validate_no_solution_set(self, canonical_impl, lookup_context, concrete_traits)
+            }
+            ImplLongId::GeneratedImpl(generated_impl) => validate_no_solution_set(
+                self,
+                canonical_impl,
+                lookup_context,
+                generated_impl
+                    .lookup_intern(self.db)
+                    .generic_params
+                    .iter()
+                    .filter_map(|generic_param| {
+                        try_extract_matches!(generic_param, GenericParam::NegImpl)
+                    })
+                    .map(|generic_param| generic_param.concrete_trait),
+            ),
+            ImplLongId::GenericParameter(_)
+            | ImplLongId::ImplVar(_)
+            | ImplLongId::ImplImpl(_)
+            | ImplLongId::TraitImpl(_) => Ok(SolutionSet::Unique(canonical_impl)),
+        }
     }
 
     // Error handling methods

--- a/crates/cairo-lang-semantic/src/expr/inference/infers.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/infers.rs
@@ -144,14 +144,14 @@ impl InferenceEmbeddings for Inference<'_> {
             }
             UninferredImpl::GeneratedImpl(generated_impl) => {
                 let long_id = generated_impl.lookup_intern(self.db);
+
+                // Only making sure the args can be inferred - as they are unused later.
+                self.infer_generic_args(&long_id.generic_params[..], lookup_context, stable_ptr)?;
+
                 ImplLongId::GeneratedImpl(
                     GeneratedImplLongId {
                         concrete_trait: long_id.concrete_trait,
-                        generic_args: self.infer_generic_args(
-                            &long_id.generic_params[..],
-                            lookup_context,
-                            stable_ptr,
-                        )?,
+                        generic_params: long_id.generic_params,
                         impl_items: long_id.impl_items,
                     }
                     .intern(self.db),

--- a/crates/cairo-lang-semantic/src/expr/test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/closure
@@ -626,3 +626,23 @@ error: Capture of mutable variables in a closure is not supported
  --> lib.cairo:5:9
         a + b
         ^
+
+//! > ==========================================================================
+
+//! > Not generating generating destruct impl when drop impl exists.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function
+fn foo() {
+    bar( || {});
+}
+
+//! > function_name
+foo
+
+//! > module_code
+fn bar<T, +Destruct<T>>(a: T) {}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -349,8 +349,9 @@ impl GeneratedImplId {
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SemanticObject)]
 pub struct GeneratedImplLongId {
     pub concrete_trait: ConcreteTraitId,
-    /// The generic arguments used by the generated impl, typically impls and negative impls.
-    pub generic_args: Vec<GenericArgumentId>,
+    /// The generic params required for the impl. Typically impls and negative impls.
+    /// We save the params so that we can validate negative impls.
+    pub generic_params: Vec<GenericParam>,
     pub impl_items: GeneratedImplItems,
 }
 #[derive(Clone, Debug, Default, PartialEq, Eq, SemanticObject)]

--- a/crates/cairo-lang-semantic/src/items/tests/trait_impl
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_impl
@@ -1239,6 +1239,7 @@ fn bar2<impl M: MyTrait<u32>>() {
 //! > expected_diagnostics
 
 //! > ==========================================================================
+
 //! > Inferring a Trait impl with generic param of a generic impl argument.
 
 //! > test_runner_name
@@ -1256,26 +1257,27 @@ trait InnerTrait<R> {
     fn foo() -> Self::X;
 }
 
-trait MyTrait<Y> {
-    impl MyImpl: InnerTrait<Y>;
+trait OuterTrait<Y> {
+    impl Inner: InnerTrait<Y>;
 }
-impl MyImpl<T, impl I: InnerTrait<T>> of MyTrait<T> {}
+impl OuterImpl<T, impl I: InnerTrait<T>> of OuterTrait<T> {}
 
 
-mod MyMod {
-    // impl of InnerTrait so MyImpl can be inferred.
-    impl MyIn<T> of super::InnerTrait<T> {
+mod my_mod {
+    // Implementing `InnerTrait` for all types.
+    impl MyInner<T> of super::InnerTrait<T> {
         type X = u16;
         fn foo() -> u16 {
             5
         }
     }
-    fn bar<F, impl A: super::MyTrait<F>>(_x: F) -> A::MyImpl::X {
-        A::MyImpl::foo()
+    fn requires_outer<T, impl O: super::OuterTrait<T>>(_x: T) -> O::Inner::X {
+        O::Inner::foo()
     }
+
     // inferring  MyTrait Impl from MyImpl with MyIn.
-    fn bar2() -> u16 {
-        bar(2_u32)
+    fn infers_outer_by_inner() -> u16 {
+        requires_outer(2_u32)
     }
 }
 


### PR DESCRIPTION
## Changes
* When importing from a module, LS provides completions with only those items which are visible in the current context
* In particular, private members are hidden