### PR TITLE
feat(corelib): OptionTrait::get_or_insert_with

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -595,6 +595,24 @@ pub trait OptionTrait<T> {
     /// assert_eq!(y, Option::None);
     /// ```
     fn take(ref self: Option<T>) -> Option<T>;
+
+    /// Inserts a value computed from `f` into the option if it is [`None`],
+    /// then returns the contained value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut x = Option::None;
+    /// let y = x.get_or_insert_with(|| 5);
+    /// assert_eq!(y, 5);
+    ///
+    /// let mut x = Option::Some(2);
+    /// let y = x.get_or_insert_with(|| 5);
+    /// assert_eq!(y, 2);
+    /// ```
+    fn get_or_insert_with<F, +core::ops::FnOnce<F, ()>[Output: T], +Drop<F>, +Copy<T>, +Drop<T>>(
+        ref self: Option<T>, f: F,
+    ) -> T;
 }
 
 pub impl OptionTraitImpl<T> of OptionTrait<T> {
@@ -781,6 +799,17 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
         let value = self;
         self = Option::None;
         value
+    }
+
+    #[inline]
+    fn get_or_insert_with<F, +core::ops::FnOnce<F, ()>[Output: T], +Drop<F>, +Copy<T>, +Drop<T>>(
+        ref self: Option<T>, f: F,
+    ) -> T {
+        if self.is_none() {
+            self = Option::Some(f());
+        };
+
+        self.unwrap()
     }
 }
 

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -805,11 +805,14 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
     fn get_or_insert_with<F, +core::ops::FnOnce<F, ()>[Output: T], +Drop<F>, +Copy<T>, +Drop<T>>(
         ref self: Option<T>, f: F,
     ) -> T {
-        if self.is_none() {
-            self = Option::Some(f());
-        };
-
-        self.unwrap()
+        match self {
+            Option::Some(value) => value,
+            Option::None => {
+                let value = f();
+                self = Option::Some(value);
+                value
+            }
+        }
     }
 }
 

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -270,3 +270,14 @@ fn test_option_take() {
     assert_eq!(x, Option::None);
     assert_eq!(y, Option::None);
 }
+
+#[test]
+fn test_option_get_or_insert_with() {
+    let mut x: Option<u8> = Option::None;
+    let y = x.get_or_insert_with(|| 5);
+    assert_eq!(y, 5);
+
+    let mut x = Option::Some(2);
+    let y = x.get_or_insert_with(|| 5);
+    assert_eq!(y, 2);
+}


### PR DESCRIPTION
Inserts a value computed from a provided closure into the option if it is [`None`], then returns the contained value.

### Example

```cairo
let mut x = Option::None;
let y = x.get_or_insert_with(|| 5);
assert_eq!(y, 5);

let mut x = Option::Some(2);
let y = x.get_or_insert_with(|| 5);
assert_eq!(y, 2);
```