### PR TITLE
[Merge after 2.10 release] Introduced per-crate plugins model

### DIFF
--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -37,7 +37,7 @@ use itertools::Itertools;
 fn test_lowering_consistency() {
     let db_val = RootDatabase::builder()
         .detect_corelib()
-        .with_plugin_suite(starknet_plugin_suite())
+        .with_default_plugin_suite(starknet_plugin_suite())
         .build()
         .unwrap();
 
@@ -225,7 +225,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut db_val = RootDatabase::builder()
         .detect_corelib()
-        .with_plugin_suite(starknet_plugin_suite())
+        .with_default_plugin_suite(starknet_plugin_suite())
         .build()?;
 
     let main_crate_ids = setup_project(&mut db_val, Path::new(&args.path))?;

--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::{Result, anyhow, bail};
 use cairo_lang_defs::db::{DefsDatabase, DefsGroup, try_ext_as_virtual_impl};
-use cairo_lang_defs::plugin::{InlineMacroExprPlugin, MacroPlugin};
 use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::db::{
     AsFilesGroupMut, CORELIB_VERSION, ExternalFiles, FilesDatabase, FilesGroup, FilesGroupEx,
@@ -14,13 +13,12 @@ use cairo_lang_filesystem::ids::{CrateId, FlagId, VirtualFile};
 use cairo_lang_lowering::db::{LoweringDatabase, LoweringGroup, init_lowering_group};
 use cairo_lang_parser::db::{ParserDatabase, ParserGroup};
 use cairo_lang_project::ProjectConfig;
-use cairo_lang_semantic::db::{SemanticDatabase, SemanticGroup};
+use cairo_lang_semantic::db::{PluginSuiteInput, SemanticDatabase, SemanticGroup};
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
-use cairo_lang_semantic::plugin::{AnalyzerPlugin, PluginSuite};
+use cairo_lang_semantic::plugin::PluginSuite;
 use cairo_lang_sierra_generator::db::SierraGenDatabase;
 use cairo_lang_syntax::node::db::{SyntaxDatabase, SyntaxGroup};
 use cairo_lang_utils::Upcast;
-use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 
 use crate::InliningStrategy;
 use crate::project::update_crate_roots_from_project_config;
@@ -49,18 +47,14 @@ impl salsa::ParallelDatabase for RootDatabase {
     }
 }
 impl RootDatabase {
-    fn new(
-        plugins: Vec<Arc<dyn MacroPlugin>>,
-        inline_macro_plugins: OrderedHashMap<String, Arc<dyn InlineMacroExprPlugin>>,
-        analyzer_plugins: Vec<Arc<dyn AnalyzerPlugin>>,
-        inlining_strategy: InliningStrategy,
-    ) -> Self {
+    fn new(default_plugin_suite: PluginSuite, inlining_strategy: InliningStrategy) -> Self {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
         init_lowering_group(&mut res, inlining_strategy);
-        res.set_macro_plugins(plugins);
-        res.set_inline_macro_plugins(inline_macro_plugins.into());
-        res.set_analyzer_plugins(analyzer_plugins);
+
+        let suite = res.intern_plugin_suite(default_plugin_suite);
+        res.set_default_plugins_from_suite(suite);
+
         res
     }
 
@@ -86,7 +80,7 @@ impl Default for RootDatabase {
 
 #[derive(Clone, Debug)]
 pub struct RootDatabaseBuilder {
-    plugin_suite: PluginSuite,
+    default_plugin_suite: PluginSuite,
     detect_corelib: bool,
     auto_withdraw_gas: bool,
     add_redeposit_gas: bool,
@@ -98,7 +92,7 @@ pub struct RootDatabaseBuilder {
 impl RootDatabaseBuilder {
     fn new() -> Self {
         Self {
-            plugin_suite: get_default_plugin_suite(),
+            default_plugin_suite: get_default_plugin_suite(),
             detect_corelib: false,
             auto_withdraw_gas: true,
             add_redeposit_gas: false,
@@ -108,13 +102,13 @@ impl RootDatabaseBuilder {
         }
     }
 
-    pub fn with_plugin_suite(&mut self, suite: PluginSuite) -> &mut Self {
-        self.plugin_suite.add(suite);
+    pub fn with_default_plugin_suite(&mut self, suite: PluginSuite) -> &mut Self {
+        self.default_plugin_suite.add(suite);
         self
     }
 
     pub fn clear_plugins(&mut self) -> &mut Self {
-        self.plugin_suite = get_default_plugin_suite();
+        self.default_plugin_suite = get_default_plugin_suite();
         self
     }
 
@@ -153,12 +147,7 @@ impl RootDatabaseBuilder {
         //   Errors if something is not OK are very subtle, mostly this results in missing
         //   identifier diagnostics, or panics regarding lack of corelib items.
 
-        let mut db = RootDatabase::new(
-            self.plugin_suite.plugins.clone(),
-            self.plugin_suite.inline_macro_plugins.clone(),
-            self.plugin_suite.analyzer_plugins.clone(),
-            self.inlining_strategy,
-        );
+        let mut db = RootDatabase::new(self.default_plugin_suite.clone(), self.inlining_strategy);
 
         if let Some(cfg_set) = &self.cfg_set {
             db.use_cfg(cfg_set);

--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow, bail};
-use cairo_lang_defs::db::{DefsDatabase, DefsGroup, try_ext_as_virtual_impl};
+use cairo_lang_defs::db::{DefsDatabase, DefsGroup, init_defs_group, try_ext_as_virtual_impl};
 use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::db::{
     AsFilesGroupMut, CORELIB_VERSION, ExternalFiles, FilesDatabase, FilesGroup, FilesGroupEx,
@@ -13,7 +13,9 @@ use cairo_lang_filesystem::ids::{CrateId, FlagId, VirtualFile};
 use cairo_lang_lowering::db::{LoweringDatabase, LoweringGroup, init_lowering_group};
 use cairo_lang_parser::db::{ParserDatabase, ParserGroup};
 use cairo_lang_project::ProjectConfig;
-use cairo_lang_semantic::db::{PluginSuiteInput, SemanticDatabase, SemanticGroup};
+use cairo_lang_semantic::db::{
+    PluginSuiteInput, SemanticDatabase, SemanticGroup, init_semantic_group,
+};
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
 use cairo_lang_semantic::plugin::PluginSuite;
 use cairo_lang_sierra_generator::db::SierraGenDatabase;
@@ -51,6 +53,8 @@ impl RootDatabase {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
         init_lowering_group(&mut res, inlining_strategy);
+        init_defs_group(&mut res);
+        init_semantic_group(&mut res);
 
         let suite = res.intern_plugin_suite(default_plugin_suite);
         res.set_default_plugins_from_suite(suite);

--- a/crates/cairo-lang-compiler/src/test.rs
+++ b/crates/cairo-lang-compiler/src/test.rs
@@ -43,7 +43,8 @@ fn can_collect_executables() {
     "#};
     let mut suite = PluginSuite::default();
     suite.add_plugin::<MockExecutablePlugin>();
-    let mut db = RootDatabase::builder().detect_corelib().with_plugin_suite(suite).build().unwrap();
+    let mut db =
+        RootDatabase::builder().detect_corelib().with_default_plugin_suite(suite).build().unwrap();
     let crate_id = setup_test_crate(&db, content);
     let config = CompilerConfig { replace_ids: true, ..CompilerConfig::default() };
     let artefact = compile_prepared_db_program_artifact(&mut db, vec![crate_id], config).unwrap();

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -23,10 +23,7 @@ use itertools::{Itertools, chain};
 use salsa::InternKey;
 
 use crate::ids::*;
-use crate::plugin::{
-    DynGeneratedFileAuxData, InlineMacroExprPlugin, MacroPlugin, MacroPluginMetadata,
-    PluginDiagnostic,
-};
+use crate::plugin::{DynGeneratedFileAuxData, MacroPlugin, MacroPluginMetadata, PluginDiagnostic};
 
 /// Salsa database interface.
 /// See [`super::ids`] for further details.
@@ -95,10 +92,6 @@ pub trait DefsGroup:
 
     // Plugins.
     // ========
-    #[salsa::input]
-    fn macro_plugins(&self) -> Vec<Arc<dyn MacroPlugin>>; // TODO: Delete in favour or [`default_macro_plugins`]
-    #[salsa::input] // TODO: Delete in favour or [`default_inline_macro_plugins`]
-    fn inline_macro_plugins(&self) -> Arc<OrderedHashMap<String, Arc<dyn InlineMacroExprPlugin>>>;
 
     #[salsa::input]
     fn default_macro_plugins(&self) -> Arc<[MacroPluginId]>;
@@ -140,7 +133,7 @@ pub trait DefsGroup:
 
     /// Returns the set of attributes allowed anywhere.
     /// An attribute on any item that is not in this set will be handled as an unknown attribute.
-    fn allowed_attributes(&self) -> Arc<OrderedHashSet<String>>;
+    fn allowed_attributes(&self, crate_id: CrateId) -> Arc<OrderedHashSet<String>>;
 
     /// Returns the set of attributes allowed on statements.
     /// An attribute on a statement that is not in this set will be handled as an unknown attribute.
@@ -148,11 +141,11 @@ pub trait DefsGroup:
 
     /// Returns the set of `derive` that were declared as by a plugin.
     /// A derive that is not in this set will be handled as an unknown derive.
-    fn declared_derives(&self) -> Arc<OrderedHashSet<String>>;
+    fn declared_derives(&self, crate_id: CrateId) -> Arc<OrderedHashSet<String>>;
 
     /// Returns the set of attributes that were declared as phantom type attributes by a plugin,
     /// i.e. a type marked with this attribute is considered a phantom type.
-    fn declared_phantom_type_attributes(&self) -> Arc<OrderedHashSet<String>>;
+    fn declared_phantom_type_attributes(&self, crate_id: CrateId) -> Arc<OrderedHashSet<String>>;
 
     /// Checks whether the submodule is defined as inline.
     fn is_submodule_inline(&self, submodule_id: SubmoduleId) -> Maybe<bool>;
@@ -322,7 +315,7 @@ fn crate_inline_macro_plugins(
         .unwrap_or_else(|| db.default_inline_macro_plugins())
 }
 
-fn allowed_attributes(db: &dyn DefsGroup) -> Arc<OrderedHashSet<String>> {
+fn allowed_attributes(db: &dyn DefsGroup, crate_id: CrateId) -> Arc<OrderedHashSet<String>> {
     let base_attrs = [
         INLINE_ATTR,
         MUST_USE_ATTR,
@@ -337,9 +330,14 @@ fn allowed_attributes(db: &dyn DefsGroup) -> Arc<OrderedHashSet<String>> {
         // TODO(orizi): Remove this once `starknet` is removed from corelib.
         STARKNET_INTERFACE_ATTR,
     ];
+
+    let crate_plugins = db.crate_macro_plugins(crate_id);
+
     Arc::new(OrderedHashSet::from_iter(chain!(
         base_attrs.map(|attr| attr.into()),
-        db.macro_plugins().into_iter().flat_map(|plugin| plugin.declared_attributes())
+        crate_plugins
+            .iter()
+            .flat_map(|plugin| db.lookup_intern_macro_plugin(*plugin).declared_attributes())
     )))
 }
 
@@ -348,16 +346,25 @@ fn allowed_statement_attributes(_db: &dyn DefsGroup) -> Arc<OrderedHashSet<Strin
     Arc::new(OrderedHashSet::from_iter(all_attributes.map(|attr| attr.into())))
 }
 
-fn declared_derives(db: &dyn DefsGroup) -> Arc<OrderedHashSet<String>> {
+fn declared_derives(db: &dyn DefsGroup, crate_id: CrateId) -> Arc<OrderedHashSet<String>> {
     Arc::new(OrderedHashSet::from_iter(
-        db.macro_plugins().into_iter().flat_map(|plugin| plugin.declared_derives()),
+        db.crate_macro_plugins(crate_id)
+            .iter()
+            .flat_map(|plugin| db.lookup_intern_macro_plugin(*plugin).declared_derives()),
     ))
 }
 
-fn declared_phantom_type_attributes(db: &dyn DefsGroup) -> Arc<OrderedHashSet<String>> {
+fn declared_phantom_type_attributes(
+    db: &dyn DefsGroup,
+    crate_id: CrateId,
+) -> Arc<OrderedHashSet<String>> {
+    let crate_plugins = db.crate_macro_plugins(crate_id);
+
     Arc::new(OrderedHashSet::from_iter(chain!(
         [PHANTOM_ATTR.into()],
-        db.macro_plugins().into_iter().flat_map(|plugin| plugin.phantom_type_attributes())
+        crate_plugins
+            .iter()
+            .flat_map(|plugin| db.lookup_intern_macro_plugin(*plugin).phantom_type_attributes())
     )))
 }
 
@@ -707,11 +714,12 @@ fn priv_module_sub_files(
     }
     .unwrap_or_else(|| file_syntax.items(syntax_db));
 
-    let allowed_attributes = db.allowed_attributes();
+    let crate_id = module_id.owning_crate(db);
+
+    let allowed_attributes = db.allowed_attributes(crate_id);
     // TODO(orizi): Actually extract the allowed features per module.
     let allowed_features = Default::default();
 
-    let crate_id = module_id.owning_crate(db);
     let cfg_set = db
         .crate_config(crate_id)
         .and_then(|cfg| cfg.settings.cfg_set.map(Arc::new))
@@ -722,7 +730,7 @@ fn priv_module_sub_files(
         .unwrap_or_default();
     let metadata = MacroPluginMetadata {
         cfg_set: &cfg_set,
-        declared_derives: &db.declared_derives(),
+        declared_derives: &db.declared_derives(crate_id),
         allowed_features: &allowed_features,
         edition,
     };
@@ -737,7 +745,9 @@ fn priv_module_sub_files(
         // Iterate the plugins by their order. The first one to change something (either
         // generate new code, remove the original code, or both), breaks the loop. If more
         // plugins might have act on the item, they can do it on the generated code.
-        for plugin in db.macro_plugins() {
+        for plugin_id in db.crate_macro_plugins(crate_id).iter() {
+            let plugin = db.lookup_intern_macro_plugin(*plugin_id);
+
             let result = plugin.generate_code(db.upcast(), item_ast.clone(), &metadata);
             plugin_diagnostics.extend(result.diagnostics);
             if result.remove_original_item {

--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -96,9 +96,47 @@ pub trait DefsGroup:
     // Plugins.
     // ========
     #[salsa::input]
-    fn macro_plugins(&self) -> Vec<Arc<dyn MacroPlugin>>;
-    #[salsa::input]
+    fn macro_plugins(&self) -> Vec<Arc<dyn MacroPlugin>>; // TODO: Delete in favour or [`default_macro_plugins`]
+    #[salsa::input] // TODO: Delete in favour or [`default_inline_macro_plugins`]
     fn inline_macro_plugins(&self) -> Arc<OrderedHashMap<String, Arc<dyn InlineMacroExprPlugin>>>;
+
+    #[salsa::input]
+    fn default_macro_plugins(&self) -> Arc<[MacroPluginId]>;
+
+    #[salsa::input]
+    fn macro_plugin_overrides(&self) -> Arc<OrderedHashMap<CrateId, Arc<[MacroPluginId]>>>;
+
+    #[salsa::interned]
+    fn intern_macro_plugin(&self, plugin: MacroPluginLongId) -> MacroPluginId;
+
+    /// Returns [`MacroPluginId`]s of the plugins set for the crate with [`CrateId`].
+    /// Provides an override if it has been set with
+    /// [`DefsGroupEx::set_override_crate_macro_plugins`] or the default
+    /// ([`DefsGroup::default_macro_plugins`]) otherwise.
+    fn crate_macro_plugins(&self, crate_id: CrateId) -> Arc<[MacroPluginId]>;
+
+    #[salsa::input]
+    fn default_inline_macro_plugins(&self) -> Arc<OrderedHashMap<String, InlineMacroExprPluginId>>;
+
+    #[salsa::input]
+    fn inline_macro_plugin_overrides(
+        &self,
+    ) -> Arc<OrderedHashMap<CrateId, Arc<OrderedHashMap<String, InlineMacroExprPluginId>>>>;
+
+    #[salsa::interned]
+    fn intern_inline_macro_plugin(
+        &self,
+        plugin: InlineMacroExprPluginLongId,
+    ) -> InlineMacroExprPluginId;
+
+    /// Returns [`InlineMacroExprPluginId`]s of the plugins set for the crate with [`CrateId`].
+    /// Provides an override if it has been set with
+    /// [`DefsGroupEx::set_override_crate_inline_macro_plugins`] or the default
+    /// ([`DefsGroup::default_inline_macro_plugins`]) otherwise.
+    fn crate_inline_macro_plugins(
+        &self,
+        crate_id: CrateId,
+    ) -> Arc<OrderedHashMap<String, InlineMacroExprPluginId>>;
 
     /// Returns the set of attributes allowed anywhere.
     /// An attribute on any item that is not in this set will be handled as an unknown attribute.
@@ -259,6 +297,29 @@ pub trait DefsGroup:
         &self,
         module_id: ModuleId,
     ) -> Maybe<Arc<PluginFileDiagnosticNotes>>;
+}
+
+/// Initializes the [`DefsGroup`] database to a proper state.
+pub fn init_defs_group(db: &mut dyn DefsGroup) {
+    db.set_macro_plugin_overrides(Arc::new(OrderedHashMap::default()));
+    db.set_inline_macro_plugin_overrides(Arc::new(OrderedHashMap::default()));
+}
+
+fn crate_macro_plugins(db: &dyn DefsGroup, crate_id: CrateId) -> Arc<[MacroPluginId]> {
+    db.macro_plugin_overrides()
+        .get(&crate_id)
+        .cloned()
+        .unwrap_or_else(|| db.default_macro_plugins())
+}
+
+fn crate_inline_macro_plugins(
+    db: &dyn DefsGroup,
+    crate_id: CrateId,
+) -> Arc<OrderedHashMap<String, InlineMacroExprPluginId>> {
+    db.inline_macro_plugin_overrides()
+        .get(&crate_id)
+        .cloned()
+        .unwrap_or_else(|| db.default_inline_macro_plugins())
 }
 
 fn allowed_attributes(db: &dyn DefsGroup) -> Arc<OrderedHashSet<String>> {
@@ -1145,3 +1206,33 @@ fn module_item_name_stable_ptr(
         }
     })
 }
+
+pub trait DefsGroupEx: DefsGroup {
+    /// Overrides the default macro plugins available for [`CrateId`] with `plugins`.
+    ///
+    /// *Note*: Sets the following Salsa input: `DefsGroup::macro_plugin_overrides`.
+    fn set_override_crate_macro_plugins(
+        &mut self,
+        crate_id: CrateId,
+        plugins: Arc<[MacroPluginId]>,
+    ) {
+        let mut overrides = self.macro_plugin_overrides().as_ref().clone();
+        overrides.insert(crate_id, plugins);
+        self.set_macro_plugin_overrides(Arc::new(overrides));
+    }
+
+    /// Overrides the default inline macro plugins available for [`CrateId`] with `plugins`.
+    ///
+    /// *Note*: Sets the following Salsa input: `DefsGroup::inline_macro_plugin_overrides`.
+    fn set_override_crate_inline_macro_plugins(
+        &mut self,
+        crate_id: CrateId,
+        plugins: Arc<OrderedHashMap<String, InlineMacroExprPluginId>>,
+    ) {
+        let mut overrides = self.inline_macro_plugin_overrides().as_ref().clone();
+        overrides.insert(crate_id, plugins);
+        self.set_inline_macro_plugin_overrides(Arc::new(overrides));
+    }
+}
+
+impl<T: DefsGroup + ?Sized> DefsGroupEx for T {}

--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -21,6 +21,9 @@
 //
 // Call sites, variable usages, assignments, etc. are NOT definitions.
 
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
 use cairo_lang_debug::debug::DebugWithDb;
 use cairo_lang_diagnostics::Maybe;
 pub use cairo_lang_filesystem::ids::UnstableSalsaId;
@@ -37,6 +40,7 @@ use smol_str::SmolStr;
 
 use crate::db::DefsGroup;
 use crate::diagnostic_utils::StableLocation;
+use crate::plugin::{InlineMacroExprPlugin, MacroPlugin};
 
 // A trait for an id for a language element.
 pub trait LanguageElementId {
@@ -319,6 +323,104 @@ define_short_id!(
     DefsGroup,
     lookup_intern_plugin_generated_file,
     intern_plugin_generated_file
+);
+
+/// An ID allowing for interning the [`MacroPlugin`] into Salsa database.
+#[derive(Clone, Debug)]
+pub struct MacroPluginLongId(pub Arc<dyn MacroPlugin>);
+
+impl MacroPlugin for MacroPluginLongId {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        metadata: &crate::plugin::MacroPluginMetadata<'_>,
+    ) -> crate::plugin::PluginResult {
+        self.0.generate_code(db, item_ast, metadata)
+    }
+
+    fn declared_attributes(&self) -> Vec<String> {
+        self.0.declared_attributes()
+    }
+
+    fn declared_derives(&self) -> Vec<String> {
+        self.0.declared_derives()
+    }
+
+    fn executable_attributes(&self) -> Vec<String> {
+        self.0.executable_attributes()
+    }
+
+    fn phantom_type_attributes(&self) -> Vec<String> {
+        self.0.phantom_type_attributes()
+    }
+}
+
+// `PartialEq` and `Hash` cannot be derived on `Arc<dyn ...>`,
+// but pointer-based equality and hash semantics are enough in this case.
+impl PartialEq for MacroPluginLongId {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for MacroPluginLongId {}
+
+impl Hash for MacroPluginLongId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.0).hash(state)
+    }
+}
+
+define_short_id!(
+    MacroPluginId,
+    MacroPluginLongId,
+    DefsGroup,
+    lookup_intern_macro_plugin,
+    intern_macro_plugin
+);
+
+/// An ID allowing for interning the [`InlineMacroExprPlugin`] into Salsa database.
+#[derive(Clone, Debug)]
+pub struct InlineMacroExprPluginLongId(pub Arc<dyn InlineMacroExprPlugin>);
+
+impl InlineMacroExprPlugin for InlineMacroExprPluginLongId {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: &ast::ExprInlineMacro,
+        metadata: &crate::plugin::MacroPluginMetadata<'_>,
+    ) -> crate::plugin::InlinePluginResult {
+        self.0.generate_code(db, item_ast, metadata)
+    }
+
+    fn documentation(&self) -> Option<String> {
+        self.0.documentation()
+    }
+}
+
+// `PartialEq` and `Hash` cannot be derived on `Arc<dyn ...>`,
+// but pointer-based equality and hash semantics are enough in this case.
+impl PartialEq for InlineMacroExprPluginLongId {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for InlineMacroExprPluginLongId {}
+
+impl Hash for InlineMacroExprPluginLongId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.0).hash(state)
+    }
+}
+
+define_short_id!(
+    InlineMacroExprPluginId,
+    InlineMacroExprPluginLongId,
+    DefsGroup,
+    lookup_intern_inline_macro_plugin,
+    intern_inline_macro_plugin
 );
 
 define_language_element_id_as_enum! {

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -17,10 +17,10 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, LookupIntern, Upcast, extract_matches, try_extract_matches};
 use indoc::indoc;
 
-use crate::db::{DefsDatabase, DefsGroup, try_ext_as_virtual_impl};
+use crate::db::{DefsDatabase, DefsGroup, init_defs_group, try_ext_as_virtual_impl};
 use crate::ids::{
-    FileIndex, GenericParamLongId, ModuleFileId, ModuleId, ModuleItemId, NamedLanguageElementId,
-    SubmoduleLongId,
+    FileIndex, GenericParamLongId, MacroPluginLongId, ModuleFileId, ModuleId, ModuleItemId,
+    NamedLanguageElementId, SubmoduleLongId,
 };
 use crate::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
@@ -40,11 +40,12 @@ impl Default for DatabaseForTesting {
     fn default() -> Self {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
-        res.set_macro_plugins(vec![
-            Arc::new(FooToBarPlugin),
-            Arc::new(RemoveOrigPlugin),
-            Arc::new(DummyPlugin),
-        ]);
+        init_defs_group(&mut res);
+        res.set_default_macro_plugins(Arc::new([
+            res.intern_macro_plugin(MacroPluginLongId(Arc::new(FooToBarPlugin))),
+            res.intern_macro_plugin(MacroPluginLongId(Arc::new(RemoveOrigPlugin))),
+            res.intern_macro_plugin(MacroPluginLongId(Arc::new(DummyPlugin))),
+        ]));
         res
     }
 }

--- a/crates/cairo-lang-doc/src/tests/test_utils.rs
+++ b/crates/cairo-lang-doc/src/tests/test_utils.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use cairo_lang_defs::db::{DefsDatabase, DefsGroup};
+use cairo_lang_defs::db::{DefsDatabase, DefsGroup, init_defs_group};
 use cairo_lang_defs::ids::ModuleId;
 use cairo_lang_filesystem::db::{
     AsFilesGroupMut, CrateConfiguration, ExternalFiles, FilesDatabase, FilesGroup, FilesGroupEx,
@@ -8,7 +8,10 @@ use cairo_lang_filesystem::db::{
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::ids::{CrateId, Directory, FileLongId};
 use cairo_lang_parser::db::{ParserDatabase, ParserGroup};
-use cairo_lang_semantic::db::{SemanticDatabase, SemanticGroup};
+use cairo_lang_semantic::db::{
+    PluginSuiteInput, SemanticDatabase, SemanticGroup, init_semantic_group,
+};
+use cairo_lang_semantic::plugin::PluginSuite;
 use cairo_lang_syntax::node::db::{SyntaxDatabase, SyntaxGroup};
 use cairo_lang_utils::{Intern, Upcast};
 
@@ -33,7 +36,12 @@ impl Default for TestDatabase {
     fn default() -> Self {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
-        res.set_macro_plugins(vec![]);
+        init_defs_group(&mut res);
+        init_semantic_group(&mut res);
+
+        let plugin_suite = res.intern_plugin_suite(PluginSuite::default());
+        res.set_default_plugins_from_suite(plugin_suite);
+
         res
     }
 }

--- a/crates/cairo-lang-executable/src/compile.rs
+++ b/crates/cairo-lang-executable/src/compile.rs
@@ -70,7 +70,7 @@ pub fn compile_executable(
         .skip_auto_withdraw_gas()
         .with_cfg(CfgSet::from_iter([Cfg::kv("gas", "disabled")]))
         .detect_corelib()
-        .with_plugin_suite(executable_plugin_suite())
+        .with_default_plugin_suite(executable_plugin_suite())
         .build()?;
 
     let main_crate_ids = setup_project(&mut db, Path::new(&path))?;

--- a/crates/cairo-lang-executable/src/test.rs
+++ b/crates/cairo-lang-executable/src/test.rs
@@ -20,7 +20,7 @@ pub static SHARED_DB: LazyLock<Mutex<RootDatabase>> = LazyLock::new(|| {
             .skip_auto_withdraw_gas()
             .with_cfg(CfgSet::from_iter([Cfg::kv("gas", "disabled")]))
             .detect_corelib()
-            .with_plugin_suite(executable_plugin_suite())
+            .with_default_plugin_suite(executable_plugin_suite())
             .build()
             .unwrap(),
     )

--- a/crates/cairo-lang-lowering/src/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/test_utils.rs
@@ -1,13 +1,15 @@
 use std::sync::{LazyLock, Mutex};
 
-use cairo_lang_defs::db::{DefsDatabase, DefsGroup, try_ext_as_virtual_impl};
+use cairo_lang_defs::db::{DefsDatabase, DefsGroup, init_defs_group, try_ext_as_virtual_impl};
 use cairo_lang_filesystem::db::{
     AsFilesGroupMut, ExternalFiles, FilesDatabase, FilesGroup, init_dev_corelib, init_files_group,
 };
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::ids::VirtualFile;
 use cairo_lang_parser::db::{ParserDatabase, ParserGroup};
-use cairo_lang_semantic::db::{SemanticDatabase, SemanticGroup};
+use cairo_lang_semantic::db::{
+    PluginSuiteInput, SemanticDatabase, SemanticGroup, init_semantic_group,
+};
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
 use cairo_lang_syntax::node::db::{SyntaxDatabase, SyntaxGroup};
 use cairo_lang_utils::Upcast;
@@ -41,10 +43,11 @@ impl LoweringDatabaseForTesting {
     pub fn new() -> Self {
         let mut res = LoweringDatabaseForTesting { storage: Default::default() };
         init_files_group(&mut res);
-        let suite = get_default_plugin_suite();
-        res.set_macro_plugins(suite.plugins);
-        res.set_inline_macro_plugins(suite.inline_macro_plugins.into());
-        res.set_analyzer_plugins(suite.analyzer_plugins);
+        init_defs_group(&mut res);
+        init_semantic_group(&mut res);
+
+        let suite = res.intern_plugin_suite(get_default_plugin_suite());
+        res.set_default_plugins_from_suite(suite);
 
         let corelib_path = detect_corelib().expect("Corelib not found in default location.");
         init_dev_corelib(&mut res, corelib_path);

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -1,8 +1,8 @@
 use std::default::Default;
 use std::sync::Arc;
 
-use cairo_lang_defs::db::{DefsDatabase, DefsGroup, try_ext_as_virtual_impl};
-use cairo_lang_defs::ids::ModuleId;
+use cairo_lang_defs::db::{DefsDatabase, DefsGroup, init_defs_group, try_ext_as_virtual_impl};
+use cairo_lang_defs::ids::{MacroPluginLongId, ModuleId};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
@@ -23,6 +23,7 @@ use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_test_utils::verify_diagnostics_expectation;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, Upcast};
+use itertools::chain;
 
 use crate::get_base_plugins;
 use crate::test_utils::expand_module_text;
@@ -64,7 +65,13 @@ impl Default for DatabaseForTesting {
     fn default() -> Self {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
-        res.set_macro_plugins(get_base_plugins());
+        init_defs_group(&mut res);
+        res.set_default_macro_plugins(
+            get_base_plugins()
+                .into_iter()
+                .map(|plugin| res.intern_macro_plugin(MacroPluginLongId(plugin)))
+                .collect(),
+        );
         res
     }
 }
@@ -112,9 +119,15 @@ pub fn test_expand_plugin_inner(
     extra_plugins: &[Arc<dyn MacroPlugin>],
 ) -> TestRunnerResult {
     let db = &mut DatabaseForTesting::default();
-    let mut plugins = db.macro_plugins();
-    plugins.extend_from_slice(extra_plugins);
-    db.set_macro_plugins(plugins);
+
+    let extra_plugins = extra_plugins
+        .iter()
+        .cloned()
+        .map(|plugin| db.intern_macro_plugin(MacroPluginLongId(plugin)));
+
+    let default_plugins = db.default_macro_plugins();
+    let plugins = chain!(default_plugins.iter().cloned(), extra_plugins).collect::<Arc<[_]>>();
+    db.set_default_macro_plugins(plugins);
 
     let cfg_set: Option<CfgSet> =
         inputs.get("cfg").map(|s| serde_json::from_str(s.as_str()).unwrap());

--- a/crates/cairo-lang-runner/src/profiling_test.rs
+++ b/crates/cairo-lang-runner/src/profiling_test.rs
@@ -42,7 +42,7 @@ pub fn test_profiling(
     }
 
     let db = RootDatabase::builder()
-        .with_plugin_suite(starknet_plugin_suite())
+        .with_default_plugin_suite(starknet_plugin_suite())
         .detect_corelib()
         .build()
         .unwrap();

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -1,15 +1,15 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use cairo_lang_defs::db::DefsGroup;
+use cairo_lang_defs::db::{DefsGroup, DefsGroupEx};
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::{
     ConstantId, EnumId, ExternFunctionId, ExternTypeId, FreeFunctionId, FunctionTitleId,
     FunctionWithBodyId, GenericParamId, GenericTypeId, GlobalUseId, ImplAliasId, ImplConstantDefId,
-    ImplDefId, ImplFunctionId, ImplImplDefId, ImplItemId, ImplTypeDefId, LanguageElementId,
-    LookupItemId, ModuleFileId, ModuleId, ModuleItemId, ModuleTypeAliasId, StructId,
-    TraitConstantId, TraitFunctionId, TraitId, TraitImplId, TraitItemId, TraitTypeId, UseId,
-    VariantId,
+    ImplDefId, ImplFunctionId, ImplImplDefId, ImplItemId, ImplTypeDefId,
+    InlineMacroExprPluginLongId, LanguageElementId, LookupItemId, MacroPluginLongId, ModuleFileId,
+    ModuleId, ModuleItemId, ModuleTypeAliasId, StructId, TraitConstantId, TraitFunctionId, TraitId,
+    TraitImplId, TraitItemId, TraitTypeId, UseId, VariantId,
 };
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder, Maybe};
 use cairo_lang_filesystem::db::{AsFilesGroupMut, FilesGroup};
@@ -39,7 +39,7 @@ use crate::items::trt::{
 };
 use crate::items::us::{ImportedModules, SemanticUseEx};
 use crate::items::visibility::Visibility;
-use crate::plugin::AnalyzerPlugin;
+use crate::plugin::{AnalyzerPlugin, InternedPluginSuite, PluginSuite};
 use crate::resolve::{ResolvedConcreteItem, ResolvedGenericItem, ResolverData};
 use crate::substitution::GenericSubstitution;
 use crate::types::{ImplTypeById, ImplTypeId, TypeSizeInformation};
@@ -1925,3 +1925,93 @@ pub trait SemanticGroupEx: SemanticGroup {
 }
 
 impl<T: SemanticGroup + ?Sized> SemanticGroupEx for T {}
+
+/// An extension trait for [`SemanticGroup`] to manage plugin setters.
+pub trait PluginSuiteInput: SemanticGroup {
+    /// Interns each plugin from the [`PluginSuite`] into the database.
+    fn intern_plugin_suite(&mut self, suite: PluginSuite) -> InternedPluginSuite {
+        let PluginSuite { plugins, inline_macro_plugins, analyzer_plugins } = suite;
+
+        // NOTE: kept for compatibility and testing, removed later in the stack.
+        self.set_macro_plugins(plugins.clone());
+        self.set_inline_macro_plugins(Arc::new(inline_macro_plugins.clone()));
+        self.set_analyzer_plugins(analyzer_plugins.clone());
+
+        let macro_plugins = plugins
+            .into_iter()
+            .map(|plugin| self.intern_macro_plugin(MacroPluginLongId(plugin)))
+            .collect::<Arc<[_]>>();
+
+        let inline_macro_plugins = Arc::new(
+            inline_macro_plugins
+                .into_iter()
+                .map(|(name, plugin)| {
+                    (name, self.intern_inline_macro_plugin(InlineMacroExprPluginLongId(plugin)))
+                })
+                .collect::<OrderedHashMap<_, _>>(),
+        );
+
+        let analyzer_plugins = analyzer_plugins
+            .into_iter()
+            .map(|plugin| self.intern_analyzer_plugin(AnalyzerPluginLongId(plugin)))
+            .collect::<Arc<[_]>>();
+
+        InternedPluginSuite { macro_plugins, inline_macro_plugins, analyzer_plugins }
+    }
+
+    /// Sets macro, inline macro and analyzer plugins specified in the [`PluginSuite`] as default
+    /// for all crates.
+    ///
+    /// *Note*: Sets the following Salsa inputs: [`DefsGroup::default_macro_plugins`],
+    /// [`DefsGroup::default_inline_macro_plugins`], and
+    /// [`SemanticGroup::default_analyzer_plugins`].
+    fn set_default_plugins_from_suite(&mut self, suite: InternedPluginSuite) {
+        let InternedPluginSuite { macro_plugins, inline_macro_plugins, analyzer_plugins } = suite;
+
+        // NOTE: kept here for compatibility, removed in the last PR
+        // ---
+        let raw_macro_plugins = macro_plugins
+            .iter()
+            .cloned()
+            .map(|id| self.lookup_intern_macro_plugin(id).0)
+            .collect::<Vec<_>>();
+        let raw_inline_macro_plugins = inline_macro_plugins
+            .iter()
+            .map(|(name, id)| (name.clone(), self.lookup_intern_inline_macro_plugin(*id).0))
+            .collect::<OrderedHashMap<_, _>>();
+        let raw_analyzer_plugins = analyzer_plugins
+            .iter()
+            .cloned()
+            .map(|id| self.lookup_intern_analyzer_plugin(id).0)
+            .collect::<Vec<_>>();
+
+        self.set_macro_plugins(raw_macro_plugins);
+        self.set_inline_macro_plugins(Arc::new(raw_inline_macro_plugins));
+        self.set_analyzer_plugins(raw_analyzer_plugins);
+        // ---
+
+        self.set_default_macro_plugins(macro_plugins);
+        self.set_default_inline_macro_plugins(inline_macro_plugins);
+        self.set_default_analyzer_plugins(analyzer_plugins);
+    }
+
+    /// Sets macro, inline macro and analyzer plugins present in the [`PluginSuite`] for a crate
+    /// pointed to by the [`CrateId`], overriding the defaults for that crate.
+    ///
+    /// *Note*: Sets the following Salsa inputs: [`DefsGroup::macro_plugin_overrides`],
+    /// [`DefsGroup::inline_macro_plugin_overrides`], and
+    /// [`SemanticGroup::analyzer_plugin_overrides`].
+    fn set_override_crate_plugins_from_suite(
+        &mut self,
+        crate_id: CrateId,
+        suite: InternedPluginSuite,
+    ) {
+        let InternedPluginSuite { macro_plugins, inline_macro_plugins, analyzer_plugins } = suite;
+
+        self.set_override_crate_macro_plugins(crate_id, macro_plugins);
+        self.set_override_crate_inline_macro_plugins(crate_id, inline_macro_plugins);
+        self.set_override_crate_analyzer_plugins(crate_id, analyzer_plugins);
+    }
+}
+
+impl<T: SemanticGroup + ?Sized> PluginSuiteInput for T {}

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -1585,8 +1585,6 @@ pub trait SemanticGroup:
 
     // Analyzer plugins.
     // ========
-    #[salsa::input]
-    fn analyzer_plugins(&self) -> Vec<Arc<dyn AnalyzerPlugin>>;
 
     #[salsa::input]
     fn default_analyzer_plugins(&self) -> Arc<[AnalyzerPluginId]>;
@@ -1605,7 +1603,7 @@ pub trait SemanticGroup:
 
     /// Returns the set of `allow` that were declared as by a plugin.
     /// An allow that is not in this set will be handled as an unknown allow.
-    fn declared_allows(&self) -> Arc<OrderedHashSet<String>>;
+    fn declared_allows(&self, crate_id: CrateId) -> Arc<OrderedHashSet<String>>;
 
     // Helpers for language server.
     // ============================
@@ -1745,7 +1743,10 @@ fn module_semantic_diagnostics(
         diagnostics.extend(db.global_use_semantic_diagnostics(*global_use));
     }
     add_unused_item_diagnostics(db, module_id, &data, &mut diagnostics);
-    for analyzer_plugin in db.analyzer_plugins().iter() {
+    for analyzer_plugin_id in db.crate_analyzer_plugins(module_id.owning_crate(db.upcast())).iter()
+    {
+        let analyzer_plugin = db.lookup_intern_analyzer_plugin(*analyzer_plugin_id);
+
         for diag in analyzer_plugin.diagnostics(db, module_id) {
             diagnostics.add(SemanticDiagnostic::new(
                 StableLocation::new(diag.stable_ptr),
@@ -1764,9 +1765,11 @@ fn crate_analyzer_plugins(db: &dyn SemanticGroup, crate_id: CrateId) -> Arc<[Ana
         .unwrap_or_else(|| db.default_analyzer_plugins())
 }
 
-fn declared_allows(db: &dyn SemanticGroup) -> Arc<OrderedHashSet<String>> {
+fn declared_allows(db: &dyn SemanticGroup, crate_id: CrateId) -> Arc<OrderedHashSet<String>> {
     Arc::new(OrderedHashSet::from_iter(
-        db.analyzer_plugins().into_iter().flat_map(|plugin| plugin.declared_allows()),
+        db.crate_analyzer_plugins(crate_id)
+            .iter()
+            .flat_map(|plugin| db.lookup_intern_analyzer_plugin(*plugin).declared_allows()),
     ))
 }
 
@@ -1932,11 +1935,6 @@ pub trait PluginSuiteInput: SemanticGroup {
     fn intern_plugin_suite(&mut self, suite: PluginSuite) -> InternedPluginSuite {
         let PluginSuite { plugins, inline_macro_plugins, analyzer_plugins } = suite;
 
-        // NOTE: kept for compatibility and testing, removed later in the stack.
-        self.set_macro_plugins(plugins.clone());
-        self.set_inline_macro_plugins(Arc::new(inline_macro_plugins.clone()));
-        self.set_analyzer_plugins(analyzer_plugins.clone());
-
         let macro_plugins = plugins
             .into_iter()
             .map(|plugin| self.intern_macro_plugin(MacroPluginLongId(plugin)))
@@ -1967,28 +1965,6 @@ pub trait PluginSuiteInput: SemanticGroup {
     /// [`SemanticGroup::default_analyzer_plugins`].
     fn set_default_plugins_from_suite(&mut self, suite: InternedPluginSuite) {
         let InternedPluginSuite { macro_plugins, inline_macro_plugins, analyzer_plugins } = suite;
-
-        // NOTE: kept here for compatibility, removed in the last PR
-        // ---
-        let raw_macro_plugins = macro_plugins
-            .iter()
-            .cloned()
-            .map(|id| self.lookup_intern_macro_plugin(id).0)
-            .collect::<Vec<_>>();
-        let raw_inline_macro_plugins = inline_macro_plugins
-            .iter()
-            .map(|(name, id)| (name.clone(), self.lookup_intern_inline_macro_plugin(*id).0))
-            .collect::<OrderedHashMap<_, _>>();
-        let raw_analyzer_plugins = analyzer_plugins
-            .iter()
-            .cloned()
-            .map(|id| self.lookup_intern_analyzer_plugin(id).0)
-            .collect::<Vec<_>>();
-
-        self.set_macro_plugins(raw_macro_plugins);
-        self.set_inline_macro_plugins(Arc::new(raw_inline_macro_plugins));
-        self.set_analyzer_plugins(raw_analyzer_plugins);
-        // ---
 
         self.set_default_macro_plugins(macro_plugins);
         self.set_default_inline_macro_plugins(inline_macro_plugins);

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -24,6 +24,7 @@ use smol_str::SmolStr;
 
 use crate::diagnostic::SemanticDiagnosticKind;
 use crate::expr::inference::{self, ImplVar, ImplVarId};
+use crate::ids::{AnalyzerPluginId, AnalyzerPluginLongId};
 use crate::items::constant::{ConstCalcInfo, ConstValueId, Constant, ImplConstantId};
 use crate::items::function_with_body::FunctionBody;
 use crate::items::functions::{GenericFunctionId, ImplicitPrecedence, InlineConfiguration};
@@ -1587,6 +1588,21 @@ pub trait SemanticGroup:
     #[salsa::input]
     fn analyzer_plugins(&self) -> Vec<Arc<dyn AnalyzerPlugin>>;
 
+    #[salsa::input]
+    fn default_analyzer_plugins(&self) -> Arc<[AnalyzerPluginId]>;
+
+    #[salsa::input]
+    fn analyzer_plugin_overrides(&self) -> Arc<OrderedHashMap<CrateId, Arc<[AnalyzerPluginId]>>>;
+
+    #[salsa::interned]
+    fn intern_analyzer_plugin(&self, plugin: AnalyzerPluginLongId) -> AnalyzerPluginId;
+
+    /// Returns [`AnalyzerPluginId`]s of the plugins set for the crate with [`CrateId`].
+    /// Returns
+    /// [`SemanticGroupEx::set_override_crate_analyzer_plugins`] if it has been set,
+    /// or the ([`SemanticGroup::default_analyzer_plugins`]) otherwise.
+    fn crate_analyzer_plugins(&self, crate_id: CrateId) -> Arc<[AnalyzerPluginId]>;
+
     /// Returns the set of `allow` that were declared as by a plugin.
     /// An allow that is not in this set will be handled as an unknown allow.
     fn declared_allows(&self) -> Arc<OrderedHashSet<String>>;
@@ -1631,6 +1647,11 @@ pub trait SemanticGroup:
         crate_id: CrateId,
         user_module_file_id: ModuleFileId,
     ) -> Arc<[(TraitId, String)]>;
+}
+
+/// Initializes the [`SemanticGroup`] database to a proper state.
+pub fn init_semantic_group(db: &mut dyn SemanticGroup) {
+    db.set_analyzer_plugin_overrides(Arc::new(OrderedHashMap::default()));
 }
 
 impl<T: Upcast<dyn SemanticGroup + 'static>> Elongate for T {
@@ -1734,6 +1755,13 @@ fn module_semantic_diagnostics(
     }
 
     Ok(diagnostics.build())
+}
+
+fn crate_analyzer_plugins(db: &dyn SemanticGroup, crate_id: CrateId) -> Arc<[AnalyzerPluginId]> {
+    db.analyzer_plugin_overrides()
+        .get(&crate_id)
+        .cloned()
+        .unwrap_or_else(|| db.default_analyzer_plugins())
 }
 
 fn declared_allows(db: &dyn SemanticGroup) -> Arc<OrderedHashSet<String>> {
@@ -1880,3 +1908,20 @@ pub fn get_resolver_data_options(
     .flatten()
     .collect()
 }
+
+pub trait SemanticGroupEx: SemanticGroup {
+    /// Overrides the default analyzer plugins available for [`CrateId`] with `plugins`.
+    ///
+    /// *Note*: Sets the following Salsa input: `SemanticGroup::analyzer_plugin_overrides`.
+    fn set_override_crate_analyzer_plugins(
+        &mut self,
+        crate_id: CrateId,
+        plugins: Arc<[AnalyzerPluginId]>,
+    ) {
+        let mut overrides = self.analyzer_plugin_overrides().as_ref().clone();
+        overrides.insert(crate_id, plugins);
+        self.set_analyzer_plugin_overrides(Arc::new(overrides));
+    }
+}
+
+impl<T: SemanticGroup + ?Sized> SemanticGroupEx for T {}

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use cairo_lang_defs::db::DefsGroup;
-use cairo_lang_defs::ids::{GenericTypeId, ModuleId, TopLevelLanguageElementId};
+use cairo_lang_defs::ids::{GenericTypeId, MacroPluginLongId, ModuleId, TopLevelLanguageElementId};
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
@@ -14,6 +14,7 @@ use pretty_assertions::assert_eq;
 use test_log::test;
 
 use crate::db::SemanticGroup;
+use crate::ids::AnalyzerPluginLongId;
 use crate::items::us::SemanticUseEx;
 use crate::plugin::AnalyzerPlugin;
 use crate::resolve::ResolvedGenericItem;
@@ -140,7 +141,9 @@ impl MacroPlugin for AddInlineModuleDummyPlugin {
 fn test_inline_module_diagnostics() {
     let mut db_val = SemanticDatabaseForTesting::new_empty();
     let db = &mut db_val;
-    db.set_macro_plugins(vec![Arc::new(AddInlineModuleDummyPlugin)]);
+    db.set_default_macro_plugins(Arc::new([
+        db.intern_macro_plugin(MacroPluginLongId(Arc::new(AddInlineModuleDummyPlugin)))
+    ]));
     let crate_id = setup_test_crate(db, indoc! {"
             mod a {
                 #[test_change_return_type]
@@ -240,7 +243,9 @@ impl AnalyzerPlugin for NoU128RenameAnalyzerPlugin {
 fn test_analyzer_diagnostics() {
     let mut db_val = SemanticDatabaseForTesting::new_empty();
     let db = &mut db_val;
-    db.set_analyzer_plugins(vec![Arc::new(NoU128RenameAnalyzerPlugin)]);
+    db.set_default_analyzer_plugins(Arc::new([
+        db.intern_analyzer_plugin(AnalyzerPluginLongId(Arc::new(NoU128RenameAnalyzerPlugin)))
+    ]));
     let crate_id = setup_test_crate(db, indoc! {"
             mod inner {
                 use core::integer::u128 as long_u128_rename;

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -15,7 +15,7 @@ use cairo_lang_defs::ids::{
     MemberId, ModuleFileId, ModuleItemId, NamedLanguageElementId, StatementConstLongId,
     StatementItemId, StatementUseLongId, TraitFunctionId, TraitId, VarId,
 };
-use cairo_lang_defs::plugin::MacroPluginMetadata;
+use cairo_lang_defs::plugin::{InlineMacroExprPlugin, MacroPluginMetadata};
 use cairo_lang_diagnostics::{Maybe, ToOption, skip_diagnostic};
 use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::ids::{FileKind, FileLongId, VirtualFile};
@@ -434,10 +434,15 @@ fn compute_expr_inline_macro_semantic(
 ) -> Maybe<Expr> {
     let syntax_db = ctx.db.upcast();
 
+    let crate_id = ctx.resolver.owning_crate_id;
+
     let macro_name = syntax.path(syntax_db).as_syntax_node().get_text_without_trivia(syntax_db);
-    let Some(macro_plugin) = ctx.db.inline_macro_plugins().get(&macro_name).cloned() else {
+    let Some(macro_plugin_id) =
+        ctx.db.crate_inline_macro_plugins(crate_id).get(&macro_name).cloned()
+    else {
         return Err(ctx.diagnostics.report(syntax, InlineMacroNotFound(macro_name.into())));
     };
+    let macro_plugin = ctx.db.lookup_intern_inline_macro_plugin(macro_plugin_id);
 
     // Skipping expanding an inline macro if it had a parser error.
     if syntax.as_syntax_node().descendants(syntax_db).any(|node| {
@@ -458,7 +463,7 @@ fn compute_expr_inline_macro_semantic(
 
     let result = macro_plugin.generate_code(syntax_db, syntax, &MacroPluginMetadata {
         cfg_set: &ctx.cfg_set,
-        declared_derives: &ctx.db.declared_derives(),
+        declared_derives: &ctx.db.declared_derives(crate_id),
         allowed_features: &ctx.resolver.data.feature_config.allowed_features,
         edition: ctx.resolver.settings.edition,
     });
@@ -3497,6 +3502,9 @@ pub fn compute_statement_semantic(
 ) -> Maybe<StatementId> {
     let db = ctx.db;
     let syntax_db = db.upcast();
+
+    let crate_id = ctx.resolver.owning_crate_id;
+
     // As for now, statement attributes does not have any semantic affect, so we only validate they
     // are allowed.
     validate_statement_attributes(ctx, &syntax);
@@ -3504,7 +3512,7 @@ pub fn compute_statement_semantic(
         .resolver
         .data
         .feature_config
-        .override_with(extract_item_feature_config(db, &syntax, ctx.diagnostics));
+        .override_with(extract_item_feature_config(db, crate_id, &syntax, ctx.diagnostics));
     let statement = match &syntax {
         ast::Statement::Let(let_syntax) => {
             let rhs_syntax = &let_syntax.rhs(syntax_db);

--- a/crates/cairo-lang-semantic/src/ids.rs
+++ b/crates/cairo-lang-semantic/src/ids.rs
@@ -1,0 +1,49 @@
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use cairo_lang_utils::define_short_id;
+
+use crate::db::SemanticGroup;
+use crate::plugin::AnalyzerPlugin;
+
+/// An Id allowing interning [`AnalyzerPlugin`] into Salsa database.
+#[derive(Clone, Debug)]
+pub struct AnalyzerPluginLongId(pub Arc<dyn AnalyzerPlugin>);
+
+impl AnalyzerPlugin for AnalyzerPluginLongId {
+    fn diagnostics(
+        &self,
+        db: &dyn crate::db::SemanticGroup,
+        module_id: cairo_lang_defs::ids::ModuleId,
+    ) -> Vec<cairo_lang_defs::plugin::PluginDiagnostic> {
+        self.0.diagnostics(db, module_id)
+    }
+
+    fn declared_allows(&self) -> Vec<String> {
+        self.0.declared_allows()
+    }
+}
+
+// `PartialEq` and `Hash` cannot be derived on `Arc<dyn ...>`,
+// but pointer-based equality and hash semantics are enough in this case.
+impl PartialEq for AnalyzerPluginLongId {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for AnalyzerPluginLongId {}
+
+impl Hash for AnalyzerPluginLongId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.0).hash(state)
+    }
+}
+
+define_short_id!(
+    AnalyzerPluginId,
+    AnalyzerPluginLongId,
+    SemanticGroup,
+    lookup_intern_analyzer_plugin,
+    intern_analyzer_plugin
+);

--- a/crates/cairo-lang-semantic/src/items/enm.rs
+++ b/crates/cairo-lang-semantic/src/items/enm.rs
@@ -188,7 +188,10 @@ pub fn priv_enum_definition_data(
     db: &dyn SemanticGroup,
     enum_id: EnumId,
 ) -> Maybe<EnumDefinitionData> {
-    let module_file_id = enum_id.module_file_id(db.upcast());
+    let defs_db = db.upcast();
+
+    let module_file_id = enum_id.module_file_id(defs_db);
+    let crate_id = module_file_id.0.owning_crate(defs_db);
     let mut diagnostics = SemanticDiagnostics::default();
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
@@ -213,7 +216,7 @@ pub fn priv_enum_definition_data(
         let feature_restore = resolver
             .data
             .feature_config
-            .override_with(extract_item_feature_config(db, &variant, &mut diagnostics));
+            .override_with(extract_item_feature_config(db, crate_id, &variant, &mut diagnostics));
         let id = VariantLongId(module_file_id, variant.stable_ptr()).intern(db);
         let ty = match variant.type_clause(syntax_db) {
             ast::OptionTypeClause::Empty(_) => unit_ty(db),
@@ -254,10 +257,13 @@ pub fn enum_definition_diagnostics(
     let Ok(data) = db.priv_enum_definition_data(enum_id) else {
         return Default::default();
     };
+
+    let crate_id = data.resolver_data.module_file_id.0.owning_crate(db.upcast());
+
     // If the enum is a phantom type, no need to check if its variants are fully valid types, as
     // they won't be used.
     if db
-        .declared_phantom_type_attributes()
+        .declared_phantom_type_attributes(crate_id)
         .iter()
         .any(|attr| enum_id.has_attr(db, attr).unwrap_or_default())
     {

--- a/crates/cairo-lang-semantic/src/items/feature_kind.rs
+++ b/crates/cairo-lang-semantic/src/items/feature_kind.rs
@@ -1,6 +1,7 @@
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::{LanguageElementId, ModuleId};
 use cairo_lang_diagnostics::DiagnosticsBuilder;
+use cairo_lang_filesystem::ids::CrateId;
 use cairo_lang_syntax::attribute::consts::{
     ALLOW_ATTR, DEPRECATED_ATTR, FEATURE_ATTR, INTERNAL_ATTR, UNSTABLE_ATTR,
 };
@@ -177,6 +178,7 @@ pub struct FeatureConfigRestore {
 /// Returns the allowed features of an object which supports attributes.
 pub fn extract_item_feature_config(
     db: &dyn SemanticGroup,
+    crate_id: CrateId,
     syntax: &impl QueryAttrs,
     diagnostics: &mut SemanticDiagnostics,
 ) -> FeatureConfig {
@@ -212,7 +214,7 @@ pub fn extract_item_feature_config(
                 config.allow_unused_imports = true;
                 true
             }
-            other => db.declared_allows().contains(other),
+            other => db.declared_allows(crate_id).contains(other),
         },
     );
     config
@@ -253,7 +255,8 @@ pub fn extract_feature_config(
 ) -> FeatureConfig {
     let defs_db = db.upcast();
     let mut current_module_id = element_id.parent_module(defs_db);
-    let mut config_stack = vec![extract_item_feature_config(db, syntax, diagnostics)];
+    let crate_id = current_module_id.owning_crate(defs_db);
+    let mut config_stack = vec![extract_item_feature_config(db, crate_id, syntax, diagnostics)];
     let mut config = loop {
         match current_module_id {
             ModuleId::CrateRoot(crate_id) => {
@@ -270,7 +273,7 @@ pub fn extract_feature_config(
                 let module = &db.module_submodules(current_module_id).unwrap()[&id];
                 // TODO(orizi): Add parent module diagnostics.
                 let ignored = &mut SemanticDiagnostics::default();
-                config_stack.push(extract_item_feature_config(db, module, ignored));
+                config_stack.push(extract_item_feature_config(db, crate_id, module, ignored));
             }
         }
     };

--- a/crates/cairo-lang-semantic/src/lib.rs
+++ b/crates/cairo-lang-semantic/src/lib.rs
@@ -7,6 +7,7 @@ pub mod db;
 pub mod diagnostic;
 pub mod expr;
 pub mod helper;
+pub mod ids;
 pub mod inline_macros;
 pub mod items;
 pub mod literals;

--- a/crates/cairo-lang-semantic/src/plugin.rs
+++ b/crates/cairo-lang-semantic/src/plugin.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
-use cairo_lang_defs::ids::ModuleId;
+use cairo_lang_defs::ids::{InlineMacroExprPluginId, MacroPluginId, ModuleId};
 use cairo_lang_defs::plugin::{InlineMacroExprPlugin, MacroPlugin, NamedPlugin, PluginDiagnostic};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 
 use crate::db::SemanticGroup;
+use crate::ids::AnalyzerPluginId;
 
 /// A trait for an analyzer plugin: external plugin that generates additional diagnostics for
 /// modules.
@@ -71,4 +72,13 @@ impl PluginSuite {
         self.analyzer_plugins.extend(suite.analyzer_plugins);
         self
     }
+}
+
+/// A helper representation for the plugin IDs obtained from
+/// [`crate::db::PluginSuiteInput::intern_plugin_suite`].
+#[derive(Clone, Debug)]
+pub struct InternedPluginSuite {
+    pub macro_plugins: Arc<[MacroPluginId]>,
+    pub inline_macro_plugins: Arc<OrderedHashMap<String, InlineMacroExprPluginId>>,
+    pub analyzer_plugins: Arc<[AnalyzerPluginId]>,
 }

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -1,6 +1,6 @@
 use std::sync::{LazyLock, Mutex};
 
-use cairo_lang_defs::db::{DefsDatabase, DefsGroup, try_ext_as_virtual_impl};
+use cairo_lang_defs::db::{DefsDatabase, DefsGroup, init_defs_group, try_ext_as_virtual_impl};
 use cairo_lang_defs::ids::{FunctionWithBodyId, ModuleId, SubmoduleId, SubmoduleLongId};
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder};
 use cairo_lang_filesystem::db::{
@@ -17,7 +17,7 @@ use cairo_lang_test_utils::verify_diagnostics_expectation;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, LookupIntern, OptionFrom, Upcast, extract_matches};
 
-use crate::db::{SemanticDatabase, SemanticGroup};
+use crate::db::{PluginSuiteInput, SemanticDatabase, SemanticGroup, init_semantic_group};
 use crate::inline_macros::get_default_plugin_suite;
 use crate::items::functions::GenericFunctionId;
 use crate::plugin::PluginSuite;
@@ -47,9 +47,12 @@ impl SemanticDatabaseForTesting {
     pub fn with_plugin_suite(suite: PluginSuite) -> Self {
         let mut res = SemanticDatabaseForTesting { storage: Default::default() };
         init_files_group(&mut res);
-        res.set_macro_plugins(suite.plugins);
-        res.set_inline_macro_plugins(suite.inline_macro_plugins.into());
-        res.set_analyzer_plugins(suite.analyzer_plugins);
+        init_defs_group(&mut res);
+        init_semantic_group(&mut res);
+
+        let suite = res.intern_plugin_suite(suite);
+        res.set_default_plugins_from_suite(suite);
+
         let corelib_path = detect_corelib().expect("Corelib not found in default location.");
         init_dev_corelib(&mut res, corelib_path);
         res

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -144,18 +144,36 @@ impl TypeLongId {
     /// declared by a plugin as defining a phantom type), or is a tuple or fixed sized array
     /// containing it.
     pub fn is_phantom(&self, db: &dyn SemanticGroup) -> bool {
-        let phantom_type_attributes = db.declared_phantom_type_attributes();
+        let defs_db = db.upcast();
+
         match self {
             TypeLongId::Concrete(id) => match id {
-                ConcreteTypeId::Struct(id) => phantom_type_attributes
-                    .iter()
-                    .any(|attr| id.has_attr(db, attr).unwrap_or_default()),
-                ConcreteTypeId::Enum(id) => phantom_type_attributes
-                    .iter()
-                    .any(|attr| id.has_attr(db, attr).unwrap_or_default()),
-                ConcreteTypeId::Extern(id) => phantom_type_attributes
-                    .iter()
-                    .any(|attr| id.has_attr(db, attr).unwrap_or_default()),
+                ConcreteTypeId::Struct(id) => {
+                    let crate_id =
+                        db.lookup_intern_struct(id.struct_id(db)).0.0.owning_crate(defs_db);
+
+                    db.declared_phantom_type_attributes(crate_id)
+                        .iter()
+                        .any(|attr| id.has_attr(db, attr).unwrap_or_default())
+                }
+                ConcreteTypeId::Enum(id) => {
+                    let crate_id = db.lookup_intern_enum(id.enum_id(db)).0.0.owning_crate(defs_db);
+
+                    db.declared_phantom_type_attributes(crate_id)
+                        .iter()
+                        .any(|attr| id.has_attr(db, attr).unwrap_or_default())
+                }
+                ConcreteTypeId::Extern(id) => {
+                    let crate_id = db
+                        .lookup_intern_extern_type(id.extern_type_id(db))
+                        .0
+                        .0
+                        .owning_crate(defs_db);
+
+                    db.declared_phantom_type_attributes(crate_id)
+                        .iter()
+                        .any(|attr| id.has_attr(db, attr).unwrap_or_default())
+                }
             },
             TypeLongId::Tuple(inner) => inner.iter().any(|ty| ty.is_phantom(db)),
             TypeLongId::FixedSizeArray { type_id, .. } => type_id.is_phantom(db),

--- a/crates/cairo-lang-sierra-generator/src/test_utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/test_utils.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, LazyLock, Mutex};
 
-use cairo_lang_defs::db::{DefsDatabase, DefsGroup, try_ext_as_virtual_impl};
+use cairo_lang_defs::db::{DefsDatabase, DefsGroup, init_defs_group, try_ext_as_virtual_impl};
 use cairo_lang_defs::ids::ModuleId;
 use cairo_lang_filesystem::db::{
     AsFilesGroupMut, ExternalFiles, FilesDatabase, FilesGroup, FilesGroupEx, init_dev_corelib,
@@ -11,7 +11,9 @@ use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::{FlagId, VirtualFile};
 use cairo_lang_lowering::db::{LoweringDatabase, LoweringGroup};
 use cairo_lang_parser::db::{ParserDatabase, ParserGroup};
-use cairo_lang_semantic::db::{SemanticDatabase, SemanticGroup};
+use cairo_lang_semantic::db::{
+    PluginSuiteInput, SemanticDatabase, SemanticGroup, init_semantic_group,
+};
 use cairo_lang_semantic::test_utils::setup_test_crate;
 use cairo_lang_sierra::ids::{ConcreteLibfuncId, GenericLibfuncId};
 use cairo_lang_sierra::program;
@@ -65,10 +67,11 @@ impl SierraGenDatabaseForTesting {
     pub fn new_empty() -> Self {
         let mut res = SierraGenDatabaseForTesting { storage: Default::default() };
         init_files_group(&mut res);
-        let suite = get_default_plugin_suite();
-        res.set_macro_plugins(suite.plugins);
-        res.set_inline_macro_plugins(suite.inline_macro_plugins.into());
-        res.set_analyzer_plugins(suite.analyzer_plugins);
+        init_defs_group(&mut res);
+        init_semantic_group(&mut res);
+
+        let plugin_suite = res.intern_plugin_suite(get_default_plugin_suite());
+        res.set_default_plugins_from_suite(plugin_suite);
 
         res.set_optimization_config(Arc::new(
             OptimizationConfig::default().with_minimal_movable_functions(),

--- a/crates/cairo-lang-starknet/src/abi_test.rs
+++ b/crates/cairo-lang-starknet/src/abi_test.rs
@@ -17,7 +17,7 @@ pub fn test_abi_failure(
 ) -> TestRunnerResult {
     let db = &mut RootDatabase::builder()
         .detect_corelib()
-        .with_plugin_suite(starknet_plugin_suite())
+        .with_default_plugin_suite(starknet_plugin_suite())
         .build()
         .unwrap();
     let (_, cairo_code) = get_direct_or_file_content(&inputs["cairo_code"]);
@@ -62,7 +62,7 @@ pub fn test_storage_path_check(
 ) -> TestRunnerResult {
     let db = &mut RootDatabase::builder()
         .detect_corelib()
-        .with_plugin_suite(starknet_plugin_suite())
+        .with_default_plugin_suite(starknet_plugin_suite())
         .build()
         .unwrap();
     let (_, cairo_code) = get_direct_or_file_content(&inputs["cairo_code"]);

--- a/crates/cairo-lang-starknet/src/compile.rs
+++ b/crates/cairo-lang-starknet/src/compile.rs
@@ -43,7 +43,7 @@ pub fn compile_path(
 ) -> Result<ContractClass> {
     let mut db = RootDatabase::builder()
         .detect_corelib()
-        .with_plugin_suite(starknet_plugin_suite())
+        .with_default_plugin_suite(starknet_plugin_suite())
         .build()?;
 
     let main_crate_ids = setup_project(&mut db, Path::new(&path))?;

--- a/crates/cairo-lang-starknet/src/contract_test.rs
+++ b/crates/cairo-lang-starknet/src/contract_test.rs
@@ -12,7 +12,7 @@ use crate::starknet_plugin_suite;
 fn test_contract_resolving() {
     let db = &mut RootDatabase::builder()
         .detect_corelib()
-        .with_plugin_suite(starknet_plugin_suite())
+        .with_default_plugin_suite(starknet_plugin_suite())
         .build()
         .unwrap();
     let crate_id = setup_test_crate(db, indoc! {"

--- a/crates/cairo-lang-starknet/src/test_utils.rs
+++ b/crates/cairo-lang-starknet/src/test_utils.rs
@@ -29,7 +29,7 @@ pub static SHARED_DB: LazyLock<Mutex<RootDatabase>> = LazyLock::new(|| {
     Mutex::new(
         RootDatabase::builder()
             .detect_corelib()
-            .with_plugin_suite(starknet_plugin_suite())
+            .with_default_plugin_suite(starknet_plugin_suite())
             .build()
             .unwrap(),
     )
@@ -47,7 +47,7 @@ pub static SHARED_DB_WITH_CONTRACTS: LazyLock<Mutex<RootDatabase>> = LazyLock::n
             .with_project_config(
                 ProjectConfig::from_directory(Path::new(CONTRACTS_CRATE_DIR)).unwrap(),
             )
-            .with_plugin_suite(starknet_plugin_suite())
+            .with_default_plugin_suite(starknet_plugin_suite())
             .build()
             .unwrap(),
     )

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -224,9 +224,9 @@ impl TestCompiler {
             }
             b.detect_corelib();
             b.with_cfg(cfg);
-            b.with_plugin_suite(test_plugin_suite());
+            b.with_default_plugin_suite(test_plugin_suite());
             if config.starknet {
-                b.with_plugin_suite(starknet_plugin_suite());
+                b.with_default_plugin_suite(starknet_plugin_suite());
             }
             b.build()?
         };


### PR DESCRIPTION
This PR reintroduces the changes that have been reverted in #7206

## Changes
* Instances of the compiler plugins are now assigned to crates, using new inputs and queries in `SyntaxGroup` and `SemanticGroup`

Original stack:
- #6843
- #6852
- #6840