### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/crates/cairo-lang-doc @orizi @mkaput @wawel37


### PR DESCRIPTION
This was a noble idea. But in many cases stack generating tools that we use generate PRs that initially touch codeowned files and then force push desired changes that do not, causing false positive review assignments that are more frequent than real ones 😢