### PR TITLE
feat(corelib): range is_empty

### DIFF
--- a/corelib/src/ops.cairo
+++ b/corelib/src/ops.cairo
@@ -8,10 +8,10 @@ mod deref;
 pub use deref::DerefMut;
 pub use deref::{Deref, SnapshotDeref};
 mod range;
-pub use range::Range;
 // `RangeOp` is used internally by the compiler.
 #[allow(unused_imports)]
 use range::RangeOp;
+pub use range::{Range, RangeTrait};
 
 mod function;
 pub use function::{Fn, FnOnce};

--- a/corelib/src/ops/range.cairo
+++ b/corelib/src/ops/range.cairo
@@ -11,6 +11,23 @@ pub struct Range<T> {
     pub end: T,
 }
 
+#[generate_trait]
+pub impl RangeImpl<T, +Copy<T>, +Drop<T>, +PartialOrd<T>> of RangeTrait<T> {
+    /// Returns `true` if the range contains no items.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert!(!(3_u8..5_u8).is_empty());
+    /// assert!( (3_u8..3_u8).is_empty());
+    /// assert!( (3_u8..2_u8).is_empty());
+    /// ```
+    #[inline]
+    fn is_empty(self: @Range<T>) -> bool {
+        !(self.start < self.end)
+    }
+}
+
 /// Handles the range operator (`..`).
 #[generate_trait]
 pub impl RangeOpImpl<T> of RangeOp<T> {

--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -20,6 +20,7 @@ mod num_test;
 mod option_test;
 mod plugins_test;
 mod print_test;
+mod range_test;
 mod result_test;
 mod secp256k1_test;
 mod secp256r1_test;

--- a/corelib/src/test/range_test.cairo
+++ b/corelib/src/test/range_test.cairo
@@ -1,0 +1,8 @@
+use core::ops::RangeTrait;
+
+#[test]
+fn test_range_is_empty() {
+    assert!(!(3_u8..5_u8).is_empty());
+    assert!((3_u8..3_u8).is_empty());
+    assert!((3_u8..2_u8).is_empty());
+}


### PR DESCRIPTION
Add `core::ops::RangeTrait` with:

`fn is_empty(self: @Range<T>) -> bool`

Returns `true` if the range contains no items.

#### Examples

```cairo
assert!(!(3_u8..5_u8).is_empty());
assert!( (3_u8..3_u8).is_empty());
assert!( (3_u8..2_u8).is_empty());
```