### PR TITLE
fix: correct typo "filed_id" to "file_id" in cache module

### DIFF
--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -540,9 +540,9 @@ impl<'db> ModuleDataCached<'db> {
             diagnostics_notes: module_data
                 .diagnostics_notes
                 .iter()
-                .map(|(filed_id, note)| {
+                .map(|(file_id, note)| {
                     (
-                        FileIdCached::new(*filed_id, ctx),
+                        FileIdCached::new(*file_id, ctx),
                         DiagnosticNoteCached::new(note.clone(), ctx),
                     )
                 })


### PR DESCRIPTION
Fixed a typo in the diagnostics_notes mapping where "filed_id" was incorrectly used instead of "file_id". This ensures proper variable naming consistency and prevents potential compilation errors.

- Updated the corresponding variable usage in FileIdCached::new call
