### PR TITLE
Removed query group from filesgroup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
  "env_logger",
  "indoc",
  "itertools 0.14.0",
+ "salsa",
  "test-log",
 ]
 
@@ -650,7 +651,6 @@ name = "cairo-lang-filesystem"
 version = "2.12.0"
 dependencies = [
  "cairo-lang-debug",
- "cairo-lang-proc-macros",
  "cairo-lang-utils",
  "env_logger",
  "path-clean",
@@ -677,6 +677,7 @@ dependencies = [
  "ignore",
  "itertools 0.14.0",
  "pretty_assertions",
+ "salsa",
  "serde",
  "test-case",
  "thiserror",
@@ -1028,6 +1029,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "pretty_assertions",
+ "salsa",
  "serde",
  "serde_json",
  "starknet-types-core",
@@ -1116,6 +1118,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
+ "salsa",
  "serde",
  "starknet-types-core",
 ]

--- a/crates/cairo-lang-compiler/src/db.rs
+++ b/crates/cairo-lang-compiler/src/db.rs
@@ -4,9 +4,7 @@ use anyhow::{Result, anyhow, bail};
 use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::cfg::CfgSet;
-use cairo_lang_filesystem::db::{
-    CORELIB_VERSION, FilesGroup, FilesGroupEx, init_dev_corelib, init_files_group,
-};
+use cairo_lang_filesystem::db::{CORELIB_VERSION, FilesGroup, init_dev_corelib, init_files_group};
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::{CrateId, FlagLongId};
@@ -222,7 +220,7 @@ impl RootDatabaseBuilder {
 }
 
 /// Validates that the corelib version matches the expected one.
-pub fn validate_corelib(db: &(dyn FilesGroup + 'static)) -> Result<()> {
+pub fn validate_corelib(db: &(dyn salsa::Database + 'static)) -> Result<()> {
     let Some(config) = db.crate_config(CrateId::core(db)) else {
         return Ok(());
     };
@@ -244,8 +242,8 @@ pub fn validate_corelib(db: &(dyn FilesGroup + 'static)) -> Result<()> {
     bail!("Corelib version mismatch: expected `{expected}`, found `{found}`{path_part}.");
 }
 
-impl<'db> Upcast<'db, dyn FilesGroup> for RootDatabase {
-    fn upcast(&self) -> &dyn FilesGroup {
+impl<'db> Upcast<'db, dyn salsa::Database> for RootDatabase {
+    fn upcast(&self) -> &dyn salsa::Database {
         self
     }
 }

--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -189,7 +189,7 @@ impl<'a> DiagnosticsReporter<'a> {
                     for file_id in module_files.iter().copied() {
                         if processed_file_ids.insert(file_id) {
                             found_diagnostics |= self.check_diag_group(
-                                db.upcast(),
+                                db.as_dyn_database(),
                                 db.file_syntax_diagnostics(file_id),
                                 ignore_warnings_in_crate,
                                 &diagnostic_notes,

--- a/crates/cairo-lang-compiler/src/test.rs
+++ b/crates/cairo-lang-compiler/src/test.rs
@@ -1,9 +1,9 @@
 use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginResult};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_semantic::plugin::PluginSuite;
 use cairo_lang_semantic::test_utils::setup_test_crate;
 use cairo_lang_syntax::node::ast::ModuleItem;
 use indoc::indoc;
+use salsa::Database;
 use smol_str::SmolStr;
 
 use crate::db::RootDatabase;
@@ -15,7 +15,7 @@ pub struct MockExecutablePlugin {}
 impl MacroPlugin for MockExecutablePlugin {
     fn generate_code<'db>(
         &self,
-        _db: &'db dyn FilesGroup,
+        _db: &'db dyn Database,
         _item_ast: ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-defs/src/diagnostic_utils.rs
+++ b/crates/cairo-lang-defs/src/diagnostic_utils.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_diagnostics::DiagnosticLocation;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_filesystem::span::{TextSpan, TextWidth};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
@@ -37,7 +36,7 @@ impl<'db> StableLocation<'db> {
         self.stable_ptr.file_id(db)
     }
 
-    pub fn from_ast<TNode: TypedSyntaxNode<'db>>(db: &'db dyn FilesGroup, node: &TNode) -> Self {
+    pub fn from_ast<TNode: TypedSyntaxNode<'db>>(db: &'db dyn Database, node: &TNode) -> Self {
         Self::new(node.as_syntax_node().stable_ptr(db))
     }
 
@@ -52,7 +51,7 @@ impl<'db> StableLocation<'db> {
     }
 
     /// Returns the [DiagnosticLocation] that corresponds to the [StableLocation].
-    pub fn diagnostic_location(&self, db: &'db dyn FilesGroup) -> DiagnosticLocation<'db> {
+    pub fn diagnostic_location(&self, db: &'db dyn Database) -> DiagnosticLocation<'db> {
         match self.inner_span {
             Some((start, width)) => {
                 let start = self.syntax_node(db).offset(db).add_width(start);

--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -26,7 +26,6 @@ use std::sync::Arc;
 
 use cairo_lang_debug::debug::DebugWithDb;
 use cairo_lang_diagnostics::Maybe;
-use cairo_lang_filesystem::db::FilesGroup;
 pub use cairo_lang_filesystem::ids::UnstableSalsaId;
 use cairo_lang_filesystem::ids::{CrateId, FileId};
 use cairo_lang_syntax::node::ast::TerminalIdentifierGreen;
@@ -36,6 +35,7 @@ use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::stable_ptr::SyntaxStablePtr;
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::{Intern, OptionFrom, define_short_id, require};
+use salsa::Database;
 
 use crate::db::DefsGroup;
 use crate::diagnostic_utils::StableLocation;
@@ -369,7 +369,7 @@ pub struct MacroPluginLongId(pub Arc<dyn MacroPlugin>);
 impl MacroPlugin for MacroPluginLongId {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         metadata: &crate::plugin::MacroPluginMetadata<'_>,
     ) -> crate::plugin::PluginResult<'db> {
@@ -424,7 +424,7 @@ pub struct InlineMacroExprPluginLongId(pub Arc<dyn InlineMacroExprPlugin>);
 impl InlineMacroExprPlugin for InlineMacroExprPluginLongId {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: &ast::ExprInlineMacro<'db>,
         metadata: &crate::plugin::MacroPluginMetadata<'_>,
     ) -> crate::plugin::InlinePluginResult<'db> {
@@ -763,7 +763,7 @@ define_language_element_id_as_enum! {
 define_top_level_language_element_id!(ParamId, ParamLongId, ast::Param<'db>);
 define_language_element_id_basic!(GenericParamId, GenericParamLongId, ast::GenericParam<'db>);
 impl<'db> GenericParamLongId<'db> {
-    pub fn name(&self, db: &'db dyn FilesGroup) -> Option<&'db str> {
+    pub fn name(&self, db: &'db dyn Database) -> Option<&'db str> {
         let SyntaxStablePtr::Child { key_fields, kind, .. } = self.1.0.long(db) else {
             unreachable!()
         };
@@ -776,10 +776,10 @@ impl<'db> GenericParamLongId<'db> {
         Some(name_green.identifier(db))
     }
 
-    pub fn debug_name(&self, db: &'db dyn FilesGroup) -> &'db str {
+    pub fn debug_name(&self, db: &'db dyn Database) -> &'db str {
         self.name(db).unwrap_or("_")
     }
-    pub fn kind(&self, db: &dyn FilesGroup) -> GenericKind {
+    pub fn kind(&self, db: &dyn Database) -> GenericKind {
         let SyntaxStablePtr::Child { kind, .. } = self.1.0.long(db) else { unreachable!() };
         match kind {
             SyntaxKind::GenericParamType => GenericKind::Type,

--- a/crates/cairo-lang-defs/src/patcher.rs
+++ b/crates/cairo-lang-defs/src/patcher.rs
@@ -1,10 +1,10 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
 use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode};
 use cairo_lang_utils::extract_matches;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::Itertools;
+use salsa::Database;
 
 /// Interface for modifying syntax nodes.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -40,7 +40,7 @@ impl<'db> RewriteNode<'db> {
 
     pub fn mapped_text(
         text: impl Into<String>,
-        db: &dyn FilesGroup,
+        db: &dyn Database,
         origin: &impl TypedSyntaxNode<'db>,
     ) -> Self {
         RewriteNode::Text(text.into()).mapped(db, origin)
@@ -61,7 +61,7 @@ impl<'db> RewriteNode<'db> {
     }
 
     /// Prepares a node for modification.
-    pub fn modify(&mut self, db: &'db dyn FilesGroup) -> &mut ModifiedNode<'db> {
+    pub fn modify(&mut self, db: &'db dyn Database) -> &mut ModifiedNode<'db> {
         match self {
             RewriteNode::Copied(syntax_node) => {
                 *self = RewriteNode::new_modified(
@@ -136,7 +136,7 @@ impl<'db> RewriteNode<'db> {
     }
 
     /// Prepares a node for modification and returns a specific child.
-    pub fn modify_child(&mut self, db: &'db dyn FilesGroup, index: usize) -> &mut RewriteNode<'db> {
+    pub fn modify_child(&mut self, db: &'db dyn Database, index: usize) -> &mut RewriteNode<'db> {
         if matches!(self, RewriteNode::Modified(ModifiedNode { children: None })) {
             // Modification of an empty node is idempotent.
             return self;
@@ -210,7 +210,7 @@ impl<'db> RewriteNode<'db> {
     }
 
     /// Creates a new rewrite node wrapped in a mapping to the original code.
-    pub fn mapped(self, db: &dyn FilesGroup, origin: &impl TypedSyntaxNode<'db>) -> Self {
+    pub fn mapped(self, db: &dyn Database, origin: &impl TypedSyntaxNode<'db>) -> Self {
         RewriteNode::Mapped {
             origin: origin.as_syntax_node().span_without_trivia(db),
             node: Box::new(self),
@@ -239,19 +239,19 @@ pub struct ModifiedNode<'db> {
 }
 
 pub struct PatchBuilder<'a> {
-    pub db: &'a dyn FilesGroup,
+    pub db: &'a dyn Database,
     code: String,
     code_mappings: Vec<CodeMapping>,
     origin: CodeOrigin,
 }
 impl<'db> PatchBuilder<'db> {
     /// Creates a new patch builder, originating from `origin` typed node.
-    pub fn new(db: &'db dyn FilesGroup, origin: &impl TypedSyntaxNode<'db>) -> Self {
+    pub fn new(db: &'db dyn Database, origin: &impl TypedSyntaxNode<'db>) -> Self {
         Self::new_ex(db, &origin.as_syntax_node())
     }
 
     /// Creates a new patch builder, originating from `origin` node.
-    pub fn new_ex(db: &'db dyn FilesGroup, origin: &SyntaxNode<'db>) -> Self {
+    pub fn new_ex(db: &'db dyn Database, origin: &SyntaxNode<'db>) -> Self {
         Self {
             db,
             code: String::default(),

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -4,12 +4,13 @@ use std::sync::Arc;
 
 use cairo_lang_diagnostics::Severity;
 use cairo_lang_filesystem::cfg::CfgSet;
-use cairo_lang_filesystem::db::{Edition, FilesGroup};
+use cairo_lang_filesystem::db::Edition;
 use cairo_lang_filesystem::ids::CodeMapping;
 use cairo_lang_filesystem::span::TextWidth;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::{SyntaxNode, ast};
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
+use salsa::Database;
 use serde::{Deserialize, Serialize};
 
 /// A trait for arbitrary data that a macro generates along with the generated file.
@@ -100,7 +101,7 @@ impl<'db> PluginDiagnostic<'db> {
 
     /// Creates a diagnostic, pointing to an inner span inside the given stable pointer.
     pub fn error_with_inner_span(
-        db: &dyn FilesGroup,
+        db: &dyn Database,
         stable_ptr: impl Into<SyntaxStablePtrId<'db>>,
         inner_span: SyntaxNode<'_>,
         message: String,
@@ -149,7 +150,7 @@ pub trait MacroPlugin: std::fmt::Debug + Sync + Send + Any {
     /// Otherwise, returns `PluginResult` with the generated virtual submodule.
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db>;
@@ -207,7 +208,7 @@ pub trait InlineMacroExprPlugin: std::fmt::Debug + Sync + Send + Any {
     /// with that name and content should be created.
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: &ast::ExprInlineMacro<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db>;

--- a/crates/cairo-lang-defs/src/plugin_utils.rs
+++ b/crates/cairo-lang-defs/src/plugin_utils.rs
@@ -1,9 +1,9 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::helpers::WrappedArgListHelper;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode, ast};
 use cairo_lang_utils::require;
 use itertools::Itertools;
+use salsa::Database;
 
 use crate::plugin::{InlinePluginResult, PluginDiagnostic, PluginResult};
 
@@ -11,19 +11,19 @@ use crate::plugin::{InlinePluginResult, PluginDiagnostic, PluginResult};
 pub trait InlineMacroCall<'db> {
     type PathNode: TypedSyntaxNode<'db>;
     type Result: PluginResultTrait<'db>;
-    fn arguments(&self, db: &'db dyn FilesGroup) -> ast::WrappedArgList<'db>;
-    fn path(&self, db: &'db dyn FilesGroup) -> Self::PathNode;
+    fn arguments(&self, db: &'db dyn Database) -> ast::WrappedArgList<'db>;
+    fn path(&self, db: &'db dyn Database) -> Self::PathNode;
 }
 
 impl<'db> InlineMacroCall<'db> for ast::LegacyExprInlineMacro<'db> {
     type PathNode = ast::ExprPath<'db>;
     type Result = InlinePluginResult<'db>;
 
-    fn arguments(&self, db: &'db dyn FilesGroup) -> ast::WrappedArgList<'db> {
+    fn arguments(&self, db: &'db dyn Database) -> ast::WrappedArgList<'db> {
         self.arguments(db)
     }
 
-    fn path(&self, db: &'db dyn FilesGroup) -> ast::ExprPath<'db> {
+    fn path(&self, db: &'db dyn Database) -> ast::ExprPath<'db> {
         self.path(db)
     }
 }
@@ -32,11 +32,11 @@ impl<'db> InlineMacroCall<'db> for ast::LegacyItemInlineMacro<'db> {
     type PathNode = ast::ExprPath<'db>;
     type Result = PluginResult<'db>;
 
-    fn arguments(&self, db: &'db dyn FilesGroup) -> ast::WrappedArgList<'db> {
+    fn arguments(&self, db: &'db dyn Database) -> ast::WrappedArgList<'db> {
         self.arguments(db)
     }
 
-    fn path(&self, db: &'db dyn FilesGroup) -> ast::ExprPath<'db> {
+    fn path(&self, db: &'db dyn Database) -> ast::ExprPath<'db> {
         self.path(db)
     }
 }
@@ -60,7 +60,7 @@ impl<'db> PluginResultTrait<'db> for PluginResult<'db> {
 
 /// Returns diagnostics for an unsupported bracket type.
 pub fn unsupported_bracket_diagnostic<'db, CallAst: InlineMacroCall<'db>>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     legacy_macro_ast: &CallAst,
     macro_ast: impl Into<SyntaxStablePtrId<'db>>,
 ) -> CallAst::Result {
@@ -86,7 +86,7 @@ pub fn not_legacy_macro_diagnostic(stable_ptr: SyntaxStablePtrId<'_>) -> PluginD
 
 /// Extracts a single unnamed argument.
 pub fn extract_single_unnamed_arg<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     macro_arguments: ast::ArgList<'db>,
 ) -> Option<ast::Expr<'db>> {
     let mut elements = macro_arguments.elements(db);
@@ -95,7 +95,7 @@ pub fn extract_single_unnamed_arg<'db>(
 
 /// Extracts `n` unnamed arguments.
 pub fn extract_unnamed_args<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     macro_arguments: &ast::ArgList<'db>,
     n: usize,
 ) -> Option<Vec<ast::Expr<'db>>> {
@@ -106,7 +106,7 @@ pub fn extract_unnamed_args<'db>(
 
 /// Gets the syntax of an argument, and extracts the value if it is unnamed.
 pub fn try_extract_unnamed_arg<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     arg_ast: &ast::Arg<'db>,
 ) -> Option<ast::Expr<'db>> {
     if let ast::ArgClause::Unnamed(arg_clause) = arg_ast.arg_clause(db) {
@@ -117,7 +117,7 @@ pub fn try_extract_unnamed_arg<'db>(
 }
 
 /// Escapes a node for use in a format string.
-pub fn escape_node(db: &dyn FilesGroup, node: SyntaxNode<'_>) -> String {
+pub fn escape_node(db: &dyn Database, node: SyntaxNode<'_>) -> String {
     node.get_text_without_trivia(db).replace('{', "{{").replace('}', "}}").escape_unicode().join("")
 }
 

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -13,6 +13,7 @@ use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, Upcast, extract_matches, try_extract_matches};
 use indoc::indoc;
+use salsa::Database;
 
 use crate::db::{DefsGroup, init_defs_group, init_external_files};
 use crate::ids::{
@@ -50,8 +51,8 @@ impl<'db> Upcast<'db, dyn DefsGroup> for DatabaseForTesting {
         self
     }
 }
-impl<'db> Upcast<'db, dyn FilesGroup> for DatabaseForTesting {
-    fn upcast(&self) -> &dyn FilesGroup {
+impl<'db> Upcast<'db, dyn salsa::Database> for DatabaseForTesting {
+    fn upcast(&self) -> &dyn salsa::Database {
         self
     }
 }
@@ -210,7 +211,7 @@ struct DummyPlugin;
 impl MacroPlugin for DummyPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
@@ -312,7 +313,7 @@ struct RemoveOrigPlugin;
 impl MacroPlugin for RemoveOrigPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
@@ -338,7 +339,7 @@ struct FooToBarPlugin;
 impl MacroPlugin for FooToBarPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-diagnostics/src/diagnostics.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics.rs
@@ -3,12 +3,12 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use cairo_lang_debug::debug::DebugWithDb;
-use cairo_lang_filesystem::db::{FilesGroup, get_originating_location};
+use cairo_lang_filesystem::db::get_originating_location;
 use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_filesystem::span::TextSpan;
-use cairo_lang_utils::Upcast;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use itertools::Itertools;
+use salsa::{AsDynDatabase, Database};
 
 use crate::error_code::{ErrorCode, OptionErrorCodeExt};
 use crate::location_marks::get_location_marks;
@@ -35,7 +35,7 @@ impl fmt::Display for Severity {
 /// A trait for diagnostics (i.e., errors and warnings) across the compiler.
 /// Meant to be implemented by each module that may produce diagnostics.
 pub trait DiagnosticEntry<'db>: Clone + fmt::Debug + Eq + Hash {
-    type DbType: Upcast<'db, dyn FilesGroup> + ?Sized;
+    type DbType: Database + ?Sized;
     fn format(&self, db: &Self::DbType) -> String;
     fn location(&self, db: &'db Self::DbType) -> DiagnosticLocation<'db>;
     fn notes(&self, _db: &Self::DbType) -> &[DiagnosticNote<'_>] {
@@ -71,7 +71,7 @@ impl<'a> DiagnosticLocation<'a> {
     }
 
     /// Get the location of the originating user code.
-    pub fn user_location(&self, db: &'a dyn FilesGroup) -> Self {
+    pub fn user_location(&self, db: &'a dyn Database) -> Self {
         let (file_id, span) = get_originating_location(db, self.file_id, self.span, None);
         Self { file_id, span }
     }
@@ -81,7 +81,7 @@ impl<'a> DiagnosticLocation<'a> {
     /// The notes are collected from the parent files of the originating location.
     pub fn user_location_with_plugin_notes(
         &self,
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         file_notes: &PluginFileDiagnosticNotes<'a>,
     ) -> (Self, Vec<DiagnosticNote<'_>>) {
         let mut parent_files = Vec::new();
@@ -96,7 +96,7 @@ impl<'a> DiagnosticLocation<'a> {
     }
 
     /// Helper function to format the location of a diagnostic.
-    pub fn fmt_location(&self, f: &mut fmt::Formatter<'_>, db: &dyn FilesGroup) -> fmt::Result {
+    pub fn fmt_location(&self, f: &mut fmt::Formatter<'_>, db: &dyn Database) -> fmt::Result {
         let file_path = self.file_id.long(db).full_path(db);
         let start = match self.span.start.position_in_file(db, self.file_id) {
             Some(pos) => format!("{}:{}", pos.line + 1, pos.col + 1),
@@ -112,8 +112,8 @@ impl<'a> DiagnosticLocation<'a> {
 }
 
 impl<'a> DebugWithDb<'a> for DiagnosticLocation<'a> {
-    type Db = dyn FilesGroup;
-    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &'a dyn FilesGroup) -> fmt::Result {
+    type Db = dyn Database;
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &'a dyn Database) -> fmt::Result {
         let file_path = self.file_id.long(db).full_path(db);
         let mut marks = String::new();
         let mut ending_pos = String::new();
@@ -152,8 +152,8 @@ impl<'a> DiagnosticNote<'a> {
 }
 
 impl<'a> DebugWithDb<'a> for DiagnosticNote<'a> {
-    type Db = dyn FilesGroup;
-    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &'a dyn FilesGroup) -> fmt::Result {
+    type Db = dyn Database;
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, db: &'a dyn Database) -> fmt::Result {
         write!(f, "{}", self.text)?;
         if let Some(location) = &self.location {
             write!(f, ":\n  --> ")?;
@@ -254,7 +254,7 @@ impl<'db, TEntry: DiagnosticEntry<'db> + salsa::Update> Default
 }
 
 pub fn format_diagnostics(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     message: &str,
     location: DiagnosticLocation<'_>,
 ) -> String {
@@ -330,7 +330,7 @@ impl<'db, TEntry: DiagnosticEntry<'db> + salsa::Update> Diagnostics<'db, TEntry>
     ) -> Vec<FormattedDiagnosticEntry> {
         let mut res: Vec<FormattedDiagnosticEntry> = Vec::new();
 
-        let files_db = db.upcast();
+        let files_db = db.as_dyn_database();
         for entry in &self.get_diagnostics_without_duplicates(db) {
             let mut msg = String::new();
             let diag_location = entry.location(db);
@@ -397,7 +397,7 @@ impl<'db, TEntry: DiagnosticEntry<'db> + salsa::Update> Diagnostics<'db, TEntry>
         if diagnostic_with_dup.is_empty() {
             return diagnostic_with_dup;
         }
-        let files_db = db.upcast();
+        let files_db = db.as_dyn_database();
         let mut indexed_dup_diagnostic =
             diagnostic_with_dup.iter().enumerate().sorted_by_cached_key(|(idx, diag)| {
                 (diag.location(db).user_location(files_db).span, diag.format(db), *idx)

--- a/crates/cairo-lang-diagnostics/src/diagnostics_test.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics_test.rs
@@ -1,9 +1,9 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{FileId, FileKind, FileLongId, VirtualFile};
 use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
 use cairo_lang_filesystem::test_utils::FilesDatabaseForTesting;
 use cairo_lang_utils::Intern;
 use indoc::indoc;
+use salsa::Database;
 use test_log::test;
 
 use super::{DiagnosticEntry, DiagnosticLocation, DiagnosticsBuilder};
@@ -14,16 +14,13 @@ struct SimpleDiag<'db> {
     file_id: FileId<'db>,
 }
 impl<'db> DiagnosticEntry<'db> for SimpleDiag<'db> {
-    type DbType = dyn FilesGroup;
+    type DbType = dyn Database;
 
-    fn format(&self, _db: &dyn cairo_lang_filesystem::db::FilesGroup) -> String {
+    fn format(&self, _db: &dyn Database) -> String {
         "Simple diagnostic.".into()
     }
 
-    fn location(
-        &self,
-        _db: &'db dyn cairo_lang_filesystem::db::FilesGroup,
-    ) -> DiagnosticLocation<'db> {
+    fn location(&self, _db: &'db dyn Database) -> DiagnosticLocation<'db> {
         DiagnosticLocation {
             file_id: self.file_id,
             span: TextSpan::new(TextOffset::START, TextWidth::new_for_testing(6).as_offset()),

--- a/crates/cairo-lang-diagnostics/src/location_marks.rs
+++ b/crates/cairo-lang-diagnostics/src/location_marks.rs
@@ -1,5 +1,7 @@
+use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::span::{FileSummary, TextPosition, TextSpan, TextWidth};
 use itertools::repeat_n;
+use salsa::Database;
 
 use crate::DiagnosticLocation;
 
@@ -9,7 +11,7 @@ mod test;
 
 /// Given a diagnostic location, returns a string with the location marks.
 pub fn get_location_marks(
-    db: &dyn cairo_lang_filesystem::db::FilesGroup,
+    db: &dyn Database,
     location: &DiagnosticLocation<'_>,
     skip_middle_lines: bool,
 ) -> String {
@@ -32,10 +34,7 @@ pub fn get_location_marks(
 }
 
 /// Given a single line diagnostic location, returns a string with the location marks.
-fn get_single_line_location_marks(
-    db: &dyn cairo_lang_filesystem::db::FilesGroup,
-    location: &DiagnosticLocation<'_>,
-) -> String {
+fn get_single_line_location_marks(db: &dyn Database, location: &DiagnosticLocation<'_>) -> String {
     // TODO(ilya, 10/10/2023): Handle locations which spread over a few lines.
     let content =
         db.file_content(location.file_id).expect("File missing from DB.").long(db).as_ref();
@@ -65,7 +64,7 @@ fn get_single_line_location_marks(
 
 /// Given a multiple lines diagnostic location, returns a string with the location marks.
 fn get_multiple_lines_location_marks(
-    db: &dyn cairo_lang_filesystem::db::FilesGroup,
+    db: &dyn Database,
     location: &DiagnosticLocation<'_>,
     skip_middle_lines: bool,
 ) -> String {

--- a/crates/cairo-lang-doc/src/location_links.rs
+++ b/crates/cairo-lang-doc/src/location_links.rs
@@ -1,5 +1,4 @@
 use cairo_lang_diagnostics::{DiagnosticAdded, DiagnosticsBuilder, Maybe};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{FileKind, FileLongId, VirtualFile};
 use cairo_lang_formatter::{FormatterConfig, get_formatted_file};
 use cairo_lang_parser::db::ParserGroup;
@@ -8,6 +7,7 @@ use cairo_lang_syntax::node::green::GreenNodeDetails;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode};
 use cairo_lang_utils::Intern;
+use salsa::Database;
 
 use crate::documentable_item::DocumentableItemId;
 
@@ -25,7 +25,7 @@ pub struct LocationLink<'db> {
 /// Collects all [`cairo_lang_syntax::node::green::GreenNode`]s for a [`SyntaxNode`],
 /// returns a vector of their [`SyntaxKind`] and text.
 fn collect_green_nodes<'db>(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     syntax_node: &SyntaxNode<'db>,
     green_nodes: &mut Vec<(SyntaxKind, String)>,
 ) -> Vec<(SyntaxKind, String)> {

--- a/crates/cairo-lang-doc/src/tests/test_utils.rs
+++ b/crates/cairo-lang-doc/src/tests/test_utils.rs
@@ -62,8 +62,8 @@ impl<'db> Upcast<'db, dyn DefsGroup> for TestDatabase {
         self
     }
 }
-impl<'db> Upcast<'db, dyn FilesGroup> for TestDatabase {
-    fn upcast(&self) -> &dyn FilesGroup {
+impl<'db> Upcast<'db, dyn salsa::Database> for TestDatabase {
+    fn upcast(&self) -> &dyn salsa::Database {
         self
     }
 }

--- a/crates/cairo-lang-executable-plugin/Cargo.toml
+++ b/crates/cairo-lang-executable-plugin/Cargo.toml
@@ -13,6 +13,7 @@ cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "~2.12.0" }
 cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "~2.12.0" }
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }
+salsa.workspace = true
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }

--- a/crates/cairo-lang-executable-plugin/src/lib.rs
+++ b/crates/cairo-lang-executable-plugin/src/lib.rs
@@ -6,7 +6,6 @@ use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::plugin::{AnalyzerPlugin, PluginSuite};
 use cairo_lang_semantic::{GenericArgumentId, Mutability, corelib};
@@ -15,6 +14,7 @@ use cairo_lang_syntax::node::helpers::{OptionWrappedGenericParamListHelper, Quer
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
 use indoc::formatdoc;
 use itertools::Itertools;
+use salsa::Database;
 
 pub const EXECUTABLE_ATTR: &str = "executable";
 pub const EXECUTABLE_RAW_ATTR: &str = "executable_raw";
@@ -126,7 +126,7 @@ pub struct ExecutablePlugin;
 impl MacroPlugin for ExecutablePlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-filesystem/Cargo.toml
+++ b/crates/cairo-lang-filesystem/Cargo.toml
@@ -11,7 +11,6 @@ cairo-lang-debug = { path = "../cairo-lang-debug", version = "~2.12.0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "~2.12.0", features = [
     "serde",
 ] }
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "~2.12.0" }
 path-clean.workspace = true
 salsa.workspace = true
 semver.workspace = true

--- a/crates/cairo-lang-filesystem/src/db_test.rs
+++ b/crates/cairo-lang-filesystem/src/db_test.rs
@@ -5,7 +5,7 @@ use test_log::test;
 
 use super::FilesGroup;
 use crate::cfg::{Cfg, CfgSet};
-use crate::db::{CrateConfiguration, FilesGroupEx};
+use crate::db::CrateConfiguration;
 use crate::flag::Flag;
 use crate::ids::{CrateLongId, Directory, FlagId, FlagLongId};
 use crate::test_utils::FilesDatabaseForTesting;

--- a/crates/cairo-lang-filesystem/src/flag.rs
+++ b/crates/cairo-lang-filesystem/src/flag.rs
@@ -23,7 +23,7 @@ pub enum Flag {
 }
 
 /// Returns the value of the `unsafe_panic` flag, or `false` if the flag is not set.
-pub fn flag_unsafe_panic(db: &dyn FilesGroup) -> bool {
+pub fn flag_unsafe_panic(db: &dyn salsa::Database) -> bool {
     let flag = FlagId::new(db, FlagLongId("unsafe_panic".into()));
     if let Some(flag) = db.get_flag(flag) { *flag == Flag::UnsafePanic(true) } else { false }
 }

--- a/crates/cairo-lang-filesystem/src/span.rs
+++ b/crates/cairo-lang-filesystem/src/span.rs
@@ -1,6 +1,7 @@
 use std::iter::Sum;
 use std::ops::{Add, Range, Sub};
 
+use salsa::Database;
 use serde::{Deserialize, Serialize};
 
 use crate::db::FilesGroup;
@@ -179,7 +180,7 @@ impl TextSpan {
     /// Convert this span to a [`TextPositionSpan`] in the file.
     pub fn position_in_file<'db>(
         self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         file: FileId<'db>,
     ) -> Option<TextPositionSpan> {
         let start = self.start.position_in_file(db, file)?;
@@ -198,7 +199,7 @@ pub struct TextPosition {
 }
 
 impl TextOffset {
-    fn get_line_number(self, db: &dyn FilesGroup, file: FileId<'_>) -> Option<usize> {
+    fn get_line_number(self, db: &dyn Database, file: FileId<'_>) -> Option<usize> {
         let summary = db.file_summary(file)?;
         assert!(
             self <= summary.last_offset,
@@ -210,7 +211,7 @@ impl TextOffset {
     }
 
     /// Convert this offset to an equivalent [`TextPosition`] in the file.
-    pub fn position_in_file(self, db: &dyn FilesGroup, file: FileId<'_>) -> Option<TextPosition> {
+    pub fn position_in_file(self, db: &dyn Database, file: FileId<'_>) -> Option<TextPosition> {
         let summary = db.file_summary(file)?;
         let line_number = self.get_line_number(db, file)?;
         let line_offset = summary.line_offsets[line_number];
@@ -227,7 +228,7 @@ impl TextPosition {
     /// of line respectively.
     ///
     /// Returns `None` if file is not found in `db`.
-    pub fn offset_in_file(self, db: &dyn FilesGroup, file: FileId<'_>) -> Option<TextOffset> {
+    pub fn offset_in_file(self, db: &dyn Database, file: FileId<'_>) -> Option<TextOffset> {
         let file_summary = db.file_summary(file)?;
         let content = db.file_content(file)?.long(db);
 
@@ -276,7 +277,7 @@ impl TextPositionSpan {
     /// Convert this span to a [`TextSpan`] in the file.
     pub fn offset_in_file<'db>(
         Self { start, end }: Self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         file: FileId<'db>,
     ) -> Option<TextSpan> {
         Some(TextSpan::new(start.offset_in_file(db, file)?, end.offset_in_file(db, file)?))

--- a/crates/cairo-lang-formatter/Cargo.toml
+++ b/crates/cairo-lang-formatter/Cargo.toml
@@ -18,6 +18,7 @@ ignore.workspace = true
 itertools = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 thiserror.workspace = true
+salsa.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/cairo-lang-formatter/src/lib.rs
+++ b/crates/cairo-lang-formatter/src/lib.rs
@@ -6,11 +6,11 @@ pub mod formatter_impl;
 pub mod node_properties;
 
 use cairo_lang_diagnostics::DiagnosticsBuilder;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{FileKind, FileLongId, VirtualFile};
 use cairo_lang_parser::parser::Parser;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode};
 use cairo_lang_utils::Intern;
+use salsa::Database;
 use serde::{Deserialize, Serialize};
 
 pub use crate::cairo_formatter::{CairoFormatter, FormatOutcome, StdinFmt};
@@ -29,7 +29,7 @@ pub const CAIRO_FMT_IGNORE: &str = ".cairofmtignore";
 /// # Returns
 /// * `String` - The formatted file.
 pub fn get_formatted_file(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     syntax_root: &SyntaxNode<'_>,
     config: FormatterConfig,
 ) -> String {
@@ -43,7 +43,7 @@ pub fn get_formatted_file(
 /// * `content` - The code to format.
 /// # Returns
 /// * `String` - The formatted code.
-pub fn format_string(db: &dyn FilesGroup, content: String) -> String {
+pub fn format_string(db: &dyn Database, content: String) -> String {
     let virtual_file = FileLongId::Virtual(VirtualFile {
         parent: None,
         name: "string_to_format".into(),

--- a/crates/cairo-lang-formatter/src/node_properties.rs
+++ b/crates/cairo-lang-formatter/src/node_properties.rs
@@ -1,9 +1,9 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::consts::FMT_SKIP_ATTR;
 use cairo_lang_syntax::node::ast::MaybeModuleBody;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode, ast};
+use salsa::Database;
 
 use crate::formatter_impl::{
     BreakLinePointIndentation, BreakLinePointProperties, BreakLinePointsPositions,
@@ -12,7 +12,7 @@ use crate::formatter_impl::{
 use crate::{CollectionsBreakingBehavior, FormatterConfig};
 
 impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
-    fn force_no_space_before(&self, db: &dyn FilesGroup) -> bool {
+    fn force_no_space_before(&self, db: &dyn Database) -> bool {
         match self.kind(db) {
             SyntaxKind::TokenDot
             | SyntaxKind::TokenColonColon
@@ -94,7 +94,7 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
         }
     }
 
-    fn force_no_space_after(&self, db: &dyn FilesGroup) -> bool {
+    fn force_no_space_after(&self, db: &dyn Database) -> bool {
         match self.kind(db) {
             SyntaxKind::TokenDot
             | SyntaxKind::TokenNot
@@ -190,10 +190,10 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
         }
     }
     // TODO(gil): consider removing this function as it is no longer used.
-    fn allow_newline_after(&self, _db: &dyn FilesGroup) -> bool {
+    fn allow_newline_after(&self, _db: &dyn Database) -> bool {
         false
     }
-    fn allowed_empty_between(&self, db: &dyn FilesGroup) -> usize {
+    fn allowed_empty_between(&self, db: &dyn Database) -> usize {
         match self.kind(db) {
             SyntaxKind::ModuleItemList | SyntaxKind::ImplItemList | SyntaxKind::TraitItemList => 2,
             SyntaxKind::StatementList => 1,
@@ -201,7 +201,7 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
         }
     }
     // TODO(Gil): Add all protected zones and break points when the formatter is stable.
-    fn get_protected_zone_precedence(&self, db: &dyn FilesGroup) -> Option<usize> {
+    fn get_protected_zone_precedence(&self, db: &dyn Database) -> Option<usize> {
         match self.parent_kind(db) {
             // TODO(Gil): protected zone preferences should be local for each syntax node.
             Some(
@@ -467,7 +467,7 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
     }
     fn get_wrapping_break_line_point_properties(
         &self,
-        db: &dyn FilesGroup,
+        db: &dyn Database,
     ) -> BreakLinePointsPositions {
         // TODO(Gil): Make it easier to order the break points precedence.
         match self.parent_kind(db) {
@@ -824,7 +824,7 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
     }
     fn get_internal_break_line_point_properties(
         &self,
-        db: &dyn FilesGroup,
+        db: &dyn Database,
         config: &FormatterConfig,
     ) -> BreakLinePointsPositions {
         match self.kind(db) {
@@ -930,7 +930,7 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
         }
     }
 
-    fn should_skip_terminal(&self, db: &dyn FilesGroup) -> bool {
+    fn should_skip_terminal(&self, db: &dyn Database) -> bool {
         let is_last =
             |node: &SyntaxNode<'_>, siblings: &[SyntaxNode<'_>]| siblings.last() == Some(node);
         // Check for TerminalComma with specific conditions on list types and position.
@@ -1020,7 +1020,7 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
     }
 
     // Merge the `as_sort_kind` method here
-    fn as_sort_kind(&self, db: &dyn FilesGroup) -> SortKind {
+    fn as_sort_kind(&self, db: &dyn Database) -> SortKind {
         match self.kind(db) {
             SyntaxKind::ItemModule => {
                 let item_module = ast::ItemModule::from_syntax_node(db, *self);
@@ -1034,10 +1034,7 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
             _ => SortKind::Immovable,
         }
     }
-    fn should_ignore_node_format(
-        &self,
-        db: &dyn FilesGroup,
-    ) -> Option<IgnoreFormattingSpacingData> {
+    fn should_ignore_node_format(&self, db: &dyn Database) -> Option<IgnoreFormattingSpacingData> {
         if self.has_attr(db, FMT_SKIP_ATTR) {
             return Some(IgnoreFormattingSpacingData {
                 add_space_before: false,
@@ -1057,7 +1054,7 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
 }
 
 /// For statement lists, returns if we want these as a single line.
-fn is_statement_list_break_point_optional(db: &dyn FilesGroup, node: &SyntaxNode<'_>) -> bool {
+fn is_statement_list_break_point_optional(db: &dyn Database, node: &SyntaxNode<'_>) -> bool {
     // Currently, we only want single line blocks for match arms or generic args, with a single
     // statement, with no single line comments.
     matches!(

--- a/crates/cairo-lang-lowering/src/objects.rs
+++ b/crates/cairo-lang-lowering/src/objects.rs
@@ -81,7 +81,7 @@ impl<'db> Location<'db> {
 impl<'db> DebugWithDb<'db> for Location<'db> {
     type Db = dyn LoweringGroup;
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db dyn LoweringGroup) -> std::fmt::Result {
-        let files_db = db.upcast();
+        let files_db = db.as_dyn_database();
         self.stable_location.diagnostic_location(db).fmt(f, files_db)?;
 
         for note in &self.notes {

--- a/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic_test.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use cairo_lang_debug::DebugWithDb;
-use cairo_lang_filesystem::db::FilesGroupEx;
+use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::FlagLongId;
 use cairo_lang_semantic::test_utils::setup_test_function;

--- a/crates/cairo-lang-lowering/src/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/test_utils.rs
@@ -2,12 +2,13 @@ use std::sync::{LazyLock, Mutex};
 
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
-use cairo_lang_filesystem::db::{FilesGroup, init_dev_corelib, init_files_group};
+use cairo_lang_filesystem::db::{init_dev_corelib, init_files_group};
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_semantic::db::{Elongate, PluginSuiteInput, SemanticGroup, init_semantic_group};
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
 use cairo_lang_utils::Upcast;
+use salsa::Database;
 
 use crate::Lowered;
 use crate::db::{LoweringGroup, UseApproxCodeSizeEstimator, init_lowering_group};
@@ -60,8 +61,8 @@ impl Elongate for LoweringDatabaseForTesting {
     }
 }
 
-impl<'db> Upcast<'db, dyn FilesGroup> for LoweringDatabaseForTesting {
-    fn upcast(&self) -> &dyn FilesGroup {
+impl<'db> Upcast<'db, dyn Database> for LoweringDatabaseForTesting {
+    fn upcast(&self) -> &dyn Database {
         self
     }
 }

--- a/crates/cairo-lang-parser/src/colored_printer.rs
+++ b/crates/cairo-lang-parser/src/colored_printer.rs
@@ -1,11 +1,11 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::SyntaxNode;
 use cairo_lang_syntax::node::green::GreenNodeDetails;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use colored::{ColoredString, Colorize};
+use salsa::Database;
 
 struct ColoredPrinter<'a> {
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     /// Whether to also print empty and missing tokens/nodes
     verbose: bool,
     result: String,
@@ -133,7 +133,7 @@ fn set_color(text: &str, kind: SyntaxKind) -> ColoredString {
     }
 }
 
-pub fn print_colored(db: &dyn FilesGroup, syntax_root: &SyntaxNode<'_>, verbose: bool) -> String {
+pub fn print_colored(db: &dyn Database, syntax_root: &SyntaxNode<'_>, verbose: bool) -> String {
     let mut printer = ColoredPrinter { db, verbose, result: Default::default() };
     printer.print(syntax_root);
     printer.result

--- a/crates/cairo-lang-parser/src/db_test.rs
+++ b/crates/cairo-lang-parser/src/db_test.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::ast::{
@@ -9,13 +8,14 @@ use cairo_lang_syntax::node::ast::{
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, Token as SyntaxToken, TypedSyntaxNode};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
+use salsa::Database;
 
 use crate::db::ParserGroup;
 use crate::printer::print_tree;
 use crate::test_utils::{MockToken, MockTokenStream, create_virtual_file};
 use crate::utils::{SimpleParserDatabase, get_syntax_root_and_diagnostics_from_file};
 
-fn build_empty_file_green_tree<'a>(db: &'a dyn FilesGroup, file_id: FileId<'a>) -> SyntaxFile<'a> {
+fn build_empty_file_green_tree<'a>(db: &'a dyn Database, file_id: FileId<'a>) -> SyntaxFile<'a> {
     let eof_token = TokenEndOfFile::new_green(db, "");
     let eof_terminal = TerminalEndOfFile::new_green(
         db,

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -1,8 +1,8 @@
 use cairo_lang_diagnostics::DiagnosticEntry;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::kind::SyntaxKind;
+use salsa::Database;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]
 pub struct ParserDiagnostic<'a> {
@@ -130,9 +130,9 @@ pub enum ParserDiagnosticKind {
 }
 
 impl<'a> DiagnosticEntry<'a> for ParserDiagnostic<'a> {
-    type DbType = dyn FilesGroup;
+    type DbType = dyn Database;
 
-    fn format(&self, _db: &dyn FilesGroup) -> String {
+    fn format(&self, _db: &dyn Database) -> String {
         match &self.kind {
             ParserDiagnosticKind::InvalidParamKindInMacroExpansion => {
                 "Parameter kinds are not allowed in macro expansion.".to_string()
@@ -244,7 +244,7 @@ Did you mean to write `{identifier}!{left}...{right}'?",
         }
     }
 
-    fn location(&self, _db: &'a dyn FilesGroup) -> cairo_lang_diagnostics::DiagnosticLocation<'a> {
+    fn location(&self, _db: &'a dyn Database) -> cairo_lang_diagnostics::DiagnosticLocation<'a> {
         cairo_lang_diagnostics::DiagnosticLocation { file_id: self.file_id, span: self.span }
     }
 

--- a/crates/cairo-lang-parser/src/lexer.rs
+++ b/crates/cairo-lang-parser/src/lexer.rs
@@ -2,7 +2,6 @@
 #[path = "lexer_test.rs"]
 mod test;
 
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
 use cairo_lang_syntax::node::Token;
 use cairo_lang_syntax::node::ast::{
@@ -11,9 +10,10 @@ use cairo_lang_syntax::node::ast::{
 };
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_utils::require;
+use salsa::Database;
 
 pub struct Lexer<'a> {
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     text: &'a str,
     previous_position: TextOffset,
     current_position: TextOffset,
@@ -22,7 +22,7 @@ pub struct Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     // Ctors.
-    pub fn from_text(db: &'a dyn FilesGroup, text: &'a str) -> Lexer<'a> {
+    pub fn from_text(db: &'a dyn Database, text: &'a str) -> Lexer<'a> {
         Lexer {
             db,
             text,
@@ -330,7 +330,7 @@ pub struct LexerTerminal<'a> {
     pub trailing_trivia: Vec<TriviumGreen<'a>>,
 }
 impl<'a> LexerTerminal<'a> {
-    pub fn width(&self, db: &dyn FilesGroup) -> TextWidth {
+    pub fn width(&self, db: &dyn Database) -> TextWidth {
         self.leading_trivia.iter().map(|t| t.0.width(db)).sum::<TextWidth>()
             + TextWidth::from_str(self.text)
             + self.trailing_trivia.iter().map(|t| t.0.width(db)).sum::<TextWidth>()

--- a/crates/cairo-lang-parser/src/macro_helpers.rs
+++ b/crates/cairo-lang-parser/src/macro_helpers.rs
@@ -9,6 +9,7 @@ use cairo_lang_syntax::node::ast::{
 };
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode};
+use salsa::Database;
 
 use crate::ParserDiagnostic;
 use crate::diagnostic::ParserDiagnosticKind;
@@ -19,7 +20,7 @@ use crate::recovery::is_of_kind;
 /// to parse it as such and return the result.
 pub fn token_tree_as_wrapped_arg_list<'a>(
     token_tree: TokenTreeNode<'a>,
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
 ) -> Option<WrappedArgListGreen<'a>> {
     let mut diagnostics: DiagnosticsBuilder<'_, ParserDiagnostic<'a>> =
         DiagnosticsBuilder::default();
@@ -47,7 +48,7 @@ pub fn token_tree_as_wrapped_arg_list<'a>(
 pub fn as_expr_macro_token_tree<'a>(
     mut token_tree: impl DoubleEndedIterator<Item = TokenTree<'a>>,
     file_id: FileId<'a>,
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
 ) -> Option<ast::Expr<'a>> {
     let mut diagnostics: DiagnosticsBuilder<'_, ParserDiagnostic<'_>> =
         DiagnosticsBuilder::default();
@@ -73,13 +74,13 @@ pub trait AsLegacyInlineMacro<'a> {
     /// The corresponding legacy inline macro type.
     type LegacyType;
     /// Converts the inline macro to the legacy inline macro.
-    fn as_legacy_inline_macro(&self, db: &'a dyn FilesGroup) -> Option<Self::LegacyType>;
+    fn as_legacy_inline_macro(&self, db: &'a dyn Database) -> Option<Self::LegacyType>;
 }
 
 impl<'a> AsLegacyInlineMacro<'a> for ExprInlineMacro<'a> {
     type LegacyType = LegacyExprInlineMacro<'a>;
 
-    fn as_legacy_inline_macro(&self, db: &'a dyn FilesGroup) -> Option<Self::LegacyType> {
+    fn as_legacy_inline_macro(&self, db: &'a dyn Database) -> Option<Self::LegacyType> {
         let green_node = self.as_syntax_node().green_node(db);
         let [macro_name, bang, _arguments] = green_node.children() else {
             return None;
@@ -100,7 +101,7 @@ impl<'a> AsLegacyInlineMacro<'a> for ExprInlineMacro<'a> {
 impl<'a> AsLegacyInlineMacro<'a> for ItemInlineMacro<'a> {
     type LegacyType = LegacyItemInlineMacro<'a>;
 
-    fn as_legacy_inline_macro(&self, db: &'a dyn FilesGroup) -> Option<Self::LegacyType> {
+    fn as_legacy_inline_macro(&self, db: &'a dyn Database) -> Option<Self::LegacyType> {
         let green_node = self.as_syntax_node().green_node(db);
         let [attributes, macro_name, bang, _arguments, semicolon] = green_node.children() else {
             return None;

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -43,7 +43,7 @@ enum MacroParsingContext {
 }
 
 pub struct Parser<'a, 'mt> {
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     file_id: FileId<'a>,
     lexer: Lexer<'a>,
     /// The next terminal to handle.
@@ -125,7 +125,7 @@ macro_rules! or_an_attribute {
 impl<'a, 'mt> Parser<'a, 'mt> {
     /// Creates a new parser.
     pub fn new(
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         file_id: FileId<'a>,
         text: &'a str,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
@@ -155,7 +155,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
 
     /// Parses a file.
     pub fn parse_file(
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
         file_id: FileId<'a>,
         text: &'a str,
@@ -167,7 +167,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
 
     /// Parses a file expr.
     pub fn parse_file_expr(
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
         file_id: FileId<'a>,
         text: &'a str,
@@ -186,7 +186,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
 
     /// Parses a file as a list of statements.
     pub fn parse_file_statement_list(
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
         file_id: FileId<'a>,
         text: &'a str,
@@ -207,7 +207,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
 
     /// Parses a token stream.
     pub fn parse_token_stream(
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
         file_id: FileId<'a>,
         token_stream: &dyn ToPrimitiveTokenStream<Iter = impl Iterator<Item = PrimitiveToken>>,
@@ -231,7 +231,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
 
     /// Parses a token stream expression.
     pub fn parse_token_stream_expr(
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
         file_id: FileId<'a>,
         offset: Option<TextOffset>,
@@ -3845,12 +3845,12 @@ pub struct PendingParserDiagnostic {
 }
 
 /// Returns the total width of the given trivia list.
-fn trivia_total_width(db: &dyn FilesGroup, trivia: &[TriviumGreen<'_>]) -> TextWidth {
+fn trivia_total_width(db: &dyn Database, trivia: &[TriviumGreen<'_>]) -> TextWidth {
     trivia.iter().map(|trivium| trivium.0.width(db)).sum::<TextWidth>()
 }
 
 /// The width of the trailing trivia, traversing the tree to the bottom right node.
-fn trailing_trivia_width(db: &dyn FilesGroup, green_id: GreenId<'_>) -> Option<TextWidth> {
+fn trailing_trivia_width(db: &dyn Database, green_id: GreenId<'_>) -> Option<TextWidth> {
     let node = green_id.long(db);
     if node.kind == SyntaxKind::Trivia {
         return Some(node.width());

--- a/crates/cairo-lang-parser/src/printer.rs
+++ b/crates/cairo-lang-parser/src/printer.rs
@@ -1,4 +1,3 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax as syntax;
 use cairo_lang_syntax::node::SyntaxNode;
 use cairo_lang_syntax::node::kind::SyntaxKind;
@@ -6,9 +5,10 @@ use cairo_lang_syntax_codegen::cairo_spec::get_spec;
 use cairo_lang_syntax_codegen::spec::{Member, Node, NodeKind};
 use colored::{ColoredString, Colorize};
 use itertools::zip_eq;
+use salsa::Database;
 
 pub fn print_tree(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     syntax_root: &SyntaxNode<'_>,
     print_colors: bool,
     print_trivia: bool,
@@ -19,7 +19,7 @@ pub fn print_tree(
 }
 
 pub fn print_partial_tree(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     syntax_root: &SyntaxNode<'_>,
     top_level_kind: &str,
     ignored_kinds: Vec<&str>,
@@ -32,7 +32,7 @@ pub fn print_partial_tree(
 }
 
 struct Printer<'a> {
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     spec: Vec<Node>,
     print_colors: bool,
     print_trivia: bool,
@@ -45,7 +45,7 @@ struct Printer<'a> {
     result: String,
 }
 impl<'a> Printer<'a> {
-    fn new(db: &'a dyn FilesGroup, print_colors: bool, print_trivia: bool) -> Self {
+    fn new(db: &'a dyn Database, print_colors: bool, print_trivia: bool) -> Self {
         Self {
             db,
             spec: get_spec(),
@@ -59,7 +59,7 @@ impl<'a> Printer<'a> {
 
     /// Create a new printer that is capable of partial printing of the syntax tree.
     fn new_partial(
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         top_level_kind: &str,
         ignored_kinds: Vec<&str>,
         print_trivia: bool,

--- a/crates/cairo-lang-parser/src/test_utils.rs
+++ b/crates/cairo-lang-parser/src/test_utils.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 use std::vec::IntoIter;
 
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{FileId, FileKind, FileLongId, VirtualFile};
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_primitive_token::{PrimitiveSpan, PrimitiveToken, ToPrimitiveTokenStream};
@@ -9,6 +8,7 @@ use cairo_lang_syntax::node::SyntaxNode;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use salsa::Database;
 
 use crate::utils::{SimpleParserDatabase, get_syntax_root_and_diagnostics};
 
@@ -68,7 +68,7 @@ impl MockToken {
     }
 
     /// Create a token based on [SyntaxNode]
-    pub fn from_syntax_node(db: &dyn FilesGroup, node: SyntaxNode<'_>) -> MockToken {
+    pub fn from_syntax_node(db: &dyn Database, node: SyntaxNode<'_>) -> MockToken {
         MockToken::new(node.get_text(db).to_string(), node.span(db))
     }
 }
@@ -80,7 +80,7 @@ impl MockTokenStream {
     }
 
     /// Create whole [MockTokenStream] based upon the [SyntaxNode].
-    pub fn from_syntax_node(db: &dyn FilesGroup, node: SyntaxNode<'_>) -> Self {
+    pub fn from_syntax_node(db: &dyn Database, node: SyntaxNode<'_>) -> Self {
         let leaves = node.tokens(db);
         let tokens = leaves.map(|node| MockToken::from_syntax_node(db, node)).collect();
         Self::new(tokens)

--- a/crates/cairo-lang-parser/src/utils.rs
+++ b/crates/cairo-lang-parser/src/utils.rs
@@ -29,8 +29,8 @@ impl Default for SimpleParserDatabase {
     }
 }
 
-impl<'db> Upcast<'db, dyn FilesGroup> for SimpleParserDatabase {
-    fn upcast(&'db self) -> &'db dyn FilesGroup {
+impl<'db> Upcast<'db, dyn salsa::Database> for SimpleParserDatabase {
+    fn upcast(&'db self) -> &'db dyn salsa::Database {
         self
     }
 }

--- a/crates/cairo-lang-plugins/src/plugins/compile_error.rs
+++ b/crates/cairo-lang-plugins/src/plugins/compile_error.rs
@@ -1,9 +1,9 @@
 use cairo_lang_defs::extract_macro_single_unnamed_arg;
 use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginResult};
 use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode, ast};
+use salsa::Database;
 
 /// Plugin that allows writing item level `compile_error!` causing a diagnostic.
 /// Useful for testing that `cfg` attributes are valid.
@@ -14,7 +14,7 @@ pub struct CompileErrorPlugin;
 impl MacroPlugin for CompileErrorPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -5,7 +5,6 @@ use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
 use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::structured::{
     Attribute, AttributeArg, AttributeArgVariant, AttributeStructurize,
 };
@@ -13,6 +12,7 @@ use cairo_lang_syntax::node::helpers::{BodyItems, GetIdentifier, QueryAttrs};
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::try_extract_matches;
 use itertools::Itertools;
+use salsa::Database;
 
 /// Represents a predicate tree used to evaluate configuration attributes to handle nested
 /// predicates, such as logical `not` operations, and evaluate them based on a given set of
@@ -60,7 +60,7 @@ const CFG_ATTR: &str = "cfg";
 impl MacroPlugin for ConfigPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
@@ -98,7 +98,7 @@ impl MacroPlugin for ConfigPlugin {
 pub trait HasItemsInCfgEx<'a, Item: QueryAttrs<'a>>: BodyItems<'a, Item = Item> {
     fn iter_items_in_cfg(
         &self,
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         cfg_set: &CfgSet,
     ) -> impl Iterator<Item = Item>;
 }
@@ -108,7 +108,7 @@ impl<'a, Item: QueryAttrs<'a>, Body: BodyItems<'a, Item = Item>> HasItemsInCfgEx
 {
     fn iter_items_in_cfg(
         &self,
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         cfg_set: &CfgSet,
     ) -> impl Iterator<Item = Item> {
         self.iter_items(db).filter(move |item| !should_drop(db, cfg_set, item, &mut vec![]))
@@ -119,7 +119,7 @@ impl<'a, Item: QueryAttrs<'a>, Body: BodyItems<'a, Item = Item>> HasItemsInCfgEx
 /// In case it includes dropped elements and needs to be rewritten, it returns the appropriate
 /// PatchBuilder. Otherwise returns `None`, and it won't be rewritten or dropped.
 fn handle_undropped_item<'a>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     cfg_set: &CfgSet,
     item_ast: ast::ModuleItem<'a>,
     diagnostics: &mut Vec<PluginDiagnostic<'a>>,
@@ -164,7 +164,7 @@ fn handle_undropped_item<'a>(
 /// Gets the list of items that should be kept in the AST.
 /// Returns `None` if all items should be kept.
 fn get_kept_items_nodes<'a, Item: QueryAttrs<'a> + TypedSyntaxNode<'a>>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     cfg_set: &CfgSet,
     all_items: impl Iterator<Item = Item>,
     diagnostics: &mut Vec<PluginDiagnostic<'a>>,
@@ -183,7 +183,7 @@ fn get_kept_items_nodes<'a, Item: QueryAttrs<'a> + TypedSyntaxNode<'a>>(
 
 /// Check if the given item should be dropped from the AST.
 fn should_drop<'a, Item: QueryAttrs<'a>>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     cfg_set: &CfgSet,
     item: &Item,
     diagnostics: &mut Vec<PluginDiagnostic<'a>>,
@@ -198,7 +198,7 @@ fn should_drop<'a, Item: QueryAttrs<'a>>(
 
 /// Parse `#[cfg(not(ghf)...)]` attribute arguments as a predicate matching [`Cfg`] items.
 fn parse_predicate<'a>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     attr: Attribute<'a>,
     diagnostics: &mut Vec<PluginDiagnostic<'a>>,
 ) -> Option<PredicateTree> {
@@ -212,7 +212,7 @@ fn parse_predicate<'a>(
 
 /// Parse single `#[cfg(...)]` attribute argument as a [`Cfg`] item.
 fn parse_predicate_item<'a>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     item: AttributeArg<'a>,
     diagnostics: &mut Vec<PluginDiagnostic<'a>>,
 ) -> Option<PredicateTree> {
@@ -294,7 +294,7 @@ fn parse_predicate_item<'a>(
 
 /// Extracts a configuration predicate part from an attribute argument.
 fn extract_config_predicate_part<'a>(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     arg: &AttributeArg<'a>,
 ) -> Option<ConfigPredicatePart<'a>> {
     match &arg.variant {

--- a/crates/cairo-lang-plugins/src/plugins/derive/default.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/default.rs
@@ -1,9 +1,9 @@
 use cairo_lang_defs::plugin::PluginDiagnostic;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::formatdoc;
 use itertools::{Itertools, chain};
+use salsa::Database;
 
 use super::PluginTypeInfo;
 use crate::plugins::utils::TypeVariant;
@@ -12,7 +12,7 @@ pub const DEFAULT_ATTR: &str = "default";
 
 /// Adds derive result for the `Default` trait.
 pub fn handle_default<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     info: &PluginTypeInfo<'db>,
     derived: &ast::ExprPath<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,

--- a/crates/cairo-lang-plugins/src/plugins/derive/mod.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/mod.rs
@@ -2,12 +2,12 @@ use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::structured::{
     AttributeArg, AttributeArgVariant, AttributeStructurize,
 };
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
+use salsa::Database;
 
 use super::utils::PluginTypeInfo;
 use crate::plugins::DOC_ATTR;
@@ -30,7 +30,7 @@ const DERIVE_ATTR: &str = "derive";
 impl MacroPlugin for DerivePlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
@@ -78,7 +78,7 @@ impl MacroPlugin for DerivePlugin {
 
 /// Adds an implementation for all requested derives for the type.
 fn generate_derive_code_for_type<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     metadata: &MacroPluginMetadata<'_>,
     info: PluginTypeInfo<'db>,
 ) -> PluginResult<'db> {

--- a/crates/cairo-lang-plugins/src/plugins/external_attributes_validation.rs
+++ b/crates/cairo-lang-plugins/src/plugins/external_attributes_validation.rs
@@ -1,9 +1,9 @@
 use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginResult};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::structured::{AttributeArgVariant, AttributeStructurize};
 use cairo_lang_syntax::node::helpers::{GetIdentifier, QueryAttrs};
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use itertools::Itertools;
+use salsa::Database;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]
@@ -18,7 +18,7 @@ const GROUP_ATTR_SYNTAX: &str = "#[doc(group: \"group name\")]";
 impl MacroPlugin for ExternalAttributesValidationPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
@@ -36,7 +36,7 @@ impl MacroPlugin for ExternalAttributesValidationPlugin {
 }
 
 fn get_diagnostics<'a, Item: QueryAttrs<'a>>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     item: &Item,
 ) -> Option<Vec<PluginDiagnostic<'a>>> {
     let mut diagnostics: Vec<PluginDiagnostic<'_>> = Vec::new();

--- a/crates/cairo-lang-plugins/src/plugins/generate_trait.rs
+++ b/crates/cairo-lang-plugins/src/plugins/generate_trait.rs
@@ -4,11 +4,11 @@ use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::structured::{AttributeArgVariant, AttributeStructurize};
 use cairo_lang_syntax::node::helpers::{BodyItems, GenericParamEx, QueryAttrs};
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode, ast};
 use itertools::Itertools;
+use salsa::Database;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]
@@ -19,7 +19,7 @@ const GENERATE_TRAIT_ATTR: &str = "generate_trait";
 impl MacroPlugin for GenerateTraitPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
@@ -46,7 +46,7 @@ impl MacroPlugin for GenerateTraitPlugin {
 }
 
 fn generate_trait_for_impl<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     impl_ast: ast::ItemImpl<'db>,
 ) -> PluginResult<'db> {
     let Some(attr) = impl_ast.attributes(db).find_attr(db, GENERATE_TRAIT_ATTR) else {

--- a/crates/cairo-lang-plugins/src/plugins/panicable.rs
+++ b/crates/cairo-lang-plugins/src/plugins/panicable.rs
@@ -2,7 +2,6 @@ use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::structured::{
     Attribute, AttributeArg, AttributeArgVariant, AttributeStructurize,
 };
@@ -11,6 +10,7 @@ use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::try_extract_matches;
 use indoc::formatdoc;
 use itertools::Itertools;
+use salsa::Database;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]
@@ -21,7 +21,7 @@ const PANIC_WITH_ATTR: &str = "panic_with";
 impl MacroPlugin for PanicablePlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
@@ -49,7 +49,7 @@ impl MacroPlugin for PanicablePlugin {
 
 /// Generate code defining a panicable variant of a function marked with `#[panic_with]` attribute.
 fn generate_panicable_code<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     declaration: ast::FunctionDeclaration<'db>,
     attributes: ast::AttributeList<'db>,
     visibility: ast::Visibility<'db>,
@@ -147,7 +147,7 @@ fn generate_panicable_code<'db>(
 /// Given a function signature, if it returns `Option::<T>` or `Result::<T, E>`, returns T and the
 /// variant match strings. Otherwise, returns None.
 fn extract_success_ty_and_variants<'a>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     signature: &ast::FunctionSignature<'a>,
 ) -> Option<(ast::GenericArg<'a>, String, String)> {
     let ret_ty_expr =
@@ -177,7 +177,7 @@ fn extract_success_ty_and_variants<'a>(
 /// Parse `#[panic_with(...)]` attribute arguments and return a tuple with error value and
 /// panicable function name.
 fn parse_arguments<'a>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     attr: &Attribute<'a>,
 ) -> Option<(ast::TerminalShortString<'a>, ast::TerminalIdentifier<'a>)> {
     let [

--- a/crates/cairo-lang-plugins/src/plugins/utils.rs
+++ b/crates/cairo-lang-plugins/src/plugins/utils.rs
@@ -1,7 +1,7 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::helpers::{GenericParamEx, IsDependentType};
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode, ast};
 use itertools::{Itertools, chain};
+use salsa::Database;
 
 /// Information on struct members or enum variants.
 pub struct MemberInfo<'a> {
@@ -51,7 +51,7 @@ pub struct GenericParamsInfo<'a> {
 impl<'a> GenericParamsInfo<'a> {
     /// Extracts the information on generic params.
     pub fn new(
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         generic_params: ast::OptionWrappedGenericParamList<'a>,
     ) -> Self {
         let ast::OptionWrappedGenericParamList::WrappedGenericParamList(gens) = generic_params
@@ -81,7 +81,7 @@ pub struct PluginTypeInfo<'a> {
 }
 impl<'a> PluginTypeInfo<'a> {
     /// Extracts the information on the type being derived.
-    pub fn new(db: &'a dyn FilesGroup, item_ast: &ast::ModuleItem<'a>) -> Option<Self> {
+    pub fn new(db: &'a dyn Database, item_ast: &ast::ModuleItem<'a>) -> Option<Self> {
         match item_ast {
             ast::ModuleItem::Struct(struct_ast) => {
                 let generics = GenericParamsInfo::new(db, struct_ast.generic_params(db));
@@ -156,7 +156,7 @@ impl<'a> PluginTypeInfo<'a> {
 
 /// Extracts the information on the members of the struct.
 fn extract_members<'a>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     members: ast::MemberList<'a>,
     generics: &[&str],
 ) -> Vec<MemberInfo<'a>> {
@@ -173,7 +173,7 @@ fn extract_members<'a>(
 
 /// Extracts the information on the variants of the enum.
 fn extract_variants<'a>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     variants: ast::VariantList<'a>,
     generics: &[&str],
 ) -> Vec<MemberInfo<'a>> {

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -20,7 +20,7 @@ use cairo_lang_test_utils::verify_diagnostics_expectation;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, Upcast};
 use itertools::chain;
-use salsa::{AsDynDatabase, Setter};
+use salsa::{AsDynDatabase, Database, Setter};
 
 use crate::get_base_plugins;
 use crate::test_utils::expand_module_text;
@@ -73,8 +73,8 @@ impl<'db> Upcast<'db, dyn DefsGroup> for DatabaseForTesting {
         self
     }
 }
-impl<'db> Upcast<'db, dyn FilesGroup> for DatabaseForTesting {
-    fn upcast(&'db self) -> &'db dyn FilesGroup {
+impl<'db> Upcast<'db, dyn salsa::Database> for DatabaseForTesting {
+    fn upcast(&'db self) -> &'db dyn salsa::Database {
         self
     }
 }
@@ -117,7 +117,7 @@ pub fn test_expand_plugin_inner(
 
     let cairo_code = &inputs["cairo_code"];
 
-    let db_ref: &mut dyn FilesGroup = &mut db;
+    let db_ref: &mut dyn salsa::Database = &mut db;
     let crate_id = CrateId::plain(db_ref, "test");
     let root = Directory::Real("test_src".into());
     cairo_lang_filesystem::set_crate_config!(
@@ -151,7 +151,7 @@ struct DoubleIndirectionPlugin;
 impl MacroPlugin for DoubleIndirectionPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -13,7 +13,6 @@ use cairo_lang_defs::ids::{
     TraitImplId, TraitItemId, TraitTypeId, UseId, VariantId,
 };
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder, Maybe};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CrateId, CrateInput, FileId, FileLongId, StrRef};
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_syntax::attribute::structured::Attribute;
@@ -67,7 +66,7 @@ pub trait SemanticGroup:
     DefsGroup
     + for<'db> Upcast<'db, dyn DefsGroup>
     + for<'db> Upcast<'db, dyn ParserGroup>
-    + for<'db> Upcast<'db, dyn FilesGroup>
+    + for<'db> Upcast<'db, dyn salsa::Database>
     + Elongate
 {
     #[salsa::interned]

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -6,11 +6,11 @@ use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{TypedStablePtr, ast};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
+use salsa::Database;
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -77,7 +77,7 @@ struct AddInlineModuleDummyPlugin;
 impl MacroPlugin for AddInlineModuleDummyPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -18,7 +18,6 @@ use cairo_lang_defs::ids::{
 use cairo_lang_defs::plugin::{InlineMacroExprPlugin, MacroPluginMetadata};
 use cairo_lang_diagnostics::{Maybe, skip_diagnostic};
 use cairo_lang_filesystem::cfg::CfgSet;
-use cairo_lang_filesystem::db::{FilesGroup, FilesGroupEx};
 use cairo_lang_filesystem::ids::{
     CodeMapping, CodeOrigin, FileKind, FileLongId, StrRef, VirtualFile,
 };
@@ -42,6 +41,7 @@ use cairo_lang_utils::{
 use itertools::{Itertools, chain, zip_eq};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
+use salsa::Database;
 
 use super::inference::canonic::ResultNoErrEx;
 use super::inference::conform::InferenceConform;
@@ -3346,7 +3346,7 @@ fn string_literal_to_semantic<'db>(
 /// returns a tuple of (identifier, is_callsite_prefixed).
 /// Otherwise, returns None.
 fn try_extract_identifier_from_path<'a>(
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
     path: &ast::ExprPath<'a>,
 ) -> Option<(TerminalIdentifier<'a>, bool)> {
     let segments_var = path.segments(db);
@@ -3371,7 +3371,7 @@ fn try_extract_identifier_from_path<'a>(
 fn expr_as_identifier<'db>(
     ctx: &mut ComputationContext<'db, '_>,
     path: &ast::ExprPath<'db>,
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
 ) -> Maybe<&'db str> {
     let segments_var = path.segments(db);
     let mut segments = segments_var.elements(db);

--- a/crates/cairo-lang-semantic/src/inline_macros/array.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/array.rs
@@ -6,10 +6,10 @@ use cairo_lang_defs::plugin::{
 use cairo_lang_defs::plugin_utils::{
     PluginResultTrait, not_legacy_macro_diagnostic, unsupported_bracket_diagnostic,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::indoc;
+use salsa::Database;
 
 #[derive(Debug, Default)]
 pub struct ArrayMacro;
@@ -19,7 +19,7 @@ impl NamedPlugin for ArrayMacro {
 impl InlineMacroExprPlugin for ArrayMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {

--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -7,11 +7,11 @@ use cairo_lang_defs::plugin_utils::{
     PluginResultTrait, escape_node, not_legacy_macro_diagnostic, try_extract_unnamed_arg,
     unsupported_bracket_diagnostic,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::ast::WrappedArgList;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::{formatdoc, indoc};
+use salsa::Database;
 
 /// Macro for assertion.
 #[derive(Default, Debug)]
@@ -22,7 +22,7 @@ impl NamedPlugin for AssertMacro {
 impl InlineMacroExprPlugin for AssertMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {

--- a/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
@@ -4,13 +4,13 @@ use cairo_lang_defs::plugin::{
     PluginGeneratedFile,
 };
 use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::indoc;
 use num_bigint::BigInt;
+use salsa::Database;
 
 #[derive(Debug, Default)]
 pub struct ConstevalIntMacro;
@@ -20,7 +20,7 @@ impl NamedPlugin for ConstevalIntMacro {
 impl InlineMacroExprPlugin for ConstevalIntMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
@@ -99,7 +99,7 @@ impl InlineMacroExprPlugin for ConstevalIntMacro {
 /// Compute the actual value of an integer expression, or fail with diagnostics.
 /// This computation handles arbitrary integers, unlike regular Cairo math.
 pub fn compute_constant_expr<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     value: &ast::Expr<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     macro_ast: &ast::ExprInlineMacro<'db>,

--- a/crates/cairo-lang-semantic/src/inline_macros/expose.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/expose.rs
@@ -3,9 +3,9 @@ use cairo_lang_defs::plugin::{
     InlineMacroExprPlugin, InlinePluginResult, MacroPluginMetadata, NamedPlugin,
     PluginGeneratedFile,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::indoc;
+use salsa::Database;
 
 #[derive(Debug, Default)]
 pub struct ExposeMacro;
@@ -15,7 +15,7 @@ impl NamedPlugin for ExposeMacro {
 impl InlineMacroExprPlugin for ExposeMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {

--- a/crates/cairo-lang-semantic/src/inline_macros/format.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/format.rs
@@ -4,11 +4,11 @@ use cairo_lang_defs::plugin::{
     PluginGeneratedFile,
 };
 use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::helpers::WrappedArgListHelper;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::{formatdoc, indoc};
+use salsa::Database;
 
 /// Macro for formatting.
 #[derive(Default, Debug)]
@@ -19,7 +19,7 @@ impl NamedPlugin for FormatMacro {
 impl InlineMacroExprPlugin for FormatMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {

--- a/crates/cairo-lang-semantic/src/inline_macros/panic.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/panic.rs
@@ -7,17 +7,17 @@ use cairo_lang_defs::plugin_utils::{
     PluginResultTrait, not_legacy_macro_diagnostic, try_extract_unnamed_arg,
     unsupported_bracket_diagnostic,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::ast::{Arg, WrappedArgList};
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::{require, try_extract_matches};
 use indoc::{formatdoc, indoc};
+use salsa::Database;
 
 /// Try to generate a simple panic handlic code.
 /// Return `Some(())` if successful and updates the builder if successful.
 fn try_handle_simple_panic(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     builder: &mut PatchBuilder<'_>,
     arguments: &[Arg<'_>],
 ) -> Option<()> {
@@ -50,7 +50,7 @@ impl NamedPlugin for PanicMacro {
 impl InlineMacroExprPlugin for PanicMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {

--- a/crates/cairo-lang-semantic/src/inline_macros/print.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/print.rs
@@ -4,11 +4,11 @@ use cairo_lang_defs::plugin::{
     PluginGeneratedFile,
 };
 use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::helpers::WrappedArgListHelper;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::{formatdoc, indoc};
+use salsa::Database;
 
 use super::write::{WriteMacro, WritelnMacro};
 
@@ -21,7 +21,7 @@ impl NamedPlugin for PrintMacro {
 impl InlineMacroExprPlugin for PrintMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
@@ -60,7 +60,7 @@ impl NamedPlugin for PrintlnMacro {
 impl InlineMacroExprPlugin for PrintlnMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
@@ -92,7 +92,7 @@ impl InlineMacroExprPlugin for PrintlnMacro {
 
 fn generate_code_inner<'db>(
     syntax: &ast::ExprInlineMacro<'db>,
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     with_newline: bool,
 ) -> InlinePluginResult<'db> {
     let Some(syntax) = syntax.as_legacy_inline_macro(db) else {

--- a/crates/cairo-lang-semantic/src/inline_macros/write.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/write.rs
@@ -8,13 +8,13 @@ use cairo_lang_defs::plugin::{
 use cairo_lang_defs::plugin_utils::{
     not_legacy_macro_diagnostic, try_extract_unnamed_arg, unsupported_bracket_diagnostic,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::span::{TextSpan, TextWidth};
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode, ast};
 use cairo_lang_utils::{OptionHelper, try_extract_matches};
 use indoc::indoc;
 use num_bigint::{BigInt, Sign};
+use salsa::Database;
 
 pub const FELT252_BYTES: usize = 31;
 
@@ -27,7 +27,7 @@ impl NamedPlugin for WriteMacro {
 impl InlineMacroExprPlugin for WriteMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
@@ -72,7 +72,7 @@ impl NamedPlugin for WritelnMacro {
 impl InlineMacroExprPlugin for WritelnMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
@@ -110,7 +110,7 @@ impl InlineMacroExprPlugin for WritelnMacro {
 
 fn generate_code_inner<'db>(
     syntax: &ast::ExprInlineMacro<'db>,
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     with_newline: bool,
 ) -> InlinePluginResult<'db> {
     let info = match FormattingInfo::extract(db, syntax) {
@@ -157,7 +157,7 @@ struct FormattingInfo<'db> {
 impl<'db> FormattingInfo<'db> {
     /// Extracts the arguments from a formatted string macro.
     fn extract(
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
     ) -> Result<FormattingInfo<'db>, Vec<PluginDiagnostic<'db>>> {
         let Some(legacy_inline_macro) = syntax.as_legacy_inline_macro(db) else {

--- a/crates/cairo-lang-semantic/src/items/feature_kind.rs
+++ b/crates/cairo-lang-semantic/src/items/feature_kind.rs
@@ -1,7 +1,7 @@
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::{LanguageElementId, ModuleId};
 use cairo_lang_diagnostics::DiagnosticsBuilder;
-use cairo_lang_filesystem::db::{FilesGroup, default_crate_settings};
+use cairo_lang_filesystem::db::default_crate_settings;
 use cairo_lang_filesystem::ids::{CrateId, StrRef};
 use cairo_lang_syntax::attribute::consts::{
     ALLOW_ATTR, DEPRECATED_ATTR, FEATURE_ATTR, INTERNAL_ATTR, UNSTABLE_ATTR,
@@ -14,6 +14,7 @@ use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::try_extract_matches;
 use itertools::Itertools;
+use salsa::Database;
 
 use crate::SemanticDiagnostic;
 use crate::db::SemanticGroup;
@@ -34,7 +35,7 @@ pub enum FeatureKind<'db> {
 }
 impl<'db> FeatureKind<'db> {
     pub fn from_ast(
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         diagnostics: &mut DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
         attrs: &ast::AttributeList<'db>,
     ) -> Self {
@@ -93,7 +94,7 @@ pub enum FeatureMarkerDiagnostic {
 
 /// Parses the feature attribute.
 fn parse_feature_attr<'db, const EXTRA_ALLOWED: usize>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
     attr: &structured::Attribute<'db>,
     allowed_args: [&str; EXTRA_ALLOWED],
@@ -227,7 +228,7 @@ pub fn extract_item_feature_config<'db>(
 
 /// Processes the feature attribute kind.
 fn process_feature_attr_kind<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     syntax: &impl QueryAttrs<'db>,
     attr: &'db str,
     diagnostic_kind: impl Fn() -> SemanticDiagnosticKind<'db>,

--- a/crates/cairo-lang-semantic/src/items/function_with_body.rs
+++ b/crates/cairo-lang-semantic/src/items/function_with_body.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use cairo_lang_defs::ids::FunctionWithBodyId;
 use cairo_lang_diagnostics::{DiagnosticAdded, Diagnostics, Maybe, ToMaybe};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_proc_macros::DebugWithDb;
 use cairo_lang_syntax::attribute::consts::{IMPLICIT_PRECEDENCE_ATTR, INLINE_ATTR};
 use cairo_lang_syntax::attribute::structured::{Attribute, AttributeArg, AttributeArgVariant};
@@ -10,6 +9,7 @@ use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::{Upcast, try_extract_matches};
 use itertools::Itertools;
+use salsa::Database;
 
 use super::functions::InlineConfiguration;
 use crate::db::SemanticGroup;
@@ -346,7 +346,7 @@ pub fn get_inline_config<'db>(
 /// If there is no implicit precedence influencing attribute, then this function returns
 /// [ImplicitPrecedence::UNSPECIFIED].
 pub fn get_implicit_precedence<'a, 'r>(
-    syntax_db: &'a dyn FilesGroup,
+    syntax_db: &'a dyn Database,
     diagnostics: &mut SemanticDiagnostics<'a>,
     resolver: &mut Resolver<'a>,
     attributes: &'r [Attribute<'a>],

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -16,7 +16,6 @@ use cairo_lang_defs::ids::{
 use cairo_lang_diagnostics::{
     DiagnosticAdded, Diagnostics, DiagnosticsBuilder, Maybe, ToMaybe, skip_diagnostic,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{StrRef, UnstableSalsaId};
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax as syntax;
@@ -26,6 +25,7 @@ use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::{Intern, define_short_id, extract_matches};
 use itertools::{Itertools, chain, izip};
+use salsa::Database;
 use syntax::attribute::structured::{Attribute, AttributeListStructurize};
 use syntax::node::ast::{self, GenericArg, ImplItem, MaybeImplBody, OptionReturnTypeClause};
 use syntax::node::helpers::OptionWrappedGenericParamListHelper;
@@ -1406,7 +1406,7 @@ pub fn priv_impl_definition_data<'db>(
 /// A helper function to report diagnostics of items in an impl (used in
 /// priv_impl_definition_data).
 fn report_invalid_impl_item<'db, Terminal: syntax::node::Terminal<'db>>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut SemanticDiagnostics<'db>,
     kw_terminal: Terminal,
 ) {

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -4,7 +4,6 @@ use cairo_lang_defs::ids::{
     LanguageElementId, LookupItemId, MacroDeclarationId, ModuleFileId, ModuleItemId,
 };
 use cairo_lang_diagnostics::{Diagnostics, Maybe, skip_diagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
 use cairo_lang_filesystem::span::{TextSpan, TextWidth};
 use cairo_lang_parser::macro_helpers::as_expr_macro_token_tree;
@@ -15,6 +14,7 @@ use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
+use salsa::Database;
 
 use crate::SemanticDiagnostic;
 use crate::db::SemanticGroup;
@@ -173,7 +173,7 @@ pub fn priv_macro_declaration_data<'db>(
 
 /// Helper function to extract pattern elements from a WrappedMacro.
 fn get_macro_elements<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     pattern: ast::WrappedMacro<'db>,
 ) -> ast::MacroElements<'db> {
     match pattern {
@@ -186,7 +186,7 @@ fn get_macro_elements<'db>(
 /// Helper function to extract a placeholder name from an ExprPath node, if it represents a macro
 /// placeholder. Returns None if the path is not a valid macro placeholder.
 fn extract_placeholder<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     path_node: &MacroParam<'db>,
 ) -> Option<&'db str> {
     let placeholder_name = path_node.name(db).as_syntax_node().get_text_without_trivia(db);
@@ -198,7 +198,7 @@ fn extract_placeholder<'db>(
 
 /// Helper function to collect all placeholder names used in a macro expansion.
 fn collect_expansion_placeholders<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     node: SyntaxNode<'db>,
 ) -> Vec<(SyntaxStablePtrId<'db>, &'db str)> {
     let mut placeholders = Vec::new();
@@ -474,7 +474,7 @@ pub struct MacroExpansionResult {
 /// Returns an error if any used placeholder in the expansion is not found in the captures.
 /// When an error is returned, appropriate diagnostics will already have been reported.
 pub fn expand_macro_rule(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     rule: &MacroRuleData<'_>,
     matcher_ctx: &mut MatcherContext<'_>,
 ) -> Maybe<MacroExpansionResult> {
@@ -491,7 +491,7 @@ pub fn expand_macro_rule(
 /// Returns an error if a placeholder is not found in captures.
 /// When an error is returned, appropriate diagnostics will already have been reported.
 fn expand_macro_rule_ex(
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     node: SyntaxNode<'_>,
     matcher_ctx: &mut MatcherContext<'_>,
     res_buffer: &mut String,
@@ -579,7 +579,7 @@ fn expand_macro_rule_ex(
 
 /// Gets a Vec of MacroElement, and returns a vec of the params within it.
 fn get_repetition_params<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     elements: impl IntoIterator<Item = MacroElement<'db>>,
 ) -> Vec<MacroParam<'db>> {
     let mut params = vec![];
@@ -589,7 +589,7 @@ fn get_repetition_params<'db>(
 
 /// Recursively extends the provided params vector with all params within the given macro elements.
 fn repetition_params_extend<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     elements: impl IntoIterator<Item = MacroElement<'db>>,
     params: &mut Vec<MacroParam<'db>>,
 ) {

--- a/crates/cairo-lang-semantic/src/items/mod.rs
+++ b/crates/cairo-lang-semantic/src/items/mod.rs
@@ -1,10 +1,10 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{ImplDefId, TraitId};
 use cairo_lang_diagnostics::Maybe;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::TypedSyntaxNode;
 use cairo_lang_syntax::node::ast::ExprPath;
 use cairo_lang_utils::try_extract_matches;
+use salsa::Database;
 
 use crate::db::SemanticGroup;
 use crate::diagnostic::SemanticDiagnosticKind::NotATrait;
@@ -41,7 +41,7 @@ mod test;
 
 /// Tries to resolve a trait path. Reports a diagnostic if the path doesn't point to a trait.
 fn resolve_trait_path<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut SemanticDiagnostics<'db>,
     resolver: &mut Resolver<'db>,
     trait_path_syntax: &ExprPath<'db>,

--- a/crates/cairo-lang-semantic/src/items/modifiers.rs
+++ b/crates/cairo-lang-semantic/src/items/modifiers.rs
@@ -1,6 +1,6 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::ast::Modifier;
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode};
+use salsa::Database;
 
 use crate::Mutability;
 use crate::diagnostic::SemanticDiagnosticKind::RedundantModifier;
@@ -9,7 +9,7 @@ use crate::diagnostic::{SemanticDiagnostics, SemanticDiagnosticsBuilder};
 /// Returns the mutability of a variable, given the list of modifiers in the AST.
 pub fn compute_mutability<'db>(
     diagnostics: &mut SemanticDiagnostics<'db>,
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     modifier_list: &[Modifier<'db>],
 ) -> Mutability {
     let mut mutability = Mutability::Immutable;

--- a/crates/cairo-lang-semantic/src/items/us.rs
+++ b/crates/cairo-lang-semantic/src/items/us.rs
@@ -4,7 +4,6 @@ use cairo_lang_defs::ids::{
     GlobalUseId, LanguageElementId, LookupItemId, ModuleId, ModuleItemId, UseId,
 };
 use cairo_lang_diagnostics::{Diagnostics, Maybe};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_proc_macros::DebugWithDb;
 use cairo_lang_syntax::node::helpers::UsePathEx;
 use cairo_lang_syntax::node::kind::SyntaxKind;
@@ -12,6 +11,7 @@ use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::Upcast;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
+use salsa::Database;
 
 use super::module::get_module_global_uses;
 use super::visibility::peek_visible_in;
@@ -81,7 +81,7 @@ pub fn priv_use_semantic_data<'db>(
 /// Given the `c` of `use a::b::{c, d};` will return `[a, b, c]`.
 /// Given the `b` of `use a::b::{c, d};` will return `[a, b]`.
 pub fn get_use_path_segments<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     use_path: ast::UsePath<'db>,
 ) -> Maybe<UseAsPathSegments<'db>> {
     let mut rev_segments = vec![];
@@ -117,7 +117,7 @@ pub fn get_use_path_segments<'db>(
 
 /// Returns the parent `UsePathSingle` of a use path if it exists.
 fn get_parent_single_use_path<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     use_path: &ast::UsePath<'db>,
 ) -> Maybe<UsePathOrDollar<'db>> {
     let node = use_path.as_syntax_node();

--- a/crates/cairo-lang-semantic/src/items/visibility.rs
+++ b/crates/cairo-lang-semantic/src/items/visibility.rs
@@ -2,8 +2,8 @@ use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::ModuleId;
 use cairo_lang_diagnostics::DiagnosticsBuilder;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::{Terminal, ast};
+use salsa::Database;
 
 use crate::SemanticDiagnostic;
 use crate::diagnostic::SemanticDiagnosticKind;
@@ -17,7 +17,7 @@ pub enum Visibility {
 }
 impl Visibility {
     pub fn from_ast<'db>(
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         diagnostics: &mut DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
         visibility: &ast::Visibility<'db>,
     ) -> Self {

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -9,9 +9,7 @@ use cairo_lang_defs::ids::{
     ModuleId, ModuleItemId, TopLevelLanguageElementId, TraitId, TraitItemId, UseId, VariantId,
 };
 use cairo_lang_diagnostics::{Maybe, skip_diagnostic};
-use cairo_lang_filesystem::db::{
-    CORELIB_CRATE_NAME, CrateSettings, FilesGroup, default_crate_settings,
-};
+use cairo_lang_filesystem::db::{CORELIB_CRATE_NAME, CrateSettings, default_crate_settings};
 use cairo_lang_filesystem::ids::{CodeMapping, CrateId, CrateLongId, StrRef};
 use cairo_lang_filesystem::span::TextOffset;
 use cairo_lang_proc_macros::DebugWithDb;
@@ -27,6 +25,7 @@ use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::{Intern, extract_matches, require, try_extract_matches};
 pub use item::{ResolvedConcreteItem, ResolvedGenericItem};
 use itertools::Itertools;
+use salsa::Database;
 use syntax::node::TypedStablePtr;
 use syntax::node::helpers::QueryAttrs;
 
@@ -300,51 +299,51 @@ enum UseStarResult<'db> {
 
 /// A trait for things that can be interpreted as a path of segments.
 pub trait AsSegments<'db> {
-    fn to_segments(self, db: &'db dyn FilesGroup) -> Vec<ast::PathSegment<'db>>;
+    fn to_segments(self, db: &'db dyn Database) -> Vec<ast::PathSegment<'db>>;
     /// Returns placeholder marker `$` if the path prefixed with one, indicating a resolver site
     /// modifier.
-    fn placeholder_marker(&self, db: &'db dyn FilesGroup) -> Option<ast::TerminalDollar<'db>>;
+    fn placeholder_marker(&self, db: &'db dyn Database) -> Option<ast::TerminalDollar<'db>>;
     /// The offset of the path in the file.
-    fn offset(&self, db: &'db dyn FilesGroup) -> Option<TextOffset>;
+    fn offset(&self, db: &'db dyn Database) -> Option<TextOffset>;
 }
 impl<'db> AsSegments<'db> for &ast::ExprPath<'db> {
-    fn to_segments(self, db: &'db dyn FilesGroup) -> Vec<ast::PathSegment<'db>> {
+    fn to_segments(self, db: &'db dyn Database) -> Vec<ast::PathSegment<'db>> {
         self.segments(db).elements_vec(db)
     }
-    fn placeholder_marker(&self, db: &'db dyn FilesGroup) -> Option<ast::TerminalDollar<'db>> {
+    fn placeholder_marker(&self, db: &'db dyn Database) -> Option<ast::TerminalDollar<'db>> {
         match self.dollar(db) {
             ast::OptionTerminalDollar::Empty(_) => None,
             ast::OptionTerminalDollar::TerminalDollar(dollar) => Some(dollar),
         }
     }
 
-    fn offset(&self, db: &'db dyn FilesGroup) -> Option<TextOffset> {
+    fn offset(&self, db: &'db dyn Database) -> Option<TextOffset> {
         Some(self.as_syntax_node().offset(db))
     }
 }
 impl<'db> AsSegments<'db> for Vec<ast::PathSegment<'db>> {
-    fn to_segments(self, _: &'db dyn FilesGroup) -> Vec<ast::PathSegment<'db>> {
+    fn to_segments(self, _: &'db dyn Database) -> Vec<ast::PathSegment<'db>> {
         self
     }
-    fn placeholder_marker(&self, _: &'db dyn FilesGroup) -> Option<ast::TerminalDollar<'db>> {
+    fn placeholder_marker(&self, _: &'db dyn Database) -> Option<ast::TerminalDollar<'db>> {
         // A dollar can prefix only the first segment of a path, thus irrelevant to a list of
         // segments.
         None
     }
-    fn offset(&self, db: &'db dyn FilesGroup) -> Option<TextOffset> {
+    fn offset(&self, db: &'db dyn Database) -> Option<TextOffset> {
         self.first().map(|segment| segment.as_syntax_node().offset(db))
     }
 }
 impl<'db> AsSegments<'db> for UseAsPathSegments<'db> {
-    fn to_segments(self, _: &'db dyn FilesGroup) -> Vec<ast::PathSegment<'db>> {
+    fn to_segments(self, _: &'db dyn Database) -> Vec<ast::PathSegment<'db>> {
         self.segments
     }
 
-    fn placeholder_marker(&self, _: &'db dyn FilesGroup) -> Option<ast::TerminalDollar<'db>> {
+    fn placeholder_marker(&self, _: &'db dyn Database) -> Option<ast::TerminalDollar<'db>> {
         self.is_placeholder.clone()
     }
 
-    fn offset(&self, db: &'db dyn FilesGroup) -> Option<TextOffset> {
+    fn offset(&self, db: &'db dyn Database) -> Option<TextOffset> {
         if let Some(ref dollar) = self.is_placeholder {
             Some(dollar.as_syntax_node().offset(db))
         } else {

--- a/crates/cairo-lang-semantic/src/test.rs
+++ b/crates/cairo-lang-semantic/src/test.rs
@@ -3,13 +3,13 @@ use cairo_lang_defs::ids::ModuleItemId;
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginGeneratedFile, PluginResult,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin};
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::extract_matches;
 use indoc::indoc;
 use itertools::Itertools;
+use salsa::Database;
 
 use crate::db::SemanticGroup;
 use crate::inline_macros::get_default_plugin_suite;
@@ -80,7 +80,7 @@ struct MappingsPlugin;
 impl MacroPlugin for MappingsPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -4,8 +4,7 @@ use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
 use cairo_lang_defs::ids::{FunctionWithBodyId, ModuleId};
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder};
 use cairo_lang_filesystem::db::{
-    CrateSettings, Edition, ExperimentalFeaturesConfig, FilesGroup, init_dev_corelib,
-    init_files_group,
+    CrateSettings, Edition, ExperimentalFeaturesConfig, init_dev_corelib, init_files_group,
 };
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::ids::{BlobId, CrateId, CrateLongId, FileKind, FileLongId, VirtualFile};
@@ -62,8 +61,8 @@ impl Elongate for SemanticDatabaseForTesting {
         self
     }
 }
-impl<'db> Upcast<'db, dyn FilesGroup> for SemanticDatabaseForTesting {
-    fn upcast(&'db self) -> &'db dyn FilesGroup {
+impl<'db> Upcast<'db, dyn salsa::Database> for SemanticDatabaseForTesting {
+    fn upcast(&'db self) -> &'db dyn salsa::Database {
         self
     }
 }

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -7,7 +7,6 @@ use cairo_lang_defs::ids::{
     NamedLanguageElementId, StructId, TraitTypeId, UnstableSalsaId,
 };
 use cairo_lang_diagnostics::{DiagnosticAdded, Maybe};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_proc_macros::SemanticObject;
 use cairo_lang_syntax::attribute::consts::MUST_USE_ATTR;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
@@ -16,6 +15,7 @@ use cairo_lang_utils::{Intern, OptionFrom, define_short_id, try_extract_matches}
 use itertools::{Itertools, chain};
 use num_bigint::BigInt;
 use num_traits::Zero;
+use salsa::Database;
 use sha3::{Digest, Keccak256};
 
 use crate::corelib::{
@@ -636,7 +636,7 @@ pub fn extract_fixed_size_array_size<'db>(
 
 /// Verifies that a given fixed size array size is within limits, and adds a diagnostic if not.
 pub fn verify_fixed_size_array_size<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut SemanticDiagnostics<'db>,
     size: &BigInt,
     syntax: &ast::ExprFixedSizeArray<'db>,

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use cairo_lang_debug::DebugWithDb;
-use cairo_lang_filesystem::db::FilesGroupEx;
+use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::FlagLongId;
 use cairo_lang_lowering::db::LoweringGroup;

--- a/crates/cairo-lang-sierra-generator/src/test_utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/test_utils.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 
 use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
 use cairo_lang_defs::ids::ModuleId;
-use cairo_lang_filesystem::db::{FilesGroup, FilesGroupEx, init_dev_corelib, init_files_group};
+use cairo_lang_filesystem::db::{FilesGroup, init_dev_corelib, init_files_group};
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::FlagLongId;
@@ -76,8 +76,8 @@ impl Default for SierraGenDatabaseForTesting {
         SHARED_DB.lock().unwrap().snapshot()
     }
 }
-impl<'db> Upcast<'db, dyn FilesGroup> for SierraGenDatabaseForTesting {
-    fn upcast(&'db self) -> &'db dyn FilesGroup {
+impl<'db> Upcast<'db, dyn salsa::Database> for SierraGenDatabaseForTesting {
+    fn upcast(&'db self) -> &'db dyn salsa::Database {
         self
     }
 }

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -32,6 +32,7 @@ typetag.workspace = true
 starknet-types-core.workspace = true
 thiserror.workspace = true
 indent.workspace = true
+salsa.workspace = true
 
 [dev-dependencies]
 cairo-lang-debug = { path = "../cairo-lang-debug" }

--- a/crates/cairo-lang-starknet/src/inline_macros/get_dep_component.rs
+++ b/crates/cairo-lang-starknet/src/inline_macros/get_dep_component.rs
@@ -5,11 +5,11 @@ use cairo_lang_defs::plugin::{
     PluginGeneratedFile,
 };
 use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::extract_matches;
 use itertools::Itertools;
+use salsa::Database;
 
 /// Macro for getting a component given a contract state that has it.
 #[derive(Debug, Default)]
@@ -20,7 +20,7 @@ impl NamedPlugin for GetDepComponentMacro {
 impl InlineMacroExprPlugin for GetDepComponentMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
@@ -37,7 +37,7 @@ impl NamedPlugin for GetDepComponentMutMacro {
 impl InlineMacroExprPlugin for GetDepComponentMutMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
@@ -48,7 +48,7 @@ impl InlineMacroExprPlugin for GetDepComponentMutMacro {
 /// A helper function for the code generation of both [GetDepComponentMacro] and
 /// [GetDepComponentMutMacro]. `is_mut` selects between the two.
 fn get_dep_component_generate_code_helper<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     syntax: &ast::ExprInlineMacro<'db>,
     is_mut: bool,
 ) -> InlinePluginResult<'db> {

--- a/crates/cairo-lang-starknet/src/inline_macros/selector.rs
+++ b/crates/cairo-lang-starknet/src/inline_macros/selector.rs
@@ -4,10 +4,10 @@ use cairo_lang_defs::plugin::{
     PluginGeneratedFile,
 };
 use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_starknet_classes::keccak::starknet_keccak;
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
+use salsa::Database;
 
 /// Macro for expanding a selector to a string literal.
 #[derive(Debug, Default)]
@@ -18,7 +18,7 @@ impl NamedPlugin for SelectorMacro {
 impl InlineMacroExprPlugin for SelectorMacro {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {

--- a/crates/cairo-lang-starknet/src/plugin/derive/event.rs
+++ b/crates/cairo-lang-starknet/src/plugin/derive/event.rs
@@ -1,10 +1,10 @@
 use cairo_lang_defs::patcher::{ModifiedNode, RewriteNode};
 use cairo_lang_defs::plugin::PluginDiagnostic;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_starknet_classes::abi::EventFieldKind;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use indoc::{formatdoc, indoc};
+use salsa::Database;
 
 use crate::plugin::aux_data::StarknetEventAuxData;
 use crate::plugin::consts::{
@@ -14,7 +14,7 @@ use crate::plugin::events::EventData;
 
 /// Returns the relevant information for the `#[derive(starknet::Event)]` attribute.
 pub fn handle_event_derive<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     item_ast: &ast::ModuleItem<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) -> Option<(RewriteNode<'db>, StarknetEventAuxData)> {
@@ -28,7 +28,7 @@ pub fn handle_event_derive<'db>(
 // TODO(spapini): Avoid names collisions with `keys` and `data`.
 /// Derive the `Event` trait for structs annotated with `derive(starknet::Event)`.
 fn handle_struct<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     struct_ast: &ast::ItemStruct<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) -> Option<(RewriteNode<'db>, StarknetEventAuxData)> {
@@ -107,7 +107,7 @@ fn handle_struct<'db>(
 /// indicating how the field should be serialized.
 /// See [EventFieldKind].
 fn get_field_kind_for_member<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     member: &ast::Member<'db>,
     default: EventFieldKind,
@@ -141,7 +141,7 @@ fn get_field_kind_for_member<'db>(
 /// indicating how the field should be serialized.
 /// See [EventFieldKind].
 fn get_field_kind_for_variant<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     variant: &ast::Variant<'db>,
     default: EventFieldKind,
@@ -179,7 +179,7 @@ fn get_field_kind_for_variant<'db>(
 
 /// Derive the `Event` trait for enums annotated with `derive(starknet::Event)`.
 fn handle_enum<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     enum_ast: &ast::ItemEnum<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) -> Option<(RewriteNode<'db>, StarknetEventAuxData)> {

--- a/crates/cairo-lang-starknet/src/plugin/derive/mod.rs
+++ b/crates/cairo-lang-starknet/src/plugin/derive/mod.rs
@@ -2,9 +2,9 @@ use cairo_lang_defs::patcher::PatchBuilder;
 use cairo_lang_defs::plugin::{
     DynGeneratedFileAuxData, MacroPluginMetadata, PluginGeneratedFile, PluginResult,
 };
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
+use salsa::Database;
 
 use super::consts::{EVENT_TRAIT, STORE_TRAIT};
 use super::utils::has_derive;
@@ -13,14 +13,14 @@ mod event;
 mod store;
 
 /// Checks whether the given item has a starknet derive attribute.
-pub fn derive_needed<'db, T: QueryAttrs<'db>>(with_attrs: &T, db: &'db dyn FilesGroup) -> bool {
+pub fn derive_needed<'db, T: QueryAttrs<'db>>(with_attrs: &T, db: &'db dyn Database) -> bool {
     has_derive(with_attrs, db, EVENT_TRAIT).is_some()
         || has_derive(with_attrs, db, STORE_TRAIT).is_some()
 }
 
 /// Handles the derive attributes for the given item.
 pub fn handle_derive<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     item_ast: ast::ModuleItem<'db>,
     metadata: &MacroPluginMetadata<'_>,
 ) -> PluginResult<'db> {

--- a/crates/cairo-lang-starknet/src/plugin/derive/store.rs
+++ b/crates/cairo-lang-starknet/src/plugin/derive/store.rs
@@ -1,12 +1,12 @@
 use cairo_lang_defs::patcher::RewriteNode;
 use cairo_lang_defs::plugin::{MacroPluginMetadata, PluginDiagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_plugins::plugins::utils::{PluginTypeInfo, TypeVariant};
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::extract_matches;
 use indent::indent_by;
 use indoc::formatdoc;
+use salsa::Database;
 
 use crate::plugin::consts::STORE_TRAIT;
 use crate::plugin::storage_interfaces::{
@@ -15,7 +15,7 @@ use crate::plugin::storage_interfaces::{
 
 /// Returns the rewrite node for the `#[derive(starknet::Store)]` attribute.
 pub fn handle_store_derive<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     item_ast: &ast::ModuleItem<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     metadata: &MacroPluginMetadata<'_>,
@@ -211,7 +211,7 @@ fn handle_struct_store<'db>(info: &PluginTypeInfo<'db>) -> Option<RewriteNode<'d
 
 /// Derive the `starknet::Store` trait for enums annotated with `derive(starknet::Store)`.
 fn handle_enum<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     info: &PluginTypeInfo<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) -> Option<RewriteNode<'db>> {

--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -1,6 +1,5 @@
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{PluginDiagnostic, PluginGeneratedFile, PluginResult};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_semantic::keyword::SELF_PARAM_KW;
 use cairo_lang_syntax::node::ast::{
     self, MaybeTraitBody, OptionReturnTypeClause, OptionTypeClause,
@@ -10,6 +9,7 @@ use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::extract_matches;
 use indoc::formatdoc;
 use itertools::Itertools;
+use salsa::Database;
 
 use super::consts::CALLDATA_PARAM_NAME;
 use super::utils::{AstPathExtract, ParamEx};
@@ -20,7 +20,7 @@ const RET_DATA: &str = "__dispatcher_return_data__";
 
 /// If the trait is annotated with INTERFACE_ATTR, generate the relevant dispatcher logic.
 pub fn handle_trait<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     trait_ast: ast::ItemTrait<'db>,
 ) -> PluginResult<'db> {
     if trait_ast.has_attr(db, DEPRECATED_ABI_ATTR) {
@@ -452,7 +452,7 @@ fn declaration_method_impl<'db>(
 
 /// Returns the matching signature for a dispatcher implementation for the given declaration.
 fn dispatcher_signature<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     declaration: &ast::FunctionDeclaration<'db>,
     self_type_name: &str,
     unwrap: bool,

--- a/crates/cairo-lang-starknet/src/plugin/embeddable.rs
+++ b/crates/cairo-lang-starknet/src/plugin/embeddable.rs
@@ -1,11 +1,11 @@
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{PluginDiagnostic, PluginGeneratedFile, PluginResult};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::helpers::{BodyItems, GenericParamEx};
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode, ast};
 use cairo_lang_utils::try_extract_matches;
 use indoc::formatdoc;
 use itertools::chain;
+use salsa::Database;
 
 use super::consts::{
     CONSTRUCTOR_MODULE, EXTERNAL_MODULE, GENERIC_CONTRACT_STATE_NAME, L1_HANDLER_MODULE,
@@ -17,7 +17,7 @@ use super::utils::{GenericParamExtract, forbid_attributes_in_impl};
 
 /// Handles an embeddable impl, generating entry point wrappers and modules pointing to them.
 pub fn handle_embeddable<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     item_impl: ast::ItemImpl<'db>,
 ) -> PluginResult<'db> {
     let ast::MaybeImplBody::Some(body) = item_impl.body(db) else {

--- a/crates/cairo-lang-starknet/src/plugin/entry_point.rs
+++ b/crates/cairo-lang-starknet/src/plugin/entry_point.rs
@@ -1,6 +1,5 @@
 use cairo_lang_defs::patcher::RewriteNode;
 use cairo_lang_defs::plugin::PluginDiagnostic;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_plugins::plugins::HIDDEN_ATTR_SYNTAX;
 use cairo_lang_semantic::keyword::SELF_PARAM_KW;
 use cairo_lang_syntax::attribute::consts::IMPLICIT_PRECEDENCE_ATTR;
@@ -12,6 +11,7 @@ use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::extract_matches;
 use indoc::{formatdoc, indoc};
 use itertools::Itertools;
+use salsa::Database;
 
 use super::consts::{
     CONSTRUCTOR_ATTR, CONSTRUCTOR_MODULE, CONSTRUCTOR_NAME, EXTERNAL_ATTR, EXTERNAL_MODULE,
@@ -30,7 +30,7 @@ pub enum EntryPointKind {
 impl EntryPointKind {
     /// Returns the entry point kind if the given function is indeed marked as an entry point.
     pub fn try_from_function_with_body<'db>(
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         diagnostics: &mut Vec<PluginDiagnostic<'db>>,
         item_function: &FunctionWithBody<'db>,
     ) -> Option<Self> {
@@ -52,7 +52,7 @@ impl EntryPointKind {
 
     /// Returns the entry point kind if the attributes mark it as an entry point.
     pub fn try_from_attrs<'db>(
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         diagnostics: &mut Vec<PluginDiagnostic<'db>>,
         attrs: &impl QueryAttrs<'db>,
     ) -> Option<Self> {
@@ -135,7 +135,7 @@ pub struct EntryPointGenerationParams<'db, 'a> {
 
 /// Handles a contract entrypoint function.
 pub fn handle_entry_point<'db, 'a>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     EntryPointGenerationParams {
         entry_point_kind,
         item_function,
@@ -220,7 +220,7 @@ pub fn handle_entry_point<'db, 'a>(
 
 /// Generates Cairo code for an entry point wrapper.
 fn generate_entry_point_wrapper<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     function: &FunctionWithBody<'db>,
     wrapped_function_path: RewriteNode<'db>,
     wrapper_function_name: RewriteNode<'db>,
@@ -376,7 +376,7 @@ fn generate_entry_point_wrapper<'db>(
 /// Validates the first parameter of an L1 handler is `from_address: felt252` or `_from_address:
 /// felt252`.
 fn validate_l1_handler_first_parameter<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     params: &ast::ParamList<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) {

--- a/crates/cairo-lang-starknet/src/plugin/events.rs
+++ b/crates/cairo-lang-starknet/src/plugin/events.rs
@@ -1,10 +1,10 @@
 use cairo_lang_defs::db::get_all_path_leaves;
 use cairo_lang_defs::plugin::PluginDiagnostic;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_starknet_classes::abi::EventFieldKind;
 use cairo_lang_syntax::node::helpers::{GetIdentifier, QueryAttrs};
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use const_format::formatcp;
+use salsa::Database;
 use serde::{Deserialize, Serialize};
 
 use super::consts::{EVENT_ATTR, EVENT_TRAIT, EVENT_TYPE_NAME};
@@ -27,7 +27,7 @@ pub enum {EVENT_TYPE_NAME} {{}}
 /// Checks whether the given item is a starknet event, and if so - makes sure it's valid and returns
 /// its variants. Returns None if it's not a starknet event.
 pub fn get_starknet_event_variants<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     item: &ast::ModuleItem<'db>,
     module_kind: StarknetModuleKind,

--- a/crates/cairo-lang-starknet/src/plugin/mod.rs
+++ b/crates/cairo-lang-starknet/src/plugin/mod.rs
@@ -4,10 +4,10 @@ mod test;
 pub mod consts;
 
 use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginResult};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use consts::*;
+use salsa::Database;
 
 pub mod aux_data;
 mod derive;
@@ -33,7 +33,7 @@ pub struct StarknetPlugin;
 impl MacroPlugin for StarknetPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/generation_data.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/generation_data.rs
@@ -1,6 +1,6 @@
 use cairo_lang_defs::patcher::RewriteNode;
 use cairo_lang_defs::plugin::PluginDiagnostic;
-use cairo_lang_filesystem::db::FilesGroup;
+use salsa::Database;
 
 use super::component::ComponentSpecificGenerationData;
 use super::contract::ContractSpecificGenerationData;
@@ -16,7 +16,7 @@ pub struct ContractGenerationData<'db> {
 impl<'db> ContractGenerationData<'db> {
     pub fn into_rewrite_node(
         self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     ) -> RewriteNode<'db> {
         RewriteNode::interpolate_patched(
@@ -41,7 +41,7 @@ pub struct ComponentGenerationData<'db> {
 impl<'db> ComponentGenerationData<'db> {
     pub fn into_rewrite_node(
         self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         diagnostics: &mut [PluginDiagnostic<'db>],
     ) -> RewriteNode<'db> {
         RewriteNode::interpolate_patched(
@@ -66,7 +66,7 @@ pub struct StarknetModuleCommonGenerationData<'db> {
 impl<'db> StarknetModuleCommonGenerationData<'db> {
     pub fn into_rewrite_node(
         self,
-        _db: &'db dyn FilesGroup,
+        _db: &'db dyn Database,
         _diagnostics: &mut [PluginDiagnostic<'db>],
     ) -> RewriteNode<'db> {
         RewriteNode::interpolate_patched(

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/mod.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/mod.rs
@@ -5,12 +5,13 @@ use cairo_lang_defs::plugin::{
     DynGeneratedFileAuxData, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile,
     PluginResult,
 };
-use cairo_lang_filesystem::db::{Edition, FilesGroup};
+use cairo_lang_filesystem::db::Edition;
 use cairo_lang_plugins::plugins::HasItemsInCfgEx;
 use cairo_lang_syntax::node::ast::MaybeModuleBody;
 use cairo_lang_syntax::node::helpers::{BodyItems, QueryAttrs};
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode, ast};
 use cairo_lang_utils::extract_matches;
+use salsa::Database;
 
 use self::component::generate_component_specific_code;
 use self::contract::generate_contract_specific_code;
@@ -35,7 +36,7 @@ pub enum StarknetModuleKind {
 impl StarknetModuleKind {
     /// Returns the starknet module kind according to the module's attributes, if any.
     fn from_module<'db>(
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         module_ast: &ast::ItemModule<'db>,
     ) -> Option<(Self, ast::Attribute<'db>)> {
         for (attr_str, kind) in [
@@ -99,7 +100,7 @@ impl StarknetModuleKind {
 
 /// Handles a contract/component module item.
 pub(super) fn handle_module<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     module_ast: ast::ItemModule<'db>,
 ) -> PluginResult<'db> {
     if module_ast.has_attr(db, DEPRECATED_CONTRACT_ATTR) {
@@ -124,7 +125,7 @@ pub(super) fn handle_module<'db>(
 
 /// Validates the contract/component module (has body with storage named 'Storage').
 fn validate_module<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     module_ast: ast::ItemModule<'db>,
     module_kind_str: &str,
 ) -> PluginResult<'db> {
@@ -168,7 +169,7 @@ fn validate_module<'db>(
 /// If the module is annotated with CONTRACT_ATTR or COMPONENT_ATTR, generate the relevant
 /// contract/component logic.
 pub(super) fn handle_module_by_storage<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     struct_ast: ast::ItemStruct<'db>,
     metadata: &MacroPluginMetadata<'_>,
 ) -> Option<PluginResult<'db>> {
@@ -241,7 +242,7 @@ pub(super) fn handle_module_by_storage<'db>(
 /// (contract/component) and its ast.
 fn grand_grand_parent_starknet_module<'db>(
     item_node: SyntaxNode<'db>,
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
 ) -> Option<(ast::ItemModule<'db>, StarknetModuleKind, ast::Attribute<'db>)> {
     // Get the containing module node. The parent is the item list, the grand parent is the module
     // body, and the grand grand parent is the module.

--- a/crates/cairo-lang-starknet/src/plugin/storage.rs
+++ b/crates/cairo-lang-starknet/src/plugin/storage.rs
@@ -1,10 +1,10 @@
 use cairo_lang_defs::patcher::RewriteNode;
 use cairo_lang_defs::plugin::{MacroPluginMetadata, PluginDiagnostic};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::node::helpers::{GetIdentifier, QueryAttrs};
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::formatdoc;
 use itertools::zip_eq;
+use salsa::Database;
 
 use super::starknet_module::generation_data::StarknetModuleCommonGenerationData;
 use super::starknet_module::{StarknetModuleKind, backwards_compatible_storage};
@@ -17,7 +17,7 @@ use crate::plugin::SUBSTORAGE_ATTR;
 
 /// Generate getters and setters for the members of the storage struct.
 pub fn handle_storage_struct<'db, 'a>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     struct_ast: ast::ItemStruct<'db>,
     starknet_module_kind: StarknetModuleKind,
@@ -143,7 +143,7 @@ pub fn handle_storage_struct<'db, 'a>(
 
 /// Returns the relevant code for a substorage storage member.
 fn get_substorage_member_code<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     member: &ast::Member<'db>,
     metadata: &MacroPluginMetadata<'_>,
 ) -> Option<(RewriteNode<'db>, RewriteNode<'db>)> {
@@ -215,7 +215,7 @@ struct SimpleMemberGeneratedCode<'db> {
 
 /// Returns the relevant code for a substorage storage member.
 fn get_simple_member_code<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     member: &ast::Member<'db>,
     config: &StorageMemberConfig,
     metadata: &MacroPluginMetadata<'_>,

--- a/crates/cairo-lang-starknet/src/plugin/storage_interfaces.rs
+++ b/crates/cairo-lang-starknet/src/plugin/storage_interfaces.rs
@@ -3,7 +3,6 @@ use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
 use cairo_lang_defs::plugin_utils::extract_single_unnamed_arg;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::CodeMapping;
 use cairo_lang_plugins::plugins::utils::GenericParamsInfo;
 use cairo_lang_syntax::attribute::structured::{
@@ -14,6 +13,7 @@ use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::formatdoc;
 use itertools::{Itertools, zip_eq};
+use salsa::Database;
 
 use super::starknet_module::backwards_compatible_storage;
 use super::utils::{has_derive, validate_v0};
@@ -62,7 +62,7 @@ pub struct StorageInterfacesPlugin;
 impl MacroPlugin for StorageInterfacesPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
@@ -182,7 +182,7 @@ enum StorageInterfaceType {
 
 /// Helper enum to generate the code snippets for the different types of storage interfaces.
 struct StorageInterfaceInfo<'db> {
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     node_type: StorageInterfaceType,
     is_mutable: bool,
 }
@@ -191,7 +191,7 @@ struct StorageInterfaceInfo<'db> {
 impl<'db> StorageInterfaceInfo<'db> {
     /// Initializes the storage node info from en enum AST. Only supports sub pointers.
     fn from_enum_ast(
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         enum_ast: &ast::ItemEnum<'db>,
         is_mutable: bool,
     ) -> Option<Self> {
@@ -440,7 +440,7 @@ impl<'db> StorageInterfaceInfo<'db> {
 
 /// Generate the code for a single interface type.
 fn handle_storage_interface_for_interface_type<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     struct_ast: &ast::ItemStruct<'db>,
     generics: &GenericParamsInfo<'db>,
     configs: &[StorageMemberConfig],
@@ -503,7 +503,7 @@ fn handle_storage_interface_for_interface_type<'db>(
 ///  - From the derive plugin of the `Store` trait which also generates a sub-pointers interface.
 ///  - From the contract storage plugin, which generates storage base trait.
 pub fn handle_storage_interface_struct<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     struct_ast: &ast::ItemStruct<'db>,
     configs: &[StorageMemberConfig],
     metadata: &MacroPluginMetadata<'_>,
@@ -540,7 +540,7 @@ pub fn handle_storage_interface_struct<'db>(
 
 /// Adds the storage interface enum and its constructor impl, for enums with sub-pointers.
 pub fn handle_storage_interface_enum<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     enum_ast: &ast::ItemEnum<'db>,
 ) -> (String, Vec<CodeMapping>) {
     let mut builder = PatchBuilder::new(db, enum_ast);
@@ -564,7 +564,7 @@ pub fn handle_storage_interface_enum<'db>(
 
 /// Generates the struct definition for the storage interface.
 fn add_interface_struct_definition<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     builder: &mut PatchBuilder<'db>,
     struct_ast: &ast::ItemStruct<'db>,
     params: RewriteNode<'db>,
@@ -630,7 +630,7 @@ fn add_interface_struct_definition<'db>(
 
 /// Generates the impl for the storage interface.
 fn add_interface_impl<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     builder: &mut PatchBuilder<'db>,
     struct_ast: &ast::ItemStruct<'db>,
     (args, params): (RewriteNode<'db>, RewriteNode<'db>),
@@ -700,7 +700,7 @@ fn add_interface_impl<'db>(
 
 /// Generates the enum definition for an enum with sub pointers.
 fn add_node_enum_definition<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     builder: &mut PatchBuilder<'db>,
     enum_ast: &ast::ItemEnum<'db>,
     args: RewriteNode<'db>,
@@ -743,7 +743,7 @@ fn add_node_enum_definition<'db>(
 
 /// Generates the impl for the storage node for an enum with sub pointers.
 fn add_node_enum_impl<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     builder: &mut PatchBuilder<'db>,
     enum_ast: &ast::ItemEnum<'db>,
     (args, params): (RewriteNode<'db>, RewriteNode<'db>),
@@ -831,7 +831,7 @@ pub enum StorageMemberKind {
 
 /// Gets the storage configuration for members of a struct.
 pub fn struct_members_storage_configs<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     struct_ast: &ast::ItemStruct<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) -> Vec<StorageMemberConfig> {
@@ -844,7 +844,7 @@ pub fn struct_members_storage_configs<'db>(
 
 /// Gets the storage configuration of a struct member.
 pub fn get_member_storage_config<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     member: &ast::Member<'db>,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) -> StorageMemberConfig {

--- a/crates/cairo-lang-starknet/src/plugin/test.rs
+++ b/crates/cairo-lang-starknet/src/plugin/test.rs
@@ -12,8 +12,9 @@ use cairo_lang_plugins::test_utils::expand_module_text;
 use cairo_lang_semantic::test_utils::setup_test_module;
 use cairo_lang_test_utils::parse_test_file::{TestFileRunner, TestRunnerResult};
 use cairo_lang_test_utils::{get_direct_or_file_content, verify_diagnostics_expectation};
+use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{Intern, Upcast};
+use salsa::AsDynDatabase;
 
 use crate::test_utils::{SHARED_DB, SHARED_DB_WITH_CONTRACTS};
 
@@ -51,13 +52,14 @@ impl TestFileRunner for ExpandContractTestRunner {
             let content = db.file_content(file_id).unwrap().long(&db).as_ref();
             let content_location =
                 DiagnosticLocation { file_id, span: TextSpan::from_str(content) };
-            let original_location = content_location.user_location(db.upcast());
+            let db = db.as_dyn_database();
+            let original_location = content_location.user_location(db);
             let origin = if content_location == original_location {
                 "".to_string()
             } else {
-                format!("{:?}\n", original_location.debug(db.upcast()))
+                format!("{:?}\n", original_location.debug(db))
             };
-            let file_name = file_id.file_name(&db);
+            let file_name = file_id.file_name(db);
             file_contents.push(format!("{origin}{file_name}:\n\n{content}"));
         }
 

--- a/crates/cairo-lang-starknet/src/plugin/utils.rs
+++ b/crates/cairo-lang-starknet/src/plugin/utils.rs
@@ -1,5 +1,4 @@
 use cairo_lang_defs::plugin::PluginDiagnostic;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::structured::{
     AttributeArg, AttributeArgVariant, AttributeStructurize,
 };
@@ -8,34 +7,35 @@ use cairo_lang_syntax::node::ast::{self, Attribute, Modifier, OptionTypeClause};
 use cairo_lang_syntax::node::helpers::{GetIdentifier, QueryAttrs, is_single_arg_attr};
 use cairo_lang_utils::{extract_matches, require, try_extract_matches};
 use itertools::Itertools;
+use salsa::Database;
 
 use super::consts::{CONSTRUCTOR_ATTR, EXTERNAL_ATTR, L1_HANDLER_ATTR};
 
 /// Helper trait for syntax queries on `ast::Param`.
 pub trait ParamEx<'db> {
     /// Checks if the parameter is defined as a ref parameter.
-    fn is_ref_param(&self, db: &'db dyn FilesGroup) -> bool;
+    fn is_ref_param(&self, db: &'db dyn Database) -> bool;
     /// Checks if the parameter is defined as a mutable parameter.
-    fn is_mut_param(&self, db: &'db dyn FilesGroup) -> bool;
+    fn is_mut_param(&self, db: &'db dyn Database) -> bool;
     /// Extracts the snapshot type if the parameter's type is a snapshot. Otherwise, returns None.
-    fn try_extract_snapshot(&self, db: &'db dyn FilesGroup) -> Option<ast::Expr<'db>>;
+    fn try_extract_snapshot(&self, db: &'db dyn Database) -> Option<ast::Expr<'db>>;
 }
 impl<'db> ParamEx<'db> for ast::Param<'db> {
-    fn is_ref_param(&self, db: &dyn FilesGroup) -> bool {
+    fn is_ref_param(&self, db: &dyn Database) -> bool {
         let param_modifiers = self.modifiers(db).elements(db).collect_array();
         // TODO(yuval): This works only if "ref" is the only modifier. If the expansion was at the
         // semantic level, we could just ask if it's a reference.
         matches!(param_modifiers, Some([Modifier::Ref(_)]))
     }
 
-    fn is_mut_param(&self, db: &dyn FilesGroup) -> bool {
+    fn is_mut_param(&self, db: &dyn Database) -> bool {
         let param_modifiers = self.modifiers(db).elements(db).collect_array();
         // TODO(yuval): This works only if "mut" is the only modifier. If the expansion was at the
         // semantic level, we could just ask if it's a reference.
         matches!(param_modifiers, Some([Modifier::Mut(_)]))
     }
 
-    fn try_extract_snapshot(&self, db: &'db dyn FilesGroup) -> Option<ast::Expr<'db>> {
+    fn try_extract_snapshot(&self, db: &'db dyn Database) -> Option<ast::Expr<'db>> {
         let unary = try_extract_matches!(
             extract_matches!(self.type_clause(db), OptionTypeClause::TypeClause).ty(db),
             ast::Expr::Unary
@@ -49,23 +49,23 @@ impl<'db> ParamEx<'db> for ast::Param<'db> {
 pub trait AstPathExtract {
     /// Returns true if `self` matches `identifier`.
     /// Does not resolve paths or type aliases.
-    fn is_identifier(&self, db: &dyn FilesGroup, identifier: &str) -> bool;
+    fn is_identifier(&self, db: &dyn Database, identifier: &str) -> bool;
     /// Returns true if `self` matches `$name$<$generic_arg$>`.
     /// Does not resolve paths, type aliases or named generics.
-    fn is_name_with_arg(&self, db: &dyn FilesGroup, name: &str, generic_arg: &str) -> bool;
+    fn is_name_with_arg(&self, db: &dyn Database, name: &str, generic_arg: &str) -> bool;
     /// Returns true if `self` is `felt252`.
     /// Does not resolve paths or type aliases.
-    fn is_felt252(&self, db: &dyn FilesGroup) -> bool {
+    fn is_felt252(&self, db: &dyn Database) -> bool {
         self.is_identifier(db, "felt252")
     }
     /// Returns true if `type_ast` matches `Span<felt252>`.
     /// Does not resolve paths, type aliases or named generics.
-    fn is_felt252_span(&self, db: &dyn FilesGroup) -> bool {
+    fn is_felt252_span(&self, db: &dyn Database) -> bool {
         self.is_name_with_arg(db, "Span", "felt252")
     }
 }
 impl<'db> AstPathExtract for ast::ExprPath<'db> {
-    fn is_identifier(&self, db: &dyn FilesGroup, identifier: &str) -> bool {
+    fn is_identifier(&self, db: &dyn Database, identifier: &str) -> bool {
         let segments = self.segments(db);
         let type_path_elements = segments.elements(db);
         let Some([ast::PathSegment::Simple(arg_segment)]) = type_path_elements.collect_array()
@@ -76,7 +76,7 @@ impl<'db> AstPathExtract for ast::ExprPath<'db> {
         arg_segment.identifier(db) == identifier
     }
 
-    fn is_name_with_arg(&self, db: &dyn FilesGroup, name: &str, generic_arg: &str) -> bool {
+    fn is_name_with_arg(&self, db: &dyn Database, name: &str, generic_arg: &str) -> bool {
         let segments = self.segments(db);
         let type_path_elements = segments.elements(db);
         let Some([ast::PathSegment::WithGenericArgs(path_segment_with_generics)]) =
@@ -101,7 +101,7 @@ impl<'db> AstPathExtract for ast::ExprPath<'db> {
     }
 }
 impl<'db> AstPathExtract for ast::Expr<'db> {
-    fn is_identifier(&self, db: &dyn FilesGroup, identifier: &str) -> bool {
+    fn is_identifier(&self, db: &dyn Database, identifier: &str) -> bool {
         if let ast::Expr::Path(type_path) = self {
             type_path.is_identifier(db, identifier)
         } else {
@@ -109,7 +109,7 @@ impl<'db> AstPathExtract for ast::Expr<'db> {
         }
     }
 
-    fn is_name_with_arg(&self, db: &dyn FilesGroup, name: &str, generic_arg: &str) -> bool {
+    fn is_name_with_arg(&self, db: &dyn Database, name: &str, generic_arg: &str) -> bool {
         if let ast::Expr::Path(type_path) = self {
             type_path.is_name_with_arg(db, name, generic_arg)
         } else {
@@ -121,10 +121,10 @@ impl<'db> AstPathExtract for ast::Expr<'db> {
 /// Helper trait for syntax queries on `ast::GenericParam`.
 pub trait GenericParamExtract<'db> {
     /// Returns the trait_path of the generic param if it is an impl.
-    fn trait_path(&self, db: &'db dyn FilesGroup) -> Option<ast::ExprPath<'db>>;
+    fn trait_path(&self, db: &'db dyn Database) -> Option<ast::ExprPath<'db>>;
     /// Returns true if `self` matches an impl of `$trait_name$<$generic_arg$>`.
     /// Does not resolve paths or type aliases.
-    fn is_impl_of(&self, db: &'db dyn FilesGroup, trait_name: &str, generic_arg: &str) -> bool {
+    fn is_impl_of(&self, db: &'db dyn Database, trait_name: &str, generic_arg: &str) -> bool {
         if let Some(path) = self.trait_path(db) {
             path.is_name_with_arg(db, trait_name, generic_arg)
         } else {
@@ -133,7 +133,7 @@ pub trait GenericParamExtract<'db> {
     }
 }
 impl<'db> GenericParamExtract<'db> for ast::GenericParam<'db> {
-    fn trait_path(&self, db: &'db dyn FilesGroup) -> Option<ast::ExprPath<'db>> {
+    fn trait_path(&self, db: &'db dyn Database) -> Option<ast::ExprPath<'db>> {
         match self {
             ast::GenericParam::Type(_) | ast::GenericParam::Const(_) => None,
             ast::GenericParam::ImplNamed(i) => Some(i.trait_path(db)),
@@ -156,7 +156,7 @@ pub fn maybe_strip_underscore(s: &str) -> &str {
 /// Checks if the given (possibly-attributed-)object is attributed with the given `attr_name`. Also
 /// validates that the attribute is v0.
 pub fn has_v0_attribute<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     object: &impl QueryAttrs<'db>,
     attr_name: &'db str,
@@ -167,7 +167,7 @@ pub fn has_v0_attribute<'db>(
 /// Checks if the given (possibly-attributed-)object is attributed with the given `attr_name`. Also
 /// validates that the attribute is v0, and adds a warning if supplied `deprecated` returns a value.
 pub fn has_v0_attribute_ex<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     object: &impl QueryAttrs<'db>,
     attr_name: &'db str,
@@ -185,7 +185,7 @@ pub fn has_v0_attribute_ex<'db>(
 
 /// Assuming the attribute is `name`, validates it's in the form "#[name(v0)]".
 pub fn validate_v0<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     attr: &Attribute<'db>,
     name: &str,
@@ -200,7 +200,7 @@ pub fn validate_v0<'db>(
 
 /// Forbids `#[external]`, `#[l1_handler]` and `#[constructor]` attributes in the given impl.
 pub fn forbid_attributes_in_impl<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     impl_item: &ast::ImplItem<'db>,
     embedded_impl_attr: &str,
@@ -212,7 +212,7 @@ pub fn forbid_attributes_in_impl<'db>(
 
 /// Forbids the given attribute in the given impl, assuming it's marked `embedded_impl_attr`.
 pub fn forbid_attribute_in_impl<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     impl_item: &ast::ImplItem<'db>,
     attr_name: &'db str,
@@ -232,7 +232,7 @@ pub fn forbid_attribute_in_impl<'db>(
 /// Returns true if the type has a derive attribute with the given type.
 pub fn has_derive<'db, T: QueryAttrs<'db>>(
     with_attrs: &T,
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     derived_type: &str,
 ) -> Option<ast::Arg<'db>> {
     with_attrs.query_attr(db, "derive").find_map(|attr| {

--- a/crates/cairo-lang-syntax/src/node/helpers.rs
+++ b/crates/cairo-lang-syntax/src/node/helpers.rs
@@ -1,4 +1,3 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use salsa::Database;
 
 use super::ast::{
@@ -265,7 +264,7 @@ impl<'a> GenericParamEx<'a> for ast::GenericParam<'a> {
 }
 
 /// Checks if the given attribute has a single argument with the given name.
-pub fn is_single_arg_attr(db: &dyn FilesGroup, attr: &Attribute<'_>, arg_name: &str) -> bool {
+pub fn is_single_arg_attr(db: &dyn Database, attr: &Attribute<'_>, arg_name: &str) -> bool {
     match attr.arguments(db) {
         OptionArgListParenthesized::ArgListParenthesized(args) => {
             matches!(&args.arguments(db).elements_vec(db)[..],
@@ -292,7 +291,7 @@ pub trait QueryAttrs<'a> {
     /// Collect all attributes named exactly `attr` attached to this node.
     fn query_attr(
         &self,
-        db: &'a dyn FilesGroup,
+        db: &'a dyn Database,
         attr: &'a str,
     ) -> impl Iterator<Item = Attribute<'a>> {
         self.attributes_elements(db)
@@ -300,22 +299,17 @@ pub trait QueryAttrs<'a> {
     }
 
     /// Find first attribute named exactly `attr` attached do this node.
-    fn find_attr(&self, db: &'a dyn FilesGroup, attr: &'a str) -> Option<Attribute<'a>> {
+    fn find_attr(&self, db: &'a dyn Database, attr: &'a str) -> Option<Attribute<'a>> {
         self.query_attr(db, attr).next()
     }
 
     /// Check if this node has an attribute named exactly `attr`.
-    fn has_attr(&self, db: &'a dyn FilesGroup, attr: &'a str) -> bool {
+    fn has_attr(&self, db: &'a dyn Database, attr: &'a str) -> bool {
         self.find_attr(db, attr).is_some()
     }
 
     /// Checks if the given object has an attribute with the given name and argument.
-    fn has_attr_with_arg(
-        &self,
-        db: &'a dyn FilesGroup,
-        attr_name: &'a str,
-        arg_name: &str,
-    ) -> bool {
+    fn has_attr_with_arg(&self, db: &'a dyn Database, attr_name: &'a str, arg_name: &str) -> bool {
         self.query_attr(db, attr_name).any(|attr| is_single_arg_attr(db, &attr, arg_name))
     }
 }

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -195,11 +195,7 @@ impl<'a> SyntaxNode<'a> {
     }
 
     /// Lookups a syntax node using a position.
-    pub fn lookup_position(
-        &self,
-        db: &'a dyn FilesGroup,
-        position: TextPosition,
-    ) -> SyntaxNode<'a> {
+    pub fn lookup_position(&self, db: &'a dyn Database, position: TextPosition) -> SyntaxNode<'a> {
         match position.offset_in_file(db, self.stable_ptr(db).file_id(db)) {
             Some(offset) => self.lookup_offset(db, offset),
             None => *self,
@@ -207,7 +203,7 @@ impl<'a> SyntaxNode<'a> {
     }
 
     /// Returns all the text under the syntax node.
-    pub fn get_text(&self, db: &'a dyn FilesGroup) -> &'a str {
+    pub fn get_text(&self, db: &'a dyn Database) -> &'a str {
         // A `None` return from reading the file content is only expected in the case of an IO
         // error. Since a SyntaxNode exists and is being processed, we should have already
         // successfully accessed this file earlier, therefore it should never fail.
@@ -289,7 +285,7 @@ impl<'a> SyntaxNode<'a> {
     /// of the first token and the trailing trivia of the last token).
     ///
     /// Note that this traverses the syntax tree, and generates a new string, so use responsibly.
-    pub fn get_text_without_trivia(self, db: &'a dyn FilesGroup) -> &'a str {
+    pub fn get_text_without_trivia(self, db: &'a dyn Database) -> &'a str {
         let file_content = db
             .file_content(self.stable_ptr(db).file_id(db))
             .expect("Failed to read file content")
@@ -303,7 +299,7 @@ impl<'a> SyntaxNode<'a> {
     /// `span` is assumed to be contained within the span of self.
     ///
     /// Note that this traverses the syntax tree, and generates a new string, so use responsibly.
-    pub fn get_text_of_span(self, db: &'a dyn FilesGroup, span: TextSpan) -> &'a str {
+    pub fn get_text_of_span(self, db: &'a dyn Database, span: TextSpan) -> &'a str {
         assert!(self.span(db).contains(span));
         let file_content = db
             .file_content(self.stable_ptr(db).file_id(db))

--- a/crates/cairo-lang-syntax/src/node/test_utils.rs
+++ b/crates/cairo-lang-syntax/src/node/test_utils.rs
@@ -1,4 +1,3 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_utils::Upcast;
 
 #[salsa::db]
@@ -9,8 +8,8 @@ pub struct DatabaseForTesting {
 #[salsa::db]
 impl salsa::Database for DatabaseForTesting {}
 
-impl<'a> Upcast<'a, dyn FilesGroup> for DatabaseForTesting {
-    fn upcast(&'a self) -> &'a dyn FilesGroup {
+impl<'a> Upcast<'a, dyn salsa::Database> for DatabaseForTesting {
+    fn upcast(&'a self) -> &'a dyn salsa::Database {
         self
     }
 }

--- a/crates/cairo-lang-syntax/src/node/with_db.rs
+++ b/crates/cairo-lang-syntax/src/node/with_db.rs
@@ -1,16 +1,16 @@
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::span::TextWidth;
 use cairo_lang_primitive_token::{PrimitiveSpan, PrimitiveToken, ToPrimitiveTokenStream};
+use salsa::Database;
 
 use super::SyntaxNode;
 
 pub struct SyntaxNodeWithDb<'a> {
     node: &'a SyntaxNode<'a>,
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
 }
 
 impl<'a> SyntaxNodeWithDb<'a> {
-    pub fn new(node: &'a SyntaxNode<'a>, db: &'a dyn FilesGroup) -> Self {
+    pub fn new(node: &'a SyntaxNode<'a>, db: &'a dyn Database) -> Self {
         Self { node, db }
     }
 }
@@ -31,11 +31,11 @@ pub struct SyntaxNodeWithDbIterator<'a> {
     /// **INVARIANT**: The collection to the buffer only happens when the buffer was previously
     /// empty.
     buffer: Vec<PrimitiveToken>,
-    db: &'a dyn FilesGroup,
+    db: &'a dyn Database,
 }
 
 impl<'a> SyntaxNodeWithDbIterator<'a> {
-    pub fn new(db: &'a dyn FilesGroup, node: &'a SyntaxNode<'a>) -> Self {
+    pub fn new(db: &'a dyn Database, node: &'a SyntaxNode<'a>) -> Self {
         Self { db, buffer: Vec::with_capacity(3), iter_stack: vec![node] }
     }
 }
@@ -81,7 +81,7 @@ impl<'a> Iterator for SyntaxNodeWithDbIterator<'a> {
 /// **INVARIANT**: `result` **MUST** be empty when passed to this function.
 fn token_from_syntax_node(
     node: &SyntaxNode<'_>,
-    db: &dyn FilesGroup,
+    db: &dyn Database,
     result: &mut Vec<PrimitiveToken>,
 ) {
     let span_without_trivia = node.span_without_trivia(db);

--- a/crates/cairo-lang-test-plugin/Cargo.toml
+++ b/crates/cairo-lang-test-plugin/Cargo.toml
@@ -25,5 +25,6 @@ indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
+salsa.workspace = true
 serde = { workspace = true, default-features = true }
 starknet-types-core.workspace = true

--- a/crates/cairo-lang-test-plugin/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-test-plugin/src/inline_macros/assert.rs
@@ -8,11 +8,11 @@ use cairo_lang_defs::plugin_utils::{
     unsupported_bracket_diagnostic,
 };
 use cairo_lang_filesystem::cfg::Cfg;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::ast::WrappedArgList;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::formatdoc;
+use salsa::Database;
 
 /// The type of value the comparison function expects to find.
 enum ArgType {
@@ -33,7 +33,7 @@ trait CompareAssertionPlugin: NamedPlugin {
 
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         syntax: &ast::ExprInlineMacro<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
@@ -226,7 +226,7 @@ macro_rules! define_compare_assert_macro {
         impl InlineMacroExprPlugin for $ident {
             fn generate_code<'db>(
                 &self,
-                db: &'db dyn FilesGroup,
+                db: &'db dyn Database,
                 syntax: &ast::ExprInlineMacro<'db>,
                 metadata: &MacroPluginMetadata<'_>,
             ) -> InlinePluginResult<'db> {

--- a/crates/cairo-lang-test-plugin/src/plugin.rs
+++ b/crates/cairo-lang-test-plugin/src/plugin.rs
@@ -1,7 +1,7 @@
 use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginResult};
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::structured::AttributeListStructurize;
 use cairo_lang_syntax::node::ast;
+use salsa::Database;
 
 use super::{AVAILABLE_GAS_ATTR, IGNORE_ATTR, SHOULD_PANIC_ATTR, TEST_ATTR};
 use crate::test_config::try_extract_test_config;
@@ -14,7 +14,7 @@ pub struct TestPlugin;
 impl MacroPlugin for TestPlugin {
     fn generate_code<'db>(
         &self,
-        db: &'db dyn FilesGroup,
+        db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {

--- a/crates/cairo-lang-test-plugin/src/test_config.rs
+++ b/crates/cairo-lang-test-plugin/src/test_config.rs
@@ -1,5 +1,4 @@
 use cairo_lang_defs::plugin::PluginDiagnostic;
-use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_syntax::attribute::structured::{Attribute, AttributeArg, AttributeArgVariant};
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::byte_array::{BYTE_ARRAY_MAGIC, BYTES_IN_WORD};
@@ -7,6 +6,7 @@ use cairo_lang_utils::{OptionHelper, require};
 use itertools::chain;
 use num_bigint::{BigInt, Sign};
 use num_traits::ToPrimitive;
+use salsa::Database;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt as Felt252;
 
@@ -44,7 +44,7 @@ pub struct TestConfig {
 /// Extracts the configuration of a tests from attributes, or returns the diagnostics if the
 /// attributes are set illegally.
 pub fn try_extract_test_config<'db>(
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     attrs: Vec<Attribute<'db>>,
 ) -> Result<Option<TestConfig>, Vec<PluginDiagnostic<'db>>> {
     let test_attr = attrs.iter().find(|attr| attr.id == TEST_ATTR);
@@ -125,7 +125,7 @@ pub fn try_extract_test_config<'db>(
 /// Returns `None` if the attribute is "static", or the attribute is malformed.
 fn extract_available_gas<'db>(
     available_gas_attr: Option<&Attribute<'db>>,
-    db: &'db dyn FilesGroup,
+    db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) -> Option<usize> {
     let Some(attr) = available_gas_attr else {
@@ -160,7 +160,7 @@ fn extract_available_gas<'db>(
 
 /// Tries to extract the expected panic bytes out of the given `should_panic` attribute.
 /// Assumes the attribute is `should_panic`.
-fn extract_panic_bytes(db: &dyn FilesGroup, attr: &Attribute<'_>) -> Option<Vec<Felt252>> {
+fn extract_panic_bytes(db: &dyn Database, attr: &Attribute<'_>) -> Option<Vec<Felt252>> {
     let [AttributeArg { variant: AttributeArgVariant::Named { name, value, .. }, .. }] =
         &attr.args[..]
     else {
@@ -201,7 +201,7 @@ fn extract_panic_bytes(db: &dyn FilesGroup, attr: &Attribute<'_>) -> Option<Vec<
 /// Extracts panic bytes from a string.
 fn extract_string_panic_bytes(
     panic_string: &ast::TerminalString<'_>,
-    db: &dyn FilesGroup,
+    db: &dyn Database,
 ) -> Vec<Felt252> {
     let panic_string = panic_string.string_value(db).unwrap();
     let chunks = panic_string.as_bytes().chunks_exact(BYTES_IN_WORD);

--- a/tests/examples_test.rs
+++ b/tests/examples_test.rs
@@ -6,7 +6,7 @@ use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::setup_project;
 use cairo_lang_defs::db::DefsGroup;
-use cairo_lang_filesystem::db::FilesGroupEx;
+use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::flag::Flag;
 use cairo_lang_filesystem::ids::{CrateInput, FlagLongId};
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;


### PR DESCRIPTION
# Refactor FilesGroup to remove QueryGroup and use salsa::Database directly

### TL;DR

Refactors the `FilesGroup` trait to use `salsa::Database` directly, eliminating an unnecessary abstraction layer.

### What changed?

- Removed the `#[cairo_lang_proc_macros::query_group]` macro from `FilesGroup` trait
- Changed `FilesGroup` to be implemented for any type that implements `salsa::Database`
- Updated function signatures to accept `&dyn Database` instead of `&dyn FilesGroup`
- Modified `Upcast` implementations to upcast to `&dyn salsa::Database` instead of `&dyn FilesGroup`
- Converted query group functions to standalone tracked functions
- Updated all code that previously used `FilesGroup` to use `Database` directly
