### PR TITLE
feat(corelib): `FnSnapshotImpl`

### DIFF
--- a/corelib/src/ops/function.cairo
+++ b/corelib/src/ops/function.cairo
@@ -34,3 +34,12 @@ pub trait Fn<T, Args> {
     /// Performs the call operation.
     fn call(self: @T, args: Args) -> Self::Output;
 }
+
+/// Implementation of `Fn` for snapshots.
+/// This allows using a snapshot of a type that implements `Fn` as a function.
+impl FnSnapshotImpl<T, Args, impl F: Fn<T, Args>> of Fn<@T, Args> {
+    type Output = F::Output;
+    fn call(self: @@T, args: Args) -> Self::Output {
+        F::call(*self, args)
+    }
+}

--- a/corelib/src/test/language_features/closure_test.cairo
+++ b/corelib/src/test/language_features/closure_test.cairo
@@ -41,6 +41,20 @@ fn panicable_closure() {
     assert_eq!(c(2), 5);
 }
 
+struct Callable<F, +core::ops::Fn<F, ()>> {
+    f: F,
+}
+
+#[test]
+fn closure_snapshot_call() {
+    let callable = Callable { f: || 10_u8 };
+    assert_eq!(core::ops::FnOnce::call(callable.f, ()), 10);
+    assert_eq!(core::ops::Fn::call(@callable.f, ()), 10);
+    // With snapshot
+    assert_eq!(core::ops::FnOnce::call(@callable.f, ()), 10);
+    assert_eq!(core::ops::Fn::call(@@callable.f, ()), 10);
+}
+
 fn option_map<T, F, +core::ops::FnOnce<F, (T,)>, +Drop<F>>(
     opt: Option<T>, f: F,
 ) -> Option<core::ops::FnOnce::<F, (T,)>::Output> {
@@ -83,6 +97,7 @@ impl ArrayExt of ArrayExtTrait {
         output
     }
 }
+
 #[test]
 fn array_map_test() {
     let arr = array![1, 2, 3];


### PR DESCRIPTION
This implementation allows to use snapshot of type that implements `Fn`.
It is useful when we want to pass an `@Fn` to a function that expects an `FnOnce` for example.