### PR TITLE
feat(corelib): add boolean operators to Result type

### DIFF
--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -42,46 +42,6 @@
 //! which will cause the compiler to issue a warning when a Result
 //! value is ignored.
 //!
-//! # The question mark operator, `?`
-//!
-//! When writing code that calls many functions that return the [`Result`] type,
-//! handling `Ok`/`Err` can be tedious. The question mark operator, `?`,
-//! hides some of the boilerplate of propagating errors up the call stack.
-//!
-//! It replaces this:
-//!
-//! ```
-//! use core::integer::u8_overflowing_add;
-//!
-//! fn add_three_numbers(a: u8, b: u8, c: u8) -> Result<u8, u8> {
-//!     match u8_overflowing_add(a, b) {
-//!         Result::Ok(sum_ab) => {
-//!             match u8_overflowing_add(sum_ab, c) {
-//!                 Result::Ok(total) => Result::Ok(total),
-//!                 Result::Err(e) => Result::Err(e),
-//!             }
-//!         },
-//!         Result::Err(e) => Result::Err(e),
-//!     }
-//! }
-//! ```
-//!
-//! With this:
-//!
-//! ```
-//! use core::integer::u8_overflowing_add;
-//!
-//! fn add_three_numbers_2(a: u8, b: u8, c: u8) -> Result<u8, u8> {
-//!     let total = u8_overflowing_add(u8_overflowing_add(a, b)?, c)?;
-//!     Result::Ok(total)
-//! }
-//! ```
-//!
-//! *It's much nicer!*
-//!
-//! [`Ok`]: Result::Ok
-//! [`Err`]: Result::Err
-//!
 //! # Method overview
 //!
 //! In addition to working with pattern matching, [`Result`] provides a wide
@@ -169,6 +129,47 @@
 //!
 //! [`and_then`]: ResultTrait::and_then
 //! [`or_else`]: ResultTrait::or_else
+//!
+//! # The question mark operator, `?`
+//!
+//! When writing code that calls many functions that return the [`Result`] type,
+//! handling `Ok`/`Err` can be tedious. The question mark operator, `?`,
+//! hides some of the boilerplate of propagating errors up the call stack.
+//!
+//! It replaces this:
+//!
+//! ```
+//! use core::integer::u8_overflowing_add;
+//!
+//! fn add_three_numbers(a: u8, b: u8, c: u8) -> Result<u8, u8> {
+//!     match u8_overflowing_add(a, b) {
+//!         Result::Ok(sum_ab) => {
+//!             match u8_overflowing_add(sum_ab, c) {
+//!                 Result::Ok(total) => Result::Ok(total),
+//!                 Result::Err(e) => Result::Err(e),
+//!             }
+//!         },
+//!         Result::Err(e) => Result::Err(e),
+//!     }
+//! }
+//! ```
+//!
+//! With this:
+//!
+//! ```
+//! use core::integer::u8_overflowing_add;
+//!
+//! fn add_three_numbers_2(a: u8, b: u8, c: u8) -> Result<u8, u8> {
+//!     let total = u8_overflowing_add(u8_overflowing_add(a, b)?, c)?;
+//!     Result::Ok(total)
+//! }
+//! ```
+//!
+//! *It's much nicer!*
+//!
+//! [`Ok`]: Result::Ok
+//! [`Err`]: Result::Err
+//!
 
 #[allow(unused_imports)]
 use crate::array::{ArrayTrait, SpanTrait};

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -284,7 +284,7 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
         }
     }
 
-    /// Returns `res` if the result is `Ok`, otherwise returns the `Err` value of `self`.
+    /// Returns `other` if the result is `Ok`, otherwise returns the `Err` value of `self`.
     ///
     /// # Examples
     ///
@@ -305,13 +305,12 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     /// let y: Result<ByteArray, ByteArray> = Result::Ok("different result type");
     /// assert!(x.and(y) == Result::Ok("different result type"));
     /// ```
