### PR TITLE
fix: Fix ambiguous syntax in git diff command Update sierra_update_ch…

### DIFF
--- a/scripts/sierra_update_check.sh
+++ b/scripts/sierra_update_check.sh
@@ -5,7 +5,7 @@ HEAD_BRANCH=$2
 
 # Assuming all updates are provided as inputs - finding if they are in any of the relevant crates.
 MERGE_BASE=$(git merge-base $BASE_BRANCH $HEAD_BRANCH)
-git diff --name-only $MERGE_BASE $HEAD_BRANCH | grep \
+git diff --name-only $MERGE_BASE..$HEAD_BRANCH | grep \  
     -e 'crate/cairo-lang-sierra/' \
     -e 'crate/cairo-lang-sierra-gas/' \
     -e 'crate/cairo-lang-sierra-ap-change/' \


### PR DESCRIPTION

I noticed that the `git diff` command was using `$MERGE_BASE $HEAD_BRANCH`, which can be ambiguous. To make it clearer and avoid potential issues, I updated it to use `$MERGE_BASE..$HEAD_BRANCH`.

This explicitly defines the range of changes between the two commits. The fix ensures better readability and avoids confusion in the future.