### PR TITLE
Setting publish to false for all un-published crates.

### DIFF
--- a/crates/bin/generate-syntax/Cargo.toml
+++ b/crates/bin/generate-syntax/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 repository.workspace = true
 license-file.workspace = true
+publish = false
 
 [dependencies]
 log.workspace = true

--- a/crates/bin/get-lowering/Cargo.toml
+++ b/crates/bin/get-lowering/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 repository.workspace = true
 license-file.workspace = true
 description = "Compiler executable for the Cairo programming language with the Starknet plugin."
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/bin/starknet-sierra-extract-code/Cargo.toml
+++ b/crates/bin/starknet-sierra-extract-code/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 repository.workspace = true
 license-file.workspace = true
 description = "Compiler executable for printing Starknet Sierra json included code"
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
+++ b/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 repository.workspace = true
 license-file.workspace = true
 description = "Compiler executable for validating a Sierra upgrade is valid"
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/ensure-no_std/Cargo.toml
+++ b/ensure-no_std/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ensure-no_std"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 cairo-lang-utils = { path = "../crates/cairo-lang-utils", default-features = false, features = ["serde", "parity-scale-codec"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 description = ""
+publish = false
 
 [dev-dependencies]
 assert_matches.workspace = true


### PR DESCRIPTION
This allows usage of:
```
cargo install cargo-workspaces
cargo workspaces publish
```