### PR TITLE
feat(corelib): Iterator::collect

### DIFF
--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -81,7 +81,7 @@ pub trait FromIterator<T, A> {
     ///
     /// assert_eq!(v, array![0, 1, 2, 3, 4]);
     /// ```
-    fn from_iter<I, +Iterator<I>[Item: A], +Drop<I>>(iter: I) -> T;
+    fn from_iter<I, +Iterator<I>[Item: A], +Destruct<I>>(iter: I) -> T;
 }
 
 /// Conversion into an [`Iterator`].

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -65,7 +65,7 @@
 ///
 /// assert_eq!(c.arr, array![0, 1, 2, 3, 4]);
 /// ```
-pub trait FromIterator<T, G> {
+pub trait FromIterator<T, A> {
     /// Creates a value from an iterator.
     ///
     /// See the [module-level documentation] for more.
@@ -81,7 +81,7 @@ pub trait FromIterator<T, G> {
     ///
     /// assert_eq!(v, array![0, 1, 2, 3, 4]);
     /// ```
-    fn from_iter<I, +Iterator<I>[Item: G], +Destruct<I>>(iter: I) -> T;
+    fn from_iter<I, +Iterator<I>[Item: A], +Drop<I>>(iter: I) -> T;
 }
 
 /// Conversion into an [`Iterator`].

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -315,7 +315,7 @@ pub trait Iterator<T> {
 
     #[inline]
     #[must_use]
-    fn collect<B, +FromIterator<B, Self::Item>, +Drop<T>>(
+    fn collect<B, +FromIterator<B, Self::Item>, +Destruct<T>>(
         self: T,
     ) -> B {
         FromIterator::from_iter(self)

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -312,4 +312,12 @@ pub trait Iterator<T> {
     ) -> Zip<T, UIntoIter::IntoIter> {
         zipped_iterator(self, other.into_iter())
     }
+
+    #[inline]
+    #[must_use]
+    fn collect<B, +FromIterator<B, Self::Item>, +Drop<T>>(
+        self: T,
+    ) -> B {
+        FromIterator::from_iter(self)
+    }
 }

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -318,6 +318,6 @@ pub trait Iterator<T> {
     fn collect<B, +FromIterator<B, Self::Item>, +Destruct<T>>(
         self: T,
     ) -> B {
-        FromIterator::from_iter(self)
+        FromIterator::<B, Self::Item>::from_iter::<T, Self>(self)
     }
 }

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -313,6 +313,53 @@ pub trait Iterator<T> {
         zipped_iterator(self, other.into_iter())
     }
 
+    /// Transforms an iterator into a collection.
+    ///
+    /// `collect()` can take anything iterable, and turn it into a relevant
+    /// collection. This is one of the more powerful methods in the core
+    /// library, used in a variety of contexts.
+    ///
+    /// The most basic pattern in which `collect()` is used is to turn one
+    /// collection into another. You take a collection, call [`iter`] on it,
+    /// do a bunch of transformations, and then `collect()` at the end.
+    ///
+    /// `collect()` can also create instances of types that are not typical
+    /// collections.
+    ///
+    /// Because `collect()` is so general, it can cause problems with type
+    /// inference. As such, `collect()` is one of the few times you'll see
+    /// the syntax affectionately known as the 'turbofish': `::<>`. This
+    /// helps the inference algorithm understand specifically which collection
+    /// you're trying to collect into.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let doubled: Array<u32> = array![1, 2, 3].into_iter().map(|x| x * 2).collect();
+    ///
+    /// assert_eq!(array![2, 4, 6], doubled);
+    /// ```
+    ///
+    /// Note that we needed the `: Array<u32>` on the left-hand side.
+    ///
+    /// Using the 'turbofish' instead of annotating `doubled`:
+    ///
+    /// ```
+    /// let doubled = array![1, 2, 3].into_iter().map(|x| x * 2).collect::<Array<u32>>();
+    ///
+    /// assert_eq!(array![2, 4, 6], doubled);
+    /// ```
+    ///
+    /// Because `collect()` only cares about what you're collecting into, you can
+    /// still use a partial type hint, `_`, with the turbofish:
+    ///
+    /// ```
+    /// let doubled = array![1, 2, 3].into_iter().map(|x| x * 2).collect::<Array<_>>();
+    ///
+    /// assert_eq!(array![2, 4, 6], doubled);
+    /// ```
     #[inline]
     #[must_use]
     fn collect<B, +FromIterator<B, Self::Item>, +Destruct<T>>(

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -53,3 +53,12 @@ fn test_iter_adapter_fold() {
 
     assert_eq!(sum, 6);
 }
+
+#[test]
+fn test_iter_adapter_collect() {
+    let arr: Array<u32> = (0..3_u32).into_iter().collect();
+
+    assert_eq!(*arr[0], 0);
+    assert_eq!(*arr[1], 1);
+    assert_eq!(*arr[2], 2);
+}

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -56,9 +56,5 @@ fn test_iter_adapter_fold() {
 
 #[test]
 fn test_iter_adapter_collect() {
-    let arr: Array<u32> = (0..3_u32).into_iter().collect();
-
-    assert_eq!(*arr[0], 0);
-    assert_eq!(*arr[1], 1);
-    assert_eq!(*arr[2], 2);
+    assert_eq!((0..3_u32).into_iter().collect(), array![0, 1, 2]);
 }


### PR DESCRIPTION
Implementing `collect` on `Iterator`.
Currently a draft PR because I'm having some issues.

```rust
fn collect<B, +FromIterator<B, Self::Item>, +Drop<T>>(
    self: T,
) -> B {
    FromIterator::from_iter(self)
}
```

> error: Trait has no implementation in context: `Iterator::<T>`

Not sure why it's not doing the bound correctly as we're in the default implementation of trait `Iterator<T>`, so we're sure T is implementing Iterator.

I tried to force trait bound:
```rust
fn collect<B, +Iterator<T>, +FromIterator<B, Self::Item>, +Drop<T>>(
    self: T,
) -> B {
    FromIterator::from_iter(self)
}
```

> warning: In a trait, paths of the same trait are not allowed. Did you mean to use `Self::`? 
> error: Type mismatch: `Iterator::Item` and `_::Item`.

Then tried to enforce bounds on Items:
```rust
fn collect<B, impl TIter: Iterator<T>, +FromIterator<B, TIter::Item>, +Drop<T>>(
    self: T,
) -> B {
    FromIterator::from_iter(self)
}
```

> warning: In a trait, paths of the same trait are not allowed. Did you mean to use `Self::`? 
> Error: Compilation failed.

The compilation fails without any specific error.

If I replace `+Iterator<T>` with `impl TIter: Self` it always fails with `error: Trait has no implementation in context: core::iter::traits::iterator::Iterator::<T>.`