### PR TITLE
Lower recursive enum matching as multiple nested match expressions

### DIFF
--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -43,6 +43,7 @@ mod language_features {
     mod for_test;
     mod glob_use_test;
     mod macro_test;
+    mod match_test;
     mod panics_test;
     mod trait_test;
     mod while_test;

--- a/corelib/src/test/language_features/match_test.cairo
+++ b/corelib/src/test/language_features/match_test.cairo
@@ -1,0 +1,26 @@
+#[test]
+fn test_match_multienum_binding() {
+    if true {
+        match @@Some(@Some(@2)) {
+            Some(Some(x)) => {
+                assert_eq!(x, @@@@2);
+                return;
+            },
+            _ => panic!("Expected Some(Some(2)), but got a different pattern"),
+        }
+    }
+    panic!("Match expression did not return - this should be unreachable");
+}
+
+#[test]
+fn test_match_extern_multilevel() {
+    if true {
+        let x: Option<Option<Option<felt252>>> = Some(Some(None));
+        let b = BoxTrait::new(x);
+        match b.unbox() {
+            Some(Some(None)) => { return; },
+            _ => panic!("Expected Some(Some(None)), but got a different pattern"),
+        }
+    }
+    panic!("Match expression did not return - this should be unreachable");
+}

--- a/corelib/src/test/language_features/while_test.cairo
+++ b/corelib/src/test/language_features/while_test.cairo
@@ -54,3 +54,14 @@ fn test_borrow_with_inner_change() {
     }
 }
 
+#[test]
+fn test_while_let_multilevel_enum() {
+    let mut x = Some(Some(5));
+    let mut counter = 0;
+    while let Some(Some(y)) = x {
+        assert_eq!(y, 5);
+        x = Some(None); // Break the loop after one iteration
+        counter += 1;
+    }
+    assert_eq!(counter, 1);
+}

--- a/crates/cairo-lang-lowering/src/lower/lower_match.rs
+++ b/crates/cairo-lang-lowering/src/lower/lower_match.rs
@@ -1,9 +1,12 @@
 use cairo_lang_debug::DebugWithDb;
+use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::NamedLanguageElementId;
-use cairo_lang_diagnostics::{DiagnosticAdded, Maybe};
+use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::FlagId;
-use cairo_lang_semantic::{self as semantic, ConcreteVariant, GenericArgumentId, corelib};
+use cairo_lang_semantic::{
+    self as semantic, ConcreteEnumId, ConcreteVariant, GenericArgumentId, corelib,
+};
 use cairo_lang_syntax::node::TypedStablePtr;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -98,6 +101,16 @@ impl MatchArmWrapper<'_> {
     }
 }
 
