### PR TITLE
Removing intern_X functions from usage and macros

### DIFF
--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -78,8 +78,8 @@ pub trait TopLevelLanguageElementId<'db>: NamedLanguageElementId<'db> {
 /// 4. Implements `NamedLanguageElementId` using a key_field. See the documentation of
 ///    'define_short_id' and `stable_ptr.rs` for more details.
 macro_rules! define_top_level_language_element_id {
-    ($short_id:ident, $long_id:ident, $ast_ty:ty, $intern:ident) => {
-        define_named_language_element_id!($short_id, $long_id, $ast_ty, $intern);
+    ($short_id:ident, $long_id:ident, $ast_ty:ty) => {
+        define_named_language_element_id!($short_id, $long_id, $ast_ty);
         impl<'db> TopLevelLanguageElementId<'db> for $short_id<'db> {}
     };
 }
@@ -91,8 +91,8 @@ macro_rules! define_top_level_language_element_id {
 /// Note: prefer to use `define_top_level_language_element_id`, unless you need to overwrite the
 /// behavior of `TopLevelLanguageElementId` for the type.
 macro_rules! define_named_language_element_id {
-    ($short_id:ident, $long_id:ident, $ast_ty:ty, $intern:ident) => {
-        define_language_element_id_basic!($short_id, $long_id, $ast_ty, $intern);
+    ($short_id:ident, $long_id:ident, $ast_ty:ty) => {
+        define_language_element_id_basic!($short_id, $long_id, $ast_ty);
         impl<'db> cairo_lang_debug::DebugWithDb<'db> for $long_id<'db> {
             type Db = dyn DefsGroup;
 
@@ -139,13 +139,13 @@ macro_rules! define_named_language_element_id {
 ///
 /// Use for language elements that are not top level and don't have a name.
 macro_rules! define_language_element_id_basic {
-    ($short_id:ident, $long_id:ident, $ast_ty:ty, $intern:ident) => {
+    ($short_id:ident, $long_id:ident, $ast_ty:ty) => {
         #[derive(Clone, PartialEq, Eq, Hash, Debug, salsa::Update)]
         pub struct $long_id<'db>(
             pub ModuleFileId<'db>,
             pub <$ast_ty as TypedSyntaxNode<'db>>::StablePtr,
         );
-        define_short_id!($short_id, $long_id<'db>, DefsGroup, $intern);
+        define_short_id!($short_id, $long_id<'db>, DefsGroup);
         impl<'db> $short_id<'db> {
             pub fn stable_ptr(
                 &self,
@@ -360,12 +360,7 @@ pub struct PluginGeneratedFileLongId<'db> {
     /// The name of the generated file to differentiate between different generated files.
     pub name: String,
 }
-define_short_id!(
-    PluginGeneratedFileId,
-    PluginGeneratedFileLongId<'db>,
-    DefsGroup,
-    intern_plugin_generated_file
-);
+define_short_id!(PluginGeneratedFileId, PluginGeneratedFileLongId<'db>, DefsGroup);
 
 /// An ID allowing for interning the [`MacroPlugin`] into Salsa database.
 #[derive(Clone, Debug)]
@@ -420,7 +415,7 @@ impl Hash for MacroPluginLongId {
     }
 }
 
-define_short_id!(MacroPluginId, MacroPluginLongId, DefsGroup, intern_macro_plugin);
+define_short_id!(MacroPluginId, MacroPluginLongId, DefsGroup);
 
 /// An ID allowing for interning the [`InlineMacroExprPlugin`] into Salsa database.
 #[derive(Clone, Debug)]
@@ -463,12 +458,7 @@ impl Hash for InlineMacroExprPluginLongId {
     }
 }
 
-define_short_id!(
-    InlineMacroExprPluginId,
-    InlineMacroExprPluginLongId,
-    DefsGroup,
-    intern_inline_macro_plugin
-);
+define_short_id!(InlineMacroExprPluginId, InlineMacroExprPluginLongId, DefsGroup);
 
 define_language_element_id_as_enum! {
     #[toplevel]
@@ -510,51 +500,29 @@ pub enum ImportableId<'db> {
     MacroDeclaration(MacroDeclarationId<'db>),
 }
 
-define_top_level_language_element_id!(
-    SubmoduleId,
-    SubmoduleLongId,
-    ast::ItemModule<'db>,
-    intern_submodule
-);
+define_top_level_language_element_id!(SubmoduleId, SubmoduleLongId, ast::ItemModule<'db>);
 impl<'db> UnstableSalsaId for SubmoduleId<'db> {
     fn get_internal_id(&self) -> salsa::Id {
         self.0
     }
 }
 
-define_top_level_language_element_id!(
-    ConstantId,
-    ConstantLongId,
-    ast::ItemConstant<'db>,
-    intern_constant
-);
-define_language_element_id_basic!(
-    GlobalUseId,
-    GlobalUseLongId,
-    ast::UsePathStar<'db>,
-    intern_global_use
-);
-define_top_level_language_element_id!(UseId, UseLongId, ast::UsePathLeaf<'db>, intern_use);
+define_top_level_language_element_id!(ConstantId, ConstantLongId, ast::ItemConstant<'db>);
+define_language_element_id_basic!(GlobalUseId, GlobalUseLongId, ast::UsePathStar<'db>);
+define_top_level_language_element_id!(UseId, UseLongId, ast::UsePathLeaf<'db>);
 define_top_level_language_element_id!(
     FreeFunctionId,
     FreeFunctionLongId,
-    ast::FunctionWithBody<'db>,
-    intern_free_function
+    ast::FunctionWithBody<'db>
 );
 
 define_top_level_language_element_id!(
     MacroDeclarationId,
     MacroDeclarationLongId,
-    ast::ItemMacroDeclaration<'db>,
-    intern_macro_declaration
+    ast::ItemMacroDeclaration<'db>
 );
 
-define_language_element_id_basic!(
-    MacroCallId,
-    MacroCallLongId,
-    ast::ItemInlineMacro<'db>,
-    intern_macro_call
-);
+define_language_element_id_basic!(MacroCallId, MacroCallLongId, ast::ItemInlineMacro<'db>);
 
 impl<'db> UnstableSalsaId for MacroCallId<'db> {
     fn get_internal_id(&self) -> salsa::Id {
@@ -569,20 +537,10 @@ impl<'db> UnstableSalsaId for FreeFunctionId<'db> {
 }
 
 // --- Impls ---
-define_top_level_language_element_id!(
-    ImplDefId,
-    ImplDefLongId,
-    ast::ItemImpl<'db>,
-    intern_impl_def
-);
+define_top_level_language_element_id!(ImplDefId, ImplDefLongId, ast::ItemImpl<'db>);
 
 // --- Impl type items ---
-define_named_language_element_id!(
-    ImplTypeDefId,
-    ImplTypeDefLongId,
-    ast::ItemTypeAlias<'db>,
-    intern_impl_type_def
-);
+define_named_language_element_id!(ImplTypeDefId, ImplTypeDefLongId, ast::ItemTypeAlias<'db>);
 impl<'db> ImplTypeDefId<'db> {
     pub fn impl_def_id(&self, db: &'db dyn DefsGroup) -> ImplDefId<'db> {
         let ImplTypeDefLongId(module_file_id, ptr) = self.long(db).clone();
@@ -599,12 +557,7 @@ impl<'db> TopLevelLanguageElementId<'db> for ImplTypeDefId<'db> {
 }
 
 // --- Impl constant items ---
-define_named_language_element_id!(
-    ImplConstantDefId,
-    ImplConstantDefLongId,
-    ast::ItemConstant<'db>,
-    intern_impl_constant_def
-);
+define_named_language_element_id!(ImplConstantDefId, ImplConstantDefLongId, ast::ItemConstant<'db>);
 impl<'db> ImplConstantDefId<'db> {
     pub fn impl_def_id(&self, db: &'db dyn DefsGroup) -> ImplDefId<'db> {
         let ImplConstantDefLongId(module_file_id, ptr) = self.long(db).clone();
@@ -621,12 +574,7 @@ impl<'db> TopLevelLanguageElementId<'db> for ImplConstantDefId<'db> {
 }
 
 // --- Impl Impl items ---
-define_named_language_element_id!(
-    ImplImplDefId,
-    ImplImplDefLongId,
-    ast::ItemImplAlias<'db>,
-    intern_impl_impl_def
-);
+define_named_language_element_id!(ImplImplDefId, ImplImplDefLongId, ast::ItemImplAlias<'db>);
 impl<'db> ImplImplDefId<'db> {
     pub fn impl_def_id(&self, db: &'db dyn DefsGroup) -> ImplDefId<'db> {
         let ImplImplDefLongId(module_file_id, ptr) = self.long(db).clone();
@@ -643,12 +591,7 @@ impl<'db> TopLevelLanguageElementId<'db> for ImplImplDefId<'db> {
 }
 
 // --- Impl functions ---
-define_named_language_element_id!(
-    ImplFunctionId,
-    ImplFunctionLongId,
-    ast::FunctionWithBody<'db>,
-    intern_impl_function
-);
+define_named_language_element_id!(ImplFunctionId, ImplFunctionLongId, ast::FunctionWithBody<'db>);
 impl<'db> ImplFunctionId<'db> {
     pub fn impl_def_id(&self, db: &'db dyn DefsGroup) -> ImplDefId<'db> {
         let ImplFunctionLongId(module_file_id, ptr) = self.long(db).clone();
@@ -682,40 +625,23 @@ define_language_element_id_as_enum! {
 define_top_level_language_element_id!(
     ExternFunctionId,
     ExternFunctionLongId,
-    ast::ItemExternFunction<'db>,
-    intern_extern_function
+    ast::ItemExternFunction<'db>
 );
-define_top_level_language_element_id!(StructId, StructLongId, ast::ItemStruct<'db>, intern_struct);
-define_top_level_language_element_id!(EnumId, EnumLongId, ast::ItemEnum<'db>, intern_enum);
+define_top_level_language_element_id!(StructId, StructLongId, ast::ItemStruct<'db>);
+define_top_level_language_element_id!(EnumId, EnumLongId, ast::ItemEnum<'db>);
 define_top_level_language_element_id!(
     ModuleTypeAliasId,
     ModuleTypeAliasLongId,
-    ast::ItemTypeAlias<'db>,
-    intern_module_type_alias
+    ast::ItemTypeAlias<'db>
 );
-define_top_level_language_element_id!(
-    ImplAliasId,
-    ImplAliasLongId,
-    ast::ItemImplAlias<'db>,
-    intern_impl_alias
-);
-define_top_level_language_element_id!(
-    ExternTypeId,
-    ExternTypeLongId,
-    ast::ItemExternType<'db>,
-    intern_extern_type
-);
+define_top_level_language_element_id!(ImplAliasId, ImplAliasLongId, ast::ItemImplAlias<'db>);
+define_top_level_language_element_id!(ExternTypeId, ExternTypeLongId, ast::ItemExternType<'db>);
 
 // --- Trait ---
-define_top_level_language_element_id!(TraitId, TraitLongId, ast::ItemTrait<'db>, intern_trait);
+define_top_level_language_element_id!(TraitId, TraitLongId, ast::ItemTrait<'db>);
 
 // --- Trait type items ---
-define_named_language_element_id!(
-    TraitTypeId,
-    TraitTypeLongId,
-    ast::TraitItemType<'db>,
-    intern_trait_type
-);
+define_named_language_element_id!(TraitTypeId, TraitTypeLongId, ast::TraitItemType<'db>);
 impl<'db> TraitTypeId<'db> {
     pub fn trait_id(&self, db: &'db dyn DefsGroup) -> TraitId<'db> {
         let TraitTypeLongId(module_file_id, ptr) = self.long(db).clone();
@@ -739,8 +665,7 @@ impl<'db> UnstableSalsaId for TraitTypeId<'db> {
 define_named_language_element_id!(
     TraitConstantId,
     TraitConstantLongId,
-    ast::TraitItemConstant<'db>,
-    intern_trait_constant
+    ast::TraitItemConstant<'db>
 );
 impl<'db> TraitConstantId<'db> {
     pub fn trait_id(&self, db: &'db dyn DefsGroup) -> TraitId<'db> {
@@ -757,12 +682,7 @@ impl<'db> TopLevelLanguageElementId<'db> for TraitConstantId<'db> {
 }
 
 // --- Trait impl items ---
-define_named_language_element_id!(
-    TraitImplId,
-    TraitImplLongId,
-    ast::TraitItemImpl<'db>,
-    intern_trait_impl
-);
+define_named_language_element_id!(TraitImplId, TraitImplLongId, ast::TraitItemImpl<'db>);
 impl<'db> TraitImplId<'db> {
     pub fn trait_id(&self, db: &'db dyn DefsGroup) -> TraitId<'db> {
         let TraitImplLongId(module_file_id, ptr) = self.long(db).clone();
@@ -781,8 +701,7 @@ impl<'db> TopLevelLanguageElementId<'db> for TraitImplId<'db> {
 define_named_language_element_id!(
     TraitFunctionId,
     TraitFunctionLongId,
-    ast::TraitItemFunction<'db>,
-    intern_trait_function
+    ast::TraitItemFunction<'db>
 );
 impl<'db> TraitFunctionId<'db> {
     pub fn trait_id(&self, db: &'db dyn DefsGroup) -> TraitId<'db> {
@@ -799,7 +718,7 @@ impl<'db> TopLevelLanguageElementId<'db> for TraitFunctionId<'db> {
 }
 
 // --- Struct items ---
-define_named_language_element_id!(MemberId, MemberLongId, ast::Member<'db>, intern_member);
+define_named_language_element_id!(MemberId, MemberLongId, ast::Member<'db>);
 impl<'db> MemberId<'db> {
     pub fn struct_id(&self, db: &'db dyn DefsGroup) -> StructId<'db> {
         let MemberLongId(module_file_id, ptr) = self.long(db).clone();
@@ -815,7 +734,7 @@ impl<'db> TopLevelLanguageElementId<'db> for MemberId<'db> {
 }
 
 // --- Enum variants ---
-define_named_language_element_id!(VariantId, VariantLongId, ast::Variant<'db>, intern_variant);
+define_named_language_element_id!(VariantId, VariantLongId, ast::Variant<'db>);
 impl<'db> VariantId<'db> {
     pub fn enum_id(&self, db: &'db dyn DefsGroup) -> EnumId<'db> {
         let VariantLongId(module_file_id, ptr) = self.long(db).clone();
@@ -841,13 +760,8 @@ define_language_element_id_as_enum! {
 }
 
 // TODO(spapini): Override full_path for to include parents, for better debug.
-define_top_level_language_element_id!(ParamId, ParamLongId, ast::Param<'db>, intern_param);
-define_language_element_id_basic!(
-    GenericParamId,
-    GenericParamLongId,
-    ast::GenericParam<'db>,
-    intern_generic_param
-);
+define_top_level_language_element_id!(ParamId, ParamLongId, ast::Param<'db>);
+define_language_element_id_basic!(GenericParamId, GenericParamLongId, ast::GenericParam<'db>);
 impl<'db> GenericParamLongId<'db> {
     pub fn name(&self, db: &'db dyn SyntaxGroup) -> Option<&'db str> {
         let SyntaxStablePtr::Child { key_fields, kind, .. } = self.1.0.long(db) else {
@@ -1105,12 +1019,7 @@ impl std::fmt::Display for GenericKind {
 
 // TODO(spapini): change this to a binding inside a pattern.
 // TODO(spapini): Override full_path to include parents, for better debug.
-define_language_element_id_basic!(
-    LocalVarId,
-    LocalVarLongId,
-    ast::TerminalIdentifier<'db>,
-    intern_local_var
-);
+define_language_element_id_basic!(LocalVarId, LocalVarLongId, ast::TerminalIdentifier<'db>);
 impl<'db> DebugWithDb<'db> for LocalVarLongId<'db> {
     type Db = dyn DefsGroup;
 
@@ -1124,16 +1033,10 @@ impl<'db> DebugWithDb<'db> for LocalVarLongId<'db> {
 define_top_level_language_element_id!(
     StatementConstId,
     StatementConstLongId,
-    ast::ItemConstant<'db>,
-    intern_statement_const
+    ast::ItemConstant<'db>
 );
 
-define_top_level_language_element_id!(
-    StatementUseId,
-    StatementUseLongId,
-    ast::UsePathLeaf<'db>,
-    intern_statement_use
-);
+define_top_level_language_element_id!(StatementUseId, StatementUseLongId, ast::UsePathLeaf<'db>);
 
 define_language_element_id_as_enum! {
     #[toplevel]

--- a/crates/cairo-lang-filesystem/src/ids.rs
+++ b/crates/cairo-lang-filesystem/src/ids.rs
@@ -91,7 +91,7 @@ impl<'db> CrateLongId<'db> {
         CrateLongId::Real { name: name.into(), discriminator: None }
     }
 }
-define_short_id!(CrateId, CrateLongId<'db>, FilesGroup, intern_crate);
+define_short_id!(CrateId, CrateLongId<'db>, FilesGroup);
 impl<'db> CrateId<'db> {
     /// Gets the crate id for a real crate by name, without a discriminator.
     pub fn plain(db: &'db dyn FilesGroup, name: &str) -> Self {
@@ -120,7 +120,7 @@ impl UnstableSalsaId for CrateId<'_> {
 /// The long ID for a compilation flag.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct FlagLongId(pub String);
-define_short_id!(FlagId, FlagLongId, FilesGroup, intern_flag);
+define_short_id!(FlagId, FlagLongId, FilesGroup);
 
 /// Same as `FileLongId`, but without the interning inside virtual files.
 /// This is used to avoid the need to intern the file id inside salsa database inputs.
@@ -307,7 +307,7 @@ impl<'db> FileLongId<'db> {
     }
 }
 
-define_short_id!(FileId, FileLongId<'db>, FilesGroup, intern_file);
+define_short_id!(FileId, FileLongId<'db>, FilesGroup);
 impl<'db> FileId<'db> {
     pub fn new_on_disk(db: &'db dyn FilesGroup, path: PathBuf) -> FileId<'db> {
         FileLongId::OnDisk(path.clean()).intern(db)
@@ -326,7 +326,7 @@ impl<'db> FileId<'db> {
     }
 }
 
-define_short_id!(StrId, Arc<str>, FilesGroup, intern_str);
+define_short_id!(StrId, Arc<str>, FilesGroup);
 
 /// Same as `Directory`, but without the interning inside virtual directories.
 /// This is used to avoid the need to intern the file id inside salsa database inputs.
@@ -355,7 +355,7 @@ impl DirectoryInput {
     }
 }
 
-define_short_id!(SmolStrId, SmolStr, FilesGroup, intern_smol_str);
+define_short_id!(SmolStrId, SmolStr, FilesGroup);
 
 /// Returns a string with a lifetime that is valid on the database's lifetime.
 pub fn db_str(db: &dyn FilesGroup, str: impl Into<SmolStr>) -> &str {
@@ -479,7 +479,7 @@ impl BlobLongId {
     }
 }
 
-define_short_id!(BlobId, BlobLongId, FilesGroup, intern_blob);
+define_short_id!(BlobId, BlobLongId, FilesGroup);
 
 impl<'db> BlobId<'db> {
     pub fn new_on_disk(db: &'db (dyn FilesGroup + 'db), path: PathBuf) -> Self {

--- a/crates/cairo-lang-lowering/src/ids.rs
+++ b/crates/cairo-lang-lowering/src/ids.rs
@@ -31,12 +31,7 @@ pub enum FunctionWithBodyLongId<'db> {
     Semantic(defs::ids::FunctionWithBodyId<'db>),
     Generated { parent: defs::ids::FunctionWithBodyId<'db>, key: GeneratedFunctionKey<'db> },
 }
-define_short_id!(
-    FunctionWithBodyId,
-    FunctionWithBodyLongId<'db>,
-    LoweringGroup,
-    intern_lowering_function_with_body
-);
+define_short_id!(FunctionWithBodyId, FunctionWithBodyLongId<'db>, LoweringGroup);
 impl<'db> FunctionWithBodyLongId<'db> {
     pub fn base_semantic_function(
         &self,
@@ -97,12 +92,7 @@ pub enum ConcreteFunctionWithBodyLongId<'db> {
     Generated(GeneratedFunction<'db>),
     Specialized(SpecializedFunction<'db>),
 }
-define_short_id!(
-    ConcreteFunctionWithBodyId,
-    ConcreteFunctionWithBodyLongId<'db>,
-    LoweringGroup,
-    intern_lowering_concrete_function_with_body
-);
+define_short_id!(ConcreteFunctionWithBodyId, ConcreteFunctionWithBodyLongId<'db>, LoweringGroup);
 
 // The result of `generic_or_specialized`.
 pub enum GenericOrSpecialized<'db> {
@@ -261,7 +251,7 @@ pub enum FunctionLongId<'db> {
     /// A specialized function.
     Specialized(SpecializedFunction<'db>),
 }
-define_short_id!(FunctionId, FunctionLongId<'db>, LoweringGroup, intern_lowering_function);
+define_short_id!(FunctionId, FunctionLongId<'db>, LoweringGroup);
 impl<'db> FunctionLongId<'db> {
     pub fn body(
         &self,
@@ -577,7 +567,7 @@ pub(crate) fn parameter_as_member_path<'db>(
     })
 }
 
-define_short_id!(LocationId, Location<'db>, LoweringGroup, intern_location);
+define_short_id!(LocationId, Location<'db>, LoweringGroup);
 impl<'db> LocationId<'db> {
     pub fn from_stable_location(
         db: &'db dyn LoweringGroup,

--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -100,7 +100,7 @@ impl<'db> OptimizationPhase<'db> {
     }
 }
 
-define_short_id!(OptimizationStrategyId, OptimizationStrategy<'db>, LoweringGroup, intern_strategy);
+define_short_id!(OptimizationStrategyId, OptimizationStrategy<'db>, LoweringGroup);
 
 /// A strategy is a sequence of optimization phases.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -120,7 +120,7 @@ pub struct LocalImplVarId(pub usize);
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, SemanticObject, salsa::Update)]
 pub struct LocalConstVarId(pub usize);
 
-define_short_id!(ImplVarId, ImplVar<'db>, SemanticGroup, intern_impl_var);
+define_short_id!(ImplVarId, ImplVar<'db>, SemanticGroup);
 impl<'db> ImplVarId<'db> {
     pub fn id(&self, db: &dyn SemanticGroup) -> LocalImplVarId {
         self.long(db).id
@@ -132,7 +132,7 @@ impl<'db> ImplVarId<'db> {
         self.long(db).lookup_context.clone()
     }
 }
-semantic_object_for_id!(ImplVarId<'a>, intern_impl_var, ImplVar<'a>);
+semantic_object_for_id!(ImplVarId, ImplVar<'a>);
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, SemanticObject, salsa::Update)]
 pub enum InferenceVar {

--- a/crates/cairo-lang-semantic/src/ids.rs
+++ b/crates/cairo-lang-semantic/src/ids.rs
@@ -46,4 +46,4 @@ impl Hash for AnalyzerPluginLongId {
     }
 }
 
-define_short_id!(AnalyzerPluginId, AnalyzerPluginLongId, SemanticGroup, intern_analyzer_plugin);
+define_short_id!(AnalyzerPluginId, AnalyzerPluginLongId, SemanticGroup);

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -85,8 +85,8 @@ pub struct ConstantData<'db> {
     pub resolver_data: Arc<ResolverData<'db>>,
 }
 
-define_short_id!(ConstValueId, ConstValue<'db>, SemanticGroup, intern_const_value);
-semantic_object_for_id!(ConstValueId<'a>, intern_const_value, ConstValue<'a>);
+define_short_id!(ConstValueId, ConstValue<'db>, SemanticGroup);
+semantic_object_for_id!(ConstValueId, ConstValue<'a>);
 impl<'db> ConstValueId<'db> {
     pub fn format(&self, db: &dyn SemanticGroup) -> String {
         format!("{:?}", self.long(db).debug(db.elongate()))

--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -270,8 +270,8 @@ impl<'db> DebugWithDb<'db> for FunctionLongId<'db> {
     }
 }
 
-define_short_id!(FunctionId, FunctionLongId<'db>, SemanticGroup, intern_function);
-semantic_object_for_id!(FunctionId<'a>, intern_function, FunctionLongId<'a>);
+define_short_id!(FunctionId, FunctionLongId<'db>, SemanticGroup);
+semantic_object_for_id!(FunctionId, FunctionLongId<'a>);
 impl<'db> FunctionId<'db> {
     pub fn get_concrete(&self, db: &'db dyn SemanticGroup) -> ConcreteFunction<'db> {
         self.long(db).function.clone()
@@ -614,17 +614,8 @@ impl<'db> DebugWithDb<'db> for ConcreteFunctionWithBody<'db> {
     }
 }
 
-define_short_id!(
-    ConcreteFunctionWithBodyId,
-    ConcreteFunctionWithBody<'db>,
-    SemanticGroup,
-    intern_concrete_function_with_body
-);
-semantic_object_for_id!(
-    ConcreteFunctionWithBodyId<'a>,
-    intern_concrete_function_with_body,
-    ConcreteFunctionWithBody<'a>
-);
+define_short_id!(ConcreteFunctionWithBodyId, ConcreteFunctionWithBody<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteFunctionWithBodyId, ConcreteFunctionWithBody<'a>);
 impl<'db> ConcreteFunctionWithBodyId<'db> {
     pub fn function_with_body_id(&self, db: &'db dyn SemanticGroup) -> FunctionWithBodyId<'db> {
         self.long(db).function_with_body_id(db)

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -95,8 +95,8 @@ pub struct ConcreteImplLongId<'db> {
     pub impl_def_id: ImplDefId<'db>,
     pub generic_args: Vec<GenericArgumentId<'db>>,
 }
-define_short_id!(ConcreteImplId, ConcreteImplLongId<'db>, SemanticGroup, intern_concrete_impl);
-semantic_object_for_id!(ConcreteImplId<'a>, intern_concrete_impl, ConcreteImplLongId<'a>);
+define_short_id!(ConcreteImplId, ConcreteImplLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteImplId, ConcreteImplLongId<'a>);
 impl<'db> DebugWithDb<'db> for ConcreteImplLongId<'db> {
     type Db = dyn SemanticGroup;
 
@@ -277,8 +277,8 @@ impl<'db> DebugWithDb<'db> for ImplLongId<'db> {
     }
 }
 
-define_short_id!(ImplId, ImplLongId<'db>, SemanticGroup, intern_impl);
-semantic_object_for_id!(ImplId<'a>, intern_impl, ImplLongId<'a>);
+define_short_id!(ImplId, ImplLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ImplId, ImplLongId<'a>);
 impl<'db> ImplId<'db> {
     pub fn concrete_trait(&self, db: &'db dyn SemanticGroup) -> Maybe<ConcreteTraitId<'db>> {
         db.impl_concrete_trait(*self)
@@ -309,8 +309,8 @@ impl<'db> ImplId<'db> {
     }
 }
 
-define_short_id!(GeneratedImplId, GeneratedImplLongId<'db>, SemanticGroup, intern_generated_impl);
-semantic_object_for_id!(GeneratedImplId<'a>, intern_generated_impl, GeneratedImplLongId<'a>);
+define_short_id!(GeneratedImplId, GeneratedImplLongId<'db>, SemanticGroup);
+semantic_object_for_id!(GeneratedImplId, GeneratedImplLongId<'a>);
 
 impl<'db> GeneratedImplId<'db> {
     pub fn concrete_trait(self, db: &'db dyn SemanticGroup) -> ConcreteTraitId<'db> {
@@ -1844,17 +1844,8 @@ impl<'db> DebugWithDb<'db> for UninferredImpl<'db> {
     }
 }
 
-define_short_id!(
-    UninferredGeneratedImplId,
-    UninferredGeneratedImplLongId<'db>,
-    SemanticGroup,
-    intern_uninferred_generated_impl
-);
-semantic_object_for_id!(
-    UninferredGeneratedImplId<'a>,
-    intern_uninferred_generated_impl,
-    UninferredGeneratedImplLongId<'a>
-);
+define_short_id!(UninferredGeneratedImplId, UninferredGeneratedImplLongId<'db>, SemanticGroup);
+semantic_object_for_id!(UninferredGeneratedImplId, UninferredGeneratedImplLongId<'a>);
 
 impl<'db> UninferredGeneratedImplId<'db> {
     pub fn concrete_trait(self, db: &'db dyn SemanticGroup) -> ConcreteTraitId<'db> {

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -66,8 +66,8 @@ impl<'db> DebugWithDb<'db> for ConcreteTraitLongId<'db> {
     }
 }
 
-define_short_id!(ConcreteTraitId, ConcreteTraitLongId<'db>, SemanticGroup, intern_concrete_trait);
-semantic_object_for_id!(ConcreteTraitId<'a>, intern_concrete_trait, ConcreteTraitLongId<'a>);
+define_short_id!(ConcreteTraitId, ConcreteTraitLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteTraitId, ConcreteTraitLongId<'a>);
 impl<'db> ConcreteTraitId<'db> {
     pub fn trait_id(&self, db: &'db dyn SemanticGroup) -> TraitId<'db> {
         self.long(db).trait_id
@@ -133,14 +133,9 @@ impl<'db> ConcreteTraitGenericFunctionLongId<'db> {
 define_short_id!(
     ConcreteTraitGenericFunctionId,
     ConcreteTraitGenericFunctionLongId<'db>,
-    SemanticGroup,
-    intern_concrete_trait_function
+    SemanticGroup
 );
-semantic_object_for_id!(
-    ConcreteTraitGenericFunctionId<'a>,
-    intern_concrete_trait_function,
-    ConcreteTraitGenericFunctionLongId<'a>
-);
+semantic_object_for_id!(ConcreteTraitGenericFunctionId, ConcreteTraitGenericFunctionLongId<'a>);
 impl<'db> ConcreteTraitGenericFunctionId<'db> {
     pub fn new_from_data(
         db: &'db dyn SemanticGroup,
@@ -181,17 +176,8 @@ impl<'db> ConcreteTraitTypeLongId<'db> {
         Self { concrete_trait, trait_type }
     }
 }
-define_short_id!(
-    ConcreteTraitTypeId,
-    ConcreteTraitTypeLongId<'db>,
-    SemanticGroup,
-    intern_concrete_trait_type
-);
-semantic_object_for_id!(
-    ConcreteTraitTypeId<'a>,
-    intern_concrete_trait_type,
-    ConcreteTraitTypeLongId<'a>
-);
+define_short_id!(ConcreteTraitTypeId, ConcreteTraitTypeLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteTraitTypeId, ConcreteTraitTypeLongId<'a>);
 impl<'db> ConcreteTraitTypeId<'db> {
     pub fn new_from_data(
         db: &'db dyn SemanticGroup,
@@ -232,17 +218,8 @@ impl<'db> ConcreteTraitConstantLongId<'db> {
         Self { concrete_trait, trait_constant }
     }
 }
-define_short_id!(
-    ConcreteTraitConstantId,
-    ConcreteTraitConstantLongId<'db>,
-    SemanticGroup,
-    intern_concrete_trait_constant
-);
-semantic_object_for_id!(
-    ConcreteTraitConstantId<'a>,
-    intern_concrete_trait_constant,
-    ConcreteTraitConstantLongId<'a>
-);
+define_short_id!(ConcreteTraitConstantId, ConcreteTraitConstantLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteTraitConstantId, ConcreteTraitConstantLongId<'a>);
 impl<'db> ConcreteTraitConstantId<'db> {
     pub fn new_from_data(
         db: &'db dyn SemanticGroup,
@@ -283,17 +260,8 @@ impl<'db> ConcreteTraitImplLongId<'db> {
         Self { concrete_trait, trait_impl }
     }
 }
-define_short_id!(
-    ConcreteTraitImplId,
-    ConcreteTraitImplLongId<'db>,
-    SemanticGroup,
-    intern_concrete_trait_impl
-);
-semantic_object_for_id!(
-    ConcreteTraitImplId<'a>,
-    intern_concrete_trait_impl,
-    ConcreteTraitImplLongId<'a>
-);
+define_short_id!(ConcreteTraitImplId, ConcreteTraitImplLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteTraitImplId, ConcreteTraitImplLongId<'a>);
 impl<'db> ConcreteTraitImplId<'db> {
     pub fn new_from_data(
         db: &'db dyn SemanticGroup,

--- a/crates/cairo-lang-semantic/src/substitution.rs
+++ b/crates/cairo-lang-semantic/src/substitution.rs
@@ -109,13 +109,13 @@ impl<'db> DerefMut for GenericSubstitution<'db> {
 
 #[macro_export]
 macro_rules! semantic_object_for_id {
-    ($name:path, $intern:ident, $long_ty:path) => {
+    ($name:ident, $long_ty:path) => {
         impl<
             'a,
             Error,
             TRewriter: $crate::substitution::HasDb<&'a dyn $crate::db::SemanticGroup>
                 + $crate::substitution::SemanticRewriter<$long_ty, Error>,
-        > $crate::substitution::SemanticObject<TRewriter, Error> for $name
+        > $crate::substitution::SemanticObject<TRewriter, Error> for $name<'a>
         {
             fn default_rewrite(
                 &mut self,
@@ -128,7 +128,7 @@ macro_rules! semantic_object_for_id {
                         rewriter, &mut val,
                     )? {
                         $crate::substitution::RewriteResult::Modified => {
-                            *self = db.$intern(val);
+                            *self = $name::new(db, val);
                             $crate::substitution::RewriteResult::Modified
                         }
                         $crate::substitution::RewriteResult::NoChange => {

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -63,8 +63,8 @@ impl<'db> OptionFrom<TypeLongId<'db>> for ConcreteTypeId<'db> {
     }
 }
 
-define_short_id!(TypeId, TypeLongId<'db>, SemanticGroup, intern_type);
-semantic_object_for_id!(TypeId<'a>, intern_type, TypeLongId<'a>);
+define_short_id!(TypeId, TypeLongId<'db>, SemanticGroup);
+semantic_object_for_id!(TypeId, TypeLongId<'a>);
 impl<'db> TypeId<'db> {
     pub fn missing(db: &'db dyn SemanticGroup, diag_added: DiagnosticAdded) -> Self {
         TypeLongId::Missing(diag_added).intern(db)
@@ -347,13 +347,8 @@ pub struct ConcreteStructLongId<'db> {
     pub struct_id: StructId<'db>,
     pub generic_args: Vec<semantic::GenericArgumentId<'db>>,
 }
-define_short_id!(
-    ConcreteStructId,
-    ConcreteStructLongId<'db>,
-    SemanticGroup,
-    intern_concrete_struct
-);
-semantic_object_for_id!(ConcreteStructId<'a>, intern_concrete_struct, ConcreteStructLongId<'a>);
+define_short_id!(ConcreteStructId, ConcreteStructLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteStructId, ConcreteStructLongId<'a>);
 impl<'db> ConcreteStructId<'db> {
     pub fn struct_id(&self, db: &'db dyn SemanticGroup) -> StructId<'db> {
         self.long(db).struct_id
@@ -388,8 +383,8 @@ impl<'db> DebugWithDb<'db> for ConcreteEnumLongId<'db> {
     }
 }
 
-define_short_id!(ConcreteEnumId, ConcreteEnumLongId<'db>, SemanticGroup, intern_concrete_enum);
-semantic_object_for_id!(ConcreteEnumId<'a>, intern_concrete_enum, ConcreteEnumLongId<'a>);
+define_short_id!(ConcreteEnumId, ConcreteEnumLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteEnumId, ConcreteEnumLongId<'a>);
 impl<'db> ConcreteEnumId<'db> {
     pub fn enum_id(&self, db: &'db dyn SemanticGroup) -> EnumId<'db> {
         self.long(db).enum_id
@@ -401,17 +396,8 @@ pub struct ConcreteExternTypeLongId<'db> {
     pub extern_type_id: ExternTypeId<'db>,
     pub generic_args: Vec<semantic::GenericArgumentId<'db>>,
 }
-define_short_id!(
-    ConcreteExternTypeId,
-    ConcreteExternTypeLongId<'db>,
-    SemanticGroup,
-    intern_concrete_extern_type
-);
-semantic_object_for_id!(
-    ConcreteExternTypeId<'a>,
-    intern_concrete_extern_type,
-    ConcreteExternTypeLongId<'a>
-);
+define_short_id!(ConcreteExternTypeId, ConcreteExternTypeLongId<'db>, SemanticGroup);
+semantic_object_for_id!(ConcreteExternTypeId, ConcreteExternTypeLongId<'a>);
 impl<'db> ConcreteExternTypeId<'db> {
     pub fn extern_type_id(&self, db: &'db dyn SemanticGroup) -> ExternTypeId<'db> {
         self.long(db).extern_type_id

--- a/crates/cairo-lang-sierra-generator/src/pre_sierra.rs
+++ b/crates/cairo-lang-sierra-generator/src/pre_sierra.rs
@@ -19,7 +19,7 @@ pub struct LabelLongId<'db> {
     // A unique identifier inside the function
     pub id: usize,
 }
-define_short_id!(LabelId, LabelLongId<'db>, SierraGenGroup, intern_label_id);
+define_short_id!(LabelId, LabelLongId<'db>, SierraGenGroup);
 
 pub struct LabelIdWithDb<'db> {
     db: &'db dyn SierraGenGroup,

--- a/crates/cairo-lang-syntax/src/node/ids.rs
+++ b/crates/cairo-lang-syntax/src/node/ids.rs
@@ -8,7 +8,7 @@ use super::green::GreenNode;
 use super::kind::SyntaxKind;
 use crate::node::stable_ptr::SyntaxStablePtr;
 
-define_short_id!(GreenId, GreenNode<'db>, SyntaxGroup, intern_green);
+define_short_id!(GreenId, GreenNode<'db>, SyntaxGroup);
 impl<'a> GreenId<'a> {
     /// Returns the width of the node of this green id.
     pub fn width(&self, db: &dyn SyntaxGroup) -> TextWidth {
@@ -19,7 +19,7 @@ impl<'a> GreenId<'a> {
     }
 }
 
-define_short_id!(SyntaxStablePtrId, SyntaxStablePtr<'db>, SyntaxGroup, intern_stable_ptr);
+define_short_id!(SyntaxStablePtrId, SyntaxStablePtr<'db>, SyntaxGroup);
 impl<'a> SyntaxStablePtrId<'a> {
     /// Lookups a syntax node using a stable syntax pointer.
     /// Should only be called on the root from which the stable pointer was generated.

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -41,7 +41,7 @@ pub struct SyntaxNodeLongId<'a> {
     parent: Option<SyntaxNode<'a>>,
     stable_ptr: SyntaxStablePtrId<'a>,
 }
-define_short_id!(SyntaxNode, SyntaxNodeLongId<'db>, SyntaxGroup, intern_syntax_node);
+define_short_id!(SyntaxNode, SyntaxNodeLongId<'db>, SyntaxGroup);
 impl<'a> SyntaxNode<'a> {
     pub fn new_root(db: &'a dyn SyntaxGroup, file_id: FileId<'a>, green: GreenId<'a>) -> Self {
         Self::new_with_inner(

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -103,7 +103,7 @@ pub trait Intern<'db, Target> {
 //   usually include the short id of the entity's parent.
 #[macro_export]
 macro_rules! define_short_id {
-    ($short_id:ident, $long_id:path, $db:ident, $intern:ident) => {
+    ($short_id:ident, $long_id:path, $db:ident) => {
         // 1. Modern interned struct.
         #[salsa::interned]
         pub struct $short_id<'db> {


### PR DESCRIPTION
### TL;DR

Removing .intern_...() from macros and query groups.
Moving to WhateverId::new(db, Long)

### What changed?

This PR simplifies the `define_short_id!` macro and its dependent macros by removing the explicit intern function name parameter. The macros now automatically handle interning without requiring the caller to specify an interning function name. This change affects multiple macros:

- `define_short_id!`
- `define_language_element_id_basic!`
- `define_named_language_element_id!`
- `define_top_level_language_element_id!`
- `semantic_object_for_id!`

The PR updates all usages of these macros across the codebase to remove the now unnecessary intern function parameter.
