### PR TITLE
docs: fix struct names in get_dep_component comment

### DIFF
--- a/crates/cairo-lang-starknet/src/inline_macros/get_dep_component.rs
+++ b/crates/cairo-lang-starknet/src/inline_macros/get_dep_component.rs
@@ -45,8 +45,8 @@ impl InlineMacroExprPlugin for GetDepComponentMutMacro {
     }
 }
 
-/// A helper function for the code generation of both `GetDepComponentMacro` and
-/// `GetDepComponentMutMacro`. `is_mut` selects between the two.
+/// A helper function for the code generation of both [GetDepComponentMacro] and
+/// [GetDepComponentMutMacro]. `is_mut` selects between the two.
 fn get_dep_component_generate_code_helper<'db>(
     db: &'db dyn SyntaxGroup,
     syntax: &ast::ExprInlineMacro<'db>,

--- a/crates/cairo-lang-starknet/src/inline_macros/get_dep_component.rs
+++ b/crates/cairo-lang-starknet/src/inline_macros/get_dep_component.rs
@@ -45,8 +45,8 @@ impl InlineMacroExprPlugin for GetDepComponentMutMacro {
     }
 }
 
-/// A helper function for the code generation of both `DepComponentMacro` and
-/// `DepComponentMutMacro`. `is_mut` selects between the two.
+/// A helper function for the code generation of both `GetDepComponentMacro` and
+/// `GetDepComponentMutMacro`. `is_mut` selects between the two.
 fn get_dep_component_generate_code_helper<'db>(
     db: &'db dyn SyntaxGroup,
     syntax: &ast::ExprInlineMacro<'db>,


### PR DESCRIPTION
Update comment to reference correct struct names:
- DepComponentMacro → GetDepComponentMacro  
- DepComponentMutMacro → GetDepComponentMutMacro