### PR TITLE
fix: correct typos in Cairo runner module docs and comments

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/circuit.rs
+++ b/crates/cairo-lang-runner/src/casm_run/circuit.rs
@@ -95,7 +95,7 @@ impl CircuitInstance<'_> {
 
     /// Fills the values for a mul mod gate.
     /// Assumes all the inputs are ready and the modulus is not zero or one.
-    /// Returns true if the values were filled successfully, returns false if its an inverse
+    /// Returns true if the values were filled successfully, returns false if it's an inverse
     /// operation and input is not invertible.
     fn fill_mul_gate(&mut self, index: usize) -> bool {
         let lhs = self.get_mulmod_value(index);

--- a/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
+++ b/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
@@ -30,13 +30,13 @@ impl DictTrackerExecScope {
 impl DictManagerExecScope {
     pub const DICT_DEFAULT_VALUE: usize = 0;
 
-    /// Allocates a new segment for a new dictionary and return the start of the segment.
+    /// Allocates a new segment for a new dictionary and returns the start of the segment.
     pub fn new_default_dict(
         &mut self,
         vm: &mut VirtualMachine,
         no_temporary_segments: bool,
     ) -> Relocatable {
-        // If we are not on the first segment - using a temporary segments to later be merged into
+        // If we are not on the first segment - using temporary segments to later be merged into
         // the previous segments.
         let dict_segment = if self.trackers.is_empty() || no_temporary_segments {
             vm.add_memory_segment()


### PR DESCRIPTION
"its" → "it's" (possessive vs contraction)

"return" → "returns"

"a temporary segments" → "temporary segments"