### PR TITLE
Update CODEOWNERS for `cairo-lang-doc`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/crates/cairo-lang-doc @orizi @mkaput @Arcticae @Draggu @piotmag769 @integraledelebesgue
+/crates/cairo-lang-doc @orizi @mkaput @wawel37
 /crates/cairo-lang-language-server @orizi @mkaput @Arcticae @Draggu @piotmag769 @integraledelebesgue
 /vscode-cairo @orizi @mkaput @Arcticae @Draggu @piotmag769 @integraledelebesgue


### PR DESCRIPTION
This reflects actual knowledge about this crate's codebase.