### PR TITLE
feat(corelib): add RangeBounds and Bound

### DIFF
--- a/corelib/src/ops.cairo
+++ b/corelib/src/ops.cairo
@@ -11,7 +11,7 @@ mod range;
 // `RangeOp` is used internally by the compiler.
 #[allow(unused_imports)]
 use range::RangeOp;
-pub use range::{Range, RangeIterator, RangeTrait};
+pub use range::{Bound, Range, RangeBounds, RangeIterator, RangeTrait};
 
 mod function;
 pub use function::{Fn, FnOnce};

--- a/corelib/src/test/range_test.cairo
+++ b/corelib/src/test/range_test.cairo
@@ -1,4 +1,4 @@
-use core::ops::RangeTrait;
+use core::ops::{Bound, RangeBounds, RangeTrait};
 
 #[test]
 fn test_range_is_empty() {
@@ -10,4 +10,14 @@ fn test_range_is_empty() {
 #[test]
 fn test_range_format() {
     assert!(format!("{:?}", 1..5) == "1..5");
+}
+
+#[test]
+fn test_range_bounds() {
+    assert!((3_u8..5).start_bound() == Bound::Included(@3));
+    assert!((3_u8..5).end_bound() == Bound::Excluded(@5));
+
+    assert!(!(3_u8..5).contains(@2));
+    assert!((3_u8..5).contains(@4));
+    assert!(!(3_u8..5).contains(@5));
 }


### PR DESCRIPTION
With the addition of new range operators and range types (WIP in https://github.com/starkware-libs/cairo/pull/6972) , we are going to have different kinds of bounds for ranges.

Implements the `Bound` enum (representing all 3 kinds of possible bounds) and the `RangeBounds` associated trait to get the bounds of a range. 

Later this will be useful to abstract some inner impls (like whether a range `contains` a number or not) an use a single common implementation.

I left out some comments regarding internal bugs to discuss.