### PR TITLE
fix: correct typos in circuit.rs comments

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/circuit.rs
+++ b/crates/cairo-lang-runner/src/casm_run/circuit.rs
@@ -42,7 +42,7 @@ impl CircuitInstance<'_> {
         write_circuit_value(self.vm, addr, value);
     }
 
-    /// Reads a values from the location specified by `index` in the `add_mod_offsets` buffer.
+    /// Reads a value from the location specified by `index` in the `add_mod_offsets` buffer.
     fn read_addmod_value(&mut self, index: usize) -> Option<BigUint> {
         self.read_circuit_value((self.add_mod_offsets + index).unwrap())
     }
@@ -52,7 +52,7 @@ impl CircuitInstance<'_> {
         self.write_circuit_value((self.add_mod_offsets + index).unwrap(), value)
     }
 
-    /// Reads a values from the location specified by `index` in the `mul_mod_offsets` buffer.
+    /// Reads a value from the location specified by `index` in the `mul_mod_offsets` buffer.
     fn get_mulmod_value(&mut self, index: usize) -> Option<BigUint> {
         self.read_circuit_value((self.mul_mod_offsets + index).unwrap())
     }


### PR DESCRIPTION
Fix grammatical errors in circuit.rs function comments

- Change "a values" to "a value" in read_addmod_value comment
- Change "a values" to "a value" in get_mulmod_value comment
- This improves code documentation clarity and consistency