### PR TITLE
Adding docstrings for array, assert and panic macros

### DIFF
--- a/crates/cairo-lang-semantic/src/inline_macros/array.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/array.rs
@@ -75,7 +75,6 @@ impl InlineMacroExprPlugin for ArrayMacro {
             ```
             # Notes
             - Elements must be of the same type or convertible to a common type.
-            - Uses `ArrayTrait::new()` to create the array and `ArrayTrait::append()` to add elements.
             - Elements are added in the order provided.
             "#}
             .to_string(),

--- a/crates/cairo-lang-semantic/src/inline_macros/array.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/array.rs
@@ -5,7 +5,7 @@ use cairo_lang_defs::plugin::{
 };
 use cairo_lang_defs::plugin_utils::unsupported_bracket_diagnostic;
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
+use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::indoc;
 
 #[derive(Debug, Default)]

--- a/crates/cairo-lang-semantic/src/inline_macros/array.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/array.rs
@@ -5,7 +5,7 @@ use cairo_lang_defs::plugin::{
 };
 use cairo_lang_defs::plugin_utils::unsupported_bracket_diagnostic;
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
 
 #[derive(Debug, Default)]
 pub struct ArrayMacro;
@@ -48,5 +48,46 @@ impl InlineMacroExprPlugin for ArrayMacro {
             }),
             diagnostics: vec![],
         }
+    }
+
+    fn documentation(&self) -> Option<String> {
+        Some(
+            indoc! {r#"
+            Creates a new array containing the provided elements.
+    
+            The `array!` macro allows you to create an array by specifying a list of elements. \ 
+            The elements are added to a new array in the order they are provided.
+    
+            # Syntax
+    
+            ```cairo
+            array![element1, element2, element3, ...]
+            ```
+    
+            # Returns
+    
+            An array containing the specified elements.
+    
+            # Examples
+    
+            ```cairo
+            let arr = array![]; // Creates an empty array.
+    
+            let arr = array![1, 2, 3]; // Creates an array containing 1, 2, and 3.
+    
+            let x = 5;
+            let y = 10;
+            let arr = array![x, y, x + y]; // Creates an array containing 5, 10, and 15.
+            ```
+    
+            # Notes
+    
+            - All elements must be of the same type or compatible types that can be coerced to a common type.
+            - The macro internally uses `ArrayTrait::new()` to create a new array and `ArrayTrait::append()` to add each element.
+            - The order of the elements in the array is the same as the order they are provided in the macro.
+
+            "#}
+            .to_string(),
+        )
     }
 }

--- a/crates/cairo-lang-semantic/src/inline_macros/array.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/array.rs
@@ -54,38 +54,28 @@ impl InlineMacroExprPlugin for ArrayMacro {
         Some(
             indoc! {r#"
             Creates a new array containing the provided elements.
-    
             The `array!` macro allows you to create an array by specifying a list of elements. \ 
             The elements are added to a new array in the order they are provided.
     
             # Syntax
-    
             ```cairo
             array![element1, element2, element3, ...]
             ```
-    
             # Returns
-    
             An array containing the specified elements.
     
             # Examples
-    
             ```cairo
             let arr = array![]; // Creates an empty array.
-    
             let arr = array![1, 2, 3]; // Creates an array containing 1, 2, and 3.
-    
             let x = 5;
             let y = 10;
             let arr = array![x, y, x + y]; // Creates an array containing 5, 10, and 15.
             ```
-    
             # Notes
-    
-            - All elements must be of the same type or compatible types that can be coerced to a common type.
-            - The macro internally uses `ArrayTrait::new()` to create a new array and `ArrayTrait::append()` to add each element.
-            - The order of the elements in the array is the same as the order they are provided in the macro.
-
+            - Elements must be of the same type or convertible to a common type.
+            - Uses `ArrayTrait::new()` to create the array and `ArrayTrait::append()` to add elements.
+            - Elements are added in the order provided.
             "#}
             .to_string(),
         )

--- a/crates/cairo-lang-semantic/src/inline_macros/array.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/array.rs
@@ -6,6 +6,7 @@ use cairo_lang_defs::plugin::{
 use cairo_lang_defs::plugin_utils::unsupported_bracket_diagnostic;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
+use indoc::indoc;
 
 #[derive(Debug, Default)]
 pub struct ArrayMacro;

--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -116,48 +116,36 @@ impl InlineMacroExprPlugin for AssertMacro {
         Some(
             indoc! {r#"
             Asserts that a condition is true at runtime.
-    
-            The `assert!` macro is used to check whether a boolean expression evaluates to `true`. \ 
-            If the expression evaluates to `false`, the macro will cause the program to panic, \ 
-            optionally displaying a custom error message. This is useful for debugging and ensuring \ 
-            that certain conditions hold during execution.
-    
+            The `assert!` macro checks a boolean expression; if it evaluates to `false`, \ 
+            it panics with an optional custom error message. Useful for debugging and \ 
+            ensuring conditions hold during execution.
+
             # Syntax
-    
             ```cairo
             assert!(condition);
             assert!(condition, "error message");
             assert!(condition, "formatted error: {}", value);
             ```
-    
             # Parameters
-    
-            - `condition`: A boolean expression to evaluate. The assertion passes if this expression is `true`.
-            - `format_string` (optional): A string literal that may include format placeholders.
+            - `condition`: A boolean expression to evaluate.
+            - `format_string` (optional): A string literal for format placeholders.
             - `args` (optional): Arguments corresponding to the format placeholders in the `format_string`.
     
             # Examples
-    
             ```cairo
             assert!(2 + 2 == 4); // Passes, does nothing.
-    
             assert!(2 + 2 == 5); // Panics with "assertion failed: `2 + 2 == 5`."
-    
             let age = 18;
             assert!(age >= 21, "Age must be at least 21, found {}", age);
             // Panics with "Age must be at least 21, found 18."
-    
             let x = -1;
             assert!(x >= 0, "Invalid value: x = {}", x);
             // Panics with "Invalid value: x = -1."
             ```
-    
             # Notes
-    
-            - **Use Cases**: Ideal for catching programming errors and enforcing invariants.
-            - **Performance**: Assertions can impact performance; consider using `debug_assert!` for checks in debug mode only.
-            - **Error Handling**: For recoverable errors, use proper error handling mechanisms like `Result` or `Option` instead of panicking.
-    
+            - Use to catch programming errors and enforce invariants.
+            - May impact performance; consider `debug_assert!` for debug-only checks.
+            - For recoverable errors, prefer using `Result` or `Option` instead of panicking.
             "#}
             .to_string(),
         )

--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -9,7 +9,7 @@ use cairo_lang_defs::plugin_utils::{
 use cairo_lang_syntax::node::ast::WrappedArgList;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, TypedStablePtr, TypedSyntaxNode};
-use indoc::formatdoc;
+use indoc::{formatdoc, indoc};
 
 /// Macro for assertion.
 #[derive(Default, Debug)]

--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -8,7 +8,7 @@ use cairo_lang_defs::plugin_utils::{
 };
 use cairo_lang_syntax::node::ast::WrappedArgList;
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::{ast, TypedStablePtr, TypedSyntaxNode};
+use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
 use indoc::{formatdoc, indoc};
 
 /// Macro for assertion.

--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -8,7 +8,7 @@ use cairo_lang_defs::plugin_utils::{
 };
 use cairo_lang_syntax::node::ast::WrappedArgList;
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{ast, TypedStablePtr, TypedSyntaxNode};
 use indoc::{formatdoc, indoc};
 
 /// Macro for assertion.
@@ -129,7 +129,7 @@ impl InlineMacroExprPlugin for AssertMacro {
             # Parameters
             - `condition`: A boolean expression to evaluate.
             - `format_string` (optional): A string literal for format placeholders.
-            - `args` (optional): Arguments corresponding to the format placeholders in the `format_string`.
+            - `args` (optional): Values for placeholders in `format_string`.
     
             # Examples
             ```cairo

--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -8,7 +8,7 @@ use cairo_lang_defs::plugin_utils::{
 };
 use cairo_lang_syntax::node::ast::WrappedArgList;
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{ast, TypedStablePtr, TypedSyntaxNode};
 use indoc::formatdoc;
 
 /// Macro for assertion.
@@ -110,5 +110,56 @@ impl InlineMacroExprPlugin for AssertMacro {
             }),
             diagnostics: vec![],
         }
