### PR TITLE
fix: correct typo in test crate name from "bad_create" to "bad_crate"

### DIFF
--- a/crates/cairo-lang-compiler/src/diagnostics_test.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics_test.rs
@@ -8,7 +8,7 @@ use crate::diagnostics::get_diagnostics_as_string;
 fn test_diagnostics() {
     let mut db = RootDatabase::default();
 
-    let crate_id = CrateId::plain(&db, "bad_create");
+    let crate_id = CrateId::plain(&db, "bad_crate");
     db.set_crate_config(
         crate_id,
         Some(CrateConfiguration::default_for_root(Directory::Real("no/such/path".into()))),


### PR DESCRIPTION
This commit fixes a minor typo in the diagnostics test by renaming the test crate identifier from "bad_create" to the intended "bad_crate" for clarity and consistency. No functional changes to the test logic.