### PR TITLE
docs(corelib): fix Bounded::MAX syntax

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -52,9 +52,9 @@
 //! Checked operations:
 //!
 //! ```
-//! use core::traits::CheckedAdd;
+//! use core::num::traits::{CheckedAdd, Bounded};
 //!
-//! let max: u8 = Bounded::max();
+//! let max: u8 = Bounded::MAX;
 //! assert!(max.checked_add(1_u8).is_none());
 //! ```
 //!

--- a/corelib/src/test/integer_test.cairo
+++ b/corelib/src/test/integer_test.cairo
@@ -926,7 +926,7 @@ fn cast_subtype_valid<
         && max_sub_as_super.try_into().unwrap() == max_sub
 }
 
-/// Checks that `A::max()` is castable to `B`, and `A::max() + 1` is in `B`s range, and not
+/// Checks that `A::MAX` is castable to `B`, and `A::MAX + 1` is in `B`s range, and not
 /// castable back to `A`.
 fn validate_max_strictly_contained<
     A,

--- a/corelib/src/traits.cairo
+++ b/corelib/src/traits.cairo
@@ -769,7 +769,7 @@ impl TIntoT<T> of Into<T, T> {
 /// special handling. For example, there is no way to convert an [`i64`] into an [`i32`] using the
 /// [`Into`] trait, because an [`i64`] may contain a value that an [`i32`] cannot represent and so
 /// the conversion would lose data.  This might be handled by truncating the [`i64`] to an [`i32`]
-/// or by simply returning [`Bounded::<i32>::max()`], or by some other method. The [`Into`] trait
+/// or by simply returning [`Bounded::<i32>::MAX`], or by some other method. The [`Into`] trait
 /// is intended for perfect conversions, so the `TryInto` trait informs the programmer when a type
 /// conversion could go bad and lets them decide how to handle it.
 ///


### PR DESCRIPTION
Bounded::max() (previous syntax from BoundedInt) -> Bounded::MAX
