### PR TITLE
docs: fix typos and improve wording in language documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/assignment-statement.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/assignment-statement.adoc
@@ -5,5 +5,5 @@
 An _assignment statement_ moves a value into the specified target.
 
 An assignment statement consists of a xref:lvalue.adoc[lvalue] followed by an
-equals sign (=) and a expression.
+equals sign (=) and an expression.
 After the assignment, the value of the `lvalue` is changed to the value of the expression.

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/felt252dict-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/felt252dict-type.adoc
@@ -44,7 +44,7 @@ dictionary is not used while it is being modified.
 == Dictionary Destruction
 
 Dictionaries are automatically destroyed when they go out of scope. However, the destruction
-process of a dictionary is not trivial, and the `Destruct` trait is implemented for `Felt252Dict``.
+process of a dictionary is not trivial, and the `Destruct` trait is implemented for `Felt252Dict`.
 This means that `Destruct` must be derived for any type that contains a dictionary. For more
 information, see the xref:linear-types.adoc#Destructors[Destructors] section.
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
@@ -20,8 +20,8 @@ let b = false;
 
 Cairo supports the following numeric literals:
 1. A decimal literal that consists of only decimal digits.
-2. A hexadecimal literal that start with the character sequence `0x` and continues with hex digits.
-3. A binary literal that start with the character sequence `0b` and continues with binary digits.
+2. A hexadecimal literal that starts with the character sequence `0x` and continues with hex digits.
+3. A binary literal that starts with the character sequence `0b` and continues with binary digits.
 
 
 A numeric literal may be followed (immediately, without any spaces) by an underscore character (`_`)


### PR DESCRIPTION
**This PR fixes several minor text issues in the documentation:**
1. Removes unnecessary article `a` in assignment statement description
2. Fixes quotes around `Felt252Dict` and `Destruct` in dictionary type documentation
3. Changes `start` to `starts` in binary literal description for better grammar

These changes improve readability and consistency in the documentation.