### PR TITLE
feat(corelib): Iterator::last

### DIFF
--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -105,7 +105,11 @@ pub trait Iterator<T> {
         Self::Item,
     > {
         let mut self = self;
-        let some = |_acc: Option<Self::Item>, x: Self::Item| {
+        let some = |acc: Option<Self::Item>, x: Self::Item| {
+            // Hack to use `Destruct<T>` directly, instead of `Destruct<Option<T>>`.
+            match acc {
+                Option::Some(_) | Option::None => {},
+            };
             Option::Some(x)
         };
 

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -105,15 +105,8 @@ pub trait Iterator<T> {
         Self::Item,
     > {
         let mut self = self;
-        let some = |acc: Option<Self::Item>, x: Self::Item| {
-            // Hack to use `Destruct<T>` directly, instead of `Destruct<Option<T>>`.
-            match acc {
-                Option::Some(_) | Option::None => {},
-            };
-            Option::Some(x)
-        };
-
-        Self::fold(ref self, Option::None, some)
+        let next = Self::next(ref self)?;
+        Option::Some(Self::last(self).unwrap_or(next))
     }
 
     /// Advances the iterator by `n` elements.

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -83,6 +83,35 @@ pub trait Iterator<T> {
         })
     }
 
+    /// Consumes the iterator, returning the last element.
+    ///
+    /// This method will evaluate the iterator until it returns [`None`]. While
+    /// doing so, it keeps track of the current element. After [`None`] is
+    /// returned, `last()` will then return the last element it saw.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut a = array![1, 2, 3].into_iter();
+    /// assert_eq!(a.last(), Option::Some(3));
+    ///
+    /// let mut a = array![].into_iter();
+    /// assert_eq!(a.last(), Option::None);
+    /// ```
+    #[inline]
+    fn last<+Destruct<T>, +Destruct<Self::Item>>(
+        self: T,
+    ) -> Option<
+        Self::Item,
+    > {
+        let mut self = self;
+        let some = |_acc: Option<Self::Item>, x: Self::Item| {
+            Option::Some(x)
+        };
+
+        Self::fold(ref self, Option::None, some)
+    }
+
     /// Advances the iterator by `n` elements.
     ///
     /// This method will eagerly skip `n` elements by calling [`next`] up to `n`

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -11,6 +11,15 @@ fn test_iter_count() {
 }
 
 #[test]
+fn test_iter_last() {
+    let mut a = array![1_u8, 2, 3].into_iter();
+    assert_eq!(a.last(), Option::Some(3));
+
+    let mut a = ArrayTrait::<u8>::new().into_iter();
+    assert_eq!(a.last(), Option::None);
+}
+
+#[test]
 fn test_advance_by() {
     let mut iter = array![1_u8, 2, 3, 4].into_iter();
 

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -13,9 +13,7 @@ fn test_iter_count() {
 #[test]
 fn test_iter_last() {
     assert_eq!(array![1_u8, 2, 3].into_iter().last(), Option::Some(3));
-
-    let arr: Array<u8> = array![];
-    assert_eq!(arr.into_iter().last(), Option::None);
+    assert_eq!(array![].into_iter().last(), Option::<u8>::None);
 }
 
 #[test]

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -12,11 +12,10 @@ fn test_iter_count() {
 
 #[test]
 fn test_iter_last() {
-    let mut a = array![1_u8, 2, 3].into_iter();
-    assert_eq!(a.last(), Option::Some(3));
+    assert_eq!(array![1_u8, 2, 3].into_iter().last(), Option::Some(3));
 
-    let mut a = ArrayTrait::<u8>::new().into_iter();
-    assert_eq!(a.last(), Option::None);
+    let arr: Array<u8> = array![];
+    assert_eq!(arr.into_iter().last(), Option::None);
 }
 
 #[test]


### PR DESCRIPTION
Keeping this as draft, as I'm getting some issues regarding impl inference:

```
error: Cannot infer negative impl in `core::option::DestructOption::<Iterator::Item, +Destruct<Self::Item>, _>` as it contains the unresolved type `core::option::Option::<Iterator::Item>`
 --> corelib/src/iter/traits/iterator.cairo:112:15
        Self::fold(ref self, Option::None, some)
```