### PR TITLE
ExternalFiles to a db held function object

### DIFF
--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow, bail};
-use cairo_lang_defs::db::{DefsGroup, init_defs_group, try_ext_as_virtual_impl};
+use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::db::{
-    CORELIB_VERSION, ExternalFiles, FilesGroup, FilesGroupEx, init_dev_corelib, init_files_group,
+    CORELIB_VERSION, FilesGroup, FilesGroupEx, init_dev_corelib, init_files_group,
 };
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::flag::Flag;
-use cairo_lang_filesystem::ids::{CrateId, FlagLongId, VirtualFile};
+use cairo_lang_filesystem::ids::{CrateId, FlagLongId};
 use cairo_lang_lowering::db::{ExternalCodeSizeEstimator, LoweringGroup, init_lowering_group};
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
 use cairo_lang_parser::db::ParserGroup;
@@ -75,14 +75,11 @@ pub struct RootDatabase {
 }
 #[salsa::db]
 impl salsa::Database for RootDatabase {}
-impl ExternalFiles for RootDatabase {
-    fn try_ext_as_virtual(&self, external_id: salsa::Id) -> Option<VirtualFile<'_>> {
-        try_ext_as_virtual_impl(self, external_id)
-    }
-}
+
 impl RootDatabase {
     fn new(default_plugin_suite: PluginSuite, inlining_strategy: InliningStrategy) -> Self {
         let mut res = Self { storage: Default::default() };
+        init_external_files(&mut res);
         init_files_group(&mut res);
         init_lowering_group(&mut res, inlining_strategy);
         init_defs_group(&mut res);

--- a/crates/cairo-lang-compiler/src/diagnostics_test.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics_test.rs
@@ -8,10 +8,11 @@ use crate::diagnostics::get_diagnostics_as_string;
 #[test]
 fn test_diagnostics() {
     let mut db = RootDatabase::default();
+    let db_ref = &mut db;
 
-    let crate_id = CrateId::plain(&db, "bad_crate");
+    let crate_id = CrateId::plain(db_ref, "bad_crate");
     set_crate_config!(
-        db,
+        db_ref,
         crate_id,
         Some(CrateConfiguration::default_for_root(Directory::Real("no/such/path".into())))
     );

--- a/crates/cairo-lang-doc/src/tests/test_utils.rs
+++ b/crates/cairo-lang-doc/src/tests/test_utils.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, anyhow};
 use cairo_lang_defs::db::{DefsGroup, init_defs_group};
 use cairo_lang_defs::ids::ModuleId;
 use cairo_lang_filesystem::db::{
-    CrateConfiguration, ExternalFiles, FilesGroup, FilesGroupEx, init_dev_corelib, init_files_group,
+    CrateConfiguration, FilesGroup, FilesGroupEx, init_dev_corelib, init_files_group,
 };
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::ids::{CrateId, Directory, FileLongId};
@@ -22,7 +22,6 @@ pub struct TestDatabase {
 }
 #[salsa::db]
 impl salsa::Database for TestDatabase {}
-impl ExternalFiles for TestDatabase {}
 
 impl Default for TestDatabase {
     fn default() -> Self {

--- a/crates/cairo-lang-filesystem/src/ids.rs
+++ b/crates/cairo-lang-filesystem/src/ids.rs
@@ -7,7 +7,7 @@ use path_clean::PathClean;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
-use crate::db::{CORELIB_CRATE_NAME, FilesGroup};
+use crate::db::{CORELIB_CRATE_NAME, FilesGroup, get_external_files};
 use crate::span::{TextOffset, TextSpan};
 
 pub const CAIRO_FILE_EXTENSION: &str = "cairo";
@@ -276,14 +276,18 @@ impl<'db> FileLongId<'db> {
                 path.file_name().and_then(|x| x.to_str()).unwrap_or("<unknown>").to_string()
             }
             FileLongId::Virtual(vf) => vf.name.to_string(),
-            FileLongId::External(external_id) => db.ext_as_virtual(*external_id).name.to_string(),
+            FileLongId::External(external_id) => {
+                get_external_files(db).ext_as_virtual(db, *external_id).name.to_string()
+            }
         }
     }
     pub fn full_path(&self, db: &'db dyn FilesGroup) -> String {
         match self {
             FileLongId::OnDisk(path) => path.to_str().unwrap_or("<unknown>").to_string(),
             FileLongId::Virtual(vf) => vf.full_path(db),
-            FileLongId::External(external_id) => db.ext_as_virtual(*external_id).full_path(db),
+            FileLongId::External(external_id) => {
+                get_external_files(db).ext_as_virtual(db, *external_id).full_path(db)
+            }
         }
     }
     pub fn kind(&self) -> FileKind {

--- a/crates/cairo-lang-filesystem/src/test_utils.rs
+++ b/crates/cairo-lang-filesystem/src/test_utils.rs
@@ -1,4 +1,4 @@
-use crate::db::{ExternalFiles, init_files_group};
+use crate::db::init_files_group;
 
 // Test salsa database.
 #[salsa::db]
@@ -10,7 +10,6 @@ pub struct FilesDatabaseForTesting {
 #[salsa::db]
 impl salsa::Database for FilesDatabaseForTesting {}
 
-impl ExternalFiles for FilesDatabaseForTesting {}
 impl Default for FilesDatabaseForTesting {
     fn default() -> Self {
         let mut res = Self { storage: Default::default() };

--- a/crates/cairo-lang-lowering/src/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/test_utils.rs
@@ -1,10 +1,9 @@
 use std::sync::{LazyLock, Mutex};
 
 use cairo_lang_debug::DebugWithDb;
-use cairo_lang_defs::db::{DefsGroup, init_defs_group, try_ext_as_virtual_impl};
-use cairo_lang_filesystem::db::{ExternalFiles, FilesGroup, init_dev_corelib, init_files_group};
+use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
+use cairo_lang_filesystem::db::{FilesGroup, init_dev_corelib, init_files_group};
 use cairo_lang_filesystem::detect::detect_corelib;
-use cairo_lang_filesystem::ids::VirtualFile;
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_semantic::db::{Elongate, PluginSuiteInput, SemanticGroup, init_semantic_group};
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
@@ -25,14 +24,11 @@ pub struct LoweringDatabaseForTesting {
 }
 #[salsa::db]
 impl salsa::Database for LoweringDatabaseForTesting {}
-impl ExternalFiles for LoweringDatabaseForTesting {
-    fn try_ext_as_virtual(&self, external_id: salsa::Id) -> Option<VirtualFile<'_>> {
-        try_ext_as_virtual_impl(self, external_id)
-    }
-}
+
 impl LoweringDatabaseForTesting {
     pub fn new() -> Self {
         let mut res = LoweringDatabaseForTesting { storage: Default::default() };
+        init_external_files(&mut res);
         init_files_group(&mut res);
         init_defs_group(&mut res);
         init_semantic_group(&mut res);

--- a/crates/cairo-lang-parser/src/utils.rs
+++ b/crates/cairo-lang-parser/src/utils.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder};
-use cairo_lang_filesystem::db::{ExternalFiles, FilesGroup, init_files_group};
+use cairo_lang_filesystem::db::{FilesGroup, init_files_group};
 use cairo_lang_filesystem::ids::{FileId, FileKind, FileLongId, VirtualFile};
 use cairo_lang_filesystem::span::{TextOffset, TextWidth};
 use cairo_lang_primitive_token::{PrimitiveToken, ToPrimitiveTokenStream};
@@ -22,7 +22,6 @@ pub struct SimpleParserDatabase {
 }
 #[salsa::db]
 impl salsa::Database for SimpleParserDatabase {}
-impl ExternalFiles for SimpleParserDatabase {}
 impl Default for SimpleParserDatabase {
     fn default() -> Self {
         let mut res = Self { storage: Default::default() };

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -1,18 +1,14 @@
 use std::default::Default;
 use std::sync::Arc;
 
-use cairo_lang_defs::db::{DefsGroup, init_defs_group, try_ext_as_virtual_impl};
+use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
 use cairo_lang_defs::ids::{MacroPluginLongId, ModuleId};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
 use cairo_lang_filesystem::cfg::CfgSet;
-use cairo_lang_filesystem::db::{
-    CrateConfiguration, ExternalFiles, FilesGroup, FilesGroupEx, init_files_group,
-};
-use cairo_lang_filesystem::ids::{
-    CodeMapping, CodeOrigin, CrateId, Directory, FileLongId, VirtualFile,
-};
+use cairo_lang_filesystem::db::{CrateConfiguration, FilesGroup, FilesGroupEx, init_files_group};
+use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin, CrateId, Directory, FileLongId};
 use cairo_lang_filesystem::override_file_content;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -57,14 +53,11 @@ pub struct DatabaseForTesting {
 }
 #[salsa::db]
 impl salsa::Database for DatabaseForTesting {}
-impl ExternalFiles for DatabaseForTesting {
-    fn try_ext_as_virtual(&self, external_id: salsa::Id) -> Option<VirtualFile<'_>> {
-        try_ext_as_virtual_impl(self.upcast(), external_id)
-    }
-}
+
 impl Default for DatabaseForTesting {
     fn default() -> Self {
         let mut res = Self { storage: Default::default() };
+        init_external_files(&mut res);
         init_files_group(&mut res);
         init_defs_group(&mut res);
         res.set_default_macro_plugins_input(

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -1,11 +1,11 @@
 use std::sync::{LazyLock, Mutex};
 
-use cairo_lang_defs::db::{DefsGroup, init_defs_group, try_ext_as_virtual_impl};
+use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
 use cairo_lang_defs::ids::{FunctionWithBodyId, ModuleId};
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder};
 use cairo_lang_filesystem::db::{
-    CrateSettings, Edition, ExperimentalFeaturesConfig, ExternalFiles, FilesGroup,
-    init_dev_corelib, init_files_group,
+    CrateSettings, Edition, ExperimentalFeaturesConfig, FilesGroup, init_dev_corelib,
+    init_files_group,
 };
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::ids::{BlobId, CrateId, CrateLongId, FileKind, FileLongId, VirtualFile};
@@ -30,11 +30,7 @@ pub struct SemanticDatabaseForTesting {
 
 #[salsa::db]
 impl salsa::Database for SemanticDatabaseForTesting {}
-impl ExternalFiles for SemanticDatabaseForTesting {
-    fn try_ext_as_virtual(&self, external_id: salsa::Id) -> Option<VirtualFile<'_>> {
-        try_ext_as_virtual_impl(self.upcast(), external_id)
-    }
-}
+
 impl SemanticDatabaseForTesting {
     pub fn new_empty() -> Self {
         let suite = get_default_plugin_suite();
@@ -43,6 +39,7 @@ impl SemanticDatabaseForTesting {
 
     pub fn with_plugin_suite(suite: PluginSuite) -> Self {
         let mut res = SemanticDatabaseForTesting { storage: Default::default() };
+        init_external_files(&mut res);
         init_files_group(&mut res);
         init_defs_group(&mut res);
         init_semantic_group(&mut res);

--- a/crates/cairo-lang-sierra-generator/src/test_utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/test_utils.rs
@@ -1,13 +1,11 @@
 use std::sync::{Arc, LazyLock, Mutex};
 
-use cairo_lang_defs::db::{DefsGroup, init_defs_group, try_ext_as_virtual_impl};
+use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
 use cairo_lang_defs::ids::ModuleId;
-use cairo_lang_filesystem::db::{
-    ExternalFiles, FilesGroup, FilesGroupEx, init_dev_corelib, init_files_group,
-};
+use cairo_lang_filesystem::db::{FilesGroup, FilesGroupEx, init_dev_corelib, init_files_group};
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::flag::Flag;
-use cairo_lang_filesystem::ids::{FlagLongId, VirtualFile};
+use cairo_lang_filesystem::ids::FlagLongId;
 use cairo_lang_lowering::db::{LoweringGroup, UseApproxCodeSizeEstimator};
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_semantic::db::{Elongate, PluginSuiteInput, SemanticGroup, init_semantic_group};
@@ -37,11 +35,7 @@ pub struct SierraGenDatabaseForTesting {
 }
 #[salsa::db]
 impl salsa::Database for SierraGenDatabaseForTesting {}
-impl ExternalFiles for SierraGenDatabaseForTesting {
-    fn try_ext_as_virtual(&self, external_id: salsa::Id) -> Option<VirtualFile<'_>> {
-        try_ext_as_virtual_impl(self, external_id)
-    }
-}
+
 pub static SHARED_DB: LazyLock<Mutex<SierraGenDatabaseForTesting>> =
     LazyLock::new(|| Mutex::new(SierraGenDatabaseForTesting::new_empty()));
 pub static SHARED_DB_WITHOUT_AD_WITHDRAW_GAS: LazyLock<Mutex<SierraGenDatabaseForTesting>> =
@@ -54,6 +48,7 @@ pub static SHARED_DB_WITHOUT_AD_WITHDRAW_GAS: LazyLock<Mutex<SierraGenDatabaseFo
 impl SierraGenDatabaseForTesting {
     pub fn new_empty() -> Self {
         let mut res = SierraGenDatabaseForTesting { storage: Default::default() };
+        init_external_files(&mut res);
         init_files_group(&mut res);
         init_defs_group(&mut res);
         init_semantic_group(&mut res);

--- a/crates/cairo-lang-syntax/src/node/test_utils.rs
+++ b/crates/cairo-lang-syntax/src/node/test_utils.rs
@@ -1,4 +1,4 @@
-use cairo_lang_filesystem::db::{ExternalFiles, FilesGroup};
+use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_utils::Upcast;
 
 #[salsa::db]
@@ -8,8 +8,6 @@ pub struct DatabaseForTesting {
 }
 #[salsa::db]
 impl salsa::Database for DatabaseForTesting {}
-
-impl ExternalFiles for DatabaseForTesting {}
 
 impl<'a> Upcast<'a, dyn FilesGroup> for DatabaseForTesting {
     fn upcast(&'a self) -> &'a dyn FilesGroup {


### PR DESCRIPTION
Changed external files from a trait on a Database object (which Filesgroup depended on), to a function object initialized when initializing the db.
Behaviour should be the same, but code should be less coupled.
This is a preparation step to remove QueryGroup from FilesGroup