### PR TITLE
feat(corelib): IntoIter for Span-convertible @C

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -816,13 +816,6 @@ impl SpanIntoIterator<T> of crate::iter::IntoIterator<Span<T>> {
     }
 }
 
-impl SnapshotSpanIntoIterator<T> of crate::iter::IntoIterator<@Span<T>> {
-    type IntoIter = crate::array::SpanIter<T>;
-    fn into_iter(self: @Span<T>) -> Self::IntoIter {
-        (*self).into_iter()
-    }
-}
-
 /// An iterator struct over an array collection.
 #[derive(Drop)]
 pub struct ArrayIter<T> {

--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -816,8 +816,8 @@ impl SpanIntoIterator<T> of crate::iter::IntoIterator<Span<T>> {
     }
 }
 
-impl SnapshotSpanIntoIterator<T> of core::iter::IntoIterator<@Span<T>> {
-    type IntoIter = core::array::SpanIter<T>;
+impl SnapshotSpanIntoIterator<T> of crate::iter::IntoIterator<@Span<T>> {
+    type IntoIter = crate::array::SpanIter<T>;
     fn into_iter(self: @Span<T>) -> Self::IntoIter {
         (*self).into_iter()
     }

--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -852,6 +852,13 @@ impl ArrayIntoIterator<T> of crate::iter::IntoIterator<Array<T>> {
     }
 }
 
+impl SnapshotArrayIntoIterator<T> of crate::iter::IntoIterator<@Array<T>> {
+    type IntoIter = SpanIter<T>;
+    fn into_iter(self: @Array<T>) -> Self::IntoIter {
+        self.span().into_iter()
+    }
+}
+
 /// Information about a fixed-sized array.
 trait FixedSizedArrayInfo<S> {
     /// The type of the elements in the array.

--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -816,6 +816,13 @@ impl SpanIntoIterator<T> of crate::iter::IntoIterator<Span<T>> {
     }
 }
 
+impl SnapshotSpanIntoIterator<T> of core::iter::IntoIterator<@Span<T>> {
+    type IntoIter = core::array::SpanIter<T>;
+    fn into_iter(self: @Span<T>) -> Self::IntoIter {
+        (*self).into_iter()
+    }
+}
+
 /// An iterator struct over an array collection.
 #[derive(Drop)]
 pub struct ArrayIter<T> {

--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -816,6 +816,13 @@ impl SpanIntoIterator<T> of crate::iter::IntoIterator<Span<T>> {
     }
 }
 
+impl SnapshotSpanIntoIterator<T> of crate::iter::IntoIterator<@Span<T>> {
+    type IntoIter = crate::array::SpanIter<T>;
+    fn into_iter(self: @Span<T>) -> Self::IntoIter {
+        (*self).into_iter()
+    }
+}
+
 /// An iterator struct over an array collection.
 #[derive(Drop)]
 pub struct ArrayIter<T> {

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -96,25 +96,10 @@ impl IteratorIntoIterator<T, +Iterator<T>> of IntoIterator<T> {
     }
 }
 
-impl SnapshotFixedSizeArrayIntoIterator<
-    T, const SIZE: usize, +Drop<T>, impl ToSpan: core::array::ToSpanTrait<[T; SIZE], T>,
-> of IntoIterator<@[T; SIZE]> {
+impl SnapshotIteratorSpanBased<C, T, +Into<@C, Span<T>>> of IntoIterator<@C> {
     type IntoIter = crate::array::SpanIter<T>;
-    fn into_iter(self: @[T; SIZE]) -> Self::IntoIter {
-        ToSpan::span(self).into_iter()
-    }
-}
-
-impl SnapshotSpanIntoIterator<T> of IntoIterator<@Span<T>> {
-    type IntoIter = crate::array::SpanIter<T>;
-    fn into_iter(self: @Span<T>) -> Self::IntoIter {
-        (*self).into_iter()
-    }
-}
-
-impl SnapshotArrayIntoIterator<T> of IntoIterator<@Array<T>> {
-    type IntoIter = crate::array::SpanIter<T>;
-    fn into_iter(self: @Array<T>) -> Self::IntoIter {
-        self.span().into_iter()
+    fn into_iter(self: @C) -> Self::IntoIter {
+        let span: Span<T> = self.into();
+        span.into_iter()
     }
 }

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -96,8 +96,8 @@ impl IteratorIntoIterator<T, +Iterator<T>> of IntoIterator<T> {
     }
 }
 
-impl SnapshotIteratorSpanBased<C, T, +Into<@C, Span<T>>> of core::iter::IntoIterator<@C> {
-    type IntoIter = core::array::SpanIter<T>;
+impl SnapshotIteratorSpanBased<C, T, +Into<@C, Span<T>>> of IntoIterator<@C> {
+    type IntoIter = crate::array::SpanIter<T>;
     fn into_iter(self: @C) -> Self::IntoIter {
         let span: Span<T> = self.into();
         span.into_iter()

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -96,10 +96,11 @@ impl IteratorIntoIterator<T, +Iterator<T>> of IntoIterator<T> {
     }
 }
 
-impl SnapshotIteratorSpanBased<C, T, +Into<@C, Span<T>>> of IntoIterator<@C> {
+impl SnapshotFixedSizeArrayIntoIterator<
+    T, const SIZE: usize, +Drop<T>, impl ToSpan: crate::array::ToSpanTrait<[T; SIZE], T>,
+> of IntoIterator<@[T; SIZE]> {
     type IntoIter = crate::array::SpanIter<T>;
-    fn into_iter(self: @C) -> Self::IntoIter {
-        let span: Span<T> = self.into();
-        span.into_iter()
+    fn into_iter(self: @[T; SIZE]) -> Self::IntoIter {
+        ToSpan::span(self).into_iter()
     }
 }

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -96,11 +96,10 @@ impl IteratorIntoIterator<T, +Iterator<T>> of IntoIterator<T> {
     }
 }
 
-impl SnapshotFixedSizeArrayIntoIterator<
-    T, const SIZE: usize, +Drop<T>, impl ToSpan: core::array::ToSpanTrait<[T; SIZE], T>,
-> of IntoIterator<@[T; SIZE]> {
-    type IntoIter = crate::array::SpanIter<T>;
-    fn into_iter(self: @[T; SIZE]) -> Self::IntoIter {
-        ToSpan::span(self).into_iter()
+impl SnapshotIteratorSpanBased<C, T, +Into<@C, Span<T>>> of core::iter::IntoIterator<@C> {
+    type IntoIter = core::array::SpanIter<T>;
+    fn into_iter(self: @C) -> Self::IntoIter {
+        let span: Span<T> = self.into();
+        span.into_iter()
     }
 }

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -96,10 +96,25 @@ impl IteratorIntoIterator<T, +Iterator<T>> of IntoIterator<T> {
     }
 }
 
-impl SnapshotIteratorSpanBased<C, T, +Into<@C, Span<T>>> of IntoIterator<@C> {
+impl SnapshotFixedSizeArrayIntoIterator<
+    T, const SIZE: usize, +Drop<T>, impl ToSpan: core::array::ToSpanTrait<[T; SIZE], T>,
+> of IntoIterator<@[T; SIZE]> {
     type IntoIter = crate::array::SpanIter<T>;
-    fn into_iter(self: @C) -> Self::IntoIter {
-        let span: Span<T> = self.into();
-        span.into_iter()
+    fn into_iter(self: @[T; SIZE]) -> Self::IntoIter {
+        ToSpan::span(self).into_iter()
+    }
+}
+
+impl SnapshotSpanIntoIterator<T> of IntoIterator<@Span<T>> {
+    type IntoIter = crate::array::SpanIter<T>;
+    fn into_iter(self: @Span<T>) -> Self::IntoIter {
+        (*self).into_iter()
+    }
+}
+
+impl SnapshotArrayIntoIterator<T> of IntoIterator<@Array<T>> {
+    type IntoIter = crate::array::SpanIter<T>;
+    fn into_iter(self: @Array<T>) -> Self::IntoIter {
+        self.span().into_iter()
     }
 }

--- a/corelib/src/test/array_test.cairo
+++ b/corelib/src/test/array_test.cairo
@@ -215,27 +215,25 @@ fn test_empty_snapshot_fixed_size_array_iterator() {
 }
 
 
-#[test]
 fn test_snapshot_array_into_iter() {
-    let mut arr = array![1, 2, 3, 4, 5];
-    let mut arr_iter = (@arr).into_iter();
-
-    let mut i = 1;
-    while let Option::Some(value) = arr_iter.next() {
-        assert_eq!(value, @i);
-        i += 1;
-    }
+    let mut iter = (@array![1, 2, 3, 4, 5]).into_iter();
+    assert_eq!(iter.next(), Option::Some(@1));
+    assert_eq!(iter.next(), Option::Some(@2));
+    assert_eq!(iter.next(), Option::Some(@3));
+    assert_eq!(iter.next(), Option::Some(@4));
+    assert_eq!(iter.next(), Option::Some(@5));
+    assert!(iter.next().is_none());
 }
 
 #[test]
 fn test_snapshot_span_into_iter() {
-    let span = array![1, 2, 3, 4, 5].span();
-    let mut span_iter = (@span).into_iter();
-    let mut i = 1;
-    while let Option::Some(value) = span_iter.next() {
-        assert_eq!(value, @i);
-        i += 1;
-    }
+    let mut iter = (@(array![1, 2, 3, 4, 5].span())).into_iter();
+    assert_eq!(iter.next(), Option::Some(@1));
+    assert_eq!(iter.next(), Option::Some(@2));
+    assert_eq!(iter.next(), Option::Some(@3));
+    assert_eq!(iter.next(), Option::Some(@4));
+    assert_eq!(iter.next(), Option::Some(@5));
+    assert!(iter.next().is_none());
 }
 
 #[test]

--- a/corelib/src/test/array_test.cairo
+++ b/corelib/src/test/array_test.cairo
@@ -198,22 +198,50 @@ fn test_array_iterator() {
 }
 
 #[test]
-fn test_fixed_size_array_iterator() {
-    let mut iter = (@[10_usize, 11, 12, 13]).into_iter();
+fn test_snapshot_fixed_size_array_iterator() {
+    let fixed_arr = [10_usize, 11, 12, 13];
+    let mut iter = (@fixed_arr).into_iter();
     assert_eq!(iter.next(), Option::Some(@10));
     assert_eq!(iter.next(), Option::Some(@11));
     assert_eq!(iter.next(), Option::Some(@12));
     assert_eq!(iter.next(), Option::Some(@13));
     assert!(iter.next().is_none());
+
+    assert_eq!(fixed_arr.span()[1], @11);
 }
 
 #[test]
-fn test_empty_fixed_size_array_iterator() {
-    let mut input: [usize; 0] = [];
-    let mut iter = (@input).into_iter();
+fn test_empty_snapshot_fixed_size_array_iterator() {
+    let mut fixed_arr: [usize; 0] = [];
+    let mut iter = (@fixed_arr).into_iter();
     assert!(iter.next().is_none());
+
+    assert_eq!(fixed_arr.span().len(), 0);
 }
 
+
+#[test]
+fn test_snapshot_array_into_iter() {
+    let mut arr = array![1, 2, 3, 4, 5];
+    let mut arr_iter = (@arr).into_iter();
+
+    let next = arr_iter.next();
+    assert!(next == Option::Some(@1));
+
+    assert!(arr[1] == @2);
+}
+
+#[test]
+fn test_snapshot_span_into_iter() {
+    let span = array![1, 2, 3, 4, 5].span();
+    let mut span_iter = (@span).into_iter();
+    let next = span_iter.next();
+    assert!(next == Option::Some(@1));
+
+    assert!(span[1] == @2);
+}
+
+#[test]
 fn test_array_into_span() {
     assert_eq!(array![1, 2, 3].span(), array![1, 2, 3].into())
 }

--- a/corelib/src/test/array_test.cairo
+++ b/corelib/src/test/array_test.cairo
@@ -199,24 +199,19 @@ fn test_array_iterator() {
 
 #[test]
 fn test_snapshot_fixed_size_array_iterator() {
-    let fixed_arr = [10_usize, 11, 12, 13];
-    let mut iter = (@fixed_arr).into_iter();
+    let mut iter = (@[10_usize, 11, 12, 13]).into_iter();
     assert_eq!(iter.next(), Option::Some(@10));
     assert_eq!(iter.next(), Option::Some(@11));
     assert_eq!(iter.next(), Option::Some(@12));
     assert_eq!(iter.next(), Option::Some(@13));
     assert!(iter.next().is_none());
-
-    assert_eq!(fixed_arr.span()[1], @11);
 }
 
 #[test]
 fn test_empty_snapshot_fixed_size_array_iterator() {
-    let mut fixed_arr: [usize; 0] = [];
-    let mut iter = (@fixed_arr).into_iter();
+    let mut input: [usize; 0] = [];
+    let mut iter = (@input).into_iter();
     assert!(iter.next().is_none());
-
-    assert_eq!(fixed_arr.span().len(), 0);
 }
 
 
@@ -225,20 +220,22 @@ fn test_snapshot_array_into_iter() {
     let mut arr = array![1, 2, 3, 4, 5];
     let mut arr_iter = (@arr).into_iter();
 
-    let next = arr_iter.next();
-    assert!(next == Option::Some(@1));
-
-    assert!(arr[1] == @2);
+    let mut i = 1;
+    while let Option::Some(value) = arr_iter.next() {
+        assert_eq!(value, @i);
+        i += 1;
+    }
 }
 
 #[test]
 fn test_snapshot_span_into_iter() {
     let span = array![1, 2, 3, 4, 5].span();
     let mut span_iter = (@span).into_iter();
-    let next = span_iter.next();
-    assert!(next == Option::Some(@1));
-
-    assert!(span[1] == @2);
+    let mut i = 1;
+    while let Option::Some(value) = span_iter.next() {
+        assert_eq!(value, @i);
+        i += 1;
+    }
 }
 
 #[test]


### PR DESCRIPTION
Implementes `IntoIter` for all Containers-snapshots convertible to span

Enables:
`@array![].into_iter()`
`(@(array![].span())).into_iter`

Supercedes the implementation specific to `@[T; SIZE]`: `@[].into_iter()`