### PR TITLE
Run diagnostics check before compilation when using parallel compilation

### DIFF
--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -22,7 +22,7 @@ use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 
 use crate::db::RootDatabase;
-use crate::diagnostics::DiagnosticsReporter;
+use crate::diagnostics::{DiagnosticsError, DiagnosticsReporter};
 use crate::project::{ProjectConfig, get_main_crate_ids_from_project, setup_project};
 
 pub mod db;
@@ -154,6 +154,88 @@ pub fn compile_prepared_db(
     Ok(sierra_program_with_debug)
 }
 
+/// Context for database warmup.
+///
+/// This struct will spawn a thread pool that can be used for parallel database warmup.
+/// This can be both diagnostics warmup and function compilation warmup.
+/// We encapsulate the thread pool here so that we can reuse it easily for both.
+/// Note: Usually diagnostics should be checked as early as possible to avoid running into
+/// compilation errors that have not been reported to the user yet (which can result in compiler
+/// panic). This requires us to split the diagnostics warmup and function compilation warmup into
+/// two separate steps (note that we don't usually know the `ConcreteFunctionWithBodyId` yet when
+/// calculating diagnostics).
+pub enum DbWarmupContext {
+    Warmup { pool: ThreadPool },
+    NoWarmup,
+}
+
+impl DbWarmupContext {
+    /// Creates a new thread pool.
+    pub fn new() -> Self {
+        if !Self::should_warmup() {
+            return Self::NoWarmup;
+        }
+        const MAX_WARMUP_PARALLELISM: usize = 4;
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(rayon::current_num_threads().min(MAX_WARMUP_PARALLELISM))
+            .build()
+            .expect("failed to build rayon thread pool");
+        Self::Warmup { pool }
+    }
+
+    /// Checks if parallelism is available for warmup.
+    fn should_warmup() -> bool {
+        rayon::current_num_threads() > 1
+    }
+
+    /// Performs parallel database warmup (if possible)
+    fn warmup_diagnostics(
+        &self,
+        db: &RootDatabase,
+        diagnostic_reporter: &mut DiagnosticsReporter<'_>,
+    ) {
+        match self {
+            Self::Warmup { pool } => diagnostic_reporter.warm_up_diagnostics(db, pool),
+            Self::NoWarmup => {}
+        }
+    }
+
+    /// Checks if there are diagnostics and reports them to the provided callback as strings.
+    /// Returns `Err` if diagnostics were found.
+    ///
+    /// Performs parallel database warmup (if possible) and calls `DiagnosticsReporter::ensure`.
+    pub fn ensure_diagnostics(
+        &self,
+        db: &RootDatabase,
+        diagnostic_reporter: &mut DiagnosticsReporter<'_>,
+    ) -> std::result::Result<(), DiagnosticsError> {
+        self.warmup_diagnostics(db, diagnostic_reporter);
+        diagnostic_reporter.ensure(db)?;
+        Ok(())
+    }
+
+    /// Spawns a task to warm up the db for the requested functions (if possible).
+    fn warmup_db(
+        &self,
+        db: &RootDatabase,
+        requested_function_ids: Vec<ConcreteFunctionWithBodyId>,
+    ) {
+        match self {
+            Self::Warmup { pool } => {
+                let snapshot = salsa::ParallelDatabase::snapshot(db);
+                pool.spawn(move || warmup_db_blocking(snapshot, requested_function_ids));
+            }
+            Self::NoWarmup => {}
+        }
+    }
+}
+
+impl Default for DbWarmupContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Spawns threads to compute the `function_with_body_sierra` query and all dependent queries for
 /// the requested functions and their dependencies.
 ///
@@ -206,35 +288,14 @@ fn warmup_db_blocking(
     });
 }
 
