### PR TITLE
Update pattern

### DIFF
--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/pattern
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/pattern
@@ -5,8 +5,8 @@ get_diagnostics
 
 //! > cairo_code
 fn f() {
-    let ref abc::def = 5;
-    let A { x
+    let x = abc::def;  
+    let A { x } = value;  
     let x = 5;
 }
 


### PR DESCRIPTION
Why needed:
- Fixed incorrect ref modifier placement
- Added missing closing brace } for struct pattern
- Added missing semicolons
- Completed incomplete expressions


These changes aim to fix basic syntax errors and make the code compilable. However, the exact syntax should be verified against Cairo's official documentation.