### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/cairo-lang-primitive-token/src/lib.rs
+++ b/crates/cairo-lang-primitive-token/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-//! This crate defines unfiorm and primitive form of the TokenStream.
+//! This crate defines uniform and primitive form of the TokenStream.
 //! We want this to be as stable as possible and limit the changes here to bare minimum.
 
 /// Primitive representation of a token's span.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `unfiorm` to `uniform`

Please review the changes and let me know if any additional changes are needed.