### PR TITLE
feat(corelib): FromIterator takes IntoIterator instead of Iterator

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -858,7 +858,15 @@ impl SnapshotArrayIntoIterator<T> of crate::iter::IntoIterator<@Array<T>> {
 }
 
 impl ArrayFromIterator<T, +Drop<T>> of crate::iter::FromIterator<Array<T>, T> {
-    fn from_iter<I, +Iterator<I>[Item: T], +Destruct<I>>(iter: I) -> Array<T> {
+    fn from_iter<
+        I,
+        impl IntoIter: IntoIterator<I>,
+        +core::metaprogramming::TypeEqual<IntoIter::Iterator::Item, T>,
+        +Destruct<IntoIter::IntoIter>,
+        +Destruct<I>,
+    >(
+        iter: I,
+    ) -> Array<T> {
         let mut arr = array![];
         for elem in iter {
             arr.append(elem);

--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -512,7 +512,15 @@ impl ByteArrayIntoIterator of crate::iter::IntoIterator<ByteArray> {
 }
 
 impl ByteArrayFromIterator of crate::iter::FromIterator<ByteArray, u8> {
-    fn from_iter<I, +Iterator<I>[Item: u8], +Destruct<I>>(iter: I) -> ByteArray {
+    fn from_iter<
+        I,
+        impl IntoIter: IntoIterator<I>,
+        +core::metaprogramming::TypeEqual<IntoIter::Iterator::Item, u8>,
+        +Destruct<IntoIter::IntoIter>,
+        +Destruct<I>,
+    >(
+        iter: I,
+    ) -> ByteArray {
         let mut ba = Default::default();
         for byte in iter {
             ba.append_byte(byte);

--- a/corelib/src/dict.cairo
+++ b/corelib/src/dict.cairo
@@ -270,7 +270,15 @@ impl Felt252DictFromIterator<
     /// Constructs a `Felt252Dict<T>` from an iterator of (felt252, T) key-value pairs.
     /// If the iterator contains repeating keys,
     /// only the last value in the iterator for each key will be kept.
-    fn from_iter<I, +Iterator<I>[Item: (felt252, T)], +Destruct<I>>(iter: I) -> Felt252Dict<T> {
+    fn from_iter<
+        I,
+        impl IntoIter: IntoIterator<I>,
+        +core::metaprogramming::TypeEqual<IntoIter::Iterator::Item, (felt252, T)>,
+        +Destruct<IntoIter::IntoIter>,
+        +Destruct<I>,
+    >(
+        iter: I,
+    ) -> Felt252Dict<T> {
         let mut dict = Default::default();
         for (key, value) in iter {
             dict.insert(key, value);

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -19,7 +19,7 @@ use crate::metaprogramming::TypeEqual;
 /// Basic usage:
 ///
 /// ```
-/// let v = FromIterator::from_iter((0..5_u32));
+/// let v = FromIterator::from_iter(0..5_u32);
 ///
 /// assert_eq!(v, array![0, 1, 2, 3, 4]);
 /// ```

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -19,9 +19,7 @@ use crate::metaprogramming::TypeEqual;
 /// Basic usage:
 ///
 /// ```
-/// let iter = (0..5_u32).into_iter();
-///
-/// let v = FromIterator::from_iter(iter);
+/// let v = FromIterator::from_iter((0..5_u32));
 ///
 /// assert_eq!(v, array![0, 1, 2, 3, 4]);
 /// ```
@@ -29,6 +27,8 @@ use crate::metaprogramming::TypeEqual;
 /// Implementing `FromIterator` for your type:
 ///
 /// ```
+/// use core::metaprogramming::TypeEqual;
+///
 /// // A sample collection, that's just a wrapper over Array<T>
 /// #[derive(Drop, Debug)]
 /// struct MyCollection {
@@ -50,7 +50,15 @@ use crate::metaprogramming::TypeEqual;
 ///
 /// // and we'll implement FromIterator
 /// impl MyCollectionFromIterator of FromIterator<MyCollection, u32> {
-///     fn from_iter<I, +Iterator<I>[Item: u32], +Drop<I>>(iter: I) -> MyCollection {
+///     fn from_iter<
+///             I,
+///             impl IntoIter: IntoIterator<I>,
+///             +TypeEqual<IntoIter::Iterator::Item, u32>,
+///             +Destruct<IntoIter::IntoIter>,
+///             +Destruct<I>,
+///         >(
+///             iter: I
+///         ) -> MyCollection {
 ///         let mut c = MyCollectionTrait::new();
 ///         for i in iter {
 ///             c.add(i);
@@ -83,7 +91,15 @@ pub trait FromIterator<T, A> {
     ///
     /// assert_eq!(v, array![0, 1, 2, 3, 4]);
     /// ```
-    fn from_iter<I, +Iterator<I>[Item: A], +Destruct<I>>(iter: I) -> T;
+    fn from_iter<
+        I,
+        impl IntoIter: IntoIterator<I>,
+        +TypeEqual<IntoIter::Iterator::Item, A>,
+        +Destruct<IntoIter::IntoIter>,
+        +Destruct<I>,
+    >(
+        iter: I,
+    ) -> T;
 }
 
 /// Conversion into an [`Iterator`].

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -1,3 +1,4 @@
+use core::metaprogramming::TypeEqual;
 use crate::iter::adapters::{
     Enumerate, Filter, Map, Peekable, Zip, enumerated_iterator, filter_iterator, mapped_iterator,
     peekable_iterator, zipped_iterator,
@@ -569,10 +570,17 @@ pub trait Iterator<T> {
     /// ```
     #[inline]
     #[must_use]
-    fn collect<B, +FromIterator<B, Self::Item>, +Destruct<T>>(
+    fn collect<
+        B,
+        impl IntoIter: IntoIterator<T>,
+        impl ItemEqual: TypeEqual<IntoIter::Iterator::Item, Self::Item>,
+        +Destruct<IntoIter::IntoIter>,
+        +FromIterator<B, Self::Item>,
+        +Destruct<T>,
+    >(
         self: T,
     ) -> B {
-        FromIterator::<B, Self::Item>::from_iter::<T, Self>(self)
+        FromIterator::<B, Self::Item>::from_iter::<T, IntoIter, ItemEqual>(self)
     }
 
     /// Creates an iterator which can use the [`peek`] method to look at the next element of the

--- a/corelib/src/test/array_test.cairo
+++ b/corelib/src/test/array_test.cairo
@@ -238,9 +238,14 @@ fn test_snapshot_span_into_iter() {
 
 #[test]
 fn test_array_from_iterator() {
-    let iter = (0..5_u32).into_iter();
-    let v = FromIterator::from_iter(iter);
-    assert_eq!(v, array![0, 1, 2, 3, 4]);
+    let arr = FromIterator::from_iter((0..5_u32));
+    assert_eq!(arr, array![0, 1, 2, 3, 4]);
+}
+
+#[test]
+fn test_array_from_collect() {
+    let arr: Array<u32> = (0..5_u32).into_iter().collect();
+    assert_eq!(arr, array![0, 1, 2, 3, 4]);
 }
 
 #[test]

--- a/corelib/src/test/array_test.cairo
+++ b/corelib/src/test/array_test.cairo
@@ -238,14 +238,12 @@ fn test_snapshot_span_into_iter() {
 
 #[test]
 fn test_array_from_iterator() {
-    let arr = FromIterator::from_iter((0..5_u32));
-    assert_eq!(arr, array![0, 1, 2, 3, 4]);
+    assert_eq!(FromIterator::from_iter(0..5_u32), array![0, 1, 2, 3, 4]);
 }
 
 #[test]
 fn test_array_from_collect() {
-    let arr: Array<u32> = (0..5_u32).into_iter().collect();
-    assert_eq!(arr, array![0, 1, 2, 3, 4]);
+    assert_eq!((0..5_u32).into_iter().collect(), array![0, 1, 2, 3, 4]);
 }
 
 #[test]

--- a/corelib/src/test/byte_array_test.cairo
+++ b/corelib/src/test/byte_array_test.cairo
@@ -494,9 +494,7 @@ fn test_into_iterator() {
 
 #[test]
 fn test_from_iterator() {
-    let arr: Array<u8> = array!['h', 'e', 'l', 'l', 'o'];
-    let ba: ByteArray = FromIterator::from_iter(arr);
-    assert_eq!(ba, "hello");
+    assert_eq!(FromIterator::<ByteArray>::from_iter(array!['h'_u8, 'e', 'l', 'l', 'o']), "hello");
 }
 
 #[test]

--- a/corelib/src/test/byte_array_test.cairo
+++ b/corelib/src/test/byte_array_test.cairo
@@ -494,6 +494,13 @@ fn test_into_iterator() {
 
 #[test]
 fn test_from_iterator() {
+    let arr: Array<u8> = array!['h', 'e', 'l', 'l', 'o'];
+    let ba: ByteArray = FromIterator::from_iter(arr);
+    assert_eq!(ba, "hello");
+}
+
+#[test]
+fn test_from_collect() {
     let ba: ByteArray = array!['h', 'e', 'l', 'l', 'o'].into_iter().collect();
     assert_eq!(ba, "hello");
 }

--- a/corelib/src/test/dict_test.cairo
+++ b/corelib/src/test/dict_test.cairo
@@ -150,6 +150,18 @@ fn test_array_dict() {
 
 #[test]
 fn test_dict_from_iterator() {
+    let iter = (0..5_u32).into_iter().map(|x| (x.into(), x));
+    let mut dict: Felt252Dict<u32> = FromIterator::from_iter(iter);
+
+    assert_eq!(dict[0], 0);
+    assert_eq!(dict[1], 1);
+    assert_eq!(dict[2], 2);
+    assert_eq!(dict[3], 3);
+    assert_eq!(dict[4], 4);
+}
+
+#[test]
+fn test_dict_from_collect() {
     let mut dict: Felt252Dict<u32> = (0..5_u32).into_iter().map(|x| (x.into(), x)).collect();
 
     assert_eq!(dict[0], 0);
@@ -160,7 +172,7 @@ fn test_dict_from_iterator() {
 }
 
 #[test]
-fn test_dict_from_iterator_with_duplicate_keys() {
+fn test_dict_from_collect_with_duplicate_keys() {
     let mut dict = array![(0, 1_u32), (0, 2_u32)].into_iter().collect::<Felt252Dict<_>>();
     assert_eq!(dict[0], 2);
 }


### PR DESCRIPTION
Currently, `FromIteratorTrait` takes an `Iterator`.
This PR modify this to `+IntoIterator` (which is implemented by all `Iterator`s).

This need some update on `Iterator::collect` (#7086) as well.
And updated implementations for:
- ArrayFromIterator (#7018)
- ByteArrayFromIterator (#7130)
- Felt252DictFromIterator (#7137)