### PR TITLE
feat(corelib): iter::adapters::Filter

### DIFF
--- a/corelib/src/iter/adapters.cairo
+++ b/corelib/src/iter/adapters.cairo
@@ -17,3 +17,8 @@ mod peekable;
 #[allow(unused_imports)]
 pub(crate) use peekable::peekable_iterator;
 pub use peekable::{Peekable, PeekableTrait};
+
+mod filter;
+pub use filter::Filter;
+#[allow(unused_imports)]
+pub(crate) use filter::filter_iterator;

--- a/corelib/src/iter/adapters/filter.cairo
+++ b/corelib/src/iter/adapters/filter.cairo
@@ -19,10 +19,9 @@ pub impl FilterIterator<
     I,
     P,
     impl TIter: Iterator<I>,
-    +core::ops::Fn<P, (TIter::Item,)>[Output: bool],
+    +core::ops::Fn<P, (@TIter::Item,)>[Output: bool],
     +Destruct<I>,
     +Destruct<P>,
-    +Copy<TIter::Item>,
     +Copy<P>,
     +Destruct<TIter::Item>,
 > of Iterator<Filter<I, P>> {

--- a/corelib/src/iter/adapters/filter.cairo
+++ b/corelib/src/iter/adapters/filter.cairo
@@ -15,18 +15,17 @@ pub fn filter_iterator<I, P>(iter: I, predicate: P) -> Filter<I, P> {
     Filter { iter, predicate }
 }
 
-pub impl FilterIterator<
+impl FilterIterator<
     I,
     P,
     impl TIter: Iterator<I>,
     +core::ops::Fn<P, (@TIter::Item,)>[Output: bool],
     +Destruct<I>,
     +Destruct<P>,
-    +Copy<P>,
     +Destruct<TIter::Item>,
 > of Iterator<Filter<I, P>> {
     type Item = TIter::Item;
     fn next(ref self: Filter<I, P>) -> Option<Self::Item> {
-        self.iter.find(self.predicate)
+        self.iter.find(@self.predicate)
     }
 }

--- a/corelib/src/iter/adapters/filter.cairo
+++ b/corelib/src/iter/adapters/filter.cairo
@@ -1,0 +1,33 @@
+/// An iterator that filters the elements of `iter` with `predicate`.
+///
+/// This `struct` is created by the [`filter`] method on [`Iterator`]. See its
+/// documentation for more.
+///
+/// [`filter`]: Iterator::filter
+#[must_use]
+#[derive(Drop, Clone)]
+pub struct Filter<I, P> {
+    pub iter: I,
+    pub predicate: P,
+}
+
+pub fn filter_iterator<I, P>(iter: I, predicate: P) -> Filter<I, P> {
+    Filter { iter, predicate }
+}
+
+pub impl FilterIterator<
+    I,
+    P,
+    impl TIter: Iterator<I>,
+    +core::ops::Fn<P, (TIter::Item,)>[Output: bool],
+    +Destruct<I>,
+    +Destruct<P>,
+    +Copy<TIter::Item>,
+    +Copy<P>,
+    +Destruct<TIter::Item>,
+> of Iterator<Filter<I, P>> {
+    type Item = TIter::Item;
+    fn next(ref self: Filter<I, P>) -> Option<Self::Item> {
+        self.iter.find(self.predicate)
+    }
+}

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,5 +1,5 @@
 use crate::iter::adapters::{
-    Enumerate, Filter, Map, Zip, enumerated_iterator, filter_iterator, mapped_iterator,
+    Enumerate, Filter, Map, Peekable, Zip, enumerated_iterator, filter_iterator, mapped_iterator,
     peekable_iterator, zipped_iterator,
 };
 use crate::iter::traits::{Product, Sum};
@@ -388,7 +388,7 @@ pub trait Iterator<T> {
     }
 
     /// Creates an iterator which uses a closure to determine if an element
-    /// should be yielded.
+    /// should be yielded. The closure takes each element as a snapshot.
     ///
     /// Given an element the closure must return `true` or `false`. The returned
     /// iterator will yield only the elements for which the closure returns
@@ -401,7 +401,7 @@ pub trait Iterator<T> {
     /// ```
     /// let a = array![0_u32, 1, 2];
     ///
-    /// let mut iter = a.into_iter().filter(|x| x > 0);
+    /// let mut iter = a.into_iter().filter(|x| *x > 0);
     ///
     /// assert_eq!(iter.next(), Option::Some(1));
     /// assert_eq!(iter.next(), Option::Some(2));
@@ -412,10 +412,9 @@ pub trait Iterator<T> {
     #[inline]
     fn filter<
         P,
-        +core::ops::Fn<P, (Self::Item,)>[Output: bool],
+        +core::ops::Fn<P, (@Self::Item,)>[Output: bool],
         +Destruct<P>,
         +Destruct<T>,
-        +Copy<Self::Item>,
         +Destruct<Self::Item>,
     >(
         self: T, predicate: P,

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,6 +1,6 @@
 use crate::iter::adapters::{
-    Enumerate, Map, Peekable, Zip, enumerated_iterator, mapped_iterator, peekable_iterator,
-    zipped_iterator,
+    Enumerate, Filter, Map, Zip, enumerated_iterator, filter_iterator, mapped_iterator,
+    peekable_iterator, zipped_iterator,
 };
 use crate::iter::traits::{Product, Sum};
 
@@ -364,6 +364,8 @@ pub trait Iterator<T> {
     /// // we can still use `iter`, as there are more elements.
     /// assert_eq!(iter.next(), Option::Some(3));
     /// ```
+    ///
+    /// Note that `iter.find(f)` is equivalent to `iter.filter(f).next()`.
     fn find<
         P,
         +core::ops::Fn<P, (@Self::Item,)>[Output: bool],
@@ -383,6 +385,42 @@ pub trait Iterator<T> {
                 Self::find(ref self, predicate)
             },
         }
+    }
+
+    /// Creates an iterator which uses a closure to determine if an element
+    /// should be yielded.
+    ///
+    /// Given an element the closure must return `true` or `false`. The returned
+    /// iterator will yield only the elements for which the closure returns
+    /// `true`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let a = array![0_u32, 1, 2];
+    ///
+    /// let mut iter = a.into_iter().filter(|x| x > 0);
+    ///
+    /// assert_eq!(iter.next(), Option::Some(1));
+    /// assert_eq!(iter.next(), Option::Some(2));
+    /// assert_eq!(iter.next(), Option::None);
+    /// ```
+    ///
+    /// Note that `iter.filter(f).next()` is equivalent to `iter.find(f)`.
+    #[inline]
+    fn filter<
+        P,
+        +core::ops::Fn<P, (Self::Item,)>[Output: bool],
+        +Destruct<P>,
+        +Destruct<T>,
+        +Copy<Self::Item>,
+        +Destruct<Self::Item>,
+    >(
+        self: T, predicate: P,
+    ) -> Filter<T, P> {
+        filter_iterator(self, predicate)
     }
 
     /// 'Zips up' two iterators into a single iterator of pairs.

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -121,3 +121,11 @@ fn test_iter_find() {
     assert_eq!(iter.find(|x| *x == 2), Option::Some(2));
     assert_eq!(iter.next(), Option::Some(3));
 }
+
+#[test]
+fn test_iter_adapter_filter() {
+    let mut iter = array![0_u32, 1, 2].into_iter().filter(|x| x > 0);
+    assert_eq!(iter.next(), Option::Some(1));
+    assert_eq!(iter.next(), Option::Some(2));
+    assert_eq!(iter.next(), Option::None);
+}

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -124,7 +124,7 @@ fn test_iter_find() {
 
 #[test]
 fn test_iter_adapter_filter() {
-    let mut iter = array![0_u32, 1, 2].into_iter().filter(|x| x > 0);
+    let mut iter = array![0_u32, 1, 2].into_iter().filter(|x| *x > 0);
     assert_eq!(iter.next(), Option::Some(1));
     assert_eq!(iter.next(), Option::Some(2));
     assert_eq!(iter.next(), Option::None);


### PR DESCRIPTION
Stacked on #7151

Creates an iterator which uses a closure to determine if an element should be yielded.

Given an element the closure must return `true` or `false`. The returned iterator will yield only the elements for which the closure returns `true`.

### Example

```cairo
let a = array![0_u32, 1, 2];

let mut iter = a.into_iter().filter(|x| x > 0);

assert_eq!(iter.next(), Option::Some(1));
assert_eq!(iter.next(), Option::Some(2));
assert_eq!(iter.next(), Option::None);
```