### PR TITLE
Removed interned from SemanticGroup

### DIFF
--- a/crates/cairo-lang-doc/src/documentable_formatter.rs
+++ b/crates/cairo-lang-doc/src/documentable_formatter.rs
@@ -405,7 +405,7 @@ impl<'db> HirDisplay<'db> for ConstantId<'db> {
                             constant_full_signature.full_path.clone(),
                         )
                     })?;
-                    let constant_value = f.db.lookup_intern_const_value(const_value_id);
+                    let constant_value = const_value_id.long(f.db);
                     if let ConstValue::Int(value, _) = constant_value {
                         write_syntactic_evaluation(f, constant_full_signature.item_id).map_err(
                             |_| {

--- a/crates/cairo-lang-lowering/src/ids.rs
+++ b/crates/cairo-lang-lowering/src/ids.rs
@@ -263,7 +263,7 @@ impl<'db> FunctionLongId<'db> {
                 if let GenericFunctionId::Impl(ImplGenericFunctionId { impl_id, function }) =
                     concrete_function.generic_function
                 {
-                    if let ImplLongId::GeneratedImpl(imp) = db.lookup_intern_impl(impl_id) {
+                    if let ImplLongId::GeneratedImpl(imp) = impl_id.long(db) {
                         let concrete_trait = imp.concrete_trait(db);
                         let info = db.core_info();
                         assert!(

--- a/crates/cairo-lang-lowering/src/optimizations/trim_unreachable.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/trim_unreachable.rs
@@ -22,8 +22,7 @@ pub fn trim_unreachable<'db>(db: &'db dyn LoweringGroup, lowered: &mut Lowered<'
     // Otherwise, it returns `false.
     let mut handle_var = |var_id: &VariableId, introduction_block| {
         let variable = &lowered.variables[*var_id];
-        let TypeLongId::Concrete(ConcreteTypeId::Enum(concrete_enum_id)) =
-            db.lookup_intern_type(variable.ty)
+        let TypeLongId::Concrete(ConcreteTypeId::Enum(concrete_enum_id)) = variable.ty.long(db)
         else {
             return false;
         };
@@ -58,7 +57,7 @@ pub fn trim_unreachable<'db>(db: &'db dyn LoweringGroup, lowered: &mut Lowered<'
         block.statements.truncate(0);
         block.end = BlockEnd::Match {
             info: MatchInfo::Enum(MatchEnumInfo {
-                concrete_enum_id,
+                concrete_enum_id: *concrete_enum_id,
                 input: VarUsage { var_id: output, location },
                 arms: vec![],
                 location,

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -24,7 +24,7 @@ use itertools::Itertools;
 
 use crate::corelib::CoreInfo;
 use crate::diagnostic::SemanticDiagnosticKind;
-use crate::expr::inference::{self, ImplVar, ImplVarId, InferenceError};
+use crate::expr::inference::{self, InferenceError};
 use crate::ids::{AnalyzerPluginId, AnalyzerPluginLongId};
 use crate::items::constant::{ConstCalcInfo, ConstValueId, Constant, ImplConstantId};
 use crate::items::function_with_body::FunctionBody;
@@ -65,85 +65,6 @@ pub trait Elongate {
 pub trait SemanticGroup:
     DefsGroup + for<'db> Upcast<'db, dyn DefsGroup> + for<'db> Upcast<'db, dyn ParserGroup> + Elongate
 {
-    #[salsa::interned]
-    fn intern_function<'db>(
-        &'db self,
-        id: items::functions::FunctionLongId<'db>,
-    ) -> semantic::FunctionId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_function_with_body<'db>(
-        &'db self,
-        id: items::functions::ConcreteFunctionWithBody<'db>,
-    ) -> semantic::ConcreteFunctionWithBodyId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_struct<'db>(
-        &'db self,
-        id: types::ConcreteStructLongId<'db>,
-    ) -> types::ConcreteStructId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_enum<'db>(
-        &'db self,
-        id: types::ConcreteEnumLongId<'db>,
-    ) -> types::ConcreteEnumId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_extern_type<'db>(
-        &'db self,
-        id: types::ConcreteExternTypeLongId<'db>,
-    ) -> types::ConcreteExternTypeId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_trait<'db>(
-        &'db self,
-        id: items::trt::ConcreteTraitLongId<'db>,
-    ) -> items::trt::ConcreteTraitId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_trait_function<'db>(
-        &'db self,
-        id: items::trt::ConcreteTraitGenericFunctionLongId<'db>,
-    ) -> items::trt::ConcreteTraitGenericFunctionId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_trait_type<'db>(
-        &'db self,
-        id: items::trt::ConcreteTraitTypeLongId<'db>,
-    ) -> items::trt::ConcreteTraitTypeId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_trait_constant<'db>(
-        &'db self,
-        id: items::trt::ConcreteTraitConstantLongId<'db>,
-    ) -> items::trt::ConcreteTraitConstantId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_impl<'db>(
-        &'db self,
-        id: items::imp::ConcreteImplLongId<'db>,
-    ) -> items::imp::ConcreteImplId<'db>;
-    #[salsa::interned]
-    fn intern_concrete_trait_impl<'db>(
-        &'db self,
-        id: items::trt::ConcreteTraitImplLongId<'db>,
-    ) -> items::trt::ConcreteTraitImplId<'db>;
-    #[salsa::interned]
-    fn intern_type<'db>(&'db self, id: types::TypeLongId<'db>) -> semantic::TypeId<'db>;
-    #[salsa::interned]
-    fn intern_const_value<'db>(
-        &'db self,
-        id: items::constant::ConstValue<'db>,
-    ) -> items::constant::ConstValueId<'db>;
-    #[salsa::interned]
-    fn intern_impl<'db>(&'db self, id: items::imp::ImplLongId<'db>) -> items::imp::ImplId<'db>;
-    #[salsa::interned]
-    fn intern_impl_var<'db>(&'db self, id: ImplVar<'db>) -> ImplVarId<'db>;
-
-    #[salsa::interned]
-    fn intern_generated_impl<'db>(
-        &'db self,
-        id: items::imp::GeneratedImplLongId<'db>,
-    ) -> items::imp::GeneratedImplId<'db>;
-
-    #[salsa::interned]
-    fn intern_uninferred_generated_impl<'db>(
-        &'db self,
-        id: items::imp::UninferredGeneratedImplLongId<'db>,
-    ) -> items::imp::UninferredGeneratedImplId<'db>;
-
     // Const.
     // ====
     /// Private query to compute data about a constant definition.
