### PR TITLE
fix: argument order in cargo clippy command

### DIFF
--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -2,5 +2,5 @@
 
 export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2025-04-04}"
 
-cargo clippy "$@" --all-targets --all-features -- -D warnings -D future-incompatible \
+cargo clippy --all-targets --all-features "$@" -- -D warnings -D future-incompatible \
     -D nonstandard-style -D rust-2018-idioms -D unused


### PR DESCRIPTION
Hey, I noticed that user-provided arguments (`$@`) were placed before the standard `cargo clippy` flags. This could cause conflicts or unexpected behavior if user args overlap with cargo's own flags.  

I moved `$@` to the correct spot—after `cargo clippy` but before `--all-targets`, etc.—so everything gets passed as intended.