### PR TITLE
Fix quotation mark

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/contracts.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/contracts.adoc
@@ -30,8 +30,8 @@ module as a contract.
 == Storage
 
 
-Unlike a Cairo program, which is stateless, a Starknet contract has a state, called “the contract’s
-storage”.
+Unlike a Cairo program, which is stateless, a Starknet contract has a state, called "the contract’s
+storage".
 Transactions invoked on such contracts may modify this state.
 
 In a contract, you can define a struct named `Storage`. The members of this struct are the storage


### PR DESCRIPTION
the unexpected marks might confuse readers and be distracted by them. Also some editors might not render correctly depending on the software or platform used, appearing as gibberish or causing formatting problems.