### PR TITLE
Introduce error code for 'Not all trait items are implemented' diagnostic

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1343,6 +1343,7 @@ impl SemanticDiagnosticKind {
                 error_code!(E0002)
             }
             Self::MissingMember(_) => error_code!(E0003),
+            Self::MissingItemsInImpl(_) => error_code!(E0004),
             _ => return None,
         })
     }

--- a/crates/cairo-lang-semantic/src/items/tests/trait
+++ b/crates/cairo-lang-semantic/src/items/tests/trait
@@ -72,7 +72,7 @@ error: Type not found.
     fn param_test(ref a: u128) -> bad_type nopanic;
                                   ^******^
 
-error: Not all trait items are implemented. Missing: 'param_test', 'no_ret_ty'.
+error[E0004]: Not all trait items are implemented. Missing: 'param_test', 'no_ret_ty'.
  --> lib.cairo:7:6
 impl MyImpl of MyTrait::<A>;
      ^****^
@@ -425,7 +425,7 @@ trait MyTrait {
 impl MyImpl of MyTrait;
 
 //! > expected_diagnostics
-error: Not all trait items are implemented. Missing: 'foo1', 'foo2'.
+error[E0004]: Not all trait items are implemented. Missing: 'foo1', 'foo2'.
  --> lib.cairo:5:6
 impl MyImpl of MyTrait;
      ^****^
@@ -456,7 +456,7 @@ impl MyImpl of MyTrait;
 // TODO(TomerStarkware): improve diagnostics for missing impls.
 
 //! > expected_diagnostics
-error: Not all trait items are implemented. Missing: 'foo1', 'foo2', 'X', 'C'.
+error[E0004]: Not all trait items are implemented. Missing: 'foo1', 'foo2', 'X', 'C'.
  --> lib.cairo:9:6
 impl MyImpl of MyTrait;
      ^****^
@@ -509,7 +509,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error: Not all trait items are implemented. Missing: 'foo1', 'foo3', 'Y', 'D'.
+error[E0004]: Not all trait items are implemented. Missing: 'foo1', 'foo3', 'Y', 'D'.
  --> lib.cairo:16:6
 impl MyImpl of MyTrait {
      ^****^

--- a/crates/cairo-lang-semantic/src/items/tests/trait_const
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_const
@@ -732,7 +732,7 @@ trait MyTrait {
 impl MyImpl of MyTrait {}
 
 //! > expected_diagnostics
-error: Not all trait items are implemented. Missing: 'Y'.
+error[E0004]: Not all trait items are implemented. Missing: 'Y'.
  --> lib.cairo:4:6
 impl MyImpl of MyTrait {}
      ^****^

--- a/crates/cairo-lang-semantic/src/items/tests/trait_type
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_type
@@ -2276,7 +2276,7 @@ trait MyTrait {
 impl MyImpl of MyTrait {}
 
 //! > expected_diagnostics
-error: Not all trait items are implemented. Missing: 'ty'.
+error[E0004]: Not all trait items are implemented. Missing: 'ty'.
  --> lib.cairo:4:6
 impl MyImpl of MyTrait {}
      ^****^

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/diagnostics
@@ -1674,7 +1674,7 @@ warning: Plugin diagnostic: Impls with the embeddable attribute must implement a
     #[embeddable_as(MyImpl)]
     ^**********************^
 
-error: Not all trait items are implemented. Missing: 'no_self', 'self_of_wrong_type'.
+error[E0004]: Not all trait items are implemented. Missing: 'no_self', 'self_of_wrong_type'.
  --> lib.cairo:8:21
     #[embeddable_as(MyImpl)]
                     ^****^


### PR DESCRIPTION
Related to #5944

These are the changes from [this PR](https://github.com/starkware-libs/cairo/pull/6690) but without the LS part since we moved to a new repository.

## Changes
* "Not all trait items are implemented" diagnostic now has an error code `E0004`.