### PR TITLE
matching un-imported traits

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -795,20 +795,40 @@ impl DiagnosticEntry for SemanticDiagnostic {
                 "`#[inline(always)]` is not allowed for functions with impl generic parameters."
                     .into()
             }
-            SemanticDiagnosticKind::CannotCallMethod { ty, method_name, inference_errors } => {
-                if inference_errors.is_empty() {
+            SemanticDiagnosticKind::CannotCallMethod {
+                ty,
+                method_name,
+                inference_errors,
+                relevant_traits,
+            } => {
+                if !inference_errors.is_empty() {
+                    return format!(
+                        "Method `{}` could not be called on type `{}`.\n{}",
+                        method_name,
+                        ty.format(db),
+                        inference_errors.format(db)
+                    );
+                }
+                if !relevant_traits.is_empty() {
+                    let suggestions = relevant_traits
+                        .iter()
+                        .map(|trait_path| format!("`{trait_path}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+
+                    format!(
+                        "Method `{}` not found on type `{}`. Consider importing one of the \
+                         following traits: {}.",
+                        method_name,
+                        ty.format(db),
+                        suggestions
+                    )
+                } else {
                     format!(
                         "Method `{}` not found on type `{}`. Did you import the correct trait and \
                          impl?",
                         method_name,
                         ty.format(db)
-                    )
-                } else {
-                    format!(
-                        "Method `{}` could not be called on type `{}`.\n{}",
-                        method_name,
-                        ty.format(db),
-                        inference_errors.format(db)
                     )
                 }
             }
@@ -1212,6 +1232,7 @@ pub enum SemanticDiagnosticKind {
         ty: semantic::TypeId,
         method_name: SmolStr,
         inference_errors: TraitInferenceErrors,
+        relevant_traits: Vec<String>,
     },
     NoSuchStructMember {
         struct_id: StructId,
@@ -1519,7 +1540,7 @@ pub struct TraitInferenceErrors {
 }
 impl TraitInferenceErrors {
     /// Is the error list empty.
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.traits_and_errors.is_empty()
     }
     /// Format the list of errors.

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/not_found
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/not_found
@@ -1,7 +1,7 @@
 //! > Test PathNotFound.
 
 //! > test_runner_name
-test_expr_diagnostics
+test_expr_diagnostics(expect_diagnostics: true)
 
 //! > expr_code
 {
@@ -30,7 +30,7 @@ error: Function not found.
 //! > Test trying to access a function from a module whose file is missing.
 
 //! > test_runner_name
-test_expr_diagnostics
+test_expr_diagnostics(expect_diagnostics: true)
 
 //! > expr_code
 module_does_not_exist::bar()
@@ -51,7 +51,7 @@ mod module_does_not_exist;
 //! > Test missing implicit in implicit_precedence
 
 //! > test_runner_name
-test_expr_diagnostics
+test_expr_diagnostics(expect_diagnostics: true)
 
 //! > expr_code
 {}
@@ -67,3 +67,40 @@ error: Type not found.
  --> lib.cairo:1:23
 #[implicit_precedence(MissingBuiltin1, MissingBuiltin2)]
                       ^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test matching imports for missing methods.
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: true)
+
+//! > expr_code
+{
+    let struct_a = A {a: 0};
+    struct_a.foo()
+}
+
+//! > module_code
+struct A {
+    a: felt252,
+}
+mod module {
+    use super::A;
+    pub trait Trt1 {
+        fn foo(self: A) -> felt252;
+    }
+    impl Imp1 of Trt1 {
+        fn foo(self: A) -> felt252 {
+            0
+        }
+    }
+}
+
+//! > function_body
+
+//! > expected_diagnostics
+error[E0002]: Method `foo` not found on type `test::A`. Consider importing one of the following traits: `module::Trt1`.
+ --> lib.cairo:18:14
+    struct_a.foo()
+             ^^^

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -12,8 +12,8 @@ use cairo_lang_defs::db::{get_all_path_leaves, validate_attributes_flat};
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::{
     EnumId, FunctionTitleId, GenericKind, LanguageElementId, LocalVarLongId, LookupItemId,
-    MemberId, ModuleItemId, NamedLanguageElementId, StatementConstLongId, StatementItemId,
-    StatementUseLongId, TraitFunctionId, TraitId, VarId,
+    MemberId, ModuleFileId, ModuleItemId, NamedLanguageElementId, StatementConstLongId,
+    StatementItemId, StatementUseLongId, TraitFunctionId, TraitId, VarId,
 };
 use cairo_lang_defs::plugin::MacroPluginMetadata;
 use cairo_lang_diagnostics::{Maybe, ToOption, skip_diagnostic};
@@ -34,18 +34,17 @@ use cairo_lang_utils::ordered_hash_map::{Entry, OrderedHashMap};
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
-use cairo_lang_utils::{LookupIntern, OptionHelper, extract_matches, try_extract_matches};
+use cairo_lang_utils::{Intern, LookupIntern, OptionHelper, extract_matches, try_extract_matches};
 use itertools::{Itertools, chain, zip_eq};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use salsa::InternKey;
 use smol_str::SmolStr;
-use utils::Intern;
 
 use super::inference::canonic::ResultNoErrEx;
 use super::inference::conform::InferenceConform;
 use super::inference::infers::InferenceEmbeddings;
-use super::inference::{Inference, InferenceError};
+use super::inference::{Inference, InferenceData, InferenceError};
 use super::objects::*;
 use super::pattern::{
     Pattern, PatternEnumVariant, PatternFixedSizeArray, PatternLiteral, PatternMissing,
@@ -62,11 +61,13 @@ use crate::diagnostic::{
     ElementKind, MultiArmExprKind, NotFoundItemType, SemanticDiagnostics,
     SemanticDiagnosticsBuilder, TraitInferenceErrors, UnsupportedOutsideOfFunctionFeatureName,
 };
+use crate::expr::inference::solver::SolutionSet;
+use crate::expr::inference::{ImplVarTraitItemMappings, InferenceId};
 use crate::items::constant::{ConstValue, resolve_const_expr_and_evaluate, validate_const_expr};
 use crate::items::enm::SemanticEnumEx;
 use crate::items::feature_kind::extract_item_feature_config;
 use crate::items::functions::function_signature_params;
-use crate::items::imp::{filter_candidate_traits, infer_impl_by_self};
+use crate::items::imp::{ImplLookupContext, filter_candidate_traits, infer_impl_by_self};
 use crate::items::modifiers::compute_mutability;
 use crate::items::us::get_use_path_segments;
 use crate::items::visibility;
@@ -2778,6 +2779,11 @@ fn method_call_expr(
         }
     }
 
+    // Extracting the possible traits that should be imported, in order to use the method.
+    let module_file_id = ctx.resolver.module_file_id;
+    let lookup_context = ctx.resolver.impl_lookup_context();
+    let lexpr_clone = lexpr.clone();
+    let db = ctx.db;
     let (function_id, actual_trait_id, fixed_lexpr, mutability) =
         compute_method_function_call_data(
             ctx,
@@ -2787,7 +2793,19 @@ fn method_call_expr(
             path.stable_ptr().untyped(),
             generic_args_syntax,
             |ty, method_name, inference_errors| {
-                Some(CannotCallMethod { ty, method_name, inference_errors })
+                let relevant_traits = if !inference_errors.is_empty() {
+                    vec![]
+                } else {
+                    match_method_to_traits(
+                        db,
+                        ty,
+                        &method_name,
+                        lookup_context.clone(),
+                        module_file_id,
+                        lexpr_clone.stable_ptr().untyped(),
+                    )
+                };
+                Some(CannotCallMethod { ty, method_name, inference_errors, relevant_traits })
             },
             |_, trait_function_id0, trait_function_id1| {
                 Some(AmbiguousTrait { trait_function_id0, trait_function_id1 })
@@ -3800,4 +3818,46 @@ fn function_parameter_types(
     let signature = ctx.db.concrete_function_signature(function)?;
     let param_types = signature.params.into_iter().map(|param| param.ty);
     Ok(param_types)
+}
+
+/// Finds traits which contain a method matching the given name and type.
+/// This function checks for visible traits in the specified module file and filters
+/// methods based on their association with the given type and method name.
+fn match_method_to_traits(
+    db: &dyn SemanticGroup,
+    ty: semantic::TypeId,
+    method_name: &SmolStr,
+    lookup_context: ImplLookupContext,
+    module_file_id: ModuleFileId,
+    stable_ptr: SyntaxStablePtrId,
+) -> Vec<String> {
+    let visible_traits = db
+        .visible_traits_from_module(module_file_id)
+        .unwrap_or_else(|| Arc::new(OrderedHashMap::default()));
+
+    visible_traits
+        .iter()
+        .filter_map(|(trait_id, path)| {
+            let mut data = InferenceData::new(InferenceId::NoContext);
+            let mut inference = data.inference(db);
+            let trait_function =
+                db.trait_function_by_name(*trait_id, method_name.clone()).ok()??;
+            let (concrete_trait_id, _) = inference.infer_concrete_trait_by_self(
+                trait_function,
+                ty,
+                &lookup_context,
+                Some(stable_ptr),
+                |_| {},
+            )?;
+            inference.solve().ok();
+            match inference.trait_solution_set(
+                concrete_trait_id,
+                ImplVarTraitItemMappings::default(),
+                lookup_context.clone(),
+            ) {
+                Ok(SolutionSet::Unique(_) | SolutionSet::Ambiguous(_)) => Some(path.clone()),
+                _ => None,
+            }
+        })
+        .collect()
 }

--- a/crates/cairo-lang-semantic/src/lsp_helpers.rs
+++ b/crates/cairo-lang-semantic/src/lsp_helpers.rs
@@ -4,12 +4,15 @@ use cairo_lang_defs::ids::{
     FileIndex, LanguageElementId, ModuleFileId, ModuleId, NamedLanguageElementId, TraitFunctionId,
     TraitId,
 };
-use cairo_lang_filesystem::ids::CrateId;
+use cairo_lang_filesystem::db::CORELIB_CRATE_NAME;
+use cairo_lang_filesystem::ids::{CrateId, CrateLongId};
+use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::{Entry, OrderedHashMap};
 use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
+use itertools::chain;
 use smol_str::SmolStr;
 
-use crate::corelib::{core_submodule, get_submodule};
+use crate::corelib::{self, core_submodule, get_submodule};
 use crate::db::SemanticGroup;
 use crate::expr::inference::InferenceId;
 use crate::items::us::SemanticUseEx;
@@ -244,7 +247,17 @@ pub fn visible_traits_from_module(
     );
     module_visible_traits
         .extend_from_slice(&db.visible_traits_in_module(module_id, module_file_id, true)[..]);
-    for crate_id in db.crates() {
+    let settings = db.crate_config(current_crate_id).map(|c| c.settings).unwrap_or_default();
+    for crate_id in chain!(
+        (!settings.dependencies.contains_key(CORELIB_CRATE_NAME)).then(|| corelib::core_crate(db)),
+        settings.dependencies.iter().map(|(name, setting)| {
+            CrateLongId::Real {
+                name: name.clone().into(),
+                discriminator: setting.discriminator.clone(),
+            }
+            .intern(db)
+        })
+    ) {
         if crate_id == current_crate_id {
             continue;
         }


### PR DESCRIPTION
- This PR adds proper diagnostics to suggest importing a relevant trait containing the method being used when it is not found on the given type.

- However, this behavior does not function correctly in our current test framework due to a bug with in the test infrastructure (where the test's crate is not properly integrated into the db).
This will require a designated PR to deal with this issue.

- Note that the added test does not return the proper diagnostic as a result of this bug- and we need to make sure it will be updated after the fix.

- Also note that the changes were implemented in the compute.rs and not in the diagnostics.rs file due to the direct involvement of virtual files in the computation process.

- It is also necessary to evaluate and refactor the functions used here to better align with the existing code within the langauge-server repo. The find_methods_for_type function particularly relevant for review and potential integration (and to decide whether and how to move them back into our repo).