### PR TITLE
feat(corelib): Sum for snapshot of addable types

### DIFF
--- a/corelib/src/iter/traits/accum.cairo
+++ b/corelib/src/iter/traits/accum.cairo
@@ -17,6 +17,15 @@ impl SumAddableTypesImpl<A, +Add<A>, impl ZeroA: core::num::traits::Zero<A>> of 
         iter.fold(ZeroA::zero(), |acc, x| acc + x)
     }
 }
+
+impl SumSnapshotAddableTypesImpl<
+    A, +Add<A>, +Copy<A>, +Drop<A>, impl ZeroA: core::num::traits::Zero<A>,
+> of Sum<@A> {
+    fn sum<I, +Iterator<I>[Item: @A], +Destruct<I>, +Destruct<@A>>(mut iter: I) -> @A {
+        @(iter.fold(ZeroA::zero(), |acc: A, x: @A| acc + (*x)))
+    }
+}
+
 /// Trait to represent types that can be created by multiplying elements of an
 /// iterator.
 ///

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -111,6 +111,9 @@ fn test_iter_adapter_peekable() {
 fn test_iter_accum_sum() {
     assert_eq!(array![1, 2, 3].into_iter().sum(), 6);
     assert_eq!(array![].into_iter().sum(), 0);
+
+    assert_eq!(array![1_u8, 2, 3].span().into_iter().sum(), @6);
+    assert_eq!([].span().into_iter().sum(), @0);
 }
 
 #[test]


### PR DESCRIPTION
enables usages like:
```
    let span = array![4_u8, 5, 6].span();
    println!("sum of span: {}", span.into_iter().sum());
```