### PR TITLE
Fix typo in closure test data

### DIFF
--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/closure
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/closure
@@ -57,7 +57,7 @@ foo
 //! > module_code
 struct PanicDestructable {}
 
-impl MyPanicDesruct of PanicDestruct<PanicDestructable> {
+impl MyPanicDestruct of PanicDestruct<PanicDestructable> {
     fn panic_destruct(self: PanicDestructable, ref panic: Panic) nopanic {
         let PanicDestructable { } = self;
     }
@@ -422,7 +422,7 @@ foo
 //! > module_code
 struct Destructable {}
 
-impl MyDesruct of Destruct<Destructable> {
+impl MyDestruct of Destruct<Destructable> {
     fn destruct(self: Destructable) nopanic {
         let Destructable { } = self;
     }


### PR DESCRIPTION
- **Fixed incorrect struct implementation names:**

  - `MyPanicDesruct` → `MyPanicDestruct`
  - `MyDesruct` → `MyDestruct`
