### PR TITLE
Dean/formatter struct linebreaking

### DIFF
--- a/crates/bin/cairo-format/src/main.rs
+++ b/crates/bin/cairo-format/src/main.rs
@@ -51,6 +51,12 @@ struct FormatterArgs {
     /// same line (as space permits). Defaults to single line.
     #[arg(long, default_value_t = true)]
     fixed_array_line_breaking: bool,
+    /// Enable merging of `use` items.
+    #[arg(long, default_value_t = false)]
+    merge_use_items: bool,
+    ///  Enable duplicates in `use` items.
+    #[arg(long, default_value_t = false)]
+    allow_duplicates: bool,
     /// A list of files and directories to format. Use "-" for stdin.
     files: Vec<String>,
 }
@@ -206,8 +212,9 @@ fn main() -> ExitCode {
             CollectionsBreakingBehavior::LineByLine
         } else {
             CollectionsBreakingBehavior::SingleBreakPoint
-        });
-
+        })
+        .merge_use_items(args.merge_use_items)
+        .allow_duplicate_uses(args.allow_duplicates);
     let fmt = CairoFormatter::new(config);
 
     eprintln_if_verbose(

--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -1,17 +1,138 @@
 use std::cmp::Ordering;
 use std::fmt;
 
+use cairo_lang_diagnostics::DiagnosticsBuilder;
+use cairo_lang_filesystem::ids::{FileKind, FileLongId, VirtualFile};
 use cairo_lang_filesystem::span::TextWidth;
+use cairo_lang_parser::ParserDiagnostic;
+use cairo_lang_parser::parser::Parser;
 use cairo_lang_syntax as syntax;
 use cairo_lang_syntax::attribute::consts::FMT_SKIP_ATTR;
 use cairo_lang_syntax::node::ast::UsePath;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode, ast};
-use itertools::Itertools;
+use cairo_lang_utils::Intern;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use itertools::{Itertools, chain};
 use syntax::node::helpers::QueryAttrs;
 use syntax::node::kind::SyntaxKind;
 
 use crate::FormatterConfig;
+
+/// Represents a tree structure for organizing and merging `use` statements.
+#[derive(Default, Debug)]
+struct UseTree {
+    /// A map of child nodes, where the key is the segment of the `use` path and the value is
+    /// another `UseTree` representing the nested structure.
+    children: OrderedHashMap<String, UseTree>,
+    /// A list of `Leaf` nodes, representing individual `use` path endpoints
+    /// or aliases. Each leaf contains optional alias information.
+    leaves: Vec<Leaf>,
+}
+
+/// Represents a terminal node in a `UseTree`, corresponding to a specific `use` path.
+#[derive(Default, Debug, Clone)]
+struct Leaf {
+    name: String,
+    alias: Option<String>,
+}
+
+impl UseTree {
+    /// Inserts a path into the `UseTree`, creating nested entries as needed.
+    fn insert_path(&mut self, db: &dyn SyntaxGroup, use_path: UsePath) {
+        match use_path {
+            UsePath::Leaf(leaf) => {
+                let name = leaf.extract_ident(db);
+                let alias = leaf.extract_alias(db);
+                self.leaves.push(Leaf { name, alias });
+            }
+            UsePath::Single(single) => {
+                let segment = single.extract_ident(db);
+                let subtree = self.children.entry(segment).or_default();
+                subtree.insert_path(db, single.use_path(db));
+            }
+            UsePath::Multi(multi) => {
+                for sub_path in multi.use_paths(db).elements(db) {
+                    self.insert_path(db, sub_path);
+                }
+            }
+            UsePath::Star(_) => {
+                self.leaves.push(Leaf { name: "*".to_string(), alias: None });
+            }
+        }
+    }
+
+    /// Merge and organize the `use` paths in a hierarchical structure.
+    /// Additionally returns whether the returned elements are a single leaf.
+    pub fn create_merged_use_items(self, allow_duplicate_uses: bool) -> (Vec<String>, bool) {
+        let mut leaf_paths: Vec<_> = self
+            .leaves
+            .into_iter()
+            .map(|leaf| {
+                if let Some(alias) = leaf.alias {
+                    format!("{} as {alias}", leaf.name)
+                } else {
+                    leaf.name
+                }
+            })
+            .collect();
+
+        let mut nested_paths = vec![];
+        for (segment, subtree) in self.children {
+            let (subtree_merged_use_items, is_single_leaf) =
+                subtree.create_merged_use_items(allow_duplicate_uses);
+
+            let formatted_subtree_paths =
+                subtree_merged_use_items.into_iter().map(|child| format!("{segment}::{child}"));
+
+            if is_single_leaf {
+                leaf_paths.extend(formatted_subtree_paths);
+            } else {
+                nested_paths.extend(formatted_subtree_paths);
+            }
+        }
+
+        if !allow_duplicate_uses {
+            leaf_paths.sort();
+            leaf_paths.dedup();
+        }
+
+        match leaf_paths.len() {
+            0 => {}
+            1 if nested_paths.is_empty() => return (leaf_paths, true),
+            1 => nested_paths.extend(leaf_paths),
+            _ => nested_paths.push(format!("{{{}}}", leaf_paths.join(", "))),
+        }
+
+        (nested_paths, false)
+    }
+
+    /// Formats `use` items, creates a virtual file, and parses it into a syntax node.
+    pub fn generate_syntax_node_from_use(
+        self,
+        db: &dyn SyntaxGroup,
+        allow_duplicate_uses: bool,
+        decorations: String,
+    ) -> SyntaxNode {
+        let mut formatted_use_items = String::new();
+        for statement in self.create_merged_use_items(allow_duplicate_uses).0 {
+            formatted_use_items.push_str(&format!("{decorations}use {statement};\n"));
+        }
+
+        // Create a virtual file ID for the formatted statements.
+        let file_id = FileLongId::Virtual(VirtualFile {
+            parent: None,
+            name: "parser_input".into(),
+            content: formatted_use_items.clone().into(),
+            code_mappings: [].into(),
+            kind: FileKind::Module,
+        })
+        .intern(db);
+
+        let mut diagnostics = DiagnosticsBuilder::<ParserDiagnostic>::default();
+        Parser::parse_file(db, &mut diagnostics, file_id, &formatted_use_items).as_syntax_node()
+    }
+}
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Defines the break point behaviour.
@@ -72,10 +193,9 @@ pub struct BreakLinePointProperties {
 }
 impl Ord for BreakLinePointProperties {
     fn cmp(&self, other: &Self) -> Ordering {
-        match (self.is_empty_line_breakpoint, other.is_empty_line_breakpoint) {
-            (true, true) | (false, false) => self.precedence.cmp(&other.precedence),
-            (true, false) => Ordering::Greater,
-            (false, true) => Ordering::Less,
+        match self.is_empty_line_breakpoint.cmp(&other.is_empty_line_breakpoint) {
+            Ordering::Equal => self.precedence.cmp(&other.precedence),
+            other => other,
         }
     }
 }
@@ -802,6 +922,7 @@ pub struct FormatterImpl<'a> {
     is_current_line_whitespaces: bool,
     /// Indicates whether the last element handled was a comment.
     is_last_element_comment: bool,
+    is_merging_use_items: bool,
 }
 
 impl<'a> FormatterImpl<'a> {
@@ -813,6 +934,7 @@ impl<'a> FormatterImpl<'a> {
             empty_lines_allowance: 0,
             is_current_line_whitespaces: true,
             is_last_element_comment: false,
+            is_merging_use_items: false,
         }
     }
     /// Gets a root of a syntax tree and returns the formatted string of the code it represents.