+    }
+
+    fn documentation(&self) -> Option<String> {
+        Some(
+            indoc! {r#"
+            Asserts that a condition is true at runtime.
+    
+            The `assert!` macro is used to check whether a boolean expression evaluates to `true`. \ 
+            If the expression evaluates to `false`, the macro will cause the program to panic, \ 
+            optionally displaying a custom error message. This is useful for debugging and ensuring \ 
+            that certain conditions hold during execution.
+    
+            # Syntax
+    
+            ```cairo
+            assert!(condition);
+            assert!(condition, "error message");
+            assert!(condition, "formatted error: {}", value);
+            ```
+    
+            # Parameters
+    
+            - `condition`: A boolean expression to evaluate. The assertion passes if this expression is `true`.
+            - `format_string` (optional): A string literal that may include format placeholders.
+            - `args` (optional): Arguments corresponding to the format placeholders in the `format_string`.
+    
+            # Examples
+    
+            ```cairo
+            assert!(2 + 2 == 4); // Passes, does nothing.
+    
+            assert!(2 + 2 == 5); // Panics with "assertion failed: `2 + 2 == 5`."
+    
+            let age = 18;
+            assert!(age >= 21, "Age must be at least 21, found {}", age);
+            // Panics with "Age must be at least 21, found 18."
+    
+            let x = -1;
+            assert!(x >= 0, "Invalid value: x = {}", x);
+            // Panics with "Invalid value: x = -1."
+            ```
+    
+            # Notes
+    
+            - **Use Cases**: Ideal for catching programming errors and enforcing invariants.
+            - **Performance**: Assertions can impact performance; consider using `debug_assert!` for checks in debug mode only.
+            - **Error Handling**: For recoverable errors, use proper error handling mechanisms like `Result` or `Option` instead of panicking.
+    
+            "#}
+            .to_string(),
+        )
     }
 }

