### PR TITLE
fix typos and improve clarity

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/context.rs
+++ b/crates/cairo-lang-lowering/src/lower/context.rs
@@ -148,7 +148,7 @@ pub struct LoweringContext<'a, 'db> {
     /// Id for the current function being lowered.
     pub function_id: FunctionWithBodyId,
     /// Id for the current concrete function to be used when generating recursive calls.
-    /// This it the generic function specialized with its own generic parameters.
+    /// This is the generic function specialized with its own generic parameters.
     pub concrete_function_id: ConcreteFunctionWithBodyId,
     /// Current loop context.
     pub current_loop_ctx: Option<LoopContext>,

--- a/crates/cairo-lang-lowering/src/lower/generators.rs
+++ b/crates/cairo-lang-lowering/src/lower/generators.rs
@@ -182,8 +182,8 @@ impl Desnap {
 
 /// Generator for [StatementStructDestructure].
 ///
-/// Note that we return `Vec<VariableId>` rather then `Vec<VarUsage>` as the caller typically
-/// has a more accurate location then the one we have in the var requests.
+/// Note that we return `Vec<VariableId>` rather than `Vec<VarUsage>` as the caller typically
+/// has a more accurate location than the one we have in the var requests.
 pub struct StructDestructure {
     /// Variable that holds the struct value.
     pub input: VarUsage,

--- a/crates/cairo-lang-lowering/src/lower/lower_match.rs
+++ b/crates/cairo-lang-lowering/src/lower/lower_match.rs
@@ -48,7 +48,7 @@ struct ExtractedEnumDetails {
     n_snapshots: usize,
 }
 
-/// MatchArm wrapper that allow for optional expression clause.
+/// MatchArm wrapper that allows for optional expression clause.
 /// Used in the case of if-let with missing else clause.
 pub struct MatchArmWrapper {
     pub patterns: Vec<PatternId>,

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -11,7 +11,7 @@ use itertools::chain;
 use crate::VariableId;
 use crate::db::LoweringGroup;
 
-//  Information about members captured by the closure and their types.
+// Information about members captured by the closure and their types.
 #[derive(Clone, Debug)]
 pub struct ClosureInfo {
     // TODO(TomerStarkware): unite copiable members and snapshots into a single map.

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -128,7 +128,7 @@ impl SemanticLoweringMapping {
         // TODO(TomerStarkware): check if path is captured by a closure and invalidate the closure.
         // Right now this can only happen if we take a snapshot of the variable (as the
         // snapshot function returns a new var).
-        // we need the make sure the borrow checker invalidates the closure when mutable capture
+        // we need to ensure the borrow checker invalidates the closure when mutable capture
         // is supported.
 
         let value = self.break_into_value(ctx, path)?;

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -11,7 +11,7 @@ use itertools::chain;
 use crate::VariableId;
 use crate::db::LoweringGroup;
 
-// Information about members captured by the closure and their types.
+/// Information about members captured by the closure and their types.
 #[derive(Clone, Debug)]
 pub struct ClosureInfo {
     // TODO(TomerStarkware): unite copiable members and snapshots into a single map.


### PR DESCRIPTION
This PR corrects several typos and improves clarity in documentation across multiple files in the `cairo-lang-lowering` crate. Key fixes include:  

- Correcting spelling mistakes such as `rather then` → `rather than` and `allow` → `allows`.  
- Improving phrasing for better readability `we need the make sure` → `we need to ensure`.  
- Deleted extra space in comment section.  