### PR TITLE
Core Lib Documentation: `Iter` module

### DIFF
--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -1,20 +1,2 @@
-//! Traits and utilities for iterating over sequences of values.
-//!
-//! # Overview
-//!
-//! This module defines the basic abstraction for iteration in Cairo, allowing for generic
-//! and efficient traversal over collections. The `Iterator` trait is fundamental for
-//! implementing iterators, which are used to perform operations like mapping, filtering,
-//! and reducing over collections. The `IntoIterator` trait is also very useful as it allows to
-//! convert any collection into an iterator.
-//!
-//! # Traits
-//!
-//! - [`Iterator`]: Defines the method to advance an iterator and retrieve the next value.
-//! - [`IntoIterator`]: Allows to convert a collection into an iteror.
-//!
-//! [`Iterator`]: crate::iter::Iterator
-//! [`IntoIterator`]: crate::iter::IntoIterator
-
 mod traits;
 pub use traits::{IntoIterator, Iterator};

--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -5,13 +5,16 @@
 //! This module defines the basic abstraction for iteration in Cairo, allowing for generic
 //! and efficient traversal over collections. The `Iterator` trait is fundamental for
 //! implementing iterators, which are used to perform operations like mapping, filtering,
-//! and reducing over collections. The `IntoIterator` is also very useful as it allows to convert
-//! any collection into an iterator.
+//! and reducing over collections. The `IntoIterator` trait is also very useful as it allows to
+//! convert any collection into an iterator.
 //!
 //! # Traits
 //!
 //! - [`Iterator`]: Defines the method to advance an iterator and retrieve the next value.
 //! - [`IntoIterator`]: Allows to convert a collection into an iteror.
+//!
+//! [`Iterator`]: crate::iter::Iterator
+//! [`IntoIterator`]: crate::iter::IntoIterator
 
 mod traits;
 pub use traits::{IntoIterator, Iterator};

--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -1,2 +1,17 @@
+//! Traits and utilities for iterating over sequences of values.
+//!
+//! # Overview
+//!
+//! This module defines the basic abstraction for iteration in Cairo, allowing for generic
+//! and efficient traversal over collections. The `Iterator` trait is fundamental for
+//! implementing iterators, which are used to perform operations like mapping, filtering,
+//! and reducing over collections. The `IntoIterator` is also very useful as it allows to convert
+//! any collection into an iterator.
+//!
+//! # Traits
+//!
+//! - [`Iterator`]: Defines the method to advance an iterator and retrieve the next value.
+//! - [`IntoIterator`]: Allows to convert a collection into an iteror.
+
 mod traits;
 pub use traits::{IntoIterator, Iterator};

--- a/corelib/src/iter/traits.cairo
+++ b/corelib/src/iter/traits.cairo
@@ -1,4 +1,5 @@
 mod collect;
-mod iterator;
 pub use collect::IntoIterator;
