### PR TITLE
Fixed inline-macros expansion to statement-lists.

### DIFF
--- a/crates/cairo-lang-filesystem/src/ids.rs
+++ b/crates/cairo-lang-filesystem/src/ids.rs
@@ -83,6 +83,7 @@ pub enum FileLongId {
 pub enum FileKind {
     Module,
     Expr,
+    StatementList,
 }
 
 /// A mapping for a code rewrite.

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -184,6 +184,7 @@ impl<'a> Parser<'a> {
         text: &'a str,
     ) -> StatementList {
         let mut parser = Parser::new(db, file_id, text, diagnostics);
+        parser.macro_parsing_context = MacroParsingContext::ExpandedMacro;
         let statements = StatementList::new_green(
             db,
             parser.parse_list(Self::try_parse_statement, Self::is_eof, "statement"),

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -467,9 +467,9 @@ fn validate_repetition_operator_constraints(ctx: &MatcherContext) -> bool {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MacroExpansionResult {
     /// The expanded text.
-    pub text: String,
+    pub text: Arc<str>,
     /// Information about placeholder expansions in this macro expansion.
-    pub code_mappings: Vec<CodeMapping>,
+    pub code_mappings: Arc<[CodeMapping]>,
 }
 
 impl MacroExpansionResult {
@@ -495,7 +495,7 @@ pub fn expand_macro_rule(
     let mut res_buffer = String::new();
     let mut code_mappings = Vec::new();
     expand_macro_rule_ex(db, node, matcher_ctx, &mut res_buffer, &mut code_mappings)?;
-    Ok(MacroExpansionResult { text: res_buffer, code_mappings })
+    Ok(MacroExpansionResult { text: res_buffer.into(), code_mappings: code_mappings.into() })
 }
 
 /// Helper function for [expand_macro_rule]. Traverses the macro expansion and replaces the

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -229,7 +229,7 @@ pub struct ResolverMacroData {
     pub callsite_module_file_id: ModuleFileId,
     /// This is the result of the macro expansion. It is used to determine if a part of the code
     /// came from a macro argument or from the macro expansion template.
-    pub expansion_result: Arc<MacroExpansionResult>,
+    pub expansion_result: MacroExpansionResult,
     /// The parent macro data. Exists in case of a macro calling another macro, and is used if we
     /// climb to the callsite environment.
     pub parent_macro_call_data: Option<Box<ResolverMacroData>>,


### PR DESCRIPTION
* Reduced generated text duplication.
* Never falling back to `expr`.
* Actually setting up resolvers.
* Handling tail the same way.

---

**Stack**:
- #7888
- #7887
- #7883
- #7886 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*