### PR TITLE
Pattern

### DIFF
--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -35,7 +35,7 @@ pub enum ParserDiagnosticKind {
     MissingTypeClause,
     MissingTypeExpression,
     MissingWrappedArgList,
-    MissingPatteren,
+    MissingPattern,
     ExpectedInToken,
     ItemInlineMacroWithoutBang { identifier: SmolStr, bracket_type: SyntaxKind },
     ReservedIdentifier { identifier: SmolStr },
@@ -82,7 +82,7 @@ impl DiagnosticEntry for ParserDiagnostic {
                                                             list wrapped in either parentheses, \
                                                             brackets, or braces."
                 .to_string(),
-            ParserDiagnosticKind::MissingPatteren => {
+            ParserDiagnosticKind::MissingPattern => {
                 "Missing tokens. Expected a pattern.".to_string()
             }
             ParserDiagnosticKind::ExpectedInToken => {

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -1752,7 +1752,7 @@ impl<'a> Parser<'a> {
 
             let pattern_list_green = if pattern_list.is_empty() {
                 self.create_and_report_missing::<PatternListOr>(
-                    ParserDiagnosticKind::MissingPatteren,
+                    ParserDiagnosticKind::MissingPattern,
                 )
             } else {
                 PatternListOr::new_green(self.db, pattern_list)


### PR DESCRIPTION
This change fixes a spelling error in the diagnostic message enum variant. The word "Patteren" was incorrectly spelled and has been corrected to "Pattern". This improvement: