### PR TITLE
Remove ReorderStatements after BranchInversion.

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/branch_inversion.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/branch_inversion.rs
@@ -17,19 +17,10 @@ use crate::{FlatBlockEnd, FlatLowered, MatchInfo, Statement, StatementCall};
 ///
 /// This optimization is valid only if all paths leading to the match enum pass through the call to
 /// `bool_not_impl`. Therefore, the call to `bool_not_impl` should be in the same block as the match
-/// enum.
+/// enum. `reorder_statements` can be used to ensure the condition above is met.
 ///
-/// The call to `bool_not_impl` is not deleted as we don't know if its output
+/// Note: The call to `bool_not_impl` is not deleted as we don't know if its output
 /// is used by other statements (or block ending).
-///
-/// Due to the limitations above, the `reorder_statements` function should be called before this
-/// optimization and between this optimization and the match optimization.
-///
-/// The first call to `reorder_statements` moves the call to `bool_not_impl` into the block whose
-/// match enum we want to optimize.
-/// The second call to `reorder_statements` removes the call to `bool_not_impl` if it is unused,
-/// allowing the match optimization to be applied to enum_init statements that appeared before the
-/// `bool_not_impl`.
 pub fn branch_inversion(db: &dyn LoweringGroup, lowered: &mut FlatLowered) {
     if lowered.blocks.is_empty() {
         return;

--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -114,11 +114,8 @@ pub fn baseline_optimization_strategy(db: &dyn LoweringGroup) -> OptimizationStr
         OptimizationPhase::ApplyInlining,
         OptimizationPhase::ReturnOptimization,
         OptimizationPhase::ReorganizeBlocks,
-        // The call to `reorder_statements` before and after `branch_inversion` is intentional.
-        // See description of `branch_inversion` for more details.
         OptimizationPhase::ReorderStatements,
         OptimizationPhase::BranchInversion,
-        OptimizationPhase::ReorderStatements,
         OptimizationPhase::CancelOps,
         // Must be right before const folding.
         OptimizationPhase::ReorganizeBlocks,


### PR DESCRIPTION
After the improvements to the OptimizeMatches it is no longer needed.