### PR TITLE
Removed partial-member const propagation.

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/local_variables.rs
+++ b/crates/cairo-lang-sierra-generator/src/local_variables.rs
@@ -287,14 +287,8 @@ impl<'a> FindLocalsContext<'a> {
                 return false;
             }
         }
-        let mut parent_var = self.peel_const_aliases(var);
-        while let Some(grandparent) = self.partial_param_parents.get(parent_var) {
-            parent_var = self.peel_const_aliases(grandparent);
-            if self.constants.contains(parent_var) || peeled_used_after_revoke.contains(parent_var)
-            {
-                return false;
-            }
-        }
+        // Not recursively peeling partial constants, as has low effect, and can cause bad merges
+        // in some instances.
         true
     }
 

--- a/tests/bug_samples/lib.cairo
+++ b/tests/bug_samples/lib.cairo
@@ -67,6 +67,7 @@ mod issue7544;
 mod issue7640;
 mod loop_break_in_match;
 mod loop_only_change;
+mod merge_const_member;
 mod partial_param_local;
 mod revoked_locals;
 mod self_ref_non_derived;

--- a/tests/bug_samples/merge_const_member.cairo
+++ b/tests/bug_samples/merge_const_member.cairo
@@ -1,0 +1,44 @@
+#[derive(Drop, Copy)]
+enum Inner {
+    V1,
+    V2,
+}
+
+#[derive(Drop, Copy)]
+struct Struct {
+    inner: Inner,
+    rest: felt252,
+}
+
+#[derive(Drop, Copy)]
+enum Outer {
+    V1,
+    V2: (Inner, felt252),
+}
+
+#[inline(never)]
+fn revoke(input: felt252) {
+    core::internal::revoke_ap_tracking();
+}
+
+#[test]
+fn const_with_snap() {
+    const outer: Outer = Outer::V1;
+    let mut x = 1;
+    match @outer {
+        Outer::V1 => { x += 1; },
+        Outer::V2((
+            inner, y,
+        )) => {
+            x += 2;
+            match inner {
+                Inner::V1 => { x += 3; },
+                Inner::V2 => { x += 4; },
+            }
+            x += *y;
+        },
+    }
+
+    revoke(x);
+}
+


### PR DESCRIPTION
Solved issues with propagation of constsness post enum-match.

Has no negative effect, so preferable.