### PR TITLE
Fix typos and improve doc comment formatting in Cairo codebase

### DIFF
--- a/crates/cairo-lang-executable/src/executable.rs
+++ b/crates/cairo-lang-executable/src/executable.rs
@@ -67,7 +67,7 @@ pub enum EntryPointKind {
     Bootloader,
     /// Entrypoint is for running this executable as a standalone program.
     ///
-    /// The entrypoint starts with `ap += <builtins.len()>` and expected the builtins to be injected
+    /// The entrypoint starts with `ap += <builtins.len()>` and expects the builtins to be injected
     /// there, and ends with an infinite loop.
     Standalone,
 }

--- a/crates/cairo-lang-filesystem/src/flag.rs
+++ b/crates/cairo-lang-filesystem/src/flag.rs
@@ -18,7 +18,7 @@ pub enum Flag {
     PanicBacktrace(bool),
     /// Whether to use unsafe_panic in the generated code.
     ///
-    /// Default is false as it make panic unprovable.
+    /// Default is false as it makes panic unprovable.
     UnsafePanic(bool),
 }
 

--- a/crates/cairo-lang-formatter/src/cairo_formatter.rs
+++ b/crates/cairo-lang-formatter/src/cairo_formatter.rs
@@ -248,7 +248,7 @@ impl CairoFormatter {
     }
 
     /// Formats the path in place, writing changes to the files.
-    /// The ['FormattableInput'] trait implementation defines the method for persisting changes.
+    /// The [`FormattableInput`] trait implementation defines the method for persisting changes.
     pub fn format_in_place(
         &self,
         input: &dyn FormattableInput,


### PR DESCRIPTION
In executable.rs: changed "expected" → "expects" in EntryPointKind::Standalone doc.

In flag.rs: changed "make" → "makes" for correct verb agreement in UnsafePanic description.

In cairo_formatter.rs: changed ['FormattableInput'] to the proper Rust doc link format [`FormattableInput`].