### PR TITLE
chore: fix typo in code comment

### DIFF
--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -285,7 +285,7 @@ pub enum ResolutionContext<'a, 'mt> {
     Statement(&'mt mut Environment<'a>),
 }
 
-/// The result of resolveing an item using `use *` imports.
+/// The result of resolving an item using `use *` imports.
 enum UseStarResult<'db> {
     /// A unique path was found, considering only the `use *` imports.
     UniquePathFound(ModuleItemInfo<'db>),


### PR DESCRIPTION
fixed typo 'resolveing' -> 'resolve'