### PR TITLE
fix: Improve error message for invalid parameter name in write macro

### DIFF
--- a/crates/cairo-lang-semantic/src/inline_macros/write.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/write.rs
@@ -529,7 +529,7 @@ fn extract_placeholder_argument(
     } else if let Ok(position) = parameter_name.parse::<usize>() {
         PlaceholderArgumentSource::Positional(position)
     } else if parameter_name.starts_with(|c: char| c.is_ascii_digit()) {
-        return Err("Invalid parameter name");
+        return Err("Invalid parameter name: cannot start with a digit");
     } else {
         PlaceholderArgumentSource::Named(parameter_name)
     };


### PR DESCRIPTION
Make the error message more descriptive when a parameter name starts with a digit in the write macro formatter.
Changed from "Invalid parameter name" to "Invalid parameter name: cannot start with a digit".