### PR TITLE
LS: Get rid of needless `scarb metadata` calls

### DIFF
--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -392,7 +392,7 @@ impl Backend {
         match ProjectManifestPath::discover(file_path) {
             Some(ProjectManifestPath::Scarb(manifest_path)) => {
                 if loaded_scarb_manifests.contains(&manifest_path) {
-                    trace!("Project with manifest `{}` is already loaded", manifest_path.display());
+                    trace!("scarb project is already loaded: {}", manifest_path.display());
                     return;
                 }
 

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -392,7 +392,7 @@ impl Backend {
         match ProjectManifestPath::discover(file_path) {
             Some(ProjectManifestPath::Scarb(manifest_path)) => {
                 if loaded_scarb_manifests.contains(&manifest_path) {
-                    trace!("Project with manifest {} is already loaded", manifest_path.display());
+                    trace!("Project with manifest `{}` is already loaded", manifest_path.display());
                     return;
                 }
 

--- a/crates/cairo-lang-language-server/src/lib.rs
+++ b/crates/cairo-lang-language-server/src/lib.rs
@@ -55,7 +55,7 @@ use cairo_lang_semantic::plugin::PluginSuite;
 use lsp_server::Message;
 use lsp_types::RegistrationParams;
 use salsa::{Database, Durability};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::config::Config;
 use crate::lang::db::AnalysisDatabase;
@@ -392,6 +392,7 @@ impl Backend {
         match ProjectManifestPath::discover(file_path) {
             Some(ProjectManifestPath::Scarb(manifest_path)) => {
                 if loaded_scarb_manifests.contains(&manifest_path) {
+                    trace!("Project with manifest {} is already loaded", manifest_path.display());
                     return;
                 }
 
@@ -407,11 +408,7 @@ impl Backend {
                     .ok();
 
                 if let Some(metadata) = metadata {
-                    let manifests = get_workspace_members_manifests(&metadata);
-                    for manifest in manifests {
-                        loaded_scarb_manifests.insert(manifest);
-                    }
-
+                    loaded_scarb_manifests.extend(get_workspace_members_manifests(&metadata));
                     update_crate_roots(&metadata, db);
                 } else {
                     // Try to set up a corelib at least.

--- a/crates/cairo-lang-language-server/src/project/scarb.rs
+++ b/crates/cairo-lang-language-server/src/project/scarb.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail, ensure};
 use cairo_lang_filesystem::cfg::CfgSet;
@@ -17,6 +17,15 @@ use tracing::{debug, error, warn};
 
 use crate::lang::db::AnalysisDatabase;
 use crate::project::crate_data::Crate;
+
+pub fn get_workspace_members_manifests(metadata: &Metadata) -> Vec<PathBuf> {
+    metadata
+        .workspace
+        .members
+        .iter()
+        .map(|package_id| metadata[package_id].manifest_path.clone().into())
+        .collect()
+}
 
 /// Updates crate roots in the database with the information from Scarb metadata.
 ///

--- a/crates/cairo-lang-language-server/src/project/scarb.rs
+++ b/crates/cairo-lang-language-server/src/project/scarb.rs
@@ -18,6 +18,7 @@ use tracing::{debug, error, warn};
 use crate::lang::db::AnalysisDatabase;
 use crate::project::crate_data::Crate;
 
+/// Get paths to manifests of the workspace members.
 pub fn get_workspace_members_manifests(metadata: &Metadata) -> Vec<PathBuf> {
     metadata
         .workspace

--- a/crates/cairo-lang-language-server/src/server/routing/traits.rs
+++ b/crates/cairo-lang-language-server/src/server/routing/traits.rs
@@ -250,6 +250,7 @@ impl SyncNotificationHandler for DidOpenTextDocument {
                 &state.config,
                 &path,
                 &notifier,
+                &mut state.loaded_scarb_manifests,
             );
         }
 

--- a/crates/cairo-lang-language-server/src/state.rs
+++ b/crates/cairo-lang-language-server/src/state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use lsp_types::{ClientCapabilities, Url};
@@ -17,6 +18,7 @@ use crate::toolchain::scarb::ScarbToolchain;
 pub struct State {
     pub db: AnalysisDatabase,
     pub open_files: Owned<HashSet<Url>>,
+    pub loaded_scarb_manifests: HashSet<PathBuf>,
     pub config: Owned<Config>,
     pub client_capabilities: Owned<ClientCapabilities>,
     pub scarb_toolchain: ScarbToolchain,
@@ -38,6 +40,7 @@ impl State {
         Self {
             db: AnalysisDatabase::new(&tricks),
             open_files: Default::default(),
+            loaded_scarb_manifests: Default::default(),
             config: Default::default(),
             client_capabilities: Owned::new(client_capabilities.into()),
             scarb_toolchain,

--- a/crates/cairo-lang-language-server/src/state.rs
+++ b/crates/cairo-lang-language-server/src/state.rs
@@ -18,7 +18,7 @@ use crate::toolchain::scarb::ScarbToolchain;
 pub struct State {
     pub db: AnalysisDatabase,
     pub open_files: Owned<HashSet<Url>>,
-    pub loaded_scarb_manifests: HashSet<PathBuf>,
+    pub loaded_scarb_manifests: Owned<HashSet<PathBuf>>,
     pub config: Owned<Config>,
     pub client_capabilities: Owned<ClientCapabilities>,
     pub scarb_toolchain: ScarbToolchain,


### PR DESCRIPTION
This PR improves UX regarding project loading for Scarb projects (so assume the rest of the description concerns only these). Logic regarding `cairo_project.toml`-based projects remains unchanged as there is no such an UX issue associated with them.

Before this PR `scarb metadata` was called on every `didOpen` notification. Moreover it was called once per each currently open file when:
- `cairo/reloadWorkspace` command was executed
- `didChangeWatchedFiles` informing about `Scarb.toml` change was received

This PR changes it so we keep *paths* to `Scarb.toml`s that correspond to members of Scarb's workspaces we already analysed/loaded. 

When a `didOpen` notification is received, we check if the path to `Scarb.toml` for the opened file is in *paths*. If it is, we skip the `scarb metadata` execution, else we do as before, but we add paths of all workspace members' manifests to *paths*.

Keep in mind it also improves UX for the two remaining cases: we clear *paths* and load projects for all currently open files, but loading a project for one file from workspace A will prevent redundant `scarb metadata` calls for all the other open files from workspace A (via mechanism described above).