### PR TITLE
Allow to debug print ascii escape sequence

### DIFF
--- a/crates/cairo-lang-runner/src/short_string.rs
+++ b/crates/cairo-lang-runner/src/short_string.rs
@@ -42,7 +42,7 @@ pub fn as_cairo_short_string_ex(value: &Felt252, length: usize) -> Option<String
     for byte in bytes {
         if byte == 0 {
             as_string.push_str(r"\0");
-        } else if byte.is_ascii_graphic() || byte.is_ascii_whitespace() {
+        } else if byte.is_ascii_graphic() || byte.is_ascii_whitespace() || is_ascii_escape_sequence(byte) {
             as_string.push(byte as char);
         } else {
             as_string.push_str(format!(r"\x{:02x}", byte).as_str());
@@ -54,4 +54,10 @@ pub fn as_cairo_short_string_ex(value: &Felt252, length: usize) -> Option<String
     as_string.insert_str(0, &r"\0".repeat(missing_nulls));
 
     Some(as_string)
+}
+
+/// Checks if given byte is a beginning of an ASCII escape sequence
+/// https://gist.github.com/ConnerWill/d4b6c776b509add763e17f9f113fd25b
+fn is_ascii_escape_sequence(byte: u8) -> bool {
+    byte == 0x1b
 }


### PR DESCRIPTION
This change enables ASCII escape sequences in `println!`, which allows to change output text color and style.  

Why:
This is fun and can be used to promote Cairo as a generic programming language.
Also enables some legit use cases e.g. https://github.com/m-kus/cairo-pretty-assertions

Security considerations:
If the source Cairo file is provided by an untrusted third party it can potentially mess with the terminal window title and style; also if the output is logged, there are ways to confuse the log reader (see https://nvd.nist.gov/vuln/detail/CVE-2009-4487)
