### PR TITLE
Typo Update readme.md

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -60,7 +60,7 @@ asciidoctor-pdf src/Summary.adoc
 
 - Convert all files
 ```bash
-asciidoctor-pdf src/*.adoc`
+asciidoctor-pdf src/*.adoc
 ```
 
 Now `PDF` versions of the documentation will be generated.


### PR DESCRIPTION
### Description:  
This pull request fixes a minor but potentially confusing typo in the **"View in PDF"** section of the documentation.  

#### Issue:  
In the final command under "Convert to PDF," there was an unnecessary backtick (`) at the end of the command:  

```bash  
asciidoctor-pdf src/*.adoc`  
```  

#### Fix:  
The command has been corrected by removing the stray backtick:  

```bash  
asciidoctor-pdf src/*.adoc  
```  

---

### Importance of Fix:  
1. **Clarity**: Ensures readers can copy-paste the command directly without encountering syntax errors.  
2. **User Experience**: Reduces confusion for users, especially those new to using `asciidoctor-pdf`.  
3. **Consistency**: Maintains professional and error-free documentation.  

---

### Testing:  
- Verified that the corrected command executes without errors.  
- Ensured consistency with other commands in the documentation.  

Please review and merge this fix to improve the documentation's accuracy.