### PR TITLE
updated struct line breaking

### DIFF
--- a/crates/cairo-lang-formatter/src/node_properties.rs
+++ b/crates/cairo-lang-formatter/src/node_properties.rs
@@ -458,6 +458,20 @@ impl SyntaxNodeFormat for SyntaxNode {
                 ))
             }
             _ => match self.kind(db) {
+                SyntaxKind::PatternStructParamList => {
+                    let leading_break_point = BreakLinePointProperties::new(
+                        2,
+                        BreakLinePointIndentation::IndentedWithTail,
+                        true,
+                        true,
+                    );
+                    let mut trailing_break_point = leading_break_point.clone();
+                    trailing_break_point.set_comma_if_broken();
+                    BreakLinePointsPositions::Both {
+                        leading: leading_break_point,
+                        trailing: trailing_break_point,
+                    }
+                }
                 SyntaxKind::ExprList | SyntaxKind::PatternList => {
                     let leading_break_point = BreakLinePointProperties::new(
                         2,

--- a/crates/cairo-lang-formatter/test_data/cairo_files/linebreaking.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/linebreaking.cairo
@@ -79,3 +79,12 @@ fn comment_remains_after_last_comma() {
         0 // Second comment that needs to remain although it follows a comma.
     ];
 }
+fn struct_line_breaking() {
+    let MyStruct { long_long_long_long_key_a,
+        long_long_long_long_key_b,
+        long_long_long_long_key_c,
+            long_long_long_long_key_b,
+            long_long_long_long_key_b,
+ } =
+            my_val;
+}

--- a/crates/cairo-lang-formatter/test_data/expected_results/linebreaking.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/linebreaking.cairo
@@ -295,3 +295,13 @@ fn comment_remains_after_last_comma() {
         0 // Second comment that needs to remain although it follows a comma.
     ];
 }
+fn struct_line_breaking() {
+    let MyStruct {
+        long_long_long_long_key_a,
+        long_long_long_long_key_b,
+        long_long_long_long_key_c,
+        long_long_long_long_key_b,
+        long_long_long_long_key_b,
+    } =
+        my_val;
+}


### PR DESCRIPTION
Note:
This is the best we can do for now.

This means we get:

let MyStruct {
long_long_long_long_key_a,
long_long_long_long_key_b,
long_long_long_long_key_c,
long_long_long_long_key_b,
long_long_long_long_key_b,
} =
my_val;

Instead of:

let MyStruct {
long_long_long_long_key_a,
long_long_long_long_key_b,
long_long_long_long_key_c,
} = my_val;

This results from our breaking mechanism—always breaking the right-hand side first, which causes my_val to drop to the next line first.

It’s possible to change this, but it wouldn’t be a simple fix.