### PR TITLE
fix(diagnostics): correct logical error in check_diag_group method

### DIFF
--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -239,7 +239,7 @@ impl<'a> DiagnosticsReporter<'a> {
             }
             if !entry.is_empty() {
                 self.callback.on_diagnostic(entry);
-                found |= !self.allow_warnings || group.check_error_free().is_err();
+                found |= !self.allow_warnings && group.check_error_free().is_err();
             }
         }
         found


### PR DESCRIPTION
Fix incorrect boolean logic in check_diag_group method that was causing
diagnostics to always be marked as found when allow_warnings was false.

The issue was in line 229 where the expression used OR (||) instead of AND (&&):
- Before: found |= !self.allow_warnings || group.check_error_free().is_err()
- After:  found |= !self.allow_warnings && group.check_error_free().is_err()

This caused the method to return true whenever allow_warnings was false,
regardless of whether there were actual errors in the diagnostics group.
Now it correctly only marks diagnostics as found when both conditions are met:
1. allow_warnings is false (warnings are not allowed)
2. The diagnostics group contains errors (check_error_free() returns Err)
