### PR TITLE
Move `smol_str` default features disabling to workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 serde_json = "1.0.138"
 sha2 = "0.10.8"
 sha3 = "0.10.8"
-smol_str = { version = "0.3.2", features = ["serde"] }
+smol_str = { version = "0.3.2", default-features = false }
 starknet-types-core = { version = "0.1.7", features = [
     "hash",
     "prime-bigint",

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -12,7 +12,7 @@ indexmap = { workspace = true }
 itertools = { workspace = true, features = ["use_alloc"] }
 num-bigint.workspace = true
 num-traits.workspace = true
-smol_str = { workspace = true, default-features = false }
+smol_str.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["alloc"], optional = true }


### PR DESCRIPTION
This change makes `ensure-no_std` crate build successfully again.

We got bitten by using Rust 2021 and this: https://doc.rust-lang.org/edition-guide/rust-2024/cargo-inherited-default-features.html