### PR TITLE
feat(corelib): Impl fmt::debug for Range

### DIFF
--- a/corelib/src/ops/range.cairo
+++ b/corelib/src/ops/range.cairo
@@ -11,6 +11,22 @@ pub struct Range<T> {
     pub end: T,
 }
 
+impl RangeDebug<T, impl TDebug: crate::fmt::Debug<T>> of crate::fmt::Debug<Range<T>> {
+    /// Formats a `Range` type, allowing to print `Range` instances for debugging purposes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// println!("{:?}", 1..5); // Result will be `1..5`
+    /// ```
+    fn fmt(self: @Range<T>, ref f: crate::fmt::Formatter) -> Result<(), crate::fmt::Error> {
+        self.start.fmt(ref f)?;
+        write!(f, "..")?;
+        self.end.fmt(ref f)?;
+        Result::Ok(())
+    }
+}
+
 /// Handles the range operator (`..`).
 #[generate_trait]
 pub impl RangeOpImpl<T> of RangeOp<T> {

--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -20,6 +20,7 @@ mod num_test;
 mod option_test;
 mod plugins_test;
 mod print_test;
+mod range_test;
 mod result_test;
 mod secp256k1_test;
 mod secp256r1_test;

--- a/corelib/src/test/range_test.cairo
+++ b/corelib/src/test/range_test.cairo
@@ -1,4 +1,4 @@
 #[test]
 fn test_range_format() {
-    assert(format!("{:?}", 1..5) == "1..5", 'bad range debug formatting');
+    assert!(format!("{:?}", 1..5) == "1..5");
 }

--- a/corelib/src/test/range_test.cairo
+++ b/corelib/src/test/range_test.cairo
@@ -1,0 +1,4 @@
+#[test]
+fn test_range_format() {
+    assert(format!("{:?}", 1..5) == "1..5", 'bad range debug formatting');
+}


### PR DESCRIPTION
Formats a `Range` type, allowing to print `Range` instances for debugging purposes.

#### Example

```
println!("{:?}", 1..5); // Result will be `1..5`
```