### PR TITLE
Fix duplication of the 'deploy' entry

### DIFF
--- a/docs/reference/src/components/cairo/modules/ROOT/pages/roadmap.adoc
+++ b/docs/reference/src/components/cairo/modules/ROOT/pages/roadmap.adoc
@@ -57,5 +57,4 @@ We divided them by Cairo, Starknet and specific system calls in Starknet OS.
 |get_sequencer_address    |✅
 |get_transaction_info    |✅
 |send_message_to_l1     |✅
-|deploy    |✅
 |===


### PR DESCRIPTION
Fix duplication of the 'deploy' entry in the Starknet system calls table
