### PR TITLE
feat(corelib): Felt252DictFromIterator

### DIFF
--- a/corelib/src/dict.cairo
+++ b/corelib/src/dict.cairo
@@ -263,3 +263,16 @@ impl Felt252DictIndex<
         self.get(index)
     }
 }
+
+impl Felt252DictFromIterator<
+    T, +Destruct<T>, +Destruct<Felt252Dict<T>>, +Felt252DictValue<T>,
+> of crate::iter::FromIterator<Felt252Dict<T>, (felt252, T)> {
+    /// Constructs a `Felt252Dict<T>` from an iterator of (felt252, T) key-value pairs.
+    fn from_iter<I, +Iterator<I>[Item: (felt252, T)], +Destruct<I>>(iter: I) -> Felt252Dict<T> {
+        let mut dict = Default::default();
+        for (key, value) in iter {
+            dict.insert(key, value);
+        };
+        dict
+    }
+}

--- a/corelib/src/dict.cairo
+++ b/corelib/src/dict.cairo
@@ -268,6 +268,8 @@ impl Felt252DictFromIterator<
     T, +Destruct<T>, +Destruct<Felt252Dict<T>>, +Felt252DictValue<T>,
 > of crate::iter::FromIterator<Felt252Dict<T>, (felt252, T)> {
     /// Constructs a `Felt252Dict<T>` from an iterator of (felt252, T) key-value pairs.
+    /// If the iterator contains repeating keys,
+    /// only the last value in the iterator for each key will be kept.
     fn from_iter<I, +Iterator<I>[Item: (felt252, T)], +Destruct<I>>(iter: I) -> Felt252Dict<T> {
         let mut dict = Default::default();
         for (key, value) in iter {

--- a/corelib/src/test/dict_test.cairo
+++ b/corelib/src/test/dict_test.cairo
@@ -150,14 +150,11 @@ fn test_array_dict() {
 
 #[test]
 fn test_dict_from_iterator() {
-    let mut dict: Felt252Dict<u32> = (0..5_u32)
-        .into_iter()
-        .map(|x| (Into::<u32, felt252>::into(x), x))
-        .collect();
+    let mut dict: Felt252Dict<u32> = (0..5_u32).into_iter().map(|x| (x.into(), x)).collect();
 
-    assert_eq!(@dict[0], @0);
-    assert_eq!(@dict[1], @1);
-    assert_eq!(@dict[2], @2);
-    assert_eq!(@dict[3], @3);
-    assert_eq!(@dict[4], @4);
+    assert_eq!(dict[0], 0);
+    assert_eq!(dict[1], 1);
+    assert_eq!(dict[2], 2);
+    assert_eq!(dict[3], 3);
+    assert_eq!(dict[4], 4);
 }

--- a/corelib/src/test/dict_test.cairo
+++ b/corelib/src/test/dict_test.cairo
@@ -148,3 +148,16 @@ fn test_array_dict() {
     assert(value.is_null(), 'dict[10] == null');
 }
 
+#[test]
+fn test_dict_from_iterator() {
+    let mut dict: Felt252Dict<u32> = (0..5_u32)
+        .into_iter()
+        .map(|x| (Into::<u32, felt252>::into(x), x))
+        .collect();
+
+    assert_eq!(@dict[0], @0);
+    assert_eq!(@dict[1], @1);
+    assert_eq!(@dict[2], @2);
+    assert_eq!(@dict[3], @3);
+    assert_eq!(@dict[4], @4);
+}

--- a/corelib/src/test/dict_test.cairo
+++ b/corelib/src/test/dict_test.cairo
@@ -158,3 +158,9 @@ fn test_dict_from_iterator() {
     assert_eq!(dict[3], 3);
     assert_eq!(dict[4], 4);
 }
+
+#[test]
+fn test_dict_from_iterator_with_duplicate_keys() {
+    let mut dict = array![(0, 1_u32), (0, 2_u32)].into_iter().collect::<Felt252Dict<_>>();
+    assert_eq!(dict[0], 2);
+}


### PR DESCRIPTION
Implement `iter::FromIterator<Felt252Dict<T>, (felt252, T)>`

Constructs a `Felt252Dict<T>` from an iterator of (felt252, T) key-value pairs.

### Example 

```cairo
let mut dict: Felt252Dict<u32> = (0..5_u32).into_iter().map(|x| (x.into(), x)).collect();

assert_eq!(dict[0], 0);
assert_eq!(dict[1], 1);
assert_eq!(dict[2], 2);
assert_eq!(dict[3], 3);
assert_eq!(dict[4], 4);
```