@@ -823,6 +945,11 @@ impl<'a> FormatterImpl<'a> {
     /// Appends a formatted string, representing the syntax_node, to the result.
     /// Should be called with a root syntax node to format a file.
     fn format_node(&mut self, syntax_node: &SyntaxNode) {
+        if self.is_merging_use_items {
+            // When merging, only format this node once and return to avoid recursion.
+            self.line_state.line_buffer.push_str(syntax_node.get_text(self.db).trim());
+            return;
+        }
         if syntax_node.text(self.db).is_some() {
             panic!("Token reached before terminal.");
         }
@@ -854,9 +981,8 @@ impl<'a> FormatterImpl<'a> {
             }
             self.append_break_line_point(Some(trailing_break_point));
         }
-
-        // self.append_break_line_point(node_break_points.trailing());
     }
+
     /// Formats an internal node and appends the formatted string to the result.
     fn format_internal(&mut self, syntax_node: &SyntaxNode) {
         let allowed_empty_between = syntax_node.allowed_empty_between(self.db);
@@ -865,19 +991,26 @@ impl<'a> FormatterImpl<'a> {
         // TODO(ilya): consider not copying here.
         let mut children = self.db.get_children(syntax_node.clone()).to_vec();
         let n_children = children.len();
+
+        if self.config.merge_use_items {
+            self.merge_use_items(&mut children);
+        }
+
         if self.config.sort_module_level_items {
+            self.sort_items_sections(&mut children);
             if let SyntaxKind::UsePathList = syntax_node.kind(self.db) {
                 self.sort_inner_use_path(&mut children);
-            } else {
-                self.sort_items_sections(&mut children);
             }
         }
+
+        // Format each child node, inserting breaks where specified.
         for (i, child) in children.iter().enumerate() {
             if child.width(self.db) == TextWidth::default() {
-                // Skip empty nodes.
                 continue;
             }
+
             self.format_node(child);
+
             if let BreakLinePointsPositions::List { properties, breaking_frequency } =
                 &internal_break_line_points_positions
             {
@@ -885,9 +1018,83 @@ impl<'a> FormatterImpl<'a> {
                     self.append_break_line_point(Some(properties.clone()));
                 }
             }
-
             self.empty_lines_allowance = allowed_empty_between;
         }
+    }
+
+    /// Merges `use` statements within a given set of syntax nodes, organizing and deduplicating
+    /// them into a clean, structured format.
+    fn merge_use_items(&mut self, children: &mut Vec<SyntaxNode>) {
+        let mut new_children = Vec::new();
+
+        for (section_kind, section_nodes) in extract_sections(children, self.db) {
+            if section_kind != SortKind::UseItem {
+                new_children.extend(section_nodes.iter().cloned());
+                continue;
+            }
+
+            let mut decoration_to_use_tree: OrderedHashMap<String, UseTree> =
+                OrderedHashMap::default();
+
+            for node in section_nodes {
+                // Check if the node has any non-trivial trivia (i.e., comments).
+                let has_non_whitespace_trivia = !node.descendants(self.db).all(|descendant| {
+                    if descendant.kind(self.db) == SyntaxKind::Trivia {
+                        ast::Trivia::from_syntax_node(self.db, descendant)
+                            .elements(self.db)
+                            .into_iter()
+                            .all(|element| {
+                                matches!(
+                                    element,
+                                    ast::Trivium::Whitespace(_) | ast::Trivium::Newline(_)
+                                )
+                            })
+                    } else {
+                        true
+                    }
+                });
+
+                if has_non_whitespace_trivia {
+                    new_children.push(node.clone());
+                    continue;
+                }
+
+                let use_item = ast::ItemUse::from_syntax_node(self.db, node.clone());
+
+                let decorations = chain!(
+                    use_item
+                        .attributes(self.db)
+                        .elements(self.db)
+                        .into_iter()
+                        .map(|attr| attr.as_syntax_node().get_text_without_trivia(self.db)),
+                    [use_item.visibility(self.db).as_syntax_node().get_text(self.db)],
+                )
+                .join("\n");
+
+                let tree = decoration_to_use_tree.entry(decorations).or_default();
+                tree.insert_path(self.db, use_item.use_path(self.db));
+            }
+
+            // Generate merged syntax nodes from the `decoration_to_use_tree`.
+            for (decorations, tree) in decoration_to_use_tree {
+                let merged_node = tree.generate_syntax_node_from_use(
+                    self.db,
+                    self.config.allow_duplicate_uses,
+                    decorations,
+                );
+
+                // Add merged children to the new_children list.
+                let children = self.db.get_children(merged_node.clone()).to_vec();
+                if !children.is_empty() {
+                    let grandchildren = self.db.get_children(children[0].clone()).to_vec();
+                    for child in grandchildren {
+                        new_children.push(child.clone());
+                    }
+                }
+            }
+        }
+
+        *children = new_children;
     }
 
     /// Sorting function for `UsePathMulti` children.
@@ -918,42 +1125,40 @@ impl<'a> FormatterImpl<'a> {
     }
 
     /// Sorting function for module-level items.
-    fn sort_items_sections(&self, children: &mut [SyntaxNode]) {
-        let mut start_idx = 0;
-        while start_idx < children.len() {
-            let kind = children[start_idx].as_sort_kind(self.db);
-            let mut end_idx = start_idx + 1;
-            // Find the end of the current section.
-            while end_idx < children.len() {
-                if kind != children[end_idx].as_sort_kind(self.db) {
-                    break;
-                }
-                end_idx += 1;
-            }
-            // Sort within this section if it's `Module` or `UseItem`.
-            match kind {
+    fn sort_items_sections(&self, children: &mut Vec<SyntaxNode>) {
+        let sections = extract_sections(children, self.db);
+        let mut sorted_children = Vec::with_capacity(children.len());
+        for (section_kind, section_nodes) in sections {
+            match section_kind {
                 SortKind::Module => {
-                    children[start_idx..end_idx].sort_by_key(|node| {
+                    // Sort `Module` items alphabetically by their name.
+                    let mut sorted_section = section_nodes.to_vec();
+                    sorted_section.sort_by_key(|node| {
                         ast::ItemModule::from_syntax_node(self.db, node.clone())
                             .name(self.db)
                             .text(self.db)
                     });
+                    sorted_children.extend(sorted_section);
                 }
                 SortKind::UseItem => {
-                    children[start_idx..end_idx].sort_by(|a, b| {
+                    // Sort `UseItem` items based on their use paths.
+                    let mut sorted_section = section_nodes.to_vec();
+                    sorted_section.sort_by(|a, b| {
                         compare_use_paths(
                             &ast::ItemUse::from_syntax_node(self.db, a.clone()).use_path(self.db),
                             &ast::ItemUse::from_syntax_node(self.db, b.clone()).use_path(self.db),
                             self.db,
                         )
                     });
+                    sorted_children.extend(sorted_section);
                 }
                 SortKind::Immovable => {
-                    // Do nothing for immovable sections.
+                    sorted_children.extend(section_nodes.iter().cloned());
                 }
             }
-            start_idx = end_idx;
         }
+
+        *children = sorted_children;
     }
 
     /// Formats a terminal node and appends the formatted string to the result.
@@ -1067,8 +1272,8 @@ fn compare_use_paths(a: &UsePath, b: &UsePath, db: &dyn SyntaxGroup) -> Ordering
             let b_str = b_single.extract_ident(db);
 
             match a_str.cmp(&b_str) {
-                Ordering::Equal => Ordering::Less, // Leaf is always ordered before Single if
-                // equal.
+                // Leaf is always ordered before Single if equal.
+                Ordering::Equal => Ordering::Less,
                 other => other,
             }
         }
@@ -1079,7 +1284,8 @@ fn compare_use_paths(a: &UsePath, b: &UsePath, db: &dyn SyntaxGroup) -> Ordering
 
             // Compare the extracted identifiers.
             match a_str.cmp(&b_str) {
-                Ordering::Equal => Ordering::Greater, // Single is ordered after Leaf if equal.
+                // Single is ordered after Leaf if equal.
+                Ordering::Equal => Ordering::Greater,
                 other => other,
             }
         }
@@ -1096,12 +1302,8 @@ fn compare_use_paths(a: &UsePath, b: &UsePath, db: &dyn SyntaxGroup) -> Ordering
         // Case for Single vs Single: compare their identifiers, then move to the next segment if
         // equal.
         (UsePath::Single(a_single), UsePath::Single(b_single)) => {
-            // this is the problem. it takes the whole path instead of only the single before the ::
-            let a_str = a_single.extract_ident(db);
-            let b_str = b_single.extract_ident(db);
-            match a_str.cmp(&b_str) {
+            match a_single.extract_ident(db).cmp(&b_single.extract_ident(db)) {
                 Ordering::Equal => {
-                    // If the identifiers are equal, compare the next path segment.
                     compare_use_paths(&a_single.use_path(db), &b_single.use_path(db), db)
                 }
                 other => other,
@@ -1163,6 +1365,27 @@ impl IdentExtractor for ast::UsePathSingle {
     fn extract_alias(&self, _db: &dyn SyntaxGroup) -> Option<String> {
         None
     }
+}
+
+/// Extracts sections of syntax nodes based on their `SortKind`.
+fn extract_sections<'a>(
+    children: &'a [SyntaxNode],
+    db: &'a dyn SyntaxGroup,
+) -> Vec<(SortKind, &'a [SyntaxNode])> {
+    let mut sections = Vec::new();
+    let mut start_idx = 0;
+
+    while start_idx < children.len() {
+        let kind = children[start_idx].as_sort_kind(db);
+        let mut end_idx = start_idx + 1;
+        while end_idx < children.len() && kind == children[end_idx].as_sort_kind(db) {
+            end_idx += 1;
+        }
+        sections.push((kind, &children[start_idx..end_idx]));
+        start_idx = end_idx;
+    }
+
+    sections
 }
 
 /// Represents the kind of sections in the syntax tree that can be sorted.

--- a/crates/cairo-lang-formatter/src/lib.rs
+++ b/crates/cairo-lang-formatter/src/lib.rs
@@ -77,6 +77,8 @@ pub struct FormatterConfig {
     sort_module_level_items: bool,
     tuple_breaking_behavior: CollectionsBreakingBehavior,
     fixed_array_breaking_behavior: CollectionsBreakingBehavior,
+    merge_use_items: bool,
+    allow_duplicate_uses: bool,
 }
 
 // Config params
@@ -91,6 +93,8 @@ impl FormatterConfig {
         sort_module_level_items: bool,
         tuple_breaking_behavior: CollectionsBreakingBehavior,
         fixed_array_breaking_behavior: CollectionsBreakingBehavior,
+        merge_use_items: bool,
+        allow_duplicate_uses: bool,
     ) -> Self {
         Self {
             tab_size,
@@ -98,6 +102,8 @@ impl FormatterConfig {
             sort_module_level_items,
             tuple_breaking_behavior,
             fixed_array_breaking_behavior,
+            merge_use_items,
+            allow_duplicate_uses,
         }
     }
 
@@ -115,6 +121,14 @@ impl FormatterConfig {
         self.fixed_array_breaking_behavior = behavior;
         self
     }
+    pub fn merge_use_items(mut self, merge: bool) -> Self {
+        self.merge_use_items = merge;
+        self
+    }
+    pub fn allow_duplicate_uses(mut self, allow: bool) -> Self {
+        self.allow_duplicate_uses = allow;
+        self
+    }
 }
 impl Default for FormatterConfig {
     fn default() -> Self {
@@ -124,6 +138,8 @@ impl Default for FormatterConfig {
             sort_module_level_items: false,
             tuple_breaking_behavior: CollectionsBreakingBehavior::LineByLine,
             fixed_array_breaking_behavior: CollectionsBreakingBehavior::SingleBreakPoint,
+            merge_use_items: false,
+            allow_duplicate_uses: false,
         }
     }
 }

--- a/crates/cairo-lang-formatter/src/node_properties.rs
+++ b/crates/cairo-lang-formatter/src/node_properties.rs
@@ -458,6 +458,20 @@ impl SyntaxNodeFormat for SyntaxNode {
                 ))
             }
             _ => match self.kind(db) {
+                SyntaxKind::PatternStructParamList => {
+                    let leading_break_point = BreakLinePointProperties::new(
+                        2,
+                        BreakLinePointIndentation::IndentedWithTail,
+                        true,
+                        true,
+                    );
+                    let mut trailing_break_point = leading_break_point.clone();
+                    trailing_break_point.set_comma_if_broken();
+                    BreakLinePointsPositions::Both {
+                        leading: leading_break_point,
+                        trailing: trailing_break_point,
+                    }
+                }
                 SyntaxKind::ExprList | SyntaxKind::PatternList => {
                     let leading_break_point = BreakLinePointProperties::new(
                         2,

--- a/crates/cairo-lang-formatter/src/test.rs
+++ b/crates/cairo-lang-formatter/src/test.rs
@@ -29,11 +29,15 @@ impl Upcast<dyn FilesGroup> for DatabaseImpl {
     "test_data/expected_results/test1.cairo",
     false,
     false,
+    false,
+    false,
     false
 )]
 #[test_case(
     "test_data/cairo_files/linebreaking.cairo",
     "test_data/expected_results/linebreaking.cairo",
+    false,
+    false,
     false,
     false,
     false
@@ -43,6 +47,8 @@ impl Upcast<dyn FilesGroup> for DatabaseImpl {
     "test_data/expected_results/attrs.cairo",
     false,
     false,
+    false,
+    false,
     false
 )]
 #[test_case(
@@ -50,11 +56,15 @@ impl Upcast<dyn FilesGroup> for DatabaseImpl {
     "test_data/expected_results/use_sorting.cairo",
     true,
     false,
+    false,
+    false,
     false
 )]
 #[test_case(
     "test_data/cairo_files/fmt_skip.cairo",
     "test_data/expected_results/fmt_skip.cairo",
+    false,
+    false,
     false,
     false,
     false
@@ -64,12 +74,16 @@ impl Upcast<dyn FilesGroup> for DatabaseImpl {
     "test_data/expected_results/sorted_mod_use.cairo",
     true,
     false,
+    false,
+    false,
     false
 )]
 #[test_case(
     "test_data/cairo_files/sort_inner_use.cairo",
     "test_data/expected_results/sort_inner_use.cairo",
     true,
+    false,
+    false,
     false,
     false
 )]
@@ -79,12 +93,34 @@ impl Upcast<dyn FilesGroup> for DatabaseImpl {
     "test_data/expected_results/sort_single_line.cairo",
     true,
     false,
+    false,
+    false,
     false
 )]
 #[test_case(
     "test_data/cairo_files/sort_line_by_line.cairo",
     "test_data/expected_results/sort_line_by_line.cairo",
     true,
+    true,
+    true,
+    false,
+    false
+)]
+#[test_case(
+    "test_data/cairo_files/use_merge.cairo",
+    "test_data/expected_results/use_merge.cairo",
+    true,
+    false,
+    false,
+    true,
+    false
+)]
+#[test_case(
+    "test_data/cairo_files/use_merge_with_dup.cairo",
+    "test_data/expected_results/use_merge_with_dup.cairo",
+    true,
+    false,
+    false,
     true,
     true
 )]
