### PR TITLE
fix: add missing semicolon in db_test.rs

### DIFF
--- a/crates/cairo-lang-parser/src/db_test.rs
+++ b/crates/cairo-lang-parser/src/db_test.rs
@@ -80,7 +80,7 @@ fn test_token_stream_parser() {
     assert_eq!(
         print_tree(db, &root_node, false, true),
         print_tree(db, &node_from_token_stream, false, true)
-    )
+    );
 }
 
 #[test]


### PR DESCRIPTION
Add semicolon after the last assert_eq! in test_token_stream_parser
function to maintain consistent code style.