### PR TITLE
Fix typos and grammar in documentation

### DIFF
--- a/crates/cairo-lang-runner/README.md
+++ b/crates/cairo-lang-runner/README.md
@@ -10,7 +10,7 @@ If we want to run code that is gas tested:
 cargo run --bin cairo-run -- --single-file /path/to/file.cairo --available-gas 200
 ```
 
-We currently only run the `main` function with no arguments beside implicits.
+We currently only run the `main` function with no arguments besides implicits.
 
 # Example
 


### PR DESCRIPTION
Corrected a minor grammatical error in the documentation by changing "beside implicits" to "besides implicits". This improves the clarity and grammatical accuracy of the text for better readability.
