### PR TITLE
Correct file content in `Parser::parse_token_stream_expr`

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -225,10 +225,10 @@ impl<'a> Parser<'a> {
         db: &'a dyn SyntaxGroup,
         diagnostics: &mut DiagnosticsBuilder<ParserDiagnostic>,
         file_id: FileId,
-        token_stream: &'a dyn ToPrimitiveTokenStream<Iter = impl Iterator<Item = PrimitiveToken>>,
+        content: &str,
+        offset: Option<TextOffset>,
     ) -> Expr {
-        let (content, offset) = primitive_token_stream_content_and_offset(token_stream);
-        let mut parser = Parser::new(db, file_id, &content, diagnostics);
+        let mut parser = Parser::new(db, file_id, content, diagnostics);
         let green = parser.parse_expr();
         if let Err(SkippedError(span)) = parser.skip_until(is_of_kind!()) {
             parser.diagnostics.add(ParserDiagnostic {

--- a/crates/cairo-lang-parser/src/utils.rs
+++ b/crates/cairo-lang-parser/src/utils.rs
@@ -108,19 +108,21 @@ impl SimpleParserDatabase {
         &self,
         token_stream: &dyn ToPrimitiveTokenStream<Iter = impl Iterator<Item = PrimitiveToken>>,
     ) -> (SyntaxNode, Diagnostics<ParserDiagnostic>) {
-        let file_id = FileLongId::Virtual(VirtualFile {
+        let (content, offset) = primitive_token_stream_content_and_offset(token_stream);
+        let vfs = VirtualFile {
             parent: Default::default(),
             name: "token_stream_expr_parser_input".into(),
-            content: Default::default(),
+            content: content.into(),
             code_mappings: Default::default(),
             kind: FileKind::Module,
             original_item_removed: false,
-        })
-        .intern(self);
+        };
+        let content = vfs.content.clone();
+        let file_id = FileLongId::Virtual(vfs).intern(self);
         let mut diagnostics = DiagnosticsBuilder::default();
 
         (
-            Parser::parse_token_stream_expr(self, &mut diagnostics, file_id, token_stream)
+            Parser::parse_token_stream_expr(self, &mut diagnostics, file_id, &content, offset)
                 .as_syntax_node(),
             diagnostics.build(),
         )


### PR DESCRIPTION
It was using empty string istead of correct content when creating vfs.

---

**Stack**:
- #7964
- #7965
- #7963
- #7962 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*