### PR TITLE
Change `Secp256k1` and `Secp256r1` visibility

### DIFF
--- a/corelib/src/starknet/secp256k1.cairo
+++ b/corelib/src/starknet/secp256k1.cairo
@@ -15,7 +15,7 @@ use starknet::{
 #[derive(Copy, Drop)]
 pub extern type Secp256k1Point;
 
-pub(crate) impl Secp256k1Impl of Secp256Trait<Secp256k1Point> {
+pub impl Secp256k1Impl of Secp256Trait<Secp256k1Point> {
     // TODO(yuval): change to constant once u256 constants are supported.
     fn get_curve_size() -> u256 {
         0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
@@ -40,7 +40,7 @@ pub(crate) impl Secp256k1Impl of Secp256Trait<Secp256k1Point> {
     }
 }
 
-pub(crate) impl Secp256k1PointImpl of Secp256PointTrait<Secp256k1Point> {
+pub impl Secp256k1PointImpl of Secp256PointTrait<Secp256k1Point> {
     fn get_coordinates(self: Secp256k1Point) -> SyscallResult<(u256, u256)> {
         secp256k1_get_xy_syscall(self)
     }

--- a/corelib/src/starknet/secp256r1.cairo
+++ b/corelib/src/starknet/secp256r1.cairo
@@ -12,7 +12,7 @@ use starknet::{
 #[derive(Copy, Drop)]
 pub extern type Secp256r1Point;
 
-pub(crate) impl Secp256r1Impl of Secp256Trait<Secp256r1Point> {
+pub impl Secp256r1Impl of Secp256Trait<Secp256r1Point> {
     // TODO(yuval): change to constant once u256 constants are supported.
     fn get_curve_size() -> u256 {
         0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
@@ -37,7 +37,7 @@ pub(crate) impl Secp256r1Impl of Secp256Trait<Secp256r1Point> {
     }
 }
 
-pub(crate) impl Secp256r1PointImpl of Secp256PointTrait<Secp256r1Point> {
+pub impl Secp256r1PointImpl of Secp256PointTrait<Secp256r1Point> {
     fn get_coordinates(self: Secp256r1Point) -> SyscallResult<(u256, u256)> {
         secp256r1_get_xy_syscall(self)
     }


### PR DESCRIPTION
There is a problem with migrating `snforge_std` to the newest edition.
Snforge requires these impls to cheat and verify signatures.

reference issue: https://github.com/foundry-rs/starknet-foundry/issues/2638
pr: https://github.com/foundry-rs/starknet-foundry/pull/2691
