### PR TITLE
fix: small typo in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Please try to create bug reports that are:
 
 - _Reproducible._ Include steps to reproduce the problem.
 - _Specific._ Include as much detail as possible: which version, what environment, etc.
-- _Unique._ Do not duplicate existing opened issues.
+- _Unique._ Do not duplicate existing open issues.
 - _Scoped to a Single Bug._ One bug per report.
 
 **Even better: Submit a pull request with a fix or new feature!**


### PR DESCRIPTION
"Open" is an adjective describing the current status of the issues, while "opened" is the past participle of the verb "to open," which focuses on the action of opening.