### PR TITLE
update error message for missing '0x' prefix

### DIFF
--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -31,7 +31,7 @@ where
     match s.strip_prefix("0x") {
         Some(num_no_prefix) => BigUint::from_str_radix(num_no_prefix, 16)
             .map_err(|error| serde::de::Error::custom(format!("{error}"))),
-        None => Err(serde::de::Error::custom(format!("{s} does not start with `0x` is missing."))),
+        None => Err(serde::de::Error::custom(format!("{s} does not start with '0x', which is missing."))),
     }
 }
 

--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -31,7 +31,9 @@ where
     match s.strip_prefix("0x") {
         Some(num_no_prefix) => BigUint::from_str_radix(num_no_prefix, 16)
             .map_err(|error| serde::de::Error::custom(format!("{error}"))),
-        None => Err(serde::de::Error::custom(format!("{s} does not start with '0x', which is missing."))),
+        None => Err(serde::de::Error::custom(format!(
+            "{s} does not start with `0x`, which is missing."
+        ))),
     }
 }
 


### PR DESCRIPTION
## Summary

The error message read a bit strange, so I updated it to make it more explicit.






