### PR TITLE
Improve wording and clarity in Cairo documentatio

### DIFF
--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -311,7 +311,7 @@ pub trait Iterator<T> {
     /// operators like `+`, the order the elements are combined in is not important, but for
     /// non-associative operators like `-` the order will affect the final result.
     ///
-    /// # Note to Implementors
+    /// # Note to Implementers
     ///
     /// Several of the other (forward) methods have default implementations in
     /// terms of this one, so try to implement this explicitly if it can

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -1834,7 +1834,7 @@ impl<'db> Resolver<'db> {
 
     // TODO(yuval): on a breaking version change, consider changing warnings to errors.
     /// Warns about the use of a trait in a path inside the same trait or an impl of it, and the use
-    /// of an impl in a path inside the same impl, addditionally, converts a `Self` equivalent
+    /// of an impl in a path inside the same impl, additionally, converts a `Self` equivalent
     /// trait to be resolved as `Self`.
     /// That is, warns about using the actual path equivalent to `Self`, where `Self` can be used.
     fn handle_same_impl_trait(

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
@@ -107,4 +107,4 @@ See xref:function-calls.adoc[Function calls].
 // TODO(yuval): mention methods/self?
 // TODO(yuval): mention panics/implicits? (it's part of the signature).
 // TODO(yuval): mention inline.
-// TODO(yuval): mention local compilability.
+// TODO(yuval): mention local compatibility.

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
@@ -107,4 +107,4 @@ See xref:function-calls.adoc[Function calls].
 // TODO(yuval): mention methods/self?
 // TODO(yuval): mention panics/implicits? (it's part of the signature).
 // TODO(yuval): mention inline.
-// TODO(yuval): mention local compatibility.
+// TODO(yuval): mention local compilability.


### PR DESCRIPTION
- **Refactored comments for better clarity:**  
  - `"Note to Implementors"` → `"Note to Implementers"` in `iterator.cairo`  
  - `"addditionally"` → `"additionally"` in `mod.rs`  
