### PR TITLE
Fix grep syntax for multi-line pattern matching in sierra_update_check.sh

### DIFF
--- a/scripts/sierra_update_check.sh
+++ b/scripts/sierra_update_check.sh
@@ -5,7 +5,7 @@ HEAD_BRANCH=$2
 
 # Assuming all updates are provided as inputs - finding if they are in any of the relevant crates.
 MERGE_BASE=$(git merge-base $BASE_BRANCH $HEAD_BRANCH)
-git diff --name-only "$MERGE_BASE".."$HEAD_BRANCH" | grep -q -E
+git diff --name-only "$MERGE_BASE".."$HEAD_BRANCH" | grep -q -E \
     -e 'crate/cairo-lang-sierra/' \
     -e 'crate/cairo-lang-sierra-gas/' \
     -e 'crate/cairo-lang-sierra-ap-change/' \


### PR DESCRIPTION
Corrected the usage of grep with the -E flag to properly handle multiple patterns across lines. Added a backslash after grep -q -E so that each -e pattern is recognized as part of the same command, preventing a syntax error. No other changes were made.