### PR TITLE
feat(parser): Improve module declaration error diagnostics

### DIFF
--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -123,6 +123,7 @@ pub enum ParserDiagnosticKind {
     AttributesWithoutStatement,
     DisallowedTrailingSeparatorOr,
     ConsecutiveMathOperators { first_op: SyntaxKind, second_op: SyntaxKind },
+    ExpectedSemicolonOrBody,
 }
 impl DiagnosticEntry for ParserDiagnostic {
     type DbType = dyn FilesGroup;
@@ -214,6 +215,9 @@ Did you mean to write `{identifier}!{left}...{right}'?",
                     self.kind_to_string(*first_op),
                     self.kind_to_string(*second_op)
                 )
+            }
+            ParserDiagnosticKind::ExpectedSemicolonOrBody => {
+                "Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.".to_string()
             }
         }
     }

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -217,7 +217,9 @@ Did you mean to write `{identifier}!{left}...{right}'?",
                 )
             }
             ParserDiagnosticKind::ExpectedSemicolonOrBody => {
-                "Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.".to_string()
+                "Expected either ';' or '{' after module name. \
+                Use ';' for an external module declaration or '{' for a module with a body."
+                    .to_string()
             }
         }
     }

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -217,8 +217,8 @@ Did you mean to write `{identifier}!{left}...{right}'?",
                 )
             }
             ParserDiagnosticKind::ExpectedSemicolonOrBody => {
-                "Expected either ';' or '{' after module name. \
-                Use ';' for an external module declaration or '{' for a module with a body."
+                "Expected either ';' or '{' after module name. Use ';' for an external module \
+                 declaration or '{' for a module with a body."
                     .to_string()
             }
         }

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -413,13 +413,9 @@ impl<'a> Parser<'a> {
                 self.take::<TerminalSemicolon>().into()
             }
             _ => {
-                // Report diagnostic showing that either ';' or '{' is expected after module name
-                let next_offset = self.offset.add_width(self.current_width - self.last_trivia_length);
-                self.add_diagnostic(
-                    ParserDiagnosticKind::ExpectedSemicolonOrBody,
-                    TextSpan { start: next_offset, end: next_offset },
-                );
-                TerminalSemicolon::missing(self.db).into()
+                self.skip_token_and_return_missing::<TerminalSemicolon>(
+                    ParserDiagnosticKind::ExpectedSemicolonOrBody
+                ).into()
             }
         };
 

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -413,7 +413,7 @@ impl<'a> Parser<'a> {
                 self.take::<TerminalSemicolon>().into()
             }
             _ => {
-                self.skip_token_and_return_missing::<TerminalSemicolon>(
+                self.create_and_report_missing::<TerminalSemicolon>(
                     ParserDiagnosticKind::ExpectedSemicolonOrBody
                 ).into()
             }

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -420,10 +420,10 @@ impl<'a> Parser<'a> {
                     TextSpan { start: next_offset, end: next_offset },
                 );
 
-                // Create a missing semicolon node as fallback and skip the current token
-                // to prevent cascading errors from invalid syntax
+                // Skip the current token if it's not EOF, but don't generate another diagnostic
                 if self.peek().kind != SyntaxKind::TerminalEndOfFile {
-                    self.skip_token(ParserDiagnosticKind::ExpectedSemicolonOrBody);
+                    // Use take_raw instead of skip_token to avoid generating another diagnostic
+                    self.take_raw();
                 }
 
                 TerminalSemicolon::missing(self.db).into()

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -409,14 +409,12 @@ impl<'a> Parser<'a> {
                 let rbrace = self.parse_token::<TerminalRBrace>();
                 ModuleBody::new_green(self.db, lbrace, items, rbrace).into()
             }
-            SyntaxKind::TerminalSemicolon => {
-                self.take::<TerminalSemicolon>().into()
-            }
-            _ => {
-                self.create_and_report_missing::<TerminalSemicolon>(
-                    ParserDiagnosticKind::ExpectedSemicolonOrBody
-                ).into()
-            }
+            SyntaxKind::TerminalSemicolon => self.take::<TerminalSemicolon>().into(),
+            _ => self
+                .create_and_report_missing::<TerminalSemicolon>(
+                    ParserDiagnosticKind::ExpectedSemicolonOrBody,
+                )
+                .into(),
         };
 
         ItemModule::new_green(self.db, attributes, visibility, module_kw, name, body)

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -420,9 +420,8 @@ impl<'a> Parser<'a> {
                     TextSpan { start: next_offset, end: next_offset },
                 );
 
-                // Skip the current token if it's not EOF, but don't generate another diagnostic
+                // Directly use take_raw() to advance the parser without generating another diagnostic
                 if self.peek().kind != SyntaxKind::TerminalEndOfFile {
-                    // Use take_raw instead of skip_token to avoid generating another diagnostic
                     self.take_raw();
                 }
 

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -419,12 +419,6 @@ impl<'a> Parser<'a> {
                     ParserDiagnosticKind::ExpectedSemicolonOrBody,
                     TextSpan { start: next_offset, end: next_offset },
                 );
-
-                // Directly use take_raw() to advance the parser without generating another diagnostic
-                if self.peek().kind != SyntaxKind::TerminalEndOfFile {
-                    self.take_raw();
-                }
-
                 TerminalSemicolon::missing(self.db).into()
             }
         };

--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
@@ -8,26 +8,10 @@ mod my_mod
 fn foo() {}
 
 //! > expected_diagnostics
-error: Expected a '!' after the identifier 'foo' to start an inline macro.
-Did you mean to write `foo!(...)'?
- --> dummy_file.cairo:2:4
-fn foo() {}
-   ^^^
-
 error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
