### PR TITLE
feat(corelib): OptionTrait::filter

### DIFF
--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -595,6 +595,28 @@ pub trait OptionTrait<T> {
     /// assert_eq!(y, Option::None);
     /// ```
     fn take(ref self: Option<T>) -> Option<T>;
+
+    /// Returns [`None`] if the option is [`None`], otherwise calls `predicate`
+    /// with the wrapped value and returns:
+    ///
+    /// - [`Some(t)`] if `predicate` returns `true` (where `t` is the wrapped
+    ///   value), and
+    /// - [`None`] if `predicate` returns `false`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let is_even = |n: u32| -> bool {
+    ///     n % 2 == 0
+    /// };
+    ///
+    /// assert_eq!(Option::None.filter(is_even), Option::None);
+    /// assert_eq!(Option::Some(3).filter(is_even), Option::None);
+    /// assert_eq!(Option::Some(4).filter(is_even), Option::Some(4));
+    /// ```
+    fn filter<P, +core::ops::FnOnce<P, (T,)>[Output: bool], +Drop<T>, +Drop<P>, +Copy<T>>(
+        self: Option<T>, predicate: P,
+    ) -> Option<T>;
 }
 
 pub impl OptionTraitImpl<T> of OptionTrait<T> {
@@ -781,6 +803,18 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
         let value = self;
         self = Option::None;
         value
+    }
+
+    fn filter<P, +core::ops::FnOnce<P, (T,)>[Output: bool], +Drop<T>, +Drop<P>, +Copy<T>>(
+        self: Option<T>, predicate: P,
+    ) -> Option<T> {
+        if let Option::Some(value) = self {
+            if predicate(value) {
+                return Option::Some(value);
+            }
+        }
+
+        Option::None
     }
 }
 

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -606,15 +606,15 @@ pub trait OptionTrait<T> {
     /// # Example
     ///
     /// ```
-    /// let is_even = |n: u32| -> bool {
-    ///     n % 2 == 0
+    /// let is_even = |n: @u32| -> bool {
+    ///     *n % 2 == 0
     /// };
     ///
     /// assert_eq!(Option::None.filter(is_even), Option::None);
     /// assert_eq!(Option::Some(3).filter(is_even), Option::None);
     /// assert_eq!(Option::Some(4).filter(is_even), Option::Some(4));
     /// ```
-    fn filter<P, +core::ops::FnOnce<P, (T,)>[Output: bool], +Drop<T>, +Drop<P>, +Copy<T>>(
+    fn filter<P, +core::ops::FnOnce<P, (@T,)>[Output: bool], +Destruct<T>, +Destruct<P>>(
         self: Option<T>, predicate: P,
     ) -> Option<T>;
 }
@@ -805,11 +805,11 @@ pub impl OptionTraitImpl<T> of OptionTrait<T> {
         value
     }
 
-    fn filter<P, +core::ops::FnOnce<P, (T,)>[Output: bool], +Drop<T>, +Drop<P>, +Copy<T>>(
+    fn filter<P, +core::ops::FnOnce<P, (@T,)>[Output: bool], +Destruct<T>, +Destruct<P>>(
         self: Option<T>, predicate: P,
     ) -> Option<T> {
         if let Option::Some(value) = self {
-            if predicate(value) {
+            if predicate(@value) {
                 return Option::Some(value);
             }
         }

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -270,3 +270,14 @@ fn test_option_take() {
     assert_eq!(x, Option::None);
     assert_eq!(y, Option::None);
 }
+
+#[test]
+fn test_option_filter() {
+    let is_even = |x: u32| -> bool {
+        x % 2 == 0
+    };
+
+    assert!(Option::None.filter(is_even) == Option::None);
+    assert!(Option::Some(3).filter(is_even) == Option::None);
+    assert!(Option::Some(4).filter(is_even) == Option::Some(4));
+}

--- a/corelib/src/test/option_test.cairo
+++ b/corelib/src/test/option_test.cairo
@@ -273,8 +273,8 @@ fn test_option_take() {
 
 #[test]
 fn test_option_filter() {
-    let is_even = |x: u32| -> bool {
-        x % 2 == 0
+    let is_even = |x: @u32| -> bool {
+        *x % 2 == 0
     };
 
     assert!(Option::None.filter(is_even) == Option::None);


### PR DESCRIPTION
I suggest the addition of `OptionTrait::filter` method that:

returns [`None`] if the option is [`None`], otherwise calls `predicate` with the wrapped value and returns:
- [`Some(t)`] if `predicate` returns `true` (where `t` is the wrapped value)
- [`None`] if `predicate` returns `false`.


```cairo
let is_even = |x: u32| -> bool {
    x % 2 == 0
};

assert!(Option::None.filter(is_even) == Option::None);
assert!(Option::Some(3).filter(is_even) == Option::None);
assert!(Option::Some(4).filter(is_even) == Option::Some(4));
```