### PR TITLE
feat(corelib): OptionTrait::is_none_or

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -87,6 +87,7 @@
 //! is [`Some`] or [`None`], respectively.
 //!
 //! [`is_none`]: OptionTrait::is_none
+//! [`is_none_or`]: OptionTrait::is_none_or
 //! [`is_some`]: OptionTrait::is_some
 //!
 //! ## Extracting the contained value
@@ -222,7 +223,7 @@ pub trait OptionTrait<T> {
     /// assert_eq!(option.is_none_or(|x| x > 1), true);
     /// ```
     #[must_use]
-    fn is_none_or<F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: bool]>(
+    fn is_none_or<F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: bool]>(
         self: Option<T>, f: F,
     ) -> bool;
 
@@ -309,7 +310,7 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
     }
 
     #[inline]
-    fn is_none_or<F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: bool]>(
+    fn is_none_or<F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: bool]>(
         self: Option<T>, f: F,
     ) -> bool {
         match self {

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -209,6 +209,23 @@ pub trait OptionTrait<T> {
     #[must_use]
     fn is_none(self: @Option<T>) -> bool;
 
+    /// Returns `true` if the `Option` is `Option::None` or the value inside of it matches a
+    /// predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(Option::Some(2_u8).is_none_or(|x| x > 1), true);
+    /// assert_eq!(Option::Some(0_u8).is_none_or(|x| x > 1), false);
+    ///
+    /// let option: Option<u8> = Option::None;
+    /// assert_eq!(option.is_none_or(|x| x > 1), true);
+    /// ```
+    #[must_use]
+    fn is_none_or<F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: bool]>(
+        self: Option<T>, f: F,
+    ) -> bool;
+
     /// Returns the contained `Some` value if `self` is `Option::Some(x)`. Otherwise, returns the
     /// provided default.
     ///
@@ -287,6 +304,16 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
     fn is_none(self: @Option<T>) -> bool {
         match self {
             Option::Some(_) => false,
+            Option::None => true,
+        }
+    }
+
+    #[inline]
+    fn is_none_or<F, +Drop<F>, impl func: core::ops::FnOnce<F, (T,)>[Output: bool]>(
+        self: Option<T>, f: F,
+    ) -> bool {
+        match self {
+            Option::Some(x) => f(x),
             Option::None => true,
         }
     }

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -70,6 +70,18 @@ fn test_option_none_is_none() {
     assert!(Option::<felt252>::None.is_none());
 }
 
+#[test]
+fn test_option_some_is_none_or() {
+    assert_eq!(Option::Some(2_u8).is_none_or(|x| x > 1), true);
+    assert_eq!(Option::Some(0_u8).is_none_or(|x| x > 1), false);
+}
+
+#[test]
+fn test_option_none_is_none_or() {
+    let option: Option<u8> = Option::None;
+    assert_eq!(option.is_none_or(|x| x > 1), true);
+}
+
 #[derive(Drop)]
 struct NonCopy {}
 


### PR DESCRIPTION
Returns `true` if the `Option` is `Option::None` or the value inside of it matches a
predicate.

#### Examples

```cairo
assert_eq!(Option::Some(2_u8).is_none_or(|x| x > 1), true);
assert_eq!(Option::Some(0_u8).is_none_or(|x| x > 1), false);

let option: Option<u8> = Option::None;
assert_eq!(option.is_none_or(|x| x > 1), true);
```