### PR TITLE
fix: correct grammatical error in formatter comment

### DIFF
--- a/crates/cairo-lang-formatter/src/cairo_formatter.rs
+++ b/crates/cairo-lang-formatter/src/cairo_formatter.rs
@@ -46,7 +46,7 @@ impl Debug for FileDiff {
 
 /// A helper struct for displaying a file diff with colored output.
 ///
-/// This is implements a [`Display`] trait, so it can be used with `format!` and `println!`.
+/// This struct implements a [`Display`] trait, so it can be used with `format!` and `println!`.
 /// If you prefer output without colors, use [`FileDiff`] instead.
 pub struct FileDiffColoredDisplay<'a> {
     diff: &'a FileDiff,


### PR DESCRIPTION
- Fixed grammatical error: "This is implements" → "This struct implements"