@@ -94,6 +130,8 @@ fn format_and_compare_file(
     use_sorting: bool,
     tuple_line_breaking: bool,
     fixed_array_line_breaking: bool,
+    merge_use_statements: bool,
+    allow_duplicate_uses: bool,
 ) {
     let db_val = SimpleParserDatabase::default();
     let db = &db_val;
@@ -118,7 +156,9 @@ fn format_and_compare_file(
             CollectionsBreakingBehavior::LineByLine
         } else {
             CollectionsBreakingBehavior::SingleBreakPoint
-        });
+        })
+        .merge_use_items(merge_use_statements)
+        .allow_duplicate_uses(allow_duplicate_uses);
 
     let formatted_file = get_formatted_file(db, &syntax_root, config);
     let expected_file =

--- a/crates/cairo-lang-formatter/test_data/cairo_files/linebreaking.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/linebreaking.cairo
@@ -79,3 +79,12 @@ fn comment_remains_after_last_comma() {
         0 // Second comment that needs to remain although it follows a comma.
     ];
 }
+fn struct_line_breaking() {
+    let MyStruct { long_long_long_long_key_a,
+        long_long_long_long_key_b,
+        long_long_long_long_key_c,
+            long_long_long_long_key_b,
+            long_long_long_long_key_b,
+ } =
+            my_val;
+}

