### PR TITLE
fix: Fix potential issue with variable usage in script

### DIFF
--- a/scripts/starknet_sierra_validate.sh
+++ b/scripts/starknet_sierra_validate.sh
@@ -3,4 +3,4 @@
 export FULLNODE_URL="${1:-https://papyrus-integration-mainnet.sw-dev.io/rpc/v0_7}"
 export N_BLOCKS="${2:-1000}"
 
-cargo run --bin starknet-sierra-upgrade-validate -- --fullnode-url $FULLNODE_URL --last-n-blocks $N_BLOCKS
+cargo run --bin starknet-sierra-upgrade-validate -- --fullnode-url "$FULLNODE_URL" --last-n-blocks "$N_BLOCKS"


### PR DESCRIPTION
I noticed a issue in the script where variables `$FULLNODE_URL` and `$N_BLOCKS` were being used without quotes.

This can potentially cause issues, especially if the values contain spaces or special characters.

I’ve fixed this by adding quotes around the variables to ensure they are correctly interpreted by Bash. 
