### PR TITLE
feat(corelib): Iterator::any

### DIFF
--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -381,6 +381,49 @@ pub trait Iterator<T> {
         }
     }
 
+    /// Tests if any element of the iterator matches a predicate.
+    ///
+    /// `any()` takes a closure that returns `true` or `false`. It applies
+    /// this closure to each element of the iterator, and if any of them return
+    /// `true`, then so does `any()`. If they all return `false`, it
+    /// returns `false`.
+    ///
+    /// `any()` is short-circuiting; in other words, it will stop processing
+    /// as soon as it finds a `true`, given that no matter what else happens,
+    /// the result will also be `true`.
+    ///
+    /// An empty iterator returns `false`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let mut iter = array![1, 2, 3].into_iter();
+    ///
+    /// assert!(iter.any(|x| x == 2));
+    ///
+    /// assert!(!iter.any(|x| x > 5));
+    /// ```
+    fn any<
+        P,
+        +core::ops::Fn<P, (@Self::Item,)>[Output: bool],
+        +Destruct<P>,
+        +Destruct<T>,
+        +Destruct<Self::Item>,
+    >(
+        ref self: T, predicate: P,
+    ) -> bool {
+        match Self::next(ref self) {
+            Option::None => false,
+            Option::Some(x) => if predicate(@x) {
+                true
+            } else {
+                Self::any(ref self, predicate)
+            },
+        }
+    }
+
     /// Searches for an element of an iterator that satisfies a predicate.
     ///
     /// `find()` takes a closure that returns `true` or `false`. It applies

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -121,6 +121,23 @@ fn test_iter_accum_product() {
 }
 
 #[test]
+fn test_iter_any() {
+    let mut iter = array![1, 2, 3].into_iter();
+    assert!(iter.any(|x| *x == 2));
+    assert!(!iter.any(|x| *x == 5));
+
+    // Test short-circuiting behavior
+    let mut iter = array![1, 2, 3].into_iter();
+    assert!(iter.any(|x| *x == 2));
+    // Iterator should continue after any()
+    assert_eq!(iter.next(), Option::Some(3));
+
+    // Test empty iterator
+    let mut empty_iter = ArrayTrait::<felt252>::new().into_iter();
+    assert!(!empty_iter.any(|x| *x == 1));
+}
+
+#[test]
 fn test_iter_find() {
     let mut iter = array![1, 2, 3].into_iter();
     assert_eq!(iter.find(|x| *x == 2), Option::Some(2));


### PR DESCRIPTION
This function checks if any element satisfies a predicate, stopping at the first match. It currently processes elements in order (`O(n)` complexity), like find(), but we might want leverage Cairo's non-determinism in the future for `O(1)`, in which case the "first match" property couldn't be guaranteed, so please don’t rely on its sequential behavior.