### PR TITLE
docs: Fix parameter type and return value to match trait signature

### DIFF
--- a/adrs/003_simple_trait_system.md
+++ b/adrs/003_simple_trait_system.md
@@ -27,7 +27,7 @@ Note that there is no `Self` or a type this trait is `for`. It is stand alone.
 ```
 impl MyImpl<A> for MyTrait<A, felt252> {
   type T = A;
-  fn f(a: A, b: felt252) -> T { ... }
+  fn f(a: A, t: T) -> (T, felt252) { ... }
 }
 ```
 This item introduces an implementation for this trait.

--- a/adrs/003_simple_trait_system.md
+++ b/adrs/003_simple_trait_system.md
@@ -25,9 +25,10 @@ Note that there is no `Self` or a type this trait is `for`. It is stand alone.
 
 ### Impl top level item
 ```
-impl MyImpl<A> for MyTrait<A, felt252> {
+impl<A> MyTrait<A, felt252> for MyImpl<A> {
   type T = A;
-  fn f(a: A, t: T) -> (T, felt252) { ... }
+  fn f(a: A, t: Self::T) -> (Self::T, felt252) {
+  }
 }
 ```
 This item introduces an implementation for this trait.


### PR DESCRIPTION
I noticed a mismatch in the parameter type and return value compared to the trait signature. I've updated the parameter `b: felt252` to `t: T` and corrected the return value to `(T, felt252)` to align with the expected trait implementation.

This should resolve the inconsistency.  
