### PR TITLE
Check on enum variant type matching in patterns

### DIFF
--- a/crates/cairo-lang-lowering/src/test_data/match
+++ b/crates/cairo-lang-lowering/src/test_data/match
@@ -1126,10 +1126,10 @@ fn foo(a: A, b: A) -> felt252 {
     let x = (@a, b);
     let y = @x;
     match y {
-        (A::Two((t, _)), A::One) => **t + 3,
-        (A::Two, _) => 2,
+        (A::Two((t, _)), A::One(_)) => **t + 3,
+        (A::Two(_), _) => 2,
         (A::One(_), A::One(_)) => 1,
-        (_, A::Three(_)) => 3,
+        (_, A::Three) => 3,
         (_, _) => 6,
     }
 }
@@ -1270,10 +1270,10 @@ test_function_lowering(expect_diagnostics: true)
 //! > function
 fn foo(a: A, b: A) -> felt252 {
     match (a, b) {
-        (A::Two, A::One) => 5,
-        (A::Two, _) => 2,
+        (A::Two(_), A::One(_)) => 5,
+        (A::Two(_), _) => 2,
         (A::One(_), A::One(_)) => 1,
-        (_, A::Three(_)) => 3,
+        (_, A::Three) => 3,
         (_, A::Four) => 4,
     }
 }
@@ -1331,7 +1331,7 @@ test_function_lowering(expect_diagnostics: true)
 //! > function
 fn foo(a: A, b: A) -> felt252 {
     match (a, (a, b)) {
-        (A::Two, (A::One, A::One)) => 8,
+        (A::Two(_), (A::One(_), A::One(_))) => 8,
         _ => 4,
     }
 }