+/// Returns the concrete enum and the number of snapshots of the type if it is an enum.
+fn peel_snapshots_and_try_enum(
+    ctx: &mut LoweringContext<'_, '_>,
+    ty: semantic::TypeId,
+) -> Option<(ConcreteEnumId, usize)> {
+    let (n_snapshots, long_ty) = peel_snapshots(ctx.db, ty);
+    let TypeLongId::Concrete(ConcreteTypeId::Enum(concrete_enum_id)) = long_ty else { return None };
+    Some((concrete_enum_id, n_snapshots))
+}
+
 /// Extracts concrete enum and variants from a match expression. Assumes it is indeed a concrete
 /// enum.
 fn extract_concrete_enum(
@@ -106,15 +119,12 @@ fn extract_concrete_enum(
     ty: semantic::TypeId,
     match_type: MatchKind,
 ) -> Result<ExtractedEnumDetails, LoweringFlowError> {
-    let (n_snapshots, long_ty) = peel_snapshots(ctx.db, ty);
-
-    // Semantic model should have made sure the type is an enum.
-    let TypeLongId::Concrete(ConcreteTypeId::Enum(concrete_enum_id)) = long_ty else {
+    let Some((concrete_enum_id, n_snapshots)) = peel_snapshots_and_try_enum(ctx, ty) else {
         return Err(LoweringFlowError::Failed(ctx.diagnostics.report(
             stable_ptr,
             MatchError(MatchError {
                 kind: match_type,
-                error: MatchDiagnostic::UnsupportedMatchedType(long_ty.format(ctx.db)),
+                error: MatchDiagnostic::UnsupportedMatchedType(ty.format(ctx.db)),
             }),
         )));
     };
@@ -230,6 +240,31 @@ fn get_underscore_pattern_path_and_mark_unreachable(
     Some(otherwise_variant)
 }
 
+/// Information kept in a match tree Mapping node for matching on an enum.
+#[derive(Debug, Clone)]
+struct MappingInfo {
+    /// The number of snapshots of the enum type.
+    n_snapshots: usize,
+    /// The [ConcreteEnumId] of the enum type.
+    concrete_enum_id: ConcreteEnumId,
+    /// The [LocationId] of the pattern representing this tree.
+    location: LocationId,
+    /// The [ConcreteVariant]s of the enum type.
+    variants: Vec<ConcreteVariant>,
+}
+
+impl MappingInfo {
+    /// Creates a new [MappingInfo] from the given parameters.
+    fn new(
+        n_snapshots: usize,
+        concrete_enum_id: ConcreteEnumId,
+        location: LocationId,
+        variants: Vec<ConcreteVariant>,
+    ) -> Self {
+        Self { n_snapshots, concrete_enum_id, location, variants }
+    }
+}
+
 /// A sparse tree that records the structure of the match expression.
 /// This tree is created after checking that all variants are covered, and lowering of the patterns.
 ///
@@ -237,8 +272,14 @@ fn get_underscore_pattern_path_and_mark_unreachable(
 #[derive(Clone)]
 enum VariantMatchTree {
     /// The current variant is itself an enum; a `Vec` entry is kept for
-    /// every child variant match tree.
-    Mapping(Vec<(VariantMatchTree, ConcreteVariant)>),
+    /// every child variant match tree. The n_snapshots of the enum type, the [ConcreteEnumId], and
+    /// [SyntaxStablePtrId] of the pattern are also stored.
+    Mapping {
+        /// Additional information about the enum type.
+        mapping_info: MappingInfo,
+        /// The sub-[VariantMatchTree]s for each enum variant.
+        mapping: Vec<VariantMatchTree>,
+    },
     /// A pattern fully covers this enum type/variant. Additional patterns
     /// reaching here are unreachable (even if current variant is itself an enum, subtrees are
     /// irrelevant).
@@ -247,8 +288,6 @@ enum VariantMatchTree {
         pattern_path: PatternPath,
         /// The inner pattern after unwrapping all enum variants.
         inner_pattern: Option<PatternId>,
-        /// An error on inner pattern if it is not supported.
-        err: Option<DiagnosticAdded>,
     },
     /// No pattern has covered this enum type/variant. A `MissingMatchArm` diagnostic
     /// has been emitted and the error saved.
@@ -273,15 +312,15 @@ impl std::fmt::Debug for VariantMatchTree {
                         pattern_path.arm_index, pattern_path.pattern_index
                     )
                 }
-                VariantMatchTree::Mapping(variants) => {
+                VariantMatchTree::Mapping { mapping, .. } => {
                     writeln!(f, "{prefix}Mapping:")?;
-                    for (i, (variant, _)) in variants.iter().enumerate() {
-                        let is_last = i == variants.len() - 1;
+                    for (i, subtree) in mapping.iter().enumerate() {
+                        let is_last = i == mapping.len() - 1;
                         let branch = if is_last { "└───" } else { "├───" };
                         writeln!(f, "{prefix}{branch}")?;
                         let new_prefix =
                             format!("{prefix}{}", if is_last { "    " } else { "│   " });
-                        fmt_inner(variant, f, &new_prefix)?;
+                        fmt_inner(subtree, f, &new_prefix)?;
                     }
                     Ok(())
                 }
@@ -293,20 +332,12 @@ impl std::fmt::Debug for VariantMatchTree {
 }
 
 impl VariantMatchTree {
-    /// Utility to return subtree of the given variants.
+    /// Utility to return subtree of the given variant.
     /// If a full path is found, it is returned (as it covers all variants).
-    fn get_subtree<'a>(
-        &self,
-        variants: impl IntoIterator<Item = &'a ConcreteVariant>,
-    ) -> &VariantMatchTree {
-        let mut it = variants.into_iter();
-        if let Some(variant) = it.next() {
-            match self {
-                VariantMatchTree::Missing(_) | VariantMatchTree::Full { .. } => self,
-                VariantMatchTree::Mapping(mapping) => mapping[variant.idx].0.get_subtree(it),
-            }
-        } else {
-            self
+    fn get_subtree(&self, variant: &ConcreteVariant) -> &VariantMatchTree {
+        match self {
+            VariantMatchTree::Missing(_) | VariantMatchTree::Full { .. } => self,
+            VariantMatchTree::Mapping { mapping, .. } => &mapping[variant.idx],
         }
     }
 }
@@ -318,8 +349,13 @@ impl VariantMatchTree {
 #[derive(Clone)]
 enum PatternTree {
     /// The current variant is itself an enum; a `Vec` entry is kept for
-    /// every child pattern tree.
-    Mapping(Vec<(ConcreteVariant, PatternTree)>),
+    /// every child variant match tree along with additional metadata on the match.
+    Mapping {
+        /// Additional information about the enum type.
+        mapping_info: MappingInfo,
+        /// The sub-[PatternTree]s for each enum variant.
+        mapping: Vec<PatternTree>,
+    },
     /// A pattern fully covers this enum type/variant. Additional patterns
     /// reaching here are unreachable (even if current variant is itself an enum, subtrees are
     /// irrelevant).
@@ -328,8 +364,6 @@ enum PatternTree {
         pattern_path: PatternPath,
         /// The inner pattern after unwrapping all enum variants.
         inner_pattern: Option<PatternId>,
-        /// An error on inner pattern if it is not supported.
-        err: Option<DiagnosticAdded>,
     },
     /// No pattern has covered this enum type/variant yet.
     Empty,
@@ -342,24 +376,22 @@ impl PatternTree {
         match_type: MatchKind,
         pattern_path: PatternPath,
         inner_pattern: Option<PatternId>,
-        err: Option<DiagnosticAdded>,
     ) -> Result<(), LoweringDiagnosticKind> {
         match self {
             PatternTree::Empty => {
-                *self = PatternTree::Full { pattern_path, inner_pattern, err };
+                *self = PatternTree::Full { pattern_path, inner_pattern };
                 Ok(())
             }
             PatternTree::Full { .. } => Err(MatchError(MatchError {
                 kind: match_type,
                 error: MatchDiagnostic::UnreachableMatchArm,
             })),
-            PatternTree::Mapping(mapping) => {
+            PatternTree::Mapping { mapping, .. } => {
                 // Need at least one empty path, but should write to all (pattern covers multiple
                 // paths).
                 let mut any_ok = false;
-                for (_, path) in mapping.iter_mut() {
-                    if path.push_pattern_path(match_type, pattern_path, inner_pattern, err).is_ok()
-                    {
+                for path in mapping.iter_mut() {
+                    if path.push_pattern_path(match_type, pattern_path, inner_pattern).is_ok() {
                         any_ok = true;
                     }
                 }
@@ -382,21 +414,35 @@ impl PatternTree {
         &mut self,
         ctx: &mut LoweringContext<'_, '_>,
         concrete_variant: ConcreteVariant,
-    ) -> cairo_lang_diagnostics::Maybe<Option<&mut PatternTree>> {
+        n_snapshots: usize,
+        stable_ptr: SyntaxStablePtrId,
+    ) -> LoweringResult<Option<&mut PatternTree>> {
         match self {
             PatternTree::Empty => {
-                let variants = ctx.db.concrete_enum_variants(concrete_variant.concrete_enum_id)?;
-                *self = PatternTree::Mapping(
-                    variants.into_iter().map(|variant| (variant, PatternTree::Empty)).collect(),
-                );
-                if let PatternTree::Mapping(items) = self {
-                    Ok(Some(&mut items[concrete_variant.idx].1))
+                let variants = ctx
+                    .db
+                    .concrete_enum_variants(concrete_variant.concrete_enum_id)
+                    .map_err(LoweringFlowError::Failed)?;
+                let location =
+                    LocationId::from_stable_location(ctx.db, StableLocation::new(stable_ptr));
+                let variants_len = variants.len();
+                *self = PatternTree::Mapping {
+                    mapping_info: MappingInfo::new(
+                        n_snapshots,
+                        concrete_variant.concrete_enum_id,
+                        location,
+                        variants,
+                    ),
+                    mapping: vec![PatternTree::Empty; variants_len],
+                };
+                if let PatternTree::Mapping { mapping, .. } = self {
+                    Ok(Some(&mut mapping[concrete_variant.idx]))
                 } else {
                     unreachable!("We just created the mapping.")
                 }
             }
             PatternTree::Full { .. } => Ok(None),
-            PatternTree::Mapping(items) => Ok(Some(&mut items[concrete_variant.idx].1)),
+            PatternTree::Mapping { mapping, .. } => Ok(Some(&mut mapping[concrete_variant.idx])),
         }
     }
 
@@ -438,14 +484,15 @@ impl PatternTree {
                     match_type,
                     &*variants_being_explored,
                 )),
-                PatternTree::Full { pattern_path, inner_pattern, err } => {
-                    VariantMatchTree::Full { pattern_path, inner_pattern, err }
+                PatternTree::Full { pattern_path, inner_pattern } => {
+                    VariantMatchTree::Full { pattern_path, inner_pattern }
                 }
-                PatternTree::Mapping(mapping) => {
-                    let children: Vec<(VariantMatchTree, ConcreteVariant)> = mapping
+                PatternTree::Mapping { mapping_info, mapping } => {
+                    let mapping = mapping
                         .into_iter()
-                        .map(|(concrete_variant, subtree)| {
-                            variants_being_explored.push(concrete_variant);
+                        .zip(mapping_info.variants.iter())
+                        .map(|(subtree, concrete_variant)| {
+                            variants_being_explored.push(concrete_variant.clone());
                             let variant_match_tree = build_tree_helper(
                                 subtree,
                                 ctx,
@@ -453,14 +500,13 @@ impl PatternTree {
                                 match_type,
                                 variants_being_explored,
                             );
-                            let concrete_variant = variants_being_explored.pop().expect(
+                            let _ = variants_being_explored.pop().expect(
                                 "We should have popped the variant inserted before recursive call.",
                             );
-                            (variant_match_tree, concrete_variant)
+                            variant_match_tree
                         })
                         .collect();
-
-                    VariantMatchTree::Mapping(children)
+                    VariantMatchTree::Mapping { mapping_info, mapping }
                 }
             }
         }
@@ -985,18 +1031,15 @@ pub(crate) fn lower_concrete_enum_match(
         arms: vec![],
         location,
     });
-    if concrete_variants.is_empty() {
-        return builder.merge_and_end_with_match(ctx, empty_match_info, vec![], location);
-    }
-    let mut builder_context =
-        MatchArmsLoweringContext::new(builder, match_type, arms, empty_match_info);
 
-    let pattern_builder =
-        ConcreteEnumVariantPatternBuilder { n_snapshots, default_location: location };
+    let builder_context =
+        MatchArmsLoweringContext::new(builder, match_type, arms, empty_match_info, location);
+
+    let pattern_builder = ConcreteEnumVariantPatternBuilder { n_snapshots };
 
     pattern_builder.create_scopes_and_collect_match_arms(
         ctx,
-        &mut builder_context,
+        builder_context,
         location,
         concrete_enum_id,
         concrete_variants,
@@ -1029,14 +1072,14 @@ pub(crate) fn lower_optimized_extern_match(
         arms: vec![],
         location,
     });
-    let mut builder_context =
-        MatchArmsLoweringContext::new(builder, match_type, arms, empty_match_info);
+    let builder_context =
+        MatchArmsLoweringContext::new(builder, match_type, arms, empty_match_info, location);
 
     let pattern_builder = ExternEnumVariantPatternBuilder { extern_enum: extern_enum.clone() };
 
     pattern_builder.create_scopes_and_collect_match_arms(
         ctx,
-        &mut builder_context,
+        builder_context,
         location,
         extern_enum.concrete_enum_id,
         concrete_variants,
@@ -1069,10 +1112,14 @@ trait EnumVariantScopeBuilder {
     fn lower_concrete_enum_variant(
         &self,
         ctx: &mut LoweringContext<'_, '_>,
+        builder_context: &mut MatchArmsLoweringContext<'_>,
         subscope: &mut BlockBuilder,
         ty: semantic::TypeId,
         inner_pattern: Option<PatternId>,
     ) -> Result<Vec<VariableId>, LoweringFlowError>;
+
+    /// Returns number of snapshots on the matched type.
+    fn n_snapshots(&self) -> usize;
 
     /// Builds a variant match tree from the arms of a match statement.
     /// The tree is used to check for unreachable patterns and represent for each variant it's
@@ -1113,7 +1160,6 @@ trait EnumVariantScopeBuilder {
                         match_type,
                         PatternPath { arm_index, pattern_index: None },
                         None,
-                        None,
                     );
                     continue;
                 }
@@ -1126,7 +1172,6 @@ trait EnumVariantScopeBuilder {
                         PatternPath { arm_index, pattern_index: None },
                         &mut pattern_tree,
                         None,
-                        None,
                     );
                     continue;
                 }
@@ -1136,7 +1181,7 @@ trait EnumVariantScopeBuilder {
                 let pattern_path = PatternPath { arm_index, pattern_index: Some(pattern_index) };
                 let pattern_ptr = ctx.function_body.arenas.patterns[pattern].stable_ptr();
 
-                let variant_match_tree = &mut pattern_tree;
+                let pattern_tree = &mut pattern_tree;
                 if !(matches_enum(ctx, pattern) | matches_other(ctx, pattern)) {
                     return Err(LoweringFlowError::Failed(ctx.diagnostics.report(
                         pattern_ptr,
@@ -1151,8 +1196,9 @@ trait EnumVariantScopeBuilder {
                     match_type,
                     pattern,
                     pattern_path,
-                    variant_match_tree,
+                    pattern_tree,
                     concrete_enum_id,
+                    0,
                 )?;
             }
         }
@@ -1176,22 +1222,14 @@ trait EnumVariantScopeBuilder {
             pattern_path: PatternPath,
             mut pattern_tree: &mut PatternTree,
             mut concrete_enum_id: semantic::ConcreteEnumId,
+            mut n_snapshots: usize,
         ) -> Result<(), LoweringFlowError> {
             let pattern_ptr = ctx.function_body.arenas.patterns[pattern].stable_ptr();
-            let mut err = None;
             loop {
                 match &ctx.function_body.arenas.patterns[pattern] {
                     semantic::Pattern::Otherwise(_) => {
                         // Fill leaves and check for usefulness.
-                        try_push(
-                            ctx,
-                            match_type,
-                            pattern_ptr,
-                            pattern_path,
-                            pattern_tree,
-                            None,
-                            err,
-                        );
+                        try_push(ctx, match_type, pattern_ptr, pattern_path, pattern_tree, None);
                         break;
                     }
                     semantic::Pattern::EnumVariant(enum_pattern) => {
@@ -1208,11 +1246,14 @@ trait EnumVariantScopeBuilder {
                         let inner_pattern_opt = enum_pattern.inner_pattern;
                         let pattern_variant_idx = enum_pattern.variant.idx;
 
+                        let stable_ptr = enum_pattern.stable_ptr.untyped();
                         // Expand paths in map to include all variants of this enum_pattern.
-                        if let Some(vmap) = pattern_tree
-                            .get_mapping_or_insert(ctx, enum_pattern.variant.clone())
-                            .map_err(LoweringFlowError::Failed)?
-                        {
+                        if let Some(vmap) = pattern_tree.get_mapping_or_insert(
+                            ctx,
+                            enum_pattern.variant.clone(),
+                            n_snapshots,
+                            stable_ptr,
+                        )? {
                             pattern_tree = vmap;
                         } else {
                             ctx.diagnostics.report(
@@ -1228,23 +1269,26 @@ trait EnumVariantScopeBuilder {
                         // Check if we need to process a nested enum pattern
                         match inner_pattern_opt {
                             Some(inner_pattern) if matches_enum(ctx, inner_pattern) => {
-                                // If pattern is not top pattern it is still unsupported so we
-                                // report it.
-                                if err.is_none() {
-                                    let ptr = ctx.function_body.arenas.patterns[inner_pattern]
-                                        .stable_ptr();
-                                    err = Some(ctx.diagnostics.report(ptr, UnsupportedPattern));
-                                }
-
-                                let ptr =
-                                    ctx.function_body.arenas.patterns[inner_pattern].stable_ptr();
                                 let variant = &ctx
                                     .db
                                     .concrete_enum_variants(concrete_enum_id)
                                     .map_err(LoweringFlowError::Failed)?[pattern_variant_idx];
-                                let next_enum =
-                                    extract_concrete_enum(ctx, ptr.into(), variant.ty, match_type);
-                                concrete_enum_id = next_enum?.concrete_enum_id;
+                                let Some((next_enum, new_n_snapshots)) =
+                                    peel_snapshots_and_try_enum(ctx, variant.ty)
+                                else {
+                                    try_push(
+                                        ctx,
+                                        match_type,
+                                        pattern_ptr,
+                                        pattern_path,
+                                        pattern_tree,
+                                        inner_pattern_opt,
+                                    );
+                                    break;
+                                };
+                                // Update data for deeper pattern.
+                                n_snapshots = new_n_snapshots;
+                                concrete_enum_id = next_enum;
                                 pattern = inner_pattern;
                             }
                             _ => {
@@ -1255,7 +1299,6 @@ trait EnumVariantScopeBuilder {
                                     pattern_path,
                                     pattern_tree,
                                     inner_pattern_opt,
-                                    err,
                                 );
                                 break;
                             }
@@ -1280,10 +1323,9 @@ trait EnumVariantScopeBuilder {
             pattern_path: PatternPath,
             pattern_tree: &mut PatternTree,
             inner_pattern: Option<PatternId>,
-            err: Option<DiagnosticAdded>,
         ) {
             let _ = pattern_tree
-                .push_pattern_path(match_type, pattern_path, inner_pattern, err)
+                .push_pattern_path(match_type, pattern_path, inner_pattern)
                 .map_err(|e| ctx.diagnostics.report(stable_ptr, e));
         }
 
@@ -1315,12 +1357,37 @@ trait EnumVariantScopeBuilder {
     fn create_scopes_and_collect_match_arms(
         &self,
         ctx: &mut LoweringContext<'_, '_>,
-        builder_context: &mut MatchArmsLoweringContext<'_>,
+        mut builder_context: MatchArmsLoweringContext<'_>,
         location: LocationId,
         concrete_enum_id: semantic::ConcreteEnumId,
         concrete_variants: Vec<ConcreteVariant>,
         create_match_info: impl Fn(&mut LoweringContext<'_, '_>, Vec<MatchArm>) -> MatchInfo,
     ) -> LoweringResult<LoweredExpr> {
+        if concrete_variants.is_empty() {
+            for arm in builder_context.arms {
+                match arm {
+                    MatchArmWrapper::Arm(_, expr) |
+                    // Should actually never happen, as we can't if-let, but careful anyway.
+                    MatchArmWrapper::ElseClause(expr) => {
+                        ctx.diagnostics.report(
+                            ctx.function_body.arenas.exprs[*expr].stable_ptr(),
+                            MatchError(MatchError {
+                                kind: builder_context.kind,
+                                error: MatchDiagnostic::UnreachableMatchArm,
+                            }),
+                        );
+                    },
+                    MatchArmWrapper::DefaultClause => (),
+                }
+            }
+            return builder_context.builder.merge_and_end_with_match(
+                ctx,
+                builder_context.empty_match_info,
+                vec![],
+                location,
+            );
+        }
+
         let pattern_tree: PatternTree = self.build_pattern_tree(
             ctx,
             builder_context.arms,
@@ -1334,17 +1401,13 @@ trait EnumVariantScopeBuilder {
             &concrete_variants,
         );
 
-        trace!(
-            "Lowering match arms for enum {concrete_enum_id:?} with match type {:?} and variant \
-             match tree:\n{variant_match_tree:?}",
-            builder_context.kind
-        );
+        trace!("Lowering match arms of variant match tree:\n{variant_match_tree:?}");
 
         // Collect the block builders per variant and the corresponding input variables.
         // Also group variants by arm to later create a single sealed block for each arm.
         let (variant_contexts, arm_blocks) = self.collect_match_lowering_info_and_arms(
             ctx,
-            builder_context,
+            &mut builder_context,
             concrete_variants,
             &variant_match_tree,
         );
@@ -1395,113 +1458,98 @@ trait EnumVariantScopeBuilder {
         let mut pattern_lowering_err = None;
         for variant in concrete_variants {
             let mut variant_scope = create_subscope(ctx, builder_context.builder);
-            let subtree = variant_match_tree.get_subtree(std::iter::once(&variant));
+            let subtree = variant_match_tree.get_subtree(&variant);
 
-            let (vars, arm_and_lowering_res) = match subtree {
-                VariantMatchTree::Full { pattern_path, inner_pattern, err } => {
-                    match (
-                        err,
-                        self.lower_concrete_enum_variant(
-                            ctx,
-                            &mut variant_scope,
-                            variant.ty,
-                            *inner_pattern,
-                        ),
+            let (block_id, vars, arm_and_lowering_res) = match subtree {
+                VariantMatchTree::Full { pattern_path, inner_pattern } => {
+                    match self.lower_concrete_enum_variant(
+                        ctx,
+                        builder_context,
+                        &mut variant_scope,
+                        variant.ty,
+                        *inner_pattern,
                     ) {
-                        (None, Ok(vars)) => (vars, Ok((pattern_path.arm_index, Ok(())))),
-                        (_, Err(err)) => (vec![], Ok((pattern_path.arm_index, Err(err)))),
-                        (Some(err), _) => (vec![], Err(LoweringFlowError::Failed(*err))),
+                        Ok(vars) => (
+                            variant_scope.block_id,
+                            vars,
+                            Ok(Some((pattern_path.arm_index, variant_scope, Ok(())))),
+                        ),
+                        Err(err) => (
+                            variant_scope.block_id,
+                            vec![],
+                            Ok(Some((pattern_path.arm_index, variant_scope, Err(err)))),
+                        ),
                     }
                 }
-                VariantMatchTree::Mapping(mapping) => {
+                VariantMatchTree::Mapping { mapping_info, .. } => {
                     // For variance the match tree is a mapping for a submatch tree.
                     // We need to lower the submatch tree and return the result.
-                    let mut first_error = None;
-                    // Get sub variants for type of this variant.
-                    for (subtree, concrete_variant) in mapping {
-                        // TODO(eytan-starkware) For now just put all variants, but in the future we
-                        // should check if it is needed.
-                        let (_n_snapshots, long_ty) = peel_snapshots(ctx.db, concrete_variant.ty);
+                    // *fresh* builder – always concrete as this is an inner enum match (indicated
+                    // by mapping) and thus has a type.
+                    let nested_builder = ConcreteEnumVariantPatternBuilder {
+                        n_snapshots: self.n_snapshots() + mapping_info.n_snapshots, /* propagate snapshots */
+                    };
+                    // Recursive call splits the mapping by variant.
+                    let (nested_variant_contexts, nested_arm_blocks) = nested_builder
+                        .collect_match_lowering_info_and_arms(
+                            ctx,
+                            builder_context,
+                            mapping_info.variants.clone(),
+                            subtree,
+                        );
 
-                        // Semantic model should have made sure the type is an enum.
-                        let variants =
-                            if let TypeLongId::Concrete(ConcreteTypeId::Enum(concrete_enum_id)) =
-                                long_ty
-                            {
-                                match ctx
-                                    .db
-                                    .concrete_enum_variants(concrete_enum_id)
-                                    .map_err(LoweringFlowError::Failed)
-                                {
-                                    Ok(variants) => variants,
-                                    Err(err) => {
-                                        first_error = Some(err);
-                                        continue;
-                                    }
-                                }
-                            } else {
-                                vec![concrete_variant.clone()]
-                            };
-                        let (arms, _arm_pattern_blocks) = self
-                            .collect_match_lowering_info_and_arms(
-                                ctx,
-                                builder_context,
-                                variants,
-                                subtree,
-                            );
-                        if let Err(e) = arms {
-                            first_error = Some(e);
-                        }
+                    let block_id = variant_scope.block_id;
+                    for (arm_index, nested_arm_blocks) in nested_arm_blocks {
+                        arm_blocks.entry(arm_index).or_default().extend(nested_arm_blocks);
                     }
-
-                    // TODO(eytan-starkware) At the moment this will always be an error, but that
-                    // should be changed soon. The reason is that a mapping in the subtree of the
-                    // root variant match tree (i.e. here) will only happen if we have a depth 2+
-                    // enum pattern.
-                    fn get_first_error_from_full(
-                        variant_match_tree: &VariantMatchTree,
-                    ) -> Option<LoweringFlowError> {
-                        match variant_match_tree {
-                            VariantMatchTree::Full { err, .. } => {
-                                (*err).map(LoweringFlowError::Failed)
-                            }
-                            VariantMatchTree::Mapping(mapping) => mapping
-                                .iter()
-                                .map(|(subtree, _)| get_first_error_from_full(subtree))
-                                .find(|e| e.is_some())
-                                .flatten(),
-                            VariantMatchTree::Missing(_) => None,
+                    // Merge the nested variant contexts into the current variant_scope.
+                    match nested_variant_contexts {
+                        Ok(contexts) => {
+                            let input_var = ctx.new_var(VarRequest {
+                                ty: wrap_in_snapshots(ctx.db, variant.ty, mapping_info.n_snapshots),
+                                location: mapping_info.location,
+                            });
+                            let var_usage =
+                                VarUsage { var_id: input_var, location: mapping_info.location };
+                            let match_info = MatchInfo::Enum(MatchEnumInfo {
+                                concrete_enum_id: mapping_info.concrete_enum_id,
+                                input: var_usage,
+                                arms: contexts,
+                                location: mapping_info.location,
+                            });
+                            variant_scope.finalize(ctx, BlockEnd::Match { info: match_info });
+                            // Create a block to do a match into match arms, and propagate the
+                            // nested arm blocks to parent.
+                            (block_id, vec![input_var], Ok(None))
                         }
+                        Err(err) => (block_id, vec![], Err((err, variant_scope))),
                     }
-                    let err = first_error.unwrap_or_else(|| {
-                        get_first_error_from_full(subtree).expect(
-                            "Expected to find an error in the match tree as we encountered a \
-                             nested enum pattern.",
-                        )
-                    });
-
-                    (vec![], Err(err))
                 }
-                VariantMatchTree::Missing(lowering_flow_error) => {
-                    (vec![], Err(lowering_flow_error.clone()))
-                }
+                VariantMatchTree::Missing(lowering_flow_error) => (
+                    variant_scope.block_id,
+                    vec![],
+                    Err((lowering_flow_error.clone(), variant_scope)),
+                ),
             };
 
             variant_contexts.push(MatchArm {
                 arm_selector: MatchArmSelector::VariantId(variant),
-                block_id: variant_scope.block_id,
+                block_id,
                 var_ids: vars,
             });
 
             match arm_and_lowering_res {
-                Ok((arm_index, lowering_res)) => {
+                Ok(Some((arm_index, variant_scope, lowering_res))) => {
                     arm_blocks.entry(arm_index).or_default().push(MatchLeafBuilder {
                         lowering_result: lowering_res,
                         builder: variant_scope,
                         arm_index,
                     });
                 }
-                Err(e) => {
+                Ok(None) => (),
+                Err((e, variant_scope)) => {
+                    // If we have an error, we need to report it and finalize the block.
+                    let _ = lowering_flow_error_to_sealed_block(ctx, variant_scope, e.clone());
                     pattern_lowering_err.get_or_insert(e);
                 }
             }
@@ -1521,6 +1569,7 @@ impl EnumVariantScopeBuilder for ExternEnumVariantPatternBuilder {
     fn lower_concrete_enum_variant(
         &self,
         ctx: &mut LoweringContext<'_, '_>,
+        _builder_context: &mut MatchArmsLoweringContext<'_>,
         subscope: &mut BlockBuilder,
         ty: semantic::TypeId,
         inner_pattern: Option<PatternId>,
@@ -1540,19 +1589,23 @@ impl EnumVariantScopeBuilder for ExternEnumVariantPatternBuilder {
         }
         .map(|_| input_vars_to_report)
     }
+
+    fn n_snapshots(&self) -> usize {
+        0 // Extern enums do not have snapshots.
+    }
 }
 
 /// Implements the [EnumVariantScopeBuilder] trait for concrete enum variants.
 /// This struct is used to prepare for lowering match arms for concrete enums.
 struct ConcreteEnumVariantPatternBuilder {
     n_snapshots: usize,
-    default_location: LocationId,
 }
 
 impl EnumVariantScopeBuilder for ConcreteEnumVariantPatternBuilder {
     fn lower_concrete_enum_variant(
         &self,
         ctx: &mut LoweringContext<'_, '_>,
+        builder_context: &mut MatchArmsLoweringContext<'_>,
         subscope: &mut BlockBuilder,
         ty: semantic::TypeId,
         inner_pattern: Option<PatternId>,
@@ -1572,10 +1625,14 @@ impl EnumVariantScopeBuilder for ConcreteEnumVariantPatternBuilder {
         } else {
             let var_id = ctx.new_var(VarRequest {
                 ty: wrap_in_snapshots(ctx.db, ty, self.n_snapshots),
-                location: self.default_location,
+                location: builder_context.location,
             });
             Ok(vec![var_id])
         }
+    }
+
+    fn n_snapshots(&self) -> usize {
+        self.n_snapshots
     }
 }
 
@@ -1589,6 +1646,8 @@ struct MatchArmsLoweringContext<'a> {
     arms: &'a [MatchArmWrapper<'a>],
     /// Empty match info to be used for lowering match arms.
     empty_match_info: MatchInfo,
+    /// The location of the match expression.
+    location: LocationId,
 }
 
 impl<'a> MatchArmsLoweringContext<'a> {
@@ -1598,8 +1657,9 @@ impl<'a> MatchArmsLoweringContext<'a> {
         kind: MatchKind,
         match_arms: &'a [MatchArmWrapper<'_>],
         empty_match_info: MatchInfo,
+        location: LocationId,
     ) -> Self {
-        Self { builder, kind, arms: match_arms, empty_match_info }
+        Self { builder, kind, arms: match_arms, empty_match_info, location }
     }
 }
 
@@ -1615,6 +1675,7 @@ impl std::fmt::Debug for MatchLeafBuilder {
         f.debug_struct("MatchLeafBuilder")
             .field("arm_index", &self.arm_index)
             .field("lowering_result", &self.lowering_result)
+            .field("builder", &self.builder.block_id)
             .finish()
     }
 }

--- a/crates/cairo-lang-lowering/src/test_data/if
+++ b/crates/cairo-lang-lowering/src/test_data/if
@@ -910,3 +910,80 @@ Statements:
   (v7: core::felt252) <- core::felt252_add(v5, v6)
 End:
   Return(v7)
+
+//! > ==========================================================================
+
+//! > Test if let multipattern multilevel enum
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo(a: Option<Result<felt252, felt252>>) -> felt252 {
+    let mut y = 0;
+    if let Some(Err(v)) | Some(Ok(v)) = a {
+        y = y + v;
+    } else {
+        y = y + 8;
+    }
+    y = y + 1;
+    return y;
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: core::option::Option::<core::result::Result::<core::felt252, core::felt252>>
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 0
+End:
+  Match(match_enum(v0) {
+    Option::Some(v2) => blk1,
+    Option::None(v3) => blk5,
+  })
+
+blk1:
+Statements:
+End:
+  Match(match_enum(v2) {
+    Result::Ok(v4) => blk2,
+    Result::Err(v5) => blk3,
+  })
+
+blk2:
+Statements:
+End:
+  Goto(blk4, {v4 -> v6})
+
+blk3:
+Statements:
+End:
+  Goto(blk4, {v5 -> v6})
+
+blk4:
+Statements:
+  (v7: core::felt252) <- core::felt252_add(v1, v6)
+End:
+  Goto(blk6, {v7 -> v8})
+
+blk5:
+Statements:
+  (v9: core::felt252) <- 8
+  (v10: core::felt252) <- core::felt252_add(v1, v9)
+End:
+  Goto(blk6, {v10 -> v8})
+
+blk6:
+Statements:
+  (v11: core::felt252) <- 1
+  (v12: core::felt252) <- core::felt252_add(v8, v11)
+End:
+  Return(v12)

--- a/crates/cairo-lang-lowering/src/test_data/match
+++ b/crates/cairo-lang-lowering/src/test_data/match
@@ -857,11 +857,6 @@ foo
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error: Inner patterns are not allowed in this context.
- --> lib.cairo:3:14
-        Some(Some(x)) => x,
-             ^^^^^^^
-
 error: Missing match arm: `Some(None)` not covered.
  --> lib.cairo:2:5-5:5
       match a {
@@ -2181,7 +2176,7 @@ End:
 //! > Test empty enum match on empty enum with otherwise.
 
 //! > test_runner_name
-test_function_lowering(expect_diagnostics: false)
+test_function_lowering(expect_diagnostics: warnings_only)
 
 //! > function
 fn foo(e: EmptyEnum) -> felt252 {
@@ -2208,6 +2203,10 @@ enum EmptyEnum {}
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
+warning: Unreachable pattern arm.
+ --> lib.cairo:5:14
+        _ => { 1 },
+             ^^^^^
 
 //! > lowering_flat
 Parameters: v0: core::option::Option::<test::EmptyEnum>
@@ -2242,7 +2241,7 @@ test_function_lowering(expect_diagnostics: true)
 fn foo(a: Option<Option<A>>) -> felt252 {
     match a {
         Some(Some(A::One)) => 3,
-        // Creates two patterns in variant tree.
+        // Creates two `Full` nodes in variant tree.
         Some(Some(_)) => 2,
         None(_) => 1,
     }
@@ -2261,16 +2260,6 @@ enum A {
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error: Inner patterns are not allowed in this context.
- --> lib.cairo:8:14
-        Some(Some(A::One)) => 3,
-             ^^^^^^^^^^^^
-
-error: Inner patterns are not allowed in this context.
- --> lib.cairo:10:14
-        Some(Some(_)) => 2,
-             ^^^^^^^
-
 error: Missing match arm: `Some(None)` not covered.
  --> lib.cairo:7:5-12:5
       match a {
@@ -2287,7 +2276,7 @@ error: Missing match arm: `Some(None)` not covered.
 //! > Match with complex patterns and no other diagnostics.
 
 //! > test_runner_name
-test_function_lowering(expect_diagnostics: true)
+test_function_lowering(expect_diagnostics: false)
 
 //! > function
 fn foo(a: Option<Option<A>>) -> felt252 {
@@ -2313,20 +2302,919 @@ enum A {
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error: Inner patterns are not allowed in this context.
- --> lib.cairo:8:14
-        Some(Some(A::One)) => 3,
-             ^^^^^^^^^^^^
 
-error: Inner patterns are not allowed in this context.
- --> lib.cairo:10:14
-        Some(Some(_)) => 2,
-             ^^^^^^^
+//! > lowering_flat
+Parameters: v0: core::option::Option::<core::option::Option::<test::A>>
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    Option::Some(v1) => blk1,
+    Option::None(v2) => blk8,
+  })
 
-error: Inner patterns are not allowed in this context.
- --> lib.cairo:11:14
-        Some(None) => 4,
-             ^^^^
+blk1:
+Statements:
+End:
+  Match(match_enum(v1) {
+    Option::Some(v3) => blk2,
+    Option::None(v4) => blk7,
+  })
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v3) {
+    A::One(v5) => blk3,
+    A::Two(v6) => blk4,
+    A::Three(v7) => blk5,
+  })
+
+blk3:
+Statements:
+  (v8: core::felt252) <- 3
+End:
+  Return(v8)
+
+blk4:
+Statements:
+End:
+  Goto(blk6, {})
+
+blk5:
+Statements:
+End:
+  Goto(blk6, {})
+
+blk6:
+Statements:
+  (v9: core::felt252) <- 2
+End:
+  Return(v9)
+
+blk7:
+Statements:
+  (v10: core::felt252) <- 4
+End:
+  Return(v10)
+
+blk8:
+Statements:
+  (v11: core::felt252) <- 1
+End:
+  Return(v11)
+
+//! > ==========================================================================
+
+//! > Match on enum variants and bind vars from different variants.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo(c: C) -> felt252 {
+    match c {
+        C::One(B::One(A::Two(x))) | C::One(B::One(A::One(x))) => x + x,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    One: felt252,
+    Two: felt252,
+}
+
+enum B {
+    One: A,
+}
+
+enum C {
+    One: B,
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: test::C
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    C::One(v1) => blk1,
+  })
+
+blk1:
+Statements:
+End:
+  Match(match_enum(v1) {
+    B::One(v2) => blk2,
+  })
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v2) {
+    A::One(v3) => blk3,
+    A::Two(v4) => blk4,
+  })
+
+blk3:
+Statements:
+End:
+  Goto(blk5, {v3 -> v5})
+
+blk4:
+Statements:
+End:
+  Goto(blk5, {v4 -> v5})
+
+blk5:
+Statements:
+  (v6: core::felt252) <- core::felt252_add(v5, v5)
+End:
+  Return(v6)
+
+//! > ==========================================================================
+
+//! > Match on 3 level enum variants with a pattern binding.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo(a: A) -> felt252 {
+    match a {
+        Ok(Ok(Ok(x))) => x,
+        Ok(Ok(Err(x))) | Err(Err(Err(x))) | Ok(Err(Ok(x))) | Err(Ok(Ok(x))) => x + x,
+        Err(Ok(Err(x))) | Ok(Err(Err(x))) | Err(Err(Ok(x))) => x * x,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+type A = Result<B, B>;
+type B = Result<C, C>;
+type C = Result<felt252, felt252>;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: core::result::Result::<core::result::Result::<core::result::Result::<core::felt252, core::felt252>, core::result::Result::<core::felt252, core::felt252>>, core::result::Result::<core::result::Result::<core::felt252, core::felt252>, core::result::Result::<core::felt252, core::felt252>>>
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    Result::Ok(v1) => blk1,
+    Result::Err(v2) => blk8,
+  })
+
+blk1:
+Statements:
+End:
+  Match(match_enum(v1) {
+    Result::Ok(v3) => blk2,
+    Result::Err(v4) => blk5,
+  })
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v3) {
+    Result::Ok(v5) => blk3,
+    Result::Err(v6) => blk4,
+  })
+
+blk3:
+Statements:
+End:
+  Return(v5)
+
+blk4:
+Statements:
+End:
+  Goto(blk16, {v6 -> v7})
+
+blk5:
+Statements:
+End:
+  Match(match_enum(v4) {
+    Result::Ok(v8) => blk6,
+    Result::Err(v9) => blk7,
+  })
+
+blk6:
+Statements:
+End:
+  Goto(blk16, {v8 -> v7})
+
+blk7:
+Statements:
+End:
+  Goto(blk14, {v9 -> v10})
+
+blk8:
+Statements:
+End:
+  Match(match_enum(v2) {
+    Result::Ok(v11) => blk9,
+    Result::Err(v12) => blk12,
+  })
+
+blk9:
+Statements:
+End:
+  Match(match_enum(v11) {
+    Result::Ok(v13) => blk10,
+    Result::Err(v14) => blk11,
+  })
+
+blk10:
+Statements:
+End:
+  Goto(blk16, {v13 -> v7})
+
+blk11:
+Statements:
+End:
+  Goto(blk14, {v14 -> v10})
+
+blk12:
+Statements:
+End:
+  Match(match_enum(v12) {
+    Result::Ok(v15) => blk13,
+    Result::Err(v16) => blk15,
+  })
+
+blk13:
+Statements:
+End:
+  Goto(blk14, {v15 -> v10})
+
+blk14:
+Statements:
+  (v17: core::felt252) <- core::felt252_mul(v10, v10)
+End:
+  Return(v17)
+
+blk15:
+Statements:
+End:
+  Goto(blk16, {v16 -> v7})
+
+blk16:
+Statements:
+  (v18: core::felt252) <- core::felt252_add(v7, v7)
+End:
+  Return(v18)
+
+//! > ==========================================================================
+
+//! > Match on 3 level enum variants with a missing pattern on variant in bottom type.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(a: A) -> felt252 {
+    match a {
+        // Ok(Ok(Ok(()))) => 1,
+        Ok(Ok(Err(()))) => 2,
+        Ok(Err(Ok(()))) => 3,
+        Ok(Err(Err(()))) => 4,
+        Err(Ok(Ok(()))) => 5,
+        Err(Ok(Err(()))) => 6,
+        Err(Err(Ok(()))) => 7,
+        Err(Err(Err(()))) => 8,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+type A = Result<B, B>;
+type B = Result<C, C>;
+type C = Result<(), ()>;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error: Missing match arm: `Ok(Ok(Ok))` not covered.
+ --> lib.cairo:5:5-14:5
+      match a {
+ _____^
+| ...
+|     }
+|_____^
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Match on 3 level enum variants with a missing pattern on variant in middle type.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(a: A) -> felt252 {
+    match a {
+        Ok(Ok(Ok(()))) => 1,
+        Ok(Ok(Err(()))) => 2,
+        // Ok(Err(Ok(()))) => 3,
+        // Ok(Err(Err(()))) => 4,
+        Err(Ok(Ok(()))) => 5,
+        Err(Ok(Err(()))) => 6,
+        Err(Err(Ok(()))) => 7,
+        Err(Err(Err(()))) => 8,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+type A = Result<B, B>;
+type B = Result<C, C>;
+type C = Result<(), ()>;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error: Missing match arm: `Ok(Err)` not covered.
+ --> lib.cairo:5:5-14:5
+      match a {
+ _____^
+| ...
+|     }
+|_____^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Match on 3 level enum variants with a missing pattern on variant in top type.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(a: A) -> felt252 {
+    match a {
+        // Ok(Ok(Ok(()))) => 1,
+        // Ok(Ok(Err(()))) => 2,
+        // Ok(Err(Ok(()))) => 3,
+        // Ok(Err(Err(()))) => 4,
+        Err(Ok(Ok(()))) => 5,
+        Err(Ok(Err(()))) => 6,
+        Err(Err(Ok(()))) => 7,
+        Err(Err(Err(()))) => 8,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+type A = Result<B, B>;
+type B = Result<C, C>;
+type C = Result<(), ()>;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error: Missing match arm: `Ok` not covered.
+ --> lib.cairo:5:5-14:5
+      match a {
+ _____^
+| ...
+|     }
+|_____^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Match on 3 level enum variants with a single variant.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo(c: C) -> felt252 {
+    match c {
+        C::One(B::One(A::One)) => 1,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    One: (),
+}
+
+enum B {
+    One: A,
+}
+
+enum C {
+    One: B,
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: test::C
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    C::One(v1) => blk1,
+  })
+
+blk1:
+Statements:
+End:
+  Match(match_enum(v1) {
+    B::One(v2) => blk2,
+  })
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v2) {
+    A::One(v3) => blk3,
+  })
+
+blk3:
+Statements:
+  (v4: core::felt252) <- 1
+End:
+  Return(v4)
+
+//! > ==========================================================================
+
+//! > Match on enum variants and bind vars from different enum types.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo(c: C) -> felt252 {
+    match c {
+        C::One(B::One(A::One(x))) | C::One(B::Two(x)) => x + x,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    One: felt252,
+}
+
+enum B {
+    One: A,
+    Two: felt252,
+}
+
+enum C {
+    One: B,
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: test::C
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    C::One(v1) => blk1,
+  })
+
+blk1:
+Statements:
+End:
+  Match(match_enum(v1) {
+    B::One(v2) => blk2,
+    B::Two(v3) => blk4,
+  })
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v2) {
+    A::One(v4) => blk3,
+  })
+
+blk3:
+Statements:
+End:
+  Goto(blk5, {v4 -> v5})
+
+blk4:
+Statements:
+End:
+  Goto(blk5, {v3 -> v5})
+
+blk5:
+Statements:
+  (v6: core::felt252) <- core::felt252_add(v5, v5)
+End:
+  Return(v6)
+
+//! > ==========================================================================
+
+//! > Match on enum variants and bind vars from a tuple.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo(b: B) -> felt252 {
+    match b {
+        B::One(A::One((x, _))) => x,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    One: (felt252, felt252),
+}
+
+enum B {
+    One: A,
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: test::B
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    B::One(v1) => blk1,
+  })
+
+blk1:
+Statements:
+End:
+  Match(match_enum(v1) {
+    A::One(v2) => blk2,
+  })
+
+blk2:
+Statements:
+  (v3: core::felt252, v4: core::felt252) <- struct_destructure(v2)
+End:
+  Return(v3)
+
+//! > ==========================================================================
+
+//! > Match on enum with snapshots in types.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo(x: @B) -> felt252 {
+    match x {
+        B::Two(A::One(v)) => *****v,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    One: @felt252,
+}
+
+enum B {
+    Two: @@@A,
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: @test::B
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    B::Two(v1) => blk1,
+  })
+
+blk1:
+Statements:
+End:
+  Match(match_enum(v1) {
+    A::One(v2) => blk2,
+  })
+
+blk2:
+Statements:
+  (v3: @@@@core::felt252) <- desnap(v2)
+  (v4: @@@core::felt252) <- desnap(v3)
+  (v5: @@core::felt252) <- desnap(v4)
+  (v6: @core::felt252) <- desnap(v5)
+  (v7: core::felt252) <- desnap(v6)
+End:
+  Return(v7)
+
+//! > ==========================================================================
+
+//! > Test extern to inner match arm.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo() -> felt252 {
+    match get_a() {
+        A::One(Some(Some(v))) => v,
+        _ => 3,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {
+    One: Option<Option<felt252>>,
+}
+
+extern fn get_a() -> A nopanic;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+End:
+  Match(match test::get_a() {
+    A::One(v0) => blk1,
+  })
+
+blk1:
+Statements:
+End:
+  Match(match_enum(v0) {
+    Option::Some(v1) => blk2,
+    Option::None(v2) => blk5,
+  })
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v1) {
+    Option::Some(v3) => blk3,
+    Option::None(v4) => blk4,
+  })
+
+blk3:
+Statements:
+End:
+  Return(v3)
+
+blk4:
+Statements:
+End:
+  Goto(blk6, {})
+
+blk5:
+Statements:
+End:
+  Goto(blk6, {})
+
+blk6:
+Statements:
+  (v5: core::felt252) <- 3
+End:
+  Return(v5)
+
+//! > ==========================================================================
+
+//! > Test extern to inner match arm with snapshots.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo() -> felt252 {
+    match @get_a() {
+        A::One(Some(Some(v))) => *****v,
+        _ => 3,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+enum A {
+    One: @Option<@@Option<@felt252>>,
+}
+
+extern fn get_a() -> A nopanic;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+End:
+  Match(match test::get_a() {
+    A::One(v0) => blk1,
+  })
+
+blk1:
+Statements:
+  (v1: test::A) <- A::One(v0)
+  (v2: test::A, v3: @test::A) <- snapshot(v1)
+End:
+  Match(match_enum(v3) {
+    A::One(v4) => blk2,
+  })
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v4) {
+    Option::Some(v5) => blk3,
+    Option::None(v6) => blk6,
+  })
+
+blk3:
+Statements:
+End:
+  Match(match_enum(v5) {
+    Option::Some(v7) => blk4,
+    Option::None(v8) => blk5,
+  })
+
+blk4:
+Statements:
+  (v9: @@@@core::felt252) <- desnap(v7)
+  (v10: @@@core::felt252) <- desnap(v9)
+  (v11: @@core::felt252) <- desnap(v10)
+  (v12: @core::felt252) <- desnap(v11)
+  (v13: core::felt252) <- desnap(v12)
+End:
+  Return(v13)
+
+blk5:
+Statements:
+End:
+  Goto(blk7, {})
+
+blk6:
+Statements:
+End:
+  Goto(blk7, {})
+
+blk7:
+Statements:
+  (v14: core::felt252) <- 3
+End:
+  Return(v14)
+
+//! > ==========================================================================
+
+//! > Test enum match after destruct disallowed.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(x: Option<Option<A>>) -> felt252 {
+    match x {
+        Some(Some(A { opt: Some(v) })) => v,
+        _ => 3,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+struct A {
+    opt: Option<felt252>,
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error: Inner patterns are not allowed in this context.
+ --> lib.cairo:7:28
+        Some(Some(A { opt: Some(v) })) => v,
+                           ^^^^^^^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Test value match after enum match.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function
+fn foo(x: Option<Option<felt252>>) -> felt252 {
+    match x {
+        Some(Some(0)) => 0,
+        _ => 3,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+struct A {
+    opt: Option<felt252>,
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error: Inner patterns are not allowed in this context.
+ --> lib.cairo:7:19
+        Some(Some(0)) => 0,
+                  ^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Test lowering of empty extern enum.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function
+fn foo() -> felt252 {
+    match get_a() {}
+}
+
+//! > function_name
+foo
+
+//! > module_code
+enum A {}
+
+extern fn get_a() -> A nopanic;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+End:
+  Match(match test::get_a() {
+  })

--- a/crates/cairo-lang-semantic/src/expr/test_data/match
+++ b/crates/cairo-lang-semantic/src/expr/test_data/match
@@ -452,3 +452,89 @@ warning: Pattern missing subpattern for the payload of variant. Consider using `
  --> lib.cairo:4:9
         Option::Some => 2,
         ^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test bad type in multi level enum pattern variable binding.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo(x: Result<Option<u8>, felt252>) {
+    let _y = match x {
+        Ok(Some(x)) | Err(x) => x,
+        _ => 3,
+    };
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error: Expected type "core::integer::u8", found: "core::felt252".
+ --> lib.cairo:3:27
+        Ok(Some(x)) | Err(x) => x,
+                          ^
+
+//! > ==========================================================================
+
+//! > Test bad inner pattern type in multi level enum pattern.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo(x: Result<Option<u8>, felt252>) {
+    let _y = match x {
+        Ok(Ok(x)) | Err(x) => x,
+        _ => 3,
+    };
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error: Wrong enum in pattern. Expected: "core::option::Option". Got: "core::result::Result".
+ --> lib.cairo:3:12
+        Ok(Ok(x)) | Err(x) => x,
+           ^^^^^
+
+error: Missing variable in pattern.
+ --> lib.cairo:3:9
+        Ok(Ok(x)) | Err(x) => x,
+        ^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test value match after enum match.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn bar(x: felt252) {
+    foo(Ok(Some(x)));
+}
+
+//! > function_name
+bar
+
+//! > module_code
+fn foo<T>(x: Result<Option<T>, felt252>) {
+    let _y = match x {
+        Ok(Some(x)) | Err(x) => x,
+        _ => 3,
+    };
+}
+
+//! > expected_diagnostics
+error: Expected type "T", found: "core::felt252".
+ --> lib.cairo:3:27
+        Ok(Some(x)) | Err(x) => x,
+                          ^


### PR DESCRIPTION
This PR does the following:
1. Update match lowering code to handle mapping case (nested enum).
This is done by lowering the match expression into a series of
nested lowered match expressions, where each nested match expression
corresponds to a variant in the original enum being matched.
The related code has been modified to collect errors and close all
opened subscopes (block builders).
2. Give an unreachability warning on all arms when a match is done on a
never type (also include external enum).
3. Add a tests for recursive enum matching in the language features
tests, semantic tests, and lowering tests.
4. Code hygiene:
- Extracted helper function `peel_snapshots_and_try_enum`.
- Removed `prepare_and_lower_concrete_variant` and use inner pattern
saved in `Full` node instead.
- Extracted MappingInfo structure common to `PatternTree` and
`VariantMatchTree`.
- Small changes.