### PR TITLE
UnreachableArm is warning and match lowering checks and scope building use VariantMatchTree

### DIFF
--- a/crates/cairo-lang-lowering/src/diagnostic.rs
+++ b/crates/cairo-lang-lowering/src/diagnostic.rs
@@ -87,7 +87,11 @@ impl DiagnosticEntry for LoweringDiagnostic {
 
     fn severity(&self) -> Severity {
         match self.kind {
-            LoweringDiagnosticKind::Unreachable { .. } => Severity::Warning,
+            LoweringDiagnosticKind::Unreachable { .. }
+            | LoweringDiagnosticKind::MatchError(MatchError {
+                kind: _,
+                error: MatchDiagnostic::UnreachableMatchArm,
+            }) => Severity::Warning,
             _ => Severity::Error,
         }
     }

--- a/crates/cairo-lang-lowering/src/test_data/if
+++ b/crates/cairo-lang-lowering/src/test_data/if
@@ -697,7 +697,7 @@ enum MyEnum {
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error: Unreachable else clause.
+warning: Unreachable else clause.
  --> lib.cairo:10:12-12:5
       } else {
  ____________^
@@ -706,7 +706,40 @@ error: Unreachable else clause.
 |_____^
 
 //! > lowering_flat
-<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+Parameters: v0: test::MyEnum
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 0
+End:
+  Match(match_enum(v0) {
+    MyEnum::A(v2) => blk1,
+    MyEnum::B(v3) => blk2,
+    MyEnum::C(v4) => blk3,
+  })
+
+blk1:
+Statements:
+End:
+  Goto(blk4, {})
+
+blk2:
+Statements:
+End:
+  Goto(blk4, {})
+
+blk3:
+Statements:
+End:
+  Goto(blk4, {})
+
+blk4:
+Statements:
+  (v5: core::felt252) <- 5
+  (v6: core::felt252) <- core::felt252_add(v1, v5)
+  (v7: core::felt252) <- 1
+  (v8: core::felt252) <- core::felt252_add(v6, v7)
+End:
+  Return(v8)
 
 //! > ==========================================================================
 
@@ -812,3 +845,68 @@ Statements:
   (v3: core::felt252) <- 2
 End:
   Return(v3)
+
+//! > ==========================================================================
+
+//! > Test if let unreachable-else by multipattern
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(a: Option<felt252>) -> felt252 {
+    let mut y = 0;
+    if let None | Some(_) = a {
+        y = y + 5;
+    } else {
+        y = y + 8;
+    }
+    y = y + 1;
+    return y;
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+warning: Unreachable else clause.
+ --> lib.cairo:5:12-7:5
+      } else {
+ ____________^
+|         y = y + 8;
+|     }
+|_____^
+
+//! > lowering_flat
+Parameters: v0: core::option::Option::<core::felt252>
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 0
+End:
+  Match(match_enum(v0) {
+    Option::Some(v2) => blk1,
+    Option::None(v3) => blk2,
+  })
+
+blk1:
+Statements:
+End:
+  Goto(blk3, {})
+
+blk2:
+Statements:
+End:
+  Goto(blk3, {})
+
+blk3:
+Statements:
+  (v4: core::felt252) <- 5
+  (v5: core::felt252) <- core::felt252_add(v1, v4)
+  (v6: core::felt252) <- 1
+  (v7: core::felt252) <- core::felt252_add(v5, v6)
+End:
+  Return(v7)

--- a/crates/cairo-lang-lowering/src/test_data/match
+++ b/crates/cairo-lang-lowering/src/test_data/match
@@ -651,18 +651,55 @@ enum A {
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error: Unreachable pattern arm.
+warning: Unreachable pattern arm.
  --> lib.cairo:12:9
         A::Two(_) => 4,
         ^^^^^^^^^
 
-error: Unreachable pattern arm.
+warning: Unreachable pattern arm.
  --> lib.cairo:13:9
         A::Three(_) => 5,
         ^^^^^^^^^^^
 
 //! > lowering_flat
-<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+Parameters: v0: test::A
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    A::One(v1) => blk1,
+    A::Two(v2) => blk2,
+    A::Three(v3) => blk3,
+    A::Four(v4) => blk4,
+  })
+
+blk1:
+Statements:
+  (v5: core::felt252) <- 1
+End:
+  Return(v5)
+
+blk2:
+Statements:
+  (v6: core::felt252) <- 2
+End:
+  Return(v6)
+
+blk3:
+Statements:
+End:
+  Goto(blk5, {})
+
+blk4:
+Statements:
+End:
+  Goto(blk5, {})
+
+blk5:
+Statements:
+  (v7: core::felt252) <- 3
+End:
+  Return(v7)
 
 //! > ==========================================================================
 
@@ -824,14 +861,6 @@ error: Inner patterns are not allowed in this context.
  --> lib.cairo:3:14
         Some(Some(x)) => x,
              ^^^^^^^
-
-error: Missing match arm: `Some` not covered.
- --> lib.cairo:2:5-5:5
-      match a {
- _____^
-| ...
-|     }
-|_____^
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
@@ -1678,13 +1707,50 @@ enum A {
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error: Unreachable pattern arm.
+warning: Unreachable pattern arm.
  --> lib.cairo:12:9
         _ => 5,
         ^
 
 //! > lowering_flat
-<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+Parameters: v0: test::A
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    A::One(v1) => blk1,
+    A::Two(v2) => blk2,
+    A::Three(v3) => blk3,
+    A::Four(v4) => blk4,
+  })
+
+blk1:
+Statements:
+  (v5: core::felt252) <- 1
+End:
+  Return(v5)
+
+blk2:
+Statements:
+  (v6: core::felt252) <- 2
+End:
+  Return(v6)
+
+blk3:
+Statements:
+End:
+  Goto(blk5, {})
+
+blk4:
+Statements:
+End:
+  Goto(blk5, {})
+
+blk5:
+Statements:
+  (v7: core::felt252) <- 0
+End:
+  Return(v7)
 
 //! > ==========================================================================
 
