### PR TITLE
LS: Take `FileId` by value in `map_cairo_diagnostics_to_lsp`

### DIFF
--- a/crates/cairo-lang-language-server/src/lang/diagnostics/lsp.rs
+++ b/crates/cairo-lang-language-server/src/lang/diagnostics/lsp.rs
@@ -14,7 +14,7 @@ pub fn map_cairo_diagnostics_to_lsp<T: DiagnosticEntry>(
     db: &T::DbType,
     diags: &mut Vec<Diagnostic>,
     diagnostics: &Diagnostics<T>,
-    processed_file_id: &FileId,
+    processed_file_id: FileId,
     trace_macro_diagnostics: bool,
 ) {
     for diagnostic in if trace_macro_diagnostics {
@@ -56,7 +56,7 @@ pub fn map_cairo_diagnostics_to_lsp<T: DiagnosticEntry>(
             continue;
         };
 
-        if mapped_file_id != *processed_file_id {
+        if mapped_file_id != processed_file_id {
             continue;
         }
         diags.push(Diagnostic {

--- a/crates/cairo-lang-language-server/src/lang/diagnostics/refresh.rs
+++ b/crates/cairo-lang-language-server/src/lang/diagnostics/refresh.rs
@@ -188,21 +188,21 @@ fn refresh_file_diagnostics(
         (*db).upcast(),
         &mut diags,
         &new_file_diagnostics.parser,
-        &file,
+        file,
         trace_macro_diagnostics,
     );
     map_cairo_diagnostics_to_lsp(
         (*db).upcast(),
         &mut diags,
         &new_file_diagnostics.semantic,
-        &file,
+        file,
         trace_macro_diagnostics,
     );
     map_cairo_diagnostics_to_lsp(
         (*db).upcast(),
         &mut diags,
         &new_file_diagnostics.lowering,
-        &file,
+        file,
         trace_macro_diagnostics,
     );
 


### PR DESCRIPTION
`FileId: Copy`, so taking reference here was useless.