### PR TITLE
Fix Typos in Documentation Files

### DIFF
--- a/adrs/003_simple_trait_system.md
+++ b/adrs/003_simple_trait_system.md
@@ -21,7 +21,7 @@ trait MyTrait<A, B> {
 ```
 This item introduces an "interface", with function signatures and associated types that need to be
 defined by the implementations.
-Not that there is no `Self` or a type this trait is `for`. It is stand alone.
+Note that there is no `Self` or a type this trait is `for`. It is stand alone.
 
 ### Impl top level item
 ```

--- a/vscode-cairo/README.md
+++ b/vscode-cairo/README.md
@@ -41,7 +41,7 @@ Happy coding!
 ## Configuration
 
 This extension can be configured through VS Code's configuration settings.
-All settings all under the `cairo1.*` section.
+All settings are under the `cairo1.*` section.
 Consult the settings UI in VS Code for more documentation.
 
 ## Support


### PR DESCRIPTION
This pull request fixes minor typographical errors in the following documentation files:  

1. **`adrs/003_simple_trait_system.md`**  
   - Corrected the phrase "Not that there is no `Self`" to "Note that there is no `Self`."  

2. **`vscode-cairo/README.md`**  
   - Fixed "All settings all under the `cairo1.*` section" to "All settings are under the `cairo1.*` section."  