--- a/crates/cairo-lang-formatter/test_data/cairo_files/use_merge.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/use_merge.cairo
@@ -1,0 +1,46 @@
+use a::a;
+use a::a;
+use a::b;
+use a::c;
+mod a;
+use a::e;
+use a::n;
+use v::t;
+use v::{a, b};
+mod b;
+use z::a;
+/// Testing attributes.
+mod b;
+use a::a;
+#[cfg(test)]
+use a::a;
+use a::b;
+use a::c;
+/// Testing aliases.
+mod c;
+use a;
+use a::a as c;
+use a::b as d;
+/// Testing visibility settings.
+mod d;
+pub use a::c;
+pub use a::{a, b};
+use e::e;
+mod e;
+use a::b;
+use a::b::c;
+use a::b::c::d;
+use a::b::c::d::e;
+use a::b::c::d::f::g;
+/// Testing not merging with trivia.
+mod t;
+// This is a comment for a::b.
+use a::b;
+use a::c;
+use a::d;
+// Testing wildcard.
+mod w;
+use a::a;
+use a::{c, b};
+use a::*;
+use d::{e, *};

--- a/crates/cairo-lang-formatter/test_data/cairo_files/use_merge_with_dup.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/use_merge_with_dup.cairo
@@ -1,0 +1,46 @@
+use a::a;
+use a::a;
+use a::b;
+use a::c;
+mod a;
+use a::e;
+use a::n;
+use v::t;
+use v::{a, b};
+mod b;
+use z::a;
+/// Testing attributes.
+mod b;
+use a::a;
+#[cfg(test)]
+use a::a;
+use a::b;
+use a::c;
+/// Testing aliases.
+mod c;
+use a;
+use a::a as c;
+use a::b as d;
+/// Testing visibility settings.
+mod d;
+pub use a::{a, b};
+use e::e;
+pub use a::b;
+mod e;
+use a::b;
+use a::b::c;
+use a::b::c::d;
+use a::b::c::d::e;
+use a::b::c::d::f::g;
+/// Testing not merging with trivia.
+mod t;
+// This is a comment for a::b.
+use a::b;
+use a::c;
+use a::c;
+// Testing wildcard.
+mod w;
+use a::b;
+use a::{c, b};
+use a::*;
+use d::{e, *};

