### PR TITLE
fix grammar in documentation comments

### DIFF
--- a/corelib/src/starknet/storage_access.cairo
+++ b/corelib/src/starknet/storage_access.cairo
@@ -299,7 +299,7 @@ pub trait Store<T> {
 /// }
 /// ```
 ///
-/// By implementing `StorePacking` for `Sizes`, the `Sizes` will be stored in it's packed form,
+/// By implementing `StorePacking` for `Sizes`, the `Sizes` will be stored in its packed form,
 /// using a single storage slot instead of 3. When retrieved, it will automatically be unpacked back
 /// into the original type.
 pub trait StorePacking<T, PackedT> {

--- a/corelib/src/starknet/syscalls.cairo
+++ b/corelib/src/starknet/syscalls.cairo
@@ -70,9 +70,8 @@ pub extern fn get_block_hash_syscall(
     block_number: u64,
 ) -> SyscallResult<felt252> implicits(GasBuiltin, System) nopanic;
 
-/// Gets information about the currently executing block and transactions in the block. For a
-/// complete description of this information, see [`Execution information`].
-///
+/// Gets information about the currently executing block and the transactions within it.
+/// For a complete description of this information, see [`Execution information`].
 /// When an account’s `__validate__`, `__validate_deploy__`, or `__validate_declare__` function
 /// calls `get_execution_info`, the return values for `block_timestamp` and `block_number` are
 /// modified as follows:

--- a/corelib/src/starknet/syscalls.cairo
+++ b/corelib/src/starknet/syscalls.cairo
@@ -70,7 +70,7 @@ pub extern fn get_block_hash_syscall(
     block_number: u64,
 ) -> SyscallResult<felt252> implicits(GasBuiltin, System) nopanic;
 
-/// Gets information about the currently executing block and the transactions in the block. For a
+/// Gets information about the currently executing block and transactions in the block. For a
 /// complete description of this information, see [`Execution information`].
 ///
 /// When an account’s `__validate__`, `__validate_deploy__`, or `__validate_declare__` function

--- a/corelib/src/starknet/syscalls.cairo
+++ b/corelib/src/starknet/syscalls.cairo
@@ -73,6 +73,7 @@ pub extern fn get_block_hash_syscall(
 /// Gets information about the currently executing block and the transactions within it.
 /// For a complete description of this information, see [`Execution information`].
 /// When an account’s `__validate__`, `__validate_deploy__`, or `__validate_declare__` function
+///
 /// calls `get_execution_info`, the return values for `block_timestamp` and `block_number` are
 /// modified as follows:
 /// * `block_timestamp` returns the hour, rounded down to the nearest hour.


### PR DESCRIPTION
This PR fixes two grammatical issues in documentation comments:

**1. In storage_access.cairo:**
- Changed `it's` to `its` in the `StorePacking` documentation

**2. In syscalls.cairo:**
- Removed redundant `the` article in `get_block_hash_syscall` documentation

These changes improve the readability and correctness of the documentation without affecting any functionality.