### PR TITLE
Fix documentation comments in function.cairo and testing.cairo

### DIFF
--- a/corelib/src/ops/function.cairo
+++ b/corelib/src/ops/function.cairo
@@ -68,7 +68,7 @@ impl FnOnceImpl<T, Args, +Destruct<T>, +Fn<T, Args>> of FnOnce<T, Args> {
 ///
 /// Instances of `Fn` can be called repeatedly.
 ///
-/// `Fn` is implemented automatically by closures which only whose captured variable are all `Copy`.
+/// /// `Fn` is implemented automatically by closures whose captured variables are all `Copy`.
 /// Additionally, for any type `F` that implements `Fn`, `@F` implements `Fn`, too.
 ///
 /// Since [`FnOnce`] is implemented for all implementers  of `Fn`, any instance of `Fn` can be used

--- a/corelib/src/ops/function.cairo
+++ b/corelib/src/ops/function.cairo
@@ -68,7 +68,7 @@ impl FnOnceImpl<T, Args, +Destruct<T>, +Fn<T, Args>> of FnOnce<T, Args> {
 ///
 /// Instances of `Fn` can be called repeatedly.
 ///
-/// /// `Fn` is implemented automatically by closures whose captured variables are all `Copy`.
+/// `Fn` is implemented automatically by closures whose captured variables are all `Copy`.
 /// Additionally, for any type `F` that implements `Fn`, `@F` implements `Fn`, too.
 ///
 /// Since [`FnOnce`] is implemented for all implementers  of `Fn`, any instance of `Fn` can be used

--- a/corelib/src/testing.cairo
+++ b/corelib/src/testing.cairo
@@ -41,7 +41,7 @@ pub extern fn get_available_gas() -> u128 implicits(GasBuiltin) nopanic;
 /// Returns the amount of gas available in the `GasBuiltin`, as well as the amount of gas unused in
 /// the local wallet.
 ///
-/// Useful for asserting that a certain amount of gas used.
+/// Useful for asserting that a certain amount of gas was used.
 /// Note: This function call costs exactly `2300` gas, so this may be ignored in calculations.
 /// # Examples
 ///


### PR DESCRIPTION
This PR makes the following documentation improvements:

1. In corelib/src/ops/function.cairo:
- Updated comment to clarify that `Fn` is implemented automatically by closures whose captured variables are all `Copy`
- Removed redundant "which only" wording

2. In corelib/src/testing.cairo:
- Added missing "was" in the comment "Useful for asserting that a certain amount of gas was used"
- Fixed grammar in gas usage documentation

These changes improve readability and accuracy of the documentation without changing any functionality.