### PR TITLE
Add optional `relative_span` to `PluginDiagnostic`

### DIFF
--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -1757,6 +1757,7 @@ impl PluginDiagnosticCached {
     fn embed(self, ctx: &mut DefCacheLoadingContext<'_>) -> PluginDiagnostic {
         PluginDiagnostic {
             stable_ptr: self.stable_ptr.embed(ctx),
+            relative_span: None,
             message: self.message,
             severity: match self.severity {
                 SeverityCached::Error => Severity::Error,

--- a/crates/cairo-lang-defs/src/diagnostic_utils.rs
+++ b/crates/cairo-lang-defs/src/diagnostic_utils.rs
@@ -56,6 +56,16 @@ impl StableLocation {
         let end = until_stable_ptr.lookup(syntax_db).span_end_without_trivia(syntax_db);
         DiagnosticLocation { file_id: self.0.file_id(syntax_db), span: TextSpan { start, end } }
     }
+
+    /// Returns the [DiagnosticLocation] that corresponds to the [StableLocation] with precise span
+    /// that might not exactly match the span of the syntax node.
+    pub fn diagnostic_location_with_span(
+        &self,
+        db: &dyn DefsGroup,
+        span: TextSpan,
+    ) -> DiagnosticLocation {
+        DiagnosticLocation { file_id: self.file_id(db), span }
+    }
 }
 
 impl DebugWithDb<dyn DefsGroup> for StableLocation {

--- a/crates/cairo-lang-defs/src/diagnostic_utils.rs
+++ b/crates/cairo-lang-defs/src/diagnostic_utils.rs
@@ -57,9 +57,8 @@ impl StableLocation {
         DiagnosticLocation { file_id: self.0.file_id(syntax_db), span: TextSpan { start, end } }
     }
 
-    /// Returns the [DiagnosticLocation] corresponding to a span defined by offsets relative to the
-    /// start of the syntax node, allowing partial highlighting of the node with character-level
-    /// precision.
+    /// Returns the [DiagnosticLocation] corresponding to a subrange of the [StableLocation],
+    /// defined by character offsets relative to the start of the syntax node.
     pub fn diagnostic_location_with_offsets(
         &self,
         db: &dyn DefsGroup,

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -73,7 +73,9 @@ pub struct PluginResult {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PluginDiagnostic {
     pub stable_ptr: SyntaxStablePtrId,
-    /// Span relative to the start of the `stable_ptr`
+    /// Span relative to the start of the `stable_ptr`.
+    /// No assertion is made that the span is fully contained within the node pointed to by `stable_ptr`.
+    /// When printing diagnostics, any part of the span that falls outside the referenced node will be silently ignored.
     pub relative_span: Option<TextSpan>,
     pub message: String,
     pub severity: Severity,

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -74,8 +74,9 @@ pub struct PluginResult {
 pub struct PluginDiagnostic {
     pub stable_ptr: SyntaxStablePtrId,
     /// Span relative to the start of the `stable_ptr`.
-    /// No assertion is made that the span is fully contained within the node pointed to by `stable_ptr`.
-    /// When printing diagnostics, any part of the span that falls outside the referenced node will be silently ignored.
+    /// No assertion is made that the span is fully contained within the node pointed to by
+    /// `stable_ptr`. When printing diagnostics, any part of the span that falls outside the
+    /// referenced node will be silently ignored.
     pub relative_span: Option<TextSpan>,
     pub message: String,
     pub severity: Severity,

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -73,7 +73,8 @@ pub struct PluginResult {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PluginDiagnostic {
     pub stable_ptr: SyntaxStablePtrId,
-    pub span: Option<TextSpan>,
+    /// Span relative to the start of the `stable_ptr`
+    pub relative_span: Option<TextSpan>,
     pub message: String,
     pub severity: Severity,
 }
@@ -81,7 +82,7 @@ impl PluginDiagnostic {
     pub fn error(stable_ptr: impl Into<SyntaxStablePtrId>, message: String) -> PluginDiagnostic {
         PluginDiagnostic {
             stable_ptr: stable_ptr.into(),
-            span: None,
+            relative_span: None,
             message,
             severity: Severity::Error,
         }
@@ -89,14 +90,14 @@ impl PluginDiagnostic {
     pub fn warning(stable_ptr: impl Into<SyntaxStablePtrId>, message: String) -> PluginDiagnostic {
         PluginDiagnostic {
             stable_ptr: stable_ptr.into(),
-            span: None,
+            relative_span: None,
             message,
             severity: Severity::Warning,
         }
     }
 
-    pub fn with_span(mut self, span: TextSpan) -> Self {
-        self.span = Some(span);
+    pub fn with_relative_span(mut self, span: TextSpan) -> Self {
+        self.relative_span = Some(span);
         self
     }
 }

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -6,6 +6,7 @@ use cairo_lang_diagnostics::Severity;
 use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::db::Edition;
 use cairo_lang_filesystem::ids::CodeMapping;
+use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
@@ -72,15 +73,31 @@ pub struct PluginResult {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PluginDiagnostic {
     pub stable_ptr: SyntaxStablePtrId,
+    pub span: Option<TextSpan>,
     pub message: String,
     pub severity: Severity,
 }
 impl PluginDiagnostic {
     pub fn error(stable_ptr: impl Into<SyntaxStablePtrId>, message: String) -> PluginDiagnostic {
-        PluginDiagnostic { stable_ptr: stable_ptr.into(), message, severity: Severity::Error }
+        PluginDiagnostic {
+            stable_ptr: stable_ptr.into(),
+            span: None,
+            message,
+            severity: Severity::Error,
+        }
     }
     pub fn warning(stable_ptr: impl Into<SyntaxStablePtrId>, message: String) -> PluginDiagnostic {
-        PluginDiagnostic { stable_ptr: stable_ptr.into(), message, severity: Severity::Warning }
+        PluginDiagnostic {
+            stable_ptr: stable_ptr.into(),
+            span: None,
+            message,
+            severity: Severity::Warning,
+        }
+    }
+
+    pub fn with_span(mut self, span: TextSpan) -> Self {
+        self.span = Some(span);
+        self
     }
 }
 

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -488,7 +488,7 @@ fn test_unknown_item_macro() {
     assert_eq!(
         format!("{:?}", db.module_plugin_diagnostics(module_id).unwrap()),
         "[(ModuleFileId(CrateRoot(CrateId(0)), FileIndex(0)), PluginDiagnostic { stable_ptr: \
-         SyntaxStablePtrId(3), message: \"Unknown inline item macro: 'unknown_item_macro'.\", \
-         severity: Error })]"
+         SyntaxStablePtrId(3), relative_span: None, message: \"Unknown inline item macro: \
+         'unknown_item_macro'.\", severity: Error })]"
     )
 }

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1039,6 +1039,13 @@ impl DiagnosticEntry for SemanticDiagnostic {
     }
 
     fn location(&self, db: &Self::DbType) -> DiagnosticLocation {
+        if let SemanticDiagnosticKind::PluginDiagnostic(diag) = &self.kind {
+            if let Some(span) = diag.span {
+                let file_id = self.stable_location.file_id(db.upcast());
+                return DiagnosticLocation { file_id, span };
+            }
+        }
+
         let mut location = self.stable_location.diagnostic_location(db.upcast());
         if self.after {
             location = location.after();

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1041,8 +1041,7 @@ impl DiagnosticEntry for SemanticDiagnostic {
     fn location(&self, db: &Self::DbType) -> DiagnosticLocation {
         if let SemanticDiagnosticKind::PluginDiagnostic(diag) = &self.kind {
             if let Some(span) = diag.span {
-                let file_id = self.stable_location.file_id(db.upcast());
-                return DiagnosticLocation { file_id, span };
+                return self.stable_location.diagnostic_location_with_span(db.upcast(), span);
             }
         }
 

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1040,8 +1040,12 @@ impl DiagnosticEntry for SemanticDiagnostic {
 
     fn location(&self, db: &Self::DbType) -> DiagnosticLocation {
         if let SemanticDiagnosticKind::PluginDiagnostic(diag) = &self.kind {
-            if let Some(span) = diag.span {
-                return self.stable_location.diagnostic_location_with_span(db.upcast(), span);
+            if let Some(relative_span) = diag.relative_span {
+                return self.stable_location.diagnostic_location_with_offsets(
+                    db.upcast(),
+                    relative_span.start.as_u32(),
+                    relative_span.end.as_u32(),
+                );
             }
         }
 

--- a/crates/cairo-lang-semantic/src/test.rs
+++ b/crates/cairo-lang-semantic/src/test.rs
@@ -1,7 +1,7 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::ModuleItemId;
 use cairo_lang_defs::plugin::{
-    MacroPlugin, MacroPluginMetadata, PluginGeneratedFile, PluginResult,
+    MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
 use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
 use cairo_lang_filesystem::span::{TextSpan, TextWidth};
@@ -168,5 +168,104 @@ fn test_mapping_translate_consecutive_spans() {
             ^^^^^^
 
     "#}
+    );
+}
+
+#[derive(Debug, Default)]
+struct CustomSpanTestPlugin;
+impl MacroPlugin for CustomSpanTestPlugin {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        item_ast: ast::ModuleItem,
+        _metadata: &MacroPluginMetadata<'_>,
+    ) -> PluginResult {
+        // Only run plugin in the test file.
+        let ptr = item_ast.stable_ptr();
+        let file = ptr.0.file_id(db);
+        let path = file.full_path(db.upcast());
+        if path != "lib.cairo" {
+            return PluginResult::default();
+        }
+
+        // Find the first function in the file
+        if let ast::ModuleItem::FreeFunction(function) = &item_ast {
+            // Get function body statements
+            let elements = function.body(db).statements(db).elements(db);
+            if elements.is_empty() {
+                return PluginResult::default();
+            }
+
+            // Look for a variable declaration with a string literal containing '{}'
+            for statement in elements {
+                if let ast::Statement::Let(let_stmt) = statement {
+                    if let ast::Expr::String(string_expr) = let_stmt.rhs(db) {
+                        let string_text = string_expr.as_syntax_node().get_text(db);
+                        if let Some(brace_pos) = string_text.find("{}") {
+                            let string_span = string_expr.as_syntax_node().span(db);
+                            let placeholder_span = TextSpan {
+                                start: string_span
+                                    .start
+                                    .add_width(TextWidth::new_for_testing(brace_pos as u32)),
+                                end: string_span
+                                    .start
+                                    .add_width(TextWidth::new_for_testing(brace_pos as u32 + 2)),
+                            };
+
+                            let diagnostic = PluginDiagnostic::error(
+                                string_expr.as_syntax_node().stable_ptr(),
+                                "Missing format argument for placeholder".into(),
+                            )
+                            .with_span(placeholder_span);
+
+                            return PluginResult {
+                                code: None,
+                                diagnostics: vec![diagnostic],
+                                remove_original_item: false,
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        PluginResult::default()
+    }
+
+    fn declared_attributes(&self) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+#[test]
+fn test_diagnostic_with_custom_span() {
+    // Setup db with the test plugin.
+    let mut suite = get_default_plugin_suite();
+    suite.add_plugin::<CustomSpanTestPlugin>();
+    let mut db_val = SemanticDatabaseForTesting::with_plugin_suite(suite);
+
+    // Create test file with a format string missing a value
+    let content = indoc! {r#"
+        fn test_format() -> felt252 {
+            let _x: ByteArray = "hello {}";
+            0
+        }
+    "#};
+    let (test_module, _diagnostics) = setup_test_module(&db_val, content).split();
+    let module_id = test_module.module_id;
+
+    // Read semantic diagnostics.
+    let db = &mut db_val;
+    let diags = db.module_semantic_diagnostics(module_id).unwrap();
+    let diags = diags.format(db);
+    assert_eq!(
+        diags,
+        indoc! {r#"
+        error: Plugin diagnostic: Missing format argument for placeholder
+         --> lib.cairo:2:32
+            let _x: ByteArray = "hello {}";
+                                       ^^
+
+        "#}
     );
 }

--- a/crates/cairo-lang-semantic/src/test.rs
+++ b/crates/cairo-lang-semantic/src/test.rs
@@ -181,7 +181,7 @@ impl MacroPlugin for CustomSpanTestPlugin {
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult {
         // Only run plugin in the test file.
-        let ptr = item_ast.stable_ptr();
+        let ptr = item_ast.stable_ptr(db);
         let file = ptr.0.file_id(db);
         let path = file.full_path(db.upcast());
         if path != "lib.cairo" {
@@ -200,8 +200,8 @@ impl MacroPlugin for CustomSpanTestPlugin {
             for statement in elements {
                 if let ast::Statement::Let(let_stmt) = statement {
                     if let ast::Expr::String(string_expr) = let_stmt.rhs(db) {
-                        let string_text = string_expr.as_syntax_node().get_text(db);
-                        if let Some(brace_pos) = string_text.find("{}") {
+                        let node = string_expr.as_syntax_node();
+                        if let Some(brace_pos) = node.get_text(db).find("{}") {
                             let start_offset = brace_pos as u32;
                             let end_offset = start_offset + 2;
                             let relative_span = TextSpan {
@@ -211,7 +211,7 @@ impl MacroPlugin for CustomSpanTestPlugin {
                                     .add_width(TextWidth::new_for_testing(end_offset)),
                             };
                             let diagnostic = PluginDiagnostic::error(
-                                string_expr.as_syntax_node().stable_ptr(),
+                                node.stable_ptr(db),
                                 "Missing format argument for placeholder".into(),
                             )
                             .with_relative_span(relative_span);

--- a/crates/cairo-lang-semantic/src/test.rs
+++ b/crates/cairo-lang-semantic/src/test.rs
@@ -4,7 +4,7 @@ use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
 use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
-use cairo_lang_filesystem::span::{TextSpan, TextWidth};
+use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::extract_matches;
@@ -202,21 +202,19 @@ impl MacroPlugin for CustomSpanTestPlugin {
                     if let ast::Expr::String(string_expr) = let_stmt.rhs(db) {
                         let string_text = string_expr.as_syntax_node().get_text(db);
                         if let Some(brace_pos) = string_text.find("{}") {
-                            let string_span = string_expr.as_syntax_node().span(db);
-                            let placeholder_span = TextSpan {
-                                start: string_span
-                                    .start
-                                    .add_width(TextWidth::new_for_testing(brace_pos as u32)),
-                                end: string_span
-                                    .start
-                                    .add_width(TextWidth::new_for_testing(brace_pos as u32 + 2)),
+                            let start_offset = brace_pos as u32;
+                            let end_offset = start_offset + 2;
+                            let relative_span = TextSpan {
+                                start: TextOffset::default()
+                                    .add_width(TextWidth::new_for_testing(start_offset)),
+                                end: TextOffset::default()
+                                    .add_width(TextWidth::new_for_testing(end_offset)),
                             };
-
                             let diagnostic = PluginDiagnostic::error(
                                 string_expr.as_syntax_node().stable_ptr(),
                                 "Missing format argument for placeholder".into(),
                             )
-                            .with_span(placeholder_span);
+                            .with_relative_span(relative_span);
 
                             return PluginResult {
                                 code: None,


### PR DESCRIPTION
Adds an optional `relative_span` field to `PluginDiagnostic`, allowing diagnostics to target a specific subrange within the span of a syntax node identified by `stable_ptr`.