### PR TITLE
Add matches macro

### DIFF
--- a/corelib/src/test/language_features/matches_test.cairo
+++ b/corelib/src/test/language_features/matches_test.cairo
@@ -1,0 +1,33 @@
+#[test]
+fn test_basic_match_case() {
+    let a = Some(1);
+    if !matches!(a, Some(_)) {
+        panic!("Expected `a` to be Option::Some, not Option::None");
+    }
+}
+
+enum TestEnum {
+    A,
+    B,
+}
+
+enum TestEnumWithData {
+    A: u32,
+    B: u32,
+}
+
+#[test]
+fn test_enum_match_case() {
+    let a = TestEnum::A;
+    if !matches!(a, TestEnum::A) {
+        panic!("Expected `a` to be TestEnum::A");
+    }
+}
+
+#[test]
+fn test_enum_with_data_match_case() {
+    let a = TestEnumWithData::A(1);
+    if !matches!(a, TestEnumWithData::A(_)) {
+        panic!("Expected `a` to be TestEnumWithData::A");
+    }
+}

--- a/crates/cairo-lang-semantic/src/inline_macros/matches.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/matches.rs
@@ -1,0 +1,100 @@
+use cairo_lang_defs::{
+    patcher::{PatchBuilder, RewriteNode},
+    plugin::{
+        InlineMacroExprPlugin, InlinePluginResult, MacroPluginMetadata, NamedPlugin,
+        PluginGeneratedFile,
+    },
+};
+use cairo_lang_syntax::node::{
+    ast::ExprInlineMacro, db::SyntaxGroup, helpers::WrappedArgListHelper,
+};
+use indoc::indoc;
+
+#[derive(Debug, Default)]
+pub struct MatchesMacro;
+impl NamedPlugin for MatchesMacro {
+    const NAME: &'static str = "matches";
+}
+impl InlineMacroExprPlugin for MatchesMacro {
+    fn generate_code(
+        &self,
+        db: &dyn SyntaxGroup,
+        syntax: &ExprInlineMacro,
+        _metadata: &MacroPluginMetadata<'_>,
+    ) -> InlinePluginResult {
+        let arguments = syntax.arguments(db).arg_list(db).unwrap().elements(db);
+        let mut builder = PatchBuilder::new(db, syntax);
+        builder.add_modified(RewriteNode::interpolate_patched(
+            r#"
+             {
+               match $expression$ {
+                   $pattern$ => true,
+                   _ => false,
+               }
+             }
+            "#,
+            &[
+                (
+                    "expression".to_string(),
+                    RewriteNode::from_ast_trimmed(arguments.first().unwrap()),
+                ),
+                ("pattern".to_string(), RewriteNode::from_ast_trimmed(arguments.get(1).unwrap())),
+            ]
+            .into(),
+        ));
+        let (content, code_mappings) = builder.build();
+        InlinePluginResult {
+            code: Some(PluginGeneratedFile {
+                name: format!("{}_macro", Self::NAME).into(),
+                content,
+                code_mappings,
+                aux_data: None,
+                diagnostics_note: Default::default(),
+            }),
+            diagnostics: vec![],
+        }
+    }
+
+    fn documentation(&self) -> Option<String> {
+        Some(
+            indoc! {r#"
+            Returns whether the given expression matches the provided pattern.
+            The pattern syntax is exactly the same as found in a match arm.
+
+            # Syntax
+            ```cairo
+            let a = Some(5);
+            let is_a_some = matches!(a, Some(_));
+            ```
+            # Returns
+            A boolean value indicating whether the expression matches the pattern.
+
+            # Examples
+            ```cairo
+            let a = Some(1);
+            if !matches!(a, Some(_)) {
+                panic!("Expected a to be Option::Some, not Option::None");
+            }
+            ```
+
+            ```cairo
+            enum TestEnumWithData {
+                VariantA: u32,
+                VariantB: u32,
+            }
+
+            fn main() {
+                let variable = TestEnumWithData::VariantA(5);
+                let is_variable_variant_a = matches!(variable, TestEnumWithData::VariantA(_));
+                assert!(is_variable_variant_a);
+            }
+            ```
+
+            ```cairo
+            }
+            ```
+            "#}
+            .to_string(),
+        )
+    }
+}

--- a/crates/cairo-lang-semantic/src/inline_macros/mod.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/mod.rs
@@ -2,6 +2,7 @@ mod array;
 mod assert;
 mod consteval_int;
 mod format;
+mod matches;
 mod panic;
 mod print;
 mod write;
@@ -10,6 +11,7 @@ use cairo_lang_plugins::get_base_plugins;
 
 use self::assert::AssertMacro;
 use self::format::FormatMacro;
+use self::matches::MatchesMacro;
 use self::panic::PanicMacro;
 use self::print::{PrintMacro, PrintlnMacro};
 use self::write::{WriteMacro, WritelnMacro};
@@ -25,6 +27,7 @@ pub fn get_default_plugin_suite() -> PluginSuite {
         .add_inline_macro_plugin::<AssertMacro>()
         .add_inline_macro_plugin::<ConstevalIntMacro>()
         .add_inline_macro_plugin::<FormatMacro>()
+        .add_inline_macro_plugin::<MatchesMacro>()
         .add_inline_macro_plugin::<PanicMacro>()
         .add_inline_macro_plugin::<PrintMacro>()
         .add_inline_macro_plugin::<PrintlnMacro>()


### PR DESCRIPTION
## Rationale

1. It will be helpful to have such a macro as it really makes it easier to write specific code and makes the code less bloated. It's also implemented for the Rust language, so people should already be familiar with it.
2. It will be really helpful for the fixer inside the `cairo-lint`, as we want to fix such code:
```cairo
enum Abc {
    A: u32,
    B: u32,
    C: u32
}

fn main() {
    let a = Abc::A(1);
    if let Abc::A(x) = a {
        panic!("a shouldn't be type of Abc::A");
    }
}
```

with just 

```cairo
fn main() {
    let a = Abc::A(1);
    assert!(!matches!(a, Abc::A(_)), "a shouldn't be type of Abc::A");
}
```

rather than

```cairo
fn main() {
    let a = Abc::A(1);
    assert!(!{match a {
        Abc::A(_) => true,
        _ => false,
    }}, "a shouldn't be type of Abc::A");
}
```