### PR TITLE
fix: Improve clarity of comment in the script Update sierra_update_ch…

### DIFF
--- a/scripts/sierra_update_check.sh
+++ b/scripts/sierra_update_check.sh
@@ -25,7 +25,7 @@ if [ $? -eq 0 ]; then
     echo " - Add 'SIERRA_UPDATE_NO_CHANGE_TAG=<reason>'."
     echo "If there is a change - but it does not affect which code will be compiled:"
     echo " - Add 'SIERRA_UPDATE_PATCH_CHANGE_TAG=<reason>'."
-    echo "If there is a change, but previously compilable code is still compilable:"
+    echo "If there is a change, but the code that was previously compilable remains compilable:"
     echo " - Add 'SIERRA_UPDATE_MINOR_CHANGE_TAG=<reason>'."
     echo "If there is a breaking change, and old code is no longer compilable:"
     echo " - Add 'SIERRA_UPDATE_MAJOR_CHANGE_TAG=<reason>'."


### PR DESCRIPTION
I've made a small improvement in the comment that explains when the code change does not break previously compilable code. The original phrasing was a bit unclear, so I updated it to make the message more precise.

The updated comment is now:

```bash
echo "If there is a change, but the code that was previously compilable remains compilable:"
```

This should help to avoid any confusion when reading the script and make the intention behind the condition more understandable.