### PR TITLE
feat(corelib): OptionTrait::map_or, OptionTrait::map_or_else

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -362,10 +362,10 @@ pub trait OptionTrait<T> {
     /// # Examples
     ///
     /// ```
-    /// assert_eq!(Option::Some("foo").map_or(42, |v| v.len()), 3);
+    /// assert_eq!(Option::Some("foo").map_or(42, |v: ByteArray| v.len()), 3);
     ///
     /// let x: Option<ByteArray> = Option::None;
-    /// assert_eq!(x.map_or(42, |v| v.len()), 42);
+    /// assert_eq!(x.map_or(42, |v: ByteArray| v.len()), 42);
     /// ```
     #[must_use]
     fn map_or<U, F, +Drop<U>, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -129,6 +129,15 @@
 //!   [`None`] values unchanged
 //!
 //! [`map`]: OptionTrait::map
+//!
+//! These methods transform [`Option<T>`] to a value of a possibly
+//! different type `U`:
+//!
+//! * [`map_or`] applies the provided function to the contained value of
+//!   [`Some`], or returns the provided default value if the [`Option`] is
+//!   [`None`]
+//!
+//! [`map_or`]: Option::map_or
 
 /// The `Option<T>` enum representing either `Some(value)` or `None`.
 #[must_use]
@@ -317,6 +326,28 @@ pub trait OptionTrait<T> {
     fn map<U, F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(
         self: Option<T>, f: F,
     ) -> Option<U>;
+
+    /// Returns the provided default result (if none),
+    /// or applies a function to the contained value (if any).
+    ///
+    /// Arguments passed to `map_or` are eagerly evaluated; if you are passing
+    /// the result of a function call, it is recommended to use [`map_or_else`],
+    /// which is lazily evaluated.
+    ///
+    /// [`map_or_else`]: Option::map_or_else
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(Option::Some("foo").map_or(42, |v| v.len()), 3);
+    ///
+    /// let x: Option<ByteArray> = Option::None;
+    /// assert_eq!(x.map_or(42, |v| v.len()), 42);
+    /// ```
+    #[must_use]
+    fn map_or<U, F, +Drop<U>, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(
+        self: Option<T>, default: U, f: F,
+    ) -> U;
 }
 
 pub impl OptionTraitImpl<T> of OptionTrait<T> {
@@ -412,6 +443,16 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
         match self {
             Option::Some(x) => Option::Some(f(x)),
             Option::None => Option::None,
+        }
+    }
+
+    #[inline]
+    fn map_or<U, F, +Drop<U>, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(
+        self: Option<T>, default: U, f: F,
+    ) -> U {
+        match self {
+            Option::Some(x) => f(x),
+            Option::None => default,
         }
     }
 }

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -117,6 +117,17 @@ fn test_option_none_map() {
 }
 
 #[test]
+fn test_option_some_map_or() {
+    assert_eq!(Option::Some("foo").map_or(42, |v: ByteArray| v.len()), 3);
+}
+
+#[test]
+fn test_option_none_map_or() {
+    let x: Option<ByteArray> = Option::None;
+    assert_eq!(x.map_or(42, |v: ByteArray| v.len()), 42);
+}
+
+#[test]
 fn test_option_some_ok_or() {
     let x = Option::Some(123);
     let result = x.ok_or('no value');

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -128,6 +128,20 @@ fn test_option_none_map_or() {
 }
 
 #[test]
+fn test_option_some_map_or_else() {
+    let k = 21;
+    let x = Option::Some("foo");
+    assert_eq!(x.map_or_else( || 2 * k, |v: ByteArray| v.len()), 3);
+}
+
+#[test]
+fn test_option_none_map_or_else() {
+    let k = 21;
+    let x: Option<ByteArray> = Option::None;
+    assert_eq!(x.map_or_else( || 2 * k, |v: ByteArray| v.len()), 42);
+}
+
+#[test]
 fn test_option_some_ok_or() {
     let x = Option::Some(123);
     let result = x.ok_or('no value');

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -161,17 +161,3 @@ fn test_option_none_map_or_else() {
     let x: Option<ByteArray> = Option::None;
     assert_eq!(x.map_or_else( || 2 * k, |v: ByteArray| v.len()), 42);
 }
-
-#[test]
-fn test_option_some_ok_or() {
-    let x = Option::Some(123);
-    let result = x.ok_or('no value');
-    assert!(result == Result::Ok(123));
-}
-
-#[test]
-fn test_option_none_ok_or() {
-    let x: Option<felt252> = Option::None;
-    let result = x.ok_or('no value');
-    assert!(result == Result::Err('no value'));
-}


### PR DESCRIPTION
## `OptionTrait::map_or`

Returns the provided default result (if none), or applies a function to the contained value (if any).

#### Example

```
assert_eq!(Option::Some("foo").map_or(42, |v| v.len()), 3);

let x: Option<ByteArray> = Option::None;
assert_eq!(x.map_or(42, |v| v.len()), 42);
```

## `OptionTrait::map_or_else`

Computes a default function result (if none), or applies a different function to the contained value (if any).

#### Example

```
let k = 21;

let x = Option::Some("foo");
assert_eq!(x.map_or_else( || 2 * k, |v: ByteArray| v.len()), 3);

let x: Option<ByteArray> = Option::None;
assert_eq!(x.map_or_else( || 2 * k, |v: ByteArray| v.len()), 42);
```