-/// Spawns a task to warm up the db.
-fn spawn_warmup_db(
-    db: &RootDatabase,
-    pool: &ThreadPool,
-    requested_function_ids: Vec<ConcreteFunctionWithBodyId>,
-) {
-    let snapshot = salsa::ParallelDatabase::snapshot(db);
-    pool.spawn(move || warmup_db_blocking(snapshot, requested_function_ids));
-}
-
 ///  Checks if there are diagnostics in the database and if there are None, returns
 ///  the [SierraProgramWithDebug] object of the requested functions
 pub fn get_sierra_program_for_functions(
     db: &RootDatabase,
     requested_function_ids: Vec<ConcreteFunctionWithBodyId>,
-    mut diagnostic_reporter: DiagnosticsReporter<'_>,
+    context: DbWarmupContext,
 ) -> Result<Arc<SierraProgramWithDebug>> {
-    if rayon::current_num_threads() > 1 {
-        const MAX_WARMUP_PARALLELISM: usize = 4;
-        let pool = ThreadPoolBuilder::new()
-            .num_threads(rayon::current_num_threads().min(MAX_WARMUP_PARALLELISM))
-            .build()
-            .expect("failed to build rayon thread pool");
-        // If we have more than one thread, we can use the other threads to warm up the db.
-        diagnostic_reporter.warm_up_diagnostics(db, &pool);
-        spawn_warmup_db(db, &pool, requested_function_ids.clone());
-    }
-
-    diagnostic_reporter.ensure(db)?;
+    context.warmup_db(db, requested_function_ids.clone());
     db.get_sierra_program_for_functions(requested_function_ids)
         .to_option()
         .with_context(|| "Compilation failed without any diagnostics.")

--- a/crates/cairo-lang-executable/src/compile.rs
+++ b/crates/cairo-lang-executable/src/compile.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
-use cairo_lang_compiler::get_sierra_program_for_functions;
 use cairo_lang_compiler::project::setup_project;
+use cairo_lang_compiler::{DbWarmupContext, get_sierra_program_for_functions};
 use cairo_lang_debug::debug::DebugWithDb;
 use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
 use cairo_lang_filesystem::ids::CrateId;
@@ -104,12 +104,14 @@ pub fn compile_executable_in_prepared_db(
     mut diagnostics_reporter: DiagnosticsReporter<'_>,
     config: ExecutableConfig,
 ) -> Result<CompiledFunction> {
+    let context = DbWarmupContext::new();
+    context.ensure_diagnostics(db, &mut diagnostics_reporter)?;
+
     let executables = find_executable_functions(db, main_crate_ids, executable_path);
 
     let executable = match executables.len() {
         0 => {
             // Report diagnostics as they might reveal the reason why no executable was found.
-            diagnostics_reporter.ensure(db)?;
             anyhow::bail!("Requested `#[executable]` not found.");
         }
         1 => executables[0],
@@ -126,7 +128,7 @@ pub fn compile_executable_in_prepared_db(
         }
     };
 
-    compile_executable_function_in_prepared_db(db, executable, diagnostics_reporter, config)
+    compile_executable_function_in_prepared_db(db, executable, config, context)
 }
 
 /// Search crates identified by `main_crate_ids` for executable functions.
@@ -179,11 +181,11 @@ pub fn originating_function_path(db: &RootDatabase, wrapper: ConcreteFunctionWit
 pub fn compile_executable_function_in_prepared_db(
     db: &RootDatabase,
     executable: ConcreteFunctionWithBodyId,
-    diagnostics_reporter: DiagnosticsReporter<'_>,
     config: ExecutableConfig,
+    context: DbWarmupContext,
 ) -> Result<CompiledFunction> {
     let SierraProgramWithDebug { program: sierra_program, debug_info } = Arc::unwrap_or_clone(
-        get_sierra_program_for_functions(db, vec![executable], diagnostics_reporter)
+        get_sierra_program_for_functions(db, vec![executable], context)
             .ok()
             .with_context(|| "Compilation failed without any diagnostics.")?,
     );


### PR DESCRIPTION
Functions like `compile_test_prepared_db` currently do a lot of stuff before calling `diagnostic_reporter.ensure`. From https://t.me/c/1788692421/2558 we see this may fail before diagnostics are produced. To avoid panicking, ensure should be run first. 