### PR TITLE
Fix Grammar Issues in Documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/ROOT/pages/index.adoc
+++ b/docs/reference/src/components/cairo/modules/ROOT/pages/index.adoc
@@ -32,5 +32,5 @@ site.
 |link:https://github.com/starkware-libs/cairo/issues/new?assignees=&labels=enhancement&template=02_FEATURE_REQUEST.md&title=feat%3A+[Request a feature]
 |link:https://github.com/starkware-libs/cairo/discussions[Ask a Question]
 |link:https://github.com/starkware-libs/cairo/actions/workflows/ci.yml[GitHub Workflow Status]
-|link:https://github.com/starkware-libs/cairo/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22[Submit a pull requests]
+|link:https://github.com/starkware-libs/cairo/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22[Submit a pull request]
 |===

--- a/docs/reference/src/components/cairo/modules/ROOT/pages/roadmap.adoc
+++ b/docs/reference/src/components/cairo/modules/ROOT/pages/roadmap.adoc
@@ -4,7 +4,7 @@ The next milestone is to reach feature parity with Cairo version 0.
 
 In this section we track the missing features to reach feature parity with the old compiler version.
 
-We divided them by Cairo, Starknet and specific system calls in Starknet OS.
+We divided them into Cairo, Starknet and specific system calls in Starknet OS.
 
 
 ## Cairo features


### PR DESCRIPTION

The word "requests" was incorrect in this context. Since we are referring to a single pull request, "request" should be in singular form.

"Divided by" → "Divided into"
The phrase "divided by" is generally used in mathematical contexts (e.g., "10 divided by 2").
The correct preposition for categorizing elements is "into" (e.g., "divided into sections").