### PR TITLE
Added ability to handle `never` returning functions without `match`.

### DIFF
--- a/crates/cairo-lang-lowering/src/panic/mod.rs
+++ b/crates/cairo-lang-lowering/src/panic/mod.rs
@@ -3,12 +3,11 @@ use std::collections::VecDeque;
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::FlagId;
-use cairo_lang_semantic as semantic;
-use cairo_lang_semantic::GenericArgumentId;
-use cairo_lang_semantic::corelib::{get_core_enum_concrete_variant, get_panic_ty};
+use cairo_lang_semantic::corelib::{get_core_enum_concrete_variant, get_panic_ty, never_ty};
 use cairo_lang_semantic::helper::ModuleHelper;
 use cairo_lang_semantic::items::constant::ConstValue;
-use cairo_lang_utils::{Intern, Upcast};
+use cairo_lang_semantic::{self as semantic, GenericArgumentId, TypeLongId};
+use cairo_lang_utils::{Intern, LookupIntern, Upcast};
 use itertools::{Itertools, chain, zip_eq};
 use semantic::{ConcreteVariant, MatchArmSelector, TypeId};
 
@@ -112,17 +111,19 @@ fn handle_block(
 ) -> Maybe<PanicLoweringContext<'_>> {
     let mut block_ctx = PanicBlockLoweringContext { ctx, statements: Vec::new() };
     for (i, stmt) in block.statements.iter().cloned().enumerate() {
-        if let Some((continuation_block, cur_block_end)) = block_ctx.handle_statement(&stmt)? {
+        if let Some((cur_block_end, continuation_block)) = block_ctx.handle_statement(&stmt)? {
             // This case means that the lowering should split the block here.
 
             // Block ended with a match.
             ctx = block_ctx.handle_end(cur_block_end);
-
-            // The rest of the statements in this block have not been handled yet, and should be
-            // handled as a part of the continuation block - the second block in the "split".
-            let block_to_edit = &mut ctx.block_queue[continuation_block.0 - ctx.flat_blocks.len()];
-            block_to_edit.statements.extend(block.statements.drain(i + 1..));
-            block_to_edit.end = block.end;
+            if let Some(continuation_block) = continuation_block {
+                // The rest of the statements in this block have not been handled yet, and should be
+                // handled as a part of the continuation block - the second block in the "split".
+                let block_to_edit =
+                    &mut ctx.block_queue[continuation_block.0 - ctx.flat_blocks.len()];
+                block_to_edit.statements.extend(block.statements.drain(i + 1..));
+                block_to_edit.end = block.end;
+            }
             return Ok(ctx);
         }
     }
@@ -140,7 +141,10 @@ pub struct PanicSignatureInfo {
     /// The Err() variant.
     err_variant: ConcreteVariant,
     /// The PanicResult concrete type - the new return type of the function.
-    pub panic_ty: TypeId,
+    pub actual_return_ty: TypeId,
+    /// Does the function always panic.
+    /// Note that if it does - the function returned type is always `(Panic, Array<felt252>)`.
+    always_panic: bool,
 }
 impl PanicSignatureInfo {
     pub fn new(db: &dyn LoweringGroup, signature: &Signature) -> Self {
@@ -161,8 +165,17 @@ impl PanicSignatureInfo {
             vec![GenericArgumentId::Type(ok_ty)],
             "Err",
         );
-        let panic_ty = get_panic_ty(db.upcast(), ok_ty);
-        Self { ok_ret_tys, ok_ty, ok_variant, err_variant, panic_ty }
+        let always_panic = original_return_ty == never_ty(db.upcast());
+        let panic_ty = if always_panic { err_variant.ty } else { get_panic_ty(db.upcast(), ok_ty) };
+
+        Self {
+            ok_ret_tys,
+            ok_ty,
+            ok_variant,
+            err_variant,
+            actual_return_ty: panic_ty,
+            always_panic,
+        }
     }
 }
 
@@ -201,7 +214,11 @@ impl<'a> PanicBlockLoweringContext<'a> {
     /// The continuation block happens when a panic match is added, and the block needs to be split.
     /// The continuation block is the second block in the "split". This function already partially
     /// creates this second block, and returns it.
-    fn handle_statement(&mut self, stmt: &Statement) -> Maybe<Option<(BlockId, FlatBlockEnd)>> {
+    /// In case there is no panic match - but just a panic, there is no continuation block.
+    fn handle_statement(
+        &mut self,
+        stmt: &Statement,
+    ) -> Maybe<Option<(FlatBlockEnd, Option<BlockId>)>> {
         if let Statement::Call(call) = &stmt {
             if let Some(with_body) = call.function.body(self.db())? {
                 if self.db().function_with_body_may_panic(with_body)? {
@@ -216,7 +233,10 @@ impl<'a> PanicBlockLoweringContext<'a> {
     /// Handles a call statement to a panicking function.
     /// Returns the continuation block ID for the caller to complete it, and the block end to set
     /// for the current block.
-    fn handle_call_panic(&mut self, call: &StatementCall) -> Maybe<(BlockId, FlatBlockEnd)> {
+    fn handle_call_panic(
+        &mut self,
+        call: &StatementCall,
+    ) -> Maybe<(FlatBlockEnd, Option<BlockId>)> {
         // Extract return variable.
         let mut original_outputs = call.outputs.clone();
         let location = call.location.with_auto_generation_note(self.db(), "Panic handling");
@@ -224,10 +244,64 @@ impl<'a> PanicBlockLoweringContext<'a> {
         // Get callee info.
         let callee_signature = call.function.signature(self.ctx.variables.db)?;
         let callee_info = PanicSignatureInfo::new(self.ctx.variables.db, &callee_signature);
+        if callee_info.always_panic {
+            // The panic value, which is actually of type (Panics, Array<felt252>).
+            let panic_result_var =
+                self.new_var(VarRequest { ty: callee_info.actual_return_ty, location });
+            // Emit the new statement.
+            self.statements.push(Statement::Call(StatementCall {
+                function: call.function,
+                inputs: call.inputs.clone(),
+                with_coupon: call.with_coupon,
+                outputs: vec![panic_result_var],
+                location,
+            }));
+
+            // Deconstructing and reconstructing panic, so that the later stage `Destruct` addition
+            // would have a `Panic` struct available.
+
+            let TypeLongId::Tuple(p_ty_d_ty) =
+                callee_info.actual_return_ty.lookup_intern(self.db())
+            else {
+                unreachable!();
+            };
+            let [p_ty, d_ty] = &p_ty_d_ty[..] else {
+                unreachable!();
+            };
+            let panic_var = self.new_var(VarRequest { ty: *p_ty, location });
+            let err_data_var = self.new_var(VarRequest { ty: *d_ty, location });
+            self.statements.push(Statement::StructDestructure(StatementStructDestructure {
+                input: VarUsage { var_id: panic_result_var, location },
+                outputs: vec![panic_var, err_data_var],
+            }));
+            self.statements.push(Statement::StructDestructure(StatementStructDestructure {
+                input: VarUsage { var_id: panic_var, location },
+                outputs: vec![],
+            }));
+            let panic_var = self.new_var(VarRequest { ty: *p_ty, location });
+            self.statements.push(Statement::StructConstruct(StatementStructConstruct {
+                inputs: vec![],
+                output: panic_var,
+            }));
+            let panic_result_var =
+                self.new_var(VarRequest { ty: callee_info.actual_return_ty, location });
+            self.statements.push(Statement::StructConstruct(StatementStructConstruct {
+                inputs: vec![
+                    VarUsage { var_id: panic_var, location },
+                    VarUsage { var_id: err_data_var, location },
+                ],
+                output: panic_result_var,
+            }));
+            return Ok((
+                FlatBlockEnd::Panic(VarUsage { var_id: panic_result_var, location }),
+                None,
+            ));
+        }
 
         // Allocate 2 new variables.
         // panic_result_var - for the new return variable, with is actually of type PanicResult<ty>.
-        let panic_result_var = self.new_var(VarRequest { ty: callee_info.panic_ty, location });
+        let panic_result_var =
+            self.new_var(VarRequest { ty: callee_info.actual_return_ty, location });
         let n_callee_implicits = original_outputs.len() - callee_info.ok_ret_tys.len();
         let mut call_outputs = original_outputs.drain(..n_callee_implicits).collect_vec();
         call_outputs.push(panic_result_var);
@@ -301,7 +375,7 @@ impl<'a> PanicBlockLoweringContext<'a> {
             }),
         };
 
-        Ok((block_continuation, cur_block_end))
+        Ok((cur_block_end, Some(block_continuation)))
     }
 
     fn handle_end(mut self, end: FlatBlockEnd) -> PanicLoweringContext<'a> {
@@ -309,14 +383,19 @@ impl<'a> PanicBlockLoweringContext<'a> {
             FlatBlockEnd::Goto(target, remapping) => FlatBlockEnd::Goto(target, remapping),
             FlatBlockEnd::Panic(err_data) => {
                 // Wrap with PanicResult::Err.
-                let ty = self.ctx.panic_info.panic_ty;
+                let ty = self.ctx.panic_info.actual_return_ty;
                 let location = err_data.location;
-                let output = self.new_var(VarRequest { ty, location });
-                self.statements.push(Statement::EnumConstruct(StatementEnumConstruct {
-                    variant: self.ctx.panic_info.err_variant.clone(),
-                    input: err_data,
-                    output,
-                }));
+                let output = if self.ctx.panic_info.always_panic {
+                    err_data.var_id
+                } else {
+                    let output = self.new_var(VarRequest { ty, location });
+                    self.statements.push(Statement::EnumConstruct(StatementEnumConstruct {
+                        variant: self.ctx.panic_info.err_variant.clone(),
+                        input: err_data,
+                        output,
+                    }));
+                    output
+                };
                 FlatBlockEnd::Return(vec![VarUsage { var_id: output, location }], location)
             }
             FlatBlockEnd::Return(returns, location) => {
@@ -329,7 +408,7 @@ impl<'a> PanicBlockLoweringContext<'a> {
                 }));
 
                 // Wrap with PanicResult::Ok.
-                let ty = self.ctx.panic_info.panic_ty;
+                let ty = self.ctx.panic_info.actual_return_ty;
                 let output = self.new_var(VarRequest { ty, location });
                 self.statements.push(Statement::EnumConstruct(StatementEnumConstruct {
                     variant: self.ctx.panic_info.ok_variant.clone(),

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test_data/panic
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test_data/panic
@@ -53,25 +53,13 @@ End:
 
 blk2:
 Statements:
-  (v5: core::panics::PanicResult::<(core::never,)>) <- test::no_inline_panic()
+  (v5: (core::panics::Panic, core::array::Array::<core::felt252>)) <- test::no_inline_panic()
+  (v6: core::panics::Panic, v7: core::array::Array::<core::felt252>) <- struct_destructure(v5)
+  (v8: core::panics::Panic) <- struct_construct()
+  (v9: (core::panics::Panic, core::array::Array::<core::felt252>)) <- struct_construct(v8, v7)
+  (v10: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v9)
 End:
-  Match(match_enum(v5) {
-    PanicResult::Ok(v6) => blk3,
-    PanicResult::Err(v7) => blk4,
-  })
-
-blk3:
-Statements:
-  (v8: core::never) <- struct_destructure(v6)
-End:
-  Match(match_enum(v8) {
-  })
-
-blk4:
-Statements:
-  (v9: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v7)
-End:
-  Return(v9)
+  Return(v10)
 
 //! > sierra_code
 enum_match<core::option::Option::<core::felt252>>([0]) { fallthrough([1]) label_test::foo::0([2]) }
@@ -85,15 +73,11 @@ branch_align() -> ()
 drop<Unit>([2]) -> ()
 PushValues() -> ()
 function_call<user@test::no_inline_panic>() -> ([5])
-enum_match<core::panics::PanicResult::<(core::never,)>>([5]) { fallthrough([6]) label_test::foo::2([7]) }
-branch_align() -> ()
-struct_deconstruct<Tuple<core::never>>([6]) -> ([8])
-enum_match<core::never>([8]) { }
-label_test::foo::4:
-label_test::foo::2:
-branch_align() -> ()
-enum_init<core::panics::PanicResult::<(core::felt252,)>, 1>([7]) -> ([9])
-PushValues([9]: core::panics::PanicResult::<(core::felt252,)>) -> ([9])
-return([9])
-label_test::foo::3:
+struct_deconstruct<Tuple<core::panics::Panic, Array<felt252>>>([5]) -> ([6], [7])
+drop<core::panics::Panic>([6]) -> ()
+struct_construct<core::panics::Panic>() -> ([8])
+struct_construct<Tuple<core::panics::Panic, Array<felt252>>>([8], [7]) -> ([9])
+enum_init<core::panics::PanicResult::<(core::felt252,)>, 1>([9]) -> ([10])
+PushValues([10]: core::panics::PanicResult::<(core::felt252,)>) -> ([10])
+return([10])
 label_test::foo::1:

--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -172,7 +172,7 @@ fn get_function_signature(
     let mut ret_types = implicits;
     if may_panic {
         let panic_info = PanicSignatureInfo::new(db.upcast(), &signature);
-        ret_types.push(db.get_concrete_type_id(panic_info.panic_ty)?);
+        ret_types.push(db.get_concrete_type_id(panic_info.actual_return_ty)?);
     } else {
         ret_types.extend(extra_rets);
         // Functions that return the unit type don't have a return type in the signature.


### PR DESCRIPTION
Previously a `never` returning function returned a `PanicResult<never>`
and uselessly matched on it.

---

**Stack**:
- #7386
- #7385
- #7384 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*