--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -140,6 +140,7 @@ impl InlineMacroExprPlugin for AssertMacro {
             // Panics with "Age must be at least 21, found 18."
             let x = -1;
             assert!(x >= 0, "Invalid value: x = {}", x);
+            assert!(x >= 0, "Invalid value: x = {x}");
             // Panics with "Invalid value: x = -1."
             ```
             # Notes

--- a/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
@@ -7,6 +7,7 @@ use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
 use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
+use indoc::indoc;
 use num_bigint::BigInt;
 
 #[derive(Debug, Default)]
@@ -60,6 +61,32 @@ impl InlineMacroExprPlugin for ConstevalIntMacro {
             }),
             diagnostics,
         }
+    }
+
+    fn documentation(&self) -> Option<String> {
+        Some(
+            indoc! {r#"
+            Evaluates an integer expression at compile time.
+            The `consteval_int!` macro computes an integer expression \ 
+            during compilation and replaces itself with the computed value.
+    
+            # Syntax
+            ```cairo
+            consteval_int!(expression)
+            ```
+            # Parameters
+            - `expression`: An integer expression to evaluate at compile time.
+    
+            # Examples
+            ```cairo
+            let x = consteval_int!(2 + 3); // Equivalent to: let x = 5;
+            let y = consteval_int!(4 * 5); // Equivalent to: let y = 20;
+            ```
+            # Notes
+            - Useful for compile-time computations when const expressions were not fully supported.
+            "#}
+            .to_string(),
+        )
     }
 }
 

--- a/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
@@ -69,6 +69,7 @@ impl InlineMacroExprPlugin for ConstevalIntMacro {
             Evaluates an integer expression at compile time.
             The `consteval_int!` macro computes an integer expression \ 
             during compilation and replaces itself with the computed value.
+            This macro is deprecated; use const expressions directly instead.
     
             # Syntax
             ```cairo
@@ -82,8 +83,6 @@ impl InlineMacroExprPlugin for ConstevalIntMacro {
             let x = consteval_int!(2 + 3); // Equivalent to: let x = 5;
             let y = consteval_int!(4 * 5); // Equivalent to: let y = 20;
             ```
-            # Notes
-            - Useful for compile-time computations when const expressions were not fully supported.
             "#}
             .to_string(),
         )

--- a/crates/cairo-lang-semantic/src/inline_macros/panic.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/panic.rs
@@ -6,8 +6,8 @@ use cairo_lang_defs::plugin::{
 use cairo_lang_defs::plugin_utils::{try_extract_unnamed_arg, unsupported_bracket_diagnostic};
 use cairo_lang_syntax::node::ast::{Arg, WrappedArgList};
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
-use indoc::formatdoc;
+use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
+use indoc::{formatdoc, indoc};
 use num_bigint::BigUint;
 
 use super::write::FELT252_BYTES;
@@ -130,5 +130,56 @@ impl InlineMacroExprPlugin for PanicMacro {
             }),
             diagnostics: vec![],
         }
+    }
+
+    fn documentation(&self) -> Option<String> {
+        Some(
+            indoc! {r#"
+            Terminates the program immediately with an error message.
+    
+            The `panic!` macro is used to halt execution when the program encounters an unrecoverable \ 
+            error. It prints an error message to the standard error output and exits the program. \ 
+            This macro accepts a format string and arguments, similar to the `format!` macro, allowing for \ 
+            detailed error messages.
+    
+            # Syntax
+    
+            ```cairo
+            panic!();
+            panic!("error message");
+            panic!("formatted error: {}", value);
+            ```
+    
+            # Behavior
+    
+            - If called without any arguments, it panics with a default message.
+            - If provided with a message or formatted string, it panics with the given message.
+            - The macro constructs the panic message at runtime using the provided format string and arguments.
+    
+            # Examples
+    
+            ```cairo
+            panic!(); // Panics with a default message.
+    
+            panic!("An unexpected error occurred."); // Panics with the provided message.
+    
+            let x = 10;
+            let y = 20;
+            if x + y != 30 {
+                panic!("Math is broken: {} + {} != 30", x, y);
+                // Panics with "Math is broken: 10 + 20 != 30".
+            }
+            ```
+    
+            # Notes
+    
+            - Use `panic!` for unrecoverable errors where the program cannot safely continue.
+            - Panicking will terminate the current execution flow and unwind the stack, which may skip resource cleanup.
+            - In library code, prefer returning `Result` or `Option` to allow the caller to handle errors.
+            - Avoid using `panic!` for control flow or expected error conditions.
+    
+            "#}
+            .to_string(),
+        )
     }
 }

--- a/crates/cairo-lang-semantic/src/inline_macros/panic.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/panic.rs
@@ -6,7 +6,7 @@ use cairo_lang_defs::plugin::{
 use cairo_lang_defs::plugin_utils::{try_extract_unnamed_arg, unsupported_bracket_diagnostic};
 use cairo_lang_syntax::node::ast::{Arg, WrappedArgList};
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
+use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::{formatdoc, indoc};
 use num_bigint::BigUint;
 

--- a/crates/cairo-lang-semantic/src/inline_macros/panic.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/panic.rs
@@ -136,33 +136,26 @@ impl InlineMacroExprPlugin for PanicMacro {
         Some(
             indoc! {r#"
             Terminates the program immediately with an error message.
-    
-            The `panic!` macro is used to halt execution when the program encounters an unrecoverable \ 
-            error. It prints an error message to the standard error output and exits the program. \ 
-            This macro accepts a format string and arguments, similar to the `format!` macro, allowing for \ 
-            detailed error messages.
-    
+            The `panic!` macro halts execution when an unrecoverable error \ 
+            occurs. It prints an error message and exits the program. \ 
+            Accepts a format string and arguments, similar to `format!`, \ 
+            for detailed error messages.
+
             # Syntax
-    
             ```cairo
             panic!();
             panic!("error message");
             panic!("formatted error: {}", value);
             ```
-    
             # Behavior
-    
-            - If called without any arguments, it panics with a default message.
-            - If provided with a message or formatted string, it panics with the given message.
-            - The macro constructs the panic message at runtime using the provided format string and arguments.
-    
+            - Without arguments, panics with a default message.
+            - With a message or formatted string, panics with that message.
+            - Constructs the panic message at runtime using the format string and arguments.
+
             # Examples
-    
             ```cairo
             panic!(); // Panics with a default message.
-    
             panic!("An unexpected error occurred."); // Panics with the provided message.
-    
             let x = 10;
             let y = 20;
             if x + y != 30 {
@@ -172,12 +165,9 @@ impl InlineMacroExprPlugin for PanicMacro {
             ```
     
             # Notes
-    
-            - Use `panic!` for unrecoverable errors where the program cannot safely continue.
-            - Panicking will terminate the current execution flow and unwind the stack, which may skip resource cleanup.
-            - In library code, prefer returning `Result` or `Option` to allow the caller to handle errors.
+            - Use `panic!` only for unrecoverable errors.
+            - In library code, prefer returning `Result` or `Option` to let callers handle errors.
             - Avoid using `panic!` for control flow or expected error conditions.
-    
             "#}
             .to_string(),
         )

--- a/crates/cairo-lang-semantic/src/inline_macros/panic.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/panic.rs
@@ -6,7 +6,7 @@ use cairo_lang_defs::plugin::{
 use cairo_lang_defs::plugin_utils::{try_extract_unnamed_arg, unsupported_bracket_diagnostic};
 use cairo_lang_syntax::node::ast::{Arg, WrappedArgList};
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
 use indoc::{formatdoc, indoc};
 use num_bigint::BigUint;
 
@@ -162,6 +162,10 @@ impl InlineMacroExprPlugin for PanicMacro {
                 panic!("Math is broken: {} + {} != 30", x, y);
                 // Panics with "Math is broken: 10 + 20 != 30".
             }
+            let x = -1;
+            assert!(x >= 0, "Invalid value: x = {}", x);
+            assert!(x >= 0, "Invalid value: x = {x}");
+            // Panics with "Invalid value: x = -1."
             ```
     
             # Notes


### PR DESCRIPTION
## What it solves?
It solves this issue #6541 

## Changes Made

This PR is adding the docstrings for some macros in the basecode. Specifically for `assert!`, `panic!`, `array!` macros.

## Status

This PR still work in progress. But I would like to receive some feedback about the work so far.

## Errors

I dont know why I'm getting these errors for some of the macros related to format. Look these screenshots:

![image](https://github.com/user-attachments/assets/4dca2e54-2781-49f8-993f-ee5292ae6f68)
![image](https://github.com/user-attachments/assets/01c82af0-a9f1-461b-abd1-9693c4e6620f)

In many places in the code of the macros I'm getting those weird errors.