- --> dummy_file.cairo:2:1
-fn foo() {}
-^^
-
-error: Missing token ';'.
- --> dummy_file.cairo:2:9
-fn foo() {}
-        ^
-
-error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
- --> dummy_file.cairo:2:10
-fn foo() {}
-         ^^
+ --> dummy_file.cairo:1:11
+mod my_mod
+          ^
 
 //! > ==========================================================================
 
@@ -41,6 +25,11 @@ mod my_mod }
 
 //! > expected_diagnostics
 error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
+ --> dummy_file.cairo:1:11
+mod my_mod }
+          ^
+
+error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
  --> dummy_file.cairo:1:12
 mod my_mod }
            ^
@@ -74,11 +63,6 @@ mod my_mod const X: felt252 = 5;
 
 //! > expected_diagnostics
 error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
- --> dummy_file.cairo:1:12
+ --> dummy_file.cairo:1:11
 mod my_mod const X: felt252 = 5;
-           ^^^^^
-
-error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
- --> dummy_file.cairo:1:18
-mod my_mod const X: felt252 = 5;
-                 ^^^^^^^^^^^^^^^
+          ^

--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
@@ -8,10 +8,26 @@ mod my_mod
 fn foo() {}
 
 //! > expected_diagnostics
+error: Expected a '!' after the identifier 'foo' to start an inline macro.
+Did you mean to write `foo!(...)'?
+ --> dummy_file.cairo:2:4
+fn foo() {}
+   ^^^
+
 error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
- --> dummy_file.cairo:1:11
-mod my_mod
-          ^
+ --> dummy_file.cairo:2:1
+fn foo() {}
+^^
+
+error: Missing token ';'.
+ --> dummy_file.cairo:2:9
+fn foo() {}
+        ^
+
+error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
+ --> dummy_file.cairo:2:10
+fn foo() {}
+         ^^
 
 //! > ==========================================================================
 
@@ -25,11 +41,6 @@ mod my_mod }
 
 //! > expected_diagnostics
 error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
- --> dummy_file.cairo:1:11
-mod my_mod }
-          ^
-
-error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
  --> dummy_file.cairo:1:12
 mod my_mod }
            ^
@@ -59,15 +70,15 @@ fn foo() {}
 get_diagnostics
 
 //! > cairo_code
-mod my_mod const X = 5;
+mod my_mod const X: felt252 = 5;
 
 //! > expected_diagnostics
 error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
- --> dummy_file.cairo:1:11
-mod my_mod const X = 5;
-          ^
+ --> dummy_file.cairo:1:12
+mod my_mod const X: felt252 = 5;
+           ^^^^^
 
-error: Unexpected token, expected ':' followed by a type.
- --> dummy_file.cairo:1:19
-mod my_mod const X = 5;
-                  ^
+error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
+ --> dummy_file.cairo:1:18
+mod my_mod const X: felt252 = 5;
+                 ^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
@@ -19,11 +19,6 @@ Did you mean to write `foo!(...)'?
 fn foo() {}
    ^^^
 
-error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
- --> dummy_file.cairo:2:1
-fn foo() {}
-^^
-
 error: Missing token ';'.
  --> dummy_file.cairo:2:9
 fn foo() {}
@@ -49,11 +44,6 @@ error: Expected either ';' or '{' after module name. Use ';' for an external mod
  --> dummy_file.cairo:1:11
 mod my_mod }
           ^
