### PR TITLE
Fix secp256r1 test function name

### DIFF
--- a/corelib/src/test/secp256r1_test.cairo
+++ b/corelib/src/test/secp256r1_test.cairo
@@ -5,7 +5,7 @@ use crate::option::OptionTrait;
 use crate::test::test_utils::assert_eq;
 
 #[test]
-fn test_secp256k1_point_serde() {
+fn test_secp256r1_point_serde() {
     let (x, y): (u256, u256) = (
         0x04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5,
         0x0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d,

--- a/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
@@ -62,7 +62,7 @@ fn test_library_dispatcher_serialization() {
 
 
 // Calls `withdraw_gas` and then returns the available gas.
-// This is useful in test as the `withdraw_gas` allows the gas wallet to be ~0 at the call site.
+// This is useful in a test as the `withdraw_gas` allows the gas wallet to be ~0 at the call site.
 // Note that this function must be `inline(always)`.
 #[inline(always)]
 pub fn withdraw_and_get_available_gas() -> u128 {


### PR DESCRIPTION
This PR fixes a typo in the test function name by changing `test_secp256k1_point_serde()` to `test_secp256r1_point_serde()` to correctly reflect that this test is for `secp256r1` curve, not `secp256k1`

**Changes made:**
- Renamed test function in `corelib/src/test/secp256r1_test.cairo`
- Minor comment formatting adjustment in `abi_dispatchers_tests.cairo`