### PR TITLE
Corrected spelling and grammar mistakes in documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/derive-macro.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/derive-macro.adoc
@@ -34,7 +34,7 @@ See xref:linear-types.adoc[linear types] for more information.
 * `Destruct` - Implements the destruct method to explicitly destroy the type.
 All members of the type must also be `Destruct`.
 See xref:linear-types.adoc[linear types] for more information.
-* `PartialEq` - Implements the xref::equality-operators.adoc[equality operators] `==` and `!=` for the type.
+* `PartialEq` - Implements the xref:equality-operators.adoc[equality operators] `==` and `!=` for the type.
 All members of the type must also be `PartialEq`.
 * `Serde` - Implements the Serde trait for serialization and deserialization for the type.
 All members of the type must also be `Serde`.

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/let-statement.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/let-statement.adoc
@@ -9,6 +9,6 @@ When no type annotation is given, the compiler infers the type, or signals an er
 insufficient type information is available for definite inference.
 
 // TODO(spapini): Add an explanation about shadowing.
-Any variable introduced by a this declaration is visible from the point of declaration
+Any variable introduced by this declaration is visible from the point of declaration
 until the end of the enclosing block scope, except when it is shadowed by another variable
 declaration.


### PR DESCRIPTION
changed:

xref:: - xref:

by a this - by this

I hope my correction will contribute to the project's development. Thank you for the time you gave me.