### PR TITLE
link-Update how-to-contribute.adoc

### DIFF
--- a/docs/reference/src/components/cairo/modules/ROOT/pages/how-to-contribute.adoc
+++ b/docs/reference/src/components/cairo/modules/ROOT/pages/how-to-contribute.adoc
@@ -63,4 +63,4 @@ Together, we can make Cairo **better**!
 
 ## Authors & contributors
 
-For a full list of all authors and contributors, see link:https://github.com/starkware-libs/cairo/contributors[the contributors page].
+For a full list of all authors and contributors, see link:https://github.com/starkware-libs/cairo/graphs/contributors[the contributors page].


### PR DESCRIPTION
added a current link - https://github.com/starkware-libs/cairo/graphs/contributors