@@ -1369,8 +1369,8 @@ test_function_lowering(expect_diagnostics: false)
 //! > function
 fn foo(a: A) -> felt252 {
     match (a, get_bool()) {
-        (A::Two, true) => 5,
-        (A::Two, _) => 2,
+        (A::Two(_), true) => 5,
+        (A::Two(_), _) => 2,
         (A::One(_), false) => 1,
         (_, _) => 6,
     }
@@ -1716,3 +1716,71 @@ error: Unreachable pattern arm.
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Test lower match missing args.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(a: felt252) -> felt252 {
+    match Some(a) {
+        Some => 2,
+        _ => 0,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+warning: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
+ --> lib.cairo:3:9
+        Some => 2,
+        ^^^^
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 2
+End:
+  Return(v1)
+
+//! > ==========================================================================
+
+//! > Test lower match with _ args.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo(a: felt252) -> felt252 {
+    match Some(a) {
+        Some(_) => 2,
+        _ => 0,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 2
+End:
+  Return(v1)

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -83,8 +83,8 @@ use crate::types::{
 };
 use crate::usage::Usages;
 use crate::{
-    ConcreteEnumId, GenericArgumentId, GenericParam, LocalItem, Member, Mutability, Parameter,
-    PatternStringLiteral, PatternStruct, Signature, StatementItemKind,
+    ConcreteEnumId, ConcreteVariant, GenericArgumentId, GenericParam, LocalItem, Member,
+    Mutability, Parameter, PatternStringLiteral, PatternStruct, Signature, StatementItemKind,
 };
 
 /// Expression with its id.
@@ -2219,18 +2219,13 @@ fn maybe_compute_pattern_semantic(
             let generic_variant = try_extract_matches!(item, ResolvedGenericItem::Variant)
                 .ok_or_else(|| ctx.diagnostics.report(path.stable_ptr(db), NotAVariant))?;
 
-            let (concrete_enum, n_snapshots) = extract_concrete_enum_from_pattern_and_validate(
-                ctx,
-                pattern_syntax,
-                ty,
-                generic_variant.enum_id,
-            )?;
-
-            // TODO(lior): Should we report a diagnostic here?
-            let concrete_variant = ctx
-                .db
-                .concrete_enum_variant(concrete_enum, &generic_variant)
-                .map_err(|_| ctx.diagnostics.report(path.stable_ptr(db), UnknownEnum))?;
+            let (concrete_variant, n_snapshots) =
+                extract_concrete_variant_from_pattern_and_validate(
+                    ctx,
+                    pattern_syntax,
+                    ty,
+                    generic_variant,
+                )?;
 
             // Compute inner pattern.
             let inner_ty = wrap_in_snapshots(ctx.db, concrete_variant.ty, n_snapshots);
@@ -2266,17 +2261,13 @@ fn maybe_compute_pattern_semantic(
                 if let Some(generic_variant) =
                     try_extract_matches!(item, ResolvedGenericItem::Variant)
                 {
-                    let (concrete_enum, _n_snapshots) =
-                        extract_concrete_enum_from_pattern_and_validate(
+                    let (concrete_variant, _n_snapshots) =
+                        extract_concrete_variant_from_pattern_and_validate(
                             ctx,
                             pattern_syntax,
                             ty,
-                            generic_variant.enum_id,
+                            generic_variant,
                         )?;
-                    let concrete_variant = ctx
-                        .db
-                        .concrete_enum_variant(concrete_enum, &generic_variant)
-                        .map_err(|_| ctx.diagnostics.report(path.stable_ptr(db), UnknownEnum))?;
                     return Ok(Pattern::EnumVariant(PatternEnumVariant {
                         variant: concrete_variant,
                         inner_pattern: None,
@@ -2623,6 +2614,46 @@ fn extract_concrete_enum_from_pattern_and_validate(
         ));
     }
     Ok((concrete_enum, n_snapshots))
+}
+
+/// Validates that the semantic type of an enum pattern is an enum.
+/// After that finds the concrete variant in the patter, and verifies it has args if needed.
+/// Returns the concrete variant and the number of snapshots.
+fn extract_concrete_variant_from_pattern_and_validate(
+    ctx: &mut ComputationContext<'_>,
+    pattern: &ast::Pattern,
+    ty: TypeId,
+    generic_variant: semantic::Variant,
+) -> Maybe<(ConcreteVariant, usize)> {
+    let (concrete_enum, n_snapshots) =
+        extract_concrete_enum_from_pattern_and_validate(ctx, pattern, ty, generic_variant.enum_id)?;
+    let db = ctx.db;
+
+    let needs_args = generic_variant.ty != unit_ty(db);
+    let has_args = matches!(
+        pattern,
+        ast::Pattern::Enum(inner)
+            if matches!(
+                inner.pattern(db),
+                ast::OptionPatternEnumInnerPattern::PatternEnumInnerPattern(_)
+            )
+    );
+
+    if needs_args && !has_args {
+        let path = match pattern {
+            ast::Pattern::Enum(pattern) => pattern.path(db),
+            ast::Pattern::Path(p) => p.clone(),
+            _ => unreachable!("Expected enum pattern in variant extraction."),
+        };
+        ctx.diagnostics.report(pattern.stable_ptr(db), PatternMissingArgs(path));
+    }
+
+    // TODO(lior): Should we report a diagnostic here?
+    let concrete_variant = db
+        .concrete_enum_variant(concrete_enum, &generic_variant)
+        .map_err(|_| ctx.diagnostics.report(pattern.stable_ptr(db), UnknownEnum))?;
+
+    Ok((concrete_variant, n_snapshots))
 }
 
 /// Creates a local variable pattern.

--- a/crates/cairo-lang-semantic/src/expr/test_data/if
+++ b/crates/cairo-lang-semantic/src/expr/test_data/if
@@ -137,3 +137,58 @@ error[E0006]: Identifier not found.
  --> lib.cairo:4:16
         return y == 9;
                ^
+
+//! > ==========================================================================
+
+//! > if_let some no args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo() -> bool {
+    let x = Some(7_u64);
+    if let Some = x {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+warning: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
+ --> lib.cairo:3:12
+    if let Some = x {
+           ^^^^
+
+//! > ==========================================================================
+
+//! > if_let enum unit no args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function
+fn foo() -> bool {
+    let a = A::B(());
+    if let A::B = a {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    B: (),
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/match
+++ b/crates/cairo-lang-semantic/src/expr/test_data/match
@@ -254,3 +254,201 @@ error: Unexpected argument type. Expected: "test::MyEnum::<core::integer::u32>",
  --> lib.cairo:11:9
     bar(a);
         ^
+
+//! > ==========================================================================
+
+//! > Test match on variant without args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo(a: A, b: A) -> felt252 {
+    match (a, b) {
+        (A::One, _) => 2,
+        (_, _) => 6,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+}
+
+//! > expected_diagnostics
+warning: Pattern missing subpattern for the payload of variant. Consider using `A::One(_)`
+ --> lib.cairo:7:10
+        (A::One, _) => 2,
+         ^^^^^^
+
+//! > ==========================================================================
+
+//! > Test match on unit variant without args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function
+fn foo(a: A, b: A) -> felt252 {
+    match (a, b) {
+        (A::One(_), _) => 2,
+        (A::Two, _) => 6,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+    Two: (),
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test match on unit variant with args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function
+fn foo(a: A, b: A) -> felt252 {
+    match (a, b) {
+        (A::One(_), _) => 2,
+        (A::Two(_), _) => 6,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+    Two: (),
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test match on Some without args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo<T>(a: Option<T>) -> felt252 {
+    match a {
+        Some => 2,
+        None => 6,
+    }
+}
+fn bar() -> felt252 {
+    let a = Some(());
+    foo(a)
+}
+
+//! > function_name
+bar
+
+//! > module_code
+
+//! > expected_diagnostics
+warning: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
+ --> lib.cairo:3:9
+        Some => 2,
+        ^^^^
+
+//! > ==========================================================================
+
+//! > Test match on Path no args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function
+fn foo(a: A, b: A) -> felt252 {
+    match (a, b) {
+        (A::One(_), _) => 2,
+        (Two, _) => 6,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+    Two: (),
+}
+use A::Two;
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test match on inferred unit Some without args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn fb() -> Option<()> {
+    let x = None;
+    match x {
+        Some => 2,
+        None => 6,
+    }
+    return x;
+}
+
+//! > function_name
+fb
+
+//! > module_code
+
+//! > expected_diagnostics
+warning: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
+ --> lib.cairo:4:9
+        Some => 2,
+        ^^^^
+
+//! > ==========================================================================
+
+//! > Test match on inferred unit Option::Some without args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn fb() -> Option<()> {
+    let x = None;
+    match x {
+        Option::Some => 2,
+        Option::None => 6,
+    }
+    return x;
+}
+
+//! > function_name
+fb
+
+//! > module_code
+
+//! > expected_diagnostics
+warning: Pattern missing subpattern for the payload of variant. Consider using `Option::Some(_)`
+ --> lib.cairo:4:9
+        Option::Some => 2,
+        ^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/while
+++ b/crates/cairo-lang-semantic/src/expr/test_data/while
@@ -69,3 +69,55 @@ error: Can only break with a value inside a `loop`.
  --> lib.cairo:4:9
         break x;
         ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > While let Some no args.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo() {
+    while let Some = Some(5) {
+        1;
+        break;
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+warning: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
+ --> lib.cairo:2:15
+    while let Some = Some(5) {
+              ^^^^
+
+//! > ==========================================================================
+
+//! > While let Some no args with unit.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function
+fn foo() {
+    let a = A::B(());
+    while let A::B = a {
+        1;
+        break;
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    B: (),
+}
+
+//! > expected_diagnostics


### PR DESCRIPTION
When building a semantic model a check is expected that pattern is legal.
When we match an option, we expect a case `Some` to be illegal, as it ignores the parameter. The expected pattern would be `Some(_)`.
This PR adds that check.