### PR TITLE
docs: fix typos in comments

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/compute_costs.rs
+++ b/crates/cairo-lang-sierra-gas/src/compute_costs.rs
@@ -428,7 +428,7 @@ impl<CostType: CostTypeTrait, GetCostFn: Fn(&ConcreteLibfuncId) -> Vec<BranchCos
     /// Assumes that [Self::prepare_wallet] was called before.
     ///
     /// For `branch_align` the function returns the result as if the alignment is zero (since the
-    /// alignment is not know at this point).
+    /// alignment is not known at this point).
     fn wallet_at(&self, idx: &StatementIdx) -> WalletInfo<CostType> {
         self.wallet_at_ex(idx, true)
     }

--- a/crates/cairo-lang-sierra-gas/src/objects.rs
+++ b/crates/cairo-lang-sierra-gas/src/objects.rs
@@ -138,7 +138,7 @@ impl WithdrawGasBranchInfo {
             BuiltinCostsType::cost_computation_steps(self.with_builtin_costs, token_usages)
                 .into_or_panic();
         let mut steps = 3 + cost_computation;
-        // Failure branch have some additional costs.
+        // Failure branch has some additional costs.
         if !self.success {
             if self.with_builtin_costs || cost_computation > 0 {
                 // The additional jump to failure branch, and an additional minus 1 for the


### PR DESCRIPTION
- In compute_costs.rs: corrected "alignment is not know" → "alignment is not known".
- In objects.rs: fixed grammar in comment from "Failure branch have" → "Failure branch has".

