### PR TITLE
Extend the AsSegments trait to indicate if the segments have a dollar…

### DIFF
--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -249,15 +249,28 @@ enum UseStarResult {
 /// A trait for things that can be interpreted as a path of segments.
 pub trait AsSegments {
     fn to_segments(self, db: &dyn SyntaxGroup) -> Vec<ast::PathSegment>;
+    /// Is the path prefixed with a `$`, indicating a resolver site modifier.
+    fn is_placeholder(&self, db: &dyn SyntaxGroup) -> bool;
 }
 impl AsSegments for &ast::ExprPath {
     fn to_segments(self, db: &dyn SyntaxGroup) -> Vec<ast::PathSegment> {
         self.segments(db).elements(db)
     }
+    fn is_placeholder(&self, db: &dyn SyntaxGroup) -> bool {
+        match self.dollar(db) {
+            ast::OptionTerminalDollar::Empty(_) => false,
+            ast::OptionTerminalDollar::TerminalDollar(_) => true,
+        }
+    }
 }
 impl AsSegments for Vec<ast::PathSegment> {
     fn to_segments(self, _: &dyn SyntaxGroup) -> Vec<ast::PathSegment> {
         self
+    }
+    fn is_placeholder(&self, _: &dyn SyntaxGroup) -> bool {
+        // A dollar can prefix only the first segment of a path, thus irrelevant to a list of
+        // segments.
+        false
     }
 }
 


### PR DESCRIPTION
… prefix.