### PR TITLE
chore: remove redundant word

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/function_call.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/function_call.rs
@@ -166,7 +166,7 @@ impl NamedLibfunc for DummyFunctionCallLibfunc {
     }
 }
 
-/// Given the generic arguments of a dummy function call, returns the function signature and and
+/// Given the generic arguments of a dummy function call, returns the function signature and
 /// ap_change.
 fn try_extract_dummy_func_info<'a>(
     mut args: impl Iterator<Item = &'a GenericArg>,


### PR DESCRIPTION
remove redundant word