### PR TITLE
Remove `relative_span` field from PluginDiagnostic

### DIFF
--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -1839,7 +1839,6 @@ impl PluginDiagnosticCached {
     fn embed(self, ctx: &mut DefCacheLoadingContext<'_>) -> PluginDiagnostic {
         PluginDiagnostic {
             stable_ptr: self.stable_ptr.embed(ctx),
-            relative_span: None,
             message: self.message,
             severity: match self.severity {
                 SeverityCached::Error => Severity::Error,

--- a/crates/cairo-lang-defs/src/diagnostic_utils.rs
+++ b/crates/cairo-lang-defs/src/diagnostic_utils.rs
@@ -78,31 +78,6 @@ impl StableLocation {
         let end = until_stable_ptr.lookup(db).span_end_without_trivia(db);
         DiagnosticLocation { file_id: self.stable_ptr.file_id(db), span: TextSpan { start, end } }
     }
-
-    /// Returns the [DiagnosticLocation] corresponding to a subrange of the [StableLocation],
-    /// defined by character offsets relative to the start of the syntax node.
-    pub fn diagnostic_location_with_offsets(
-        &self,
-        db: &dyn DefsGroup,
-        start_offset: u32,
-        end_offset: u32,
-    ) -> DiagnosticLocation {
-        let syntax_node = self.stable_ptr.lookup(db);
-        let node_span = syntax_node.span_without_trivia(db);
-
-        let span = TextSpan {
-            start: node_span
-                .start
-                .add_width(TextWidth::new_for_testing(start_offset))
-                .min(node_span.end),
-            end: node_span
-                .start
-                .add_width(TextWidth::new_for_testing(end_offset))
-                .min(node_span.end),
-        };
-
-        DiagnosticLocation { file_id: self.stable_ptr.file_id(db), span }
-    }
 }
 
 impl DebugWithDb<dyn DefsGroup> for StableLocation {

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -6,7 +6,7 @@ use cairo_lang_diagnostics::Severity;
 use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::db::Edition;
 use cairo_lang_filesystem::ids::CodeMapping;
-use cairo_lang_filesystem::span::{TextSpan, TextWidth};
+use cairo_lang_filesystem::span::TextWidth;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::{SyntaxNode, ast};
@@ -75,11 +75,6 @@ pub struct PluginResult {
 pub struct PluginDiagnostic {
     /// The stable pointer of the syntax node that caused the diagnostic.
     pub stable_ptr: SyntaxStablePtrId,
-    /// Span relative to the start of the `stable_ptr`.
-    /// No assertion is made that the span is fully contained within the node pointed to by
-    /// `stable_ptr`. When printing diagnostics, any part of the span that falls outside the
-    /// referenced node will be silently ignored.
-    pub relative_span: Option<TextSpan>,
     pub message: String,
     /// The severity of the diagnostic.
     pub severity: Severity,
@@ -93,7 +88,6 @@ impl PluginDiagnostic {
     pub fn error(stable_ptr: impl Into<SyntaxStablePtrId>, message: String) -> PluginDiagnostic {
         PluginDiagnostic {
             stable_ptr: stable_ptr.into(),
-            relative_span: None,
             message,
             severity: Severity::Error,
             inner_span: None,
@@ -113,7 +107,6 @@ impl PluginDiagnostic {
         PluginDiagnostic {
             stable_ptr,
             message,
-            relative_span: None,
             severity: Severity::Error,
             inner_span: Some((offset, width)),
         }
@@ -122,16 +115,10 @@ impl PluginDiagnostic {
     pub fn warning(stable_ptr: impl Into<SyntaxStablePtrId>, message: String) -> PluginDiagnostic {
         PluginDiagnostic {
             stable_ptr: stable_ptr.into(),
-            relative_span: None,
             message,
             severity: Severity::Warning,
             inner_span: None,
         }
-    }
-
-    pub fn with_relative_span(mut self, span: TextSpan) -> Self {
-        self.relative_span = Some(span);
-        self
     }
 }
 

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -479,7 +479,7 @@ fn test_unknown_item_macro() {
     assert_eq!(
         format!("{:?}", db.module_plugin_diagnostics(module_id).unwrap()),
         "[(ModuleFileId(CrateRoot(CrateId(0)), FileIndex(0)), PluginDiagnostic { stable_ptr: \
-         SyntaxStablePtrId(3), relative_span: None, message: \"Unknown inline item macro: \
-         'unknown_item_macro'.\", severity: Error, inner_span: None })]"
+         SyntaxStablePtrId(3), message: \"Unknown inline item macro: 'unknown_item_macro'.\", \
+         severity: Error, inner_span: None })]"
     )
 }

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1083,24 +1083,14 @@ impl DiagnosticEntry for SemanticDiagnostic {
         }
     }
     fn location(&self, db: &Self::DbType) -> DiagnosticLocation {
-        match &self.kind {
-            SemanticDiagnosticKind::PluginDiagnostic(diag) => {
-                if let Some(relative_span) = diag.relative_span {
-                    return self.stable_location.diagnostic_location_with_offsets(
-                        db,
-                        relative_span.start.as_u32(),
-                        relative_span.end.as_u32(),
-                    );
-                }
-            }
-            SemanticDiagnosticKind::MacroGeneratedCodeParserDiagnostic(parser_diagnostic) => {
-                return DiagnosticLocation {
-                    file_id: parser_diagnostic.file_id,
-                    span: parser_diagnostic.span,
-                };
-            }
-            _ => (),
-        }
+        if let SemanticDiagnosticKind::MacroGeneratedCodeParserDiagnostic(parser_diagnostic) =
+            &self.kind
+        {
+            return DiagnosticLocation {
+                file_id: parser_diagnostic.file_id,
+                span: parser_diagnostic.span,
+            };
+        };
 
         let mut location = self.stable_location.diagnostic_location(db);
         if self.after {

--- a/crates/cairo-lang-semantic/src/test.rs
+++ b/crates/cairo-lang-semantic/src/test.rs
@@ -1,10 +1,10 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::ModuleItemId;
 use cairo_lang_defs::plugin::{
-    MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+    MacroPlugin, MacroPluginMetadata, PluginGeneratedFile, PluginResult,
 };
 use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
-use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
+use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::extract_matches;
@@ -167,102 +167,5 @@ fn test_mapping_translate_consecutive_spans() {
             ^^^^^
 
     "#}
-    );
-}
-
-#[derive(Debug, Default)]
-struct CustomSpanTestPlugin;
-impl MacroPlugin for CustomSpanTestPlugin {
-    fn generate_code(
-        &self,
-        db: &dyn SyntaxGroup,
-        item_ast: ast::ModuleItem,
-        _metadata: &MacroPluginMetadata<'_>,
-    ) -> PluginResult {
-        // Only run plugin in the test file.
-        let ptr = item_ast.stable_ptr(db);
-        let file = ptr.0.file_id(db);
-        let path = file.full_path(db);
-        if path != "lib.cairo" {
-            return PluginResult::default();
-        }
-
-        // Find the first function in the file
-        if let ast::ModuleItem::FreeFunction(function) = &item_ast {
-            // Get function body statements
-            let elements = function.body(db).statements(db).elements(db);
-            if elements.is_empty() {
-                return PluginResult::default();
-            }
-
-            // Look for a variable declaration with a string literal containing '{}'
-            for statement in elements {
-                if let ast::Statement::Let(let_stmt) = statement {
-                    if let ast::Expr::String(string_expr) = let_stmt.rhs(db) {
-                        let node = string_expr.as_syntax_node();
-                        if let Some(brace_pos) = node.get_text(db).find("{}") {
-                            let start_offset = brace_pos as u32;
-                            let end_offset = start_offset + 2;
-                            let relative_span = TextSpan {
-                                start: TextOffset::default()
-                                    .add_width(TextWidth::new_for_testing(start_offset)),
-                                end: TextOffset::default()
-                                    .add_width(TextWidth::new_for_testing(end_offset)),
-                            };
-                            let diagnostic = PluginDiagnostic::error(
-                                node.stable_ptr(db),
-                                "Missing format argument for placeholder".into(),
-                            )
-                            .with_relative_span(relative_span);
-
-                            return PluginResult {
-                                code: None,
-                                diagnostics: vec![diagnostic],
-                                remove_original_item: false,
-                            };
-                        }
-                    }
-                }
-            }
-        }
-
-        PluginResult::default()
-    }
-
-    fn declared_attributes(&self) -> Vec<String> {
-        Vec::new()
-    }
-}
-
-#[test]
-fn test_diagnostic_with_custom_span() {
-    // Setup db with the test plugin.
-    let mut suite = get_default_plugin_suite();
-    suite.add_plugin::<CustomSpanTestPlugin>();
-    let mut db_val = SemanticDatabaseForTesting::with_plugin_suite(suite);
-
-    // Create test file with a format string missing a value
-    let content = indoc! {r#"
-        fn test_format() -> felt252 {
-            let _x: ByteArray = "hello {}";
-            0
-        }
-    "#};
-    let (test_module, _diagnostics) = setup_test_module(&db_val, content).split();
-    let module_id = test_module.module_id;
-
-    // Read semantic diagnostics.
-    let db = &mut db_val;
-    let diags = db.module_semantic_diagnostics(module_id).unwrap();
-    let diags = diags.format(db);
-    assert_eq!(
-        diags,
-        indoc! {r#"
-        error: Plugin diagnostic: Missing format argument for placeholder
-         --> lib.cairo:2:32
-            let _x: ByteArray = "hello {}";
-                                       ^^
-
-        "#}
     );
 }


### PR DESCRIPTION
This basically reverts https://github.com/starkware-libs/cairo/pull/7572 since the `relative_span` field has been functionally replaced by `inner_span`.