--- a/crates/cairo-lang-formatter/test_data/expected_results/linebreaking.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/linebreaking.cairo
@@ -295,3 +295,13 @@ fn comment_remains_after_last_comma() {
         0 // Second comment that needs to remain although it follows a comma.
     ];
 }
+fn struct_line_breaking() {
+    let MyStruct {
+        long_long_long_long_key_a,
+        long_long_long_long_key_b,
+        long_long_long_long_key_c,
+        long_long_long_long_key_b,
+        long_long_long_long_key_b,
+    } =
+        my_val;
+}

--- a/crates/cairo-lang-formatter/test_data/expected_results/use_merge.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/use_merge.cairo
@@ -1,0 +1,33 @@
+use a::{a, b, c};
+mod a;
+use a::{e, n};
+use v::{a, b, t};
+mod b;
+use z::a;
+/// Testing attributes.
+mod b;
+#[cfg(test)]
+use a::a;
+use a::{a, b, c};
+/// Testing aliases.
+mod c;
+use a;
+use a::{a as c, b as d};
+/// Testing visibility settings.
+mod d;
+pub use a::{a, b, c};
+use e::e;
+mod e;
+use a::b;
+use a::b::c;
+use a::b::c::d;
+use a::b::c::d::{e, f::g};
+/// Testing not merging with trivia.
+mod t;
+// This is a comment for a::b.
+use a::b;
+use a::{c, d};
+// Testing wildcard.
+mod w;
+use a::{*, a, b, c};
+use d::{*, e};

