### PR TITLE
Fix lint diagnostics for `write!` inline macro

### DIFF
--- a/crates/cairo-lang-semantic/src/inline_macros/write.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/write.rs
@@ -389,7 +389,7 @@ impl FormattingInfo {
 
         self.flush_pending_chars(builder, &mut pending_chars, ident_count);
         self.add_indentation(builder, ident_count);
-        builder.add_str("core::result::Result::<(), core::fmt::Error>::Ok(())\n");
+        builder.add_str("core::result::Result::<(), core::fmt::Error>::Ok\n");
         while ident_count > 1 {
             ident_count -= 1;
             self.add_indentation(builder, ident_count);


### PR DESCRIPTION
The `(())` is not necessary here as the type is inferred. This change is applied to the cairo-lint standards of the code. For more context see https://github.com/software-mansion/cairo-lint/blob/84709c709d339740c6781b74a09e88ddd10ded38/src/lints/redundant_brackets_in_enum_call.rs#L47