### PR TITLE
chore: bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Build for unknown linux
         run: ./scripts/release_tar.sh x86_64-unknown-linux-musl
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-x86_64-unknown-linux-musl
           path: target/x86_64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
GitHub deprecated v3; v4 is now GA, offers faster immutable uploads and will be required after Jan 30 2025. [Reference](https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/)