### PR TITLE
LS: Discover struct members in constructor

### DIFF
--- a/crates/cairo-lang-language-server/tests/e2e/hover.rs
+++ b/crates/cairo-lang-language-server/tests/e2e/hover.rs
@@ -17,6 +17,7 @@ cairo_lang_test_utils::test_file_test!(
         partial: "partial.txt",
         starknet: "starknet.txt",
         literals: "literals.txt",
+        structs: "structs.txt"
     },
     test_hover
 );

--- a/crates/cairo-lang-language-server/tests/test_data/hover/basic.txt
+++ b/crates/cairo-lang-language-server/tests/test_data/hover/basic.txt
@@ -232,11 +232,20 @@ Rectangle struct.
 // = source context
     let mut rect = Rectangle { wid<caret>th: 30, height: 50 };
 // = highlight
-No highlight information.
+    let mut rect = Rectangle { <sel>width</sel>: 30, height: 50 };
 // = popover
 ```cairo
-hello::Rectangle
+hello
 ```
+```cairo
+#[derive(Copy, Drop)]
+struct Rectangle {
+    width: u64,
+    height: u64,
+}
+```
+---
+Width of the rectangle.
 
 //! > hover #12
 // = source context

--- a/crates/cairo-lang-language-server/tests/test_data/hover/structs.txt
+++ b/crates/cairo-lang-language-server/tests/test_data/hover/structs.txt
@@ -1,0 +1,157 @@
+//! > Hover
+
+//! > test_runner_name
+test_hover
+
+//! > cairo_project.toml
+[crate_roots]
+hello = "src"
+
+[config.global]
+edition = "2023_11"
+
+//! > cairo_code
+/// Docstring of Struct.
+struct Struct {
+    /// Docstring of member1.
+    member<caret>1: felt252,
+    member2: u256
+}
+
+mod happy_cases {
+    use super::Struct;
+
+    fn constructor() {
+        let _s = Struct {  member1<caret>: 0, member2: 0 };
+        let _s = Struct {  member1: 0, mem<caret>ber2: 0 };
+
+        let member1 = 0;
+        let member2 = 0;
+        let _s = Struct { mem<caret>ber1, member2<caret> };
+    }
+
+    fn member_access() {
+        let s = Struct {  member1: 0, member2: 0 };
+        let _ = s.member1<caret>;
+    }
+}
+
+mod unhappy_cases {
+    fn non_existent_struct {
+        let _ = NonExistentStruct { mem<caret>ber: 0 };
+    }
+}
+
+//! > hover #0
+// = source context
+    member<caret>1: felt252,
+// = highlight
+    <sel>member1</sel>: felt252,
+// = popover
+```cairo
+hello
+```
+```cairo
+struct Struct {
+    member1: felt252,
+    member2: u256,
+}
+```
+---
+Docstring of Struct.
+
+//! > hover #1
+// = source context
+        let _s = Struct {  member1<caret>: 0, member2: 0 };
+// = highlight
+        let _s = Struct {  <sel>member1</sel>: 0, member2: 0 };
+// = popover
+```cairo
+hello
+```
+```cairo
+struct Struct {
+    member1: felt252,
+    member2: u256,
+}
+```
+---
+Docstring of member1.
+
+//! > hover #2
+// = source context
+        let _s = Struct {  member1: 0, mem<caret>ber2: 0 };
+// = highlight
+        let _s = Struct {  member1: 0, <sel>member2</sel>: 0 };
+// = popover
+```cairo
+hello
+```
+```cairo
+struct Struct {
+    member1: felt252,
+    member2: u256,
+}
+```
+
+//! > hover #3
+// = source context
+        let _s = Struct { mem<caret>ber1, member2 };
+// = highlight
+        let _s = Struct { <sel>member1</sel>, member2 };
+// = popover
+```cairo
+hello
+```
+```cairo
+struct Struct {
+    member1: felt252,
+    member2: u256,
+}
+```
+---
+Docstring of member1.
+
+//! > hover #4
+// = source context
+        let _s = Struct { member1, member2<caret> };
+// = highlight
+        let _s = Struct { member1, <sel>member2</sel> };
+// = popover
+```cairo
+hello
+```
+```cairo
+struct Struct {
+    member1: felt252,
+    member2: u256,
+}
+```
+
+//! > hover #5
+// = source context
+        let _ = s.member1<caret>;
+// = highlight
+        let _ = s.<sel>member1</sel>;
+// = popover
+```cairo
+hello
+```
+```cairo
+struct Struct {
+    member1: felt252,
+    member2: u256,
+}
+```
+---
+Docstring of member1.
+
+//! > hover #6
+// = source context
+        let _ = NonExistentStruct { mem<caret>ber: 0 };
+// = highlight
+No highlight information.
+// = popover
+```cairo
+<missing>
+```


### PR DESCRIPTION
Closes #6537

## Changes
* Struct members in constructors are properly recognized and generate hovers identical as members in any other context (e.g. `struct_var.member`)
* New test fixture - `structs.txt` - covers all struct member hovers scenarios