### PR TITLE
Optimize NonZeroNeg implementation using bounded integers

### DIFF
--- a/corelib/src/zeroable.cairo
+++ b/corelib/src/zeroable.cairo
@@ -82,12 +82,14 @@ pub extern type NonZero<T>;
 impl NonZeroCopy<T> of Copy<NonZero<T>>;
 impl NonZeroDrop<T> of Drop<NonZero<T>>;
 
-impl NonZeroNeg<T, +Neg<T>, +TryInto<T, NonZero<T>>> of Neg<NonZero<T>> {
+use crate::internal::bounded_int::{NegateHelper};
+
+impl NonZeroNeg<
+    T, +Neg<T>, +TryInto<T, NonZero<T>>, impl NH: NegateHelper<NonZero<T>>
+> of Neg<NonZero<T>> {
     fn neg(a: NonZero<T>) -> NonZero<T> {
-        // TODO(orizi): Optimize using bounded integers.
-        let value: T = a.into();
-        let negated: T = -value;
-        negated.try_into().unwrap()
+        // Using bounded integers for more efficient negation
+        NH::negate(a)
     }
 }
 


### PR DESCRIPTION
This commit optimizes the negation operation for NonZero types by leveraging bounded integers
and the NegateHelper trait already present in the codebase. The previous implementation
unwrapped the NonZero value, negated it, and then tried to wrap it back in a NonZero
container. The new implementation uses the more efficient bounded integer operations,
which provide better type safety and maintain the NonZero property throughout the
computation without unnecessary conversions.
The change addresses the TODO comment in corelib/src/zeroable.cairo that suggested
using bounded integers for this optimization.