### PR TITLE
feat(corelib): add `map` methods to `Result`

### DIFF
--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -660,7 +660,7 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
         }
     }
 
-    /// Maps a `Result<T, E>` to `Result<T, G>` by applying a function to a
+    /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a
     /// contained [`Err`] value, leaving an [`Ok`] value untouched.
     ///
     /// This function can be used to pass through a successful result while handling
@@ -677,12 +677,12 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     /// let x: Result<u32, u32> = Result::Err(13);
     /// assert!(x.map_err(stringify) == Result::Err("error code: 13"));
     /// ```
-    fn map_err<F, G, +Drop<F>, +core::ops::FnOnce<F, (E,)>[Output: G]>(
-        self: Result<T, E>, f: F,
-    ) -> Result<T, G> {
+    fn map_err<F, O, +Drop<O>, +core::ops::FnOnce<O, (E,)>[Output: F]>(
+        self: Result<T, E>, op: O,
+    ) -> Result<T, F> {
         match self {
             Result::Ok(x) => Result::Ok(x),
-            Result::Err(e) => Result::Err(f(e)),
+            Result::Err(e) => Result::Err(op(e)),
         }
     }
 }

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -81,10 +81,41 @@
 //!
 //! ## Transforming contained values
 //!
+//! These methods transform [`Result`] to [`Option`]:
+//!
 //! * [`ok`] transforms [`Result<T, E>`] into [`Option<T>`], mapping
 //!   [`Ok(v)`] to [`Some(v)`] and [`Err(e)`] to [`None`]
 //! * [`err`] transforms [`Result<T, E>`] into [`Option<E>`], mapping
 //!   [`Ok(v)`] to [`None`] and [`Err(e)`] to [`Some(e)`]
+//!
+//! This method transforms the contained value of the [`Ok`] variant:
+//!
+//! * [`map`] transforms [`Result<T, E>`] into [`Result<U, E>`] by applying
+//!   the provided function to the contained value of [`Ok`] and leaving
+//!   [`Err`] values unchanged
+//!
+//! [`map`]: ResultTrait::map
+//!
+//! This method transforms the contained value of the [`Err`] variant:
+//!
+//! * [`map_err`] transforms [`Result<T, E>`] into [`Result<T, F>`] by
+//!   applying the provided function to the contained value of [`Err`] and
+//!   leaving [`Ok`] values unchanged
+//!
+//! [`map_err`]: ResultTrait::map_err
+//!
+//! These methods transform a [`Result<T, E>`] into a value of a possibly
+//! different type `U`:
+//!
+//! * [`map_or`] applies the provided function to the contained value of
+//!   [`Ok`], or returns the provided default value if the [`Result`] is
+//!   [`Err`]
+//! * [`map_or_else`] applies the provided function to the contained value
+//!   of [`Ok`], or applies the provided default fallback function to the
+//!   contained value of [`Err`]
+//!
+//! [`map_or`]: ResultTrait::map_or
+//! [`map_or_else`]: ResultTrait::map_or_else
 //!
 //! ## Boolean operators
 //!

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -636,11 +636,11 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     /// ```
     /// let k = 21;
     ///
-    /// let x : Result<ByteArray, ByteArray> = Result::Ok("foo");
-    /// assert!(x.map_or_else(|e: ByteArray| k * 2, |v: ByteArray| v.len()) == 3);
+    /// let x: Result<ByteArray, _> = Result::Ok("foo");
+    /// assert!(x.map_or_else(|_e: ByteArray| k * 2, |v: ByteArray| v.len()) == 3);
     ///
-    /// let x : Result<ByteArray, ByteArray> = Result::Err("bar");
-    /// assert!(x.map_or_else(|e: ByteArray| k * 2, |v: ByteArray| v.len()) == 42);
+    /// let x: Result<_, ByteArray> = Result::Err("bar");
+    /// assert!(x.map_or_else(|_e: ByteArray| k * 2, |v: ByteArray| v.len()) == 42);
     /// ```
     #[inline]
     fn map_or_else<

--- a/corelib/src/result.cairo
+++ b/corelib/src/result.cairo
@@ -660,7 +660,7 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
         }
     }
 
-    /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a
+    /// Maps a `Result<T, E>` to `Result<T, G>` by applying a function to a
     /// contained [`Err`] value, leaving an [`Ok`] value untouched.
     ///
     /// This function can be used to pass through a successful result while handling
