### PR TITLE
Removed braces from match arm expansion.

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -694,7 +694,8 @@ impl<'a> Parser<'a> {
         };
         let arrow = self.parse_token::<TerminalMatchArrow>();
         self.macro_parsing_context = MacroParsingContext::MacroExpansion;
-        let macro_body = self.parse_macro_elements();
+        let macro_body =
+            self.wrap_macro::<TerminalLBrace, TerminalRBrace, _, _>(BracedMacro::new_green).into();
         let semicolon = self.parse_token::<TerminalSemicolon>();
         self.macro_parsing_context = previous_macro_parsing_context;
         Ok(MacroRule::new_green(self.db, wrapped_macro, arrow, macro_body, semicolon))

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -1074,7 +1074,7 @@ macro a_macro {
 
 //! > expected_diagnostics
 error: Empty path after `$defsite` is not allowed.
- --> lib.cairo[a_macro]:2:10
+ --> lib.cairo[a_macro]:1:10
         $defsite
          ^^^^^^^
 
@@ -1162,12 +1162,12 @@ fn consume_z(_z: felt252) {}
 
 //! > expected_diagnostics
 warning: Path in a macro without a resolver modifier ($callsite or $defsite) - currently resolving as $callsite but this will not be supported in future versions.
- --> lib.cairo[bas_use_z_from_callsite]:2:9
+ --> lib.cairo[bas_use_z_from_callsite]:1:9
         z
         ^
 
 error[E0006]: Identifier not found.
- --> lib.cairo[bas_use_z_from_callsite]:2:9
+ --> lib.cairo[bas_use_z_from_callsite]:1:9
         z
         ^
 
@@ -1206,7 +1206,7 @@ macro wrap_bas_use_z_from_callsite {
 
 //! > expected_diagnostics
 error[E0006]: Identifier not found.
- --> lib.cairo[wrap_bas_use_z_from_callsite][bas_use_z_from_callsite]:2:20
+ --> lib.cairo[wrap_bas_use_z_from_callsite][bas_use_z_from_callsite]:1:20
         $callsite::z
                    ^
 
@@ -1236,7 +1236,7 @@ fn bar() {}
 
 //! > expected_diagnostics
 warning: Path in a macro without a resolver modifier ($callsite or $defsite) - currently resolving as $callsite but this will not be supported in future versions.
- --> lib.cairo[call_bar]:2:9
+ --> lib.cairo[call_bar]:1:9
         bar()
         ^^^
 
@@ -1372,7 +1372,7 @@ macro test_macro {
 
 //! > expected_diagnostics
 error: Parser error in macro-expanded code: Missing tokens. Expected an expression.
- --> lib.cairo[test_macro]:2:12
+ --> lib.cairo[test_macro]:1:12
         1 +
            ^
 

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -74,7 +74,7 @@ pub struct MacroDeclarationData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MacroRuleData {
     pub pattern: ast::WrappedMacro,
-    pub expansion: ast::WrappedMacro,
+    pub expansion: ast::MacroElements,
 }
 
 /// The possible kinds of placeholders in a macro rule.
@@ -132,7 +132,7 @@ pub fn priv_macro_declaration_data(
     let mut rules = vec![];
     for rule_syntax in macro_declaration_syntax.rules(syntax_db).elements(syntax_db) {
         let pattern = rule_syntax.lhs(db);
-        let expansion = rule_syntax.rhs(db);
+        let expansion = rule_syntax.rhs(db).elements(db);
         let pattern_elements = get_macro_elements(db, pattern.clone());
         // Collect defined placeholders from pattern
         let defined_placeholders = OrderedHashSet::<_>::from_iter(

--- a/crates/cairo-lang-syntax-codegen/src/cairo_spec.rs
+++ b/crates/cairo-lang-syntax-codegen/src/cairo_spec.rs
@@ -902,7 +902,7 @@ pub fn get_spec() -> Vec<Node> {
     .add_struct(StructBuilder::new("MacroRule")
         .node("lhs", "WrappedMacro")
         .node("fat_arrow", "TerminalMatchArrow")
-        .node("rhs", "WrappedMacro")
+        .node("rhs", "BracedMacro")
         .node("semicolon", "TerminalSemicolon")
     )
     .add_struct(StructBuilder::new("ParamKind")

--- a/crates/cairo-lang-syntax/src/node/ast.rs
+++ b/crates/cairo-lang-syntax/src/node/ast.rs
@@ -22312,7 +22312,7 @@ impl MacroRule {
         db: &dyn SyntaxGroup,
         lhs: WrappedMacroGreen,
         fat_arrow: TerminalMatchArrowGreen,
-        rhs: WrappedMacroGreen,
+        rhs: BracedMacroGreen,
         semicolon: TerminalSemicolonGreen,
     ) -> MacroRuleGreen {
         let children: Vec<GreenId> = vec![lhs.0, fat_arrow.0, rhs.0, semicolon.0];
@@ -22333,8 +22333,8 @@ impl MacroRule {
     pub fn fat_arrow(&self, db: &dyn SyntaxGroup) -> TerminalMatchArrow {
         TerminalMatchArrow::from_syntax_node(db, self.children[1])
     }
-    pub fn rhs(&self, db: &dyn SyntaxGroup) -> WrappedMacro {
-        WrappedMacro::from_syntax_node(db, self.children[2])
+    pub fn rhs(&self, db: &dyn SyntaxGroup) -> BracedMacro {
+        BracedMacro::from_syntax_node(db, self.children[2])
     }
     pub fn semicolon(&self, db: &dyn SyntaxGroup) -> TerminalSemicolon {
         TerminalSemicolon::from_syntax_node(db, self.children[3])
@@ -22371,7 +22371,7 @@ impl TypedSyntaxNode for MacroRule {
                     children: vec![
                         WrappedMacro::missing(db).0,
                         TerminalMatchArrow::missing(db).0,
-                        WrappedMacro::missing(db).0,
+                        BracedMacro::missing(db).0,
                         TerminalSemicolon::missing(db).0,
                     ],
                     width: TextWidth::default(),


### PR DESCRIPTION
Done by removing the option of arms surrounded by `(` `)` and `[` `]`.