--- a/crates/cairo-lang-formatter/test_data/expected_results/use_merge_with_dup.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/use_merge_with_dup.cairo
@@ -1,0 +1,33 @@
+use a::{a, a, b, c};
+mod a;
+use a::{e, n};
+use v::{a, b, t};
+mod b;
+use z::a;
+/// Testing attributes.
+mod b;
+#[cfg(test)]
+use a::a;
+use a::{a, b, c};
+/// Testing aliases.
+mod c;
+use a;
+use a::{a as c, b as d};
+/// Testing visibility settings.
+mod d;
+pub use a::{a, b, b};
+use e::e;
+mod e;
+use a::b;
+use a::b::c;
+use a::b::c::d;
+use a::b::c::d::{e, f::g};
+/// Testing not merging with trivia.
+mod t;
+// This is a comment for a::b.
+use a::b;
+use a::{c, c};
+// Testing wildcard.
+mod w;
+use a::{*, b, b, c};
+use d::{*, e};

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/use
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/use
@@ -122,20 +122,17 @@ use X::R as RR;
 
 //! > expr_code
 { 
-    let _y = RR { a: 3 };
+    RR { a: 3 };
     use X::R;
-    let _x = R { a: 4 }; 
+    R { a: 4 }
 }
 
 //! > expected_semantics
 Block(
     ExprBlock {
         statements: [
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _y,
-                    ),
+            Expr(
+                StatementExpr {
                     expr: StructCtor(
                         ExprStructCtor {
                             concrete_struct_id: test::X::R,
@@ -159,34 +156,28 @@ Block(
             Item(
                 StatementItem,
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _x,
-                    ),
-                    expr: StructCtor(
-                        ExprStructCtor {
-                            concrete_struct_id: test::X::R,
-                            members: [
-                                (
-                                    MemberId(test::X::a),
-                                    Literal(
-                                        ExprLiteral {
-                                            value: 4,
-                                            ty: core::integer::u8,
-                                        },
-                                    ),
-                                ),
-                            ],
-                            base_struct: None,
-                            ty: test::X::R,
-                        },
-                    ),
+        ],
+        tail: Some(
+            StructCtor(
+                ExprStructCtor {
+                    concrete_struct_id: test::X::R,
+                    members: [
+                        (
+                            MemberId(test::X::a),
+                            Literal(
+                                ExprLiteral {
+                                    value: 4,
+                                    ty: core::integer::u8,
+                                },
+                            ),
+                        ),
+                    ],
+                    base_struct: None,
+                    ty: test::X::R,
                 },
             ),
-        ],
-        tail: None,
-        ty: (),
+        ),
+        ty: test::X::R,
     },
 )
 
@@ -211,20 +202,17 @@ use X::R as RR;
 
 //! > expr_code
 { 
-    let _y = RR::<u8> { a: 3 };
+    RR::<u8> { a: 3 };
     use X::R;
-    let _x = R::<u8> { a: 4 }; 
+    R::<u8> { a: 4 }
 }
 
 //! > expected_semantics
 Block(
     ExprBlock {
         statements: [
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _y,
-                    ),
+            Expr(
+                StatementExpr {
                     expr: StructCtor(
                         ExprStructCtor {
                             concrete_struct_id: test::X::R::<core::integer::u8>,
@@ -248,34 +236,28 @@ Block(
             Item(
                 StatementItem,
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _x,
-                    ),
-                    expr: StructCtor(
-                        ExprStructCtor {
-                            concrete_struct_id: test::X::R::<core::integer::u8>,
-                            members: [
-                                (
-                                    MemberId(test::X::a),
-                                    Literal(
-                                        ExprLiteral {
-                                            value: 4,
-                                            ty: core::integer::u8,
-                                        },
-                                    ),
-                                ),
-                            ],
-                            base_struct: None,
-                            ty: test::X::R::<core::integer::u8>,
-                        },
-                    ),
+        ],
+        tail: Some(
+            StructCtor(
+                ExprStructCtor {
+                    concrete_struct_id: test::X::R::<core::integer::u8>,
+                    members: [
+                        (
+                            MemberId(test::X::a),
+                            Literal(
+                                ExprLiteral {
+                                    value: 4,
+                                    ty: core::integer::u8,
+                                },
+                            ),
+                        ),
+                    ],
+                    base_struct: None,
+                    ty: test::X::R::<core::integer::u8>,
                 },
             ),
-        ],
-        tail: None,
-        ty: (),
+        ),
+        ty: test::X::R::<core::integer::u8>,
     },
 )
 
@@ -301,20 +283,17 @@ use X::R as RR;
 
 //! > expr_code
 { 
-    let _y = RR::A(2);
+    RR::A(2);
     use X::R;
-    let _x = R::B(3); 
+    R::B(3)
 }
 
 //! > expected_semantics
 Block(
     ExprBlock {
         statements: [
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _y,
-                    ),
+            Expr(
+                StatementExpr {
                     expr: EnumVariantCtor(
                         ExprEnumVariantCtor {
                             variant: R::A,
@@ -332,28 +311,22 @@ Block(
             Item(
                 StatementItem,
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _x,
-                    ),
-                    expr: EnumVariantCtor(
-                        ExprEnumVariantCtor {
-                            variant: R::B,
-                            value_expr: Literal(
-                                ExprLiteral {
-                                    value: 3,
-                                    ty: core::integer::u16,
-                                },
-                            ),
-                            ty: test::X::R,
+        ],
+        tail: Some(
+            EnumVariantCtor(
+                ExprEnumVariantCtor {
+                    variant: R::B,
+                    value_expr: Literal(
+                        ExprLiteral {
+                            value: 3,
+                            ty: core::integer::u16,
                         },
                     ),
+                    ty: test::X::R,
                 },
             ),
-        ],
-        tail: None,
-        ty: (),
+        ),
+        ty: test::X::R,
     },
 )
 
@@ -379,20 +352,17 @@ use X::R as RR;
 
 //! > expr_code
 { 
-    let _y = RR::<u8>::A(2);
+    RR::<u8>::A(2);
     use X::R;
-    let _x = R::<u16>::B(3); 
+    R::<u16>::B(3)
 }
 
 //! > expected_semantics
 Block(
     ExprBlock {
         statements: [
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _y,
-                    ),
+            Expr(
+                StatementExpr {
                     expr: EnumVariantCtor(
                         ExprEnumVariantCtor {
                             variant: R::A,
@@ -410,28 +380,22 @@ Block(
             Item(
                 StatementItem,
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _x,
-                    ),
-                    expr: EnumVariantCtor(
-                        ExprEnumVariantCtor {
-                            variant: R::B,
-                            value_expr: Literal(
-                                ExprLiteral {
-                                    value: 3,
-                                    ty: core::integer::u16,
-                                },
-                            ),
-                            ty: test::X::R::<core::integer::u16>,
+        ],
+        tail: Some(
+            EnumVariantCtor(
+                ExprEnumVariantCtor {
+                    variant: R::B,
+                    value_expr: Literal(
+                        ExprLiteral {
+                            value: 3,
+                            ty: core::integer::u16,
                         },
                     ),
+                    ty: test::X::R::<core::integer::u16>,
                 },
             ),
-        ],
-        tail: None,
-        ty: (),
+        ),
+        ty: test::X::R::<core::integer::u16>,
     },
 )
 
@@ -608,8 +572,8 @@ mod R {
 //! > expr_code
 { 
     use X::R;
-    let _y = R::C;
-    let _x = R::B(3); 
+    R::C;
+    R::B(3)
 }
 
 //! > expected_semantics
@@ -619,11 +583,8 @@ Block(
             Item(
                 StatementItem,
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _y,
-                    ),
+            Expr(
+                StatementExpr {
                     expr: Missing(
                         ExprMissing {
                             ty: <missing>,
@@ -631,36 +592,30 @@ Block(
                     ),
                 },
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _x,
-                    ),
-                    expr: EnumVariantCtor(
-                        ExprEnumVariantCtor {
-                            variant: R::B,
-                            value_expr: Literal(
-                                ExprLiteral {
-                                    value: 3,
-                                    ty: core::integer::u16,
-                                },
-                            ),
-                            ty: test::X::R,
+        ],
+        tail: Some(
+            EnumVariantCtor(
+                ExprEnumVariantCtor {
+                    variant: R::B,
+                    value_expr: Literal(
+                        ExprLiteral {
+                            value: 3,
+                            ty: core::integer::u16,
                         },
                     ),
+                    ty: test::X::R,
                 },
             ),
-        ],
-        tail: None,
-        ty: (),
+        ),
+        ty: test::X::R,
     },
 )
 
 //! > expected_diagnostics
 error: Enum "test::X::R" has no variant "C"
- --> lib.cairo:14:17
-    let _y = R::C;
-                ^
+ --> lib.cairo:14:8
+    R::C;
+       ^
 
 //! > ==========================================================================
 
@@ -685,7 +640,7 @@ const R: u8 = 3;
 { 
     use X::R;
     let _y = R;
-    let _x = R::B(3);
+    R::B(3)
 }
 
 //! > expected_semantics
@@ -707,28 +662,22 @@ Block(
                     ),
                 },
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _x,
-                    ),
-                    expr: EnumVariantCtor(
-                        ExprEnumVariantCtor {
-                            variant: R::B,
-                            value_expr: Literal(
-                                ExprLiteral {
-                                    value: 3,
-                                    ty: core::integer::u16,
-                                },
-                            ),
-                            ty: test::X::R,
+        ],
+        tail: Some(
+            EnumVariantCtor(
+                ExprEnumVariantCtor {
+                    variant: R::B,
+                    value_expr: Literal(
+                        ExprLiteral {
+                            value: 3,
+                            ty: core::integer::u16,
                         },
                     ),
+                    ty: test::X::R,
                 },
             ),
-        ],
-        tail: None,
-        ty: (),
+        ),
+        ty: test::X::R,
     },
 )
 
@@ -760,9 +709,8 @@ use X::R;
 //! > expr_code
 { 
     const R: u8 = 3;
-
     let _y = R;
-    let _x = R::B(3);
+    R::B(3)
 }
 
 //! > expected_semantics
@@ -785,28 +733,22 @@ Block(
                     ),
                 },
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        _x,
-                    ),
-                    expr: EnumVariantCtor(
-                        ExprEnumVariantCtor {
-                            variant: R::B,
-                            value_expr: Literal(
-                                ExprLiteral {
-                                    value: 3,
-                                    ty: core::integer::u16,
-                                },
-                            ),
-                            ty: test::X::R,
+        ],
+        tail: Some(
+            EnumVariantCtor(
+                ExprEnumVariantCtor {
+                    variant: R::B,
+                    value_expr: Literal(
+                        ExprLiteral {
+                            value: 3,
+                            ty: core::integer::u16,
                         },
                     ),
+                    ty: test::X::R,
                 },
             ),
-        ],
-        tail: None,
-        ty: (),
+        ),
+        ty: test::X::R,
     },
 )
 
@@ -837,13 +779,11 @@ use generic_type::E as EE;
 //! > expr_code
 { 
     use generic_type::E;
-    let b = EE::B(3);
-    match b {
+    match EE::B(3) {
         EE::A(_) => {},
         EE::B(_) => {},
     }
-    let e = E::A(1);
-    match e {
+    match E::A(1) {
         E::A(_) => {},
         E::B(_) => {},
     }
@@ -856,31 +796,21 @@ Block(
             Item(
                 StatementItem,
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        b,
-                    ),
-                    expr: EnumVariantCtor(
-                        ExprEnumVariantCtor {
-                            variant: E::B,
-                            value_expr: Literal(
-                                ExprLiteral {
-                                    value: 3,
-                                    ty: core::integer::u16,
-                                },
-                            ),
-                            ty: test::generic_type::E,
-                        },
-                    ),
-                },
-            ),
             Expr(
                 StatementExpr {
                     expr: Match(
                         ExprMatch {
-                            matched_expr: Var(
-                                LocalVarId(test::b),
+                            matched_expr: EnumVariantCtor(
+                                ExprEnumVariantCtor {
+                                    variant: E::B,
+                                    value_expr: Literal(
+                                        ExprLiteral {
+                                            value: 3,
+                                            ty: core::integer::u16,
+                                        },
+                                    ),
+                                    ty: test::generic_type::E,
+                                },
                             ),
                             arms: [
                                 MatchArm {
@@ -937,12 +867,11 @@ Block(
                     ),
                 },
             ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
-                        e,
-                    ),
-                    expr: EnumVariantCtor(
+        ],
+        tail: Some(
+            Match(
+                ExprMatch {
+                    matched_expr: EnumVariantCtor(
                         ExprEnumVariantCtor {
                             variant: E::A,
                             value_expr: Literal(
@@ -953,15 +882,6 @@ Block(
                             ),
                             ty: test::generic_type::E,
                         },
-                    ),
-                },
-            ),
-        ],
-        tail: Some(
-            Match(
-                ExprMatch {
-                    matched_expr: Var(
-                        LocalVarId(test::e),
                     ),
                     arms: [
                         MatchArm {

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/generation_data.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/generation_data.rs
@@ -62,8 +62,6 @@ pub struct StarknetModuleCommonGenerationData {
     pub state_struct_code: RewriteNode,
     /// The generated event-related code.
     pub event_code: RewriteNode,
-    /// Use declarations to add to the internal submodules.
-    pub extra_uses_node: RewriteNode,
 }
 impl StarknetModuleCommonGenerationData {
     pub fn into_rewrite_node(


### PR DESCRIPTION
Note:
This is the best we can do for now.

This means we get:

 let MyStruct {
        long_long_long_long_key_a,
        long_long_long_long_key_b,
        long_long_long_long_key_c,
        long_long_long_long_key_b,
        long_long_long_long_key_b,
    } =
        my_val;
        
Instead of:

let MyStruct {
    long_long_long_long_key_a,
    long_long_long_long_key_b,
    long_long_long_long_key_c,
} = my_val;

This results from our breaking mechanism—always breaking the right-hand side first, which causes my_val to drop to the next line first.

It’s possible to change this, but it wouldn’t be a simple fix.
