### PR TITLE
Fix article usage and minor typos

### DIFF
--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -171,7 +171,7 @@ impl<'a> DocumentationCommentParser<'a> {
             .to_documentable_item_id(self.db.upcast())
     }
 
-    /// Parses the path as a string to an Path Expression, which can be later used by a resolver.
+    /// Parses the path as a string to a Path Expression, which can be later used by a resolver.
     fn prase_comment_link_path(&self, path: String) -> Option<ExprPath> {
         let virtual_file = FileLongId::Virtual(VirtualFile {
             parent: Default::default(),

--- a/crates/cairo-lang-executable/src/executable.rs
+++ b/crates/cairo-lang-executable/src/executable.rs
@@ -44,7 +44,7 @@ impl Executable {
     }
 }
 
-/// Information about a executable entrypoint.
+/// Information about an executable entrypoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutableEntryPoint {
     /// The used builtins of the function.

--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -155,7 +155,7 @@ pub struct ExperimentalFeaturesConfig {
     pub associated_item_constraints: bool,
     /// Allows using coupon types and coupon calls.
     ///
-    /// Each function has a associated `Coupon` type, which represents paying the cost of the
+    /// Each function has an associated `Coupon` type, which represents paying the cost of the
     /// function before calling it.
     #[serde(default)]
     pub coupons: bool,

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -219,7 +219,7 @@ enum Value {
     Scattered(Box<Scattered>),
 }
 
-/// A value for an non-stored member path. Recursively holds the [Value] for the members.
+/// A value for a non-stored member path. Recursively holds the [Value] for the members.
 #[derive(Clone, Debug, DebugWithDb)]
 #[debug_db(ExprFormatter<'a>)]
 struct Scattered {

--- a/crates/cairo-lang-sierra-generator/src/ap_tracking.rs
+++ b/crates/cairo-lang-sierra-generator/src/ap_tracking.rs
@@ -129,7 +129,7 @@ impl Analyzer<'_> for ApTrackingAnalysisContext {
         infos: impl Iterator<Item = Self::Info>,
     ) -> Self::Info {
         // Find all the variables that are alive after this block convergence.
-        // A variable is alive after a converges if it is a alive in some block that is reachable
+        // A variable is alive after a converges if it is an alive in some block that is reachable
         // from it by any arm.
         let mut vars = OrderedHashMap::<VariableId, OrderedHashSet<BlockId>>::default();
         let mut any_merges = false;

--- a/crates/cairo-lang-starknet/src/plugin/events.rs
+++ b/crates/cairo-lang-starknet/src/plugin/events.rs
@@ -91,7 +91,7 @@ pub fn get_starknet_event_variants(
                     module_kind.to_str_capital()
                 ),
             ));
-            // The attribute is missing, but this counts as a event - we can't create another
+            // The attribute is missing, but this counts as an event - we can't create another
             // (empty) event.
             Some(variants)
         }


### PR DESCRIPTION
This pull request resolves grammatical issues in the documentation comments within multiple Rust source files. 

Specifically:  
- Corrects the use of articles ("a" vs. "an") to align with proper English grammar.  
- Fixes minor typos to improve clarity and documentation quality.  