### PR TITLE
Fix starknet-sierra-upgrade-validate/src/main.rs warning

### DIFF
--- a/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
+++ b/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
@@ -52,8 +52,8 @@ struct Cli {
     /// files should be provided.
     #[arg(
         long,
-        requires_all = ["fullnode_args"], 
-        required_unless_present = "input_files", 
+        requires_ifs = [("fullnode_args", "true")],
+        required_unless_present = "input_files",
         conflicts_with = "input_files"
     )]
     fullnode_url: Option<String>,


### PR DESCRIPTION
use of deprecated method `clap::Arg::requires_all`: Replaced with `Arg::requires_ifs`
