### PR TITLE
fix(corelib): migrate deprecated-index-traits

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -65,12 +65,12 @@ use crate::box::BoxTrait;
 use crate::iter::Iterator;
 use crate::metaprogramming::TypeEqual;
 use crate::serde::Serde;
+use crate::ops::IndexView;
 use crate::RangeCheck;
 #[allow(unused_imports)]
 use crate::gas::withdraw_gas;
 #[allow(unused_imports)]
 use crate::option::OptionTrait;
-use crate::ops::IndexView;
 /// A collection of elements of the same type continuous in memory.
 #[derive(Drop)]
 pub extern type Array<T>;

--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -70,8 +70,7 @@ use crate::RangeCheck;
 use crate::gas::withdraw_gas;
 #[allow(unused_imports)]
 use crate::option::OptionTrait;
-#[feature("deprecated-index-traits")]
-use crate::traits::IndexView;
+use crate::ops::IndexView;
 /// A collection of elements of the same type continuous in memory.
 #[derive(Drop)]
 pub extern type Array<T>;
@@ -285,7 +284,9 @@ impl ArrayDefault<T> of Default<Array<T>> {
     }
 }
 
-impl ArrayIndex<T> of IndexView<Array<T>, usize, @T> {
+impl ArrayIndexView<T> of IndexView<Array<T>, usize> {
+    // The returned target type after indexing.
+    type Target = @T;
     /// Returns a snapshot of the element at the given index.
     ///
     /// # Examples
@@ -295,7 +296,7 @@ impl ArrayIndex<T> of IndexView<Array<T>, usize, @T> {
     /// let element: @u8 = arr[0];
     /// assert!(element == @1);
     /// ```
-    fn index(self: @Array<T>, index: usize) -> @T {
+    fn index(self: @Array<T>, index: usize) -> Self::Target {
         array_at(self, index).unbox()
     }
 }
@@ -619,7 +620,9 @@ pub impl SpanImpl<T> of SpanTrait<T> {
     }
 }
 
-pub impl SpanIndex<T> of IndexView<Span<T>, usize, @T> {
+pub impl SpanIndexView<T> of IndexView<Span<T>, usize> {
+    /// The returned target type after indexing.
+    type Target = @T;
     /// Returns a snapshot of the element at the given index.
     ///
     /// # Examples
@@ -630,7 +633,7 @@ pub impl SpanIndex<T> of IndexView<Span<T>, usize, @T> {
     /// assert!(element == @1);
     /// ```
     #[inline]
-    fn index(self: @Span<T>, index: usize) -> @T {
+    fn index(self: @Span<T>, index: usize) -> Self::Target {
         array_at(*self.snapshot, index).unbox()
     }
 }

--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -484,9 +484,22 @@ impl ByteArrayAddEq of crate::traits::AddEq<ByteArray> {
     }
 }
 
-#[feature("deprecated-index-traits")]
-pub(crate) impl ByteArrayIndexView of crate::traits::IndexView<ByteArray, usize, u8> {
-    fn index(self: @ByteArray, index: usize) -> u8 {
+pub(crate) impl ByteArrayIndexView of crate::ops::IndexView<ByteArray, usize> {
+    /// The returned target type after indexing.
+    type Target = u8;
+    /// Takes a `ByteArray` index and returns the corresponding value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut ba: ByteArray = "hello";
+    /// assert!(ba[0] == 'h');
+    /// assert!(ba[1] == 'e');
+    /// assert!(ba[2] == 'l');
+    /// assert!(ba[3] == 'l');
+    /// assert!(ba[4] == 'o');
+    /// ```
+    fn index(self: @ByteArray, index: usize) -> Self::Target {
         self.at(index).expect('Index out of bounds')
     }
 }

--- a/corelib/src/bytes_31.cairo
+++ b/corelib/src/bytes_31.cairo
@@ -53,9 +53,21 @@ pub impl Bytes31Impl of Bytes31Trait {
     }
 }
 
-#[feature("deprecated-index-traits")]
-pub(crate) impl Bytes31IndexView of crate::traits::IndexView<bytes31, usize, u8> {
-    fn index(self: @bytes31, index: usize) -> u8 {
+pub(crate) impl Bytes31IndexView of crate::ops::IndexView<bytes31, usize> {
+    // The returned target type after indexing.
+    type Target = u8;
+    /// Returns the byte at the given index (LSB's index is 0).
+    ///
+    /// Assumes that `index < BYTES_IN_BYTES31`. If the assumption is not met, the behavior is
+    /// undefined.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let bytes: bytes31 = 1_u8.into();
+    /// assert!(bytes[0] == 1);
+    /// ```
+    fn index(self: @bytes31, index: usize) -> Self::Target {
         self.at(index)
     }
 }

--- a/corelib/src/dict.cairo
+++ b/corelib/src/dict.cairo
@@ -47,8 +47,8 @@
 //! dict = entry.finalize(new_value);
 //! ```
 
-#[feature("deprecated-index-traits")]
-use crate::traits::{Default, Felt252DictValue, Index};
+use crate::traits::{Default, Felt252DictValue};
+use crate::ops::Index;
 
 /// A dictionary that maps `felt252` keys to a value of any type.
 pub extern type Felt252Dict<T>;
@@ -245,7 +245,9 @@ impl Felt252DictEntryDestruct<T, +Drop<T>, +Felt252DictValue<T>> of Destruct<Fel
 /// Allows accessing dictionary elements using the index operator `[]`.
 impl Felt252DictIndex<
     T, +Felt252DictTrait<T>, +Copy<T>, +Destruct<Felt252DictEntry<T>>,
-> of Index<Felt252Dict<T>, felt252, T> {
+> of Index<Felt252Dict<T>, felt252> {
+    // The returned target type after indexing.
+    type Target = T;
     /// Takes a `felt252` index and returns the corresponding value.
     ///
     /// # Examples
@@ -260,7 +262,7 @@ impl Felt252DictIndex<
     /// assert!(value == 10);
     /// ```
     #[inline]
-    fn index(ref self: Felt252Dict<T>, index: felt252) -> T {
+    fn index(ref self: Felt252Dict<T>, index: felt252) -> Self::Target {
         self.get(index)
     }
 }


### PR DESCRIPTION
- Migrate all deprecated `core::traits::{IndexView, Index}` to `core::ops::{IndexView, Index}` (`Array`, `ByteArray`, `bytes31`, `Felt252Dict`)
- Add missing documentation
- Rename `IndexView` implementation of `ArrayIndex` and `SpanIndex` to `ArrayIndexView` and `SpanIndexView`
