### PR TITLE
chore: fix typos in code comments

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/store_variables/state.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/state.rs
@@ -42,7 +42,7 @@ pub enum VarState {
     ZeroSizedVar,
     /// The variable was consumed and can no longer be used.
     /// This state is used because there is no efficient way of removing variables
-    /// from [VariablesState::variables] without effecting their order.
+    /// from [VariablesState::variables] without affecting their order.
     Removed,
 }
 
@@ -50,7 +50,7 @@ pub enum VarState {
 /// For example, which variable contains a deferred value and which variable is on the stack.
 #[derive(Clone, Debug, Default)]
 pub struct VariablesState {
-    /// A map from [sierra::ids::VarId] of to its state.
+    /// A map from [sierra::ids::VarId] to its state.
     pub variables: OrderedHashMap<sierra::ids::VarId, VarState>,
     /// The information known about the top of the stack.
     pub known_stack: KnownStack,


### PR DESCRIPTION
Changed "effecting" to "affecting" 

(“of to” → “to”).