### PR TITLE
fix(corelib): Add the #[test] annotation to enumerate test

### DIFF
--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -18,6 +18,7 @@ fn test_iter_adapter_map() {
     assert_eq!(iter.next(), Option::None);
 }
 
+#[test]
 fn test_iterator_enumerate() {
     let mut iter = array!['a', 'b', 'c'].into_iter().enumerate();
 


### PR DESCRIPTION
Just add the forgotten `#[test]` notation to a test related to `Iterator::enumerate`