### PR TITLE
fix: whitespace, factual error

### DIFF
--- a/crates/cairo-lang-doc/src/documentable_formatter.rs
+++ b/crates/cairo-lang-doc/src/documentable_formatter.rs
@@ -252,7 +252,7 @@ impl HirDisplay for EnumId {
                         f.write_str(&format!("\n{INDENT}{name},",)).unwrap()
                     }
                 });
-                f.write_str("\n}")
+                f.write_str(if variants.is_empty() { "}" } else { "\n}" })
             }
             None => f.write_str("}"),
         }
@@ -442,7 +442,7 @@ impl HirDisplay for ModuleTypeAliasId {
     fn hir_fmt(&self, f: &mut HirFormatter<'_>) -> Result<(), fmt::Error> {
         let module_type_alias_full_signature = get_module_type_alias_full_signature(f.db, *self);
         f.write_str(&format!(
-            "{}impl {} = ",
+            "{}type {} = ",
             get_syntactic_visibility(&module_type_alias_full_signature.visibility),
             self.name(f.db.upcast()),
         ))?;


### PR DESCRIPTION
Fixes: 
- Formatting Enum adds an unnecessary new line when no variants present
- ModuleTypeAliasId writes `impl MyExampleType ...` instead of `type MyExampleType ...`