### PR TITLE
Fix Grammar Issues

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/block-expression.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/block-expression.adoc
@@ -13,7 +13,7 @@ flow control expression.
 Furthermore, extra semicolons between statements are allowed, but these semicolons do not affect
 semantics.
 
-The type of a block is the type of the final operand if exists.
+The type of a block is the type of the final operand if it exists.
 Otherwise, if the last statement is a xref:never-type.adoc[never type] emitting statement (e.g.
 return, break) the block's type is the xref:never-type.adoc[never type], otherwise it is the
 xref:unit-type.adoc[unit type].

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/integer-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/integer-types.adoc
@@ -14,7 +14,7 @@ Cairo uses the following integer types:
 | u256  | 0       | 2^256 - 1
 |===
 
-The `usize` type is an alias to `u32`, and is used for array indexing.
+The `usize` type is an alias for `u32`, and is used for array indexing.
 
 == Integer Creation
 


### PR DESCRIPTION
1. File: block-expression.adoc
Change:

Old: "The type of a block is the type of the final operand if exists."
New: "The type of a block is the type of the final operand if it exists."
Reason for Change:
The original sentence was grammatically incorrect. "If exists" is incorrect in English; the correct phrasing is "if it exists" since "it" is required to reference the noun "operand."

2. File: integer-types.adoc
Change:

Old: "The usize type is an alias to u32, and is used for array indexing."
New: "The usize type is an alias for u32, and is used for array indexing."
Reason for Change:
The phrase "is an alias to" is incorrect. The correct usage is "is an alias for" when referring to something being another name for an entity. This change ensures proper English syntax and maintains consistency with common technical documentation.