@@ -1897,12 +1818,6 @@ pub trait SemanticGroup:
         &'db self,
     ) -> Arc<OrderedHashMap<CrateId<'db>, Arc<Vec<AnalyzerPluginId<'db>>>>>;
 
-    #[salsa::interned]
-    fn intern_analyzer_plugin<'db>(
-        &'db self,
-        plugin: AnalyzerPluginLongId,
-    ) -> AnalyzerPluginId<'db>;
-
     /// Returns [`AnalyzerPluginId`]s of the plugins set for the crate with [`CrateId`].
     /// Returns
     /// [`SemanticGroupEx::set_override_crate_analyzer_plugins`] if it has been set,
@@ -2093,7 +2008,7 @@ fn module_semantic_diagnostics<'db>(
     }
     add_unused_item_diagnostics(db, module_id, &data, &mut diagnostics);
     for analyzer_plugin_id in db.crate_analyzer_plugins(module_id.owning_crate(db)).iter() {
-        let analyzer_plugin = db.lookup_intern_analyzer_plugin(*analyzer_plugin_id);
+        let analyzer_plugin = analyzer_plugin_id.long(db);
 
         for diag in analyzer_plugin.diagnostics(db, module_id) {
             diagnostics.add(SemanticDiagnostic::new(
@@ -2120,7 +2035,7 @@ fn declared_allows(db: &dyn SemanticGroup, crate_id: CrateId<'_>) -> Arc<Ordered
     Arc::new(OrderedHashSet::from_iter(
         db.crate_analyzer_plugins(crate_id)
             .iter()
-            .flat_map(|plugin| db.lookup_intern_analyzer_plugin(*plugin).declared_allows()),
+            .flat_map(|plugin| plugin.long(db).declared_allows()),
     ))
 }
 
@@ -2274,8 +2189,7 @@ pub trait SemanticGroupEx: SemanticGroup {
         plugins: Arc<[AnalyzerPluginId<'_>]>,
     ) {
         let mut overrides = self.analyzer_plugin_overrides_input().as_ref().clone();
-        let plugins =
-            plugins.iter().map(|plugin| self.lookup_intern_analyzer_plugin(*plugin)).collect_vec();
+        let plugins = plugins.iter().map(|plugin| plugin.long(self).clone()).collect_vec();
         overrides.insert(self.crate_input(crate_id), Arc::from(plugins));
         self.set_analyzer_plugin_overrides_input(Arc::new(overrides));
     }
@@ -2342,7 +2256,7 @@ pub trait PluginSuiteInput: SemanticGroup {
 
         let analyzer_plugins = analyzer_plugins
             .into_iter()
-            .map(|plugin| self.intern_analyzer_plugin(AnalyzerPluginLongId(plugin)))
+            .map(|plugin| AnalyzerPluginId::new(self, AnalyzerPluginLongId(plugin)))
             .collect::<Arc<[_]>>();
 
         InternedPluginSuite { macro_plugins, inline_macro_plugins, analyzer_plugins }

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -65,7 +65,9 @@ use crate::diagnostic::{
 };
 use crate::expr::inference::solver::SolutionSet;
 use crate::expr::inference::{ImplVarTraitItemMappings, InferenceId};
-use crate::items::constant::{ConstValue, resolve_const_expr_and_evaluate, validate_const_expr};
+use crate::items::constant::{
+    ConstValue, ConstValueId, resolve_const_expr_and_evaluate, validate_const_expr,
+};
 use crate::items::enm::SemanticEnumEx;
 use crate::items::feature_kind::extract_item_feature_config;
 use crate::items::functions::{concrete_function_closure_params, function_signature_params};
@@ -4379,7 +4381,7 @@ pub fn compute_and_append_statement_semantic<'db>(
                     let var_def = Binding::LocalItem(LocalItem {
                         id: StatementItemId::Constant(rhs_id.intern(db)),
                         kind: StatementItemKind::Constant(
-                            db.intern_const_value(rhs_resolved_expr.clone()),
+                            ConstValueId::new(db, rhs_resolved_expr.clone()),
                             rhs_resolved_expr.ty(db)?,
                         ),
                     });

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -1948,10 +1948,13 @@ pub fn find_closure_generated_candidate<'db>(
             closure_type_long.captured_types.iter().unique().map(|ty| {
                 GenericParam::Impl(GenericParamImpl {
                     id,
-                    concrete_trait: Maybe::Ok(db.intern_concrete_trait(ConcreteTraitLongId {
-                        trait_id,
-                        generic_args: vec![GenericArgumentId::Type(*ty)],
-                    })),
+                    concrete_trait: Maybe::Ok(ConcreteTraitId::new(
+                        db,
+                        ConcreteTraitLongId {
+                            trait_id,
+                            generic_args: vec![GenericArgumentId::Type(*ty)],
+                        },
+                    )),
                     type_constraints: Default::default(),
                 })
             }),

--- a/crates/cairo-lang-starknet/src/analyzer.rs
+++ b/crates/cairo-lang-starknet/src/analyzer.rs
@@ -182,7 +182,7 @@ fn analyze_storage_struct<'db>(
     for (member_name, member) in members.iter() {
         let member_ast = member.id.stable_ptr(db).lookup(db);
         let member_type = member.ty.long(db).clone();
-        let concrete_trait_id = concrete_valid_storage_trait(db, db.intern_type(member_type));
+        let concrete_trait_id = concrete_valid_storage_trait(db, TypeId::new(db, member_type));
 
         let member_allows_invalid =
             member_ast.has_attr_with_arg(db, ALLOW_ATTR, ALLOW_INVALID_STORAGE_MEMBERS_ATTR);


### PR DESCRIPTION
### TL;DR

Removed `#[salsa::interned]` from SemanticGroup

### What changed?

The PR removes redundant interned function declarations from the `SemanticGroup` trait, as these are now handled through the `long()` method.

This PR replaces direct database lookups like `db.lookup_intern_X(id)` with the more idiomatic `id.long(db)` method across multiple crates. The change affects:

- `cairo-lang-doc`: Updated constant value lookup in the documentable formatter
- `cairo-lang-lowering`: Changed impl and type lookups in function long IDs and unreachable code trimming
- `cairo-lang-semantic`: Refactored bounded int type range extraction and analyzer plugin lookups
- `cairo-lang-starknet`: Updated type interning in storage struct analysis