### PR TITLE
Fix typos and grammar in documentation comments

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -25,9 +25,9 @@ pub struct ClosureInfo {
 pub struct SemanticLoweringMapping {
     /// Maps member paths ([MemberPath]) to lowered variable ids or scattered variable ids.
     scattered: OrderedHashMap<MemberPath, Value>,
-    /// Maps captured member paths to a clusure that captured them.
+    /// Maps captured member paths to a closure that captured them.
     pub captured: UnorderedHashMap<MemberPath, VariableId>,
-    /// Maps captured member paths which are copiable to a clusure that captured them.
+    /// Maps captured member paths which are copiable to a closure that captured them.
     pub copiable_captured: UnorderedHashMap<MemberPath, VariableId>,
     /// Maps the variable id of a closure to the closure info.
     pub closures: UnorderedHashMap<VariableId, ClosureInfo>,

--- a/crates/cairo-lang-lowering/src/optimizations/cancel_ops.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/cancel_ops.rs
@@ -38,7 +38,7 @@ pub fn cancel_ops(lowered: &mut FlatLowered) {
     let CancelOpsContext { mut var_remapper, stmts_to_remove, .. } = analysis.analyzer;
 
     // Remove no-longer needed statements.
-    // Note that dedup() is used since a statement might be marked for removal more then once.
+    // Note that dedup() is used since a statement might be marked for removal more than once.
     for (block_id, stmt_id) in stmts_to_remove
         .into_iter()
         .sorted_by_key(|(block_id, stmt_id)| (block_id.0, *stmt_id))

--- a/crates/cairo-lang-lowering/src/optimizations/match_optimizer.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/match_optimizer.rs
@@ -242,7 +242,7 @@ pub struct FixInfo {
 
 #[derive(Clone)]
 struct OptimizationCandidate<'a> {
-    /// The variable that is match.
+    /// The variable that is matched.
     match_variable: VariableId,
 
     /// The match arms of the extern match that we are optimizing.


### PR DESCRIPTION
## Reason for Changes

1. "clusure" → "closure"
   - Fixes a spelling error of a technical term
   - "Closure" is the correct spelling for this programming concept

2. "then" → "than"
   - Fixes incorrect word usage
   - "Than" is the correct word for comparisons
   - "Then" is used for sequential events

3. "match" → "matched"
   - Fixes grammar in passive voice construction
   - When using "is" in passive voice, the past participle form ("matched") is required