### PR TITLE
chore: fix minor typo in comment

### DIFF
--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -39,7 +39,7 @@ use crate::plugin::{DynGeneratedFileAuxData, PluginDiagnostic};
 /// Metadata for a cached crate.
 #[derive(Serialize, Deserialize)]
 pub struct CachedCrateMetadata {
-    /// Hash of the settings the crate was compiles with.
+    /// Hash of the settings the crate was compiled with.
     pub settings: Option<u64>,
     /// The version of the compiler that compiled the crate.
     pub compiler_version: String,


### PR DESCRIPTION
seems that `compiles` should be `compiled`