### PR TITLE
Remove most remaining SmolStrs from the project.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,6 @@ dependencies = [
  "itertools 0.14.0",
  "pulldown-cmark",
  "salsa",
- "smol_str",
  "test-log",
 ]
 
@@ -724,7 +723,6 @@ dependencies = [
  "num-traits",
  "pretty_assertions",
  "salsa",
- "smol_str",
  "test-log",
  "unescaper",
 ]
@@ -828,7 +826,6 @@ dependencies = [
  "rand 0.9.0",
  "serde",
  "sha2",
- "smol_str",
  "starknet-types-core",
  "test-case",
  "test-log",
@@ -859,7 +856,6 @@ dependencies = [
  "pretty_assertions",
  "salsa",
  "sha3",
- "smol_str",
  "test-log",
  "toml",
 ]
@@ -1022,7 +1018,6 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "smol_str",
  "starknet-types-core",
  "test-case",
  "test-log",
@@ -1074,7 +1069,6 @@ dependencies = [
  "pretty_assertions",
  "salsa",
  "serde",
- "smol_str",
  "test-log",
  "unescaper",
 ]

--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use cairo_lang_diagnostics::{DiagnosticLocation, DiagnosticNote, Maybe, Severity};
 use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::{
-    CodeMapping, CrateId, CrateLongId, FileId, FileKind, FileLongId, VirtualFile,
+    CodeMapping, CrateId, CrateLongId, FileId, FileKind, FileLongId, VirtualFile, db_str,
 };
 use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
 use cairo_lang_syntax::node::ast::{
@@ -44,7 +44,7 @@ pub struct CachedCrateMetadata {
     /// The version of the compiler that compiled the crate.
     pub compiler_version: String,
     /// The global flags the crate was compiled with.
-    pub global_flags: OrderedHashMap<SmolStr, Flag>,
+    pub global_flags: OrderedHashMap<String, Flag>,
 }
 
 impl CachedCrateMetadata {
@@ -1700,7 +1700,7 @@ impl GreenNodeDetailsCached {
     fn embed<'db>(&self, ctx: &mut DefCacheLoadingContext<'db>) -> GreenNodeDetails<'db> {
         match self {
             GreenNodeDetailsCached::Token(token) => {
-                GreenNodeDetails::Token(token.clone().intern(ctx.db).long(ctx.db).as_str())
+                GreenNodeDetails::Token(db_str(ctx.db, token.clone()))
             }
             GreenNodeDetailsCached::Node { children, width } => GreenNodeDetails::Node {
                 children: children.iter().map(|child| child.embed(ctx)).collect(),

--- a/crates/cairo-lang-doc/Cargo.toml
+++ b/crates/cairo-lang-doc/Cargo.toml
@@ -17,7 +17,6 @@ cairo-lang-formatter = { path = "../cairo-lang-formatter", version = "~2.12.0" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "~2.12.0" }
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "~2.12.0" }
 cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "~2.12.0" }
-smol_str.workspace = true
 pulldown-cmark = "0.13.0"
 salsa.workspace = true
 itertools.workspace = true

--- a/crates/cairo-lang-doc/src/documentable_formatter.rs
+++ b/crates/cairo-lang-doc/src/documentable_formatter.rs
@@ -801,18 +801,14 @@ fn write_function_signature<'db>(
             let modifier_postfix = if modifier.is_empty() { "" } else { " " };
             if param.ty.is_fully_concrete(f.db) {
                 f.write_type(
-                    Some(&format!("{modifier}{modifier_postfix}{}: ", param.name.long(f.db))),
+                    Some(&format!("{modifier}{modifier_postfix}{}: ", param.name)),
                     param.ty,
                     Some(&postfix),
                     &documentable_signature.full_path,
                 )?;
             } else {
                 let type_definition = get_type_clause(syntax_node, f.db).unwrap_or_default();
-                write!(
-                    f,
-                    "{modifier}{modifier_postfix}{}{type_definition}{postfix}",
-                    param.name.long(f.db),
-                )?;
+                write!(f, "{modifier}{modifier_postfix}{}{type_definition}{postfix}", param.name,)?;
             }
             count -= 1;
         }

--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -5,7 +5,7 @@ use cairo_lang_defs::ids::{
     FileIndex, GenericTypeId, LookupItemId, ModuleFileId, ModuleId, ModuleItemId, TraitItemId,
 };
 use cairo_lang_diagnostics::DiagnosticsBuilder;
-use cairo_lang_filesystem::ids::{FileKind, FileLongId, SmolStrId, VirtualFile};
+use cairo_lang_filesystem::ids::{FileKind, FileLongId, VirtualFile};
 use cairo_lang_parser::parser::Parser;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::diagnostic::{NotFoundItemType, SemanticDiagnostics};
@@ -428,7 +428,7 @@ impl<'db> DocumentationCommentParser<'db> {
             // And get id of the (sub)module containing the node by traversing this stack top-down.
             .try_rfold(main_module, |module, name| {
                 let ModuleItemId::Submodule(submodule) =
-                    db.module_item_by_name(module, SmolStrId::from_str(db, name)).ok()??
+                    db.module_item_by_name(module, name.into()).ok()??
                 else {
                     return None;
                 };

--- a/crates/cairo-lang-executable/src/plugin.rs
+++ b/crates/cairo-lang-executable/src/plugin.rs
@@ -186,7 +186,7 @@ impl AnalyzerPlugin for RawExecutableAnalyzer {
             if input.ty
                 != corelib::get_core_ty_by_name(
                     db,
-                    "Span".into(),
+                    "Span",
                     vec![GenericArgumentId::Type(db.core_info().felt252)],
                 )
             {

--- a/crates/cairo-lang-filesystem/src/cfg.rs
+++ b/crates/cairo-lang-filesystem/src/cfg.rs
@@ -2,23 +2,22 @@ use std::collections::BTreeSet;
 use std::fmt;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use smol_str::SmolStr;
 
 /// Option for the `#[cfg(...)]` language attribute.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Cfg {
-    pub key: SmolStr,
-    pub value: Option<SmolStr>,
+    pub key: String,
+    pub value: Option<String>,
 }
 
 impl Cfg {
     /// Creates a `cfg` option that is matchable as `#[cfg(name)]`.
-    pub fn name(name: impl Into<SmolStr>) -> Self {
+    pub fn name(name: impl Into<String>) -> Self {
         Self { key: name.into(), value: None }
     }
 
     /// Creates a `cfg` option that is matchable as `#[cfg(key: "value")]`.
-    pub fn kv(key: impl Into<SmolStr>, value: impl Into<SmolStr>) -> Self {
+    pub fn kv(key: impl Into<String>, value: impl Into<String>) -> Self {
         Self { key: key.into(), value: Some(value.into()) }
     }
 }
@@ -43,13 +42,12 @@ impl fmt::Debug for Cfg {
 
 mod serde_ext {
     use serde::{Deserialize, Serialize};
-    use smol_str::SmolStr;
 
     #[derive(Serialize, Deserialize)]
     #[serde(untagged)]
     pub enum Cfg {
-        KV(SmolStr, SmolStr),
-        Name(SmolStr),
+        KV(String, String),
+        Name(String),
     }
 }
 

--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -149,7 +149,7 @@ impl Edition {
     }
 
     /// The name of the prelude submodule of `core::prelude` for this compatibility version.
-    pub fn prelude_submodule_name(&self) -> &str {
+    pub fn prelude_submodule_name(&self) -> &'static str {
         match self {
             Self::V2023_01 => "v2023_01",
             Self::V2023_10 | Self::V2023_11 => "v2023_10",

--- a/crates/cairo-lang-filesystem/src/flag.rs
+++ b/crates/cairo-lang-filesystem/src/flag.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use smol_str::SmolStr;
 
 use crate::db::FilesGroup;
 use crate::ids::FlagLongId;
@@ -25,6 +24,6 @@ pub enum Flag {
 
 /// Returns the value of the `unsafe_panic` flag, or `false` if the flag is not set.
 pub fn flag_unsafe_panic(db: &dyn FilesGroup) -> bool {
-    let flag = db.intern_flag(FlagLongId(SmolStr::from("unsafe_panic")));
+    let flag = db.intern_flag(FlagLongId("unsafe_panic".into()));
     if let Some(flag) = db.get_flag(flag) { *flag == Flag::UnsafePanic(true) } else { false }
 }

--- a/crates/cairo-lang-lowering/src/add_withdraw_gas/mod.rs
+++ b/crates/cairo-lang-lowering/src/add_withdraw_gas/mod.rs
@@ -48,13 +48,8 @@ fn add_withdraw_gas_to_function<'db>(
         statements: vec![],
         end: BlockEnd::Match {
             info: MatchInfo::Extern(MatchExternInfo {
-                function: get_function_id(
-                    db,
-                    core_submodule(db, "gas"),
-                    "withdraw_gas".into(),
-                    vec![],
-                )
-                .lowered(db),
+                function: get_function_id(db, core_submodule(db, "gas"), "withdraw_gas", vec![])
+                    .lowered(db),
                 inputs: vec![],
                 arms: vec![
                     MatchArm {
@@ -96,7 +91,7 @@ fn create_panic_block<'db>(
     let gas_panic_fn = get_function_id(
         db,
         core_module(db),
-        "panic_with_const_felt252".into(),
+        "panic_with_const_felt252",
         vec![GenericArgumentId::Constant(
             ConstValue::Int(
                 BigInt::from_bytes_be(Sign::Plus, "Out of gas".as_bytes()),

--- a/crates/cairo-lang-lowering/src/destructs.rs
+++ b/crates/cairo-lang-lowering/src/destructs.rs
@@ -276,7 +276,7 @@ impl<'db> Analyzer<'db, '_> for DestructAdder<'db, '_> {
 }
 
 fn panic_ty<'db>(db: &'db dyn LoweringGroup) -> semantic::TypeId<'db> {
-    get_ty_by_name(db, core_module(db), "Panic".into(), vec![])
+    get_ty_by_name(db, core_module(db), "Panic", vec![])
 }
 
 /// Inserts destructor calls into the lowered function.

--- a/crates/cairo-lang-lowering/src/graph_algorithms/feedback_set.rs
+++ b/crates/cairo-lang-lowering/src/graph_algorithms/feedback_set.rs
@@ -3,7 +3,6 @@ use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::{FlagId, FlagLongId};
 use cairo_lang_utils::graph_algos::feedback_set::calc_feedback_set;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
-use cairo_lang_utils::smol_str::SmolStr;
 
 use super::concrete_function_node::ConcreteFunctionWithBodyNode;
 use crate::db::{ConcreteSCCRepresentative, LoweringGroup};
@@ -22,7 +21,7 @@ pub fn function_with_body_feedback_set<'db>(
 
 /// Returns the value of the `add_withdraw_gas` flag, or `true` if the flag is not set.
 pub fn flag_add_withdraw_gas(db: &dyn LoweringGroup) -> bool {
-    db.get_flag(FlagId::new(db, FlagLongId(SmolStr::from("add_withdraw_gas"))))
+    db.get_flag(FlagId::new(db, FlagLongId("add_withdraw_gas".into())))
         .map(|flag| *flag == Flag::AddWithdrawGas(true))
         .unwrap_or(true)
 }

--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -1,7 +1,6 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{MemberId, NamedLanguageElementId};
 use cairo_lang_diagnostics::Maybe;
-use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::expr::fmt::ExprFormatter;
 use cairo_lang_semantic::types::{peel_snapshots, wrap_in_snapshots};
@@ -437,9 +436,7 @@ fn get_ty<'db>(
     match member_path {
         MemberPath::Var(var) => ctx.semantic_defs[var].ty(),
         MemberPath::Member { member_id, concrete_struct_id, .. } => {
-            ctx.db.concrete_struct_members(*concrete_struct_id).unwrap()
-                [&SmolStrId::from_str(ctx.db, member_id.name(ctx.db))]
-                .ty
+            ctx.db.concrete_struct_members(*concrete_struct_id).unwrap()[member_id.name(ctx.db)].ty
         }
     }
 }

--- a/crates/cairo-lang-lowering/src/lower/context.rs
+++ b/crates/cairo-lang-lowering/src/lower/context.rs
@@ -458,7 +458,7 @@ pub fn handle_lowering_flow_error<'db, 'mt>(
         LoweringFlowError::Panic(data_var, location) => {
             let panic_instance = generators::StructConstruct {
                 inputs: vec![],
-                ty: get_ty_by_name(ctx.db, core_module(ctx.db), "Panic".into(), vec![]),
+                ty: get_ty_by_name(ctx.db, core_module(ctx.db), "Panic", vec![]),
                 location,
             }
             .add(ctx, &mut builder.statements);

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -17,7 +17,6 @@ use cairo_lang_semantic::{
 use cairo_lang_syntax::node::TypedStablePtr;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::smol_str::SmolStr;
 use cairo_lang_utils::unordered_hash_map::{Entry, UnorderedHashMap};
 use cairo_lang_utils::{Intern, extract_matches, try_extract_matches};
 use context::handle_lowering_flow_error;
@@ -969,23 +968,22 @@ fn lower_expr_string_literal<'db>(
     let db = ctx.db;
 
     // Get all the relevant types from the corelib.
-    let bytes31_ty = get_core_ty_by_name(db, "bytes31".into(), vec![]);
-    let data_array_ty =
-        get_core_ty_by_name(db, "Array".into(), vec![GenericArgumentId::Type(bytes31_ty)]);
-    let byte_array_ty = get_core_ty_by_name(db, "ByteArray".into(), vec![]);
+    let bytes31_ty = get_core_ty_by_name(db, "bytes31", vec![]);
+    let data_array_ty = get_core_ty_by_name(db, "Array", vec![GenericArgumentId::Type(bytes31_ty)]);
+    let byte_array_ty = get_core_ty_by_name(db, "ByteArray", vec![]);
 
     let array_submodule = core_submodule(db, "array");
     let data_array_new_function = FunctionLongId::Semantic(get_function_id(
         db,
         array_submodule,
-        "array_new".into(),
+        "array_new",
         vec![GenericArgumentId::Type(bytes31_ty)],
     ))
     .intern(ctx.db);
     let data_array_append_function = FunctionLongId::Semantic(get_function_id(
         db,
         array_submodule,
-        "array_append".into(),
+        "array_append",
         vec![GenericArgumentId::Type(bytes31_ty)],
     ))
     .intern(ctx.db);
@@ -1233,7 +1231,7 @@ fn lower_expr_function_call<'db>(
     };
 
     // If the function is panic(), do something special.
-    if expr.function == get_core_function_id(ctx.db, "panic".into(), vec![]) {
+    if expr.function == get_core_function_id(ctx.db, "panic", vec![]) {
         let [input] = <[_; 1]>::try_from(arg_inputs).ok().unwrap();
         return Err(LoweringFlowError::Panic(input, location));
     }
@@ -1426,13 +1424,9 @@ fn lower_expr_loop<'db>(
             vec![GenericArgumentId::Type(return_type), GenericArgumentId::Type(ctx.return_type)];
 
         let internal_module = core_submodule(semantic_db, "internal");
-        let ret_ty = try_get_ty_by_name(
-            semantic_db,
-            internal_module,
-            "LoopResult".into(),
-            generic_args.clone(),
-        )
-        .unwrap();
+        let ret_ty =
+            try_get_ty_by_name(semantic_db, internal_module, "LoopResult", generic_args.clone())
+                .unwrap();
         (
             ret_ty,
             Some(LoopEarlyReturnInfo {
@@ -1956,7 +1950,7 @@ fn add_closure_call_function<'db>(
     }
 
     let trait_function: cairo_lang_defs::ids::TraitFunctionId<'_> = db
-        .trait_function_by_name(trait_id, SmolStr::from("call").intern(db))
+        .trait_function_by_name(trait_id, "call".into())
         .unwrap()
         .expect("Call function must exist for an Fn trait.");
 

--- a/crates/cairo-lang-lowering/src/optimizations/branch_inversion.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/branch_inversion.rs
@@ -26,7 +26,7 @@ pub fn branch_inversion(db: &dyn LoweringGroup, lowered: &mut Lowered<'_>) {
         return;
     }
     let bool_not_func_id =
-        FunctionLongId::Semantic(corelib::get_core_function_id(db, "bool_not_impl".into(), vec![]))
+        FunctionLongId::Semantic(corelib::get_core_function_id(db, "bool_not_impl", vec![]))
             .intern(db);
 
     for block in lowered.blocks.iter_mut() {

--- a/crates/cairo-lang-lowering/src/optimizations/config.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/config.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use cairo_lang_defs::ids::ExternFunctionId;
+use cairo_lang_filesystem::ids::db_str;
 use cairo_lang_semantic::helper::ModuleHelper;
 use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 
@@ -62,11 +63,11 @@ pub fn priv_movable_function_ids<'db>(
         while let Some(path_item) = next {
             next = path_iter.next();
             if next.is_some() {
-                module = module.submodule(path_item);
+                module = module.submodule(db_str(db, path_item));
                 continue;
             }
 
-            return module.extern_function_id(path_item);
+            return module.extern_function_id(db_str(db, path_item));
         }
 
         panic!("Got empty string as movable_function");

--- a/crates/cairo-lang-lowering/src/optimizations/gas_redeposit.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/gas_redeposit.rs
@@ -41,7 +41,7 @@ pub fn gas_redeposit<'db>(
     {
         return;
     }
-    let gb_ty = corelib::get_core_ty_by_name(db, "GasBuiltin".into(), vec![]);
+    let gb_ty = corelib::get_core_ty_by_name(db, "GasBuiltin", vec![]);
     // Checking if the implicits of this function past lowering includes `GasBuiltin`.
     if let Ok(implicits) = db.function_with_body_implicits(function_id) {
         if !implicits.into_iter().contains(&gb_ty) {
@@ -61,13 +61,9 @@ pub fn gas_redeposit<'db>(
     let mut analysis = BackAnalysis::new(lowered, ctx);
     analysis.get_root_info();
 
-    let redeposit_gas = corelib::get_function_id(
-        db,
-        corelib::core_submodule(db, "gas"),
-        "redeposit_gas".into(),
-        vec![],
-    )
-    .lowered(db);
+    let redeposit_gas =
+        corelib::get_function_id(db, corelib::core_submodule(db, "gas"), "redeposit_gas", vec![])
+            .lowered(db);
     for (block_id, location) in analysis.analyzer.fixes {
         let block = &mut lowered.blocks[block_id];
 

--- a/crates/cairo-lang-lowering/src/panic/mod.rs
+++ b/crates/cairo-lang-lowering/src/panic/mod.rs
@@ -10,7 +10,6 @@ use cairo_lang_semantic::corelib::{
 use cairo_lang_semantic::helper::ModuleHelper;
 use cairo_lang_semantic::items::constant::ConstValue;
 use cairo_lang_semantic::{self as semantic, GenericArgumentId};
-use cairo_lang_utils::smol_str::SmolStr;
 use cairo_lang_utils::{Intern, Upcast};
 use itertools::{Itertools, chain, zip_eq};
 use semantic::{ConcreteVariant, MatchArmSelector, TypeId};
@@ -44,7 +43,7 @@ pub fn lower_panics<'db>(
     }
 
     let opt_trace_fn = if matches!(
-        db.get_flag(FlagId::new(db, FlagLongId(SmolStr::from("panic_backtrace")))),
+        db.get_flag(FlagId::new(db, FlagLongId("panic_backtrace".into()))),
         Some(flag) if matches!(*flag, Flag::PanicBacktrace(true)),
     ) {
         Some(
@@ -121,8 +120,7 @@ fn lower_unsafe_panic<'db>(
 ) {
     let panics = core_submodule(db, "panics");
     let panic_func_id =
-        FunctionLongId::Semantic(get_function_id(db, panics, "unsafe_panic".into(), vec![]))
-            .intern(db);
+        FunctionLongId::Semantic(get_function_id(db, panics, "unsafe_panic", vec![])).intern(db);
 
     for block in lowered.blocks.iter_mut() {
         let BlockEnd::Panic(err_data) = &mut block.end else {

--- a/crates/cairo-lang-parser/Cargo.toml
+++ b/crates/cairo-lang-parser/Cargo.toml
@@ -19,7 +19,6 @@ itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
-smol_str.workspace = true
 unescaper.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -3,7 +3,6 @@ use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::kind::SyntaxKind;
-use smol_str::SmolStr;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]
 pub struct ParserDiagnostic<'a> {
@@ -97,7 +96,7 @@ impl<'a> ParserDiagnostic<'a> {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ParserDiagnosticKind {
     // TODO(spapini): Add tokens from the recovery set to the message.
-    SkippedElement { element_name: SmolStr },
+    SkippedElement { element_name: String },
     MissingToken(SyntaxKind),
     MissingExpression,
     MissingPathSegment,
@@ -109,8 +108,8 @@ pub enum ParserDiagnosticKind {
     InvalidParamKindInMacroExpansion,
     InvalidParamKindInMacroRule,
     ExpectedInToken,
-    ItemInlineMacroWithoutBang { identifier: SmolStr, bracket_type: SyntaxKind },
-    ReservedIdentifier { identifier: SmolStr },
+    ItemInlineMacroWithoutBang { identifier: String, bracket_type: SyntaxKind },
+    ReservedIdentifier { identifier: String },
     UnderscoreNotAllowedAsIdentifier,
     MissingLiteralSuffix,
     InvalidNumericLiteralValue,

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -361,7 +361,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                         // This case is treated as an item inline macro with a missing bang ('!').
                         self.add_diagnostic(
                             ParserDiagnosticKind::ItemInlineMacroWithoutBang {
-                                identifier: path.identifier(self.db).to_string().into(),
+                                identifier: path.identifier(self.db).to_string(),
                                 bracket_type: self.peek().kind,
                             },
                             TextSpan {
@@ -385,7 +385,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                             self.skip_taken_node_with_offset(
                                 attributes,
                                 ParserDiagnosticKind::SkippedElement {
-                                    element_name: or_an_attribute!(MODULE_ITEM_DESCRIPTION).into(),
+                                    element_name: or_an_attribute!(MODULE_ITEM_DESCRIPTION),
                                 },
                                 post_attributes_offset,
                             );
@@ -394,7 +394,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                             self.skip_taken_node_with_offset(
                                 visibility_pub,
                                 ParserDiagnosticKind::SkippedElement {
-                                    element_name: or_an_attribute!(MODULE_ITEM_DESCRIPTION).into(),
+                                    element_name: or_an_attribute!(MODULE_ITEM_DESCRIPTION),
                                 },
                                 post_visibility_offset,
                             );
@@ -403,7 +403,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                         self.skip_taken_node_with_offset(
                             path,
                             ParserDiagnosticKind::SkippedElement {
-                                element_name: or_an_attribute!(MODULE_ITEM_DESCRIPTION).into(),
+                                element_name: or_an_attribute!(MODULE_ITEM_DESCRIPTION),
                             },
                             post_path_offset,
                         );

--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -317,7 +317,7 @@ fn extract_config_predicate_part<'a>(
                 _ => return None,
             };
 
-            Some(ConfigPredicatePart::Cfg(Cfg::kv(name.text.clone(), value_text)))
+            Some(ConfigPredicatePart::Cfg(Cfg::kv(name.text.to_string(), value_text)))
         }
         _ => None,
     }

--- a/crates/cairo-lang-runner/Cargo.toml
+++ b/crates/cairo-lang-runner/Cargo.toml
@@ -29,7 +29,6 @@ num-traits = { workspace = true, default-features = true }
 rand.workspace = true
 serde.workspace = true
 sha2.workspace = true
-smol_str.workspace = true
 starknet-types-core.workspace = true
 thiserror.workspace = true
 

--- a/crates/cairo-lang-runner/src/profiling.rs
+++ b/crates/cairo-lang-runner/src/profiling.rs
@@ -11,7 +11,6 @@ use cairo_lang_utils::require;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_vm::vm::trace::trace_entry::RelocatedTraceEntry;
 use itertools::{Itertools, chain};
-use smol_str::SmolStr;
 
 use crate::ProfilingInfoCollectionConfig;
 
@@ -239,7 +238,7 @@ impl Display for LibfuncWeights {
 pub struct UserFunctionWeights {
     /// Weight (in steps in the relevant run) of each user function (including generated
     /// functions).
-    pub user_function_weights: Option<OrderedHashMap<SmolStr, usize>>,
+    pub user_function_weights: Option<OrderedHashMap<String, usize>>,
     /// Weight (in steps in the relevant run) of each original user function.
     pub original_user_function_weights: Option<OrderedHashMap<String, usize>>,
 }
@@ -637,7 +636,7 @@ impl<'a> ProfilingInfoProcessor<'a> {
                 .map(|(idx, weight)| {
                     let func: &cairo_lang_sierra::program::GenFunction<StatementIdx> =
                         &self.sierra_program.funcs[*idx];
-                    (func.id.to_string().into(), *weight)
+                    (func.id.to_string(), *weight)
                 })
                 .collect()
         });

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -27,7 +27,6 @@ num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
 sha3.workspace = true
-smol_str.workspace = true
 toml = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -13,7 +13,7 @@ use cairo_lang_defs::ids::{
     VariantId,
 };
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder, Maybe};
-use cairo_lang_filesystem::ids::{CrateId, CrateInput, FileId, FileLongId, SmolStrId};
+use cairo_lang_filesystem::ids::{CrateId, CrateInput, FileId, FileLongId, StrRef};
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_syntax::attribute::structured::Attribute;
 use cairo_lang_syntax::node::{TypedStablePtr, ast};
@@ -21,7 +21,6 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::{Intern, Upcast, require};
 use itertools::Itertools;
-use smol_str::SmolStr;
 
 use crate::corelib::CoreInfo;
 use crate::diagnostic::SemanticDiagnosticKind;
@@ -241,7 +240,7 @@ pub trait SemanticGroup:
     fn module_item_by_name<'db>(
         &'db self,
         module_id: ModuleId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<ModuleItemId<'db>>>;
 
     /// Returns [Maybe::Err] if the module was not properly resolved.
@@ -250,7 +249,7 @@ pub trait SemanticGroup:
     fn module_item_info_by_name<'db>(
         &'db self,
         module_id: ModuleId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<ModuleItemInfo<'db>>>;
 
     /// Returns all the items used within the module.
@@ -324,7 +323,7 @@ pub trait SemanticGroup:
     fn struct_members<'db>(
         &'db self,
         struct_id: StructId<'db>,
-    ) -> Maybe<Arc<OrderedHashMap<SmolStrId<'db>, semantic::Member<'db>>>>;
+    ) -> Maybe<Arc<OrderedHashMap<StrRef<'db>, semantic::Member<'db>>>>;
     /// Returns the resolution resolved_items of a struct definition.
     #[salsa::invoke(items::structure::struct_definition_resolver_data)]
     fn struct_definition_resolver_data<'db>(
@@ -336,7 +335,7 @@ pub trait SemanticGroup:
     fn concrete_struct_members<'db>(
         &'db self,
         concrete_struct_id: types::ConcreteStructId<'db>,
-    ) -> Maybe<Arc<OrderedHashMap<SmolStrId<'db>, semantic::Member<'db>>>>;
+    ) -> Maybe<Arc<OrderedHashMap<StrRef<'db>, semantic::Member<'db>>>>;
 
     // Enum.
     // =======
@@ -388,7 +387,7 @@ pub trait SemanticGroup:
     fn enum_variants<'db>(
         &'db self,
         enum_id: EnumId<'db>,
-    ) -> Maybe<OrderedHashMap<SmolStrId<'db>, VariantId<'db>>>;
+    ) -> Maybe<OrderedHashMap<StrRef<'db>, VariantId<'db>>>;
     /// Returns the semantic model of a variant.
     #[salsa::invoke(items::enm::variant_semantic)]
     fn variant_semantic<'db>(
@@ -551,20 +550,20 @@ pub trait SemanticGroup:
     fn trait_required_item_names<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-    ) -> Maybe<OrderedHashSet<SmolStrId<'db>>>;
+    ) -> Maybe<OrderedHashSet<StrRef<'db>>>;
     /// Returns the item of the trait, by the given `name`, if exists.
     #[salsa::invoke(items::trt::trait_item_by_name)]
     fn trait_item_by_name<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<TraitItemId<'db>>>;
     /// Returns the metadata for a trait item, by the given `name`, if exists.
     #[salsa::invoke(items::trt::trait_item_info_by_name)]
     fn trait_item_info_by_name<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<TraitItemInfo<'db>>>;
     /// Returns all the items used within the trait.
     #[salsa::invoke(items::trt::trait_all_used_uses)]
@@ -577,26 +576,26 @@ pub trait SemanticGroup:
     fn trait_functions<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-    ) -> Maybe<OrderedHashMap<SmolStrId<'db>, TraitFunctionId<'db>>>;
+    ) -> Maybe<OrderedHashMap<StrRef<'db>, TraitFunctionId<'db>>>;
     /// Returns the function with the given name of the given trait, if exists.
     #[salsa::invoke(items::trt::trait_function_by_name)]
     fn trait_function_by_name<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<TraitFunctionId<'db>>>;
     /// Returns the types of a trait.
     #[salsa::invoke(items::trt::trait_types)]
     fn trait_types<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-    ) -> Maybe<OrderedHashMap<SmolStrId<'db>, TraitTypeId<'db>>>;
+    ) -> Maybe<OrderedHashMap<StrRef<'db>, TraitTypeId<'db>>>;
     /// Returns the item type with the given name of the given trait, if exists.
     #[salsa::invoke(items::trt::trait_type_by_name)]
     fn trait_type_by_name<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<TraitTypeId<'db>>>;
 
     /// Returns the constants of a trait.
@@ -604,26 +603,26 @@ pub trait SemanticGroup:
     fn trait_constants<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-    ) -> Maybe<OrderedHashMap<SmolStrId<'db>, TraitConstantId<'db>>>;
+    ) -> Maybe<OrderedHashMap<StrRef<'db>, TraitConstantId<'db>>>;
     /// Returns the item constants with the given name of the given trait, if exists.
     #[salsa::invoke(items::trt::trait_constant_by_name)]
     fn trait_constant_by_name<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-        name: SmolStr,
+        name: StrRef<'db>,
     ) -> Maybe<Option<TraitConstantId<'db>>>;
     /// Returns the constants of a trait.
     #[salsa::invoke(items::trt::trait_impls)]
     fn trait_impls<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-    ) -> Maybe<OrderedHashMap<SmolStrId<'db>, TraitImplId<'db>>>;
+    ) -> Maybe<OrderedHashMap<StrRef<'db>, TraitImplId<'db>>>;
     /// Returns the item impls with the given name of the given trait, if exists.
     #[salsa::invoke(items::trt::trait_impl_by_name)]
     fn trait_impl_by_name<'db>(
         &'db self,
         trait_id: TraitId<'db>,
-        name: SmolStr,
+        name: StrRef<'db>,
     ) -> Maybe<Option<TraitImplId<'db>>>;
 
     /// Private query to compute definition data about a trait.
@@ -949,21 +948,21 @@ pub trait SemanticGroup:
     fn impl_item_by_name<'db>(
         &'db self,
         impl_def_id: ImplDefId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<ImplItemId<'db>>>;
     /// Returns the metadata for an impl item, by the given `name`, if exists.
     #[salsa::invoke(items::imp::impl_item_info_by_name)]
     fn impl_item_info_by_name<'db>(
         &'db self,
         impl_def_id: ImplDefId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<ImplItemInfo<'db>>>;
     /// Returns the trait impl of an implicit impl if `name` exists in trait and not in the impl.
     #[salsa::invoke(items::imp::impl_implicit_impl_by_name)]
     fn impl_implicit_impl_by_name<'db>(
         &'db self,
         impl_def_id: ImplDefId<'db>,
-        name: SmolStrId<'db>,
+        name: StrRef<'db>,
     ) -> Maybe<Option<TraitImplId<'db>>>;
     /// Returns all the items used within the impl.
     #[salsa::invoke(items::imp::impl_all_used_uses)]
@@ -1050,7 +1049,7 @@ pub trait SemanticGroup:
     fn impl_functions<'db>(
         &'db self,
         impl_def_id: ImplDefId<'db>,
-    ) -> Maybe<OrderedHashMap<SmolStrId<'db>, ImplFunctionId<'db>>>;
+    ) -> Maybe<OrderedHashMap<StrRef<'db>, ImplFunctionId<'db>>>;
     /// Returns the impl function that matches the given trait function, if exists.
     /// Note that a function that doesn't exist in the impl doesn't necessarily indicate an error,
     /// as, e.g., a trait function that has a default implementation doesn't have to be

--- a/crates/cairo-lang-semantic/src/expr/inference/infers.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/infers.rs
@@ -478,7 +478,7 @@ fn infer_concrete_trait_by_self<'r, 'db, 'mt>(
     let trait_id = trait_function.trait_id(inference.db);
     let signature = inference.db.trait_function_signature(trait_function).ok()?;
     let first_param = signature.params.into_iter().next()?;
-    require(first_param.name.as_str(inference.db) == SELF_PARAM_KW)?;
+    require(first_param.name == SELF_PARAM_KW)?;
 
     let trait_generic_params = inference.db.trait_generic_params(trait_id).ok()?;
     let trait_generic_args =

--- a/crates/cairo-lang-semantic/src/expr/pattern.rs
+++ b/crates/cairo-lang-semantic/src/expr/pattern.rs
@@ -1,10 +1,10 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::FunctionWithBodyId;
 use cairo_lang_diagnostics::DiagnosticAdded;
+use cairo_lang_filesystem::ids::StrRef;
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
-use smol_str::SmolStr;
 
 use super::fmt::ExprFormatter;
 use crate::db::SemanticGroup;
@@ -155,7 +155,7 @@ pub struct PatternStringLiteral<'db> {
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SemanticObject)]
 pub struct PatternVariable<'db> {
     #[dont_rewrite]
-    pub name: SmolStr,
+    pub name: StrRef<'db>,
     pub var: LocalVariable<'db>,
     #[dont_rewrite]
     pub stable_ptr: ast::PatternPtr<'db>,

--- a/crates/cairo-lang-semantic/src/expr/test.rs
+++ b/crates/cairo-lang-semantic/src/expr/test.rs
@@ -3,10 +3,9 @@ use cairo_lang_defs::ids::{FunctionWithBodyId, ModuleItemId, NamedLanguageElemen
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_test_utils::verify_diagnostics_expectation;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{Intern, Upcast, extract_matches};
+use cairo_lang_utils::{Upcast, extract_matches};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 
 use crate::db::SemanticGroup;
 use crate::expr::fmt::ExprFormatter;
@@ -271,9 +270,7 @@ fn test_function_body() {
     )
     .unwrap();
     let db = &db_val;
-    let smol_str = SmolStr::from("foo");
-    let item_id =
-        db.module_item_by_name(test_function.module_id, smol_str.intern(db)).unwrap().unwrap();
+    let item_id = db.module_item_by_name(test_function.module_id, "foo".into()).unwrap().unwrap();
 
     let function_id =
         FunctionWithBodyId::Free(extract_matches!(item_id, ModuleItemId::FreeFunction));

--- a/crates/cairo-lang-semantic/src/helper.rs
+++ b/crates/cairo-lang-semantic/src/helper.rs
@@ -1,6 +1,4 @@
 use cairo_lang_defs::ids::{ExternFunctionId, FreeFunctionId, ModuleId, ModuleItemId, TraitId};
-use cairo_lang_utils::Intern;
-use smol_str::SmolStr;
 
 use crate::db::SemanticGroup;
 use crate::items::functions::GenericFunctionId;
@@ -19,40 +17,34 @@ impl<'a> ModuleHelper<'a> {
         Self { db, id: db.core_module() }
     }
     /// Returns a helper for a submodule named `name` of the current module.
-    pub fn submodule(&self, name: &str) -> Self {
+    pub fn submodule(&self, name: &'a str) -> Self {
         let id = corelib::get_submodule(self.db, self.id, name)
             .unwrap_or_else(|| panic!("`{name}` missing in `{}`.", self.id.full_path(self.db)));
         Self { db: self.db, id }
     }
     /// Returns the id of an extern function named `name` in the current module.
-    pub fn extern_function_id(&self, name: impl Into<SmolStr>) -> ExternFunctionId<'a> {
-        let name = name.into();
-        let name_id = name.clone().intern(self.db);
+    pub fn extern_function_id(&self, name: &'a str) -> ExternFunctionId<'a> {
         let Ok(Some(ModuleItemId::ExternFunction(id))) =
-            self.db.module_item_by_name(self.id, name_id)
+            self.db.module_item_by_name(self.id, name.into())
         else {
-            panic!("`{}` not found in `{}`.", name, self.id.full_path(self.db));
+            panic!("`{name}` not found in `{}`.", self.id.full_path(self.db));
         };
         id
     }
     /// Returns the id of a trait named `name` in the current module.
-    pub fn trait_id(&self, name: impl Into<SmolStr>) -> TraitId<'a> {
-        let name = name.into();
-        let name_id = name.clone().intern(self.db);
-        let Ok(Some(ModuleItemId::Trait(id))) = self.db.module_item_by_name(self.id, name_id)
+    pub fn trait_id(&self, name: &'a str) -> TraitId<'a> {
+        let Ok(Some(ModuleItemId::Trait(id))) = self.db.module_item_by_name(self.id, name.into())
         else {
-            panic!("`{}` not found in `{}`.", name, self.id.full_path(self.db));
+            panic!("`{name}` not found in `{}`.", self.id.full_path(self.db));
         };
         id
     }
     /// Returns the id of a free function named `name` in the current module.
-    pub fn free_function_id(&self, name: impl Into<SmolStr>) -> FreeFunctionId<'a> {
-        let name = name.into();
-        let name_id = name.clone().intern(self.db);
+    pub fn free_function_id(&self, name: &'a str) -> FreeFunctionId<'a> {
         let Ok(Some(ModuleItemId::FreeFunction(id))) =
-            self.db.module_item_by_name(self.id, name_id)
+            self.db.module_item_by_name(self.id, name.into())
         else {
-            panic!("`{}` not found in `{}`.", name, self.id.full_path(self.db));
+            panic!("`{name}` not found in `{}`.", self.id.full_path(self.db));
         };
         id
     }
@@ -60,22 +52,18 @@ impl<'a> ModuleHelper<'a> {
     /// `generic_args`.
     pub fn function_id(
         &self,
-        name: impl Into<SmolStr>,
+        name: &'a str,
         generic_args: Vec<GenericArgumentId<'a>>,
     ) -> FunctionId<'a> {
         self.generic_function_id(name).concretize(self.db, generic_args)
     }
     /// Returns the id of a generic function named `name` in the current module.
-    pub fn generic_function_id(&self, name: impl Into<SmolStr>) -> GenericFunctionId<'a> {
-        corelib::get_generic_function_id(self.db, self.id, name.into())
+    pub fn generic_function_id(&self, name: &'a str) -> GenericFunctionId<'a> {
+        corelib::get_generic_function_id(self.db, self.id, name)
     }
     /// Returns the id of a type named `name` in the current module, with the given
     /// `generic_args`.
-    pub fn ty(
-        &self,
-        name: impl Into<SmolStr>,
-        generic_args: Vec<GenericArgumentId<'a>>,
-    ) -> TypeId<'a> {
-        corelib::get_ty_by_name(self.db, self.id, name.into(), generic_args)
+    pub fn ty(&self, name: &'a str, generic_args: Vec<GenericArgumentId<'a>>) -> TypeId<'a> {
+        corelib::get_ty_by_name(self.db, self.id, name, generic_args)
     }
 }

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -457,12 +457,12 @@ pub fn value_as_const_value<'db>(
 ) -> Result<ConstValue<'db>, LiteralError<'db>> {
     validate_literal(db, ty, value)?;
     let get_basic_const_value = |ty| {
-        let u256_ty = get_core_ty_by_name(db, "u256".into(), vec![]);
+        let u256_ty = get_core_ty_by_name(db, "u256", vec![]);
 
         if ty != u256_ty {
             ConstValue::Int(value.clone(), ty)
         } else {
-            let u128_ty = get_core_ty_by_name(db, "u128".into(), vec![]);
+            let u128_ty = get_core_ty_by_name(db, "u128", vec![]);
             let mask128 = BigInt::from(u128::MAX);
             let low = value & mask128;
             let high = value >> 128;

--- a/crates/cairo-lang-semantic/src/items/enm.rs
+++ b/crates/cairo-lang-semantic/src/items/enm.rs
@@ -4,7 +4,7 @@ use cairo_lang_defs::ids::{
     EnumId, LanguageElementId, LookupItemId, ModuleItemId, VariantId, VariantLongId,
 };
 use cairo_lang_diagnostics::{Diagnostics, Maybe, ToMaybe};
-use cairo_lang_filesystem::ids::SmolStrId;
+use cairo_lang_filesystem::ids::StrRef;
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax::attribute::structured::{Attribute, AttributeListStructurize};
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
@@ -143,7 +143,7 @@ pub fn enum_declaration_resolver_data<'db>(
 #[debug_db(dyn SemanticGroup)]
 pub struct EnumDefinitionData<'db> {
     diagnostics: Diagnostics<'db, SemanticDiagnostic<'db>>,
-    variants: OrderedHashMap<SmolStrId<'db>, VariantId<'db>>,
+    variants: OrderedHashMap<StrRef<'db>, VariantId<'db>>,
     variant_semantic: OrderedHashMap<VariantId<'db>, Variant<'db>>,
     resolver_data: Arc<ResolverData<'db>>,
 }
@@ -222,7 +222,7 @@ pub fn priv_enum_definition_data<'db>(
                 resolve_type(db, &mut diagnostics, &mut resolver, &type_clause.ty(db))
             }
         };
-        let variant_name = SmolStrId::from_str(db, variant.name(db).text(db));
+        let variant_name: StrRef<'_> = variant.name(db).text(db).into();
         if let Some(_other_variant) = variants.insert(variant_name, id) {
             diagnostics
                 .report(variant.stable_ptr(db), EnumVariantRedefinition { enum_id, variant_name });
@@ -291,7 +291,7 @@ pub fn enum_definition_resolver_data<'db>(
 pub fn enum_variants<'db>(
     db: &'db dyn SemanticGroup,
     enum_id: EnumId<'db>,
-) -> Maybe<OrderedHashMap<SmolStrId<'db>, VariantId<'db>>> {
+) -> Maybe<OrderedHashMap<StrRef<'db>, VariantId<'db>>> {
     Ok(db.priv_enum_definition_data(enum_id)?.variants)
 }
 

--- a/crates/cairo-lang-semantic/src/items/enm_test.rs
+++ b/crates/cairo-lang-semantic/src/items/enm_test.rs
@@ -1,9 +1,8 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::ModuleItemId;
-use cairo_lang_utils::{Intern, extract_matches};
+use cairo_lang_utils::extract_matches;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -48,7 +47,7 @@ fn test_enum() {
     let module_id = test_module.module_id;
 
     let enum_id = extract_matches!(
-        db.module_item_by_name(module_id, SmolStr::from("A").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(module_id, "A".into()).unwrap().unwrap(),
         ModuleItemId::Enum
     );
     let actual = db
@@ -57,8 +56,7 @@ fn test_enum() {
         .iter()
         .map(|(name, variant_id)| {
             format!(
-                "{}: {:?}, ty: {:?}",
-                name.long(db),
+                "{name}: {:?}, ty: {:?}",
                 variant_id.debug(db),
                 db.variant_semantic(enum_id, *variant_id).unwrap().ty.debug(db)
             )

--- a/crates/cairo-lang-semantic/src/items/extern_function.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_function.rs
@@ -162,10 +162,8 @@ pub fn priv_extern_function_declaration_data<'db>(
     );
 
     if signature.panicable {
-        let panic_function = extract_matches!(
-            get_core_generic_function_id(db, "panic".into()),
-            GenericFunctionId::Extern
-        );
+        let panic_function =
+            extract_matches!(get_core_generic_function_id(db, "panic"), GenericFunctionId::Extern);
         if extern_function_id != panic_function {
             diagnostics.report(extern_function_syntax.stable_ptr(db), PanicableExternFunction);
         }

--- a/crates/cairo-lang-semantic/src/items/extern_function_test.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_function_test.rs
@@ -1,8 +1,7 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::ModuleItemId;
-use cairo_lang_utils::{Intern, extract_matches};
+use cairo_lang_utils::extract_matches;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -22,7 +21,7 @@ fn test_extern_function() {
     let module_id = test_module.module_id;
 
     let extern_function_id = extract_matches!(
-        db.module_item_by_name(module_id, SmolStr::from("foo").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(module_id, "foo".into()).unwrap().unwrap(),
         ModuleItemId::ExternFunction
     );
     let signature = db.extern_function_signature(extern_function_id).unwrap();

--- a/crates/cairo-lang-semantic/src/items/extern_type_test.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_type_test.rs
@@ -1,8 +1,7 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::ModuleItemId;
-use cairo_lang_utils::{Intern, extract_matches};
+use cairo_lang_utils::extract_matches;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -22,7 +21,7 @@ fn test_extern_type() {
     let module_id = test_module.module_id;
 
     let extern_type_id = extract_matches!(
-        db.module_item_by_name(module_id, SmolStr::from("S").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(module_id, "S".into()).unwrap().unwrap(),
         ModuleItemId::ExternType
     );
     let generic_params = db.extern_type_declaration_generic_params(extern_type_id).unwrap();

--- a/crates/cairo-lang-semantic/src/items/feature_kind.rs
+++ b/crates/cairo-lang-semantic/src/items/feature_kind.rs
@@ -1,7 +1,7 @@
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::{LanguageElementId, ModuleId};
 use cairo_lang_diagnostics::DiagnosticsBuilder;
-use cairo_lang_filesystem::ids::CrateId;
+use cairo_lang_filesystem::ids::{CrateId, StrRef};
 use cairo_lang_syntax::attribute::consts::{
     ALLOW_ATTR, DEPRECATED_ATTR, FEATURE_ATTR, INTERNAL_ATTR, UNSTABLE_ATTR,
 };
@@ -14,27 +14,26 @@ use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::try_extract_matches;
 use itertools::Itertools;
-use smol_str::SmolStr;
 
 use crate::SemanticDiagnostic;
 use crate::db::SemanticGroup;
 use crate::diagnostic::{SemanticDiagnosticKind, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 
 /// The kind of a feature for an item.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum FeatureKind {
+#[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
+pub enum FeatureKind<'db> {
     /// The feature of the item is stable.
     Stable,
     /// The feature of the item is unstable, with the given name to allow.
-    Unstable { feature: SmolStr, note: Option<SmolStr> },
+    Unstable { feature: StrRef<'db>, note: Option<StrRef<'db>> },
     /// The feature of the item is deprecated, with the given name to allow, and an optional note
     /// to appear in diagnostics.
-    Deprecated { feature: SmolStr, note: Option<SmolStr> },
+    Deprecated { feature: StrRef<'db>, note: Option<StrRef<'db>> },
     /// This feature is for internal corelib use only. Using it in user code is not advised.
-    Internal { feature: SmolStr, note: Option<SmolStr> },
+    Internal { feature: StrRef<'db>, note: Option<StrRef<'db>> },
 }
-impl FeatureKind {
-    pub fn from_ast<'db>(
+impl<'db> FeatureKind<'db> {
+    pub fn from_ast(
         db: &'db dyn SyntaxGroup,
         diagnostics: &mut DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
         attrs: &ast::AttributeList<'db>,
@@ -74,9 +73,9 @@ impl FeatureKind {
 }
 
 /// A trait for retrieving the `FeatureKind` of an item.
-pub trait HasFeatureKind {
+pub trait HasFeatureKind<'db> {
     /// Returns the `FeatureKind` associated with the implementing struct.
-    fn feature_kind(&self) -> &FeatureKind;
+    fn feature_kind(&self) -> &FeatureKind<'db>;
 }
 
 /// Diagnostics for feature markers.
@@ -98,14 +97,14 @@ fn parse_feature_attr<'db, const EXTRA_ALLOWED: usize>(
     diagnostics: &mut DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
     attr: &structured::Attribute<'db>,
     allowed_args: [&str; EXTRA_ALLOWED],
-) -> [Option<SmolStr>; EXTRA_ALLOWED] {
+) -> [Option<StrRef<'db>>; EXTRA_ALLOWED] {
     let mut arg_values = std::array::from_fn(|_| None);
     for AttributeArg { variant, arg, .. } in &attr.args {
         let AttributeArgVariant::Named { value: ast::Expr::String(value), name } = variant else {
             add_diag(diagnostics, arg.stable_ptr(db), FeatureMarkerDiagnostic::UnsupportedArgument);
             continue;
         };
-        let Some(i) = allowed_args.iter().position(|x| x == &name.text.as_str()) else {
+        let Some(i) = allowed_args.iter().position(|x| *x == name.text) else {
             add_diag(diagnostics, name.stable_ptr, FeatureMarkerDiagnostic::UnsupportedArgument);
             continue;
         };
@@ -132,28 +131,28 @@ fn add_diag<'db>(
 
 /// The feature configuration on an item.
 /// May be accumulated, or overridden by inner items.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct FeatureConfig {
+#[derive(Clone, Debug, Default, PartialEq, Eq, salsa::Update)]
+pub struct FeatureConfig<'db> {
     /// The current set of allowed features.
-    pub allowed_features: OrderedHashSet<SmolStr>,
+    pub allowed_features: OrderedHashSet<StrRef<'db>>,
     /// Whether to allow all deprecated features.
     pub allow_deprecated: bool,
     /// Whether to allow unused imports.
     pub allow_unused_imports: bool,
 }
 
-impl FeatureConfig {
+impl<'db> FeatureConfig<'db> {
     /// Overrides the current configuration with another one.
     ///
     /// Returns the data required to restore the configuration.
-    pub fn override_with(&mut self, other: Self) -> FeatureConfigRestore {
+    pub fn override_with(&mut self, other: Self) -> FeatureConfigRestore<'db> {
         let mut restore = FeatureConfigRestore {
             features_to_remove: vec![],
             allow_deprecated: self.allow_deprecated,
             allow_unused_imports: self.allow_unused_imports,
         };
         for feature_name in other.allowed_features {
-            if self.allowed_features.insert(feature_name.clone()) {
+            if self.allowed_features.insert(feature_name) {
                 restore.features_to_remove.push(feature_name);
             }
         }
@@ -163,7 +162,7 @@ impl FeatureConfig {
     }
 
     /// Restores the configuration to a previous state.
-    pub fn restore(&mut self, restore: FeatureConfigRestore) {
+    pub fn restore(&mut self, restore: FeatureConfigRestore<'db>) {
         for feature_name in restore.features_to_remove {
             self.allowed_features.swap_remove(&feature_name);
         }
@@ -173,9 +172,9 @@ impl FeatureConfig {
 }
 
 /// The data required to restore the feature configuration after an override.
-pub struct FeatureConfigRestore {
+pub struct FeatureConfigRestore<'db> {
     /// The features to remove from the configuration after the override.
-    features_to_remove: Vec<SmolStr>,
+    features_to_remove: Vec<StrRef<'db>>,
     /// The previous state of the allow deprecated flag.
     allow_deprecated: bool,
     /// The previous state of the allow unused imports flag.
@@ -188,7 +187,7 @@ pub fn extract_item_feature_config<'db>(
     crate_id: CrateId<'db>,
     syntax: &impl QueryAttrs<'db>,
     diagnostics: &mut SemanticDiagnostics<'db>,
-) -> FeatureConfig {
+) -> FeatureConfig<'db> {
     let mut config = FeatureConfig::default();
     process_feature_attr_kind(
         db,
@@ -233,7 +232,7 @@ fn process_feature_attr_kind<'db>(
     attr: &'db str,
     diagnostic_kind: impl Fn() -> SemanticDiagnosticKind<'db>,
     diagnostics: &mut SemanticDiagnostics<'db>,
-    mut process: impl FnMut(&ast::Expr<'_>) -> bool,
+    mut process: impl FnMut(&ast::Expr<'db>) -> bool,
 ) {
     for attr_syntax in syntax.query_attr(db, attr) {
         let attr = attr_syntax.structurize(db);
@@ -258,7 +257,7 @@ pub fn extract_feature_config<'db>(
     element_id: &impl LanguageElementId<'db>,
     syntax: &impl QueryAttrs<'db>,
     diagnostics: &mut SemanticDiagnostics<'db>,
-) -> FeatureConfig {
+) -> FeatureConfig<'db> {
     let defs_db = db;
     let mut current_module_id = element_id.parent_module(defs_db);
     let crate_id = current_module_id.owning_crate(defs_db);

--- a/crates/cairo-lang-semantic/src/items/free_function_test.rs
+++ b/crates/cairo-lang-semantic/src/items/free_function_test.rs
@@ -1,8 +1,7 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{FunctionWithBodyId, ModuleItemId};
-use cairo_lang_utils::{Intern, Upcast, extract_matches};
+use cairo_lang_utils::{Upcast, extract_matches};
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -32,7 +31,7 @@ fn test_expr_lookup() {
     let module_id = test_module.module_id;
 
     let function_id = FunctionWithBodyId::Free(extract_matches!(
-        db.module_item_by_name(module_id, SmolStr::from("foo").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(module_id, "foo".into()).unwrap().unwrap(),
         ModuleItemId::FreeFunction
     ));
     let expr_formatter = ExprFormatter { db, function_id };

--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -9,7 +9,7 @@ use cairo_lang_defs::ids::{
     TopLevelLanguageElementId, TraitFunctionId,
 };
 use cairo_lang_diagnostics::{Diagnostics, Maybe};
-use cairo_lang_filesystem::ids::{SmolStrId, UnstableSalsaId};
+use cairo_lang_filesystem::ids::UnstableSalsaId;
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax as syntax;
 use cairo_lang_syntax::attribute::structured::Attribute;
@@ -928,7 +928,7 @@ fn ast_param_to_semantic<'db>(
     resolver: &mut Resolver<'db>,
     ast_param: &ast::Param<'db>,
 ) -> semantic::Parameter<'db> {
-    let name = SmolStrId::from_str(db, ast_param.name(db).text(db));
+    let name = ast_param.name(db);
 
     let id = ParamLongId(resolver.module_file_id, ast_param.stable_ptr(db)).intern(db);
 
@@ -944,7 +944,13 @@ fn ast_param_to_semantic<'db>(
     let mutability =
         modifiers::compute_mutability(diagnostics, db, &ast_param.modifiers(db).elements_vec(db));
 
-    semantic::Parameter { id, name, ty, mutability, stable_ptr: ast_param.name(db).stable_ptr(db) }
+    semantic::Parameter {
+        id,
+        name: name.text(db).into(),
+        ty,
+        mutability,
+        stable_ptr: name.stable_ptr(db),
+    }
 }
 
 // === Function Declaration ===

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -9,7 +9,6 @@ use cairo_lang_defs::ids::{
     LanguageElementId, LookupItemId, ModuleFileId, TraitId, TraitTypeId,
 };
 use cairo_lang_diagnostics::{Diagnostics, Maybe};
-use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax as syntax;
 use cairo_lang_syntax::node::ast::{AssociatedItemConstraints, OptionAssociatedItemConstraints};
@@ -594,7 +593,7 @@ fn impl_generic_param_semantic<'db>(
             for constraint in constraints.associated_item_constraints(syntax_db).elements(db) {
                 let Ok(trait_type_id_opt) = db.trait_type_by_name(
                     concrete_trait_id.trait_id(db),
-                    SmolStrId::from_str(db, constraint.item(syntax_db).text(syntax_db)),
+                    constraint.item(syntax_db).text(syntax_db).into(),
                 ) else {
                     continue;
                 };
@@ -602,7 +601,7 @@ fn impl_generic_param_semantic<'db>(
                     diagnostics.report(
                         constraint.stable_ptr(syntax_db),
                         SemanticDiagnosticKind::NonTraitTypeConstrained {
-                            identifier: SmolStrId::from_str(db, constraint.item(db).text(db)),
+                            identifier: constraint.item(db).text(db).into(),
                             concrete_trait_id,
                         },
                     );

--- a/crates/cairo-lang-semantic/src/items/imp_test.rs
+++ b/crates/cairo-lang-semantic/src/items/imp_test.rs
@@ -1,8 +1,7 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::ModuleItemId;
-use cairo_lang_utils::{Intern, extract_matches};
+use cairo_lang_utils::extract_matches;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -30,16 +29,14 @@ fn test_impl() {
     assert!(diagnostics.is_empty());
 
     let impl_def_id = extract_matches!(
-        db.module_item_by_name(test_module.module_id, SmolStr::from("Contract").intern(db))
-            .unwrap()
-            .unwrap(),
+        db.module_item_by_name(test_module.module_id, "Contract".into()).unwrap().unwrap(),
         ModuleItemId::Impl
     );
 
     assert_eq!(format!("{:?}", db.impl_def_generic_params(impl_def_id).unwrap()), "[]");
 
     let impl_functions = db.impl_functions(impl_def_id).unwrap();
-    let impl_function_id = impl_functions.get(&SmolStr::from("foo").intern(db)).unwrap();
+    let impl_function_id = impl_functions.get("foo").unwrap();
     let signature = db.impl_function_signature(*impl_function_id).unwrap();
     assert_eq!(
         format!("{:?}", signature.debug(db)),

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -1,7 +1,6 @@
 use cairo_lang_defs::ids::{LanguageElementId, MacroCallId, MacroDeclarationId};
 use cairo_lang_diagnostics::{Diagnostics, Maybe, ToMaybe};
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
-use cairo_lang_utils::Intern;
 
 use crate::SemanticDiagnostic;
 use crate::db::SemanticGroup;
@@ -44,10 +43,7 @@ pub fn priv_macro_call_data<'db>(
             diagnostics.report(
                 macro_call_path.stable_ptr(db).untyped(),
                 SemanticDiagnosticKind::MacroCallToNotAMacro(
-                    smol_str::SmolStr::from(
-                        macro_call_path.as_syntax_node().get_text_without_trivia(db),
-                    )
-                    .intern(db),
+                    macro_call_path.as_syntax_node().get_text_without_trivia(db).into(),
                 ),
             );
             None

--- a/crates/cairo-lang-semantic/src/items/modifiers.rs
+++ b/crates/cairo-lang-semantic/src/items/modifiers.rs
@@ -1,4 +1,3 @@
-use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_syntax::node::ast::Modifier;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode};
@@ -28,11 +27,8 @@ pub fn compute_mutability<'db>(
                     diagnostics.report(
                         terminal.stable_ptr(db),
                         RedundantModifier {
-                            current_modifier: SmolStrId::from_str(db, terminal.text(db)),
-                            previous_modifier: SmolStrId::from_str(
-                                db,
-                                get_relevant_modifier(&mutability),
-                            ),
+                            current_modifier: terminal.text(db).into(),
+                            previous_modifier: get_relevant_modifier(&mutability).into(),
                         },
                     );
                 }
@@ -40,11 +36,8 @@ pub fn compute_mutability<'db>(
                     diagnostics.report(
                         terminal.stable_ptr(db),
                         RedundantModifier {
-                            current_modifier: SmolStrId::from_str(db, terminal.text(db)),
-                            previous_modifier: SmolStrId::from_str(
-                                db,
-                                get_relevant_modifier(&mutability),
-                            ),
+                            current_modifier: terminal.text(db).into(),
+                            previous_modifier: get_relevant_modifier(&mutability).into(),
                         },
                     );
                 }

--- a/crates/cairo-lang-semantic/src/items/structure_test.rs
+++ b/crates/cairo-lang-semantic/src/items/structure_test.rs
@@ -1,9 +1,8 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::ModuleItemId;
-use cairo_lang_utils::{Intern, extract_matches};
+use cairo_lang_utils::extract_matches;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -49,14 +48,14 @@ fn test_struct() {
     let module_id = test_module.module_id;
 
     let struct_id = extract_matches!(
-        db.module_item_by_name(module_id, SmolStr::from("A").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(module_id, "A".into()).unwrap().unwrap(),
         ModuleItemId::Struct
     );
     let actual = db
         .struct_members(struct_id)
         .unwrap()
         .iter()
-        .map(|(name, member)| format!("{}: {:?}", name.long(db), member.debug(db)))
+        .map(|(name, member)| format!("{name}: {:?}", member.debug(db)))
         .collect::<Vec<_>>()
         .join(",\n");
     assert_eq!(

--- a/crates/cairo-lang-semantic/src/items/trt_test.rs
+++ b/crates/cairo-lang-semantic/src/items/trt_test.rs
@@ -1,8 +1,7 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::ModuleItemId;
-use cairo_lang_utils::{Intern, extract_matches};
+use cairo_lang_utils::extract_matches;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -25,9 +24,7 @@ fn test_trait() {
     .unwrap();
 
     let trait_id = extract_matches!(
-        db.module_item_by_name(test_module.module_id, SmolStr::from("MyContract").intern(db))
-            .unwrap()
-            .unwrap(),
+        db.module_item_by_name(test_module.module_id, "MyContract".into()).unwrap().unwrap(),
         ModuleItemId::Trait
     );
 
@@ -38,7 +35,7 @@ fn test_trait() {
     );
 
     let trait_functions = db.trait_functions(trait_id).unwrap();
-    let trait_function_id = trait_functions.get(&SmolStr::from("foo").intern(db)).unwrap();
+    let trait_function_id = trait_functions.get("foo").unwrap();
     let signature = db.trait_function_signature(*trait_function_id).unwrap();
     assert_eq!(
         format!("{:?}", signature.debug(db)),

--- a/crates/cairo-lang-semantic/src/resolve/test.rs
+++ b/crates/cairo-lang-semantic/src/resolve/test.rs
@@ -7,7 +7,6 @@ use cairo_lang_filesystem::{override_file_content, set_crate_config};
 use cairo_lang_utils::{Intern, extract_matches};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -35,7 +34,7 @@ fn test_resolve_path() {
     let module_id = test_module.module_id;
 
     let function_id = FunctionWithBodyId::Free(extract_matches!(
-        db.module_item_by_name(module_id, SmolStr::from("foo").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(module_id, "foo".into()).unwrap().unwrap(),
         ModuleItemId::FreeFunction
     ));
     let expr_formatter = ExprFormatter { db, function_id };
@@ -88,23 +87,21 @@ fn test_resolve_path_super() {
     let crate_id = CrateId::plain(db, "test");
     let test_module = ModuleId::CrateRoot(crate_id);
     let inner2_module_id = ModuleId::Submodule(extract_matches!(
-        db.module_item_by_name(test_module, SmolStr::from("inner2").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(test_module, "inner2".into()).unwrap().unwrap(),
         ModuleItemId::Submodule
     ));
     let struct_id = extract_matches!(
-        db.module_item_by_name(inner2_module_id, SmolStr::from("InnerStruct2").intern(db))
-            .unwrap()
-            .unwrap(),
+        db.module_item_by_name(inner2_module_id, "InnerStruct2".into()).unwrap().unwrap(),
         ModuleItemId::Struct
     );
     let members = db.struct_members(struct_id).unwrap();
     assert_eq!(
-        format!("{:?}", members[&SmolStr::from("a").intern(db)].debug(db)),
+        format!("{:?}", members["a"].debug(db)),
         "Member { id: MemberId(test::inner2::a), ty: test::inner1::InnerStruct1, visibility: \
          Private }"
     );
     assert_eq!(
-        format!("{:?}", members[&SmolStr::from("b").intern(db)].debug(db)),
+        format!("{:?}", members["b"].debug(db)),
         "Member { id: MemberId(test::inner2::b), ty: test::OuterStruct, visibility: Private }"
     );
 }
@@ -135,7 +132,7 @@ fn test_resolve_path_trait_impl() {
     let module_id = test_module.module_id;
 
     let function_id = FunctionWithBodyId::Free(extract_matches!(
-        db.module_item_by_name(module_id, SmolStr::from("main").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(module_id, "main".into()).unwrap().unwrap(),
         ModuleItemId::FreeFunction
     ));
     let expr_formatter = ExprFormatter { db, function_id };

--- a/crates/cairo-lang-semantic/src/semantic.rs
+++ b/crates/cairo-lang-semantic/src/semantic.rs
@@ -2,7 +2,7 @@ use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{LocalVarId, StatementItemId};
 // Reexport objects
 pub use cairo_lang_defs::ids::{ParamId, VarId};
-use cairo_lang_filesystem::ids::SmolStrId;
+use cairo_lang_filesystem::ids::StrRef;
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::{TypedStablePtr, ast};
@@ -62,7 +62,7 @@ pub enum StatementItemKind<'db> {
 pub struct Parameter<'db> {
     pub id: ParamId<'db>,
     #[dont_rewrite]
-    pub name: SmolStrId<'db>,
+    pub name: StrRef<'db>,
     pub ty: TypeId<'db>,
     #[dont_rewrite]
     pub mutability: Mutability,

--- a/crates/cairo-lang-semantic/src/test.rs
+++ b/crates/cairo-lang-semantic/src/test.rs
@@ -7,10 +7,9 @@ use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
-use cairo_lang_utils::{Intern, extract_matches};
+use cairo_lang_utils::extract_matches;
 use indoc::indoc;
 use itertools::Itertools;
-use smol_str::SmolStr;
 
 use crate::db::SemanticGroup;
 use crate::inline_macros::get_default_plugin_suite;
@@ -30,26 +29,17 @@ fn test_resolve() {
 
     let module_id = test_module.module_id;
     let db: &dyn SemanticGroup = &db_val;
-    assert!(
-        db.module_item_by_name(module_id, SmolStr::from("doesnt_exist").intern(db))
-            .unwrap()
-            .is_none()
-    );
-    let felt252_add =
-        db.module_item_by_name(module_id, SmolStr::from("felt252_add").intern(db)).unwrap();
+    assert!(db.module_item_by_name(module_id, "doesnt_exist".into()).unwrap().is_none());
+    let felt252_add = db.module_item_by_name(module_id, "felt252_add".into()).unwrap();
     assert_eq!(
         format!("{:?}", felt252_add.debug(db.upcast())),
         "Some(ExternFunctionId(test::felt252_add))"
     );
-    match db
-        .module_item_by_name(module_id, SmolStr::from("felt252_add").intern(db))
-        .unwrap()
-        .unwrap()
-    {
+    match db.module_item_by_name(module_id, "felt252_add".into()).unwrap().unwrap() {
         ModuleItemId::ExternFunction(_) => {}
         _ => panic!("Expected an extern function"),
     };
-    match db.module_item_by_name(module_id, SmolStr::from("foo").intern(db)).unwrap().unwrap() {
+    match db.module_item_by_name(module_id, "foo".into()).unwrap().unwrap() {
         ModuleItemId::FreeFunction(_) => {}
         _ => panic!("Expected a free function"),
     };
@@ -76,7 +66,7 @@ fn test_resolve_data_full() {
     let module_id = test_module.module_id;
     let db = &db_val;
     let foo = extract_matches!(
-        db.module_item_by_name(module_id, SmolStr::from("foo").intern(db)).unwrap().unwrap(),
+        db.module_item_by_name(module_id, "foo".into()).unwrap().unwrap(),
         ModuleItemId::FreeFunction
     );
     let resolver_data = db.free_function_body_resolver_data(foo).unwrap();

--- a/crates/cairo-lang-sierra-generator/src/program_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator_test.rs
@@ -8,11 +8,10 @@ use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::test_utils::setup_test_function;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{Intern, try_extract_matches};
+use cairo_lang_utils::try_extract_matches;
 use indoc::indoc;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
-use smol_str::SmolStr;
 use test_case::test_case;
 
 use super::get_dummy_program_for_size_estimation;
@@ -114,9 +113,7 @@ fn test_only_include_dependencies(func_name: &str, sierra_used_funcs: &[&str]) {
             .iter()
             .find_map(|module_id| {
                 try_extract_matches!(
-                    db.module_item_by_name(*module_id, SmolStr::from(func_name).intern(&db))
-                        .unwrap()
-                        .unwrap(),
+                    db.module_item_by_name(*module_id, func_name.into()).unwrap().unwrap(),
                     ModuleItemId::FreeFunction
                 )
             })

--- a/crates/cairo-lang-sierra-generator/src/store_variables/test.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/test.rs
@@ -32,7 +32,7 @@ fn get_lib_func_signature(db: &dyn SierraGenGroup, libfunc: ConcreteLibfuncId) -
     let array_ty = db
         .get_concrete_type_id(get_core_ty_by_name(
             db,
-            "Array".into(),
+            "Array",
             vec![GenericArgumentId::Type(db.core_info().felt252)],
         ))
         .expect("Can't find core::Array<core::felt252>.");

--- a/crates/cairo-lang-sierra/src/debug_info.rs
+++ b/crates/cairo-lang-sierra/src/debug_info.rs
@@ -38,7 +38,7 @@ pub struct DebugInfo {
     pub annotations: Annotations,
     /// List of functions marked as executable.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub executables: HashMap<SmolStr, Vec<FunctionId>>,
+    pub executables: HashMap<String, Vec<FunctionId>>,
 }
 
 /// Store for non-crucial information about the program, for use by external libraries and tools.

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -29,7 +29,6 @@ itertools = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 typetag.workspace = true 
-smol_str.workspace = true
 starknet-types-core.workspace = true
 thiserror.workspace = true
 indent.workspace = true

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -15,7 +15,6 @@ cairo-lang-primitive-token.workspace = true
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
-smol_str.workspace = true
 unescaper.workspace = true
 serde = { workspace = true, default-features = true }
 

--- a/crates/cairo-lang-syntax/src/attribute/structured.rs
+++ b/crates/cairo-lang-syntax/src/attribute/structured.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use cairo_lang_debug::DebugWithDb;
-use smol_str::SmolStr;
+use cairo_lang_filesystem::ids::StrRef;
 
 use crate::node::db::SyntaxGroup;
 use crate::node::{Terminal, TypedSyntaxNode, ast};
@@ -10,7 +10,7 @@ use crate::node::{Terminal, TypedSyntaxNode, ast};
 #[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
 pub struct Attribute<'a> {
     pub stable_ptr: ast::AttributePtr<'a>,
-    pub id: SmolStr,
+    pub id: StrRef<'a>,
     pub id_stable_ptr: ast::ExprPathPtr<'a>,
     pub args: Vec<AttributeArg<'a>>,
     pub args_stable_ptr: ast::OptionArgListParenthesizedPtr<'a>,
@@ -53,7 +53,7 @@ pub enum AttributeArgVariant<'a> {
 /// The data on a name part of an argument.
 pub struct NameInfo<'a> {
     /// The name of the argument.
-    pub text: SmolStr,
+    pub text: StrRef<'a>,
     /// The stable pointer to the name.
     pub stable_ptr: ast::TerminalIdentifierPtr<'a>,
 }
@@ -66,7 +66,7 @@ impl<'a> NameInfo<'a> {
 /// Easier to digest representation of a [`ast::Modifier`] attached to [`AttributeArg`].
 #[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
 pub struct Modifier<'a> {
-    pub text: SmolStr,
+    pub text: StrRef<'a>,
     pub stable_ptr: ast::ModifierPtr<'a>,
 }
 

--- a/crates/cairo-lang-syntax/src/node/ast_ext.rs
+++ b/crates/cairo-lang-syntax/src/node/ast_ext.rs
@@ -5,7 +5,6 @@
 use cairo_lang_utils::require;
 use num_bigint::{BigInt, Sign};
 use num_traits::Num;
-use smol_str::SmolStr;
 use unescaper::unescape;
 
 use super::{
@@ -85,14 +84,14 @@ impl<'a> TerminalShortString<'a> {
     }
 
     /// Get suffix from this literal if it has one.
-    pub fn suffix(&self, db: &'a dyn SyntaxGroup) -> Option<SmolStr> {
+    pub fn suffix(&self, db: &'a dyn SyntaxGroup) -> Option<&'a str> {
         let text = self.text(db);
         let (_literal, mut suffix) = text[1..].rsplit_once('\'')?;
         require(!suffix.is_empty())?;
         if suffix.starts_with('_') {
             suffix = &suffix[1..];
         }
-        Some(suffix.into())
+        Some(suffix)
     }
 }
 

--- a/crates/cairo-lang-test-plugin/src/test_config.rs
+++ b/crates/cairo-lang-test-plugin/src/test_config.rs
@@ -47,10 +47,10 @@ pub fn try_extract_test_config<'db>(
     db: &'db dyn SyntaxGroup,
     attrs: Vec<Attribute<'db>>,
 ) -> Result<Option<TestConfig>, Vec<PluginDiagnostic<'db>>> {
-    let test_attr = attrs.iter().find(|attr| attr.id.as_str() == TEST_ATTR);
-    let ignore_attr = attrs.iter().find(|attr| attr.id.as_str() == IGNORE_ATTR);
-    let available_gas_attr = attrs.iter().find(|attr| attr.id.as_str() == AVAILABLE_GAS_ATTR);
-    let should_panic_attr = attrs.iter().find(|attr| attr.id.as_str() == SHOULD_PANIC_ATTR);
+    let test_attr = attrs.iter().find(|attr| attr.id == TEST_ATTR);
+    let ignore_attr = attrs.iter().find(|attr| attr.id == IGNORE_ATTR);
+    let available_gas_attr = attrs.iter().find(|attr| attr.id == AVAILABLE_GAS_ATTR);
+    let should_panic_attr = attrs.iter().find(|attr| attr.id == SHOULD_PANIC_ATTR);
     let mut diagnostics = vec![];
     if let Some(attr) = test_attr {
         if !attr.args.is_empty() {


### PR DESCRIPTION
Perfromed by adding StrRef<'db> structure to have a salsa updatable value.
Cases that still require a reference can have their lifetime extended to the db context by conversion to SmolStr and interning, and we have a utility for that now.