### PR TITLE
Update indirect_impl_alias.cairo

### DIFF
--- a/tests/bug_samples/indirect_impl_alias.cairo
+++ b/tests/bug_samples/indirect_impl_alias.cairo
@@ -10,14 +10,14 @@ mod impls {
     impl Impl1<T, +Drop<T>> of super::Trait1<T> {
         fn func1(value: T) {}
     }
-    pub impl ImplAlias1 = Impl1<felt252>;
+    pub impl ImplFelt2521 = Impl1<felt252>;
     impl Impl2<T, +Drop<T>> of super::Trait2<T> {
         fn func2(value: T) {}
     }
-    pub impl ImplAlias2 = Impl2<felt252>;
+    pub impl ImplFelt2522 = Impl2<felt252>;
 }
-use impls::ImplAlias1;
-impl Impl2 = impls::ImplAlias2;
+use impls::ImplFelt2521;
+impl Impl2 = impls::ImplFelt2522;
 
 fn foo() {
     Trait1::func1(0_felt252);


### PR DESCRIPTION
# Pull Request: Refactor Implementation Aliases for Clarity

## Summary of Changes
This pull request updates implementation alias names in `tests/bug_samples/indirect_impl_alias.cairo` to enhance clarity and maintainability.

### Changes Made
1. **Renamed Implementation Aliases:**
   - **Old Name:** `ImplAlias1`
   - **New Name:** `ImplFelt2521`
   - **Reason:** Clarifies that this implementation is for the `felt252` type.

2. **Renamed Implementation Aliases:**
   - **Old Name:** `ImplAlias2`
   - **New Name:** `ImplFelt2522`
   - **Reason:** Indicates this implementation is also related to the `felt252` type.

These changes improve code clarity, making it easier for developers to understand the purpose of each implementation.