### PR TITLE
feat(corelib): Iterator::enumerate

### DIFF
--- a/corelib/src/iter/adapters.cairo
+++ b/corelib/src/iter/adapters.cairo
@@ -2,3 +2,8 @@ mod map;
 pub use map::Map;
 #[allow(unused_imports)]
 pub(crate) use map::mapped_iterator;
+
+mod enumerate;
+pub use enumerate::Enumerate;
+#[allow(unused_imports)]
+pub(crate) use enumerate::enumerated_iterator;

--- a/corelib/src/iter/adapters/enumerate.cairo
+++ b/corelib/src/iter/adapters/enumerate.cairo
@@ -1,0 +1,42 @@
+/// An iterator that yields the current count and the element during iteration.
+///
+/// This `struct` is created by the [`enumerate`] method on [`Iterator`]. See its
+/// documentation for more.
+///
+/// [`enumerate`]: Iterator::enumerate
+/// [`Iterator`]: core::iter::Iterator
+#[must_use]
+#[derive(Drop, Clone, Debug)]
+pub struct Enumerate<I> {
+    iter: I,
+    count: usize,
+}
+
+pub fn enumerated_iterator<I>(iter: I) -> Enumerate<I> {
+    Enumerate { iter, count: 0 }
+}
+
+impl EnumerateIterator<
+    I, T, +Iterator<I>[Item: T], +Destruct<I>, +Destruct<T>,
+> of Iterator<Enumerate<I>> {
+    type Item = (usize, T);
+
+    /// # Overflow Behavior
+    ///
+    /// The method does no guarding against overflows, so enumerating more than
+    /// `Bounded::<usize>::MAX` elements either produces the wrong result or panics. If
+    /// debug assertions are enabled, a panic is guaranteed.
+    ///
+    /// [`Bounded`]: core::num::traits::Bounded
+    ///
+    /// # Panics
+    ///
+    /// Might panic if the index of the element overflows a `usize`.
+    #[inline]
+    fn next(ref self: Enumerate<I>) -> Option<Self::Item> {
+        let a = self.iter.next()?;
+        let i = self.count;
+        self.count += 1;
+        Option::Some((i, a))
+    }
+}

--- a/corelib/src/iter/adapters/enumerate.cairo
+++ b/corelib/src/iter/adapters/enumerate.cairo
@@ -24,14 +24,13 @@ impl EnumerateIterator<
     /// # Overflow Behavior
     ///
     /// The method does no guarding against overflows, so enumerating more than
-    /// `Bounded::<usize>::MAX` elements either produces the wrong result or panics. If
-    /// debug assertions are enabled, a panic is guaranteed.
+    /// `Bounded::<usize>::MAX` elements will always panic.
     ///
     /// [`Bounded`]: core::num::traits::Bounded
     ///
     /// # Panics
     ///
-    /// Might panic if the index of the element overflows a `usize`.
+    /// Will panic if the index of the element overflows a `usize`.
     #[inline]
     fn next(ref self: Enumerate<I>) -> Option<Self::Item> {
         let a = self.iter.next()?;

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,4 +1,5 @@
 use crate::iter::adapters::{Map, mapped_iterator};
+use crate::iter::adapters::{Enumerate, enumerated_iterator};
 
 /// A trait for dealing with iterators.
 ///
@@ -92,5 +93,41 @@ pub trait Iterator<T> {
         self: T, f: F,
     ) -> Map<T, F> {
         mapped_iterator(self, f)
+    }
+
+    /// Creates an iterator which gives the current iteration count as well as
+    /// the next value.
+    ///
+    /// The iterator returned yields pairs `(i, val)`, where `i` is the
+    /// current index of iteration and `val` is the value returned by the
+    /// iterator.
+    ///
+    /// `enumerate()` keeps its count as a [`usize`].
+    ///
+    /// # Overflow Behavior
+    ///
+    /// The method does no guarding against overflows, so enumerating more than
+    /// [`Bounded::<usize>::MAX`] elements either produces the wrong result or panics.
+    ///
+    /// [`Bounded`]: core::num::traits::Bounded
+    ///
+    /// # Panics
+    ///
+    /// The returned iterator might panic if the to-be-returned index would
+    /// overflow a [`usize`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut iter = array!['a', 'b', 'c'].into_iter().enumerate();
+    ///
+    /// assert_eq!(iter.next(), Option::Some((0, 'a')));
+    /// assert_eq!(iter.next(), Option::Some((1, 'b')));
+    /// assert_eq!(iter.next(), Option::Some((2, 'c')));
+    /// assert_eq!(iter.next(), Option::None);
+    /// ```
+    #[inline]
+    fn enumerate(self: T) -> Enumerate<T> {
+        enumerated_iterator(self)
     }
 }

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,5 +1,4 @@
-use crate::iter::adapters::{Map, mapped_iterator};
-use crate::iter::adapters::{Enumerate, enumerated_iterator};
+use crate::iter::adapters::{Enumerate, Map, enumerated_iterator, mapped_iterator};
 
 /// A trait for dealing with iterators.
 ///
@@ -107,14 +106,13 @@ pub trait Iterator<T> {
     /// # Overflow Behavior
     ///
     /// The method does no guarding against overflows, so enumerating more than
-    /// [`Bounded::<usize>::MAX`] elements either produces the wrong result or panics.
+    /// `Bounded::<usize>::MAX` elements will always panic.
     ///
     /// [`Bounded`]: core::num::traits::Bounded
     ///
     /// # Panics
     ///
-    /// The returned iterator might panic if the to-be-returned index would
-    /// overflow a [`usize`].
+    /// Will panic if the to-be-returned index overflows a `usize`.
     ///
     /// # Examples
     ///

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -7,3 +7,12 @@ fn test_iter_adapter_map() {
     assert_eq!(iter.next(), Option::Some(6));
     assert_eq!(iter.next(), Option::None);
 }
+
+fn test_iterator_enumerate() {
+    let mut iter = array!['a', 'b', 'c'].into_iter().enumerate();
+
+    assert_eq!(iter.next(), Option::Some((0, 'a')));
+    assert_eq!(iter.next(), Option::Some((1, 'b')));
+    assert_eq!(iter.next(), Option::Some((2, 'c')));
+    assert_eq!(iter.next(), Option::None);
+}


### PR DESCRIPTION
Creates an iterator which gives the current iteration count as well as the next value.

The iterator returned yields pairs `(i, val)`, where `i` is the current index of iteration and `val` is the value returned by the iterator.

`enumerate()` keeps its count as a `usize`.


### Examples

```cairo
let a = array!['a', 'b', 'c'];

let mut iter = a.into_iter().enumerate();

assert_eq!(iter.next(), Option::Some((0, 'a')));
assert_eq!(iter.next(), Option::Some((1, 'b')));
assert_eq!(iter.next(), Option::Some((2, 'c')));
assert_eq!(iter.next(), Option::None);
```

### Overflow Behavior

The method does no guarding against overflows, so enumerating more than `Bounded::<usize>::MAX` elements either produces the wrong result or panics.
