### PR TITLE
Derive `Hash` for `TextPosition`

### DIFF
--- a/crates/cairo-lang-filesystem/src/span.rs
+++ b/crates/cairo-lang-filesystem/src/span.rs
@@ -151,7 +151,7 @@ impl TextSpan {
 }
 
 /// Human-readable position inside a file, in lines and characters.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TextPosition {
     /// Line index, 0 based.
     pub line: usize,


### PR DESCRIPTION
## Rationale
We need `TextPosition` to implement `Hash` to be able to use it as an argument for our Salsa queries in LS