### PR TITLE
Invalid identifier '__coupon__'

### DIFF
--- a/corelib/src/test/coupon_test.cairo
+++ b/corelib/src/test/coupon_test.cairo
@@ -5,7 +5,7 @@ fn arr_sum(arr: Array<(u128, arr_sum::Coupon)>) -> u128 nopanic {
     match arr.pop_front_consume() {
         Some((
             rem, (elm, coupon),
-        )) => crate::integer::u128_wrapping_add(elm, arr_sum(rem, __coupon__: coupon)),
+        )) => crate::integer::u128_wrapping_add(elm, arr_sum(rem, coupon: coupon)),
         None => 0,
     }
 }


### PR DESCRIPTION
Invalid identifier. In Rust, a normal field or parameter name is required, for example 'coupon:'
