### PR TITLE
feat: if for circuits

### DIFF
--- a/corelib/src/circuit.cairo
+++ b/corelib/src/circuit.cairo
@@ -180,6 +180,26 @@ pub fn circuit_mul<Lhs, Rhs, +CircuitElementTrait<Lhs>, +CircuitElementTrait<Rhs
     CircuitElement::<MulModGate<Lhs, Rhs>> {}
 }
 
+/// Given a condition in 0 or 1, and two circuit elements a and b, returns a new circuit element
+/// with the value of a if the condition is 1, or b if the condition is 0.
+/// Unsafe: condition not checked, Unexpected value returned if is neither 0 nor 1
+pub fn circuit_unsafe_if<
+    Cond,
+    TrueEl,
+    FalseEl,
+    +CircuitElementTrait<Cond>,
+    +CircuitElementTrait<TrueEl>,
+    +CircuitElementTrait<FalseEl>
+>(
+    condition: CircuitElement<Cond>, a: CircuitElement<TrueEl>, b: CircuitElement<FalseEl>,
+) -> CircuitElement::<AddModGate<FalseEl, MulModGate<SubModGate<TrueEl, FalseEl>, Cond>>> {
+    // a - b if condition is 1, zero if condition is 0
+    let scaled_diff = circuit_mul(circuit_sub(a, b), condition);
+
+    // returns b + (a - b)) if condition is 1, b + 0 if condition is 0
+    circuit_add(b, scaled_diff)
+}
+
 /// A 384-bit unsigned integer, used for circuit values.
 #[derive(Copy, Drop, Debug, PartialEq)]
 pub struct u384 {

--- a/corelib/src/test/circuit_test.cairo
+++ b/corelib/src/test/circuit_test.cairo
@@ -1,7 +1,7 @@
 use crate::circuit::{
     AddInputResultTrait, AddMod, CircuitElement, CircuitInput, CircuitInputs, CircuitModulus,
     CircuitOutputsTrait, EvalCircuitTrait, MulMod, RangeCheck96, circuit_add, circuit_inverse,
-    circuit_mul, circuit_sub, u384, u96,
+    circuit_mul, circuit_sub, circuit_unsafe_if, u384, u96,
 };
 use crate::num::traits::Zero;
 use crate::traits::TryInto;
@@ -47,6 +47,37 @@ fn test_circuit_success() {
     assert_eq!(outputs.get_output(inv), u384 { limb0: 4, limb1: 0, limb2: 0, limb3: 0 });
     assert_eq!(outputs.get_output(sub), u384 { limb0: 5, limb1: 0, limb2: 0, limb3: 0 });
     assert_eq!(outputs.get_output(mul), u384 { limb0: 6, limb1: 0, limb2: 0, limb3: 0 });
+}
+
+#[test]
+fn test_circuit_unsafe_if() {
+    let condition = CircuitElement::<CircuitInput<0>> {};
+    let in1 = CircuitElement::<CircuitInput<1>> {};
+    let in2 = CircuitElement::<CircuitInput<2>> {};
+    let result = circuit_unsafe_if(condition, in1, in2);
+
+    let modulus = TryInto::<_, CircuitModulus>::try_into([7, 0, 0, 0]).unwrap();
+    let outputs = (result,)
+        .new_inputs()
+        .next([1, 0, 0, 0])
+        .next([3, 0, 0, 0])
+        .next([6, 0, 0, 0])
+        .done()
+        .eval(modulus)
+        .unwrap();
+
+    assert_eq!(outputs.get_output(result), u384 { limb0: 3, limb1: 0, limb2: 0, limb3: 0 });
+
+    let outputs = (result,)
+        .new_inputs()
+        .next([0, 0, 0, 0])
+        .next([3, 0, 0, 0])
+        .next([6, 0, 0, 0])
+        .done()
+        .eval(modulus)
+        .unwrap();
+
+    assert_eq!(outputs.get_output(result), u384 { limb0: 6, limb1: 0, limb2: 0, limb3: 0 });
 }
 
 


### PR DESCRIPTION
Given a condition in 0 or 1, and two circuit elements a and b, returns a new circuit element with the value of a if the condition is 1, or b if the condition is 0.

Unsafe because condition not checked, Unexpected value returned if is neither 0 nor 1

Returns b + (a - b)) if condition is 1, b + 0 if condition is 0.