### PR TITLE
Fix typo in felt252 type name in storage_node.cairo

### DIFF
--- a/corelib/src/starknet/storage/storage_node.cairo
+++ b/corelib/src/starknet/storage/storage_node.cairo
@@ -34,7 +34,7 @@
 //! #[starknet::storage_node]
 //! struct MyStruct {
 //!    a: felt252,
-//!    b: Map<felt252, felt52>,
+//!    b: Map<felt252, felt252>,
 //! }
 //! ```
 //!
@@ -43,7 +43,7 @@
 //! ```
 //! struct MyStructStorageNode {
 //!     a: PendingStoragePath<felt252>,
-//!     b: PendingStoragePath<Map<felt252, felt52>>,
+//!     b: PendingStoragePath<Map<felt252, felt252>>,
 //! }
 //!
 //! impl MyStructStorageNodeImpl of StorageNode<MyStruct> {


### PR DESCRIPTION
This PR fixes a typo in the storage_node.cairo file where "felt52" was incorrectly written instead of "felt252".

Changes made:
- Corrected "felt52" to "felt252" in Map type declarations
- Updated both the struct definition and storage node implementation