### PR TITLE
Set `revisions = usize::MAX` for all interned values

### DIFF
--- a/crates/cairo-lang-debug/src/debug_test.rs
+++ b/crates/cairo-lang-debug/src/debug_test.rs
@@ -11,7 +11,7 @@ trait TestGroup: salsa::Database {}
 impl TestGroup for DummyDb {}
 
 // Structs.
-#[salsa::interned]
+#[salsa::interned(revisions = usize::MAX)]
 struct Dummy {
     id: usize,
 }

--- a/crates/cairo-lang-proc-macros/tests/fileid_new.rs
+++ b/crates/cairo-lang-proc-macros/tests/fileid_new.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use cairo_lang_proc_macros::query_group;
 use logger_db::LoggerDb;
 
-#[salsa::interned(no_lifetime)]
+#[salsa::interned(no_lifetime, revisions = usize::MAX)]
 pub struct LongFile {
     data: u32,
 }
@@ -30,7 +30,7 @@ pub struct LongFile {
 //     }
 // }
 
-#[salsa::interned]
+#[salsa::interned(revisions = usize::MAX)]
 pub struct I {
     val: u32,
 }
@@ -42,7 +42,7 @@ pub trait B: salsa::Database {
 
     fn inner_val(&self, id: LongFile) -> u32;
 
-    #[salsa::interned]
+    #[salsa::interned(revisions = usize::MAX)]
     fn create_file_id(&self, val: u32) -> LongFile;
 
     fn do_something<'db>(&self, i: I<'db>) -> u32;

--- a/crates/cairo-lang-proc-macros/tests/interned.rs
+++ b/crates/cairo-lang-proc-macros/tests/interned.rs
@@ -4,14 +4,14 @@ use expect_test::expect;
 mod logger_db;
 use logger_db::LoggerDb;
 
-#[salsa::interned(no_lifetime)]
+#[salsa::interned(no_lifetime, revisions = usize::MAX)]
 pub struct InternedString {
     data: String,
 }
 
 #[query_group]
 pub trait InternedDB: salsa::Database {
-    #[salsa::interned]
+    #[salsa::interned(revisions = usize::MAX)]
     fn intern_string(&self, data: String) -> InternedString;
 
     fn interned_len(&self, id: InternedString) -> usize;

--- a/crates/cairo-lang-proc-macros/tests/interned_with_defaults.rs
+++ b/crates/cairo-lang-proc-macros/tests/interned_with_defaults.rs
@@ -3,7 +3,7 @@ use expect_test::expect;
 mod logger_db;
 use logger_db::LoggerDb;
 
-#[salsa::interned(no_lifetime)]
+#[salsa::interned(no_lifetime, revisions = usize::MAX)]
 pub struct InternedWithDefaults {
     data: String,
     debug: Option<String>,
@@ -11,7 +11,7 @@ pub struct InternedWithDefaults {
 
 #[cairo_lang_proc_macros::query_group]
 pub trait InternedWithDefaultsDB: salsa::Database {
-    #[salsa::interned]
+    #[salsa::interned(revisions = usize::MAX)]
     #[default_values(debug=None)]
     fn intern_with_defaults(&self, data: String) -> InternedWithDefaults;
 

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -87,7 +87,7 @@ pub trait Elongate {
 // This prevents cycles where there shouldn't be any.
 #[cairo_lang_proc_macros::query_group]
 pub trait SemanticGroup: Database + for<'db> Upcast<'db, dyn salsa::Database> + Elongate {
-    #[salsa::interned]
+    #[salsa::interned(revisions = usize::MAX)]
     fn intern_impl_lookup_context<'db>(
         &'db self,
         id: items::imp::ImplLookupContext<'db>,

--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -31,17 +31,17 @@ pub enum SierraGeneratorTypeLongId<'db> {
     Phantom(semantic::TypeId<'db>),
 }
 
-#[salsa::interned]
+#[salsa::interned(revisions = usize::MAX)]
 struct ConcreteLibfuncIdLongWrapper {
     id: cairo_lang_sierra::program::ConcreteLibfuncLongId,
 }
 
-#[salsa::interned]
+#[salsa::interned(revisions = usize::MAX)]
 struct SierraGeneratorTypeLongIdWrapper<'db> {
     id: SierraGeneratorTypeLongId<'db>,
 }
 
-#[salsa::interned]
+#[salsa::interned(revisions = usize::MAX)]
 struct LoweringFunctionIdWrapper<'db> {
     id: lowering::ids::FunctionId<'db>,
 }

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -105,7 +105,7 @@ pub trait Intern<'db, Target> {
 macro_rules! define_short_id {
     ($short_id:ident, $long_id:path, $db:ident) => {
         // 1. Modern interned struct.
-        #[salsa::interned]
+        #[salsa::interned(revisions = usize::MAX)]
         pub struct $short_id<'db> {
             #[returns(ref)]
             pub long: $long_id,


### PR DESCRIPTION
Fix for `cairo-lint`, discussed on slack