### PR TITLE
Extended the types that are considered droppable and duplicatable.

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -9,12 +9,12 @@ use cairo_lang_sierra::extensions::{ConcreteType, GenericTypeEx};
 use cairo_lang_sierra::ids::ConcreteTypeId;
 use cairo_lang_utils::{LookupIntern, Upcast};
 use lowering::ids::ConcreteFunctionWithBodyId;
-use semantic::items::imp::ImplLookupContext;
 use {cairo_lang_lowering as lowering, cairo_lang_semantic as semantic};
 
 use crate::program_generator::{self, SierraProgramWithDebug};
 use crate::replace_ids::SierraIdReplacer;
 use crate::specialization_context::SierraSignatureSpecializationContext;
+use crate::types::cycle_breaker_info;
 use crate::{ap_change, function_generator, pre_sierra, replace_ids};
 
 /// Helper type for Sierra long ids, which can be either a type long id or a cycle breaker.
@@ -194,13 +194,12 @@ fn get_type_info(
     let long_id = match concrete_type_id.lookup_intern(db) {
         SierraGeneratorTypeLongId::Regular(long_id) => long_id,
         SierraGeneratorTypeLongId::CycleBreaker(ty) => {
-            let long_id = db.get_concrete_long_type_id(ty)?.as_ref().clone();
-            let info = db.type_info(ImplLookupContext::default(), ty)?;
+            let info = cycle_breaker_info(db, ty)?;
             return Ok(Arc::new(cairo_lang_sierra::extensions::types::TypeInfo {
-                long_id,
+                long_id: db.get_concrete_long_type_id(ty)?.as_ref().clone(),
                 storable: true,
-                droppable: info.droppable.is_ok(),
-                duplicatable: info.copyable.is_ok(),
+                droppable: info.droppable,
+                duplicatable: info.duplicatable,
                 zero_sized: false,
             }));
         }

--- a/crates/cairo-lang-sierra-generator/src/types.rs
+++ b/crates/cairo-lang-sierra-generator/src/types.rs
@@ -6,13 +6,13 @@ use cairo_lang_diagnostics::Maybe;
 use cairo_lang_lowering::ids::SemanticFunctionIdEx;
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::items::enm::SemanticEnumEx;
+use cairo_lang_semantic::items::imp::ImplLookupContext;
 use cairo_lang_sierra::extensions::snapshot::snapshot_ty;
 use cairo_lang_sierra::ids::UserTypeId;
 use cairo_lang_sierra::program::{ConcreteTypeLongId, GenericArg as SierraGenericArg};
 use cairo_lang_utils::{Intern, LookupIntern, try_extract_matches};
 use itertools::chain;
 use num_traits::ToPrimitive;
-use semantic::items::imp::ImplLookupContext;
 
 use crate::db::{SierraGenGroup, SierraGeneratorTypeLongId, sierra_concrete_long_id};
 use crate::specialization_context::SierraSignatureSpecializationContext;
@@ -23,23 +23,27 @@ pub fn get_concrete_type_id(
     type_id: semantic::TypeId,
 ) -> Maybe<cairo_lang_sierra::ids::ConcreteTypeId> {
     match type_id.lookup_intern(db) {
-        semantic::TypeLongId::Snapshot(inner_ty)
-            if db.type_info(ImplLookupContext::default(), inner_ty)?.copyable.is_ok() =>
-        {
-            db.get_concrete_type_id(inner_ty)
+        semantic::TypeLongId::Snapshot(inner_ty) => {
+            let inner = db.get_concrete_type_id(inner_ty)?;
+            if matches!(
+                inner.lookup_intern(db),
+                SierraGeneratorTypeLongId::CycleBreaker(ty) if cycle_breaker_info(db, ty)?.duplicatable
+            ) {
+                return Ok(inner);
+            }
         }
         semantic::TypeLongId::Concrete(
             semantic::ConcreteTypeId::Enum(_) | semantic::ConcreteTypeId::Struct(_),
         ) if db.is_self_referential(type_id)? => {
-            Ok(SierraGeneratorTypeLongId::CycleBreaker(type_id).intern(db))
+            return Ok(SierraGeneratorTypeLongId::CycleBreaker(type_id).intern(db));
         }
-        _ => Ok(if type_id.is_phantom(db.upcast()) {
-            SierraGeneratorTypeLongId::Phantom(type_id)
-        } else {
-            SierraGeneratorTypeLongId::Regular(db.get_concrete_long_type_id(type_id)?)
+        _ => {
+            if type_id.is_phantom(db.upcast()) {
+                return Ok(SierraGeneratorTypeLongId::Phantom(type_id).intern(db));
+            }
         }
-        .intern(db)),
     }
+    Ok(SierraGeneratorTypeLongId::Regular(db.get_concrete_long_type_id(type_id)?).intern(db))
 }
 
 /// See [SierraGenGroup::get_index_enum_type_id] for documentation.
@@ -236,4 +240,39 @@ pub fn has_in_deps_cycle(
     _needle: &semantic::TypeId,
 ) -> Maybe<bool> {
     Ok(false)
+}
+
+/// Information about a cycle breaker type.
+pub struct CycleBreakerTypeInfo {
+    /// Is the type duplicatable in Sierra - it is considered it is so if it is `Copy` or all its
+    /// dependencies are `Copy`.
+    pub duplicatable: bool,
+    /// Is the type droppable in Sierra - it is considered it is so if it is `Drop` or all its
+    /// dependencies are `Drop`.
+    pub droppable: bool,
+}
+
+/// Returns the approximation of `ty`s droppable and copyable traits.
+///
+/// Assumes the type is a cycle breaker.
+pub fn cycle_breaker_info(
+    db: &dyn SierraGenGroup,
+    ty: semantic::TypeId,
+) -> Maybe<CycleBreakerTypeInfo> {
+    let info = db.type_info(ImplLookupContext::default(), ty)?;
+    if info.copyable.is_ok() && info.droppable.is_ok() {
+        return Ok(CycleBreakerTypeInfo { duplicatable: true, droppable: true });
+    }
+    let mut deps_copyable = true;
+    let mut deps_droppable = true;
+    let deps = db.type_dependencies(ty)?;
+    for dep in deps.iter() {
+        let dep_info = db.type_info(ImplLookupContext::default(), *dep)?;
+        deps_copyable &= dep_info.copyable.is_ok();
+        deps_droppable &= dep_info.droppable.is_ok();
+    }
+    Ok(CycleBreakerTypeInfo {
+        duplicatable: info.copyable.is_ok() || deps_copyable,
+        droppable: info.droppable.is_ok() || deps_droppable,
+    })
 }

--- a/tests/bug_samples/lib.cairo
+++ b/tests/bug_samples/lib.cairo
@@ -66,4 +66,5 @@ mod loop_break_in_match;
 mod loop_only_change;
 mod partial_param_local;
 mod revoked_locals;
+mod self_ref_non_derived;
 mod zero_sized_locals;

--- a/tests/bug_samples/self_ref_non_derived.cairo
+++ b/tests/bug_samples/self_ref_non_derived.cairo
@@ -1,0 +1,19 @@
+#[test]
+fn foo() -> E {
+    let e = E::A;
+    bar(@e);
+    e
+}
+
+#[inline(never)]
+fn bar(e: @E) nopanic {
+    match e {
+        E::R(_) => {},
+        E::A => {},
+    }
+}
+
+enum E {
+    R: Box<@E>,
+    A,
+}


### PR DESCRIPTION
Fixes issue with self referencing types not `derive(Drop)` or `derive(Copy)` where all
their members are known to be `Drop` or `Copy`.