### PR TITLE
Fix typos in comments and remove redundant words

### DIFF
--- a/corelib/src/circuit.cairo
+++ b/corelib/src/circuit.cairo
@@ -674,7 +674,7 @@ impl CircuitOutputsImpl<
     }
 }
 
-/// A type that contain that is used to guarantee that the circuit evaluation has failed.
+/// A type that is used to guarantee that the circuit evaluation has failed.
 ///
 /// The guarantee is verified by `circuit_failure_guarantee_verify`, which is the only way to
 /// destruct this type. This way, one can trust that the guarantee holds although it has not yet

--- a/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
@@ -61,7 +61,7 @@ fn test_library_dispatcher_serialization() {
 }
 
 
-// Calls `withdraw_gas` then return the available gas.
+// Calls `withdraw_gas` and then returns the available gas.
 // This is useful in test as the `withdraw_gas` allows the gas wallet to be ~0 at the call site.
 // Note that this function must be `inline(always)`.
 #[inline(always)]

--- a/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
@@ -61,7 +61,7 @@ fn test_library_dispatcher_serialization() {
 }
 
 
-// Calls `withdraw_gas` the than return the available gas.
+// Calls `withdraw_gas` then return the available gas.
 // This is useful in test as the `withdraw_gas` allows the gas wallet to be ~0 at the call site.
 // Note that this function must be `inline(always)`.
 #[inline(always)]


### PR DESCRIPTION
This PR fixes grammatical issues in two files:

1. In abi_dispatchers_tests.cairo:
- Changed "Calls `withdraw_gas` the than return" to "Calls `withdraw_gas` then returns"
- Improved comment clarity for the withdraw_and_get_available_gas function

2. In circuit.cairo:
- Removed redundant words "contain that" from type documentation
- Simplified comment to "A type that is used to guarantee that the circuit evaluation has failed"

No functional changes, only documentation improvements.