### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/reference/src/components/cairo/modules/getting_started/pages/compiling-starknet-contracts.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/compiling-starknet-contracts.adoc
@@ -17,5 +17,5 @@ Compile the ContractClass of a CompiledClass:
 
 [source,bash]
 ----
-cargo run --bin starknet-sierra-compile -- /path/to/input.json /path/to/output.casm'
+cargo run --bin starknet-sierra-compile -- /path/to/input.json /path/to/output.casm
 ----

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
@@ -90,7 +90,7 @@ In the example above, the return type is of type `T`.
 
 The function body is the code that is executed when the function is called.
 It is enclosed by the curly braces (`{...}`) and consists of a list of 0 or
-more xref:statements.adoc[statements], and an then an optional xref:expressions.adoc[expression]
+more xref:statements.adoc[statements], and then an optional xref:expressions.adoc[expression]
 which is called the "tail expression".
 
 The statements are executed one after the other in the defined order.

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/linear-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/linear-types.adoc
@@ -37,7 +37,7 @@ fn main() {
 Note: the snapshot operator `@` (See the docs about snapshot) is considered not moving a value.
 
 == Clone
-Sometime a value can't be trivially copied, but we can still use code to build a copy of it.
+Sometimes a value can't be trivially copied, but we can still use code to build a copy of it.
 For example, a value containing an `Array` cannot be copied, but we can still clone it by cloning
 the array it contains with `.clone()`.
 This can be done by implementing or deriving the `Clone` trait. The derived implementation requires
@@ -71,7 +71,7 @@ fn main() {
 ----
 
 == Destructors
-Sometime a value must not be dropped, but we can still use code to get rid of it.
+Sometimes a value must not be dropped, but we can still use code to get rid of it.
 For example, a value containing a `Dict` cannot be dropped, but we can still deconstruct it by
 destructing the dict it contains with `.destruct()`.
 This can be done by implementing or deriving the `Destruct` trait, which will be called

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
@@ -62,7 +62,7 @@ Cairo syntax considers `-1` as an application of the xref:negation-operators.ado
 
 == Short string literals
 
-A short string is a ascii-string whose length is limited by the type that holds it.
+A short string is an ascii-string whose length is limited by the type that holds it.
 The default type is a `felt252` which limits the length of the string to 31 characters.
 A short string literal may be followed by an underscore character (`_`)
 and then a __literal suffix__ just like a numerical literal.

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
@@ -45,7 +45,7 @@ match enum_var {
 ----
 
 Where `enum_var` is an instance of some xref:enums.adoc[enum] and `variant_0``, `variant_1`, ...,
-`variant_k`` are all the variants of the said enum, order in the way that they were declared.
+`variant_k` are all the variants of the said enum, order in the way that they were declared.
 
 === Match on an felt252.
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
@@ -44,7 +44,7 @@ match enum_var {
 }
 ----
 
-Where `enum_var` is an instance of some xref:enums.adoc[enum] and `variant_0``, `variant_1`, ...,
+Where `enum_var` is an instance of some xref:enums.adoc[enum] and `variant_0`, `variant_1`, ...,
 `variant_k` are all the variants of the said enum, order in the way that they were declared.
 
 === Match on an felt252.

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
@@ -49,7 +49,7 @@ fn add(x: u32, mut y: u32) -> u32 {
 
 fn test() {
     let x = 1;
-    ley y = 2;
+    let y = 2;
     assert(add(x, y) == 3, 'Should be equal.');
     assert(y == 1, 'Should be equal.');
 }


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `and an then an optional` to `and then an optional`
Corrected `ley` to `let` and much more additional changes

Please review the changes and let me know if any additional changes are needed.