### PR TITLE
fix: add missing shebang to release_crates.sh script

### DIFF
--- a/scripts/release_crates.sh
+++ b/scripts/release_crates.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # An optional argument, '-s | --skip-first <#num_to_skip>', can be passed to skip the first #num_to_skip crates, otherwise SKIP_FIRST is set to 0.
 if [ "$1" = "-s" ] || [ "$1" = "--skip-first" ]; then
     if [ -z "$2" ]; then


### PR DESCRIPTION
Add missing shebang line to scripts/release_crates.sh to ensure  proper execution across different environments. This brings the  script in line with other scripts in the repository that already  have proper shebang declarations