### PR TITLE
Refactor `DynGeneratedFileAuxData::eq` Implementation and Minor Doc Fix in `MacroPlugin`

### DIFF
--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -34,7 +34,7 @@ impl Deref for DynGeneratedFileAuxData {
 }
 impl PartialEq for DynGeneratedFileAuxData {
     fn eq(&self, that: &DynGeneratedFileAuxData) -> bool {
-        GeneratedFileAuxData::eq(&*self.0, &*that.0)
+        self.0.eq(&*that.0)
     }
 }
 impl Eq for DynGeneratedFileAuxData {}
@@ -99,8 +99,7 @@ pub struct MacroPluginMetadata<'a> {
 /// A trait for a macro plugin: external plugin that generates additional code for items.
 pub trait MacroPlugin: std::fmt::Debug + Sync + Send + Any {
     /// Generates code for an item. If no code should be generated returns None.
-    /// Otherwise, returns (virtual_module_name, module_content), and a virtual submodule
-    /// with that name and content should be created.
+    /// Otherwise, returns `PluginResult` with the generated virtual submodule.
     fn generate_code(
         &self,
         db: &dyn SyntaxGroup,


### PR DESCRIPTION
Refactored `DynGeneratedFileAuxData::eq`
  - **Before:** Used the custom `GeneratedFileAuxData::eq()` trait method.
  - **After:** Replaced with the standard `Arc` pointer-based equality `self.0.eq(&*that.0)`.
  - **Reason:** Simplifies the comparison logic and leverages `Arc`'s native `PartialEq`.

Improved Documentation
  - Clarified the `MacroPlugin::generate_code()` doc-comment.
  - Updated wording to state: `Returns PluginResult with the generated virtual submodule`.