### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -27,7 +27,7 @@ pub const CORELIB_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Unique identifier of a crate.
 ///
-/// This directly translates to [`DependencySettings.discriminator`] expect the discriminator
+/// This directly translates to [`DependencySettings.discriminator`] except the discriminator
 /// **must** be `None` for the core crate.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct CrateIdentifier(SmolStr);


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `expect` to `except`

Please review the changes and let me know if any additional changes are needed.