### PR TITLE
fix(corelib): inline array iter map

### DIFF
--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -63,9 +63,7 @@ pub trait Iterator<T> {
     /// Basic usage:
     ///
     /// ```
-    /// let a = array![1, 2, 3];
-    ///
-    /// let mut iter = a.into_iter().map(|x| 2 * x);
+    /// let mut iter = array![1, 2, 3].into_iter().map(|x| 2 * x);
     ///
     /// assert!(iter.next() == Option::Some(2));
     /// assert!(iter.next() == Option::Some(4));

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -1,7 +1,6 @@
 #[test]
 fn test_iter_adapter_map() {
-    let a = array![1, 2, 3];
-    let mut iter = a.into_iter().map(|x| 2 * x);
+    let mut iter = array![1, 2, 3].into_iter().map(|x| 2 * x);
 
     assert_eq!(iter.next(), Option::Some(2));
     assert_eq!(iter.next(), Option::Some(4));


### PR DESCRIPTION
This minimal PR remove variable definition for arrays in test and documentation of `iter::map`