### PR TITLE
Kinga/doc markdown formatting

### DIFF
--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -16,9 +16,10 @@ use cairo_lang_syntax::node::ast::{Expr, ExprPath, ItemModule};
 use cairo_lang_syntax::node::helpers::GetIdentifier;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode};
 use cairo_lang_utils::Intern;
+use itertools::Itertools;
 use pulldown_cmark::{
-    BrokenLink, CodeBlockKind, Event, HeadingLevel, LinkType, Options, Parser as MarkdownParser,
-    Tag, TagEnd,
+    Alignment, BrokenLink, CodeBlockKind, Event, HeadingLevel, LinkType, Options,
+    Parser as MarkdownParser, Tag, TagEnd,
 };
 
 use crate::db::DocGroup;
@@ -94,9 +95,11 @@ impl<'a> DocumentationCommentParser<'a> {
             None
         };
 
+        let mut options = Options::empty();
+        options.insert(Options::ENABLE_TABLES);
         let parser = MarkdownParser::new_with_broken_link_callback(
             &documentation_comment,
-            Options::empty(),
+            options,
             Some(&mut replacer),
         );
 
@@ -121,8 +124,8 @@ impl<'a> DocumentationCommentParser<'a> {
                 }
             };
         let mut prefix_list_item = false;
-
         let mut last_two_events = [None, None];
+        let mut table_alignment: Vec<Alignment> = Vec::new();
 
         for event in parser {
             let current_event = event.clone();
@@ -226,17 +229,24 @@ impl<'a> DocumentationCommentParser<'a> {
                                 }
                             }
                         }
-                        Tag::Paragraph => {
+                        Tag::Paragraph | Tag::TableRow => {
                             tokens.push(DocumentationCommentToken::Content("\n".to_string()));
                         }
                         Tag::Item => {
                             prefix_list_item = true;
                         }
+                        Tag::Table(alignment) => {
+                            table_alignment = alignment;
+                            tokens.push(DocumentationCommentToken::Content("\n\n".to_string()));
+                        }
+                        Tag::TableCell => {
+                            tokens.push(DocumentationCommentToken::Content("|".to_string()));
+                        }
                         _ => {}
                     }
                 }
                 Event::End(tag_end) => match tag_end {
-                    TagEnd::Heading(_) => {
+                    TagEnd::Heading(_) | TagEnd::Table => {
                         tokens.push(DocumentationCommentToken::Content("\n".to_string()));
                     }
                     TagEnd::List(_) => {
@@ -249,6 +259,19 @@ impl<'a> DocumentationCommentParser<'a> {
                             tokens.push(DocumentationCommentToken::Content("\n".to_string()));
                         }
                     }
+                    TagEnd::TableHead => {
+                        tokens.push(DocumentationCommentToken::Content(format!(
+                            "|\n|{}|",
+                            table_alignment
+                                .iter()
+                                .map(|a| {
+                                    let (left, right) = get_alignment_markers(a);
+                                    format!("{}---{}", left, right)
+                                })
+                                .join("|")
+                        )));
+                        table_alignment.clear();
+                    }
                     TagEnd::CodeBlock => {
                         if !is_indented_code_block {
                             tokens.push(DocumentationCommentToken::Content("```\n".to_string()));
@@ -260,10 +283,16 @@ impl<'a> DocumentationCommentParser<'a> {
                             tokens.push(DocumentationCommentToken::Link(link));
                         }
                     }
+                    TagEnd::TableRow => {
+                        tokens.push(DocumentationCommentToken::Content("|".to_string()));
+                    }
                     _ => {}
                 },
                 Event::SoftBreak => {
                     tokens.push(DocumentationCommentToken::Content("\n".to_string()));
+                }
+                Event::Rule => {
+                    tokens.push(DocumentationCommentToken::Content("\n___\n".to_string()));
                 }
                 _ => {}
             }
@@ -506,4 +535,15 @@ fn heading_level_to_markdown(heading_level: HeadingLevel) -> String {
         HeadingLevel::H5 => heading_char.repeat(5),
         HeadingLevel::H6 => heading_char.repeat(6),
     }
+}
+
+/// Maps [`Alignment`] to correct markdown markers.
+fn get_alignment_markers(alignment: &Alignment) -> (String, String) {
+    let (left, right) = match alignment {
+        Alignment::None => ("", ""),
+        Alignment::Left => (":", ""),
+        Alignment::Right => ("", ":"),
+        Alignment::Center => (":", ":"),
+    };
+    (left.to_string(), right.to_string())
 }

--- a/crates/cairo-lang-doc/src/tests/test-data/rules_formatting.txt
+++ b/crates/cairo-lang-doc/src/tests/test-data/rules_formatting.txt
@@ -1,0 +1,48 @@
+//! > Documentation submodules
+
+//! > test_runner_name
+documentation_test_runner
+
+//! > cairo_project.toml
+[crate_roots]
+hello = "src"
+
+//! > cairo_code
+//! Use three or more asterisks, dashes, or underscores in one lines.
+//! ***
+//! Without blank lines, this would be a heading.
+//!
+//! -----
+//! This is also a valid way to create a horizontal rule.
+//! _____ __ __
+//! And this shouldn't work.
+//! ---_
+
+//! > Item signature #1
+//! > Item documentation #1
+Use three or more asterisks, dashes, or underscores in one lines.
+___
+
+Without blank lines, this would be a heading.
+___
+
+This is also a valid way to create a horizontal rule.
+___
+
+And this shouldn't work.
+---_
+
+//! > Item documentation tokens #1
+Content("Use three or more asterisks, dashes, or underscores in one lines.")
+Content("\n___\n")
+Content("\n")
+Content("Without blank lines, this would be a heading.")
+Content("\n___\n")
+Content("\n")
+Content("This is also a valid way to create a horizontal rule.")
+Content("\n___\n")
+Content("\n")
+Content("And this shouldn't work.")
+Content("\n")
+Content("---")
+Content("_")