-    //TODO: why can't I restrict E and U to implement Destruct rather than Drop?
     #[inline]
     fn and<U, +Destruct<T>, +Drop<E>, +Drop<U>>(
-        self: Result<T, E>, res: Result<U, E>,
+        self: Result<T, E>, other: Result<U, E>,
     ) -> Result<U, E> {
         match self {
-            Result::Ok(_) => res,
+            Result::Ok(_) => other,
             Result::Err(e) => Result::Err(e),
         }
     }
@@ -347,7 +346,7 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
         }
     }
 
-    /// Returns `res` if the result is `Err`, otherwise returns the `Ok` value of `self`.
+    /// Returns `other` if the result is `Err`, otherwise returns the `Ok` value of `self`.
     ///
     /// # Examples
     ///
@@ -368,14 +367,13 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     /// let y: Result<u32, ByteArray> = Result::Ok(100);
     /// assert!(x.or(y) == Result::Ok(2));
     /// ```
-    //TODO: why can't I restrict E and U to implement Destruct rather than Drop?
     #[inline]
     fn or<F, +Drop<T>, +Drop<F>, +Destruct<E>>(
-        self: Result<T, E>, res: Result<T, F>,
+        self: Result<T, E>, other: Result<T, F>,
     ) -> Result<T, F> {
         match self {
             Result::Ok(v) => Result::Ok(v),
-            Result::Err(_) => res,
+            Result::Err(_) => other,
         }
     }
 

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -334,7 +334,6 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     ///
     /// let y = sq_then_string(65536);
     /// assert!(y == Result::Err("overflowed"));
