### PR TITLE
fix: correct typos and wording in cairo-lang-lowering

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1644,7 +1644,7 @@ fn call_loop_func_ex<'db>(
                 return Ok(var);
             }
 
-            // TODO(TomerStaskware): make sure this is unreachable and remove
+            // TODO(TomerStarkware): make sure this is unreachable and remove
             // `MemberPathLoop` diagnostic.
             Err(LoweringFlowError::Failed(
                 ctx.diagnostics.report(param.stable_ptr(), MemberPathLoop),

--- a/crates/cairo-lang-lowering/src/optimizations/gas_redeposit.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/gas_redeposit.rs
@@ -160,7 +160,7 @@ impl<'db> Analyzer<'db, '_> for GasRedepositContext<'db> {
     fn info_from_return(&mut self, _: StatementLocation, vars: &[VarUsage<'db>]) -> Self::Info {
         // If the function has multiple returns with different gas costs, gas will get burned unless
         // we redeposit it.
-        // If however the this return corresponds to a panic, we dont redeposit due to code size
+        // If however, this return corresponds to a panic, we don't redeposit due to code size
         // concerns.
         match vars.last() {
             Some(VarUsage { var_id, location: _ }) => RedepositState::Return(*var_id),


### PR DESCRIPTION
- mod.rs: fixed author tag typo "TomerStaskware" → "TomerStarkware"
- gas_redeposit.rs: improved comment grammar  
  - "the this return" → "this return"  
  - "dont redeposit" → "don't redeposit"