### PR TITLE
fix: Fix handling of --skip-first argument Update release_crates.sh

### DIFF
--- a/scripts/release_crates.sh
+++ b/scripts/release_crates.sh
@@ -1,5 +1,9 @@
 # An optional argument, '-s | --skip-first <#num_to_skip>', can be passed to skip the first #num_to_skip crates, otherwise SKIP_FIRST is set to 0.
 if [ "$1" == "-s" ] || [ "$1" == "--skip-first" ]; then
+    if [ -z "$2" ]; then
+        echo "Error: --skip-first requires a numeric argument."
+        exit 1
+    fi
     SKIP_FIRST=$2
 else
     SKIP_FIRST=0


### PR DESCRIPTION
I noticed that the script didn't handle the case where the `-s` or `--skip-first` argument was provided without a value. This could lead to unexpected behavior. I've added a check to ensure a value is provided when using `--skip-first`. If no value is given, the script will now print an error message and exit gracefully. This makes the script more robust and prevents potential issues.  

Changes:  
- Added validation for the `--skip-first` argument to ensure a numeric value is provided.  
- Improved error handling to avoid undefined behavior.  

Thanks for Starknet!