### PR TITLE
Removing ap-change value info from ProgramRegistry.

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -465,6 +465,9 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
                 cairo_lang_sierra::extensions::lib_func::SierraApChange::BranchAlign => {
                     unreachable!("DummyFunctionCall is not a branch align libfunc.")
                 }
+                cairo_lang_sierra::extensions::lib_func::SierraApChange::FunctionCall(_) => {
+                    unreachable!("DummyFunctionCall ap change is always set.")
+                }
             }]
         }
     }

--- a/crates/cairo-lang-sierra-generator/src/store_variables/mod.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/mod.rs
@@ -170,13 +170,16 @@ impl<'a> AddStoreVariableStatements<'a> {
                     [GenBranchInfo { target: GenBranchTarget::Fallthrough, results }] => {
                         // A simple invocation.
                         let branch_signature = &signature.branch_signatures[0];
-                        match branch_signature.ap_change {
+                        match &branch_signature.ap_change {
                             SierraApChange::Unknown => {
                                 // If the ap-change is unknown, variables that will be revoked
                                 // otherwise should be stored as locals.
                                 self.store_variables_as_locals(&mut state);
                             }
                             SierraApChange::BranchAlign | SierraApChange::Known { .. } => {}
+                            SierraApChange::FunctionCall(id) => {
+                                unreachable!("Function ap-change for `{id}` missing.")
+                            }
                         }
 
                         state.register_outputs(

--- a/crates/cairo-lang-sierra-generator/src/store_variables/state.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/state.rs
@@ -66,7 +66,7 @@ impl VariablesState {
         arg_states: &[VarState],
     ) {
         // Clear the stack if needed.
-        match branch_signature.ap_change {
+        match &branch_signature.ap_change {
             SierraApChange::BranchAlign
             | SierraApChange::Unknown
             | SierraApChange::Known { new_vars_only: false } => {
@@ -75,6 +75,9 @@ impl VariablesState {
                 self.clear_known_stack();
             }
             SierraApChange::Known { new_vars_only: true } => {}
+            SierraApChange::FunctionCall(id) => {
+                unreachable!("Missing ap-change for function `{id}`.")
+            }
         }
 
         for (var, var_info) in itertools::zip_eq(results, &branch_signature.vars) {

--- a/crates/cairo-lang-sierra-generator/src/utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/utils.rs
@@ -447,7 +447,8 @@ pub fn dummy_call_libfunc_id(
             cairo_lang_sierra::extensions::lib_func::SierraApChange::Known { new_vars_only: _ } => {
                 0
             }
-            cairo_lang_sierra::extensions::lib_func::SierraApChange::BranchAlign => {
+            cairo_lang_sierra::extensions::lib_func::SierraApChange::BranchAlign
+            | cairo_lang_sierra::extensions::lib_func::SierraApChange::FunctionCall(_) => {
                 unreachable!("should never happen")
             }
         }

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/test_utils.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/test_utils.rs
@@ -141,13 +141,6 @@ impl SignatureSpecializationContext for MockSpecializationContext {
     ) -> Option<cairo_lang_sierra::program::FunctionSignature> {
         unreachable!("Function related specialization functionalities are not implemented.")
     }
-
-    fn try_get_function_ap_change(
-        &self,
-        _function_id: &cairo_lang_sierra::ids::FunctionId,
-    ) -> Option<cairo_lang_sierra::extensions::lib_func::SierraApChange> {
-        unreachable!("Function related specialization functionalities are not implemented.")
-    }
 }
 impl SpecializationContext for MockSpecializationContext {
     fn try_get_function(

--- a/crates/cairo-lang-sierra/src/extensions/lib_func.rs
+++ b/crates/cairo-lang-sierra/src/extensions/lib_func.rs
@@ -38,7 +38,9 @@ pub trait SignatureSpecializationContext: TypeSpecializationContext {
     }
 
     /// Returns the ap-change of the given function.
-    fn try_get_function_ap_change(&self, function_id: &FunctionId) -> Option<SierraApChange>;
+    fn try_get_function_ap_change(&self, function_id: &FunctionId) -> Option<SierraApChange> {
+        Some(SierraApChange::FunctionCall(function_id.clone()))
+    }
 
     /// Wraps [Self::try_get_function_ap_change] with a result object.
     fn get_function_ap_change(
@@ -430,6 +432,8 @@ pub enum SierraApChange {
     /// The lib func is `branch_align`.
     /// The `ap` change is known during compilation.
     BranchAlign,
+    /// This is a function call, and the ap change should be fetched elsewhere.
+    FunctionCall(FunctionId),
 }
 /// Trait for a specialized library function.
 pub trait ConcreteLibfunc {

--- a/crates/cairo-lang-sierra/src/extensions/test.rs
+++ b/crates/cairo-lang-sierra/src/extensions/test.rs
@@ -7,7 +7,7 @@ use super::SpecializationError::{
     WrongNumberOfGenericArgs,
 };
 use super::core::{CoreLibfunc, CoreType};
-use super::lib_func::{SierraApChange, SignatureSpecializationContext, SpecializationContext};
+use super::lib_func::{SignatureSpecializationContext, SpecializationContext};
 use super::types::TypeInfo;
 use crate::extensions::type_specialization_context::TypeSpecializationContext;
 use crate::extensions::{GenericLibfunc, GenericType};
@@ -116,10 +116,6 @@ impl SignatureSpecializationContext for MockSpecializationContext {
 
     fn try_get_function_signature(&self, function_id: &FunctionId) -> Option<FunctionSignature> {
         self.try_get_function(function_id).map(|f| f.signature)
-    }
-
-    fn try_get_function_ap_change(&self, _function_id: &FunctionId) -> Option<SierraApChange> {
-        Some(SierraApChange::Unknown)
     }
 }
 

--- a/crates/cairo-lang-sierra/src/program_registry.rs
+++ b/crates/cairo-lang-sierra/src/program_registry.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
-use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use itertools::{chain, izip};
 use thiserror::Error;
 
@@ -102,7 +101,6 @@ impl<TType: GenericType, TLibfunc: GenericLibfunc> ProgramRegistry<TType, TLibfu
                 functions: &functions,
                 concrete_type_ids: &concrete_type_ids,
                 concrete_types: &concrete_types,
-                function_ap_change: &Default::default(),
             },
         )?;
         let registry = ProgramRegistry { functions, concrete_types, concrete_libfuncs };
@@ -349,8 +347,6 @@ pub struct SpecializationContextForRegistry<'a, TType: GenericType> {
     pub functions: &'a FunctionMap,
     pub concrete_type_ids: &'a ConcreteTypeIdMap<'a>,
     pub concrete_types: &'a TypeMap<TType::Concrete>,
-    /// AP changes information for Sierra user functions.
-    pub function_ap_change: &'a OrderedHashMap<FunctionId, usize>,
 }
 impl<TType: GenericType> TypeSpecializationContext for SpecializationContextForRegistry<'_, TType> {
     fn try_get_type_info(&self, id: ConcreteTypeId) -> Option<TypeInfo> {
@@ -370,14 +366,6 @@ impl<TType: GenericType> SignatureSpecializationContext
 
     fn try_get_function_signature(&self, function_id: &FunctionId) -> Option<FunctionSignature> {
         self.try_get_function(function_id).map(|f| f.signature)
-    }
-
-    fn try_get_function_ap_change(&self, function_id: &FunctionId) -> Option<SierraApChange> {
-        Some(if self.function_ap_change.contains_key(function_id) {
-            SierraApChange::Known { new_vars_only: false }
-        } else {
-            SierraApChange::Unknown
-        })
     }
 }
 impl<TType: GenericType> SpecializationContext for SpecializationContextForRegistry<'_, TType> {

--- a/crates/cairo-lang-sierra/src/simulation/test.rs
+++ b/crates/cairo-lang-sierra/src/simulation/test.rs
@@ -11,9 +11,7 @@ use super::value::CoreValue::{
 use super::{SimulationError, core};
 use crate::extensions::GenericLibfunc;
 use crate::extensions::core::CoreLibfunc;
-use crate::extensions::lib_func::{
-    SierraApChange, SignatureSpecializationContext, SpecializationContext,
-};
+use crate::extensions::lib_func::{SignatureSpecializationContext, SpecializationContext};
 use crate::extensions::type_specialization_context::TypeSpecializationContext;
 use crate::extensions::types::TypeInfo;
 use crate::ids::{ConcreteTypeId, FunctionId, GenericTypeId};
@@ -97,10 +95,6 @@ impl SignatureSpecializationContext for MockSpecializationContext {
 
     fn try_get_function_signature(&self, function_id: &FunctionId) -> Option<FunctionSignature> {
         self.try_get_function(function_id).map(|f| f.signature)
-    }
-
-    fn try_get_function_ap_change(&self, _function_id: &FunctionId) -> Option<SierraApChange> {
-        Some(SierraApChange::Unknown)
     }
 }
 


### PR DESCRIPTION
**Stack**:
- #8019
- #8018
- #8017


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*