### PR TITLE
Deprecated const libfuncs for starknet types.

### DIFF
--- a/corelib/src/starknet.cairo
+++ b/corelib/src/starknet.cairo
@@ -47,7 +47,13 @@ pub mod contract_address;
 pub mod secp256_trait;
 pub mod secp256k1;
 pub mod secp256r1;
-pub use contract_address::{ContractAddress, contract_address_const};
+pub use contract_address::ContractAddress;
+#[deprecated(
+    feature: "deprecated-starknet-consts",
+    note: "Use `TryInto::try_into` in const context instead.",
+)]
+#[feature("deprecated-starknet-consts")]
+pub use contract_address::contract_address_const;
 #[allow(unused_imports)]
 use contract_address::{
     ContractAddressIntoFelt252, Felt252TryIntoContractAddress, contract_address_to_felt252,
@@ -68,8 +74,15 @@ use eth_signature::verify_eth_signature;
 pub mod class_hash;
 pub use class_hash::ClassHash;
 #[allow(unused_imports)]
+#[deprecated(
+    feature: "deprecated-starknet-consts",
+    note: "Use `TryInto::try_into` in const context instead.",
+)]
+#[feature("deprecated-starknet-consts")]
+use class_hash::class_hash_const;
+#[allow(unused_imports)]
 use class_hash::{
-    ClassHashIntoFelt252, Felt252TryIntoClassHash, class_hash_const, class_hash_to_felt252,
+    ClassHashIntoFelt252, Felt252TryIntoClassHash, class_hash_to_felt252,
     class_hash_try_from_felt252,
 };
 

--- a/corelib/src/starknet/class_hash.cairo
+++ b/corelib/src/starknet/class_hash.cairo
@@ -33,6 +33,10 @@ pub extern type ClassHash;
 ///
 /// let class_hash = class_hash_const::<0x123>();
 /// ```
+#[deprecated(
+    feature: "deprecated-starknet-consts",
+    note: "Use `TryInto::try_into` in const context instead.",
+)]
 pub extern fn class_hash_const<const address: felt252>() -> ClassHash nopanic;
 
 pub(crate) extern const fn class_hash_to_felt252(address: ClassHash) -> felt252 nopanic;
@@ -54,6 +58,7 @@ pub(crate) impl ClassHashIntoFelt252 of Into<ClassHash, felt252> {
 }
 
 impl ClassHashZero of core::num::traits::Zero<ClassHash> {
+    #[feature("deprecated-starknet-consts")]
     fn zero() -> ClassHash {
         class_hash_const::<0>()
     }

--- a/corelib/src/starknet/contract_address.cairo
+++ b/corelib/src/starknet/contract_address.cairo
@@ -34,6 +34,10 @@ pub extern type ContractAddress;
 ///
 /// let contract_address = contract_address_const::<0x0>();
 /// ```
+#[deprecated(
+    feature: "deprecated-starknet-consts",
+    note: "Use `TryInto::try_into` in const context instead.",
+)]
 pub extern fn contract_address_const<const address: felt252>() -> ContractAddress nopanic;
 
 pub(crate) extern const fn contract_address_to_felt252(address: ContractAddress) -> felt252 nopanic;
