### PR TITLE
fix: Remove unnecessary semicolon after while let block

### DIFF
--- a/examples/complex_input.cairo
+++ b/examples/complex_input.cairo
@@ -17,7 +17,7 @@ fn complex_input(
     r += a_input.val;
     while let Option::Some(x) = a_input.arr.pop_front() {
         r += x;
-    };
+    }
     while let Option::Some(mut a) = a_arr_input.pop_front() {
         r += a.val;
         while let Option::Some(x) = a.arr.pop_front() {


### PR DESCRIPTION
I noticed there was an extra semicolon after the closing curly brace of a `while let` block.
In Cairo (similar to Rust), this isn't required and can cause a syntax error. I've removed it to fix the issue.