@@ -677,12 +677,12 @@ pub impl ResultTraitImpl<T, E> of ResultTrait<T, E> {
     /// let x: Result<u32, u32> = Result::Err(13);
     /// assert!(x.map_err(stringify) == Result::Err("error code: 13"));
     /// ```
-    fn map_err<F, O, +Drop<O>, +core::ops::FnOnce<O, (E,)>[Output: F]>(
-        self: Result<T, E>, op: O,
-    ) -> Result<T, F> {
+    fn map_err<F, G, +Drop<F>, +core::ops::FnOnce<F, (E,)>[Output: G]>(
+        self: Result<T, E>, f: F,
+    ) -> Result<T, G> {
         match self {
             Result::Ok(x) => Result::Ok(x),
-            Result::Err(e) => Result::Err(op(e)),
+            Result::Err(e) => Result::Err(f(e)),
         }
     }
 }

--- a/corelib/src/test/result_test.cairo
+++ b/corelib/src/test/result_test.cairo
@@ -256,3 +256,59 @@ fn test_result_ok_err_should_return_none() {
     let x: Result<u32, ByteArray> = Result::Ok(2);
     assert!(x.err().is_none());
 }
+
+#[test]
+fn test_result_ok_map() {
+    let x: Result<u32, ByteArray> = Result::Ok(1);
+    assert!(x.map(|i| i * 2) == Result::Ok(2));
+}
+
+#[test]
+fn test_result_err_map() {
+    let x: Result<u32, ByteArray> = Result::Err("error");
+    assert!(x.map(|i| i * 2) == Result::Err("error"));
+}
+
+#[test]
+fn test_result_ok_map_or() {
+    let x: Result<ByteArray, ByteArray> = Result::Ok("foo");
+    assert!(x.map_or(42, |v: ByteArray| v.len()) == 3);
+}
+
+#[test]
+fn test_result_err_map_or() {
+    let x: Result<ByteArray, ByteArray> = Result::Err("bar");
+    assert!(x.map_or(42, |v: ByteArray| v.len()) == 42);
+}
+
+#[test]
+fn test_result_ok_map_or_else() {
+    let k = 21;
+    let x: Result<ByteArray, ByteArray> = Result::Ok("foo");
+    assert!(x.map_or_else(|_e| k * 2, |v: ByteArray| v.len()) == 3);
+}
+
+#[test]
+fn test_result_err_map_or_else() {
+    let k = 21;
+    let x: Result<ByteArray, ByteArray> = Result::Err("bar");
+    assert!(x.map_or_else(|_e| k * 2, |v: ByteArray| v.len()) == 42);
+}
+
+#[test]
+fn test_result_ok_map_err() {
+    let stringify = |x: u32| -> ByteArray {
+        format!("error code: {}", x)
+    };
+    let x: Result<u32, u32> = Result::Ok(2);
+    assert!(x.map_err(stringify) == Result::<u32, ByteArray>::Ok(2));
+}
+
+#[test]
+fn test_result_err_map_err() {
+    let stringify = |x: u32| -> ByteArray {
+        format!("error code: {}", x)
+    };
+    let x: Result<u32, u32> = Result::Err(13);
+    assert!(x.map_err(stringify) == Result::Err("error code: 13"));
+}

--- a/corelib/src/test/result_test.cairo
+++ b/corelib/src/test/result_test.cairo
@@ -284,14 +284,14 @@ fn test_result_err_map_or() {
 #[test]
 fn test_result_ok_map_or_else() {
     let k = 21;
-    let x: Result<ByteArray, ByteArray> = Result::Ok("foo");
-    assert!(x.map_or_else(|_e| k * 2, |v: ByteArray| v.len()) == 3);
+    let x: Result<ByteArray, _> = Result::Ok("foo");
+    assert!(x.map_or_else(|_e: ByteArray| k * 2, |v: ByteArray| v.len()) == 3);
 }
 
 #[test]
 fn test_result_err_map_or_else() {
     let k = 21;
-    let x: Result<ByteArray, ByteArray> = Result::Err("bar");
+    let x: Result<_, ByteArray> = Result::Err("bar");
     assert!(x.map_or_else(|_e| k * 2, |v: ByteArray| v.len()) == 42);
 }
 


### PR DESCRIPTION
Adds `map`, `map_or`, `map_or_else` and `map_err` to `Result`. 