### PR TITLE
fix typo lower_match.rs

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/lower_match.rs
+++ b/crates/cairo-lang-lowering/src/lower/lower_match.rs
@@ -1102,7 +1102,7 @@ pub(crate) fn lower_optimized_extern_match(
 /// An internal pattern, if exists, is passed to
 /// `lower_concrete_enum_variant`.
 ///
-/// Implementors are responsible for implementing `lower_concrete_enum_variant`.
+/// Implementers are responsible for implementing `lower_concrete_enum_variant`.
 ///
 /// Call-site entry point: `build_enum_block_variants`.
 trait EnumVariantScopeBuilder {


### PR DESCRIPTION
Hey team! Fixed error in `crates/cairo-lang-lowering/src/lower/lower_match.rs`

`Implementors` - `Implementers`