--- a/crates/cairo-lang-doc/src/tests/test-data/tables_formatting.txt
+++ b/crates/cairo-lang-doc/src/tests/test-data/tables_formatting.txt
@@ -1,0 +1,139 @@
+//! > Documentation submodules
+
+//! > test_runner_name
+documentation_test_runner
+
+//! > cairo_project.toml
+[crate_roots]
+hello = "src"
+
+//! > cairo_code
+//! simple table with alignment
+//! |C1| C2|
+//! |---:|:---:|
+//! |R1C1|R1C2|
+//! |R2C1|R2C2|
+//!
+//! A more complicated real case study from corelib.
+//! | method  | self     | input     | output   |
+//! |---------|----------|-----------|----------|
+//! | [`and`] | `Err(e)` | (ignored) | `Err(e)` |
+//! | [`and`] | `Ok(x)`  | `Err(d)`  | `Err(d)` |
+//! | [`and`] | `Ok(x)`  | `Ok(y)`   | `Ok(y)`  |
+//! | [`or`]  | `Err(e)` | `Err(d)`  | `Err(d)` |
+//! | [`or`]  | `Err(e)` | `Ok(y)`   | `Ok(y)`  |
+//! | [`or`]  | `Ok(x)`  | (ignored) | `Ok(x)`  |
+
+//! > Item signature #1
+//! > Item documentation #1
+simple table with alignment
+
+|C1|C2|
+|---:|:---:|
+|R1C1|R1C2|
+|R2C1|R2C2|
+
+A more complicated real case study from corelib.
+
+|method|self|input|output|
+|---|---|---|---|
+|[`and`]|`Err(e)`|(ignored)|`Err(e)`|
+|[`and`]|`Ok(x)`|`Err(d)`|`Err(d)`|
+|[`and`]|`Ok(x)`|`Ok(y)`|`Ok(y)`|
+|[`or`]|`Err(e)`|`Err(d)`|`Err(d)`|
+|[`or`]|`Err(e)`|`Ok(y)`|`Ok(y)`|
+|[`or`]|`Ok(x)`|(ignored)|`Ok(x)`|
+
+//! > Item documentation tokens #1
+Content("simple table with alignment")
+Content("\n\n")
+Content("|")
+Content("C1")
+Content("|")
+Content("C2")
+Content("|\n|---:|:---:|")
+Content("\n")
+Content("|")
+Content("R1C1")
+Content("|")
+Content("R1C2")
+Content("|")
+Content("\n")
+Content("|")
+Content("R2C1")
+Content("|")
+Content("R2C2")
+Content("|")
+Content("\n")
+Content("\n")
+Content("A more complicated real case study from corelib.")
+Content("\n\n")
+Content("|")
+Content("method")
+Content("|")
+Content("self")
+Content("|")
+Content("input")
+Content("|")
+Content("output")
+Content("|\n|---|---|---|---|")
+Content("\n")
+Content("|")
+CommentLinkToken { label: "`and`", path: None, resolved_item_name: None }
+Content("|")
+Content("`Err(e)`")
+Content("|")
+Content("(ignored)")
+Content("|")
+Content("`Err(e)`")
+Content("|")
+Content("\n")
+Content("|")
+CommentLinkToken { label: "`and`", path: None, resolved_item_name: None }
+Content("|")
+Content("`Ok(x)`")
+Content("|")
+Content("`Err(d)`")
+Content("|")
+Content("`Err(d)`")
+Content("|")
+Content("\n")
+Content("|")
+CommentLinkToken { label: "`and`", path: None, resolved_item_name: None }
+Content("|")
+Content("`Ok(x)`")
+Content("|")
+Content("`Ok(y)`")
+Content("|")
+Content("`Ok(y)`")
+Content("|")
+Content("\n")
+Content("|")
+CommentLinkToken { label: "`or`", path: None, resolved_item_name: None }
+Content("|")
+Content("`Err(e)`")
+Content("|")
+Content("`Err(d)`")
+Content("|")
+Content("`Err(d)`")
+Content("|")
+Content("\n")
+Content("|")
+CommentLinkToken { label: "`or`", path: None, resolved_item_name: None }
+Content("|")
+Content("`Err(e)`")
+Content("|")
+Content("`Ok(y)`")
+Content("|")
+Content("`Ok(y)`")
+Content("|")
+Content("\n")
+Content("|")
+CommentLinkToken { label: "`or`", path: None, resolved_item_name: None }
+Content("|")
+Content("`Ok(x)`")
+Content("|")
+Content("(ignored)")
+Content("|")
+Content("`Ok(x)`")
+Content("|")

--- a/crates/cairo-lang-doc/src/tests/test.rs
+++ b/crates/cairo-lang-doc/src/tests/test.rs
@@ -24,6 +24,8 @@ cairo_lang_test_utils::test_file_test!(
     comment_markers: "comment_markers.txt",
     signature: "signature.txt",
     lists_formatting: "lists_formatting.txt",
+    tables_formatting: "tables_formatting.txt",
+    rules_formatting: "rules_formatting.txt",
   },
   documentation_test_runner
 );


### PR DESCRIPTION
closes https://github.com/software-mansion/scarb/issues/2093

~It is a Draft because the branch is based on https://github.com/FroyaTheHen/cairo/tree/kinga/ref-parse-doc-comments, it heavily realies on the same changes. I will rebase it to main after the https://github.com/starkware-libs/cairo/pull/7492 is merged to improve readability and make it _ready for review_ then.~