### PR TITLE
fix: remove mut arg on ByteArray::append

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -153,7 +153,7 @@ pub impl ByteArrayImpl of ByteArrayTrait {
     /// ba.append(@"2");
     /// assert!(ba == "12");
     /// ```
-    fn append(ref self: ByteArray, mut other: @ByteArray) {
+    fn append(ref self: ByteArray, other: @ByteArray) {
         let mut other_data = other.data.span();
 
         if self.pending_word_len == 0 {

--- a/corelib/src/test/byte_array_test.cairo
+++ b/corelib/src/test/byte_array_test.cairo
@@ -496,7 +496,7 @@ fn test_iterator() {
 // ========= Test helper functions =========
 
 fn compare_byte_array(
-    mut ba: @ByteArray, mut data: Span<felt252>, pending_word_len: usize, pending_word: felt252,
+    ba: @ByteArray, mut data: Span<felt252>, pending_word_len: usize, pending_word: felt252,
 ) {
     assert(ba.data.len() == data.len(), 'wrong data len');
     let mut ba_data = ba.data.span();


### PR DESCRIPTION
The variable `other` is not mutated in the append function, so `mut` can be safely removed