### PR TITLE
Fix missing closing code block in BitAnd trait documentation 

### DIFF
--- a/corelib/src/traits.cairo
+++ b/corelib/src/traits.cairo
@@ -484,6 +484,7 @@ pub trait BitAnd<T> {
     /// assert_eq!(5_u8 & 1_u8, 1);
     /// assert_eq!(true & true, true);
     /// assert_eq!(5_u8 & 2_u8, 0);
+    /// ```
     fn bitand(lhs: T, rhs: T) -> T;
 }
 


### PR DESCRIPTION
docs: fix missing code block closure in BitAnd trait

Add missing ``` comment to properly close code example block
in BitAnd trait documentation for better markdown rendering.