### PR TITLE
Add `name_stable_ptr` methods and `GetName` trait for AST objects

### DIFF
--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -25,9 +25,9 @@ use cairo_lang_debug::debug::DebugWithDb;
 use cairo_lang_diagnostics::Maybe;
 pub use cairo_lang_filesystem::ids::UnstableSalsaId;
 use cairo_lang_filesystem::ids::{CrateId, FileId};
-use cairo_lang_syntax::node::ast::TerminalIdentifierGreen;
+use cairo_lang_syntax::node::ast::{TerminalIdentifierGreen, TerminalIdentifierPtr};
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::helpers::{GetIdentifier, NameGreen};
+use cairo_lang_syntax::node::helpers::{GetIdentifier, GetName, NameGreen};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::stable_ptr::SyntaxStablePtr;
@@ -55,9 +55,11 @@ pub trait LanguageElementId {
 
 pub trait NamedLanguageElementLongId {
     fn name(&self, db: &dyn DefsGroup) -> SmolStr;
+    fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr;
 }
 pub trait NamedLanguageElementId: LanguageElementId {
     fn name(&self, db: &dyn DefsGroup) -> SmolStr;
+    fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr;
 }
 pub trait TopLevelLanguageElementId: NamedLanguageElementId {
     fn full_path(&self, db: &dyn DefsGroup) -> String {
@@ -109,10 +111,17 @@ macro_rules! define_named_language_element_id {
                 let terminal_green = self.1.name_green(syntax_db);
                 terminal_green.identifier(syntax_db)
             }
+            fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr {
+                let syntax_db = db.upcast();
+                self.1.lookup(syntax_db).name(syntax_db).stable_ptr()
+            }
         }
         impl NamedLanguageElementId for $short_id {
             fn name(&self, db: &dyn DefsGroup) -> SmolStr {
                 db.$lookup(*self).name(db)
+            }
+            fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr {
+                db.$lookup(*self).name_stable_ptr(db)
             }
         }
     };
@@ -251,6 +260,13 @@ macro_rules! toplevel_enum {
                 match self {
                     $(
                         $enum_name::$variant(id) => id.name(db),
+                    )*
+                }
+            }
+            fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr {
+                match self {
+                    $(
+                        $enum_name::$variant(id) => id.name_stable_ptr(db),
                     )*
                 }
             }
@@ -1192,6 +1208,7 @@ impl ImplItemId {
 }
 
 define_language_element_id_as_enum! {
+    #[toplevel]
     /// Items for resolver lookups.
     /// These are top items that hold semantic information.
     /// Semantic info lookups should be performed against these items.

--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -27,7 +27,7 @@ pub use cairo_lang_filesystem::ids::UnstableSalsaId;
 use cairo_lang_filesystem::ids::{CrateId, FileId};
 use cairo_lang_syntax::node::ast::{TerminalIdentifierGreen, TerminalIdentifierPtr};
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::helpers::{GetIdentifier, GetName, NameGreen};
+use cairo_lang_syntax::node::helpers::{GetIdentifier, HasName, NameGreen};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::stable_ptr::SyntaxStablePtr;

--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -25,7 +25,7 @@ use cairo_lang_debug::debug::DebugWithDb;
 use cairo_lang_diagnostics::Maybe;
 pub use cairo_lang_filesystem::ids::UnstableSalsaId;
 use cairo_lang_filesystem::ids::{CrateId, FileId};
-use cairo_lang_syntax::node::ast::{TerminalIdentifierGreen, TerminalIdentifierPtr};
+use cairo_lang_syntax::node::ast::TerminalIdentifierGreen;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::{GetIdentifier, HasName, NameGreen};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
@@ -55,11 +55,11 @@ pub trait LanguageElementId {
 
 pub trait NamedLanguageElementLongId {
     fn name(&self, db: &dyn DefsGroup) -> SmolStr;
-    fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr;
+    fn name_identifier(&self, db: &dyn DefsGroup) -> ast::TerminalIdentifier;
 }
 pub trait NamedLanguageElementId: LanguageElementId {
     fn name(&self, db: &dyn DefsGroup) -> SmolStr;
-    fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr;
+    fn name_identifier(&self, db: &dyn DefsGroup) -> ast::TerminalIdentifier;
 }
 pub trait TopLevelLanguageElementId: NamedLanguageElementId {
     fn full_path(&self, db: &dyn DefsGroup) -> String {
@@ -111,17 +111,17 @@ macro_rules! define_named_language_element_id {
                 let terminal_green = self.1.name_green(syntax_db);
                 terminal_green.identifier(syntax_db)
             }
-            fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr {
+            fn name_identifier(&self, db: &dyn DefsGroup) -> ast::TerminalIdentifier {
                 let syntax_db = db.upcast();
-                self.1.lookup(syntax_db).name(syntax_db).stable_ptr()
+                self.1.lookup(syntax_db).name(syntax_db)
             }
         }
         impl NamedLanguageElementId for $short_id {
             fn name(&self, db: &dyn DefsGroup) -> SmolStr {
                 db.$lookup(*self).name(db)
             }
-            fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr {
-                db.$lookup(*self).name_stable_ptr(db)
+            fn name_identifier(&self, db: &dyn DefsGroup) -> ast::TerminalIdentifier {
+                db.$lookup(*self).name_identifier(db)
             }
         }
     };
@@ -263,10 +263,10 @@ macro_rules! toplevel_enum {
                     )*
                 }
             }
-            fn name_stable_ptr(&self, db: &dyn DefsGroup) -> TerminalIdentifierPtr {
+            fn name_identifier(&self, db: &dyn DefsGroup) -> ast::TerminalIdentifier {
                 match self {
                     $(
-                        $enum_name::$variant(id) => id.name_stable_ptr(db),
+                        $enum_name::$variant(id) => id.name_identifier(db),
                     )*
                 }
             }

--- a/crates/cairo-lang-syntax/src/node/helpers.rs
+++ b/crates/cairo-lang-syntax/src/node/helpers.rs
@@ -1,7 +1,15 @@
 use cairo_lang_utils::LookupIntern;
 use smol_str::SmolStr;
 
-use super::ast::{self, FunctionDeclaration, FunctionDeclarationGreen, FunctionWithBody, FunctionWithBodyPtr, ImplItem, ItemConstant, ItemEnum, ItemExternFunction, ItemExternFunctionPtr, ItemExternType, ItemImpl, ItemImplAlias, ItemInlineMacro, ItemModule, ItemStruct, ItemTrait, ItemTypeAlias, ItemUse, Member, Modifier, ModuleItem, OptionArgListParenthesized, Statement, StatementBreak, StatementContinue, StatementExpr, StatementLet, StatementReturn, TerminalIdentifier, TerminalIdentifierGreen, TokenIdentifierGreen, TraitItem, TraitItemConstant, TraitItemFunction, TraitItemFunctionPtr, TraitItemImpl, TraitItemType, UsePathLeaf, Variant, WrappedArgList};
+use super::ast::{
+    self, FunctionDeclaration, FunctionDeclarationGreen, FunctionWithBody, FunctionWithBodyPtr,
+    ImplItem, ItemConstant, ItemEnum, ItemExternFunction, ItemExternFunctionPtr, ItemExternType,
+    ItemImpl, ItemImplAlias, ItemInlineMacro, ItemModule, ItemStruct, ItemTrait, ItemTypeAlias,
+    ItemUse, Member, Modifier, ModuleItem, OptionArgListParenthesized, Statement, StatementBreak,
+    StatementContinue, StatementExpr, StatementLet, StatementReturn, TerminalIdentifier,
+    TerminalIdentifierGreen, TokenIdentifierGreen, TraitItem, TraitItemConstant, TraitItemFunction,
+    TraitItemFunctionPtr, TraitItemImpl, TraitItemType, UsePathLeaf, Variant, WrappedArgList,
+};
 use super::db::SyntaxGroup;
 use super::ids::SyntaxStablePtrId;
 use super::kind::SyntaxKind;

--- a/crates/cairo-lang-syntax/src/node/helpers.rs
+++ b/crates/cairo-lang-syntax/src/node/helpers.rs
@@ -1,15 +1,7 @@
 use cairo_lang_utils::LookupIntern;
 use smol_str::SmolStr;
 
-use super::ast::{
-    self, FunctionDeclaration, FunctionDeclarationGreen, FunctionWithBody, FunctionWithBodyPtr,
-    ImplItem, ItemConstant, ItemEnum, ItemExternFunction, ItemExternFunctionPtr, ItemExternType,
-    ItemImpl, ItemImplAlias, ItemInlineMacro, ItemModule, ItemStruct, ItemTrait, ItemTypeAlias,
-    ItemUse, Member, Modifier, ModuleItem, OptionArgListParenthesized, Statement, StatementBreak,
-    StatementContinue, StatementExpr, StatementLet, StatementReturn, TerminalIdentifierGreen,
-    TokenIdentifierGreen, TraitItem, TraitItemConstant, TraitItemFunction, TraitItemFunctionPtr,
-    TraitItemImpl, TraitItemType, UsePathLeaf, Variant, WrappedArgList,
-};
+use super::ast::{self, FunctionDeclaration, FunctionDeclarationGreen, FunctionWithBody, FunctionWithBodyPtr, ImplItem, ItemConstant, ItemEnum, ItemExternFunction, ItemExternFunctionPtr, ItemExternType, ItemImpl, ItemImplAlias, ItemInlineMacro, ItemModule, ItemStruct, ItemTrait, ItemTypeAlias, ItemUse, Member, Modifier, ModuleItem, OptionArgListParenthesized, Statement, StatementBreak, StatementContinue, StatementExpr, StatementLet, StatementReturn, TerminalIdentifier, TerminalIdentifierGreen, TokenIdentifierGreen, TraitItem, TraitItemConstant, TraitItemFunction, TraitItemFunctionPtr, TraitItemImpl, TraitItemType, UsePathLeaf, Variant, WrappedArgList};
 use super::db::SyntaxGroup;
 use super::ids::SyntaxStablePtrId;
 use super::kind::SyntaxKind;
@@ -153,6 +145,39 @@ impl NameGreen for ItemExternFunctionPtr {
 impl NameGreen for TraitItemFunctionPtr {
     fn name_green(self, db: &dyn SyntaxGroup) -> TerminalIdentifierGreen {
         self.declaration_green(db).name_green(db)
+    }
+}
+
+/// Provides methods to extract a _name_ of AST objects.
+pub trait GetName {
+    /// Gets a [`TerminalIdentifier`] that represents a _name_ of this AST object.
+    fn name(&self, db: &dyn SyntaxGroup) -> ast::TerminalIdentifier;
+}
+
+impl GetName for FunctionWithBody {
+    fn name(&self, db: &dyn SyntaxGroup) -> TerminalIdentifier {
+        self.declaration(db).name(db)
+    }
+}
+
+impl GetName for ItemExternFunction {
+    fn name(&self, db: &dyn SyntaxGroup) -> TerminalIdentifier {
+        self.declaration(db).name(db)
+    }
+}
+
+impl GetName for TraitItemFunction {
+    fn name(&self, db: &dyn SyntaxGroup) -> TerminalIdentifier {
+        self.declaration(db).name(db)
+    }
+}
+
+impl GetName for UsePathLeaf {
+    fn name(&self, db: &dyn SyntaxGroup) -> TerminalIdentifier {
+        match self.alias_clause(db) {
+            ast::OptionAliasClause::Empty(_) => self.ident(db).identifier_ast(db),
+            ast::OptionAliasClause::AliasClause(alias) => alias.alias(db),
+        }
     }
 }
 

--- a/crates/cairo-lang-syntax/src/node/helpers.rs
+++ b/crates/cairo-lang-syntax/src/node/helpers.rs
@@ -157,30 +157,30 @@ impl NameGreen for TraitItemFunctionPtr {
 }
 
 /// Provides methods to extract a _name_ of AST objects.
-pub trait GetName {
+pub trait HasName {
     /// Gets a [`TerminalIdentifier`] that represents a _name_ of this AST object.
     fn name(&self, db: &dyn SyntaxGroup) -> ast::TerminalIdentifier;
 }
 
-impl GetName for FunctionWithBody {
+impl HasName for FunctionWithBody {
     fn name(&self, db: &dyn SyntaxGroup) -> TerminalIdentifier {
         self.declaration(db).name(db)
     }
 }
 
-impl GetName for ItemExternFunction {
+impl HasName for ItemExternFunction {
     fn name(&self, db: &dyn SyntaxGroup) -> TerminalIdentifier {
         self.declaration(db).name(db)
     }
 }
 
-impl GetName for TraitItemFunction {
+impl HasName for TraitItemFunction {
     fn name(&self, db: &dyn SyntaxGroup) -> TerminalIdentifier {
         self.declaration(db).name(db)
     }
 }
 
-impl GetName for UsePathLeaf {
+impl HasName for UsePathLeaf {
     fn name(&self, db: &dyn SyntaxGroup) -> TerminalIdentifier {
         match self.alias_clause(db) {
             ast::OptionAliasClause::Empty(_) => self.ident(db).identifier_ast(db),


### PR DESCRIPTION
CairoLS needs to check whether an arbitrary `TerminalIdentifier` is a name of a given `NamedLanguageElementId`. This would be pretty tedious to implement downstream, while it is trivial to embed in the `define_*` macros we have here.