### PR TITLE
Fixing Typographical Errors in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Cairo is the first Turing-complete language for creating provable programs for g
 rustup override set stable && rustup update
 ```
 
-Ensure rust was installed correctly by running the following from the root project directory:
+Ensure Rust was installed correctly by running the following from the root project directory:
 ```bash
 cargo test
 ```
@@ -105,7 +105,7 @@ You can track the exact progress [here](./docs/FEATURE_PARITY.md).
 
 ## Support
 
-- We encourage developers to ask and answer questions on [stackoverflow](https://stackoverflow.com/questions/tagged/cairo-lang).
+- We encourage developers to ask and answer questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/cairo-lang).
 - Contact options listed on [this GitHub profile](https://github.com/starkware-libs)
 
 ## Project assistance

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -95,7 +95,7 @@ pub struct MacroPluginMetadata<'a> {
     pub edition: Edition,
 }
 
-// TOD(spapini): Move to another place.
+// TODO(spapini): Move to another place.
 /// A trait for a macro plugin: external plugin that generates additional code for items.
 pub trait MacroPlugin: std::fmt::Debug + Sync + Send {
     /// Generates code for an item. If no code should be generated returns None.

--- a/crates/cairo-lang-doc/src/tests/test-data/basic.txt
+++ b/crates/cairo-lang-doc/src/tests/test-data/basic.txt
@@ -43,7 +43,7 @@ impl TraitTestImpl of TraitTest {
 pub mod test_module {
     //! Test module used to check if the documentation is being attached to the nodes correctly.
     /// Just a function outside the test_module.
-    /// Abote that module there is a [trait](super::TraitTest).
+    /// Above that module there is a [trait](super::TraitTest).
     pub fn inner_test_module_function() -> () {
         //! Just a function inside the test_module.
         println!("inside inner test module inner function");
@@ -187,10 +187,10 @@ Content("Test module used to check if the documentation is being attached to the
 pub fn inner_test_module_function() -> ()
 
 //! > Item documentation #8
-Just a function outside the test_module. Abote that module there is a [trait](super::TraitTest). Just a function inside the test_module.
+Just a function outside the test_module. Above that module there is a [trait](super::TraitTest). Just a function inside the test_module.
 
 //! > Item documentation tokens #8
-Content("Just a function outside the test_module. Abote that module there is a ")
+Content("Just a function outside the test_module. Above that module there is a ")
 CommentLinkToken { label: "trait", path: Some("super::TraitTest"), resolved_item_name: Some("TraitTest") }
 Content(".")
 Content(" ")


### PR DESCRIPTION
changes:

rust - Rust 

stackoverflow - Stack Overflow

TOD - TODO

Abote - Above 