### PR TITLE
Fix spelling errors in `enm.rs` and `error_code.rs`

### DIFF
--- a/crates/cairo-lang-diagnostics/src/error_code.rs
+++ b/crates/cairo-lang-diagnostics/src/error_code.rs
@@ -14,7 +14,7 @@ impl ErrorCode {
     pub const fn new(code: &'static str) -> Self {
         assert!(
             matches!(code.as_bytes(), [b'E', b'0'..=b'9', b'0'..=b'9', b'0'..=b'9', b'0'..=b'9']),
-            "Error codes must start with capital `E` followed by 4 decimal digits."
+            "Error codes must start with a capital `E` followed by 4 decimal digits."
         );
         Self(code)
     }
@@ -63,7 +63,7 @@ pub trait OptionErrorCodeExt {
 }
 
 impl OptionErrorCodeExt for Option<ErrorCode> {
-    /// Format this error code in a way that is suitable for display in error message.
+    /// Formats this error code in a way that is suitable for an error message.
     ///
     /// ```
     /// # use cairo_lang_diagnostics::{error_code, OptionErrorCodeExt};

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -277,7 +277,7 @@ fn build_enum_match_short(
 /// branch index 0 (where n is the number of variants of this enum), 1 for branch index 1, 3 for
 /// branch index 2 and so on: (2 * k - 1) for branch index k).
 ///
-/// Assumes that self.invocation.branches.len() == output_expressions.len() > 2.
+/// Assumes that builder.invocation.branches.len() == output_expressions.len() > 2.
 fn build_enum_match_long(
     builder: CompiledInvocationBuilder<'_>,
     variant_selector: CellRef,


### PR DESCRIPTION
- **`error_code.rs`:**

  - Fixed typo in error message assertion:
    - Changed `"Error codes must start with capital \`E\` followed by 4 decimal digits."`
    - To `"Error codes must start with a capital \`E\` followed by 4 decimal digits."`
    
  - Improved documentation comments:
    - Changed `"Format this error code in a way that is suitable for display in error message."`
    - To `"Formats this error code in a way that is suitable for an error message."`

- **`enm.rs`:**

  - Fixed typo in a function comment:
    - Changed `"self.invocation.branches.len()"` 
    - To `"builder.invocation.branches.len()"` for clarity and consistency.
