### PR TITLE
Return `Option` from `TextSpan::take`

### DIFF
--- a/crates/cairo-lang-diagnostics/src/location_marks.rs
+++ b/crates/cairo-lang-diagnostics/src/location_marks.rs
@@ -53,7 +53,7 @@ fn get_single_line_location_marks(
     };
 
     let first_line_span = TextSpan { start: first_line_start, end: first_line_end };
-    let mut res = first_line_span.take(&content).to_string();
+    let mut res = first_line_span.take(&content).unwrap_or_default().to_string();
     res.push('\n');
     res.extend(repeat_n(' ', col));
     let subspan_in_first_line =
@@ -116,5 +116,9 @@ fn get_line_content(
     };
 
     let line_span = TextSpan { start: line_start, end: line_end };
-    format!("{}{}\n", if first_line { "  " } else { "| " }, line_span.take(&content))
+    format!(
+        "{}{}\n",
+        if first_line { "  " } else { "| " },
+        line_span.take(&content).unwrap_or_default()
+    )
 }

--- a/crates/cairo-lang-filesystem/src/span.rs
+++ b/crates/cairo-lang-filesystem/src/span.rs
@@ -122,11 +122,14 @@ impl TextSpan {
     pub fn contains(self, other: Self) -> bool {
         self.start <= other.start && self.end >= other.end
     }
-    pub fn take(self, content: &str) -> &str {
-        &content[(self.start.0.0 as usize)..(self.end.0.0 as usize)]
+    pub fn take(self, content: &str) -> Option<&str> {
+        if self.end.0.0 > content.len() as u32 {
+            return None;
+        }
+        Some(&content[(self.start.0.0 as usize)..(self.end.0.0 as usize)])
     }
     pub fn n_chars(self, content: &str) -> usize {
-        self.take(content).chars().count()
+        self.take(content).unwrap_or_default().chars().count()
     }
     /// Get the span of width 0, located right after this span.
     pub fn after(self) -> Self {

--- a/crates/cairo-lang-parser/src/lexer.rs
+++ b/crates/cairo-lang-parser/src/lexer.rs
@@ -64,7 +64,7 @@ impl<'a> Lexer<'a> {
 
     fn peek_span_text(&self) -> &'a str {
         let span = TextSpan { start: self.previous_position, end: self.current_position };
-        span.take(self.text)
+        span.take(self.text).unwrap_or_default()
     }
 
     fn consume_span(&mut self) -> &str {

--- a/crates/cairo-lang-parser/src/macro_helpers.rs
+++ b/crates/cairo-lang-parser/src/macro_helpers.rs
@@ -58,7 +58,8 @@ pub fn as_expr_macro_token_tree(
     let end = last_token.span(db).end;
     let span = TextSpan { start, end };
 
-    let mut parser = Parser::new(db, file_id, span.take(&file_content), &mut diagnostics);
+    let mut parser =
+        Parser::new(db, file_id, span.take(&file_content).unwrap_or_default(), &mut diagnostics);
     let expr_green = parser.parse_expr();
     let expr = ast::Expr::from_syntax_node(
         db,

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -218,7 +218,7 @@ impl SyntaxNode {
         let file_content =
             db.file_content(self.stable_ptr(db).file_id(db)).expect("Failed to read file content");
 
-        self.span(db).take(&file_content).to_string()
+        self.span(db).take(&file_content).unwrap_or_default().to_string()
     }
 
     /// Returns all the text under the syntax node.
@@ -293,7 +293,7 @@ impl SyntaxNode {
     pub fn get_text_without_trivia(self, db: &dyn SyntaxGroup) -> String {
         let file_content =
             db.file_content(self.stable_ptr(db).file_id(db)).expect("Failed to read file content");
-        self.span_without_trivia(db).take(&file_content).to_string()
+        self.span_without_trivia(db).take(&file_content).unwrap_or_default().to_string()
     }
 
     /// Returns the text under the syntax node, according to the given span.
@@ -305,7 +305,7 @@ impl SyntaxNode {
         assert!(self.span(db).contains(span));
         let file_content =
             db.file_content(self.stable_ptr(db).file_id(db)).expect("Failed to read file content");
-        span.take(&file_content).to_string()
+        span.take(&file_content).unwrap_or_default().to_string()
     }
 
     /// Traverse the subtree rooted at the current node (including the current node) in preorder.


### PR DESCRIPTION
## Rationale
Current implementation panics if the given span does not fit in the provided text.
Returning `Option` makes the method more explicit and safe and simplifies a lot of logic in CairoLS (text edits, macro expansions, etc.).