### PR TITLE
feat(corelib): Add `map` method to ArrayTrait

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -275,6 +275,33 @@ pub impl ArrayImpl<T> of ArrayTrait<T> {
     fn span(snapshot: @Array<T>) -> Span<T> {
         Span { snapshot }
     }
+
+    /// Returns an array of the same size as `self`, with function `f` applied to each element in order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let x = [1, 2, 3];
+    /// let y = x.map(|v| v + 1);
+    /// assert_eq!(y, [2, 3, 4]);
+    ///
+    /// let x = ["Ferris", "Bueller's", "Day", "Off"];
+    /// let y = x.map(|v: ByteArray| v.len());
+    /// assert_eq!(y, [6, 9, 3, 3]);
+    /// ```
+    #[inline]
+    #[must_use]
+    fn map<F, impl func: core::ops::Fn<F, (T,)>, +Drop<T>, +Drop<F>, +Drop<func::Output>>(
+        self: Array<T>, f: F
+    ) -> Array<func::Output> {
+        let mut result = array![];
+
+        for elem in self {
+            result.append(f(elem));
+        };
+
+        result
+    }
 }
 
 impl ArrayDefault<T> of Default<Array<T>> {

--- a/corelib/src/test/array_test.cairo
+++ b/corelib/src/test/array_test.cairo
@@ -232,6 +232,7 @@ fn test_array_snap_into_span() {
 fn test_span_into_array_snap() {
     assert_eq!(@array![1, 2, 3], array![1, 2, 3].span().into());
 }
+
 #[test]
 fn nested_for_loop() {
     let mat = array![array![1, 2], array![3, 4], array![5, 6]];

--- a/corelib/src/test/language_features/closure_test.cairo
+++ b/corelib/src/test/language_features/closure_test.cairo
@@ -85,22 +85,14 @@ fn fix_sized_array_map_test() {
     assert_eq!(fix_sized_array_map([2, 3], |x| x + 3), [5, 6]);
 }
 
-#[generate_trait]
-impl ArrayExt of ArrayExtTrait {
-    fn map<T, +Drop<T>, F, +Drop<F>, impl func: core::ops::Fn<F, (T,)>, +Drop<func::Output>>(
-        self: Array<T>, f: F,
-    ) -> Array<func::Output> {
-        let mut output: Array<func::Output> = array![];
-        for elem in self {
-            output.append(f(elem));
-        };
-        output
-    }
+#[test]
+fn test_array_map() {
+    let x = array![1, 2, 3];
+    let y = x.map(|v| v + 1);
+    assert_eq!(y, array![2, 3, 4]);
+
+    let x = array!["Ferris", "Bueller's", "Day", "Off"];
+    let y = x.map(|v: ByteArray| v.len());
+    assert_eq!(y, array![6, 9, 3, 3])
 }
 
-#[test]
-fn array_map_test() {
-    let arr = array![1, 2, 3];
-    let result = arr.map(|x| x + 1);
-    assert_eq!(result, array![2, 3, 4]);
-}


### PR DESCRIPTION
Hi,

I would like to suggest the addition of the `map` function to the ArrayTrait API in order to be able to apply a function to each single element in the array and return a new resulting array.

## Example
 
```cairo
let x = array![1, 2, 3];
let y = x.map(|v| v + 1);
assert_eq!(y, array![2, 3, 4]);

let x = array!["Ferris", "Bueller's", "Day", "Off"];
let y = x.map(|v: ByteArray| v.len());
assert_eq!(y, array![6, 9, 3, 3])
```


## Question

Originally, I did something very similar to the version I propose now, but instead of consuming the array, the `map` function took a snapshot of the array. I thought this allowed to still be able to use the original array afterwards if needed. Also, initially, I gave a snapshot of T as the closure argument, so that we did not necessarily have to desnap and therefore copy the elements of the array into the new array inside the `map` and instead just pass the snapshot of the element.

But when writing and executing tests, I realized there was what seemed to be a temporary version of the `map` method for the Array type in the `closure_test.cairo` file. In this temporary version, as well as in the rust std lib, the `map` function actually consumes the array. I therefore used this version. Is it better to consume the array because the user most likely won’t need the original array after applying `map` to it ? Also, maybe taking the ownership is more memory-efficient rather than assuming the user will want to keep the original array, and if they want to keep it, they will themselves explicitly make a copy of it ?

Thank you!