### PR TITLE
feat(corelib): ByteArray impl Hash trait

### DIFF
--- a/corelib/src/hash.cairo
+++ b/corelib/src/hash.cairo
@@ -229,3 +229,16 @@ impl TupleNextHash<
         state.update_with(head).update_with(rest)
     }
 }
+
+impl ByteArrayHash<S, +HashStateTrait<S>, +Drop<S>> of Hash<ByteArray, S> {
+    fn update_state(mut state: S, value: ByteArray) -> S {
+        state = state.update(value.data.len().into());
+
+        for word_index in 0..value.data.len() {
+            let word_in_data = (*value.data.at(word_index)).into();
+            state = state.update(word_in_data);
+        };
+
+        state.update(value.pending_word_len.into()).update(value.pending_word)
+    }
+}

--- a/corelib/src/test/hash_test.cairo
+++ b/corelib/src/test/hash_test.cairo
@@ -85,3 +85,24 @@ fn test_user_defined_hash() {
         'Bad hash of StructForHash',
     );
 }
+
+#[test]
+fn test_byte_array_hash() {
+    let byte_array: ByteArray = "This is a sentence that is longer than 31 characters.";
+
+    let word_1 = 'This is a sentence that is long';
+    let data_length = 1;
+    let pending_word = 'er than 31 characters.';
+    let pending_word_len = 22;
+
+    assert_eq(
+        @PoseidonTrait::new().update_with(byte_array).finalize(),
+        @PoseidonTrait::new()
+            .update(data_length)
+            .update(word_1)
+            .update(pending_word_len)
+            .update(pending_word)
+            .finalize(),
+        'Bad hash for ByteArray',
+    );
+}


### PR DESCRIPTION
Close #7015

Implement `Hash` trait for ByteArray

**Example**

```cairo
let byte_array: ByteArray = "A simple ByteArray";
PoseidonTrait::new().update_with(byte_array).finalize()
```