### PR TITLE
feat(corelib): range contains

### DIFF
--- a/corelib/src/ops/range.cairo
+++ b/corelib/src/ops/range.cairo
@@ -40,7 +40,23 @@ pub struct Range<T> {
 }
 
 #[generate_trait]
-pub impl RangeImpl<T, +Copy<T>, +Drop<T>, +PartialOrd<T>> of RangeTrait<T> {
+pub impl RangeImpl<T, +Destruct<T>, +PartialOrd<@T>> of RangeTrait<T> {
+    /// Returns `true` if `item` is contained in the range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert!(!(3..5).contains(@2));
+    /// assert!( (3..5).contains(@3));
+    /// assert!( (3..5).contains(@4));
+    /// assert!(!(3..5).contains(@5));
+    ///
+    /// assert!(!(3..3).contains(@3));
+    /// assert!(!(3..2).contains(@3));
+    fn contains(self: @Range<T>, item: @T) -> bool {
+        self.start <= item && item < self.end
+    }
+
     /// Returns `true` if the range contains no items.
     ///
     /// # Examples

--- a/corelib/src/test/range_test.cairo
+++ b/corelib/src/test/range_test.cairo
@@ -8,6 +8,17 @@ fn test_range_is_empty() {
 }
 
 #[test]
+fn test_range_contains() {
+    assert!(!(3_u8..5).contains(@2));
+    assert!((3_u8..5).contains(@3));
+    assert!((3_u8..5).contains(@4));
+    assert!(!(3_u8..5).contains(@5));
+
+    assert!(!(3_u8..3).contains(@3));
+    assert!(!(3_u8..2).contains(@3));
+}
+
+#[test]
 fn test_range_format() {
     assert!(format!("{:?}", 1..5) == "1..5");
 }


### PR DESCRIPTION
added `contains` on range

note: I thought it would make more sense to relax the `Copy` restrictions and make all comparison `@T` based. Let me know what you think. (also - perhaps we could relax `Drop<T>` to `Destruct<T>`)