+
+mod iterator;
 pub use iterator::Iterator;

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -1,74 +1,72 @@
-//! Conversion into an [`Iterator`].
-//!
-//! By implementing `IntoIterator` for a type, you define how it will be
-//! converted to an iterator. This is common for types which describe a
-//! collection of some kind.
-//!
-//! One benefit of implementing `IntoIterator` is that your type will [work
-//! with Cairo's `for` loop syntax](crate::iter#for-loops-and-intoiterator).
-//!
-//! # Examples
-//!
-//! Basic usage:
-//!
-//! ```
-//! let mut iter = array![1, 2, 3].into_iter();
-//!
-//! assert!(Option::Some(1) == iter.next());
-//! assert!(Option::Some(2) == iter.next());
-//! assert!(Option::Some(3) == iter.next());
-//! assert!(Option::None == iter.next());
-//! ```
-//!
-//! Implementing `IntoIterator` for your type:
-//!
-//! ```
-//! // A sample collection, that's just a wrapper over `Array<u32>`
-//! #[derive(Drop, Debug)]
-//! struct MyCollection {
-//!     arr: Array<u32>
-//! }
-//!
-//! // Let's give it some methods so we can create one and add things
-//! // to it.
-//! #[generate_trait]
-//! impl MyCollectionImpl of MyCollectionTrait {
-//!     fn new() -> MyCollection {
-//!         MyCollection {
-//!             arr: ArrayTrait::new()
-//!         }
-//!     }
-//!
-//!     fn add(ref self: MyCollection, elem: u32) {
-//!         self.arr.append(elem);
-//!     }
-//! }
-//!
-//! // and we'll implement `IntoIterator`
-//! impl MyCollectionIntoIterator of IntoIterator<MyCollection> {
-//!     type IntoIter = crate::array::ArrayIter<u32>;
-//!     fn into_iter(self: MyCollection) -> Self::IntoIter {
-//!         self.arr.into_iter()
-//!     }
-//! }
-//!
-//! // Now we can make a new collection...
-//! let mut c = MyCollectionTrait::new();
-//!
-//! // ... add some stuff to it ...
-//! c.add(0);
-//! c.add(1);
-//! c.add(2);
-//!
-//! // ... and then turn it into an `Iterator`:
-//! let mut n = 0;
-//! for i in c {
-//!     assert!(i == n);
-//!     n += 1;
-//! };
-//! ```
-
-/// A trait to create an iterator from a type.
+/// Conversion into an [`Iterator`].
+///
+/// By implementing `IntoIterator` for a type, you define how it will be
+/// converted to an iterator. This is common for types which describe a
+/// collection of some kind.
+///
+/// One benefit of implementing `IntoIterator` is that your type will work
+/// with Cairo's `for` loop syntax.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// let mut iter = array![1, 2, 3].into_iter();
+///
+/// assert!(Option::Some(1) == iter.next());
+/// assert!(Option::Some(2) == iter.next());
+/// assert!(Option::Some(3) == iter.next());
+/// assert!(Option::None == iter.next());
+/// ```
+///
+/// Implementing `IntoIterator` for your type:
+///
+/// ```
+/// // A sample collection, that's just a wrapper over `Array<u32>`
+/// #[derive(Drop, Debug)]
+/// struct MyCollection {
+///     arr: Array<u32>
+/// }
+///
+/// // Let's give it some methods so we can create one and add things
+/// // to it.
+/// #[generate_trait]
+/// impl MyCollectionImpl of MyCollectionTrait {
+///     fn new() -> MyCollection {
+///         MyCollection {
+///             arr: ArrayTrait::new()
+///         }
+///     }
+///
+///     fn add(ref self: MyCollection, elem: u32) {
+///         self.arr.append(elem);
+///     }
+/// }
+///
+/// // and we'll implement `IntoIterator`
+/// impl MyCollectionIntoIterator of IntoIterator<MyCollection> {
+///     type IntoIter = core::array::ArrayIter<u32>;
+///     fn into_iter(self: MyCollection) -> Self::IntoIter {
+///         self.arr.into_iter()
+///     }
+/// }
+///
+/// // Now we can make a new collection...
+/// let mut c = MyCollectionTrait::new();
+///
+/// // ... add some stuff to it ...
+/// c.add(0);
+/// c.add(1);
+/// c.add(2);
+///
+/// // ... and then turn it into an `Iterator`:
+/// let mut n = 0;
+/// for i in c {
+///     assert!(i == n);
+///     n += 1;
+/// };
+/// ```
 pub trait IntoIterator<T> {
     /// The iterator type that will be created.
     type IntoIter;
@@ -85,10 +83,10 @@ pub trait IntoIterator<T> {
     /// ```
     /// let mut iter = array![1, 2, 3].into_iter();
     ///
-    /// assert!(Option::Some(1) == iter.next());
-    /// assert!(Option::Some(2) == iter.next());
-    /// assert!(Option::Some(3) == iter.next());
-    /// assert!(Option::None == iter.next());
+    /// assert_eq!(Option::Some(1), iter.next());
+    /// assert_eq!(Option::Some(2), iter.next());
+    /// assert_eq!(Option::Some(3), iter.next());
+    /// assert_eq!(Option::None, iter.next());
     /// ```
     fn into_iter(self: T) -> Self::IntoIter;
 }

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -1,75 +1,79 @@
-/// Conversion into an [`Iterator`].
-///
-/// By implementing `IntoIterator` for a type, you define how it will be
-/// converted to an iterator. This is common for types which describe a
-/// collection of some kind.
-///
-/// One benefit of implementing `IntoIterator` is that your type will [work
-/// with Cairo's `for` loop syntax](crate::iter#for-loops-and-intoiterator).
-///
-/// # Examples
-///
-/// Basic usage:
-///
-/// ```
-/// let mut iter = array![1, 2, 3].into_iter();
-///
-/// assert_eq!(Option::Some(1), iter.next());
-/// assert_eq!(Option::Some(2), iter.next());
-/// assert_eq!(Option::Some(3), iter.next());
-/// assert_eq!(Option::None, iter.next());
-/// ```
-/// Implementing `IntoIterator` for your type:
-///
-/// ```
-/// // A sample collection, that's just a wrapper over Array<u32>
-/// #[derive(Drop, Debug)]
-/// struct MyCollection {
-///     arr: Array<u32>
-/// }
-///
-/// // Let's give it some methods so we can create one and add things
-/// // to it.
-/// #[generate_trait]
-/// impl MyCollectionImpl of MyCollectionTrait {
-///     fn new() -> MyCollection {
-///         MyCollection {
-///             arr: ArrayTrait::new()
-///         }
-///     }
-///
-///     fn add(ref self: MyCollection, elem: u32) {
-///         self.arr.append(elem);
-///     }
-/// }
-///
-/// // and we'll implement IntoIterator
-/// impl MyCollectionIntoIterator of IntoIterator<MyCollection> {
-///     type IntoIter = crate::array::ArrayIter<u32>;
-///     fn into_iter(self: MyCollection) -> Self::IntoIter {
-///         self.arr.into_iter()
-///     }
-/// }
-///
-/// // Now we can make a new collection...
-/// let mut c = MyCollectionTrait::new();
-///
-/// // ... add some stuff to it ...
-/// c.add(0);
-/// c.add(1);
-/// c.add(2);
-///
-/// // ... and then turn it into an Iterator:
-/// let mut n = 0;
-/// for i in c {
-///     assert_eq!(i, n);
-///     n += 1;
-/// };
-/// ```
+//! Conversion into an [`Iterator`].
+//!
+//! By implementing `IntoIterator` for a type, you define how it will be
+//! converted to an iterator. This is common for types which describe a
+//! collection of some kind.
+//!
+//! One benefit of implementing `IntoIterator` is that your type will [work
+//! with Cairo's `for` loop syntax](crate::iter#for-loops-and-intoiterator).
+//!
+//! # Examples
+//!
+//! Basic usage:
+//!
+//! ```
+//! let mut iter = array![1, 2, 3].into_iter();
+//!
+//! assert_eq!(Option::Some(1), iter.next());
+//! assert_eq!(Option::Some(2), iter.next());
+//! assert_eq!(Option::Some(3), iter.next());
+//! assert_eq!(Option::None, iter.next());
+//! ```
+//!
+//! Implementing `IntoIterator` for your type:
+//!
+//! ```
+//! // A sample collection, that's just a wrapper over `Array<u32>`
+//! #[derive(Drop, Debug)]
+//! struct MyCollection {
+//!     arr: Array<u32>
+//! }
+//!
+//! // Let's give it some methods so we can create one and add things
+//! // to it.
+//! #[generate_trait]
+//! impl MyCollectionImpl of MyCollectionTrait {
+//!     fn new() -> MyCollection {
+//!         MyCollection {
+//!             arr: ArrayTrait::new()
+//!         }
+//!     }
+//!
+//!     fn add(ref self: MyCollection, elem: u32) {
+//!         self.arr.append(elem);
+//!     }
+//! }
+//!
+//! // and we'll implement `IntoIterator`
+//! impl MyCollectionIntoIterator of IntoIterator<MyCollection> {
+//!     type IntoIter = crate::array::ArrayIter<u32>;
+//!     fn into_iter(self: MyCollection) -> Self::IntoIter {
+//!         self.arr.into_iter()
+//!     }
+//! }
+//!
+//! // Now we can make a new collection...
+//! let mut c = MyCollectionTrait::new();
+//!
+//! // ... add some stuff to it ...
+//! c.add(0);
+//! c.add(1);
+//! c.add(2);
+//!
+//! // ... and then turn it into an `Iterator`:
+//! let mut n = 0;
+//! for i in c {
+//!     assert_eq!(i, n);
+//!     n += 1;
+//! };
+//! ```
+
+/// A trait to create an iterator from a type.
 pub trait IntoIterator<T> {
     /// The iterator type that will be created.
     type IntoIter;
     impl Iterator: Iterator<Self::IntoIter>;
+
     /// Creates an iterator from a value.
     ///
     /// See the [module-level documentation] for more.

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -14,10 +14,10 @@
 //! ```
 //! let mut iter = array![1, 2, 3].into_iter();
 //!
-//! assert_eq!(Option::Some(1), iter.next());
-//! assert_eq!(Option::Some(2), iter.next());
-//! assert_eq!(Option::Some(3), iter.next());
-//! assert_eq!(Option::None, iter.next());
+//! assert!(Option::Some(1) == iter.next());
+//! assert!(Option::Some(2) == iter.next());
+//! assert!(Option::Some(3) == iter.next());
+//! assert!(Option::None == iter.next());
 //! ```
 //!
 //! Implementing `IntoIterator` for your type:
@@ -63,7 +63,7 @@
 //! // ... and then turn it into an `Iterator`:
 //! let mut n = 0;
 //! for i in c {
-//!     assert_eq!(i, n);
+//!     assert!(i == n);
 //!     n += 1;
 //! };
 //! ```
@@ -85,10 +85,10 @@ pub trait IntoIterator<T> {
     /// ```
     /// let mut iter = array![1, 2, 3].into_iter();
     ///
-    /// assert_eq!(Option::Some(1), iter.next());
-    /// assert_eq!(Option::Some(2), iter.next());
-    /// assert_eq!(Option::Some(3), iter.next());
-    /// assert_eq!(Option::None, iter.next());
+    /// assert!(Option::Some(1) == iter.next());
+    /// assert!(Option::Some(2) == iter.next());
+    /// assert!(Option::Some(3) == iter.next());
+    /// assert!(Option::None == iter.next());
     /// ```
     fn into_iter(self: T) -> Self::IntoIter;
 }

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -23,9 +23,7 @@ pub trait Iterator<T> {
     /// # Examples
     ///
     /// ```
-    /// let a = [1, 2, 3].span();
-    ///
-    /// let mut iter = a.into_iter();
+    /// let mut iter = [1, 2, 3].span().into_iter();
     ///
     /// // A call to next() returns the next value...
     /// assert_eq!(Option::Some(@1), iter.next());

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,15 +1,8 @@
-//! Traits and utilities for iterating over sequences of values.
+
+//! Iteratos for for generic and efficient traversal over collections.
 //!
-//! # Overview
-//!
-//! This module defines the basic abstraction for iteration in Cairo, allowing for generic
-//! and efficient traversal over collections. The `Iterator` trait is fundamental for
-//! implementing iterators, which are used to perform operations like mapping, filtering,
+//!  The `Iterator` trait is fundamental for implementing iterators, which are used to perform operations like mapping, filtering,
 //! and reducing over collections.
-//!
-//! # Traits
-//!
-//! - [`Iterator`]: Defines the method to advance an iterator and retrieve the next value.
 //!
 //! # Examples
 //!

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,49 +1,43 @@
-//! Iterators for generic and efficient traversal over collections.
-//!
-//! The `Iterator` trait is fundamental for implementing iterators, which are used to perform
-//! operations like mapping, filtering, and reducing over collections.
-//!
-//! # Examples
-//!
-//! Basic usage of an iterator:
-//!
-//! ```
-//! use core::iter::Iterator;
-//!
-//! #[derive(Drop, Copy)]
-//! pub struct Counter {
-//!     pub count: u32,
-//! }
-//!
-//! impl CounterIterator of Iterator<Counter> {
-//!     type Item = u32;
-//!
-//!     fn next(ref self: Counter) -> Option<Self::Item> {
-//!         if self.count < 5 {
-//!             self.count += 1;
-//!             Option::Some(self.count)
-//!         } else {
-//!             Option::None
-//!         }
-//!     }
-//! }
-//!
-//! fn main() {
-//!     let mut counter = Counter { count: 0 };
-//!     assert!(counter.next() == Option::Some(1));
-//!     assert!(counter.next() == Option::Some(2));
-//!     assert!(counter.next() == Option::Some(3));
-//!     assert!(counter.next() == Option::Some(4));
-//!     assert!(counter.next() == Option::Some(5));
-//!     assert!(counter.next() == Option::None);
-//! }
-//! ```
-
-/// An iterator over a collection of values.
+/// A trait for dealing with iterators.
+///
+/// This is the main iterator trait. For more about the concept of iterators
+/// generally, please see the [module-level documentation]. In particular, you
+/// may want to know how to [implement `Iterator`][impl].
+///
+/// [module-level documentation]: crate::iter
+/// [impl]: crate::iter#implementing-iterator
 pub trait Iterator<T> {
     /// The type of the elements being iterated over.
     type Item;
 
-    /// Advance the iterator and return the next value.
+    /// Advances the iterator and returns the next value.
+    ///
+    /// Returns [`None`] when iteration is finished. Individual iterator
+    /// implementations may choose to resume iteration, and so calling `next()`
+    /// again may or may not eventually start returning [`Some(Item)`] again at some
+    /// point.
+    ///
+    /// [`Some(Item)`]: Option::Some
+    /// [`None`]: Option::None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let a = [1, 2, 3].span();
+    ///
+    /// let mut iter = a.into_iter();
+    ///
+    /// // A call to next() returns the next value...
+    /// assert_eq!(Option::Some(@1), iter.next());
+    /// assert_eq!(Option::Some(@2), iter.next());
+    /// assert_eq!(Option::Some(@3), iter.next());
+    ///
+    /// // ... and then None once it's over.
+    /// assert_eq!(Option::None, iter.next());
+    ///
+    /// // More calls may or may not return `None`. Here, they always will.
+    /// assert_eq!(Option::None, iter.next());
+    /// assert_eq!(Option::None, iter.next());
+    /// ```
     fn next(ref self: T) -> Option<Self::Item>;
 }

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,8 +1,7 @@
-
-//! Iteratos for for generic and efficient traversal over collections.
+//! Iterators for generic and efficient traversal over collections.
 //!
-//!  The `Iterator` trait is fundamental for implementing iterators, which are used to perform operations like mapping, filtering,
-//! and reducing over collections.
+//! The `Iterator` trait is fundamental for implementing iterators, which are used to perform
+//! operations like mapping, filtering, and reducing over collections.
 //!
 //! # Examples
 //!

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,3 +1,52 @@
+//! Traits and utilities for iterating over sequences of values.
+//!
+//! # Overview
+//!
+//! This module defines the basic abstraction for iteration in Cairo, allowing for generic
+//! and efficient traversal over collections. The `Iterator` trait is fundamental for
+//! implementing iterators, which are used to perform operations like mapping, filtering,
+//! and reducing over collections.
+//!
+//! # Traits
+//!
+//! - [`Iterator`]: Defines the method to advance an iterator and retrieve the next value.
+//!
+//! # Examples
+//!
+//! Basic usage of an iterator:
+//!
+//! ```
+//! use core::iter::Iterator;
+//!
+//! #[derive(Drop, Copy)]
+//! pub struct Counter {
+//!     pub count: u32,
+//! }
+//!
+//! impl CounterIterator of Iterator<Counter> {
+//!     type Item = u32;
+//!
+//!     fn next(ref self: Counter) -> Option<Self::Item> {
+//!         if self.count < 5 {
+//!             self.count += 1;
+//!             Option::Some(self.count)
+//!         } else {
+//!             Option::None
+//!         }
+//!     }
+//! }
+//!
+//! fn main() {
+//!     let mut counter = Counter { count: 0 };
+//!     assert!(counter.next() == Option::Some(1));
+//!     assert!(counter.next() == Option::Some(2));
+//!     assert!(counter.next() == Option::Some(3));
+//!     assert!(counter.next() == Option::Some(4));
+//!     assert!(counter.next() == Option::Some(5));
+//!     assert!(counter.next() == Option::None);
+//! }
+//! ```
+
 /// An iterator over a collection of values.
 pub trait Iterator<T> {
     /// The type of the elements being iterated over.


### PR DESCRIPTION
@orizi  This PR takes into account #6949  which will add doc to iter.cairo 