-
-error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
- --> dummy_file.cairo:1:12
-mod my_mod }
-           ^
 
 //! > ==========================================================================
 
@@ -87,11 +77,6 @@ error: Expected either ';' or '{' after module name. Use ';' for an external mod
  --> dummy_file.cairo:1:11
 mod my_mod const X = 5;
           ^
-
-error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
- --> dummy_file.cairo:1:12
-mod my_mod const X = 5;
-           ^^^^^
 
 error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
  --> dummy_file.cairo:1:18

--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
@@ -13,22 +13,6 @@ error: Expected either ';' or '{' after module name. Use ';' for an external mod
 mod my_mod
           ^
 
-error: Expected a '!' after the identifier 'foo' to start an inline macro.
-Did you mean to write `foo!(...)'?
- --> dummy_file.cairo:2:4
-fn foo() {}
-   ^^^
-
-error: Missing token ';'.
- --> dummy_file.cairo:2:9
-fn foo() {}
-        ^
-
-error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
- --> dummy_file.cairo:2:10
-fn foo() {}
-         ^^
-
 //! > ==========================================================================
 
 //! > Missing lbrace.
@@ -44,6 +28,11 @@ error: Expected either ';' or '{' after module name. Use ';' for an external mod
  --> dummy_file.cairo:1:11
 mod my_mod }
           ^
+
+error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
+ --> dummy_file.cairo:1:12
+mod my_mod }
+           ^
 
 //! > ==========================================================================
 
@@ -78,7 +67,7 @@ error: Expected either ';' or '{' after module name. Use ';' for an external mod
 mod my_mod const X = 5;
           ^
 
-error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
- --> dummy_file.cairo:1:18
+error: Unexpected token, expected ':' followed by a type.
+ --> dummy_file.cairo:1:19
 mod my_mod const X = 5;
-                 ^^^^^^
+                  ^

--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
@@ -8,10 +8,31 @@ mod my_mod
 fn foo() {}
 
 //! > expected_diagnostics
-error: Missing token ';'.
+error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
  --> dummy_file.cairo:1:11
 mod my_mod
           ^
+
+error: Expected a '!' after the identifier 'foo' to start an inline macro.
+Did you mean to write `foo!(...)'?
+ --> dummy_file.cairo:2:4
+fn foo() {}
+   ^^^
+
+error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
+ --> dummy_file.cairo:2:1
+fn foo() {}
+^^
+
+error: Missing token ';'.
+ --> dummy_file.cairo:2:9
+fn foo() {}
+        ^
+
+error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
+ --> dummy_file.cairo:2:10
+fn foo() {}
+         ^^
 
 //! > ==========================================================================
 
@@ -24,12 +45,12 @@ get_diagnostics
 mod my_mod }
 
 //! > expected_diagnostics
-error: Missing token ';'.
+error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
  --> dummy_file.cairo:1:11
 mod my_mod }
           ^
 
-error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
+error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
  --> dummy_file.cairo:1:12
 mod my_mod }
            ^
@@ -50,3 +71,29 @@ error: Missing token '}'.
  --> dummy_file.cairo:2:12
 fn foo() {}
            ^
+
+//! > ==========================================================================
+
+//! > Invalid token after module name.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+mod my_mod const X = 5;
+
+//! > expected_diagnostics
+error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
+ --> dummy_file.cairo:1:11
+mod my_mod const X = 5;
+          ^
+
+error: Expected either ';' or '{' after module name. Use ';' for an external module declaration or '{' for a module with a body.
+ --> dummy_file.cairo:1:12
+mod my_mod const X = 5;
+           ^^^^^
+
+error: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
+ --> dummy_file.cairo:1:18
+mod my_mod const X = 5;
+                 ^^^^^^


### PR DESCRIPTION
This PR improves the diagnostics for module declarations in Cairo when users forget to add a semicolon or opening brace after the module name.

## Changes

- Added a new `ExpectedSemicolonOrBody` diagnostic type that provides clear guidance
- Updated the module parser to use this new diagnostic and avoid cascading errors
- Modified error message to explicitly inform users that either `;` or `{` is expected
- Includes a clarification in the message about when to use each syntax option
- Updated relevant tests to reflect the new diagnostic messages

## Motivation

Previously, users would only see a generic "Missing token ';'" error when they omitted the required syntax element after a module name. This wasn't sufficiently helpful, especially for new Cairo developers who might not understand that modules can be declared either with a body or as an external reference.

The new error message clearly explains both options, making the language more approachable and reducing confusion.

## Testing

All tests have been updated and pass, including the specific module diagnostic tests.