### PR TITLE
feat(corelib): iter::adapters::Map

### DIFF
--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -1,2 +1,3 @@
 mod traits;
+mod adapters;
 pub use traits::{IntoIterator, Iterator};

--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -54,9 +54,9 @@
 //! [`Option::Some(Item)`]: Option::Some
 //! [`next`]: Iterator::next
 //!
-//! # Iterators in Cairo
+//! # Forms of iteration
 //!
-//! There are currently one common method which can create iterators from a collection:
+//! There is currently only one common method which can create iterators from a collection:
 //!
 //! * `into_iter()`, which iterates over `T`.
 //!
@@ -138,19 +138,19 @@
 //! ```
 //!
 //! This will print the numbers one through five, each on their own line. But
-//! you'll notice something here: we never called anything on our vector to
+//! you'll notice something here: we never called anything on our array to
 //! produce an iterator. What gives?
 //!
-//! There's a trait in the standard library for converting something into an
+//! There's a trait in the core library for converting something into an
 //! iterator: [`IntoIterator`]. This trait has one method, [`into_iter`],
 //! which converts the thing implementing [`IntoIterator`] into an iterator.
 //! Let's take a look at that `for` loop again, and what the compiler converts
 //! it into:
 //!
-//! [`into_iter`]: IntoIterator::into_iter
+//! [`into_iter`]: core::iter::IntoIterator::into_iter
 //!
 //! ```
-//! let values = vec![1, 2, 3, 4, 5];
+//! let values = array![1, 2, 3, 4, 5];
 //!
 //! for x in values {
 //!     println!("{x}");
@@ -182,7 +182,7 @@
 //! that returns, calling [`next`] over and over until we see a `Option::None`. At
 //! that point, we `break` out of the loop, and we're done iterating.
 //!
-//! There's one more subtle bit here: the standard library contains an
+//! There's one more subtle bit here: the core library contains an
 //! interesting implementation of [`IntoIterator`]:
 //!
 //! ```ignore (only-for-syntax-highlight)
@@ -204,9 +204,6 @@
 //!
 //! The only adapter for now is [`map`].
 //! For more, see the [`map`] documentation.
-//!
-//! If an iterator adapter panics, the iterator will be in an unspecified (but
-//! memory safe) state.
 //!
 //! [`map`]: Iterator::map
 //!

--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -216,9 +216,8 @@
 //! method calls a closure on each element it iterates over:
 //!
 //! ```
-//! # #![allow(unused_must_use)]
 //! let v = array![1, 2, 3, 4, 5];
-//! v.into_iter().map(|x| println!("{x}"));
+//! let _ = v.into_iter().map(|x| println!("{x}"));
 //! ```
 //!
 //! This will not print any values, as we only created an iterator, rather than

