### PR TITLE
Fix variable names in array serialization examples

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -309,7 +309,7 @@ impl ArraySerde<T, +Serde<T>, +Drop<T>> of Serde<Array<T>> {
     /// ```
     /// let arr: Array<u8> = array![1, 2, 3];
     /// let mut output: Array<felt252> = array![];
-    /// span.serialize(ref output);
+    /// arr.serialize(ref output);
     /// assert!(output == array![3, 1, 2, 3])
     /// ```
     fn serialize(self: @Array<T>, ref output: Array<felt252>) {

--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -309,7 +309,7 @@ impl ArraySerde<T, +Serde<T>, +Drop<T>> of Serde<Array<T>> {
     /// ```
     /// let arr: Array<u8> = array![1, 2, 3];
     /// let mut output: Array<felt252> = array![];
-    /// arr.serialize(ref output);
+    /// span.serialize(ref output);
     /// assert!(output == array![3, 1, 2, 3])
     /// ```
     fn serialize(self: @Array<T>, ref output: Array<felt252>) {
@@ -404,7 +404,7 @@ impl SpanFelt252Serde of Serde<Span<felt252>> {
     /// ```
     /// let span: Span<felt252> = array![1, 2, 3].span();
     /// let mut output: Array<felt252> = array![];
-    /// arr.serialize(ref output);
+    /// span.serialize(ref output);
     /// assert!(output == array![3, 1, 2, 3].span());
     /// ```
     fn serialize(self: @Span<felt252>, ref output: Array<felt252>) {
@@ -438,7 +438,7 @@ impl SpanSerde<T, +Serde<T>, +Drop<T>, -TypeEqual<felt252, T>> of Serde<Span<T>>
     /// ```
     /// let span: Span<u8> = array![1, 2, 3].span();
     /// let mut output: Array<felt252> = array![];
-    /// arr.serialize(ref output);
+    /// span.serialize(ref output);
     /// assert!(output == array![3, 1, 2, 3].span());
     /// ```
     fn serialize(self: @Span<T>, ref output: Array<felt252>) {


### PR DESCRIPTION
This PR updates the variable names in the array serialization documentation examples to be consistent with the actual code:

Changes:
- Replaced "arr.serialize(ref output)" with "span.serialize(ref output)" in three examples to match the actual variable names used in the code
- This makes the documentation more accurate and helps avoid confusion for users following the examples

The changes are purely documentation-related and don't affect any functionality.