### PR TITLE
Grammar and Style Improvements

### DIFF
--- a/crates/cairo-lang-language-server/CONTRIBUTING.md
+++ b/crates/cairo-lang-language-server/CONTRIBUTING.md
@@ -65,7 +65,7 @@ To generate a profile file, paste the following into your `.vscode/settings.json
 ```
 
 This will generate a trace file that you'll be able to further analyze.
-CairoLS will print the path to this trace file and instructions how to analyze it on its standard
+CairoLS will print the path to this trace file and instructions on how to analyze it on its standard
 error.
 In Visual Studio Code you will find this output in the `Output` → `Cairo Language Server` panel.
 We're not copying these here because nobody will bother keeping this document in sync.
@@ -74,7 +74,7 @@ We're not copying these here because nobody will bother keeping this document in
 
 If you find a short reproduction of your problem, we strongly suggest writing an E2E test and
 including it in your PR.
-Not only this will make your development cycle faster (because checking your changes will be now
+Not only will this make your development cycle faster (because checking your changes will be now
 automated),
 but you will also enable future developers not to fall into the pitfall that caused the bug you
 found and debugged 🤓.

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -1,6 +1,6 @@
 # Cairo 0 Features Parity
 
- In this page we track the missing features to reach feature parity with the old compiler version. We divided them by Cairo, Starknet and specific system calls in Starknet OS.
+ On this page we track the missing features to reach feature parity with the old compiler version. We divided them by Cairo, Starknet and specific system calls in Starknet OS.
 
  If we missed a feature, please let us know.
 
@@ -56,5 +56,4 @@
 | get_sequencer_address | ✅     |
 | get_transaction_info  | ✅     |
 | send_message_to_l1    | ✅     |
-| deploy                | ✅     |
 


### PR DESCRIPTION
1. crates/cairo-lang-language-server/CONTRIBUTING.md
- CairoLS will print the path to this trace file and instructions how to analyze it
+ CairoLS will print the path to this trace file and instructions on how to analyze it

- Not only this will make your development cycle faster
+ Not only will this make your development cycle faster
Reason: Added missing preposition "on" for correct English grammar. Restructured the sentence for proper conditional clause formation.

2. docs/FEATURE_PARITY.md
- In this page we track the missing features
+ On this page we track the missing features

- | deploy                | ✅     | (duplicate entry removed)
Reason: "On this page" is the correct prepositional phrase in English when referring to page content. Removed duplicate "deploy" entry to eliminate redundancy in the system calls table.