### PR TITLE
fix(cli, examples): clearer errors and enum fix

### DIFF
--- a/crates/bin/starknet-compile/src/main.rs
+++ b/crates/bin/starknet-compile/src/main.rs
@@ -45,8 +45,9 @@ fn main() -> anyhow::Result<()> {
     check_compiler_path(args.single_file, &args.path)?;
 
     let list_selector =
-        ListSelector::new(args.allowed_libfuncs_list_name, args.allowed_libfuncs_list_file)
-            .expect("Cannot supply both --allowed-libfuncs-list-name and --allowed-libfuncs-list-file");
+        ListSelector::new(args.allowed_libfuncs_list_name, args.allowed_libfuncs_list_file).expect(
+            "Cannot supply both --allowed-libfuncs-list-name and --allowed-libfuncs-list-file",
+        );
     let mut diagnostics_reporter = DiagnosticsReporter::stderr();
     if args.allow_warnings {
         diagnostics_reporter = diagnostics_reporter.allow_warnings();

--- a/crates/bin/starknet-compile/src/main.rs
+++ b/crates/bin/starknet-compile/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> anyhow::Result<()> {
 
     let list_selector =
         ListSelector::new(args.allowed_libfuncs_list_name, args.allowed_libfuncs_list_file)
-            .expect("Both allowed libfunc list name and file were supplied.");
+            .expect("Cannot supply both --allowed-libfuncs-list-name and --allowed-libfuncs-list-file");
     let mut diagnostics_reporter = DiagnosticsReporter::stderr();
     if args.allow_warnings {
         diagnostics_reporter = diagnostics_reporter.allow_warnings();

--- a/crates/bin/starknet-sierra-extract-code/src/main.rs
+++ b/crates/bin/starknet-sierra-extract-code/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
         .with_context(|| "Failed parsing felt252s stream into Sierra program.")?;
     match args.output {
         Some(path) => fs::write(path, sierra_program.to_string())
-            .with_context(|| "Failed to write casm contract.")?,
+            .with_context(|| "Failed to write Sierra program.")?,
         None => println!("{sierra_program}"),
     }
     Ok(())

--- a/examples/enum_flow.cairo
+++ b/examples/enum_flow.cairo
@@ -27,7 +27,7 @@ fn main() -> felt252 {
     let el2 = MyEnumLong::c(22);
     match_long(el2);
     let _eg1: MyEnumGeneric<(), felt252> = MyEnumGeneric::<(), felt252>::a(30);
-    let _eg2: MyEnumGeneric<(), felt252> = MyEnumGeneric::<(), felt252>::b;
+    let _eg2: MyEnumGeneric<(), felt252> = MyEnumGeneric::<(), felt252>::b(());
     let _eg3: MyEnumGeneric<(), felt252> = MyEnumGeneric::<(), felt252>::c(32);
     300
 }

--- a/examples/enum_flow.cairo
+++ b/examples/enum_flow.cairo
@@ -27,7 +27,7 @@ fn main() -> felt252 {
     let el2 = MyEnumLong::c(22);
     match_long(el2);
     let _eg1: MyEnumGeneric<(), felt252> = MyEnumGeneric::<(), felt252>::a(30);
-    let _eg2: MyEnumGeneric<(), felt252> = MyEnumGeneric::<(), felt252>::b(());
+    let _eg2: MyEnumGeneric<(), felt252> = MyEnumGeneric::<(), felt252>::b;
     let _eg3: MyEnumGeneric<(), felt252> = MyEnumGeneric::<(), felt252>::c(32);
     300
 }


### PR DESCRIPTION
- Made the `.expect` message clearer by naming the flags that cannot be used together.
- Fixed the error text when writing the program in `starknet-sierra-extract-code`.
- In the `enum_flow.cairo` example, added `()` for the `b` variant so it compiles.
