### PR TITLE
fix: replace deprecated requires_all with requires_ifs

### DIFF
--- a/crates/bin/cairo-execute/src/main.rs
+++ b/crates/bin/cairo-execute/src/main.rs
@@ -101,7 +101,7 @@ struct RunArgs {
         long,
         default_value_t = false,
         conflicts_with_all = ["build_only", "output_path"],
-        requires_all=["air_public_input", "air_private_input"],
+        requires_ifs = [("standalone", "air_public_input"), ("standalone", "air_private_input")],
     )]
     standalone: bool,
     /// If set, the program will be run in secure mode.
@@ -152,7 +152,11 @@ struct ProofOutputArgs {
     #[arg(long, conflicts_with = "build_only")]
     air_public_input: Option<PathBuf>,
     /// The resulting AIR private input file.
-    #[arg(long, conflicts_with = "build_only", requires_all=["trace_file", "memory_file"])]
+    #[arg(
+        long,
+        conflicts_with = "build_only",
+        requires_ifs = [("standalone", "trace_file"), ("standalone", "memory_file")]
+    )]
     air_private_input: Option<PathBuf>,
 }
 

--- a/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
+++ b/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
@@ -52,7 +52,7 @@ struct Cli {
     /// files should be provided.
     #[arg(
         long,
-        requires_all = ["fullnode_args"], 
+        requires_ifs = [("fullnode_url", "fullnode_args")], 
         required_unless_present = "input_files", 
         conflicts_with = "input_files"
     )]


### PR DESCRIPTION
In clap v4.x, the usage of #[clap(...)] with `requires_all` is deprecated.
This PR replaces all deprecated `requires_all` attributes with the correct `requires_ifs` syntax as required by clap 4.x.

Before fix:
`cargo check --features clap/deprecated`

![Pasted Graphic 80](https://github.com/user-attachments/assets/6f633699-1608-4eb1-904f-8b599b8b161e)

After Fix : 
`cargo check --features clap/deprecated`

![Pasted Graphic 82](https://github.com/user-attachments/assets/1d2e1849-8da3-4000-b4e3-08ef4bd34b15)

`cargo build`

![Pasted Graphic 83](https://github.com/user-attachments/assets/75fd79b9-e6b8-4ba2-bee1-8f38eb0ec117)

