### PR TITLE
chore: orthographic correction in file if_else

### DIFF
--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/if_else
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/if_else
@@ -155,7 +155,7 @@ ExprBlock
 
 //! > ==========================================================================
 
-//! > Test if-let boolean opperators
+//! > Test if-let boolean operators
 
 //! > test_runner_name
 test_partial_parser_tree(expect_diagnostics: false)


### PR DESCRIPTION
# Chore: Orthographic Correction in if_else

## Description
Fixed a typo:
- Changed "opperators" to "operators" for correctness in the test description.


