### PR TITLE
LS: Make diagnostics state be `FileId` based instead of `Uri`

### DIFF
--- a/crates/cairo-lang-language-server/src/lang/diagnostics/file_diagnostics.rs
+++ b/crates/cairo-lang-language-server/src/lang/diagnostics/file_diagnostics.rs
@@ -30,6 +30,16 @@ pub struct FileDiagnostics {
 }
 
 impl FileDiagnostics {
+    /// Constructs a new `FileDiagnostics` with no diagnostics.
+    pub fn empty(file: FileId) -> Self {
+        FileDiagnostics {
+            file,
+            parser: Diagnostics::default(),
+            semantic: Diagnostics::default(),
+            lowering: Diagnostics::default(),
+        }
+    }
+
     /// Collects all diagnostics kinds from the given `file` and constructs a new `FileDiagnostics`.
     ///
     /// The `processed_modules` in/out parameter is used to avoid constructing two overlapping
@@ -98,6 +108,8 @@ impl FileDiagnostics {
     }
 
     /// Constructs a new [`lsp_types::PublishDiagnosticsParams`] from this `FileDiagnostics`.
+    ///
+    /// Returns `None` only if [`LsProtoGroup::url_for_file`] returns `None` for the file.
     pub fn to_lsp(
         &self,
         db: &AnalysisDatabase,

--- a/crates/cairo-lang-language-server/src/lang/diagnostics/mod.rs
+++ b/crates/cairo-lang-language-server/src/lang/diagnostics/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
-use lsp_types::Url;
+use cairo_lang_filesystem::ids::FileId;
 use tracing::{error, trace};
 
 use self::file_diagnostics::FileDiagnostics;
@@ -55,7 +55,7 @@ impl DiagnosticsController {
 
     /// Runs diagnostics controller's event loop.
     fn control_loop(receiver: trigger::Receiver<WorkerArgs>) {
-        let mut file_diagnostics = HashMap::<Url, FileDiagnostics>::new();
+        let mut file_diagnostics = HashMap::<FileId, FileDiagnostics>::new();
 
         while let Some(WorkerArgs { state, notifier }) = receiver.wait() {
             if let Err(err) = catch_unwind(AssertUnwindSafe(|| {


### PR DESCRIPTION
**Stack**:
- #6615
- #6614 ⬅
- #6613


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*