### PR TITLE
Fix incorrect formatting in panic! macro.

### DIFF
--- a/crates/cairo-lang-utils/src/casts.rs
+++ b/crates/cairo-lang-utils/src/casts.rs
@@ -5,7 +5,7 @@ pub trait IntoOrPanic: Sized + Copy + core::fmt::Debug {
         <T as TryFrom<Self>>::Error: core::fmt::Debug,
     {
         let as_opt: Result<T, _> = self.try_into();
-        as_opt.unwrap_or_else(|_| panic!("Failed to cast from {self:?}."))
+        as_opt.unwrap_or_else(|_| panic!("Failed to cast from {:?}.", self))
     }
 }
 


### PR DESCRIPTION
###The change is important because the original code uses a string literal with `{self:?}` 
directly inside `panic!`. Rust interprets this literally instead of formatting it. 
This causes a compile-time error. Using `{:?}` with `self` as an argument ensures proper formatting.

panic!("Failed to cast from {:?}.", self) // Correct
