### PR TITLE
Wrap feature config restoral

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -775,7 +775,7 @@ fn compute_tail_semantic<'db>(
     };
 
     // Pop the statement's attributes from the context.
-    ctx.resolver.data.feature_config.restore(feature_restore);
+    ctx.resolver.restore_feature_config(feature_restore);
     res
 }
 
@@ -4475,7 +4475,7 @@ pub fn compute_and_append_statement_semantic<'db>(
         }
         ast::Statement::Missing(_) => todo!(),
     };
-    ctx.resolver.data.feature_config.restore(feature_restore);
+    ctx.resolver.restore_feature_config(feature_restore);
     Ok(())
 }
 /// Adds an item to the statement environment and reports a diagnostic if the item is already

--- a/crates/cairo-lang-semantic/src/items/enm.rs
+++ b/crates/cairo-lang-semantic/src/items/enm.rs
@@ -226,7 +226,7 @@ pub fn priv_enum_definition_data<'db>(
                 .report(variant.stable_ptr(db), EnumVariantRedefinition { enum_id, variant_name });
         }
         variant_semantic.insert(id, Variant { enum_id, id, ty, idx: variant_idx });
-        resolver.data.feature_config.restore(feature_restore);
+        resolver.restore_feature_config(feature_restore);
     }
 
     // Check fully resolved.

--- a/crates/cairo-lang-semantic/src/items/structure.rs
+++ b/crates/cairo-lang-semantic/src/items/structure.rs
@@ -200,7 +200,7 @@ pub fn priv_struct_definition_data<'db>(
             diagnostics
                 .report(member.stable_ptr(db), StructMemberRedefinition { struct_id, member_name });
         }
-        resolver.data.feature_config.restore(feature_restore);
+        resolver.restore_feature_config(feature_restore);
     }
 
     // Check fully resolved.

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -302,6 +302,7 @@ impl<'db> Resolver<'db> {
 
     /// Extends the current feature config with the contents of those extracted from the given item,
     /// returns the original feature config for restoring it later.
+    /// IMPORTANT: don't forget to call `restore_feature_config`!
     pub fn extend_feature_config_from_item(
         &mut self,
         db: &'db dyn SemanticGroup,
@@ -315,6 +316,12 @@ impl<'db> Resolver<'db> {
             item,
             diagnostics,
         ))
+    }
+
+    /// Restores the feature config to its state before [Self::extend_feature_config_from_item],
+    /// using the restoration state returned by that method.
+    pub fn restore_feature_config(&mut self, restore: FeatureConfigRestore<'db>) {
+        self.data.feature_config.restore(restore);
     }
 }
 


### PR DESCRIPTION
Mainly for symmetry with `extend_feature_config_from_item` in the resolver interface.