### PR TITLE
Fix grammatical errors

### DIFF
--- a/crates/cairo-lang-lowering/src/destructs.rs
+++ b/crates/cairo-lang-lowering/src/destructs.rs
@@ -162,7 +162,7 @@ impl DemandReporter<VariableId, PanicState> for DestructAdder<'_> {
 }
 
 /// A state saved for each position in the back analysis.
-/// Used to determine if a Panic object is guaranteed to exist or be created, an where.
+/// Used to determine if a Panic object is guaranteed to exist or be created, and where.
 #[derive(Clone, Default)]
 pub enum PanicState {
     /// The flow will end with a panic. The locations are all the possible places a Panic object

--- a/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
@@ -88,7 +88,7 @@ impl CanonicalImpl {
 }
 
 /// Mapping between canonical space and inference space.
-/// Created by an either canonicalizing or embedding a trait.
+/// Created by either canonicalizing or embedding a trait.
 #[derive(Debug)]
 pub struct CanonicalMapping {
     to_canonic: VarMapping,

--- a/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
@@ -88,7 +88,7 @@ impl CanonicalImpl {
 }
 
 /// Mapping between canonical space and inference space.
-/// Created by a either canonicalizing or embedding a trait.
+/// Created by an either canonicalizing or embedding a trait.
 #[derive(Debug)]
 pub struct CanonicalMapping {
     to_canonic: VarMapping,

--- a/crates/cairo-lang-sierra-ap-change/src/compute.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/compute.rs
@@ -62,7 +62,7 @@ struct ApChangeCalcHelper<'a, TokenUsages: Fn(StatementIdx, CostTokenType) -> us
     token_usages: TokenUsages,
     /// The size of allocated locals until the statement.
     locals_size: UnorderedHashMap<StatementIdx, usize>,
-    /// The lower bound of a ap-change to the furthest return per statement.
+    /// The lower bound of an ap-change to the furthest return per statement.
     known_ap_change_to_return: UnorderedHashMap<StatementIdx, usize>,
     /// The ap_change of functions with known ap changes.
     function_ap_change: OrderedHashMap<FunctionId, usize>,
@@ -139,7 +139,7 @@ impl<'a, TokenUsages: Fn(StatementIdx, CostTokenType) -> usize>
         Ok(())
     }
 
-    /// Calculates the lower bound of a ap-change to the furthest return per statement.
+    /// Calculates the lower bound of an ap-change to the furthest return per statement.
     /// If it is unknown does not set it.
     fn calc_known_ap_change_for_statement(
         &mut self,

--- a/crates/cairo-lang-starknet/src/analyzer.rs
+++ b/crates/cairo-lang-starknet/src/analyzer.rs
@@ -257,7 +257,7 @@ fn member_analyze(
     user_data_path.pop();
 }
 
-/// Adds diagnostics for a enum deriving `starknet::Store`.
+/// Adds diagnostics for an enum deriving `starknet::Store`.
 ///
 /// Specifically finds cases missing a `#[default]` variant.
 fn add_derive_store_enum_diags(


### PR DESCRIPTION
#### Files and Changes:
1. **`destructs.rs`**
   - Corrected: `"an where"` → `"and where"` to fix grammatical inaccuracy and improve clarity.

2. **`canonic.rs`**
   - Corrected: `"a either"` → `"an either"` to align with proper article usage before a word starting with a vowel sound.

3. **`compute.rs`**
   - Corrected: `"a ap-change"` → `"an ap-change"` (twice) for proper article usage before words starting with a vowel sound.

4. **`analyzer.rs`**
   - Corrected: `"a enum"` → `"an enum"` for proper article usage before words starting with a vowel sound.
