### PR TITLE
Code cleanup and additional tests

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/lower_if.rs
+++ b/crates/cairo-lang-lowering/src/lower/lower_if.rs
@@ -102,9 +102,7 @@ pub fn lower_expr_if_let(
     log::trace!("Lowering an if let expression: {:?}", expr.debug(&ctx.expr_formatter));
     let location = ctx.get_location(expr.stable_ptr.untyped());
     let lowered_expr = lower_expr(ctx, builder, matched_expr)?;
-
-    let matched_expr = ctx.function_body.arenas.exprs[matched_expr].clone();
-    let ty = matched_expr.ty();
+    let ty = ctx.function_body.arenas.exprs[matched_expr].ty();
 
     if corelib::numeric_upcastable_to_felt252(ctx.db, ty) {
         return Err(LoweringFlowError::Failed(ctx.diagnostics.report(
@@ -128,7 +126,7 @@ pub fn lower_expr_if_let(
             ctx,
             builder,
             lowered_expr,
-            &matched_expr,
+            matched_expr,
             &TupleInfo { types, n_snapshots },
             &arms,
             MatchKind::IfLet,
@@ -143,7 +141,7 @@ pub fn lower_expr_if_let(
     lower_concrete_enum_match(
         ctx,
         builder,
-        &matched_expr,
+        matched_expr,
         lowered_expr,
         &arms,
         location,

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -356,8 +356,7 @@ pub fn lower_expr_while_let(
     let location = ctx.get_location(loop_expr.stable_ptr.untyped());
     let lowered_expr = lower_expr(ctx, builder, matched_expr)?;
 
-    let matched_expr = ctx.function_body.arenas.exprs[matched_expr].clone();
-    let ty = matched_expr.ty();
+    let ty = ctx.function_body.arenas.exprs[matched_expr].ty();
 
     if corelib::numeric_upcastable_to_felt252(ctx.db, ty) {
         return Err(LoweringFlowError::Failed(ctx.diagnostics.report(
@@ -381,7 +380,7 @@ pub fn lower_expr_while_let(
             ctx,
             builder,
             lowered_expr,
-            &matched_expr,
+            matched_expr,
             &TupleInfo { types, n_snapshots },
             &arms,
             match_type,
@@ -392,15 +391,7 @@ pub fn lower_expr_while_let(
         return lower_optimized_extern_match(ctx, builder, extern_enum, &arms, match_type);
     }
 
-    lower_concrete_enum_match(
-        ctx,
-        builder,
-        &matched_expr,
-        lowered_expr,
-        &arms,
-        location,
-        match_type,
-    )
+    lower_concrete_enum_match(ctx, builder, matched_expr, lowered_expr, &arms, location, match_type)
 }
 
 /// Lowers a loop inner function into [FlatLowered].

--- a/crates/cairo-lang-lowering/src/test_data/match
+++ b/crates/cairo-lang-lowering/src/test_data/match
@@ -1638,3 +1638,81 @@ Statements:
   (v19: core::felt252) <- 8
 End:
   Return(v4, v19)
+
+//! > ==========================================================================
+
+//! > Test double Otherwise arm.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(a: A) -> felt252 {
+    match a {
+        A::Two(_) => 2,
+        A::One(_) => 1,
+        _ => 0,
+        _ => 5,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    One: (),
+    Two: (),
+    Three: (),
+    Four: (),
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error: Unreachable pattern arm.
+ --> lib.cairo:12:9
+        _ => 5,
+        ^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Test hiding arms.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(a: A) -> felt252 {
+    match a {
+        A::Two(_) => 2,
+        A::One(_) => 1,
+        _ => 0,
+        A::One(_) => 5,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    One: (),
+    Two: (),
+    Three: (),
+    Four: (),
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error: Unreachable pattern arm.
+ --> lib.cairo:12:9
+        A::One(_) => 5,
+        ^^^^^^^^^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>


### PR DESCRIPTION
There were unnecessary clones when handling lowering, so I passed Id
instead (accordingly needed small refactor to error handling)

During match arm collection, the arms and patterns after underscore were
not being checked for diagnostics, so I changed the call to include all
arms and  not break the inner loop.

---

**Stack**:
- #7700
- #7699 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*