@@ -55,6 +59,7 @@ pub(crate) impl ContractAddressIntoFelt252 of Into<ContractAddress, felt252> {
 }
 
 impl ContractAddressZero of core::num::traits::Zero<ContractAddress> {
+    #[feature("deprecated-starknet-consts")]
     fn zero() -> ContractAddress {
         contract_address_const::<0>()
     }

--- a/crates/cairo-lang-runner/src/profiling_test_data/major_test_cases
+++ b/crates/cairo-lang-runner/src/profiling_test_data/major_test_cases
@@ -836,7 +836,7 @@ trait IERC20<TContractState> {
 mod erc_20 {
     use core::num::traits::Zero;
     use starknet::storage::Map;
-    use starknet::{ContractAddress, contract_address_const, get_caller_address};
+    use starknet::{ContractAddress, get_caller_address};
 
 
     #[storage]
@@ -894,9 +894,8 @@ mod erc_20 {
 }
 
 fn erc20_transfer() {
-    starknet::testing::set_caller_address(
-        starknet::contract_address::contract_address_const::<2>(),
-    );
+    const CONTRACT_ADDRESS: ContractAddress = 2_felt252.try_into().unwrap();
+    starknet::testing::set_caller_address(CONTRACT_ADDRESS);
     erc_20::__external::transfer(array![1, 0, 0].span());
 }
 

--- a/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
@@ -48,16 +48,16 @@ mod test_contract {
 
 #[test]
 fn test_dispatcher_serialization() {
-    let a = starknet::contract_address_const::<11>();
-    test_contract::__external::set_another_address(serialized(a));
-    assert_eq!(test_contract::__external::get_another_address(serialized(())), serialized(a));
+    const A: starknet::ContractAddress = 11_felt252.try_into().unwrap();
+    test_contract::__external::set_another_address(serialized(A));
+    assert_eq!(test_contract::__external::get_another_address(serialized(())), serialized(A));
 }
 
 #[test]
 fn test_library_dispatcher_serialization() {
-    let a = starknet::contract_address_const::<11>();
-    test_contract::__external::set_another_class_hash(serialized(a));
-    assert_eq!(test_contract::__external::get_another_class_hash(serialized(())), serialized(a));
+    const A: starknet::ClassHash = 11_felt252.try_into().unwrap();
+    test_contract::__external::set_another_class_hash(serialized(A));
+    assert_eq!(test_contract::__external::get_another_class_hash(serialized(())), serialized(A));
 }
 
 
@@ -74,11 +74,11 @@ pub fn withdraw_and_get_available_gas() -> u128 {
 // Tests the serialization and deserialize of the arguments to `__validate__`.
 #[test]
 fn test_validate_gas_cost() {
-    let contract_address = starknet::contract_address_const::<11>();
+    const CONTRACT_ADDRESS: starknet::ContractAddress = 11_felt252.try_into().unwrap();
     let base_gas = withdraw_and_get_available_gas();
     let calls = [
         Call {
-            to: contract_address,
+            to: CONTRACT_ADDRESS,
             selector: 0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c,
             calldata: [
                 0x7a6f98c03379b9513ca84cca1373ff452a7462a3b61598f0af5bb27ad7f76d1, 0x4db5d32, 0x0,
@@ -86,7 +86,7 @@ fn test_validate_gas_cost() {
                 .span(),
         },
         Call {
-            to: contract_address,
+            to: CONTRACT_ADDRESS,
             selector: 0x2c0f7bf2d6cf5304c29171bf493feb222fef84bdaf17805a6574b0c2e8bcc87,
             calldata: [
                 0x4db5d32, 0x0, 0x896ba264a31df2, 0x0, 0x2,

--- a/crates/cairo-lang-starknet/cairo_level_tests/components/erc20.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/components/erc20.cairo
@@ -24,7 +24,7 @@ pub mod erc20 {
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
-    use starknet::{ContractAddress, contract_address_const, get_caller_address};
+    use starknet::{ContractAddress, get_caller_address};
     #[storage]
     pub struct Storage {
         pub name: felt252,
@@ -191,11 +191,7 @@ pub mod erc20 {
             self
                 .emit(
                     Event::Transfer(
-                        TransferEvent {
-                            from: contract_address_const::<0>(),
-                            to: recipient,
-                            value: initial_supply,
-                        },
+                        TransferEvent { from: Zero::zero(), to: recipient, value: initial_supply },
                     ),
                 );
         }

--- a/crates/cairo-lang-starknet/cairo_level_tests/components/erc20_mini.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/components/erc20_mini.cairo
@@ -2,7 +2,7 @@ use starknet::storage::{
     StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
     StoragePointerWriteAccess,
 };
-use starknet::{ContractAddress, contract_address_const, get_caller_address};
+use starknet::{ContractAddress, get_caller_address};
 
 
 #[starknet::interface]
@@ -195,9 +195,7 @@ pub impl ERC20HelperImpl<
         self
             .emit(
                 Event::Transfer(
-                    TransferEvent {
-                        from: contract_address_const::<0>(), to: recipient, value: initial_supply,
-                    },
+                    TransferEvent { from: Zero::zero(), to: recipient, value: initial_supply },
                 ),
             );
     }

--- a/crates/cairo-lang-starknet/cairo_level_tests/components/mintable.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/components/mintable.cairo
@@ -9,11 +9,11 @@ pub trait MintTrait<TContractState> {
 pub mod mintable {
     use core::num::traits::Zero;
     use ownable_comp::OwnableHelperImpl;
+    use starknet::ContractAddress;
     use starknet::storage::{
         StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
-    use starknet::{ContractAddress, contract_address_const};
     use crate::components::erc20::erc20 as erc20_comp;
     use crate::components::ownable::ownable as ownable_comp;
 
@@ -38,11 +38,7 @@ pub mod mintable {
                 .balances
                 .write(account, erc20_component.balances.read(account) + amount);
             erc20_component
-                .emit(
-                    erc20_comp::TransferEvent {
-                        from: contract_address_const::<0>(), to: account, value: amount,
-                    },
-                );
+                .emit(erc20_comp::TransferEvent { from: Zero::zero(), to: account, value: amount });
         }
     }
 }

--- a/crates/cairo-lang-starknet/cairo_level_tests/contracts/erc20.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/contracts/erc20.cairo
@@ -26,7 +26,7 @@ pub mod erc_20 {
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
-    use starknet::{ContractAddress, contract_address_const, get_caller_address};
+    use starknet::{ContractAddress, get_caller_address};
 
     #[storage]
     struct Storage {
@@ -75,9 +75,7 @@ pub mod erc_20 {
         self
             .emit(
                 Event::Transfer(
-                    Transfer {
-                        from: contract_address_const::<0>(), to: recipient, value: initial_supply,
-                    },
+                    Transfer { from: Zero::zero(), to: recipient, value: initial_supply },
                 ),
             );
     }

--- a/crates/cairo-lang-starknet/cairo_level_tests/contracts/libfuncs_coverage.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/contracts/libfuncs_coverage.cairo
@@ -489,10 +489,8 @@ extern fn i32_const<const VALUE: i32>() -> i32 nopanic;
 extern fn i64_const<const VALUE: i64>() -> i64 nopanic;
 extern fn i128_const<const VALUE: i128>() -> i128 nopanic;
 extern fn bytes31_const<const VALUE: felt252>() -> bytes31 nopanic;
-use starknet::class_hash::class_hash_const;
-use starknet::contract_address::contract_address_const;
-use starknet::storage_access::storage_base_address_const;
 
+#[feature("deprecated-starknet-consts")]
 fn consts_libfuncs(libfuncs: ConstsLibfuncs) {
     match libfuncs {
         ConstsLibfuncs::Felt252 => use_and_panic(felt252_const::<0>()),
@@ -507,9 +505,13 @@ fn consts_libfuncs(libfuncs: ConstsLibfuncs) {
         ConstsLibfuncs::I64 => use_and_panic(i64_const::<0>()),
         ConstsLibfuncs::I128 => use_and_panic(i128_const::<0>()),
         ConstsLibfuncs::Byte31 => use_and_panic(bytes31_const::<0>()),
-        ConstsLibfuncs::StorageBase => use_and_panic(storage_base_address_const::<0>()),
-        ConstsLibfuncs::ClassHash => use_and_panic(class_hash_const::<0>()),
-        ConstsLibfuncs::ContractAddress => use_and_panic(contract_address_const::<0>()),
+        ConstsLibfuncs::StorageBase => use_and_panic(
+            starknet::storage_access::storage_base_address_const::<0>(),
+        ),
+        ConstsLibfuncs::ClassHash => use_and_panic(starknet::class_hash::class_hash_const::<0>()),
+        ConstsLibfuncs::ContractAddress => use_and_panic(
+            starknet::contract_address::contract_address_const::<0>(),
+        ),
     }
 }
 

--- a/crates/cairo-lang-starknet/cairo_level_tests/deployment.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/deployment.cairo
@@ -34,9 +34,7 @@ mod self_caller {
 
 #[test]
 fn test_deploy_in_construct() {
-    let (contract_address, _) = deploy_syscall(
-        self_caller::TEST_CLASS_HASH.try_into().unwrap(), 0, [].span(), false,
-    )
+    let (contract_address, _) = deploy_syscall(self_caller::TEST_CLASS_HASH, 0, [].span(), false)
         .expect('deployment failed');
     assert!(IValueDispatcher { contract_address }.get_value() == 1);
 }
@@ -44,13 +42,10 @@ fn test_deploy_in_construct() {
 
 #[test]
 fn test_redeploy_in_construct() {
-    assert!(
-        deploy_syscall(self_caller::TEST_CLASS_HASH.try_into().unwrap(), 0, [].span(), false)
-            .is_ok(),
-    );
+    assert!(deploy_syscall(self_caller::TEST_CLASS_HASH, 0, [].span(), false).is_ok());
     assert!(
         deploy_syscall(
-            self_caller::TEST_CLASS_HASH.try_into().unwrap(), 0, [].span(), false,
+            self_caller::TEST_CLASS_HASH, 0, [].span(), false,
         ) == Err(array!['CONTRACT_ALREADY_DEPLOYED']),
     );
 }

--- a/crates/cairo-lang-starknet/cairo_level_tests/erc20_test.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/erc20_test.cairo
@@ -1,12 +1,9 @@
-use starknet::contract_address::contract_address_const;
 use starknet::testing::set_caller_address;
 use crate::contracts::erc20::{IERC20DispatcherTrait, IERC20LibraryDispatcher, erc_20};
 
 #[test]
 fn test_erc20_transfer() {
-    let class_hash = erc_20::TEST_CLASS_HASH.try_into().unwrap();
-
-    set_caller_address(contract_address_const::<2_felt252>());
-    let contract_address = contract_address_const::<1_felt252>();
-    IERC20LibraryDispatcher { class_hash }.transfer(contract_address, 0_u256);
+    set_caller_address(2.try_into().unwrap());
+    IERC20LibraryDispatcher { class_hash: erc_20::TEST_CLASS_HASH }
+        .transfer(1.try_into().unwrap(), 0_u256);
 }

--- a/crates/cairo-lang-starknet/cairo_level_tests/events.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/events.cairo
@@ -117,12 +117,12 @@ fn test_events() {
 
 #[test]
 fn test_pop_log() {
-    let contract_address = starknet::contract_address_const::<0x1234>();
-    starknet::testing::set_contract_address(contract_address);
+    const CONTRACT_ADDRESS: starknet::ContractAddress = 0x1234_felt252.try_into().unwrap();
+    starknet::testing::set_contract_address(CONTRACT_ADDRESS);
     let (keys, data) = ([1234].span(), [2345].span());
     starknet::syscalls::emit_event_syscall(keys, data).unwrap_syscall();
     starknet::syscalls::emit_event_syscall(keys, data).unwrap_syscall();
 
-    assert_eq!(starknet::testing::pop_log_raw(contract_address), Some((keys, data)));
-    assert_eq!(starknet::testing::pop_log_raw(contract_address), Some((keys, data)));
+    assert_eq!(starknet::testing::pop_log_raw(CONTRACT_ADDRESS), Some((keys, data)));
+    assert_eq!(starknet::testing::pop_log_raw(CONTRACT_ADDRESS), Some((keys, data)));
 }

--- a/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo
@@ -44,14 +44,10 @@ fn test_internal_func() {
 #[test]
 fn test_flow() {
     // Set up.
-    let (address0, _) = deploy_syscall(
-        contract_a::TEST_CLASS_HASH.try_into().unwrap(), 0, [100].span(), false,
-    )
+    let (address0, _) = deploy_syscall(contract_a::TEST_CLASS_HASH, 0, [100].span(), false)
         .unwrap();
     let mut contract0 = IContractDispatcher { contract_address: address0 };
-    let (address1, _) = deploy_syscall(
-        contract_a::TEST_CLASS_HASH.try_into().unwrap(), 0, [200].span(), false,
-    )
+    let (address1, _) = deploy_syscall(contract_a::TEST_CLASS_HASH, 0, [200].span(), false)
         .unwrap();
     let mut contract1 = IContractDispatcher { contract_address: address1 };
 
@@ -62,9 +58,7 @@ fn test_flow() {
     assert_eq!(contract1.foo(300), 300);
 
     // Library calls.
-    let mut library = IContractLibraryDispatcher {
-        class_hash: contract_a::TEST_CLASS_HASH.try_into().unwrap(),
-    };
+    let mut library = IContractLibraryDispatcher { class_hash: contract_a::TEST_CLASS_HASH };
     assert_eq!(library.foo(300), 0);
 }
 
@@ -72,9 +66,7 @@ fn test_flow() {
 #[feature("safe_dispatcher")]
 fn test_flow_safe_dispatcher() {
     // Set up.
-    let (contract_address, _) = deploy_syscall(
-        contract_a::TEST_CLASS_HASH.try_into().unwrap(), 0, [100].span(), false,
-    )
+    let (contract_address, _) = deploy_syscall(contract_a::TEST_CLASS_HASH, 0, [100].span(), false)
         .unwrap();
     let mut contract = IContractSafeDispatcher { contract_address };
 
@@ -82,9 +74,7 @@ fn test_flow_safe_dispatcher() {
     assert_eq!(contract.foo(300), Ok(100));
 
     // Library calls.
-    let mut library = IContractSafeLibraryDispatcher {
-        class_hash: contract_a::TEST_CLASS_HASH.try_into().unwrap(),
-    };
+    let mut library = IContractSafeLibraryDispatcher { class_hash: contract_a::TEST_CLASS_HASH };
     assert_eq!(library.foo(300), Ok(0));
 }
 
@@ -130,7 +120,7 @@ fn test_failed_constructor() {
     let mut calldata = array![];
     calldata.append(100);
     let mut err = deploy_syscall(
-        contract_failed_constructor::TEST_CLASS_HASH.try_into().unwrap(), 0, calldata.span(), false,
+        contract_failed_constructor::TEST_CLASS_HASH, 0, calldata.span(), false,
     )
         .unwrap_err();
     assert_eq!(err.pop_front().unwrap(), 'Failure');
@@ -151,10 +141,7 @@ mod contract_failed_entrypoint {
 #[test]
 fn test_non_empty_calldata_nonexistent_constructor() {
     let mut err = deploy_syscall(
-        contract_failed_entrypoint::TEST_CLASS_HASH.try_into().unwrap(),
-        0,
-        array![100].span(),
-        false,
+        contract_failed_entrypoint::TEST_CLASS_HASH, 0, array![100].span(), false,
     )
         .unwrap_err();
     assert_eq!(err.pop_front().unwrap(), 'INVALID_CALLDATA_LEN');
@@ -164,7 +151,7 @@ fn test_non_empty_calldata_nonexistent_constructor() {
 #[should_panic(expected: ('Failure', 'ENTRYPOINT_FAILED'))]
 fn test_entrypoint_failed() {
     let (address0, _) = deploy_syscall(
-        contract_failed_entrypoint::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false,
+        contract_failed_entrypoint::TEST_CLASS_HASH, 0, array![].span(), false,
     )
         .unwrap();
     let mut contract = IContractDispatcher { contract_address: address0 };

--- a/crates/cairo-lang-starknet/cairo_level_tests/l2_to_l1_messages.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/l2_to_l1_messages.cairo
@@ -56,10 +56,10 @@ fn generate_payload(n: u128) -> Array<felt252> {
 fn test_l2_to_l1_messages() {
     // Set up.
     let mut contract = contract_with_messages_sent_to_l1::unsafe_new_contract_state();
-    let contract_address = starknet::contract_address_const::<0x42>();
-    let other_contract_address = starknet::contract_address_const::<0xdead>();
+    const CONTRACT_ADDRESS: starknet::ContractAddress = 0x42_felt252.try_into().unwrap();
+    const OTHER_CONTRACT_ADDRESS: starknet::ContractAddress = 0xdead_felt252.try_into().unwrap();
 
-    testing::set_contract_address(contract_address);
+    testing::set_contract_address(CONTRACT_ADDRESS);
 
     // Send messages.
     contract.send_message_to_l1();
@@ -67,21 +67,21 @@ fn test_l2_to_l1_messages() {
     contract.send_message_to_l1();
 
     // Assert other addresses did not sent messages.
-    assert!(testing::pop_l2_to_l1_message(other_contract_address).is_none());
+    assert!(testing::pop_l2_to_l1_message(OTHER_CONTRACT_ADDRESS).is_none());
 
     // Pop messages.
-    assert_eq!(testing::pop_l2_to_l1_message(contract_address), Some((0, [0].span())));
-    assert_eq!(testing::pop_l2_to_l1_message(contract_address), Some((1, [0, 1].span())));
-    assert_eq!(testing::pop_l2_to_l1_message(contract_address), Some((2, [0, 1, 2].span())));
+    assert_eq!(testing::pop_l2_to_l1_message(CONTRACT_ADDRESS), Some((0, [0].span())));
+    assert_eq!(testing::pop_l2_to_l1_message(CONTRACT_ADDRESS), Some((1, [0, 1].span())));
+    assert_eq!(testing::pop_l2_to_l1_message(CONTRACT_ADDRESS), Some((2, [0, 1, 2].span())));
 
     // Assert all messages have been popped.
-    assert!(testing::pop_l2_to_l1_message(contract_address).is_none());
+    assert!(testing::pop_l2_to_l1_message(CONTRACT_ADDRESS).is_none());
 }
 
 #[test]
 fn test_pop_l2_to_l1_message() {
-    let contract_address = starknet::contract_address_const::<0x42>();
-    testing::set_contract_address(contract_address);
+    const CONTRACT_ADDRESS: starknet::ContractAddress = 0x42_felt252.try_into().unwrap();
+    testing::set_contract_address(CONTRACT_ADDRESS);
 
     let mut to_address = 1234;
     let mut payload = [2345].span();
@@ -89,6 +89,6 @@ fn test_pop_l2_to_l1_message() {
     starknet::syscalls::send_message_to_l1_syscall(to_address, payload).unwrap_syscall();
     starknet::syscalls::send_message_to_l1_syscall(to_address, payload).unwrap_syscall();
 
-    assert_eq!(testing::pop_l2_to_l1_message(contract_address), Some((to_address, payload)));
-    assert_eq!(testing::pop_l2_to_l1_message(contract_address), Some((to_address, payload)));
+    assert_eq!(testing::pop_l2_to_l1_message(CONTRACT_ADDRESS), Some((to_address, payload)));
+    assert_eq!(testing::pop_l2_to_l1_message(CONTRACT_ADDRESS), Some((to_address, payload)));
 }

--- a/crates/cairo-lang-starknet/cairo_level_tests/multi_component_test.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/multi_component_test.cairo
@@ -7,18 +7,18 @@ use super::utils::serialized;
 #[test]
 fn test_flow() {
     // Set up.
-    let recipient = starknet::contract_address_const::<0x1337>();
+    const RECIPIENT: starknet::ContractAddress = 0x1337_felt252.try_into().unwrap();
     let (contract_address, _) = starknet::syscalls::deploy_syscall(
-        contract_with_4_components::TEST_CLASS_HASH.try_into().unwrap(),
+        contract_with_4_components::TEST_CLASS_HASH,
         0,
-        serialized((('name', 'symbol'), (18_u8, 1000_u256, recipient), recipient)),
+        serialized((('name', 'symbol'), (18_u8, 1000_u256, RECIPIENT), RECIPIENT)),
         false,
     )
         .unwrap();
     let mut get_supply_dispatcher = GetSupplyDispatcher { contract_address };
     assert_eq!(get_supply_dispatcher.get_total_supply_plus_1(), 1001);
     let mut mint_dispatcher = MintTraitDispatcher { contract_address };
-    starknet::testing::set_contract_address(recipient);
-    mint_dispatcher.mint(recipient, 1999_u256);
+    starknet::testing::set_contract_address(RECIPIENT);
+    mint_dispatcher.mint(RECIPIENT, 1999_u256);
     assert_eq!(get_supply_dispatcher.get_total_supply_plus_1(), 3000);
 }

--- a/crates/cairo-lang-starknet/cairo_level_tests/replace_class_test.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/replace_class_test.cairo
@@ -1,5 +1,4 @@
-use starknet::class_hash::{ClassHash, class_hash_const};
-use starknet::contract_address::contract_address_const;
+use starknet::class_hash::ClassHash;
 use starknet::syscalls::{deploy_syscall, get_class_hash_at_syscall};
 
 #[starknet::interface]
@@ -54,7 +53,7 @@ mod contract_b {
 fn test_replace_flow() {
     // Deploy ContractA with 100 in the storage.
     let (address0, _) = deploy_syscall(
-        class_hash: contract_a::TEST_CLASS_HASH.try_into().unwrap(),
+        class_hash: contract_a::TEST_CLASS_HASH,
         contract_address_salt: 0,
         calldata: [100].span(),
         deploy_from_zero: false,
@@ -63,7 +62,7 @@ fn test_replace_flow() {
 
     // Replace its class hash to Class B.
     let mut contract0 = IWithReplaceDispatcher { contract_address: address0 };
-    contract0.replace(contract_b::TEST_CLASS_HASH.try_into().unwrap());
+    contract0.replace(contract_b::TEST_CLASS_HASH);
 
     // Read the previously stored value.
     let mut contract1 = IWithFooDispatcher { contract_address: address0 };
@@ -76,7 +75,7 @@ fn test_replace_flow() {
 fn test_cannot_replace_with_non_existing_class_hash() {
     // Deploy ContractA with 100 in the storage.
     let (address0, _) = deploy_syscall(
-        class_hash: contract_a::TEST_CLASS_HASH.try_into().unwrap(),
+        class_hash: contract_a::TEST_CLASS_HASH,
         contract_address_salt: 0,
         calldata: [100].span(),
         deploy_from_zero: false,
@@ -90,26 +89,25 @@ fn test_cannot_replace_with_non_existing_class_hash() {
 
 #[test]
 fn test_class_hash_at_syscall() {
-    let a_class_hash = class_hash_const::<contract_a::TEST_CLASS_HASH>();
     // Deploy ContractA with 100 in the storage.
     let (address0, _) = deploy_syscall(
-        class_hash: a_class_hash,
+        class_hash: contract_a::TEST_CLASS_HASH,
         contract_address_salt: 0,
         calldata: [100].span(),
         deploy_from_zero: false,
     )
         .unwrap();
 
-    assert_eq!(get_class_hash_at_syscall(address0), Ok(a_class_hash));
+    assert_eq!(get_class_hash_at_syscall(address0), Ok(contract_a::TEST_CLASS_HASH));
     // Replace its class hash to Class B.
-    let b_class_hash = class_hash_const::<contract_b::TEST_CLASS_HASH>();
-    IWithReplaceDispatcher { contract_address: address0 }.replace(b_class_hash);
-    assert_eq!(get_class_hash_at_syscall(address0), Ok(b_class_hash));
+    IWithReplaceDispatcher { contract_address: address0 }.replace(contract_b::TEST_CLASS_HASH);
+    assert_eq!(get_class_hash_at_syscall(address0), Ok(contract_b::TEST_CLASS_HASH));
 }
 
 #[test]
 fn test_class_hash_at_syscall_undeployed_contract() {
     assert_eq!(
-        get_class_hash_at_syscall(contract_address_const::<123456>()), Ok(class_hash_const::<0>()),
+        get_class_hash_at_syscall('undeployed'.try_into().unwrap()),
+        Ok(core::num::traits::Zero::zero()),
     );
 }

--- a/crates/cairo-lang-starknet/src/contract.rs
+++ b/crates/cairo-lang-starknet/src/contract.rs
@@ -5,7 +5,6 @@ use cairo_lang_defs::ids::{
 };
 use cairo_lang_diagnostics::ToOption;
 use cairo_lang_filesystem::ids::CrateId;
-use cairo_lang_semantic::Expr;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::diagnostic::{NotFoundItemType, SemanticDiagnostics};
 use cairo_lang_semantic::expr::inference::InferenceId;
@@ -25,7 +24,7 @@ use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::ordered_hash_map::{
     OrderedHashMap, deserialize_ordered_hashmap_vec, serialize_ordered_hashmap_vec,
 };
-use cairo_lang_utils::{Intern, extract_matches};
+use cairo_lang_utils::{Intern, LookupIntern, extract_matches};
 use itertools::chain;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt as Felt252;
@@ -315,12 +314,8 @@ fn analyze_contract<T: SierraIdReplacer>(
     let item =
         db.module_item_by_name(contract.module_id(), "TEST_CLASS_HASH".into()).unwrap().unwrap();
     let constant_id = extract_matches!(item, ModuleItemId::Constant);
-    let constant = db.constant_semantic_data(constant_id).unwrap();
     let class_hash: Felt252 =
-        extract_matches!(&constant.arenas.exprs[constant.value], Expr::Literal)
-            .value
-            .clone()
-            .into();
+        db.constant_const_value(constant_id).unwrap().lookup_intern(db).into_int().unwrap().into();
 
     // Extract functions.
     let SemanticEntryPoints { external, l1_handler, constructor } =

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
@@ -178,7 +178,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x512a6d7124a897370409ddf4a36e94192a8e84b6eb12aa805962db55776618;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x512a6d7124a897370409ddf4a36e94192a8e84b6eb12aa805962db55776618.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -105,7 +105,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x198f4bc6efa8417922f8041d6e73821af41c6bbf15f1c93084da188702456b;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x198f4bc6efa8417922f8041d6e73821af41c6bbf15f1c93084da188702456b.try_into().unwrap();
 
 
 pub mod __external {
@@ -301,7 +301,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x3bd690d1a73da0d8c43f46ecc3a006978d8343a075e91a1c7a24529e7d244a;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x3bd690d1a73da0d8c43f46ecc3a006978d8343a075e91a1c7a24529e7d244a.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -513,7 +513,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x547f368ac55821b57d7da42588a2985edb69dd87af9e9c16e740d6e14b2420;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x547f368ac55821b57d7da42588a2985edb69dd87af9e9c16e740d6e14b2420.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -783,7 +783,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x16fce813e4d7f676441c2cffa36b5101b7e75cb787a8aec7259094fdbacb80e;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x16fce813e4d7f676441c2cffa36b5101b7e75cb787a8aec7259094fdbacb80e.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -992,7 +992,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x2c31752790f50b7f25195fc7cc9dcc1234d7af736c5ed771c69ddc8bb9fd8d4;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2c31752790f50b7f25195fc7cc9dcc1234d7af736c5ed771c69ddc8bb9fd8d4.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -1197,7 +1197,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x2bcbd7e08add1bbb62c174729940be27dbe922f83afd842f02af5355af726a1;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2bcbd7e08add1bbb62c174729940be27dbe922f83afd842f02af5355af726a1.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -1427,7 +1427,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x51e947dc07c2918ff505d4f848310fd40dc215c7a78b8e0ec19a8c6ab47ce3;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x51e947dc07c2918ff505d4f848310fd40dc215c7a78b8e0ec19a8c6ab47ce3.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -1651,7 +1651,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x291a42fae50c99636dc1d6bc0c4e28fdb0e21f47c26aa0d5e22c21d993823d8;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x291a42fae50c99636dc1d6bc0c4e28fdb0e21f47c26aa0d5e22c21d993823d8.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -1978,7 +1978,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0xe6da8c1c7f4f4eacbcd1e253492a549cdbe26d925524eeed0c44aaaf75d668;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0xe6da8c1c7f4f4eacbcd1e253492a549cdbe26d925524eeed0c44aaaf75d668.try_into().unwrap();
 
 
 pub mod __external {
@@ -2205,7 +2205,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x271c051b9d25373bc88ddfddfb1c29cc601d7014c5343fe167b82768570a896;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x271c051b9d25373bc88ddfddfb1c29cc601d7014c5343fe167b82768570a896.try_into().unwrap();
 
 
 pub mod __external {
@@ -2469,7 +2469,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x1f35904b8fc9bed6ac08457ded74e522aa254844ebb1d7da8eaff06532a8b4d;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1f35904b8fc9bed6ac08457ded74e522aa254844ebb1d7da8eaff06532a8b4d.try_into().unwrap();
 
 
 pub mod __external {
@@ -3475,7 +3475,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0xb2b80f78cee80a1a53222a998e318822f6d9d701bdc8037948c5964158503c;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0xb2b80f78cee80a1a53222a998e318822f6d9d701bdc8037948c5964158503c.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -3790,7 +3790,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x820d41c225755fd6813443e1db69b44d323763bb1bdc6c58da9d8011855f0b;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x820d41c225755fd6813443e1db69b44d323763bb1bdc6c58da9d8011855f0b.try_into().unwrap();
 
 
 pub mod __external {
@@ -3978,7 +3978,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x1786cd1474db7f1bf61efa820fedb6cc8a9892313c56a8ab854a488db0d2879;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1786cd1474db7f1bf61efa820fedb6cc8a9892313c56a8ab854a488db0d2879.try_into().unwrap();
 
 
 pub mod __external {
@@ -8259,7 +8259,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x291a893aaae68e6364fac8003da0089f1c976946ebe457ce78ed62b5e680be2;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x291a893aaae68e6364fac8003da0089f1c976946ebe457ce78ed62b5e680be2.try_into().unwrap();
 
 impl ContractStateMyEmbeddableImpl of
     super::component::UnsafeNewContractStateTraitForMyEmbeddableImpl<ContractState> {
@@ -8525,7 +8525,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x7bfb361123ab6c75c9b1db29acd3b69ea425da0db94322a959835a160c41da;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x7bfb361123ab6c75c9b1db29acd3b69ea425da0db94322a959835a160c41da.try_into().unwrap();
 
 
 pub mod __external {
@@ -11865,7 +11865,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x3232c860888b3e1c54dda19284c63d6667fbbdebe403a54921a6dfbbe3134c9;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x3232c860888b3e1c54dda19284c63d6667fbbdebe403a54921a6dfbbe3134c9.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -12846,7 +12846,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x29df08f1d7a448905745936c947da165c96a5e2fdbd90ffd2bdabbc7a7e0b1d;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x29df08f1d7a448905745936c947da165c96a5e2fdbd90ffd2bdabbc7a7e0b1d.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -13784,7 +13784,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0xc5af418eb5eed4ff51ca2888dc884ade488de0dea59772fe757c6cfc2d73f3;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0xc5af418eb5eed4ff51ca2888dc884ade488de0dea59772fe757c6cfc2d73f3.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -14807,7 +14807,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x3168f720317a98a00e5727dec4873607cd97bfa1e65fef0524f5661f2b767ed;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x3168f720317a98a00e5727dec4873607cd97bfa1e65fef0524f5661f2b767ed.try_into().unwrap();
 
 impl ContractStateMyImpl of
     super::component::UnsafeNewContractStateTraitForMyImpl<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
@@ -864,7 +864,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x24989c51cc02d16815c925171e8167063fde5b6487bb15a58d126a7bc4f3591;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x24989c51cc02d16815c925171e8167063fde5b6487bb15a58d126a7bc4f3591.try_into().unwrap();
 
 impl ContractStateOutsideImpl of
     super::UnsafeNewContractStateTraitForOutsideImpl<ContractState> {
@@ -2360,7 +2360,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x2f3505035216cb9786b44e88c45f03e355e52c775f1b6ee6be27556e20667b;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2f3505035216cb9786b44e88c45f03e355e52c775f1b6ee6be27556e20667b.try_into().unwrap();
 
 impl ContractStateOutsideImplWithDestruct of
     super::UnsafeNewContractStateTraitForOutsideImplWithDestruct<ContractState> {
@@ -3214,7 +3214,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x7abed9c637e9d7ff4d836f1e5e23fa64efc1ba2169cc22aa5d822ad70fed47;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x7abed9c637e9d7ff4d836f1e5e23fa64efc1ba2169cc22aa5d822ad70fed47.try_into().unwrap();
 
 impl ContractStateOutsideImplWithDrop of
     super::UnsafeNewContractStateTraitForOutsideImplWithDrop<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/external_event
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/external_event
@@ -240,7 +240,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x32ff02b6abf104297a08971d16f6970b6530be8e49a83bde923ea117b47a37e;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x32ff02b6abf104297a08971d16f6970b6530be8e49a83bde923ea117b47a37e.try_into().unwrap();
 
 
 pub mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
@@ -1572,7 +1572,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x22aa9f2c832fb18ac0ec19b508b86f5fc9d78a62b4d7a72ee2a8c7c11a786b5;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x22aa9f2c832fb18ac0ec19b508b86f5fc9d78a62b4d7a72ee2a8c7c11a786b5.try_into().unwrap();
 
 impl ContractStateI1I1 of
     super::comp::UnsafeNewContractStateTraitForI1I1<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/l1_handler
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/l1_handler
@@ -105,7 +105,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x32a1956d182625bfe7f9834635d01441624366b326c190ecbf557e699f94b76;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x32a1956d182625bfe7f9834635d01441624366b326c190ecbf557e699f94b76.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
@@ -2633,7 +2633,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x26adb8ccfd72d720830db9bdc718b9399f62cee2dbb74a9e8e2d33b70e8e117;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x26adb8ccfd72d720830db9bdc718b9399f62cee2dbb74a9e8e2d33b70e8e117.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/raw_output
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/raw_output
@@ -117,7 +117,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0xd3e4aedceb9023ffd093c5d4d4605354999ba4a10776d97d533a048d33898;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0xd3e4aedceb9023ffd093c5d4d4605354999ba4a10776d97d533a048d33898.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage
@@ -363,7 +363,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x25c680547752cece853ea35e00dbd269ee33545db32a2d900eb20e872e0d255;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x25c680547752cece853ea35e00dbd269ee33545db32a2d900eb20e872e0d255.try_into().unwrap();
 
 
 pub mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/user_defined_types
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/user_defined_types
@@ -195,7 +195,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x31eca83a5f161f61a5b51407b0d5138ae6f487b968308516a9cddc5b9d4d8da;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x31eca83a5f161f61a5b51407b0d5138ae6f487b968308516a9cddc5b9d4d8da.try_into().unwrap();
 
 
 pub mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
@@ -306,7 +306,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x13b620794e5b3dc7cc2033d0b9381b35d5d10d1f0a43fe1f5e1d495f793ebab;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x13b620794e5b3dc7cc2033d0b9381b35d5d10d1f0a43fe1f5e1d495f793ebab.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -910,7 +910,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x20768e618c747c9e742de0446492553ae65eafb837da660ed6516e1ed6b52fc;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x20768e618c747c9e742de0446492553ae65eafb837da660ed6516e1ed6b52fc.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -1560,7 +1560,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x20768e618c747c9e742de0446492553ae65eafb837da660ed6516e1ed6b52fc;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x20768e618c747c9e742de0446492553ae65eafb837da660ed6516e1ed6b52fc.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
@@ -265,7 +265,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x2943e6b272892c78655f823e0abb3da425a1ac0c3f9bdd70869a3f37bc54797;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2943e6b272892c78655f823e0abb3da425a1ac0c3f9bdd70869a3f37bc54797.try_into().unwrap();
 
 
 pub mod __external {
@@ -655,7 +655,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0xe61d99740f46b06b2ccd91d014bc9f9acc438fec59d79dd30fd0d852e5210;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0xe61d99740f46b06b2ccd91d014bc9f9acc438fec59d79dd30fd0d852e5210.try_into().unwrap();
 
 
 pub mod __external {
@@ -1033,7 +1033,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x14aaf6de6aff44d64b4c3609768860615e979fdd851d125bbdfc10597a50a1d;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x14aaf6de6aff44d64b4c3609768860615e979fdd851d125bbdfc10597a50a1d.try_into().unwrap();
 
 
 pub mod __external {
@@ -1424,7 +1424,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x121a1470e2769fd2e9f4441ff7ab7e2ae96e0f4e0446116a0f29d76df75b33;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x121a1470e2769fd2e9f4441ff7ab7e2ae96e0f4e0446116a0f29d76df75b33.try_into().unwrap();
 
 
 pub mod __external {
@@ -1858,7 +1858,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x13a81b6876baa1445c90fd69add3e928a4f6c6807e5227544ac6f6698c463b2;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x13a81b6876baa1445c90fd69add3e928a4f6c6807e5227544ac6f6698c463b2.try_into().unwrap();
 
 
 pub mod __external {
@@ -2265,7 +2265,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x1092f63083af07b77ee426fd76d9695c3747a2e42571a914cee1dd17960254f;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1092f63083af07b77ee426fd76d9695c3747a2e42571a914cee1dd17960254f.try_into().unwrap();
 
 
 pub mod __external {
@@ -2644,7 +2644,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x8618264598f52601eed9355f5b7c0fc7c8912d966e620eb0a2914ed8cb5c10;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x8618264598f52601eed9355f5b7c0fc7c8912d966e620eb0a2914ed8cb5c10.try_into().unwrap();
 
 
 pub mod __external {
@@ -3032,7 +3032,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x8f9d2a9bd3a3fe28e42c16030ed25a2756a86a13d4297597e43683c3df9a02;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x8f9d2a9bd3a3fe28e42c16030ed25a2756a86a13d4297597e43683c3df9a02.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -3482,7 +3482,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0x1c59c1f2e69fc61b0f9162b5cdb7fd6a0828ffb8f03548b02c3c52f2ef1c284;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1c59c1f2e69fc61b0f9162b5cdb7fd6a0828ffb8f03548b02c3c52f2ef1c284.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -4036,7 +4036,7 @@ pub fn contract_state_for_testing() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
-pub const TEST_CLASS_HASH: felt252 = 0xa09b926ceb282d29edce76bb84e4aeb97f1a82ce15099322f1c2869a49b549;
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0xa09b926ceb282d29edce76bb84e4aeb97f1a82ce15099322f1c2869a49b549.try_into().unwrap();
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
@@ -323,7 +323,7 @@ pub(super) fn generate_contract_specific_code(
 
     generation_data.specific.test_config = RewriteNode::Text(formatdoc!(
         "#[cfg(target: 'test')]
-            pub const TEST_CLASS_HASH: felt252 = {test_class_hash};
+            pub const TEST_CLASS_HASH: starknet::ClassHash = {test_class_hash}.try_into().unwrap();
 "
     ));
 

--- a/crates/cairo-lang-test-runner/test_data/lib.cairo
+++ b/crates/cairo-lang-test-runner/test_data/lib.cairo
@@ -36,15 +36,11 @@ mod tests {
 
     #[test]
     fn test_flow() {
-        let (address0, _) = deploy_syscall(
-            Balance::TEST_CLASS_HASH.try_into().unwrap(), 0, [100].span(), false,
-        )
+        let (address0, _) = deploy_syscall(Balance::TEST_CLASS_HASH, 0, [100].span(), false)
             .unwrap();
         let mut contract0 = IBalanceDispatcher { contract_address: address0 };
 
-        let (address1, _) = deploy_syscall(
-            Balance::TEST_CLASS_HASH.try_into().unwrap(), 0, [200].span(), false,
-        )
+        let (address1, _) = deploy_syscall(Balance::TEST_CLASS_HASH, 0, [200].span(), false)
             .unwrap();
         let mut contract1 = IBalanceDispatcher { contract_address: address1 };
 

--- a/tests/bug_samples/issue4036.cairo
+++ b/tests/bug_samples/issue4036.cairo
@@ -15,9 +15,8 @@ mod toto {
 
     #[external(v0)]
     fn test_mint_and_unbox(self: @ContractState) {
-        let contract = FirstInterfaceDispatcher {
-            contract_address: starknet::contract_address_const::<5>(),
-        };
+        const CONTRACT_ADDRESS: starknet::ContractAddress = 5_felt252.try_into().unwrap();
+        let contract = FirstInterfaceDispatcher { contract_address: CONTRACT_ADDRESS };
 
         contract.balance_of();
         contract.toto(array![contract.contract_address]);


### PR DESCRIPTION
Specifically ClassHash and ContractClass.

---

**Stack**:
- #7306
- #7304
- #7302 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*