### PR TITLE
grammar and spelling errors

### DIFF
--- a/adrs/001_enum_definition_syntax.md
+++ b/adrs/001_enum_definition_syntax.md
@@ -48,7 +48,7 @@ Advantages of the suggestion:
 Disadvantages:
 * Straying away from rust.
 * Unfamiliar syntax for most users.
-* Tuple types need an extra parenthesis. On `Variant0: (A, B)`, construction is using
+* Tuple types need an extra parentheses. On `Variant0: (A, B)`, construction is using
   `Variant0((a, b))`.
 
 ## Open questions

--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -35,7 +35,7 @@ impl DiagnosticCallback for Option<Box<dyn DiagnosticCallback + '_>> {
     }
 }
 
-/// Collects compilation diagnostics and presents them in preconfigured way.
+/// Collects compilation diagnostics and presents them in a preconfigured way.
 pub struct DiagnosticsReporter<'a> {
     callback: Option<Box<dyn DiagnosticCallback + 'a>>,
     // Ignore all warnings, the `ignore_warnings_crate_ids` field is irrelevant in this case.

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -12,7 +12,7 @@ use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use smol_str::SmolStr;
 
-/// A trait for arbitrary data that a macro generates along with a generated file.
+/// A trait for arbitrary data that a macro generates along with the generated file.
 pub trait GeneratedFileAuxData: std::fmt::Debug + Sync + Send {
     fn as_any(&self) -> &dyn Any;
     fn eq(&self, other: &dyn GeneratedFileAuxData) -> bool;

--- a/crates/cairo-lang-diagnostics/src/error_code.rs
+++ b/crates/cairo-lang-diagnostics/src/error_code.rs
@@ -19,7 +19,7 @@ impl ErrorCode {
         Self(code)
     }
 
-    /// Format this error code in a way that is suitable for display in error message.
+    /// Format this error code in a way that is suitable for display in an error message.
     ///
     /// ```
     /// # use cairo_lang_diagnostics::error_code;


### PR DESCRIPTION
changed:

parenthesis - parentheses

in preconfigured - in a preconfigured

with a generated - with the generated

in error - in an error
