### PR TITLE
Removed interned from SyntaxGroup and SierraGenGroup

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -2311,13 +2311,13 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     /// kind.
     /// Otherwise, returns `None`.
     fn get_binary_operator(&self, condition: ConditionGreen<'_>) -> Option<SyntaxKind> {
-        let condition_expr_green = self.db.lookup_intern_green(condition.0);
+        let condition_expr_green = condition.0.long(self.db);
         require(condition_expr_green.kind == SyntaxKind::ConditionExpr)?;
 
-        let expr_binary_green = self.db.lookup_intern_green(condition_expr_green.children()[0]);
+        let expr_binary_green = condition_expr_green.children()[0].long(self.db);
         require(expr_binary_green.kind == SyntaxKind::ExprBinary)?;
 
-        Some(self.db.lookup_intern_green(expr_binary_green.children()[1]).kind)
+        Some(expr_binary_green.children()[1].long(self.db).kind)
     }
 
     /// Parses a conjunction of conditions of the form `<condition> && <condition> && ...`,

--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -98,12 +98,6 @@ fn lookup_sierra_function<'db>(
 
 #[cairo_lang_proc_macros::query_group]
 pub trait SierraGenGroup: LoweringGroup + for<'db> Upcast<'db, dyn LoweringGroup> {
-    #[salsa::interned]
-    fn intern_label_id<'db>(
-        &'db self,
-        id: pre_sierra::LabelLongId<'db>,
-    ) -> pre_sierra::LabelId<'db>;
-
     fn intern_concrete_lib_func(
         &self,
         id: cairo_lang_sierra::program::ConcreteLibfuncLongId,

--- a/crates/cairo-lang-syntax/src/node/db.rs
+++ b/crates/cairo-lang-syntax/src/node/db.rs
@@ -1,21 +1,11 @@
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_utils::Upcast;
 
-use super::green::GreenNode;
-use super::ids::{GreenId, SyntaxStablePtrId};
-use super::stable_ptr::SyntaxStablePtr;
-use super::{SyntaxNode, SyntaxNodeLongId};
+use super::SyntaxNode;
 
 // Salsa database interface.
 #[cairo_lang_proc_macros::query_group]
 pub trait SyntaxGroup: FilesGroup + for<'a> Upcast<'a, dyn FilesGroup> {
-    #[salsa::interned]
-    fn intern_green<'a>(&'a self, field: GreenNode<'a>) -> GreenId<'a>;
-    #[salsa::interned]
-    fn intern_stable_ptr<'a>(&'a self, field: SyntaxStablePtr<'a>) -> SyntaxStablePtrId<'a>;
-    #[salsa::interned]
-    fn intern_syntax_node<'a>(&'a self, field: SyntaxNodeLongId<'a>) -> SyntaxNode<'a>;
-
     /// Query for caching [SyntaxNode::get_children].
     #[salsa::transparent]
     fn get_children<'a>(&'a self, node: SyntaxNode<'a>) -> &'a [SyntaxNode<'a>];


### PR DESCRIPTION
### TL;DR

Removed `#[salsa::interned]` from `SyntaxGroup` and  `SierraGenGroup`

### What changed?

- Removed three interned queries from `SyntaxGroup` trait:
  - `intern_green`
  - `intern_stable_ptr`
  - `intern_syntax_node`

- Removed one interned query from `SierraGenGroup` trait:
  - `intern_label_id`

- Updated the `get_binary_operator` method in the parser to use the `.long()` method instead of database lookups via `lookup_intern_green`