### PR TITLE
Changed Database inputs to use LongIds with a wrapper for interning

### DIFF
--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -40,10 +40,10 @@ impl Default for DatabaseForTesting {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
         init_defs_group(&mut res);
-        res.set_default_macro_plugins(Arc::new([
-            res.intern_macro_plugin(MacroPluginLongId(Arc::new(FooToBarPlugin))),
-            res.intern_macro_plugin(MacroPluginLongId(Arc::new(RemoveOrigPlugin))),
-            res.intern_macro_plugin(MacroPluginLongId(Arc::new(DummyPlugin))),
+        res.set_default_macro_plugins_input(Arc::new([
+            MacroPluginLongId(Arc::new(FooToBarPlugin)),
+            MacroPluginLongId(Arc::new(RemoveOrigPlugin)),
+            MacroPluginLongId(Arc::new(DummyPlugin)),
         ]));
         res
     }

--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -3,8 +3,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use cairo_lang_utils::LookupIntern;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::{Intern, LookupIntern};
 use salsa::Durability;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -192,6 +192,9 @@ pub trait FilesGroup: ExternalFiles {
 
     /// Main input of the project. Lists all the crates configurations.
     #[salsa::input]
+    fn crate_configs_input(&self) -> Arc<OrderedHashMap<CrateLongId, CrateConfiguration>>;
+
+    /// Interned version of `crate_configs_input`.
     fn crate_configs(&self) -> Arc<OrderedHashMap<CrateId, CrateConfiguration>>;
 
     /// Overrides for file content. Mostly used by language server and tests.
@@ -200,12 +203,19 @@ pub trait FilesGroup: ExternalFiles {
     /// Change this mechanism to hold file_overrides on the db struct outside salsa mechanism,
     /// and invalidate manually.
     #[salsa::input]
+    fn file_overrides_input(&self) -> Arc<OrderedHashMap<FileLongId, Arc<str>>>;
+
+    /// Interned version of `file_overrides_input`.
     fn file_overrides(&self) -> Arc<OrderedHashMap<FileId, Arc<str>>>;
 
     // TODO(yuval): consider moving this to a separate crate, or rename this crate.
     /// The compilation flags.
     #[salsa::input]
+    fn flags_input(&self) -> Arc<OrderedHashMap<FlagLongId, Arc<Flag>>>;
+
+    /// Interned version of `flags_input`.
     fn flags(&self) -> Arc<OrderedHashMap<FlagId, Arc<Flag>>>;
+
     /// The `#[cfg(...)]` options.
     #[salsa::input]
     fn cfg_set(&self) -> Arc<CfgSet>;
@@ -229,10 +239,33 @@ pub trait FilesGroup: ExternalFiles {
 
 pub fn init_files_group(db: &mut (dyn FilesGroup + 'static)) {
     // Initialize inputs.
-    db.set_file_overrides(Arc::new(OrderedHashMap::default()));
-    db.set_crate_configs(Arc::new(OrderedHashMap::default()));
-    db.set_flags(Arc::new(OrderedHashMap::default()));
+    db.set_file_overrides_input(Arc::new(OrderedHashMap::default()));
+    db.set_crate_configs_input(Arc::new(OrderedHashMap::default()));
+    db.set_flags_input(Arc::new(OrderedHashMap::default()));
     db.set_cfg_set(Arc::new(CfgSet::new()));
+}
+
+pub fn file_overrides(db: &dyn FilesGroup) -> Arc<OrderedHashMap<FileId, Arc<str>>> {
+    let inp = db.file_overrides_input();
+    Arc::new(
+        inp.iter()
+            .map(|(file_id, content)| (file_id.clone().intern(db), content.clone()))
+            .collect(),
+    )
+}
+
+pub fn crate_configs(db: &dyn FilesGroup) -> Arc<OrderedHashMap<CrateId, CrateConfiguration>> {
+    let inp = db.crate_configs_input();
+    Arc::new(
+        inp.iter()
+            .map(|(crate_id, config)| (crate_id.clone().intern(db), config.clone()))
+            .collect(),
+    )
+}
+
+pub fn flags(db: &dyn FilesGroup) -> Arc<OrderedHashMap<FlagId, Arc<Flag>>> {
+    let inp = db.flags_input();
+    Arc::new(inp.iter().map(|(flag_id, flag)| (flag_id.clone().intern(db), flag.clone())).collect())
 }
 
 pub fn init_dev_corelib(db: &mut (dyn FilesGroup + 'static), core_lib_dir: PathBuf) {
@@ -261,30 +294,33 @@ pub fn init_dev_corelib(db: &mut (dyn FilesGroup + 'static), core_lib_dir: PathB
 pub trait FilesGroupEx: FilesGroup {
     /// Overrides file content. None value removes the override.
     fn override_file_content(&mut self, file: FileId, content: Option<Arc<str>>) {
-        let mut overrides = self.file_overrides().as_ref().clone();
+        let file = self.lookup_intern_file(file);
+        let mut overrides = self.file_overrides_input().as_ref().clone();
         match content {
             Some(content) => overrides.insert(file, content),
             None => overrides.swap_remove(&file),
         };
-        self.set_file_overrides(Arc::new(overrides));
+        self.set_file_overrides_input(Arc::new(overrides));
     }
     /// Sets the root directory of the crate. None value removes the crate.
     fn set_crate_config(&mut self, crt: CrateId, root: Option<CrateConfiguration>) {
-        let mut crate_configs = self.crate_configs().as_ref().clone();
+        let crt = self.lookup_intern_crate(crt);
+        let mut crate_configs = self.crate_configs_input().as_ref().clone();
         match root {
             Some(root) => crate_configs.insert(crt, root),
             None => crate_configs.swap_remove(&crt),
         };
-        self.set_crate_configs(Arc::new(crate_configs));
+        self.set_crate_configs_input(Arc::new(crate_configs));
     }
     /// Sets the given flag value. None value removes the flag.
     fn set_flag(&mut self, id: FlagId, value: Option<Arc<Flag>>) {
-        let mut flags = self.flags().as_ref().clone();
+        let flag = self.lookup_intern_flag(id);
+        let mut flags = self.flags_input().as_ref().clone();
         match value {
-            Some(value) => flags.insert(id, value),
-            None => flags.swap_remove(&id),
+            Some(value) => flags.insert(flag, value),
+            None => flags.swap_remove(&flag),
         };
-        self.set_flags(Arc::new(flags));
+        self.set_flags_input(Arc::new(flags));
     }
     /// Merges specified [`CfgSet`] into one already stored in this db.
     fn use_cfg(&mut self, cfg_set: &CfgSet) {

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -65,11 +65,8 @@ impl Default for DatabaseForTesting {
         let mut res = Self { storage: Default::default() };
         init_files_group(&mut res);
         init_defs_group(&mut res);
-        res.set_default_macro_plugins(
-            get_base_plugins()
-                .into_iter()
-                .map(|plugin| res.intern_macro_plugin(MacroPluginLongId(plugin)))
-                .collect(),
+        res.set_default_macro_plugins_input(
+            get_base_plugins().into_iter().map(MacroPluginLongId).collect(),
         );
         res
     }
@@ -114,14 +111,11 @@ pub fn test_expand_plugin_inner(
 ) -> TestRunnerResult {
     let db = &mut DatabaseForTesting::default();
 
-    let extra_plugins = extra_plugins
-        .iter()
-        .cloned()
-        .map(|plugin| db.intern_macro_plugin(MacroPluginLongId(plugin)));
+    let extra_plugins = extra_plugins.iter().cloned().map(MacroPluginLongId);
 
-    let default_plugins = db.default_macro_plugins();
+    let default_plugins = db.default_macro_plugins_input();
     let plugins = chain!(default_plugins.iter().cloned(), extra_plugins).collect::<Arc<[_]>>();
-    db.set_default_macro_plugins(plugins);
+    db.set_default_macro_plugins_input(plugins);
 
     let cfg_set: Option<CfgSet> =
         inputs.get("cfg").map(|s| serde_json::from_str(s.as_str()).unwrap());

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -2040,9 +2040,21 @@ pub trait PluginSuiteInput: SemanticGroup {
     /// [`SemanticGroup::default_analyzer_plugins`].
     fn set_default_plugins_from_suite(&mut self, suite: InternedPluginSuite) {
         let InternedPluginSuite { macro_plugins, inline_macro_plugins, analyzer_plugins } = suite;
-
-        self.set_default_macro_plugins(macro_plugins);
-        self.set_default_inline_macro_plugins(inline_macro_plugins);
+        let macro_plugins = macro_plugins
+            .iter()
+            .map(|plugin| self.lookup_intern_macro_plugin(*plugin))
+            .collect::<Vec<_>>();
+        let macro_plugins = Arc::from(macro_plugins);
+        let inline_macro_plugins = Arc::new(
+            inline_macro_plugins
+                .iter()
+                .map(|(name, plugin)| {
+                    (name.clone(), self.lookup_intern_inline_macro_plugin(*plugin))
+                })
+                .collect(),
+        );
+        self.set_default_macro_plugins_input(macro_plugins);
+        self.set_default_inline_macro_plugins_input(inline_macro_plugins);
         self.set_default_analyzer_plugins(analyzer_plugins);
     }
 

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -144,9 +144,9 @@ impl MacroPlugin for AddInlineModuleDummyPlugin {
 fn test_inline_module_diagnostics() {
     let mut db_val = SemanticDatabaseForTesting::new_empty();
     let db = &mut db_val;
-    db.set_default_macro_plugins(Arc::new([
-        db.intern_macro_plugin(MacroPluginLongId(Arc::new(AddInlineModuleDummyPlugin)))
-    ]));
+    db.set_default_macro_plugins_input(Arc::new([MacroPluginLongId(Arc::new(
+        AddInlineModuleDummyPlugin,
+    ))]));
     let crate_id = setup_test_crate(
         db,
         indoc! {"


### PR DESCRIPTION
This is a preparation step towards using salsa 0.22.X, as interned values will have lifetime which is disallowed on inputs.

This also changes the public api of:
default_macro_plugins
macro_plugin_overrides
default_inline_macro_plugins
inline_macro_plugin_overrides
crate_configs
file_overrides
flags

---

**Stack**:
- #8053
- #8050
- #8044
- #8043
- #8042
- #7805
- #7831
- #7830
- #7829 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*