### PR TITLE
Move DefsGroup input out of querygroup trait

### DIFF
--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -13,9 +13,9 @@ use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, Upcast, extract_matches, try_extract_matches};
 use indoc::indoc;
-use salsa::Database;
+use salsa::{Database, Setter};
 
-use crate::db::{DefsGroup, init_defs_group, init_external_files};
+use crate::db::{DefsGroup, defs_group_input, init_defs_group, init_external_files};
 use crate::ids::{
     FileIndex, GenericParamLongId, MacroPluginLongId, ModuleFileId, ModuleId, ModuleItemId,
     NamedLanguageElementId, SubmoduleLongId,
@@ -38,7 +38,7 @@ impl Default for DatabaseForTesting {
         init_external_files(&mut res);
         init_files_group(&mut res);
         init_defs_group(&mut res);
-        res.set_default_macro_plugins_input(Arc::new([
+        defs_group_input(&res).set_default_macro_plugins(&mut res).to(Some(vec![
             MacroPluginLongId(Arc::new(FooToBarPlugin)),
             MacroPluginLongId(Arc::new(RemoveOrigPlugin)),
             MacroPluginLongId(Arc::new(DummyPlugin)),

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use cairo_lang_defs::db::{DefsGroup, DefsGroupEx};
+use cairo_lang_defs::db::{DefsGroup, DefsGroupEx, defs_group_input};
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::{
     ConstantId, EnumId, ExternFunctionId, ExternTypeId, FreeFunctionId, FunctionTitleId,
@@ -21,6 +21,7 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::{Intern, Upcast, require};
 use itertools::Itertools;
+use salsa::Setter;
 
 use crate::corelib::CoreInfo;
 use crate::diagnostic::SemanticDiagnosticKind;
@@ -2362,20 +2363,21 @@ pub trait PluginSuiteInput: SemanticGroup {
         let PluginSuite { plugins, inline_macro_plugins, analyzer_plugins } = suite;
         // let interned = self.intern_plugin_suite(suite);
 
-        let macro_plugins = plugins.into_iter().map(MacroPluginLongId).collect::<Arc<[_]>>();
+        let macro_plugins = plugins.into_iter().map(MacroPluginLongId).collect_vec();
 
-        let inline_macro_plugins = Arc::new(
-            inline_macro_plugins
-                .into_iter()
-                .map(|(name, plugin)| (name, InlineMacroExprPluginLongId(plugin)))
-                .collect::<OrderedHashMap<_, _>>(),
-        );
+        let inline_macro_plugins = inline_macro_plugins
+            .into_iter()
+            .map(|(name, plugin)| (name, InlineMacroExprPluginLongId(plugin)))
+            .collect::<OrderedHashMap<_, _>>();
 
         let analyzer_plugins =
             analyzer_plugins.into_iter().map(AnalyzerPluginLongId).collect::<Arc<[_]>>();
 
-        self.set_default_macro_plugins_input(macro_plugins);
-        self.set_default_inline_macro_plugins_input(inline_macro_plugins);
+        let db_ref = self.as_dyn_database_mut();
+        defs_group_input(db_ref).set_default_macro_plugins(db_ref).to(Some(macro_plugins));
+        defs_group_input(db_ref)
+            .set_default_inline_macro_plugins(db_ref)
+            .to(Some(inline_macro_plugins));
         self.set_default_analyzer_plugins_input(analyzer_plugins);
     }
 

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cairo_lang_defs::db::DefsGroup;
+use cairo_lang_defs::db::{DefsGroup, defs_group_input};
 use cairo_lang_defs::ids::{GenericTypeId, MacroPluginLongId, ModuleId, TopLevelLanguageElementId};
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
@@ -10,7 +10,7 @@ use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{TypedStablePtr, ast};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
-use salsa::Database;
+use salsa::{Database, Setter};
 use test_log::test;
 
 use crate::db::SemanticGroup;
@@ -144,9 +144,9 @@ impl MacroPlugin for AddInlineModuleDummyPlugin {
 fn test_inline_module_diagnostics() {
     let mut db_val = SemanticDatabaseForTesting::new_empty();
     let db = &mut db_val;
-    db.set_default_macro_plugins_input(Arc::new([MacroPluginLongId(Arc::new(
-        AddInlineModuleDummyPlugin,
-    ))]));
+    defs_group_input(db)
+        .set_default_macro_plugins(db)
+        .to(Some(vec![MacroPluginLongId(Arc::new(AddInlineModuleDummyPlugin))]));
     let crate_id = setup_test_crate(
         db,
         indoc! {"


### PR DESCRIPTION
# Refactor DefsGroup inputs to use a single salsa input struct

### TL;DR

Refactored the DefsGroup inputs to use a single salsa input struct instead of multiple individual query inputs, improving the API and making it more maintainable (to eventually remove query group from defsgroup).

### What changed?

- Created a new `DefsGroupInput` struct that contains all the input fields previously defined as separate salsa input queries
- Added a `defs_group_input` tracked function to access the inputs
- Converted individual input functions to be transparent queries that access the fields from the input struct
- Updated all callers to use the new API for setting inputs

