### PR TITLE
When precomputing closure params - still fully validate types.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1694,7 +1694,11 @@ fn compute_expr_closure_semantic(
         if let Some(param_types) = params_tuple_ty {
             if let Err(err_set) = new_ctx.resolver.inference().conform_ty(closure_type, param_types)
             {
-                new_ctx.resolver.inference().consume_error_without_reporting(err_set);
+                new_ctx.resolver.inference().report_on_pending_error(
+                    err_set,
+                    new_ctx.diagnostics,
+                    syntax.stable_ptr().untyped(),
+                );
             }
         }
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/closure
@@ -819,3 +819,29 @@ error: Ambiguous method call. More than one applicable trait function with a sui
  --> lib.cairo:9:13
         arr.len();
             ^^^
+
+//! > ==========================================================================
+
+//! > Closures bad param count.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo() {
+    call_with(|| {})
+}
+
+//! > function_name
+foo
+
+//! > module_code
+fn call_with<F, +core::ops::Fn<F, (i32,)>>(func: F) {
+    func(1);
+}
+
+//! > expected_diagnostics
+error: Type mismatch: `()` and `(core::integer::i32,)`.
+ --> lib.cairo:5:15
+    call_with(|| {})
+              ^^^^^


### PR DESCRIPTION
Fixes #7245.