@@ -1717,13 +1783,50 @@ enum A {
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error: Unreachable pattern arm.
+warning: Unreachable pattern arm.
  --> lib.cairo:12:9
         A::One(_) => 5,
         ^^^^^^^^^
 
 //! > lowering_flat
-<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+Parameters: v0: test::A
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    A::One(v1) => blk1,
+    A::Two(v2) => blk2,
+    A::Three(v3) => blk3,
+    A::Four(v4) => blk4,
+  })
+
+blk1:
+Statements:
+  (v5: core::felt252) <- 1
+End:
+  Return(v5)
+
+blk2:
+Statements:
+  (v6: core::felt252) <- 2
+End:
+  Return(v6)
+
+blk3:
+Statements:
+End:
+  Goto(blk5, {})
+
+blk4:
+Statements:
+End:
+  Goto(blk5, {})
+
+blk5:
+Statements:
+  (v7: core::felt252) <- 0
+End:
+  Return(v7)
 
 //! > ==========================================================================
 
@@ -1765,7 +1868,7 @@ enum B {
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error: Unreachable pattern arm.
+warning: Unreachable pattern arm.
  --> lib.cairo:20:9
         (_, A::Three(((_, _), x))) => x,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1948,10 +2051,10 @@ error: Unsupported matched value. Currently, match on tuples only supports enums
 
 //! > ==========================================================================
 
-//! > Test Match unreachable Otherwise.
+//! > Test match unreachable Otherwise.
 
 //! > test_runner_name
-test_function_lowering(expect_diagnostics: false)
+test_function_lowering(expect_diagnostics: true)
 
 //! > function
 fn foo(a: Option<felt252>) -> felt252 {
@@ -1970,6 +2073,10 @@ foo
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
+warning: Unreachable pattern arm.
+ --> lib.cairo:5:9
+        _ => 7,
+        ^
 
 //! > lowering_flat
 Parameters: v0: core::option::Option::<core::felt252>


### PR DESCRIPTION
The variant match tree now replaces the hash map for pattern coverage checking and scope building.
Previously, UnreachableArm was an error, but now it is a warning and covers more cases.

---

**Stack**:
- #7747
- #7743 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*