### PR TITLE
feat(semantic): support allow(unused_variables)

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1401,6 +1401,7 @@ fn lower_expr_loop<'db>(
                 ty: semantic_db.concrete_function_signature(into_iter).unwrap().return_type,
                 is_mut: true,
                 id: extract_matches!(into_iter_member_path.base_var(), VarId::Local),
+                allow_unused: true, // Synthetic variables should never generate unused warnings.
             };
             builder.put_semantic(into_iter_member_path.base_var(), into_iter_var.var_id);
 

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/allow
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/allow
@@ -24,3 +24,50 @@ warning: `allow` attribute argument not supported.
  --> lib.cairo:6:8
 #[allow(invalid_lint)] // Invalid allow arg.
        ^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test allow(unused_variables)
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: true)
+
+//! > expr_code
+{
+}
+
+//! > module_code
+fn without_allow() {
+    let warn_without_allow = 1;
+}
+
+#[allow(unused_variables)]
+fn allow_on_function() {
+    let function_allows_x = 2;
+    let function_allows_y = 3;
+}
+
+fn with_underscore() {
+    let _undescroe_no_warn = 4;
+}
+
+fn allow_on_statements() {
+    #[allow(unused_variables)]
+    let unused_works_on_statements = 5;
+    let warn_since_allow_only_on_prev_statement = 6;
+}
+
+//! > generated_cairo_code
+
+//! > function_body
+
+//! > expected_diagnostics
+warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:2:9
+    let warn_without_allow = 1;
+        ^^^^^^^^^^^^^^^^^^
+
+warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:18:9
+    let warn_since_allow_only_on_prev_statement = 6;
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -71,7 +71,7 @@ use crate::items::constant::{
     ConstValue, ConstValueId, resolve_const_expr_and_evaluate, validate_const_expr,
 };
 use crate::items::enm::SemanticEnumEx;
-use crate::items::feature_kind::FeatureConfigRestore;
+use crate::items::feature_kind::{FeatureConfig, FeatureConfigRestore};
 use crate::items::functions::{concrete_function_closure_params, function_signature_params};
 use crate::items::imp::{
     DerefInfo, ImplLookupContextId, filter_candidate_traits, infer_impl_by_self,
@@ -338,6 +338,7 @@ impl<'ctx, 'mt> ComputationContext<'ctx, 'mt> {
                         &parent.used_variables,
                         &name,
                         &old_var,
+                        &self.resolver.data.feature_config,
                     );
                 }
                 if let Some(parent_macro_info) = parent.macro_info.as_mut() {
@@ -352,6 +353,7 @@ impl<'ctx, 'mt> ComputationContext<'ctx, 'mt> {
                 &closed.used_variables,
                 &name,
                 &binding,
+                &self.resolver.data.feature_config,
             );
         }
         // Adds warning for unused items if required.
@@ -440,6 +442,7 @@ fn add_unused_binding_warning<'db>(
     used_bindings: &UnorderedHashSet<VarId<'db>>,
     name: &str,
     binding: &Binding<'db>,
+    ctx_feature_config: &FeatureConfig<'db>,
 ) {
     if !name.starts_with('_') && !used_bindings.contains(&binding.id()) {
         match binding {
@@ -451,8 +454,15 @@ fn add_unused_binding_warning<'db>(
                     diagnostics.report(binding.stable_ptr(db), UnusedUse);
                 }
             },
-            Binding::LocalVar(_) | Binding::Param(_) => {
-                diagnostics.report(binding.stable_ptr(db), UnusedVariable);
+            Binding::LocalVar(local_var) => {
+                if !local_var.allow_unused && !ctx_feature_config.allow_unused_variables {
+                    diagnostics.report(binding.stable_ptr(db), UnusedVariable);
+                }
+            }
+            Binding::Param(_) => {
+                if !ctx_feature_config.allow_unused_variables {
+                    diagnostics.report(binding.stable_ptr(db), UnusedVariable);
+                }
             }
         }
     }
@@ -3124,9 +3134,10 @@ fn create_variable_pattern<'db>(
             false
         }
     };
+    let allow_unused = ctx.resolver.data.feature_config.allow_unused_variables;
     Pattern::Variable(PatternVariable {
         name: identifier.text(db).into(),
-        var: LocalVariable { id: var_id, ty, is_mut },
+        var: LocalVariable { id: var_id, ty, is_mut, allow_unused },
         stable_ptr,
     })
 }
@@ -4233,6 +4244,7 @@ pub fn compute_and_append_statement_semantic<'db>(
                         &ctx.environment.used_variables,
                         &v.name,
                         &old_var,
+                        &ctx.resolver.data.feature_config,
                     );
                 }
                 if ctx.macro_defined_var_unhygienic

--- a/crates/cairo-lang-semantic/src/semantic.rs
+++ b/crates/cairo-lang-semantic/src/semantic.rs
@@ -35,6 +35,8 @@ pub struct LocalVariable<'db> {
     pub ty: TypeId<'db>,
     #[dont_rewrite]
     pub is_mut: bool,
+    #[dont_rewrite]
+    pub allow_unused: bool,
 }
 impl<'db> LocalVariable<'db> {
     pub fn stable_ptr(&self, db: &'db dyn Database) -> ast::TerminalIdentifierPtr<'db> {


### PR DESCRIPTION
For statements, we cache the attribute on the semantic binding itself, to
avoid extra lookups later on (unused are checked only at the end of the scope).
For all other unused checks, the current mechanism that checks the context's feature_config
suffices.

Note 1: if/when we support log levels, replace bool with enum.
Note 2: unused consts, and any other unused definition will be similar: if the unused check is
deferred, like in unused variables, we save it on the binding, otherwise feature_config.