### PR TITLE
Fix capitalization error

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1,14 +1,14 @@
 The docs are written in [AsciiDoc](https://asciidoc.org/)(`.adoc`). You can view the docs locally in many ways.
 
 - View on IDE
-- View in Html
+- View in HTML
 - View in PDF
 
 ## View on IDE
 
 - Install `AsciiDoc`plugins in `VsCode` or `Intellij IDEA`
 
-## View in Html
+## View in HTML
 ### Install `asciidoctor`
 
 - Mac OS
@@ -21,7 +21,7 @@ brew install asciidoctor
 apt-get install asciidoctor
 ```
 
-### Convert to Html
+### Convert to HTML
 > Tips:`pwd` is `cairo/docs/reference`
 
 - Convert a single file
@@ -34,7 +34,7 @@ asciidoctor src/Summary.adoc
 asciidoctor src/*.adoc
 ```
 
-Now `Html` versions of the documentation will be generated.
+Now `HTML` versions of the documentation will be generated.
 
 ## View in PDF
 ### Install `asciidoctor`


### PR DESCRIPTION
Fixed:
Corrected Html to HTML for proper capitalization.

Why it's useful:
This change ensures correct capitalization, improving accuracy and consistency in the text.