### PR TITLE
docs: fix formatting and clarify panic documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
@@ -1,6 +1,6 @@
 = Panic
 
-Code in _Cairo1.0_ may _panic_ - which means it may fail with an unrecoverable error - meaning
+Code in Cairo1.0 may _panic_ - which means it may fail with an unrecoverable error - meaning
 it is impossible to catch and handle.
 When the program panics, using the xref:linear-types.adoc[linear type system] all living variables
 on the stack would be `Dropped` or otherwise destructed, which makes sure the run remains provable
@@ -41,14 +41,14 @@ An example for such a function is `Add` trait `add` function, which is _nopanic_
 == `panic_with` macro
 
 A function returning an `Option` or `Result` may be marked with the `panic_with` macro.
-This macro takes two arguments, which is the data that is passed as the panic reason as well as the
+This macro takes two arguments: the data that is passed as the panic reason as well as the
 name for a wrapping function.
 If the function returns `None` or `Err`, _panic_ function will be called with the given data.
 
 [source,rust]
 ----
 #[panic_with('got none value', unwrap)]
-fn identity(value: Option<u128>) -> Option<u128> { a }
+fn identity(value: Option<u128>) -> Option<u128> { value }
 ----
 
 Some `fn unwrap(value: Option<u128>) -> u128` that internally may panic may be created.

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
@@ -1,6 +1,6 @@
 = Panic
 
-Code in Cairo1.0 may _panic_ - which means it may fail with an unrecoverable error - meaning
+Code in _Cairo1.0_ may _panic_ - which means it may fail with an unrecoverable error - meaning
 it is impossible to catch and handle.
 When the program panics, using the xref:linear-types.adoc[linear type system] all living variables
 on the stack would be `Dropped` or otherwise destructed, which makes sure the run remains provable


### PR DESCRIPTION
**This PR makes several improvements to the panic documentation:**

- Update example parameter name from 'a' to 'value' in identity function for better readability
- Fix formatting of code blocks and inline code references

These changes make the documentation more consistent and easier to understand while maintaining technical accuracy.