-    ///
     /// ```
     #[inline]
     fn and_then<U, F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: Result<U, E>]>(

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -270,13 +270,7 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     /// assert!(Result::Err("foo").unwrap_or_else(|e: ByteArray| e.len()) == 3);
     /// ```
     #[inline]
-    fn unwrap_or_else<
-        F,
-        +Destruct<E>,
-        +Drop<F>,
-        impl func: core::ops::FnOnce<F, (E,)>[Output: T],
-        +Drop<func::Output>,
-    >(
+    fn unwrap_or_else<F, +Destruct<E>, +Drop<F>, +core::ops::FnOnce<F, (E,)>[Output: T]>(
         self: Result<T, E>, f: F,
     ) -> T {
         match self {
@@ -337,7 +331,7 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     /// assert!(y == Result::Err("overflowed"));
     /// ```
     #[inline]
-    fn and_then<U, F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: Result<U, E>]>(
+    fn and_then<U, F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: Result<U, E>]>(
         self: Result<T, E>, op: F,
     ) -> Result<U, E> {
         match self {
@@ -397,7 +391,7 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     /// assert!(z == Result::Ok(100));
     /// ```
     #[inline]
-    fn or_else<F, O, +Drop<O>, impl func: core::ops::FnOnce<O, (E,)>[Output: Result<T, F>]>(
+    fn or_else<F, O, +Drop<O>, +core::ops::FnOnce<O, (E,)>[Output: Result<T, F>]>(
         self: Result<T, E>, op: O,
     ) -> Result<T, F> {
         match self {

--- a/corelib/src/test/result_test.cairo
+++ b/corelib/src/test/result_test.cairo
@@ -51,6 +51,115 @@ fn test_result_err_unwrap_or_default() {
 }
 
 #[test]
+fn test_result_ok_unwrap_or_else() {
+    assert!(Result::Ok(2).unwrap_or_else(|e: ByteArray| e.len()) == 2);
+}
+
+#[test]
+fn test_result_err_unwrap_or_else() {
+    assert!(Result::Err("foo").unwrap_or_else(|e: ByteArray| e.len()) == 3);
+}
+
+#[test]
+fn test_result_ok_and_err() {
+    let x: Result<u32, ByteArray> = Result::Ok(2);
+    let y: Result<ByteArray, ByteArray> = Result::Err("late error");
+    assert!(x.and(y) == Result::Err("late error"));
+}
+
+#[test]
+fn test_result_err_and_ok() {
+    let x: Result<u32, ByteArray> = Result::Err("early error");
+    let y: Result<ByteArray, ByteArray> = Result::Ok("foo");
+    assert!(x.and(y) == Result::Err("early error"));
+}
+
+#[test]
+fn test_result_err_and_err() {
+    let x: Result<u32, ByteArray> = Result::Err("not a 2");
+    let y: Result<ByteArray, ByteArray> = Result::Err("late error");
+    assert!(x.and(y) == Result::Err("not a 2"));
+}
+
+#[test]
+fn test_result_and_ok_and_ok() {
+    let x: Result<u32, ByteArray> = Result::Ok(2);
+    let y: Result<ByteArray, ByteArray> = Result::Ok("different result type");
+    assert!(x.and(y) == Result::Ok("different result type"));
+}
+
+#[test]
+fn test_result_err_and_then() {
+    let checked_mul = core::num::traits::CheckedMul::checked_mul(65536_u32, 65536_u32)
+        .ok_or("overflowed");
+    let res: Result<ByteArray, ByteArray> = checked_mul.and_then(|v| Result::Ok(format!("{}", v)));
+    assert!(res == Result::Err("overflowed"));
+}
+
+#[test]
+fn test_result_ok_and_then_err() {
+    let x: Result<u32, ByteArray> = Result::<u32, ByteArray>::Ok(2)
+        .and_then(|_x| Result::Err("late error"));
+    assert!(x == Result::Err("late error"));
+}
+
+#[test]
+fn test_result_ok_and_then_ok() {
+    let checked_mul = core::num::traits::CheckedMul::checked_mul(4_u32, 4_u32).ok_or("overflowed");
+    let res: Result<ByteArray, ByteArray> = checked_mul.and_then(|v| Result::Ok(format!("{}", v)));
+    assert!(res == Result::Ok("16"));
+}
+
+#[test]
+fn test_result_or_ok_and_err() {
+    let x: Result<u32, ByteArray> = Result::Ok(2);
+    let y: Result<u32, ByteArray> = Result::Err("late error");
+    assert!(x.or(y) == Result::Ok(2));
+}
+
+#[test]
+fn test_result_or_err_and_ok() {
+    let x: Result<u32, ByteArray> = Result::Err("early error");
+    let y: Result<u32, ByteArray> = Result::Ok(2);
+    assert!(x.or(y) == Result::Ok(2));
+}
+
+#[test]
+fn test_result_or_err_and_err() {
+    let x: Result<u32, ByteArray> = Result::Err("not a 2");
+    let y: Result<u32, ByteArray> = Result::Err("late error");
+    assert!(x.or(y) == Result::Err("late error"));
+}
+
+#[test]
+fn test_result_or_ok_and_ok() {
+    let x: Result<u32, ByteArray> = Result::Ok(2);
+    let y: Result<u32, ByteArray> = Result::Ok(100);
+    assert!(x.or(y) == Result::Ok(2));
+}
+
+#[test]
+fn test_result_err_or_else_err() {
+    let y: Result<u32, ByteArray> = Result::<u32, ByteArray>::Err("bad input")
+        .or_else(|_e| Result::Err("not 42"));
+    assert!(y == Result::Err("not 42"));
+}
+
+#[test]
+fn test_result_err_or_else_ok() {
+    let x: Result<u32, ByteArray> = Result::<u32, ByteArray>::Err("bad input")
+        .or_else(|_e| Result::Ok(42));
+    assert!(x == Result::Ok(42));
+}
+
+#[test]
+fn test_result_ok_or_else() {
+    let z: Result<u32, ByteArray> = Result::<u32, ByteArray>::Ok(100).or_else(|_e| Result::Ok(42));
+    assert!(z == Result::Ok(100));
+}
+
+
+#[test]
 #[should_panic(expected: ('err msg',))]
 fn test_result_ok_expect_err() {
     let result: Result<u32, felt252> = Result::Ok(42);


### PR DESCRIPTION
Adds `and`, `and_then`, `or`, `or_else`, `unwrap_or_else` to ResultTrait along with tests.

note: the module documentation is taken from Rust's. the item-level doc was adapted to Cairo.