### PR TITLE
fix(scripts): improve path matching and quoting in version bump and Sierra check scripts

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -49,5 +49,5 @@ check_scarb_version_sync() {
 check_scarb_version_sync
 
 sed -i "s/$CURRENT_VERSION/$NEW_VERSION/g" \
-    $(find . -type f -iname "*.toml"  -o -iname "Scarb.lock") \
+    $(find . -type f \( -iname "*.toml" -o -name "Scarb.lock" \)) \
     ./scripts/bump_version.sh

--- a/scripts/sierra_update_check.sh
+++ b/scripts/sierra_update_check.sh
@@ -4,15 +4,15 @@ BASE_BRANCH=$1
 HEAD_BRANCH=$2
 
 # Assuming all updates are provided as inputs - finding if they are in any of the relevant crates.
-MERGE_BASE=$(git merge-base $BASE_BRANCH $HEAD_BRANCH)
-git diff --name-only "$MERGE_BASE".."$HEAD_BRANCH" | grep -q -E
-    -e 'crate/cairo-lang-sierra/' \
-    -e 'crate/cairo-lang-sierra-gas/' \
-    -e 'crate/cairo-lang-sierra-ap-change/' \
-    -e 'crate/cairo-lang-sierra-to-casm/' >/dev/null
+MERGE_BASE=$(git merge-base "$BASE_BRANCH" "$HEAD_BRANCH")
+git diff --name-only "$MERGE_BASE".."$HEAD_BRANCH" | grep -q -E \
+    -e 'crates/cairo-lang-sierra/' \
+    -e 'crates/cairo-lang-sierra-gas/' \
+    -e 'crates/cairo-lang-sierra-ap-change/' \
+    -e 'crates/cairo-lang-sierra-to-casm/' >/dev/null
 if [ $? -eq 0 ]; then
     # If so, check if the commit message contains an explanation tag.
-    git log $MERGE_BASE..$HEAD_BRANCH --pretty=format:"%b" | grep \
+    git log "$MERGE_BASE".."$HEAD_BRANCH" --pretty=format:"%b" | grep \
         -e 'SIERRA_UPDATE_NO_CHANGE_TAG=' \
         -e 'SIERRA_UPDATE_PATCH_CHANGE_TAG=' \
         -e 'SIERRA_UPDATE_MINOR_CHANGE_TAG=' \


### PR DESCRIPTION
scripts/bump_version.sh:
- Corrected `find` command grouping by adding parentheses around `-o` expressions to ensure both file patterns are matched under `-type f`.
- This change prevents unintended matches and improves cross-platform compatibility.

scripts/sierra_update_check.sh:
- Fixed crate path patterns from `crate/...` to `crates/...` to align with the actual repository structure.
- Added missing backslashes for proper multi-line `grep -q -E` syntax.
- Quoted all variable references (`"$BASE_BRANCH"`, `"$HEAD_BRANCH"`, `"$MERGE_BASE"`) to avoid issues with spaces or special characters.
