### PR TITLE
feat(corelib): Extend trait (wip)

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -860,12 +860,28 @@ impl SnapshotArrayIntoIterator<T> of crate::iter::IntoIterator<@Array<T>> {
 }
 
 impl ArrayFromIterator<T, +Drop<T>> of crate::iter::FromIterator<Array<T>, T> {
-    fn from_iter<I, +Iterator<I>[Item: T], +Destruct<I>>(mut iter: I) -> Array<T> {
+    fn from_iter<I, +Iterator<I>[Item: T], +Destruct<I>>(iter: I) -> Array<T> {
         let mut arr = array![];
         for elem in iter {
             arr.append(elem);
         };
         arr
+    }
+}
+
+impl ArrayExtend<T, +Drop<T>> of crate::iter::Extend<Array<T>, T> {
+    fn extend<
+        I,
+        impl IntoIter: IntoIterator<I>,
+        +TypeEqual<IntoIter::Iterator::Item, T>,
+        +Destruct<IntoIter::IntoIter>,
+        +Destruct<I>,
+    >(
+        ref self: Array<T>, iter: I,
+    ) {
+        for elem in iter.into_iter() {
+            self.append(elem);
+        };
     }
 }
 

--- a/corelib/src/iter.cairo
+++ b/corelib/src/iter.cairo
@@ -231,4 +231,4 @@
 //! [`map`]: Iterator::map
 mod adapters;
 mod traits;
-pub use traits::{FromIterator, IntoIterator, Iterator};
+pub use traits::{Extend, FromIterator, IntoIterator, Iterator};

--- a/corelib/src/iter/traits.cairo
+++ b/corelib/src/iter/traits.cairo
@@ -1,4 +1,4 @@
 mod collect;
 mod iterator;
-pub use collect::{FromIterator, IntoIterator};
+pub use collect::{Extend, FromIterator, IntoIterator};
 pub use iterator::Iterator;

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -1,3 +1,5 @@
+use crate::metaprogramming::TypeEqual;
+
 /// Conversion from an [`Iterator`].
 ///
 /// By implementing `FromIterator` for a type, you define how it will be
@@ -195,3 +197,37 @@ impl SnapshotFixedSizeArrayIntoIterator<
         ToSpan::span(self).into_iter()
     }
 }
+
+/// Extend a collection with the contents of an iterator.
+///
+/// Iterators produce a series of values, and collections can also be thought
+/// of as a series of values. The `Extend` trait bridges this gap, allowing you
+/// to extend a collection by including the contents of that iterator. When
+/// extending a collection with an already existing key, that entry is updated
+/// or, in the case of collections that permit multiple entries with equal
+/// keys, that entry is inserted.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// let mut arr = array![1, 2];
+///
+/// arr.extend(array![3, 4, 5]);
+///
+/// assert_eq!(arr, array![1, 2, 3, 4, 5]);
+/// ```
+pub trait Extend<T, A> {
+    /// Extends a collection with the contents of an iterator.
+    fn extend<
+        I,
+        impl IntoIter: IntoIterator<I>,
+        +TypeEqual<IntoIter::Iterator::Item, A>,
+        +Destruct<IntoIter::IntoIter>,
+        +Destruct<I>,
+    >(
+        ref self: T, iter: I,
+    );
+}
+

--- a/corelib/src/test/array_test.cairo
+++ b/corelib/src/test/array_test.cairo
@@ -1,4 +1,5 @@
 use crate::test::test_utils::assert_eq;
+use crate::iter::Extend;
 
 #[test]
 fn test_array() {
@@ -241,6 +242,20 @@ fn test_array_from_iterator() {
     let v = FromIterator::from_iter(iter);
     assert_eq!(v, array![0, 1, 2, 3, 4]);
 }
+
+#[test]
+fn test_array_extend() {
+    let mut arr: Array<u32> = array![1, 2, 3];
+    arr.extend((4..6_u32));
+    assert_eq!(arr, array![1, 2, 3, 4, 5]);
+}
+
+// #[test]
+// fn test_array_extend_panic() {
+//     let mut arr: Array<u32> = array![1, 2, 3];
+//     arr.extend((4..6_u32).into_iter());
+//     assert_eq!(arr, array![1, 2, 3, 4, 5]);
+// }
 
 #[test]
 fn test_array_into_span() {


### PR DESCRIPTION
- Define the `Extend` trait: Extend a collection with the contents of an iterator.
- Implement `ArrayExtend`

### Examples

```cairo
let mut arr = array![1, 2, 3];
arr.extend((4..6_u32));
assert_eq!(arr, array![1, 2, 3, 4, 5]);
```

### Current Issue

Doing the trait bound on `+IntoIterator<I>` has the benefit of being able to pass any values that can be transformed in an Iterator, including Iterator themselve.
However it seems there's some inference issues:
```cairo
let mut arr = array![1, 2];
arr.extend(array![3, 4, 5]);
```
Cause panic:
```
thread '<unnamed>' panicked at crates/cairo-lang-semantic/src/expr/inference.rs:1239:25:
assertion failed: impl_impl.impl_id().is_var_free(self.db)
```

Using `+Iterator<I>` works fine, but it's better to use IntoIterator here