### PR TITLE
feat(corelib): OptionTrait::ok_or_else

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -188,6 +188,28 @@ pub trait OptionTrait<T> {
     /// ```
     fn ok_or<E, +Destruct<E>>(self: Option<T>, err: E) -> Result<T, E>;
 
+    /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Option::Some(v)` to
+    /// `Result::Ok(v)` and `Option::None` to `Result::Err(err())`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(Option::Some('foo').ok_or_else(|| 0), Result::Ok('foo'));
+    ///
+    /// let option: Option<felt252> = Option::None;
+    /// assert_eq!(option.ok_or_else(|| 0), Result::Err(0));
+    /// ```
+    fn ok_or_else<
+        F,
+        +Drop<F>,
+        E,
+        +Destruct<E>,
+        impl func: core::ops::FnOnce<F, ()>[Output: E],
+        +Drop<func::Output>,
+    >(
+        self: Option<T>, err: F,
+    ) -> Result<T, E>;
+
     /// Returns `true` if the `Option` is `Option::Some`, `false` otherwise.
     ///
     /// # Examples
@@ -273,6 +295,23 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
         match self {
             Option::Some(v) => Result::Ok(v),
             Option::None => Result::Err(err),
+        }
+    }
+
+    #[inline]
+    fn ok_or_else<
+        F,
+        +Drop<F>,
+        E,
+        +Destruct<E>,
+        impl func: core::ops::FnOnce<F, ()>[Output: E],
+        +Drop<func::Output>,
+    >(
+        self: Option<T>, err: F,
+    ) -> Result<T, E> {
+        match self {
+            Option::Some(v) => Result::Ok(v),
+            Option::None => Result::Err(err()),
         }
     }
 

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -202,14 +202,7 @@ pub trait OptionTrait<T> {
     /// let option: Option<felt252> = Option::None;
     /// assert_eq!(option.ok_or_else(|| 0), Result::Err(0));
     /// ```
-    fn ok_or_else<
-        F,
-        +Drop<F>,
-        E,
-        +Destruct<E>,
-        impl func: core::ops::FnOnce<F, ()>[Output: E],
-        +Drop<func::Output>,
-    >(
+    fn ok_or_else<E, F, +Destruct<E>, +core::ops::FnOnce<F, ()>[Output: E], +Drop<F>>(
         self: Option<T>, err: F,
     ) -> Result<T, E>;
 
@@ -302,14 +295,7 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
     }
 
     #[inline]
-    fn ok_or_else<
-        F,
-        +Drop<F>,
-        E,
-        +Destruct<E>,
-        impl func: core::ops::FnOnce<F, ()>[Output: E],
-        +Drop<func::Output>,
-    >(
+    fn ok_or_else<E, F, +Destruct<E>, +core::ops::FnOnce<F, ()>[Output: E], +Drop<F>>(
         self: Option<T>, err: F,
     ) -> Result<T, E> {
         match self {

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -181,9 +181,10 @@ pub trait OptionTrait<T> {
     /// # Examples
     ///
     /// ```
-    /// let option = Option::Some(123);
-    /// let result = option.ok_or('no value');
-    /// assert!(result.unwrap() == 123);
+    /// assert_eq!(Option::Some('foo').ok_or(0), Result::Ok('foo'));
+    ///
+    /// let option: Option<felt252> = Option::None;
+    /// assert_eq!(option.ok_or(0), Result::Err(0));
     /// ```
     fn ok_or<E, +Destruct<E>>(self: Option<T>, err: E) -> Result<T, E>;
 

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -114,11 +114,14 @@
 //!
 //! * [`ok_or`] transforms [`Some(v)`] to [`Ok(v)`], and [`None`] to
 //!   [`Err(err)`] using the provided default `err` value.
+//! * [`ok_or_else`] transforms [`Some(v)`] to [`Ok(v)`], and [`None`] to
+//!   a value of [`Err`] using the provided function
 //!
 //! [`Err(err)`]: Result::Err
 //! [`Ok(v)`]: Result::Ok
 //! [`Some(v)`]: Option::Some
 //! [`ok_or`]: OptionTrait::ok_or
+//! [`ok_or_else`]: OptionTrait::ok_or_else
 
 /// The `Option<T>` enum representing either `Some(value)` or `None`.
 #[must_use]

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -70,6 +70,17 @@ fn test_option_none_is_none() {
     assert!(Option::<felt252>::None.is_none());
 }
 
+#[test]
+fn test_option_some_ok_or() {
+    assert_eq!(Option::Some('foo').ok_or(0), Result::Ok('foo'));
+}
+
+#[test]
+fn test_option_none_ok_or() {
+    let option: Option<felt252> = Option::None;
+    assert_eq!(option.ok_or(0), Result::Err(0));
+}
+
 #[derive(Drop)]
 struct NonCopy {}
 

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -81,6 +81,17 @@ fn test_option_none_ok_or() {
     assert_eq!(option.ok_or(0), Result::Err(0));
 }
 
+#[test]
+fn test_option_some_ok_or_else() {
+    assert_eq!(Option::Some('foo').ok_or_else( || 0), Result::Ok('foo'));
+}
+
+#[test]
+fn test_option_none_ok_or_else() {
+    let option: Option<felt252> = Option::None;
+    assert_eq!(option.ok_or_else( || 0), Result::Err(0));
+}
+
 #[derive(Drop)]
 struct NonCopy {}
 


### PR DESCRIPTION
Transforms the `Option<T>` into a `Result<T, E>`, mapping `Option::Some(v)` to
`Result::Ok(v)` and `Option::None` to `Result::Err(err())`.

Also add missing tests for `OptionTrait::ok_or`

#### Examples

```cairo
assert_eq!(Option::Some('foo').ok_or_else(|| 0), Result::Ok('foo'));

let option: Option<felt252> = Option::None;
assert_eq!(option.ok_or_else(|| 0), Result::Err(0));
```