### PR TITLE
feat(corelib): add `map` to `Option`

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -183,6 +183,18 @@ pub trait OptionTrait<T> {
     /// ```
     fn unwrap(self: Option<T>) -> T;
 
+    /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Option::Some(v)` to
+    /// `Result::Ok(v)` and `Option::None` to `Result::Err(err)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let option = Option::Some(123);
+    /// let result = option.ok_or('no value');
+    /// assert!(result.unwrap() == 123);
+    /// ```
+    fn ok_or<E, +Destruct<E>>(self: Option<T>, err: E) -> Result<T, E>;
+
     /// Returns `true` if the `Option` is `Option::Some`, `false` otherwise.
     ///
     /// # Examples
@@ -269,18 +281,6 @@ pub trait OptionTrait<T> {
     fn map<U, F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(
         self: Option<T>, f: F,
     ) -> Option<U>;
-
-    /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Option::Some(v)` to
-    /// `Result::Ok(v)` and `Option::None` to `Result::Err(err)`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let option = Option::Some(123);
-    /// let result = option.ok_or('no value');
-    /// assert!(result.unwrap() == 123);
-    /// ```
-    fn ok_or<E, +Destruct<E>>(self: Option<T>, err: E) -> Result<T, E>;
 }
 
 pub impl OptionTraitImpl<T> of OptionTrait<T> {
@@ -295,6 +295,14 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
     #[inline(always)]
     fn unwrap(self: Option<T>) -> T {
         self.expect('Option::unwrap failed.')
+    }
+
+    #[inline]
+    fn ok_or<E, +Destruct<E>>(self: Option<T>, err: E) -> Result<T, E> {
+        match self {
+            Option::Some(v) => Result::Ok(v),
+            Option::None => Result::Err(err),
+        }
     }
 
     #[inline]
@@ -348,14 +356,6 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
         match self {
             Option::Some(x) => Option::Some(f(x)),
             Option::None => Option::None,
-        }
-    }
-
-    #[inline]
-    fn ok_or<E, +Destruct<E>>(self: Option<T>, err: E) -> Result<T, E> {
-        match self {
-            Option::Some(v) => Result::Ok(v),
-            Option::None => Result::Err(err),
         }
     }
 }

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -78,3 +78,30 @@ fn test_default_for_option() {
     assert!(Default::<Option<felt252>>::default().is_none());
     assert!(Default::<Option<NonCopy>>::default().is_none());
 }
+
+#[test]
+fn test_option_some_map() {
+    let maybe_some_string: Option<ByteArray> = Option::Some("Hello, World!");
+    let maybe_some_len = maybe_some_string.map(|s: ByteArray| s.len());
+    assert!(maybe_some_len == Option::Some(13));
+}
+
+#[test]
+fn test_option_none_map() {
+    let x: Option<ByteArray> = Option::None;
+    assert!(x.map(|s: ByteArray| s.len()) == Option::None);
+}
+
+#[test]
+fn test_option_some_ok_or() {
+    let x = Option::Some(123);
+    let result = x.ok_or('no value');
+    assert!(result == Result::Ok(123));
+}
+
+#[test]
+fn test_option_none_ok_or() {
+    let x: Option<felt252> = Option::None;
+    let result = x.ok_or('no value');
+    assert!(result == Result::Err('no value'));
+}


### PR DESCRIPTION
Adds `map` to `OptionTrait` for more functional programming features.

moved `ok_or` to be close to `map`, regrouping functions by concern (transforming contained values).

adds missing test for `ok_or`.