### PR TITLE
Removed interned from loweringgroup

### DIFF
--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -282,7 +282,8 @@ fn main() -> anyhow::Result<()> {
                 )
             })?;
 
-            function_id = db.intern_lowering_concrete_function_with_body(
+            function_id = ConcreteFunctionWithBodyId::new(
+                db,
                 ConcreteFunctionWithBodyLongId::Generated(GeneratedFunction {
                     parent: function_id.base_semantic_function(db),
                     key,

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -35,7 +35,7 @@ use crate::inline::statements_weights::{ApproxCasmInlineWeight, InlineWeight};
 use crate::lower::{MultiLowering, lower_semantic_function};
 use crate::optimizations::config::OptimizationConfig;
 use crate::optimizations::scrub_units::scrub_units;
-use crate::optimizations::strategy::{OptimizationStrategy, OptimizationStrategyId};
+use crate::optimizations::strategy::OptimizationStrategyId;
 use crate::panic::lower_panics;
 use crate::specialization::specialized_function_lowered;
 use crate::utils::InliningStrategy;
@@ -65,31 +65,6 @@ impl<T: UseApproxCodeSizeEstimator> ExternalCodeSizeEstimator for T {
 pub trait LoweringGroup:
     SemanticGroup + for<'a> Upcast<'a, dyn SemanticGroup> + ExternalCodeSizeEstimator
 {
-    #[salsa::interned]
-    fn intern_lowering_function<'db>(
-        &'db self,
-        id: ids::FunctionLongId<'db>,
-    ) -> ids::FunctionId<'db>;
-    #[salsa::interned]
-    fn intern_lowering_concrete_function_with_body<'db>(
-        &'db self,
-        id: ids::ConcreteFunctionWithBodyLongId<'db>,
-    ) -> ids::ConcreteFunctionWithBodyId<'db>;
-    #[salsa::interned]
-    fn intern_lowering_function_with_body<'db>(
-        &'db self,
-        id: ids::FunctionWithBodyLongId<'db>,
-    ) -> ids::FunctionWithBodyId<'db>;
-
-    #[salsa::interned]
-    fn intern_location<'db>(&'db self, id: Location<'db>) -> ids::LocationId<'db>;
-
-    #[salsa::interned]
-    fn intern_strategy<'db>(
-        &'db self,
-        id: OptimizationStrategy<'db>,
-    ) -> OptimizationStrategyId<'db>;
-
     /// Computes the lowered representation of a function with a body, along with all it generated
     /// functions (e.g. closures, lambdas, loops, ...).
     fn priv_function_with_body_multi_lowering<'db>(

--- a/crates/cairo-lang-lowering/src/ids.rs
+++ b/crates/cairo-lang-lowering/src/ids.rs
@@ -102,14 +102,14 @@ pub enum GenericOrSpecialized<'db> {
 
 impl<'db> ConcreteFunctionWithBodyId<'db> {
     pub fn is_panic_destruct_fn(&self, db: &'db dyn LoweringGroup) -> Maybe<bool> {
-        match db.lookup_intern_lowering_concrete_function_with_body(*self) {
+        match self.long(db) {
             ConcreteFunctionWithBodyLongId::Semantic(semantic_func) => {
                 semantic_func.is_panic_destruct_fn(db)
             }
             ConcreteFunctionWithBodyLongId::Generated(GeneratedFunction {
                 parent: _,
                 key: GeneratedFunctionKey::TraitFunc(function, _),
-            }) => Ok(function == db.core_info().panic_destruct_fn),
+            }) => Ok(function == &db.core_info().panic_destruct_fn),
             _ => Ok(false),
         }
     }

--- a/crates/cairo-lang-lowering/src/lower/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/lower/test_utils.rs
@@ -1,7 +1,6 @@
 use {cairo_lang_defs as defs, cairo_lang_semantic as semantic};
 
 use super::context::{EncapsulatingLoweringContext, LoweringContext};
-use crate::db::LoweringGroup;
 use crate::ids::{FunctionWithBodyLongId, Signature};
 use crate::test_utils::LoweringDatabaseForTesting;
 
@@ -34,7 +33,7 @@ pub fn create_lowering_context<'a, 'db>(
     let return_type = lowering_signature.return_type;
 
     let lowering_function_id =
-        db.intern_lowering_function_with_body(FunctionWithBodyLongId::Semantic(function_id));
+        crate::ids::FunctionWithBodyId::new(db, FunctionWithBodyLongId::Semantic(function_id));
     LoweringContext::new(encapsulating_ctx, lowering_function_id, lowering_signature, return_type)
         .unwrap()
 }


### PR DESCRIPTION
### TL;DR

Removed `#[salsa::interned]` from LoweringGroup

### What changed?

- Removed the interning methods from the `LoweringGroup` trait in `db.rs`
- Added static `new` methods to the ID types to handle interning
- Updated call sites to use the new interning approach
- Modified `ConcreteFunctionWithBodyId::is_panic_destruct_fn` to use the new pattern
- Fixed a comparison in the panic destruct function check to use reference comparison
