### PR TITLE
Allow obtaining the `TypeId`s of plugins

### DIFF
--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -370,6 +370,12 @@ impl MacroPlugin for MacroPluginLongId {
     fn phantom_type_attributes(&self) -> Vec<String> {
         self.0.phantom_type_attributes()
     }
+
+    fn plugin_type_id(&self) -> std::any::TypeId {
+        // Ensure the implementation for `MacroPluginLongId` returns the same value
+        // as the underlying plugin object.
+        self.0.plugin_type_id()
+    }
 }
 
 // `PartialEq` and `Hash` cannot be derived on `Arc<dyn ...>`,
@@ -412,6 +418,12 @@ impl InlineMacroExprPlugin for InlineMacroExprPluginLongId {
 
     fn documentation(&self) -> Option<String> {
         self.0.documentation()
+    }
+
+    fn plugin_type_id(&self) -> std::any::TypeId {
+        // Ensure the implementation for `InlineMacroExprPluginLongId` returns the same value
+        // as the underlying plugin object.
+        self.0.plugin_type_id()
     }
 }
 

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::any::{self, Any};
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -97,7 +97,7 @@ pub struct MacroPluginMetadata<'a> {
 
 // TODO(spapini): Move to another place.
 /// A trait for a macro plugin: external plugin that generates additional code for items.
-pub trait MacroPlugin: std::fmt::Debug + Sync + Send {
+pub trait MacroPlugin: std::fmt::Debug + Sync + Send + Any {
     /// Generates code for an item. If no code should be generated returns None.
     /// Otherwise, returns (virtual_module_name, module_content), and a virtual submodule
     /// with that name and content should be created.
@@ -139,6 +139,12 @@ pub trait MacroPlugin: std::fmt::Debug + Sync + Send {
     fn phantom_type_attributes(&self) -> Vec<String> {
         Vec::new()
     }
+
+    /// A `TypeId` of the plugin, used to compare the concrete types
+    /// of plugins given as trait objects.
+    fn plugin_type_id(&self) -> any::TypeId {
+        self.type_id()
+    }
 }
 
 /// Result of plugin code generation.
@@ -149,7 +155,7 @@ pub struct InlinePluginResult {
     pub diagnostics: Vec<PluginDiagnostic>,
 }
 
-pub trait InlineMacroExprPlugin: std::fmt::Debug + Sync + Send {
+pub trait InlineMacroExprPlugin: std::fmt::Debug + Sync + Send + Any {
     /// Generates code for an item. If no code should be generated returns None.
     /// Otherwise, returns (virtual_module_name, module_content), and a virtual submodule
     /// with that name and content should be created.
@@ -163,6 +169,12 @@ pub trait InlineMacroExprPlugin: std::fmt::Debug + Sync + Send {
     /// Allows for the plugin to provide documentation for an inline macro.
     fn documentation(&self) -> Option<String> {
         None
+    }
+
+    /// A `TypeId` of the plugin, used to compare the concrete types
+    /// of plugins given as trait objects.
+    fn plugin_type_id(&self) -> any::TypeId {
+        self.type_id()
     }
 }
 

--- a/crates/cairo-lang-semantic/src/ids.rs
+++ b/crates/cairo-lang-semantic/src/ids.rs
@@ -22,6 +22,12 @@ impl AnalyzerPlugin for AnalyzerPluginLongId {
     fn declared_allows(&self) -> Vec<String> {
         self.0.declared_allows()
     }
+
+    fn plugin_type_id(&self) -> std::any::TypeId {
+        // Ensure the implementation for `AnalyzerPluginLongId` returns the same value
+        // as the underlying plugin object.
+        self.0.plugin_type_id()
+    }
 }
 
 // `PartialEq` and `Hash` cannot be derived on `Arc<dyn ...>`,

--- a/crates/cairo-lang-semantic/src/plugin.rs
+++ b/crates/cairo-lang-semantic/src/plugin.rs
@@ -1,3 +1,4 @@
+use std::any::{self, Any};
 use std::sync::Arc;
 
 use cairo_lang_defs::ids::{InlineMacroExprPluginId, MacroPluginId, ModuleId};
@@ -9,7 +10,7 @@ use crate::ids::AnalyzerPluginId;
 
 /// A trait for an analyzer plugin: external plugin that generates additional diagnostics for
 /// modules.
-pub trait AnalyzerPlugin: std::fmt::Debug + Sync + Send {
+pub trait AnalyzerPlugin: std::fmt::Debug + Sync + Send + Any {
     /// Runs the plugin on a module.
     fn diagnostics(&self, db: &dyn SemanticGroup, module_id: ModuleId) -> Vec<PluginDiagnostic>;
     /// Allows this plugin supplies.
@@ -19,6 +20,12 @@ pub trait AnalyzerPlugin: std::fmt::Debug + Sync + Send {
     /// `#[allow(some_pattern)]` you will need to declare it here.
     fn declared_allows(&self) -> Vec<String> {
         Vec::new()
+    }
+
+    /// A `TypeId` of the plugin, used to compare the concrete types
+    /// of plugins given as trait objects.
+    fn plugin_type_id(&self) -> any::TypeId {
+        self.type_id()
     }
 }
 


### PR DESCRIPTION
## Changes
* Introduced `Any` as a supertrait of `MacroPlugin`, `InlineMacroExprPlugin` and `AnalyzerPlugin` traits
* Added a `plugin_type_id` method to all those traits. It can be used to discover the concrete type of the plugin in the `dyn` context. For all plugins, implementations of this method for the plugin and its corresponding `LongId` return the same `TypeId`.

## Use cases
* In LS, we sometimes need to discover and compare the concrete types of plugins given as trait objects. Thus, we need a robust mechanism.