### PR TITLE
added macro_array to prelude

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -904,3 +904,20 @@ impl FixedSizedArrayInfoImpl<T, const SIZE: usize> of FixedSizedArrayInfo<[T; SI
     type Element = T;
     const SIZE: usize = SIZE;
 }
+
+/// Inline macro to create an array with the given elements.
+pub macro array_macro {
+    // TODO(Dean): rename to `array!` to match the Cairo 1.0 macro.
+    [$x:expr] => {
+        let mut arr = Array::new();
+        arr.append($x);
+        arr
+    };
+
+    [$first:expr, $($rest:expr),
+        *] => {
+            let mut arr = array_macro![$($rest), *];
+            arr.append($first);
+            arr
+        };
+}

--- a/corelib/src/prelude/v2024_07.cairo
+++ b/corelib/src/prelude/v2024_07.cairo
@@ -1,4 +1,4 @@
-pub use crate::array::{Array, ArrayTrait, Span, SpanTrait, ToSpanTrait};
+pub use crate::array::{Array, ArrayTrait, Span, SpanTrait, ToSpanTrait, array_macro};
 pub use crate::box::{Box, BoxTrait};
 pub use crate::byte_array::{ByteArray, ByteArrayTrait};
 pub use crate::bytes_31::{Bytes31Trait, bytes31};


### PR DESCRIPTION
Not replacing array! yet (thus the temporary name `macro_array`) because full support for the array interface needs to be provided first.