--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -1,3 +1,237 @@
+//! Composable external iteration.
+//!
+//! If you've found yourself with a collection of some kind, and needed to
+//! perform an operation on the elements of said collection, you'll quickly run
+//! into 'iterators'. Iterators are heavily used in idiomatic code, so
+//! it's worth becoming familiar with them.
+//!
+//! Before explaining more, let's talk about how this module is structured:
+//!
+//! # Organization
+//!
+//! This module is largely organized by type:
+//!
+//! * [Traits] are the core portion: these traits define what kind of iterators
+//!   exist and what you can do with them. The methods of these traits are worth
+//!   putting some extra study time into.
+//! * [Functions] provide some helpful ways to create some basic iterators.
+//! * [Structs] are often the return types of the various methods on this
+//!   module's traits. You'll usually want to look at the method that creates
+//!   the `struct`, rather than the `struct` itself. For more detail about why,
+//!   see '[Implementing Iterator](#implementing-iterator)'.
+//!
+//! [Traits]: #traits
+//! [Functions]: #functions
+//! [Structs]: #structs
+//!
+//! That's it! Let's dig into iterators.
+//!
+//! # Iterator
+//!
+//! The heart and soul of this module is the [`Iterator`] trait. The core of
+//! [`Iterator`] looks like this:
+//!
+//! ```
+//! trait Iterator {
+//!     type Item;
+//!     fn next(ref self) -> Option<Self::Item>;
+//! }
+//! ```
+//!
+//! An iterator has a method, [`next`], which when called, returns an
+//! <code>[Option]\<Item></code>. Calling [`next`] will return [`Option::Some(Item)`] as long as
+//! there are elements, and once they've all been exhausted, will return `Option::None` to
+//! indicate that iteration is finished.
+//!
+//! [`Iterator`]'s full definition includes a number of other methods as well,
+//! but they are default methods, built on top of [`next`], and so you get
+//! them for free.
+//!
+//! Iterators are also composable, and it's common to chain them together to do
+//! more complex forms of processing. See the [Adapters](#adapters) section
+//! below for more details.
+//!
+//! [`Option::Some(Item)`]: Option::Some
+//! [`next`]: Iterator::next
+//!
+//! # Iterators in Cairo
+//!
+//! There are currently one common method which can create iterators from a collection:
+//!
+//! * `into_iter()`, which iterates over `T`.
+//!
+//! # Implementing Iterator
+//!
+//! Creating an iterator of your own involves two steps: creating a `struct` to
+//! hold the iterator's state, and then implementing [`Iterator`] for that `struct`.
+//! This is why there are so many `struct`s in this module: there is one for
+//! each iterator and iterator adapter.
+//!
+//! Let's make an iterator named `Counter` which counts from `1` to `5`:
+//!
+//! ```
+//! // First, the struct:
+//!
+//! /// An iterator which counts from one to five
+//! #[derive(Drop)]
+//! struct Counter {
+//!     count: usize,
+//! }
+//!
+//! // we want our count to start at one, so let's add a new() method to help.
+//! // This isn't strictly necessary, but is convenient. Note that we start
+//! // `count` at zero, we'll see why in `next()`'s implementation below.
+//! #[generate_trait]
+//! impl CounterImpl of CounterTrait {
+//!     fn new() -> Counter {
+//!         Counter { count: 0 }
+//!     }
+//! }
+//!
+//! // Then, we implement `Iterator` for our `Counter`:
+//!
+//! impl CounterIter of core::iter::Iterator<Counter> {
+//!     // we will be counting with usize
+//!     type Item = usize;
+//!
+//!     // next() is the only required method
+//!     fn next(ref self: Counter) -> Option<Self::Item> {
+//!         // Increment our count. This is why we started at zero.
+//!         self.count += 1;
+//!
+//!         // Check to see if we've finished counting or not.
+//!         if self.count < 6 {
+//!             Option::Some(self.count)
+//!         } else {
+//!             Option::None
+//!         }
+//!     }
+//! }
+//!
+//! // And now we can use it!
+//!
+//! let mut counter = CounterTrait::new();
+//!
+//! assert!(counter.next() == Option::Some(1));
+//! assert!(counter.next() == Option::Some(2));
+//! assert!(counter.next() == Option::Some(3));
+//! assert!(counter.next() == Option::Some(4));
+//! assert!(counter.next() == Option::Some(5));
+//! assert!(counter.next() == Option::None);
+//! ```
+//!
+//! Calling [`next`] this way gets repetitive. Cairo has a construct which can
+//! call [`next`] on your iterator, until it reaches `Option::None`. Let's go over that
+//! next.
+//!
+//! # `for` loops and `IntoIterator`
+//!
+//! Cairo's `for` loop syntax is actually sugar for iterators. Here's a basic
+//! example of `for`:
+//!
+//! ```
+//! let values = array![1, 2, 3, 4, 5];
+//!
+//! for x in values {
+//!     println!("{x}");
+//! }
+//! ```
+//!
+//! This will print the numbers one through five, each on their own line. But
+//! you'll notice something here: we never called anything on our vector to
+//! produce an iterator. What gives?
+//!
+//! There's a trait in the standard library for converting something into an
+//! iterator: [`IntoIterator`]. This trait has one method, [`into_iter`],
+//! which converts the thing implementing [`IntoIterator`] into an iterator.
+//! Let's take a look at that `for` loop again, and what the compiler converts
+//! it into:
+//!
+//! [`into_iter`]: IntoIterator::into_iter
+//!
+//! ```
+//! let values = vec![1, 2, 3, 4, 5];
+//!
+//! for x in values {
+//!     println!("{x}");
+//! }
+//! ```
+//!
+//! Cairo de-sugars this into:
+//!
+//! ```
+//! let values = array![1, 2, 3, 4, 5];
+//! {
+//!     let mut iter = IntoIterator::into_iter(values);
+//!     let result = loop {
+//!             let mut next = 0;
+//!             match iter.next() {
+//!                 Option::Some(val) => next = val,
+//!                 Option::None => {
+//!                     break;
+//!                 },
+//!             };
+//!             let x = next;
+//!             let () = { println!("{x}"); };
+//!         };
+//!     result
+//! }
+//! ```
+//!
+//! First, we call `into_iter()` on the value. Then, we match on the iterator
+//! that returns, calling [`next`] over and over until we see a `Option::None`. At
+//! that point, we `break` out of the loop, and we're done iterating.
+//!
+//! There's one more subtle bit here: the standard library contains an
+//! interesting implementation of [`IntoIterator`]:
+//!
+//! ```ignore (only-for-syntax-highlight)
+//! impl IteratorIntoIterator<T, +Iterator<T>> of IntoIterator<T>
+//! ```
+//!
+//! In other words, all [`Iterator`]s implement [`IntoIterator`], by just
+//! returning themselves. This means two things:
+//!
+//! 1. If you're writing an [`Iterator`], you can use it with a `for` loop.
+//! 2. If you're creating a collection, implementing [`IntoIterator`] for it
+//!    will allow your collection to be used with the `for` loop.
+//!
+//! # Adapters
+//!
+//! Functions which take an [`Iterator`] and return another [`Iterator`] are
+//! often called 'iterator adapters', as they're a form of the 'adapter
+//! pattern'.
+//!
+//! The only adapter for now is [`map`].
+//! For more, see the [`map`] documentation.
+//!
+//! If an iterator adapter panics, the iterator will be in an unspecified (but
+//! memory safe) state.
+//!
+//! [`map`]: Iterator::map
+//!
+//! # Laziness
+//!
+//! Iterators (and iterator [adapters](#adapters)) are *lazy*. This means that
+//! just creating an iterator doesn't _do_ a whole lot. Nothing really happens
+//! until you call [`next`]. This is sometimes a source of confusion when
+//! creating an iterator solely for its side effects. For example, the [`map`]
+//! method calls a closure on each element it iterates over:
+//!
+//! ```
+//! # #![allow(unused_must_use)]
+//! let v = array![1, 2, 3, 4, 5];
+//! v.into_iter().map(|x| println!("{x}"));
+//! ```
+//!
+//! This will not print any values, as we only created an iterator, rather than
+//! using it. The compiler will warn us about this kind of behavior:
+//!
+//! ```text
+//! Unhandled `#[must_use]` type
+//! ```
+//!
+//! [`map`]: Iterator::map
 mod traits;
 mod adapters;
 pub use traits::{IntoIterator, Iterator};

