### PR TITLE
feat(corelib): OptionTrait::is_some_and

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -88,6 +88,7 @@
 //!
 //! [`is_none`]: OptionTrait::is_none
 //! [`is_some`]: OptionTrait::is_some
+//! [`is_some_and`]: OptionTrait::is_some_and
 //!
 //! ## Extracting the contained value
 //!
@@ -211,7 +212,7 @@ pub trait OptionTrait<T> {
     /// assert_eq!(option.is_some_and(|x| x > 1), false);
     /// ```
     #[must_use]
-    fn is_some_and<F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: bool]>(
+    fn is_some_and<F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: bool]>(
         self: Option<T>, f: F,
     ) -> bool;
 
@@ -301,7 +302,7 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
     }
 
     #[inline]
-    fn is_some_and<F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: bool]>(
+    fn is_some_and<F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: bool]>(
         self: Option<T>, f: F,
     ) -> bool {
         match self {

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -198,6 +198,23 @@ pub trait OptionTrait<T> {
     #[must_use]
     fn is_some(self: @Option<T>) -> bool;
 
+    /// Returns `true` if the `Option` is `Option::Some` and the value inside of it matches a
+    /// predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(Option::Some(2_u8).is_some_and(|x| x > 1), true);
+    /// assert_eq!(Option::Some(0_u8).is_some_and(|x| x > 1), false);
+    ///
+    /// let option: Option<u8> = Option::None;
+    /// assert_eq!(option.is_some_and(|x| x > 1), false);
+    /// ```
+    #[must_use]
+    fn is_some_and<F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: bool]>(
+        self: Option<T>, f: F,
+    ) -> bool;
+
     /// Returns `true` if the `Option` is `Option::None`, `false` otherwise.
     ///
     /// # Examples
@@ -280,6 +297,16 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
         match self {
             Option::Some(_) => true,
             Option::None => false,
+        }
+    }
+
+    #[inline]
+    fn is_some_and<F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: bool]>(
+        self: Option<T>, f: F,
+    ) -> bool {
+        match self {
+            Option::None => false,
+            Option::Some(x) => f(x),
         }
     }
 

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -61,6 +61,18 @@ fn test_option_none_is_some() {
 }
 
 #[test]
+fn test_option_some_is_some_and() {
+    assert_eq!(Option::Some(2_u8).is_some_and(|x| x > 1), true);
+    assert_eq!(Option::Some(0_u8).is_some_and(|x| x > 1), false);
+}
+
+#[test]
+fn test_option_none_is_some_and() {
+    let option: Option<u8> = Option::None;
+    assert_eq!(option.is_some_and(|x| x > 1), false);
+}
+
+#[test]
 fn test_option_some_is_none() {
     assert!(!Option::Some(42).is_none());
 }


### PR DESCRIPTION
Returns `true` if the `Option` is `Option::Some` and the value inside of it matches a predicate.

#### Examples

```cairo
assert_eq!(Option::Some(2_u8).is_some_and(|x| x > 1), true);
assert_eq!(Option::Some(0_u8).is_some_and(|x| x > 1), false);

let option: Option<u8> = Option::None;
assert_eq!(option.is_some_and(|x| x > 1), false);
```