### PR TITLE
chore: handle missing crates/ directory safely

### DIFF
--- a/scripts/release_crates.sh
+++ b/scripts/release_crates.sh
@@ -56,7 +56,7 @@ CRATES_TO_PUBLISH=(
 
 # Assert that the number of crates to publish is equal to the number of crates in the workspace
 # - 5 (the number of crates that are for internal use only).
-NUM_CRATES_IN_WORKSPACE=$(find crates/ -name Cargo.toml | wc -l)
+NUM_CRATES_IN_WORKSPACE=$(find crates/ -name Cargo.toml 2>/dev/null | wc -l)
 if [ "${#CRATES_TO_PUBLISH[@]}" -ne "$((NUM_CRATES_IN_WORKSPACE - 5))" ]; then
     echo "The number of crates to publish is not equal to the number of crates in the workspace,"
     echo "new crates were probably added, please update the list of crates to publish."


### PR DESCRIPTION
Noticed that if the `crates/` directory is missing, the `find` command throws an error. This update suppresses the error output, making the script more robust:  

```bash
NUM_CRATES_IN_WORKSPACE=$(find crates/ -name Cargo.toml 2>/dev/null | wc -l)
```

Now, even if the directory doesn't exist, the script works without issues.