--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -228,6 +228,6 @@
 //! ```
 //!
 //! [`map`]: Iterator::map
-mod traits;
 mod adapters;
+mod traits;
 pub use traits::{IntoIterator, Iterator};

--- a/corelib/src/iter/adapters.cairo
+++ b/corelib/src/iter/adapters.cairo
@@ -1,2 +1,2 @@
 mod map;
-pub use map::{Map, MapTrait};
+pub use map::{Map, mapped_iterator};

--- a/corelib/src/iter/adapters.cairo
+++ b/corelib/src/iter/adapters.cairo
@@ -1,2 +1,4 @@
 mod map;
-pub use map::{Map, mapped_iterator};
+pub use map::Map;
+#[allow(unused_imports)]
+pub(crate) use map::mapped_iterator;

--- a/corelib/src/iter/adapters.cairo
+++ b/corelib/src/iter/adapters.cairo
@@ -1,0 +1,2 @@
+mod map;
+pub use map::{Map, MapTrait};

--- a/corelib/src/iter/adapters/map.cairo
+++ b/corelib/src/iter/adapters/map.cairo
@@ -24,16 +24,14 @@ pub(crate) impl MapImpl<I, F> of MapTrait<I, F> {
 
 impl MapIterator<
     I,
-    B,
     F,
     impl TIter: Iterator<I>,
-    +core::ops::FnOnce<F, (TIter::Item,)>[Output: B],
+    impl func: core::ops::Fn<F, (TIter::Item,)>,
     +Destruct<I>,
     +Destruct<F>,
-    +Copy<F>,
 > of Iterator<Map<I, F>> {
-    type Item = B;
-    fn next(ref self: Map<I, F>) -> Option<B> {
-        self.iter.next().map(self.f)
+    type Item = func::Output;
+    fn next(ref self: Map<I, F>) -> Option<func::Output> {
+        self.iter.next().map(@self.f)
     }
 }

--- a/corelib/src/iter/adapters/map.cairo
+++ b/corelib/src/iter/adapters/map.cairo
@@ -28,8 +28,8 @@ impl MapIterator<
     F,
     impl TIter: Iterator<I>,
     +core::ops::FnOnce<F, (TIter::Item,)>[Output: B],
-    +Drop<I>,
-    +Drop<F>,
+    +Destruct<I>,
+    +Destruct<F>,
     +Copy<F>,
 > of Iterator<Map<I, F>> {
     type Item = B;

--- a/corelib/src/iter/adapters/map.cairo
+++ b/corelib/src/iter/adapters/map.cairo
@@ -1,7 +1,7 @@
 use crate::iter::Iterator;
 
 #[must_use]
-#[derive(Clone)]
+#[derive(Drop, Clone)]
 pub struct Map<I, F> {
     iter: I,
     f: F,
@@ -15,8 +15,8 @@ pub(crate) impl MapImpl<I, F> of MapTrait<I, F> {
 }
 
 impl MapIterator<
-    B,
     I,
+    B,
     F,
     impl TIter: Iterator<I>,
     +core::ops::FnOnce<F, (TIter::Item,)>[Output: B],

--- a/corelib/src/iter/adapters/map.cairo
+++ b/corelib/src/iter/adapters/map.cairo
@@ -15,11 +15,8 @@ pub struct Map<I, F> {
     f: F,
 }
 
-#[generate_trait]
-pub(crate) impl MapImpl<I, F> of MapTrait<I, F> {
-    fn new(iter: I, f: F) -> Map<I, F> {
-        Map { iter, f }
-    }
+pub(crate) fn mapped_iterator<I, F>(iter: I, f: F) -> Map<I, F> {
+    Map { iter, f }
 }
 
 impl MapIterator<

--- a/corelib/src/iter/adapters/map.cairo
+++ b/corelib/src/iter/adapters/map.cairo
@@ -1,5 +1,13 @@
 use crate::iter::Iterator;
 
+/// An iterator that maps the values of `iter` with `f`.
+///
+/// This `struct` is created by the [`map`] method on [`Iterator`]. See its
+/// documentation for more.
+///
+/// [`map`]: Iterator::map
+/// [`Iterator`]: core::iter::Iterator
+///
 #[must_use]
 #[derive(Drop, Clone)]
 pub struct Map<I, F> {

--- a/corelib/src/iter/adapters/map.cairo
+++ b/corelib/src/iter/adapters/map.cairo
@@ -1,0 +1,31 @@
+use crate::iter::Iterator;
+
+#[must_use]
+#[derive(Clone)]
+pub struct Map<I, F> {
+    iter: I,
+    f: F,
+}
+
+#[generate_trait]
+pub(crate) impl MapImpl<I, F> of MapTrait<I, F> {
+    fn new(iter: I, f: F) -> Map<I, F> {
+        Map { iter, f }
+    }
+}
+
+impl MapIterator<
+    B,
+    I,
+    F,
+    impl TIter: Iterator<I>,
+    +core::ops::FnOnce<F, (TIter::Item,)>[Output: B],
+    +Drop<I>,
+    +Drop<F>,
+    +Copy<F>,
+> of Iterator<Map<I, F>> {
+    type Item = B;
+    fn next(ref self: Map<I, F>) -> Option<B> {
+        self.iter.next().map(self.f)
+    }
+}

--- a/corelib/src/iter/adapters/map.cairo
+++ b/corelib/src/iter/adapters/map.cairo
@@ -1,5 +1,3 @@
-use crate::iter::Iterator;
-
 /// An iterator that maps the values of `iter` with `f`.
 ///
 /// This `struct` is created by the [`map`] method on [`Iterator`]. See its
@@ -15,7 +13,7 @@ pub struct Map<I, F> {
     f: F,
 }
 
-pub(crate) fn mapped_iterator<I, F>(iter: I, f: F) -> Map<I, F> {
+pub fn mapped_iterator<I, F>(iter: I, f: F) -> Map<I, F> {
     Map { iter, f }
 }
 

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -76,9 +76,8 @@ pub trait Iterator<T> {
     /// If you're doing some sort of side effect, prefer `for` to `map()`:
     ///
     /// ```
-    /// # #![allow(unused_must_use)]
     /// // don't do this:
-    /// (0..5_usize).into_iter().map(|x| println!("{x}"));
+    /// let _ = (0..5_usize).into_iter().map(|x| println!("{x}"));
     ///
     /// // it won't even execute, as it is lazy. Cairo will warn you about this.
     ///

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,4 +1,4 @@
-use crate::iter::adapters::{Map, MapTrait};
+use crate::iter::adapters::{Map, mapped_iterator};
 
 /// A trait for dealing with iterators.
 ///
@@ -98,6 +98,6 @@ pub trait Iterator<T> {
     >(
         self: T, f: F,
     ) -> Map<T, F> {
-        MapTrait::new(self, f)
+        mapped_iterator(self, f)
     }
 }

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -12,7 +12,8 @@ pub trait Iterator<T> {
     fn map<
         B,
         F,
-        +core::ops::FnOnce<F, (Self::Item,)>[Output: B],
+        impl TIter: Self,
+        +core::ops::FnOnce<F, (TIter::Item,)>[Output: B],
         +Drop<T>,
         +Drop<F>,
         +Copy<F>,

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,3 +1,5 @@
+use crate::iter::adapters::{Map, MapTrait};
+
 /// An iterator over a collection of values.
 pub trait Iterator<T> {
     /// The type of the elements being iterated over.
@@ -5,4 +7,18 @@ pub trait Iterator<T> {
 
     /// Advance the iterator and return the next value.
     fn next(ref self: T) -> Option<Self::Item>;
+
+    #[inline]
+    fn map<
+        B,
+        F,
+        +core::ops::FnOnce<F, (Self::Item,)>[Output: B],
+        +Drop<T>,
+        +Drop<F>,
+        +Copy<F>,
+    >(
+        self: T, f: F,
+    ) -> Map<T, F> {
+        MapTrait::new(self, f)
+    }
 }

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -79,7 +79,8 @@ pub trait Iterator<T> {
     /// // don't do this:
     /// let _ = (0..5_usize).into_iter().map(|x| println!("{x}"));
     ///
-    /// // it won't even execute, as it is lazy. Cairo will warn you about this.
+    /// // it won't even execute, as it is lazy. Cairo will warn you about this if not specifically
+    /// ignored, as is done here.
     ///
     /// // Instead, use for:
     /// for x in 0..5_usize {

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -89,13 +89,7 @@ pub trait Iterator<T> {
     /// ```
     #[inline]
     fn map<
-        B,
-        F,
-        impl TIter: Self,
-        +core::ops::FnOnce<F, (TIter::Item,)>[Output: B],
-        +Drop<T>,
-        +Drop<F>,
-        +Copy<F>,
+        B, F, impl TIter: Self, +core::ops::Fn<F, (TIter::Item,)>[Output: B], +Drop<T>, +Drop<F>,
     >(
         self: T, f: F,
     ) -> Map<T, F> {

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,13 +1,92 @@
 use crate::iter::adapters::{Map, MapTrait};
 
-/// An iterator over a collection of values.
+/// A trait for dealing with iterators.
+///
+/// This is the main iterator trait. For more about the concept of iterators
+/// generally, please see the [module-level documentation]. In particular, you
+/// may want to know how to [implement `Iterator`][impl].
+///
+/// [module-level documentation]: crate::iter
+/// [impl]: crate::iter#implementing-iterator
 pub trait Iterator<T> {
     /// The type of the elements being iterated over.
     type Item;
 
-    /// Advance the iterator and return the next value.
+
+    /// Advances the iterator and returns the next value.
+    ///
+    /// Returns [`Option::None`] when iteration is finished.
+    ///
+    /// [`Option::Some(Item)`]: Option::Some
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let a = array![1, 2, 3];
+    ///
+    /// let mut iter = a.into_iter();
+    ///
+    /// // A call to next() returns the next value...
+    /// assert!(Option::Some(1) == iter.next());
+    /// assert!(Option::Some(2) == iter.next());
+    /// assert!(Option::Some(3) == iter.next());
+    ///
+    /// // ... and then None once it's over.
+    /// assert!(Option::None == iter.next());
+    ///
+    /// // More calls may or may not return `Option::None`. Here, they always will.
+    /// assert!(Option::None == iter.next());
+    /// assert!(Option::None == iter.next());
+    /// ```
     fn next(ref self: T) -> Option<Self::Item>;
 
+
+    /// Takes a closure and creates an iterator which calls that closure on each
+    /// element.
+    ///
+    /// `map()` transforms one iterator into another, by means of its argument:
+    /// something that implements [`FnOnce`]. It produces a new iterator which
+    /// calls this closure on each element of the original iterator.
+    ///
+    /// If you are good at thinking in types, you can think of `map()` like this:
+    /// If you have an iterator that gives you elements of some type `A`, and
+    /// you want an iterator of some other type `B`, you can use `map()`,
+    /// passing a closure that takes an `A` and returns a `B`.
+    ///
+    /// `map()` is conceptually similar to a `for` loop. However, as `map()` is
+    /// lazy, it is best used when you're already working with other iterators.
+    /// If you're doing some sort of looping for a side effect, it's considered
+    /// more idiomatic to use `for` than `map()`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let a = array![1, 2, 3];
+    ///
+    /// let mut iter = a.into_iter().map(|x| 2 * x);
+    ///
+    /// assert!(iter.next() == Option::Some(2));
+    /// assert!(iter.next() == Option::Some(4));
+    /// assert!(iter.next() == Option::Some(6));
+    /// assert!(iter.next() == Option::None);
+    /// ```
+    ///
+    /// If you're doing some sort of side effect, prefer `for` to `map()`:
+    ///
+    /// ```
+    /// # #![allow(unused_must_use)]
+    /// // don't do this:
+    /// (0..5_usize).into_iter().map(|x| println!("{x}"));
+    ///
+    /// // it won't even execute, as it is lazy. Cairo will warn you about this.
+    ///
+    /// // Instead, use for:
+    /// for x in 0..5_usize {
+    ///     println!("{x}");
+    /// }
+    /// ```
     #[inline]
     fn map<
         B,

--- a/corelib/src/ops/function.cairo
+++ b/corelib/src/ops/function.cairo
@@ -23,6 +23,15 @@ impl FnOnceImpl<T, Args, +Destruct<T>, +Fn<T, Args>> of FnOnce<T, Args> {
     }
 }
 
+/// An implementation of `FnOnce` when `Fn` is implemented and the receiver is by-reference.
+/// Makes sure we can always pass an `Fn` to a function that expects an `FnOnce`.
+impl FnOnceSnapImpl<T, Args, +Destruct<T>, +Fn<T, Args>> of FnOnce<@T, Args> {
+    type Output = Fn::<T, Args>::Output;
+    fn call(self: @T, args: Args) -> Self::Output {
+        Fn::call(self, args)
+    }
+}
+
 /// The version of the call operator that takes a by-snapshot receiver.
 ///
 /// Instances of `Fn` can be called multiple times.

--- a/corelib/src/ops/function.cairo
+++ b/corelib/src/ops/function.cairo
@@ -23,15 +23,6 @@ impl FnOnceImpl<T, Args, +Destruct<T>, +Fn<T, Args>> of FnOnce<T, Args> {
     }
 }
 
-/// An implementation of `FnOnce` when `Fn` is implemented and the receiver is by-reference.
-/// Makes sure we can always pass an `Fn` to a function that expects an `FnOnce`.
-impl FnOnceSnapImpl<T, Args, +Destruct<T>, +Fn<T, Args>> of FnOnce<@T, Args> {
-    type Output = Fn::<T, Args>::Output;
-    fn call(self: @T, args: Args) -> Self::Output {
-        Fn::call(self, args)
-    }
-}
-
 /// The version of the call operator that takes a by-snapshot receiver.
 ///
 /// Instances of `Fn` can be called multiple times.

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -508,6 +508,10 @@ pub trait OptionTrait<T> {
         self: Option<T>, f: F,
     ) -> T;
 
+    /////////////////////////////////////////////////////////////////////////
+    // Transforming contained values
+    /////////////////////////////////////////////////////////////////////////
+
     /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained value (if `Some`)
     /// or returns `Option::None` (if `None`).
     ///
@@ -718,7 +722,7 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
     }
 
     #[inline]
-    fn map<U, F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(
+    fn map<U, F, +Destruct<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(
         self: Option<T>, f: F,
     ) -> Option<U> {
         match self {

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -508,12 +508,8 @@ pub trait OptionTrait<T> {
         self: Option<T>, f: F,
     ) -> T;
 
-    /////////////////////////////////////////////////////////////////////////
-    // Transforming contained values
-    /////////////////////////////////////////////////////////////////////////
-
     /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained value (if `Some`)
-    /// or returns `None` (if `None`).
+    /// or returns `Option::None` (if `None`).
     ///
     /// # Examples
     ///
@@ -526,7 +522,7 @@ pub trait OptionTrait<T> {
     /// let x: Option<ByteArray> = Option::None;
     /// assert!(x.map(|s: ByteArray| s.len()) == Option::None);
     /// ```
-    fn map<U, F, +Drop<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(
+    fn map<U, F, +Destruct<F>, +core::ops::FnOnce<F, (T,)>[Output: U]>(
         self: Option<T>, f: F,
     ) -> Option<U>;
 

--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -13,6 +13,7 @@ mod felt_test;
 mod fmt_test;
 mod hash_test;
 mod integer_test;
+mod iter_test;
 mod keccak_test;
 mod math_test;
 mod nullable_test;

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -2,10 +2,9 @@ use crate::iter::{IntoIterator, Iterator};
 
 #[test]
 fn test_iter_adapter_map() {
-    let mut iter = (1..3_u8).into_iter().map(|x: u8| 2 * x);
-
-    assert_eq!(iter.next(), Option::Some(2));
-    assert_eq!(iter.next(), Option::Some(4));
-    assert_eq!(iter.next(), Option::Some(6));
-    assert_eq!(iter.next(), Option::None);
+    let mut i = 1;
+    for elem in (1..4_u8).into_iter().map(|x| 2 * x).map(|x| x + 1) {
+        assert_eq!(elem, i * 2 + 1);
+        i += 1;
+    }
 }

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -4,7 +4,7 @@ use crate::iter::{IntoIterator, Iterator};
 fn test_iter_adapter_map() {
     let a = array![1, 2, 3];
     let mut iter = a.into_iter().map(|x| 2 * x);
-    
+
     assert_eq!(iter.next(), Option::Some(2));
     assert_eq!(iter.next(), Option::Some(4));
     assert_eq!(iter.next(), Option::Some(6));

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -1,0 +1,11 @@
+use crate::iter::{IntoIterator, Iterator};
+
+#[test]
+fn test_iter_adapter_map() {
+    let mut iter = (1..3_u8).into_iter().map(|x: u8| 2 * x);
+
+    assert_eq!(iter.next(), Option::Some(2));
+    assert_eq!(iter.next(), Option::Some(4));
+    assert_eq!(iter.next(), Option::Some(6));
+    assert_eq!(iter.next(), Option::None);
+}

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -1,5 +1,3 @@
-use crate::iter::{IntoIterator, Iterator};
-
 #[test]
 fn test_iter_adapter_map() {
     let a = array![1, 2, 3];

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -2,9 +2,11 @@ use crate::iter::{IntoIterator, Iterator};
 
 #[test]
 fn test_iter_adapter_map() {
-    let mut i = 1;
-    for elem in (1..4_u8).into_iter().map(|x| 2 * x).map(|x| x + 1) {
-        assert_eq!(elem, i * 2 + 1);
-        i += 1;
-    }
+    let a = array![1, 2, 3];
+    let mut iter = a.into_iter().map(|x| 2 * x);
+    
+    assert_eq!(iter.next(), Option::Some(2));
+    assert_eq!(iter.next(), Option::Some(4));
+    assert_eq!(iter.next(), Option::Some(6));
+    assert_eq!(iter.next(), Option::None);
 }


### PR DESCRIPTION
This is mostly an exploratory PR to test implementation of iterator adapters, i.e. functions that take an `Iterator` to return another `Iterator`. It's really useful as any type that implement `IntoIterator` can benefits from these adapters, and it also enables function chaining on iterators.

Added a first implementation of `iter::adapters::Map`:

```cairo
let mut i = 1;
for elem in (1..4_u8).into_iter().map(|x| 2 * x).map(|x| x + 1) {
    assert_eq!(elem, i * 2 + 1);
    i += 1;
}
```

---

I'm curious to know if an implementation of `ops::FnMut` would be possible, to be able to perform function calls with a reference? With it I believe the efficiency of these adapters can be greatly improved to avoid excessive copy/drop.

Feedback welcome on both the current implementation and potential optimization