### PR TITLE
Fixed typos and improved clarity in documentation

### DIFF
--- a/crates/cairo-lang-doc/src/tests/test-data/basic.txt
+++ b/crates/cairo-lang-doc/src/tests/test-data/basic.txt
@@ -43,7 +43,7 @@ impl TraitTestImpl of TraitTest {
 pub mod test_module {
     //! Test module used to check if the documentation is being attached to the nodes correctly.
     /// Just a function outside the test_module.
-    /// Abote that module there is a [trait](super::TraitTest).
+    /// Above that module there is a [trait](super::TraitTest).
     pub fn inner_test_module_function() -> () {
         //! Just a function inside the test_module.
         println!("inside inner test module inner function");
@@ -187,10 +187,10 @@ Content("Test module used to check if the documentation is being attached to the
 pub fn inner_test_module_function() -> ()
 
 //! > Item documentation #8
-Just a function outside the test_module. Abote that module there is a [trait](super::TraitTest). Just a function inside the test_module.
+Just a function outside the test_module. Above that module there is a [trait](super::TraitTest). Just a function inside the test_module.
 
 //! > Item documentation tokens #8
-Content("Just a function outside the test_module. Abote that module there is a ")
+Content("Just a function outside the test_module. Above that module there is a ")
 CommentLinkToken { label: "trait", path: Some("super::TraitTest"), resolved_item_name: Some("TraitTest") }
 Content(".")
 Content(" ")


### PR DESCRIPTION
changed: 

Abote - Above 

