### PR TITLE
fix: comment in define_language_element_id_as_enum! macro

### DIFF
--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -164,7 +164,7 @@ macro_rules! define_language_element_id_basic {
     };
 }
 
-/// Defines and implements LanguageElementId for a subset of other language elements.
+/// Defines and implements LanguageElementId, DebugWithDb, and OptionFrom for a subset of other language elements.
 macro_rules! define_language_element_id_as_enum {
     (
         #[toplevel]


### PR DESCRIPTION
I updated the comment for the `define_language_element_id_as_enum!` macro. The previous comment was misleading as it only mentioned the definition of `LanguageElementId`. However, the macro also implements `DebugWithDb` and provides conversion via `OptionFrom`. Now, the comment reflects the full functionality of the macro:

```rust
/// Defines and implements LanguageElementId, DebugWithDb, and OptionFrom for a subset of other language elements.
```

This should clarify the purpose of the macro more accurately.