### PR TITLE
LS: Refactor `DiagnosticsController`

### DIFF
--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -372,8 +372,8 @@ impl Backend {
     }
 
     /// Calls [`lang::diagnostics::DiagnosticsController::refresh`] to do its work.
-    fn refresh_diagnostics(state: &mut State, notifier: Notifier) {
-        state.diagnostics_controller.refresh(state.snapshot(), notifier);
+    fn refresh_diagnostics(state: &mut State, _notifier: Notifier) {
+        state.diagnostics_controller.refresh(state);
     }
 
     /// Tries to detect the crate root the config that contains a cairo file, and add it to the

--- a/crates/cairo-lang-language-server/src/state.rs
+++ b/crates/cairo-lang-language-server/src/state.rs
@@ -32,7 +32,7 @@ impl State {
         tricks: Tricks,
     ) -> Self {
         let notifier = Client::new(sender).notifier();
-        let scarb_toolchain = ScarbToolchain::new(notifier);
+        let scarb_toolchain = ScarbToolchain::new(notifier.clone());
         let db_swapper = AnalysisDatabaseSwapper::new(scarb_toolchain.clone());
 
         Self {
@@ -43,7 +43,7 @@ impl State {
             scarb_toolchain,
             db_swapper,
             tricks: Owned::new(tricks.into()),
-            diagnostics_controller: DiagnosticsController::new(),
+            diagnostics_controller: DiagnosticsController::new(notifier),
         }
     }
 


### PR DESCRIPTION
This commit prepares `DiagnosticsController`
for adding multithreaded processing.

1. `DiagnosticsController::refresh` takes shared reference to owned
state and makes snapshots internally.
2. Encapsulated controller thread state into a struct.
3. `Notifier` and `file_diagnostics` are now stored in controller's
state instead of being passed around.
4. Some minor renames and doc rewordings.

---

**Stack**:
- #6658
- #6657 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*