### PR TITLE
docs: improve naming examples and remove TODO in casing section

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/naming-conventions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/naming-conventions.adoc
@@ -22,13 +22,13 @@ More precisely:
 | Type parameters | `PascalCase` generally, a single letter like `T` usually
 |===
 
-In `PascalCase`, acronyms count as one word: use `Sha` rather than `SHA`.
-In `snake_case`, acronyms are lower-cased: `sha3_hash`, `http_request`.
+In `PascalCase`, acronyms count as one word: use `L1Handler` rather than `L1_Handler`.
+In `snake_case`, acronyms are lower-cased: `rpc_call`, `json_data`.
 
 In `snake_case` or `UPPER_CASE`, a _word_ should never consist of a single character unless it is
 a digit or the last _word_.
-Thus, we have `file_system` rather than `f_system`, `btree_map` rather than `b_tree_map`, and `data_stream` instead of `d_stream`.
-Also, examples like `PI_2` and `HTTP_404_ERROR` illustrate correct handling of digits and acronyms.
+Thus, we have `contract_class` rather than `c_class`, `compiled_program` rather than `c_program`, and `entry_point_selector` instead of `e_selector`.
+Also, examples like `CHAIN_ID_MAINNET` and `RPC_429_ERROR` illustrate correct handling of digits and acronyms.
 
 Language implementations can emit warnings when names do not follow these rules.
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/naming-conventions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/naming-conventions.adoc
@@ -23,12 +23,12 @@ More precisely:
 |===
 
 In `PascalCase`, acronyms count as one word: use `Sha` rather than `SHA`.
-In `snake_case`, acronyms are lower-cased: `sha3_hash`.
+In `snake_case`, acronyms are lower-cased: `sha3_hash`, `http_request`.
 
 In `snake_case` or `UPPER_CASE`, a _word_ should never consist of a single character unless it is
 a digit or the last _word_.
-So, we have `btree_map` rather than `b_tree_map`, but `PI_2` rather than `PI2`.
-// TODO: More suitable examples
+Thus, we have `file_system` rather than `f_system`, `btree_map` rather than `b_tree_map`, and `data_stream` instead of `d_stream`.
+Also, examples like `PI_2` and `HTTP_404_ERROR` illustrate correct handling of digits and acronyms.
 
 Language implementations can emit warnings when names do not follow these rules.
 


### PR DESCRIPTION
This PR improves the examples provided in the Casing section of the naming conventions document.
More realistic and clearer examples have been added, replacing the previous placeholder examples.
The TODO comment has been fully addressed.

No changes were made to the rules or structure of the document.