### PR TITLE
fix: panic in nested closure lowering

### DIFF
--- a/tests/bug_samples/issue7957.cairo
+++ b/tests/bug_samples/issue7957.cairo
@@ -1,0 +1,9 @@
+fn outer<F, impl Fn: core::ops::Fn<F, (u32,)>[Output: u32], +Drop<F>>(f: F) -> u32 {
+    let inner = |x| {
+        let nested = |y| {
+            f(y)
+        };
+        nested(x)
+    };
+    inner(42)
+}

--- a/tests/bug_samples/lib.cairo
+++ b/tests/bug_samples/lib.cairo
@@ -65,6 +65,7 @@ mod issue7233;
 mod issue7234;
 mod issue7544;
 mod issue7640;
+mod issue7957;
 mod loop_break_in_match;
 mod loop_only_change;
 mod merge_const_member;


### PR DESCRIPTION
Fixes #7957.

Adds a new bug sample. Without the patch running the test results in a panic.