### PR TITLE
Refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x 

### DIFF
--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -29,7 +29,7 @@ impl From<crate::InliningStrategy> for cairo_lang_lowering::utils::InliningStrat
 /// Compiles a Cairo project to Sierra.
 /// Exits with 0/1 if the compilation succeeds/fails.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The Cairo project path.
     path: PathBuf,

--- a/crates/bin/cairo-execute/src/main.rs
+++ b/crates/bin/cairo-execute/src/main.rs
@@ -47,10 +47,10 @@ struct Args {
     #[arg(long, default_value_t = false, conflicts_with = "build_only")]
     prebuilt: bool,
 
-    #[arg(flatten)]
+    #[command(flatten)]
     build: BuildArgs,
 
-    #[arg(flatten)]
+    #[command(flatten)]
     run: RunArgs,
 
     /// Prints the bytecode size.
@@ -83,7 +83,7 @@ struct BuildArgs {
 #[derive(Parser, Debug)]
 struct RunArgs {
     /// Serialized arguments to the executable function.
-    #[arg(flatten)]
+    #[command(flatten)]
     args: SerializedArgs,
     /// Whether to print the outputs.
     #[arg(long, default_value_t = false, conflicts_with = "build_only")]
@@ -119,7 +119,7 @@ struct RunArgs {
     ///   instances of the builtin) compared to their sizes at the end of the execution.
     #[arg(long, conflicts_with = "build_only")]
     disable_trace_padding: Option<bool>,
-    #[arg(flatten)]
+    #[command(flatten)]
     proof_outputs: ProofOutputArgs,
 }
 

--- a/crates/bin/cairo-execute/src/main.rs
+++ b/crates/bin/cairo-execute/src/main.rs
@@ -22,7 +22,7 @@ use num_bigint::BigInt;
 /// Compiles a Cairo project and runs a function marked `#[executable]`.
 /// Exits with 1 if the compilation or run fails, otherwise 0.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The basic input path for the run.
     /// If `--prebuilt` is provided, this is the path to the prebuilt executable.
@@ -32,7 +32,7 @@ struct Args {
     input_path: PathBuf,
 
     /// Whether to only build and save into the given path.
-    #[clap(long, requires = "output_path")]
+    #[arg(long, requires = "output_path")]
     build_only: bool,
 
     /// The path to save the result of the run.
@@ -40,17 +40,17 @@ struct Args {
     /// In `--build-only` this would be the executable artifact.
     /// In bootloader mode it will be the resulting cairo PIE file.
     /// In standalone mode this parameter is disallowed.
-    #[clap(long, required_unless_present("standalone"))]
+    #[arg(long, required_unless_present("standalone"))]
     output_path: Option<PathBuf>,
 
     /// Whether to only run a prebuilt executable.
     #[arg(long, default_value_t = false, conflicts_with = "build_only")]
     prebuilt: bool,
 
-    #[clap(flatten)]
+    #[arg(flatten)]
     build: BuildArgs,
 
-    #[clap(flatten)]
+    #[arg(flatten)]
     run: RunArgs,
 
     /// Prints the bytecode size.
@@ -83,21 +83,21 @@ struct BuildArgs {
 #[derive(Parser, Debug)]
 struct RunArgs {
     /// Serialized arguments to the executable function.
-    #[clap(flatten)]
+    #[arg(flatten)]
     args: SerializedArgs,
     /// Whether to print the outputs.
     #[arg(long, default_value_t = false, conflicts_with = "build_only")]
     print_outputs: bool,
 
     /// When using dynamic layout, its parameters must be specified through a layout params file.
-    #[clap(long, default_value = "plain", value_enum, conflicts_with = "build_only")]
+    #[arg(long, default_value = "plain", value_enum, conflicts_with = "build_only")]
     layout: LayoutName,
     /// Required when using with dynamic layout.
     /// Ignored otherwise.
-    #[clap(long, required_if_eq("layout", "dynamic"))]
+    #[arg(long, required_if_eq("layout", "dynamic"))]
     cairo_layout_params_file: Option<PathBuf>,
     /// If set, the program will be run in standalone mode.
-    #[clap(
+    #[arg(
         long,
         default_value_t = false,
         conflicts_with_all = ["build_only", "output_path"],
@@ -105,10 +105,10 @@ struct RunArgs {
     )]
     standalone: bool,
     /// If set, the program will be run in secure mode.
-    #[clap(long, conflicts_with = "build_only")]
+    #[arg(long, conflicts_with = "build_only")]
     secure_run: Option<bool>,
     /// Can we allow for missing builtins.
-    #[clap(long, conflicts_with = "build_only")]
+    #[arg(long, conflicts_with = "build_only")]
     allow_missing_builtins: Option<bool>,
     /// Disable padding of the trace.
     /// By default, the trace is padded to accommodate the expected builtins-n_steps relationships
@@ -117,9 +117,9 @@ struct RunArgs {
     /// - It doesn't modify/pad n_steps.
     /// - It still pads each builtin segment to the next power of 2 (w.r.t the number of used
     ///   instances of the builtin) compared to their sizes at the end of the execution.
-    #[clap(long, conflicts_with = "build_only")]
+    #[arg(long, conflicts_with = "build_only")]
     disable_trace_padding: Option<bool>,
-    #[clap(flatten)]
+    #[arg(flatten)]
     proof_outputs: ProofOutputArgs,
 }
 
@@ -143,16 +143,16 @@ struct SerializedArgs {
 #[derive(Parser, Debug)]
 struct ProofOutputArgs {
     /// The resulting trace file.
-    #[clap(long, conflicts_with = "build_only")]
+    #[arg(long, conflicts_with = "build_only")]
     trace_file: Option<PathBuf>,
     /// The resulting memory file.
-    #[clap(long, conflicts_with = "build_only")]
+    #[arg(long, conflicts_with = "build_only")]
     memory_file: Option<PathBuf>,
     /// The resulting AIR public input file.
-    #[clap(long, conflicts_with = "build_only")]
+    #[arg(long, conflicts_with = "build_only")]
     air_public_input: Option<PathBuf>,
     /// The resulting AIR private input file.
-    #[clap(long, conflicts_with = "build_only", requires_all=["trace_file", "memory_file"])]
+    #[arg(long, conflicts_with = "build_only", requires_all=["trace_file", "memory_file"])]
     air_private_input: Option<PathBuf>,
 }
 

--- a/crates/bin/cairo-format/src/main.rs
+++ b/crates/bin/cairo-format/src/main.rs
@@ -21,7 +21,7 @@ fn eprintln_if_verbose(s: &str, verbose: bool) {
 /// Formats a file or directory with the Cairo formatter.
 /// Exits with 0/1 if the input is formatted correctly/incorrectly.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct FormatterArgs {
     /// Check mode, don't write the formatted files,
     /// just output the diff between the original and the formatted file.

--- a/crates/bin/cairo-run/src/main.rs
+++ b/crates/bin/cairo-run/src/main.rs
@@ -26,23 +26,18 @@ use clap::Parser;
 struct Args {
     /// The Cairo project path to compile and run.
     path: PathBuf,
-
     /// Whether path is a single file.
     #[arg(short, long)]
     single_file: bool,
-
     /// Allows the compilation to succeed with warnings.
     #[arg(long)]
     allow_warnings: bool,
-
     /// In cases where gas is available, the amount of provided gas.
     #[arg(long)]
     available_gas: Option<usize>,
-
     /// Whether to print the memory.
     #[arg(long, default_value_t = false)]
     print_full_memory: bool,
-
     /// Whether to run the profiler.
     #[arg(long, default_value_t = false)]
     run_profiler: bool,

--- a/crates/bin/cairo-run/src/main.rs
+++ b/crates/bin/cairo-run/src/main.rs
@@ -22,22 +22,27 @@ use clap::Parser;
 /// Compiles a Cairo project and runs the function `main`.
 /// Exits with 1 if the compilation or run fails, otherwise 0.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The Cairo project path to compile and run.
     path: PathBuf,
+
     /// Whether path is a single file.
     #[arg(short, long)]
     single_file: bool,
+
     /// Allows the compilation to succeed with warnings.
     #[arg(long)]
     allow_warnings: bool,
+
     /// In cases where gas is available, the amount of provided gas.
     #[arg(long)]
     available_gas: Option<usize>,
+
     /// Whether to print the memory.
     #[arg(long, default_value_t = false)]
     print_full_memory: bool,
+
     /// Whether to run the profiler.
     #[arg(long, default_value_t = false)]
     run_profiler: bool,

--- a/crates/bin/cairo-test/src/main.rs
+++ b/crates/bin/cairo-test/src/main.rs
@@ -30,7 +30,7 @@ impl From<RunProfilerConfigArg> for RunProfilerConfig {
 /// Compiles a Cairo project and runs all the functions marked as `#[test]`.
 /// Exits with 1 if the compilation or run fails, otherwise 0.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The Cairo project path to compile and run its tests.
     path: PathBuf,
@@ -54,7 +54,7 @@ struct Args {
     starknet: bool,
     /// Whether to run the profiler, and what results to produce. See
     /// [cairo_lang_test_runner::RunProfilerConfig]
-    #[clap(short, long, default_value_t, value_enum)]
+    #[arg(short, long, default_value_t, value_enum)]
     run_profiler: RunProfilerConfigArg,
     /// Should disable gas calculation.
     #[arg(long)]

--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -60,7 +60,7 @@ fn test_lowering_consistency() {
 ///
 /// Exits with 0/1 if the input is formatted correctly/incorrectly.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The crate to compile.
     path: PathBuf,

--- a/crates/bin/sierra-compile/src/main.rs
+++ b/crates/bin/sierra-compile/src/main.rs
@@ -11,7 +11,7 @@ use indoc::formatdoc;
 /// Compiles a Sierra file to CASM.
 /// Exits with 0/1 if the compilation succeeds/fails.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The path of the file to compile.
     file: String,

--- a/crates/bin/sierra-compile/src/main.rs
+++ b/crates/bin/sierra-compile/src/main.rs
@@ -14,11 +14,8 @@ use indoc::formatdoc;
 #[command(version, verbatim_doc_comment)]
 struct Args {
     /// The path of the file to compile.
-    #[arg()]
     file: String,
-
     /// The output file path.
-    #[arg()]
     output: String,
 }
 

--- a/crates/bin/sierra-compile/src/main.rs
+++ b/crates/bin/sierra-compile/src/main.rs
@@ -14,7 +14,11 @@ use indoc::formatdoc;
 #[command(version, verbatim_doc_comment)]
 struct Args {
     /// The path of the file to compile.
+    #[arg()]
     file: String,
+
+    /// The output file path.
+    #[arg()]
     output: String,
 }
 

--- a/crates/bin/starknet-compile/src/main.rs
+++ b/crates/bin/starknet-compile/src/main.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 /// Compiles the specified contract from a Cairo project, into a contract class file.
 /// Exits with 0/1 if the compilation succeeds/fails.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The path of the crate to compile.
     path: PathBuf,

--- a/crates/bin/starknet-sierra-compile/src/main.rs
+++ b/crates/bin/starknet-sierra-compile/src/main.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 /// Compiles a Sierra contract class into CASM contract class.
 /// Exits with 0/1 if the compilation succeeds/fails.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The path of the file to compile.
     file: String,

--- a/crates/bin/starknet-sierra-extract-code/src/main.rs
+++ b/crates/bin/starknet-sierra-extract-code/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 /// Extracts sierra code from a contract class file.
 /// Exits with 0/1 if the extraction succeeds/fails.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Args {
     /// The path of the file with the contract class.
     file: String,

--- a/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
+++ b/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
@@ -36,23 +36,18 @@ struct Cli {
         conflicts_with_all = ["fullnode_url", "fullnode_args"]
     )]
     input_files: Vec<String>,
-
     /// The allowed libfuncs list to use (default: most recent audited list).
     #[arg(long, conflicts_with = "allowed_libfuncs_list_file")]
     allowed_libfuncs_list_name: Option<String>,
-
     /// A file of the allowed libfuncs list to use.
     #[arg(long, conflicts_with = "allowed_libfuncs_list_name")]
     allowed_libfuncs_list_file: Option<String>,
-
     /// Sierra version to override to prior to compilation.
     #[arg(long)]
     override_version: Option<String>,
-
     /// The max bytecode size.
     #[arg(long, default_value_t = 180000)]
     max_bytecode_size: usize,
-
     /// The url of the rpc server, if provided - Sierra classes would be read from it, and no input
     /// files should be provided.
     #[arg(
@@ -62,10 +57,8 @@ struct Cli {
         conflicts_with = "input_files"
     )]
     fullnode_url: Option<String>,
-
     #[command(flatten)]
     fullnode_args: Option<FullnodeArgs>,
-
     /// The output file to write the Sierra classes into.
     #[arg(long)]
     class_info_output_file: Option<String>,

--- a/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
+++ b/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
@@ -28,37 +28,44 @@ const NUM_OF_PROCESSORS: usize = 32;
 /// 2. If class_info_output_file is not provided, it returns the report of the runs over the
 ///    processes of the classes.
 #[derive(Parser, Debug)]
-#[clap(version, verbatim_doc_comment)]
+#[command(version, verbatim_doc_comment)]
 struct Cli {
     /// The input files with declared classes info.
     #[arg(
         required_unless_present = "fullnode_url",
-        conflicts_with_all = ["fullnode_url", "FullnodeArgs"],
+        conflicts_with_all = ["fullnode_url", "fullnode_args"]
     )]
     input_files: Vec<String>,
+
     /// The allowed libfuncs list to use (default: most recent audited list).
     #[arg(long, conflicts_with = "allowed_libfuncs_list_file")]
     allowed_libfuncs_list_name: Option<String>,
+
     /// A file of the allowed libfuncs list to use.
     #[arg(long, conflicts_with = "allowed_libfuncs_list_name")]
     allowed_libfuncs_list_file: Option<String>,
+
     /// Sierra version to override to prior to compilation.
     #[arg(long)]
     override_version: Option<String>,
+
     /// The max bytecode size.
     #[arg(long, default_value_t = 180000)]
     max_bytecode_size: usize,
+
     /// The url of the rpc server, if provided - Sierra classes would be read from it, and no input
     /// files should be provided.
     #[arg(
         long,
-        requires_all = &["FullnodeArgs"], 
+        requires_all = ["fullnode_args"], 
         required_unless_present = "input_files", 
         conflicts_with = "input_files"
     )]
     fullnode_url: Option<String>,
-    #[clap(flatten)]
+
+    #[command(flatten)]
     fullnode_args: Option<FullnodeArgs>,
+
     /// The output file to write the Sierra classes into.
     #[arg(long)]
     class_info_output_file: Option<String>,


### PR DESCRIPTION
This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

Fixes #7450 
