### PR TITLE
feat(corelib): ByteArrayFromIterator

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -45,7 +45,6 @@
 use crate::array::{ArrayTrait, SpanTrait};
 use crate::clone::Clone;
 use crate::cmp::min;
-use crate::option::OptionTrait;
 use crate::traits::{Into, TryInto};
 #[allow(unused_imports)]
 use crate::bytes_31::{
@@ -511,5 +510,15 @@ impl ByteArrayIntoIterator of crate::iter::IntoIterator<ByteArray> {
     #[inline]
     fn into_iter(self: ByteArray) -> Self::IntoIter {
         ByteArrayIter { current_index: (0..self.len()).into_iter(), ba: self }
+    }
+}
+
+impl ByteArrayFromIterator of crate::iter::FromIterator<ByteArray, u8> {
+    fn from_iter<I, +Iterator<I>[Item: u8], +Destruct<I>>(mut iter: I) -> ByteArray {
+        let mut ba = Default::default();
+        for byte in iter {
+            ba.append_byte(byte);
+        };
+        ba
     }
 }

--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -514,7 +514,7 @@ impl ByteArrayIntoIterator of crate::iter::IntoIterator<ByteArray> {
 }
 
 impl ByteArrayFromIterator of crate::iter::FromIterator<ByteArray, u8> {
-    fn from_iter<I, +Iterator<I>[Item: u8], +Destruct<I>>(mut iter: I) -> ByteArray {
+    fn from_iter<I, +Iterator<I>[Item: u8], +Destruct<I>>(iter: I) -> ByteArray {
         let mut ba = Default::default();
         for byte in iter {
             ba.append_byte(byte);

--- a/corelib/src/test/byte_array_test.cairo
+++ b/corelib/src/test/byte_array_test.cairo
@@ -494,7 +494,7 @@ fn test_into_iterator() {
 
 #[test]
 fn test_from_iterator() {
-    let ba: ByteArray = FromIterator::from_iter(array!['h', 'e', 'l', 'l', 'o'].into_iter());
+    let ba: ByteArray = array!['h', 'e', 'l', 'l', 'o'].into_iter().collect();
     assert_eq!(ba, "hello");
 }
 

--- a/corelib/src/test/byte_array_test.cairo
+++ b/corelib/src/test/byte_array_test.cairo
@@ -1,4 +1,3 @@
-use crate::iter::{IntoIterator, Iterator};
 use crate::test::test_utils::{assert_eq, assert_ne};
 
 #[test]
@@ -482,7 +481,7 @@ fn test_serde() {
 }
 
 #[test]
-fn test_iterator() {
+fn test_into_iterator() {
     let ba: ByteArray = "hello";
     let mut iter = ba.into_iter();
     assert_eq!(iter.next(), Option::Some('h'));
@@ -491,6 +490,12 @@ fn test_iterator() {
     assert_eq!(iter.next(), Option::Some('l'));
     assert_eq!(iter.next(), Option::Some('o'));
     assert_eq!(iter.next(), Option::None);
+}
+
+#[test]
+fn test_from_iterator() {
+    let ba: ByteArray = FromIterator::from_iter(array!['h', 'e', 'l', 'l', 'o'].into_iter());
+    assert_eq!(ba, "hello");
 }
 
 // ========= Test helper functions =========


### PR DESCRIPTION
Implement `iter::FromIterator<ByteArray, u8>`

#### Example

```cairo
let iter = array!['h', 'e', 'l', 'l', 'o'].into_iter();
let ba: ByteArray = FromIterator::from_iter(iter);
assert_eq!(ba, "hello");
```