### PR TITLE
Using the tracing library for logging to get finegrained tracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           - test --profile=ci-dev -p cairo-lang-test-plugin
           - test --profile=ci-dev -p cairo-lang-test-runner
           - test --profile=ci-dev -p cairo-lang-test-utils
-          - test --profile=ci-dev -p cairo-lang-utils --features=serde,parity-scale-codec,schemars,testing,env_logger
+          - test --profile=ci-dev -p cairo-lang-utils --features=serde,parity-scale-codec,schemars,testing,tracing
           - test --profile=ci-dev -p cairo-lang-utils --no-default-features --features=serde,parity-scale-codec
           - test --profile=ci-dev -p tests
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "cairo-lang-utils",
  "clap",
  "log",
+ "tracing",
 ]
 
 [[package]]
@@ -469,6 +470,7 @@ dependencies = [
  "colored",
  "ignore",
  "log",
+ "tracing",
 ]
 
 [[package]]
@@ -476,7 +478,6 @@ name = "cairo-lang-casm"
 version = "2.12.0"
 dependencies = [
  "cairo-lang-utils",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "num-bigint",
@@ -487,6 +488,7 @@ dependencies = [
  "serde",
  "test-case",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -520,10 +522,10 @@ version = "2.12.0"
 dependencies = [
  "cairo-lang-proc-macros",
  "cairo-lang-utils",
- "env_logger",
  "id-arena",
  "salsa",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -538,7 +540,6 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "pretty_assertions",
@@ -546,6 +547,7 @@ dependencies = [
  "serde",
  "smol_str",
  "test-log",
+ "tracing",
  "typetag",
  "xxhash-rust",
 ]
@@ -557,12 +559,12 @@ dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
  "cairo-lang-utils",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "pretty_assertions",
  "salsa",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -586,6 +588,7 @@ dependencies = [
  "pulldown-cmark",
  "salsa",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -593,9 +596,9 @@ name = "cairo-lang-eq-solver"
 version = "2.12.0"
 dependencies = [
  "cairo-lang-utils",
- "env_logger",
  "good_lp",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -633,11 +636,11 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "salsa",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -660,7 +663,6 @@ version = "2.12.0"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
- "env_logger",
  "path-clean",
  "salsa",
  "semver",
@@ -669,6 +671,7 @@ dependencies = [
  "smol_str",
  "test-log",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -707,7 +710,6 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "id-arena",
  "indent",
  "indoc",
@@ -720,6 +722,7 @@ dependencies = [
  "salsa",
  "serde",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -735,7 +738,6 @@ dependencies = [
  "cairo-lang-test-utils",
  "cairo-lang-utils",
  "colored",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "num-bigint",
@@ -743,6 +745,7 @@ dependencies = [
  "pretty_assertions",
  "salsa",
  "test-log",
+ "tracing",
  "unescaper",
 ]
 
@@ -758,13 +761,13 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "indent",
  "indoc",
  "itertools 0.14.0",
  "salsa",
  "serde_json",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -835,7 +838,6 @@ dependencies = [
  "cairo-lang-utils",
  "cairo-vm",
  "clap",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "keccak",
@@ -849,6 +851,7 @@ dependencies = [
  "test-case",
  "test-log",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -865,7 +868,6 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "id-arena",
  "indoc",
  "itertools 0.14.0",
@@ -877,6 +879,7 @@ dependencies = [
  "sha3",
  "test-log",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -890,7 +893,6 @@ dependencies = [
  "const-fnv1a-hash",
  "convert_case",
  "derivative",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "lalrpop",
@@ -908,6 +910,7 @@ dependencies = [
  "test-case",
  "test-log",
  "thiserror",
+ "tracing",
  "vector-map",
 ]
 
@@ -919,11 +922,11 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
- "env_logger",
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -935,7 +938,6 @@ dependencies = [
  "cairo-lang-sierra-type-size",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "num-bigint",
@@ -944,6 +946,7 @@ dependencies = [
  "test-case",
  "test-log",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -962,7 +965,6 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "log",
@@ -974,6 +976,7 @@ dependencies = [
  "smol_str",
  "test-case",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -988,7 +991,6 @@ dependencies = [
  "cairo-lang-sierra-type-size",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "num-bigint",
@@ -998,6 +1000,7 @@ dependencies = [
  "test-case",
  "test-log",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1029,7 +1032,6 @@ dependencies = [
  "cairo-lang-test-utils",
  "cairo-lang-utils",
  "const_format",
- "env_logger",
  "indent",
  "indoc",
  "itertools 0.14.0",
@@ -1041,6 +1043,7 @@ dependencies = [
  "test-case",
  "test-log",
  "thiserror",
+ "tracing",
  "typetag",
 ]
 
@@ -1056,7 +1059,6 @@ dependencies = [
  "cairo-lang-test-utils",
  "cairo-lang-utils",
  "convert_case",
- "env_logger",
  "indoc",
  "itertools 0.14.0",
  "num-bigint",
@@ -1071,6 +1073,7 @@ dependencies = [
  "test-case",
  "test-log",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1081,13 +1084,13 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-primitive-token",
  "cairo-lang-utils",
- "env_logger",
  "num-bigint",
  "num-traits",
  "pretty_assertions",
  "salsa",
  "serde",
  "test-log",
+ "tracing",
  "unescaper",
 ]
 
@@ -1095,9 +1098,9 @@ dependencies = [
 name = "cairo-lang-syntax-codegen"
 version = "2.12.0"
 dependencies = [
- "env_logger",
  "genco",
  "test-log",
+ "tracing",
  "xshell",
 ]
 
@@ -1158,21 +1161,19 @@ dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
  "colored",
- "env_logger",
  "log",
  "pretty_assertions",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
 name = "cairo-lang-utils"
 version = "2.12.0"
 dependencies = [
- "env_logger",
  "hashbrown",
  "indexmap",
  "itertools 0.14.0",
- "log",
  "num-bigint",
  "num-traits",
  "parity-scale-codec",
@@ -1183,7 +1184,9 @@ dependencies = [
  "smol_str",
  "test-case",
  "test-log",
- "time",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1521,7 +1524,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
 dependencies = [
- "nu-ansi-term 0.50.1",
+ "nu-ansi-term",
 ]
 
 [[package]]
@@ -1618,29 +1621,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -1851,6 +1831,7 @@ dependencies = [
  "cairo-lang-syntax-codegen",
  "cairo-lang-utils",
  "log",
+ "tracing",
 ]
 
 [[package]]
@@ -1936,8 +1917,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.10",
- "regex-syntax 0.8.6",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2254,7 +2235,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.10",
+ "regex-automata",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -2383,30 +2364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2396,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax 0.8.6",
+ "regex-syntax",
  "sha3",
  "string_cache",
  "term",
@@ -2453,7 +2410,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
- "regex-automata 0.4.10",
+ "regex-automata",
  "rustversion",
 ]
 
@@ -2533,11 +2490,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2657,16 +2614,6 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
-name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
@@ -2747,15 +2694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,12 +2767,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "papaya"
@@ -3199,17 +3131,8 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.10",
- "regex-syntax 0.8.6",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3220,14 +3143,8 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.6",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3670,6 +3587,7 @@ dependencies = [
  "clap",
  "indoc",
  "log",
+ "tracing",
 ]
 
 [[package]]
@@ -3994,7 +3912,6 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
 dependencies = [
- "env_logger",
  "test-log-macros",
  "tracing-subscriber",
 ]
@@ -4033,7 +3950,6 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
- "env_logger",
  "itertools 0.14.0",
  "log",
  "num-bigint",
@@ -4042,6 +3958,7 @@ dependencies = [
  "salsa",
  "starknet-types-core",
  "test-log",
+ "tracing",
 ]
 
 [[package]]
@@ -4087,9 +4004,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4294,7 +4209,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4320,16 +4247,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
- "nu-ansi-term 0.46.0",
+ "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4617,22 +4546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4640,12 +4553,6 @@ checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,12 +86,12 @@ members = [
 exclude = ["ensure-no_std"]
 
 [workspace.package]
-version = "2.12.0"
 edition = "2024"
-rust-version = "1.86"
-repository = "https://github.com/starkware-libs/cairo/"
 license = "Apache-2.0"
 license-file = "LICENSE"
+repository = "https://github.com/starkware-libs/cairo/"
+rust-version = "1.86"
+version = "2.12.0"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
@@ -111,7 +111,6 @@ const_format = "0.2.34"
 convert_case = "0.8.0"
 derivative = "2.2.0"
 diffy = "0.4.2"
-env_logger = "0.11.8"
 genco = "0.18.0"
 good_lp = { version = "1.14.0", features = ["minilp"], default-features = false }
 hashbrown = "0.15.4"
@@ -147,11 +146,14 @@ starknet-types-core = { version = "0.2.0", features = ["hash", "prime-bigint", "
 syn = { version = "2.0.104", features = ["extra-traits", "full"] }
 test-case = "3.3.1"
 test-case-macros = "3.3.1"
-test-log = "0.2.18"
+test-log = { version = "0.2.18", features = ["trace"], default-features = false }
 thiserror = "2.0.12"
 time = { version = "0.3.41", features = ["formatting", "local-offset", "macros"] }
 tokio = { version = "1.47.1", features = ["full", "sync"] }
 toml = "0.9.5"
+tracing = "0.1.40"
+tracing-log = "0.2.0"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "time"] }
 typetag = "0.2"
 unescaper = "0.1.6"
 vector-map = { version = "1.0.2", features = ["serde_impl"] }

--- a/crates/bin/cairo-compile/Cargo.toml
+++ b/crates/bin/cairo-compile/Cargo.toml
@@ -10,9 +10,8 @@ description = "Cairo compiler executable for the Cairo programming language"
 anyhow.workspace = true
 clap.workspace = true
 log.workspace = true
+tracing.workspace = true
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "~2.12.0" }
 cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "~2.12.0" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.12.0", features = [
-  "env_logger",
-] }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.12.0", features = ["tracing"] }

--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -47,7 +47,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    init_logging(log::LevelFilter::Off);
+    init_logging(tracing::Level::ERROR);
     log::info!("Starting Cairo compilation.");
 
     let args = Args::parse();

--- a/crates/bin/cairo-format/Cargo.toml
+++ b/crates/bin/cairo-format/Cargo.toml
@@ -11,8 +11,7 @@ clap.workspace = true
 colored.workspace = true
 ignore.workspace = true
 log.workspace = true
+tracing.workspace = true
 
 cairo-lang-formatter = { path = "../../cairo-lang-formatter", version = "~2.12.0" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.12.0", features = [
-  "env_logger",
-] }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.12.0", features = ["tracing"] }

--- a/crates/bin/cairo-format/src/main.rs
+++ b/crates/bin/cairo-format/src/main.rs
@@ -198,7 +198,7 @@ fn format_stdin(args: &FormatterArgs, fmt: &CairoFormatter) -> bool {
 }
 
 fn main() -> ExitCode {
-    init_logging(log::LevelFilter::Off);
+    init_logging(tracing::Level::ERROR);
     log::info!("Starting formatting.");
 
     let args = FormatterArgs::parse();

--- a/crates/bin/generate-syntax/Cargo.toml
+++ b/crates/bin/generate-syntax/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 
 [dependencies]
 log.workspace = true
+tracing.workspace = true
 
 cairo-lang-syntax-codegen = { path = "../../cairo-lang-syntax-codegen", version = "~2.12.0" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.12.0", features = [
-  "env_logger",
-] }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.12.0", features = ["tracing"] }

--- a/crates/bin/generate-syntax/src/main.rs
+++ b/crates/bin/generate-syntax/src/main.rs
@@ -2,7 +2,7 @@ use cairo_lang_syntax_codegen::generator::{ensure_file_content, get_codes, proje
 use cairo_lang_utils::logging::init_logging;
 
 fn main() {
-    init_logging(log::LevelFilter::Info);
+    init_logging(tracing::Level::INFO);
     log::info!("Starting syntax generation.");
 
     for (suffix, code) in get_codes() {

--- a/crates/bin/sierra-compile/Cargo.toml
+++ b/crates/bin/sierra-compile/Cargo.toml
@@ -11,10 +11,9 @@ anyhow.workspace = true
 clap.workspace = true
 indoc.workspace = true
 log.workspace = true
+tracing.workspace = true
 
 cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "~2.12.0" }
 cairo-lang-sierra-to-casm = { path = "../../cairo-lang-sierra-to-casm", version = "~2.12.0" }
 cairo-lang-sierra-type-size = { path = "../../cairo-lang-sierra-type-size", version = "~2.12.0" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.12.0", features = [
-  "env_logger",
-] }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.12.0", features = ["tracing"] }

--- a/crates/bin/sierra-compile/src/main.rs
+++ b/crates/bin/sierra-compile/src/main.rs
@@ -21,7 +21,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    init_logging(log::LevelFilter::Off);
+    init_logging(tracing::Level::ERROR);
     log::info!("Starting Sierra compilation.");
 
     let args = Args::parse();

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -18,11 +18,11 @@ schemars = { workspace = true, features = ["preserve_order"], optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-env_logger.workspace = true
 itertools = { workspace = true, default-features = true }
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/cairo-lang-casm/src/ap_change_test.rs
+++ b/crates/cairo-lang-casm/src/ap_change_test.rs
@@ -1,6 +1,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 
+#[cfg(feature = "std")]
 use test_log::test;
 
 use super::{BinOpOperand, DerefOrImmediate};

--- a/crates/cairo-lang-casm/src/assembler_test.rs
+++ b/crates/cairo-lang-casm/src/assembler_test.rs
@@ -1,5 +1,6 @@
 use num_bigint::ToBigInt;
 use pretty_assertions::assert_eq;
+#[cfg(feature = "std")]
 use test_log::test;
 
 use super::InstructionRepr;

--- a/crates/cairo-lang-casm/src/hints/test.rs
+++ b/crates/cairo-lang-casm/src/hints/test.rs
@@ -1,4 +1,5 @@
 use indoc::indoc;
+#[cfg(feature = "std")]
 use test_log::test;
 
 use crate::hints::{CoreHint, PythonicHint, StarknetHint};

--- a/crates/cairo-lang-casm/src/inline_test.rs
+++ b/crates/cairo-lang-casm/src/inline_test.rs
@@ -4,6 +4,7 @@ use alloc::string::ToString;
 use indoc::indoc;
 use itertools::join;
 use pretty_assertions::assert_eq;
+#[cfg(feature = "std")]
 use test_log::test;
 
 use crate::instructions::Instruction;

--- a/crates/cairo-lang-casm/src/instructions_test.rs
+++ b/crates/cairo-lang-casm/src/instructions_test.rs
@@ -2,6 +2,7 @@
 use alloc::{string::ToString, vec};
 
 use indoc::indoc;
+#[cfg(feature = "std")]
 use test_log::test;
 
 use crate::hints::CoreHint;

--- a/crates/cairo-lang-casm/src/operand_test.rs
+++ b/crates/cairo-lang-casm/src/operand_test.rs
@@ -1,6 +1,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 
+#[cfg(feature = "std")]
 use test_log::test;
 
 use super::{BinOpOperand, DerefOrImmediate, Operation};

--- a/crates/cairo-lang-debug/Cargo.toml
+++ b/crates/cairo-lang-debug/Cargo.toml
@@ -13,5 +13,5 @@ salsa.workspace = true
 
 [dev-dependencies]
 cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros" }
-env_logger.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-defs/Cargo.toml
+++ b/crates/cairo-lang-defs/Cargo.toml
@@ -23,7 +23,7 @@ xxhash-rust.workspace = true
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-diagnostics/Cargo.toml
+++ b/crates/cairo-lang-diagnostics/Cargo.toml
@@ -14,7 +14,7 @@ itertools = { workspace = true, default-features = true }
 salsa.workspace = true
 
 [dev-dependencies]
-env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-doc/Cargo.toml
+++ b/crates/cairo-lang-doc/Cargo.toml
@@ -27,3 +27,4 @@ cairo-lang-semantic = { path = "../cairo-lang-semantic" }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
 indoc.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-eq-solver/Cargo.toml
+++ b/crates/cairo-lang-eq-solver/Cargo.toml
@@ -11,5 +11,5 @@ cairo-lang-utils = { path = "../cairo-lang-utils", version = "~2.12.0" }
 good_lp.workspace = true
 
 [dev-dependencies]
-env_logger.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-executable-plugin/Cargo.toml
+++ b/crates/cairo-lang-executable-plugin/Cargo.toml
@@ -20,6 +20,6 @@ cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "~2.12.0" }
 cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "~2.12.0", features = ["testing"] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "~2.12.0" }
-env_logger.workspace = true
 indoc.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-filesystem/Cargo.toml
+++ b/crates/cairo-lang-filesystem/Cargo.toml
@@ -17,9 +17,9 @@ smol_str.workspace = true
 toml.workspace = true
 
 [dev-dependencies]
-env_logger.workspace = true
 serde_json.workspace = true
 test-log.workspace = true
+tracing.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["cairo-lang-debug"]

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -31,7 +31,7 @@ serde = { workspace = true, default-features = true }
 cairo-lang-plugins = { path = "../cairo-lang-plugins" }
 cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-parser/Cargo.toml
+++ b/crates/cairo-lang-parser/Cargo.toml
@@ -23,7 +23,7 @@ unescaper.workspace = true
 [dev-dependencies]
 anstream = "0.6.19"
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-plugins/Cargo.toml
+++ b/crates/cairo-lang-plugins/Cargo.toml
@@ -25,7 +25,7 @@ salsa.workspace = true
 cairo-lang-debug = { path = "../cairo-lang-debug" }
 cairo-lang-parser = { path = "../cairo-lang-parser" }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 serde_json.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-runner/Cargo.toml
+++ b/crates/cairo-lang-runner/Cargo.toml
@@ -36,10 +36,10 @@ thiserror.workspace = true
 cairo-lang-compiler = { path = "../cairo-lang-compiler" }
 cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["ark-secp256k1", "ark-secp256r1"]

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -34,8 +34,8 @@ toml = { workspace = true, optional = true }
 [dev-dependencies]
 cairo-lang-plugins = { path = "../cairo-lang-plugins" }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 log.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true
 toml.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -11,7 +11,6 @@ use cairo_lang_syntax::node::{TypedStablePtr, ast};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 use salsa::{AsDynDatabase, Database, Setter};
-use test_log::test;
 
 use crate::db::{SemanticGroup, semantic_group_input};
 use crate::ids::AnalyzerPluginLongId;
@@ -40,7 +39,7 @@ cairo_lang_test_utils::test_file_test!(
     test_expr_diagnostics
 );
 
-#[test]
+#[test_log::test]
 fn test_missing_module_file() {
     let db_val = SemanticDatabaseForTesting::default();
     let db = &db_val;
@@ -140,7 +139,7 @@ impl MacroPlugin for AddInlineModuleDummyPlugin {
     }
 }
 
-#[test]
+#[test_log::test]
 fn test_inline_module_diagnostics() {
     let mut db_val = SemanticDatabaseForTesting::new_empty();
     let db = &mut db_val;
@@ -177,7 +176,7 @@ fn test_inline_module_diagnostics() {
     );
 }
 
-#[test]
+#[test_log::test]
 fn test_inline_inline_module_diagnostics() {
     let db_val = SemanticDatabaseForTesting::default();
     let db = &db_val;
@@ -255,7 +254,7 @@ impl AnalyzerPlugin for NoU128RenameAnalyzerPlugin {
     }
 }
 
-#[test]
+#[test_log::test]
 fn test_analyzer_diagnostics() {
     let mut db_val = SemanticDatabaseForTesting::new_empty();
     let db = &mut db_val;

--- a/crates/cairo-lang-sierra-ap-change/Cargo.toml
+++ b/crates/cairo-lang-sierra-ap-change/Cargo.toml
@@ -17,4 +17,4 @@ num-traits = { workspace = true, default-features = true }
 thiserror.workspace = true
 
 [dev-dependencies]
-env_logger.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-sierra-gas/Cargo.toml
+++ b/crates/cairo-lang-sierra-gas/Cargo.toml
@@ -18,8 +18,8 @@ thiserror.workspace = true
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-sierra-generator/Cargo.toml
+++ b/crates/cairo-lang-sierra-generator/Cargo.toml
@@ -35,9 +35,9 @@ smol_str.workspace = true
 cairo-lang-plugins = { path = "../cairo-lang-plugins" }
 cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 log.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-sierra-to-casm/Cargo.toml
+++ b/crates/cairo-lang-sierra-to-casm/Cargo.toml
@@ -23,11 +23,11 @@ thiserror.workspace = true
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true
 
 [features]
 testing = []

--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -36,8 +36,8 @@ vector-map.workspace = true
 [dev-dependencies]
 bimap.workspace = true
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-starknet-classes/Cargo.toml
+++ b/crates/cairo-lang-starknet-classes/Cargo.toml
@@ -29,8 +29,8 @@ thiserror.workspace = true
 [dev-dependencies]
 cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator" }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -38,7 +38,7 @@ cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics" }
 cairo-lang-plugins = { path = "../cairo-lang-plugins", features = ["testing"] }
 cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-env_logger.workspace = true
 pretty_assertions.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-syntax-codegen/Cargo.toml
+++ b/crates/cairo-lang-syntax-codegen/Cargo.toml
@@ -14,5 +14,5 @@ genco.workspace = true
 xshell.workspace = true
 
 [dev-dependencies]
-env_logger.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -18,6 +18,6 @@ serde = { workspace = true, default-features = true }
 unescaper.workspace = true
 
 [dev-dependencies]
-env_logger.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-test-utils/Cargo.toml
+++ b/crates/cairo-lang-test-utils/Cargo.toml
@@ -27,7 +27,7 @@ pretty_assertions = { workspace = true, optional = true }
 [dev-dependencies]
 cairo-lang-utils = { path = "../cairo-lang-utils" }
 colored.workspace = true
-env_logger.workspace = true
 log.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true
+tracing.workspace = true

--- a/crates/cairo-lang-test-utils/src/parse_test_file.rs
+++ b/crates/cairo-lang-test-utils/src/parse_test_file.rs
@@ -332,8 +332,9 @@ macro_rules! test_file_test {
         mod $suite {
             use super::*;
         $(
-            #[test_log::test]
+            #[test]
             fn $test_name() -> Result<(), std::io::Error> {
+                cairo_lang_utils::logging::init_logging(tracing::Level::INFO);
                 let path: std::path::PathBuf = [env!("CARGO_MANIFEST_DIR"), $base_dir, $test_file].iter().collect();
                 cairo_lang_test_utils::parse_test_file::run_test_file(
                     path.as_path(),

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -15,25 +15,26 @@ num-traits.workspace = true
 smol_str.workspace = true
 
 # Optional
-env_logger = { workspace = true, optional = true }
-log = { workspace = true, optional = true }
 parity-scale-codec = { workspace = true, optional = true }
 salsa = { workspace = true, optional = true }
 schemars = { workspace = true, features = ["preserve_order"], optional = true }
 serde = { workspace = true, features = ["alloc"], optional = true }
-time = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+tracing-log = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]
-env_logger.workspace = true
 serde_json.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+tracing.workspace = true
 
 [features]
-default = ["std"]
-env_logger = ["dep:env_logger", "dep:log", "dep:time", "std"]
+default = ["std", "tracing"]
+env_logger = ["tracing"]
 parity-scale-codec = ["dep:parity-scale-codec"]
 schemars = ["dep:schemars", "serde", "std"]
 serde = ["dep:serde", "indexmap/serde", "num-bigint/serde", "smol_str/serde"]
 std = ["indexmap/std", "num-bigint/std", "num-traits/std", "salsa", "serde?/std", "smol_str/std"]
 testing = []
+tracing = ["dep:tracing", "dep:tracing-log", "dep:tracing-subscriber", "std"]

--- a/crates/cairo-lang-utils/src/collection_arithmetics_test.rs
+++ b/crates/cairo-lang-utils/src/collection_arithmetics_test.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::RandomState as HashBuilderType;
 
 #[cfg(not(feature = "std"))]
 use hashbrown::DefaultHashBuilder as HashBuilderType;
+#[cfg(feature = "std")]
 use test_log::test;
 
 use crate::collection_arithmetics::{AddCollection, SubCollection};

--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use itertools::chain;
 use test_case::test_case;
+#[cfg(feature = "std")]
 use test_log::test;
 
 use crate::graph_algos::feedback_set::calc_feedback_set;

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use itertools::chain;
 use test_case::test_case;
+#[cfg(feature = "std")]
 use test_log::test;
 
 use super::GraphNode;

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -22,7 +22,7 @@ pub mod extract_matches;
 #[cfg(feature = "std")]
 pub mod graph_algos;
 pub mod iterators;
-#[cfg(feature = "env_logger")]
+#[cfg(feature = "tracing")]
 pub mod logging;
 pub mod ordered_hash_map;
 pub mod ordered_hash_set;

--- a/crates/cairo-lang-utils/src/logging.rs
+++ b/crates/cairo-lang-utils/src/logging.rs
@@ -1,22 +1,67 @@
-use std::io::Write;
+use std::sync::Once;
 
-use log::LevelFilter;
+use tracing::Level;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::filter::dynamic_filter_fn;
+use tracing_subscriber::prelude::*;
 
-/// Initializes env_logger.
+static INIT: Once = Once::new();
+
+/// Initializes logging (tracing library).
 /// The format is:
 /// `<level>  /path/to/file:<line_number>  <time>  <log_message>`
-pub fn init_logging(log_level: LevelFilter) {
-    env_logger::Builder::new()
-        .filter_level(log_level)
-        .format(|buf, record| {
-            let location =
-                format!("{}:{}", record.file().unwrap_or("unknown"), record.line().unwrap_or(0),);
-            let time_format = time::macros::format_description!("[hour]:[minute]:[second]");
-            let formatted_time = time::OffsetDateTime::from(std::time::SystemTime::now())
-                .format(time_format)
-                .unwrap();
-            writeln!(buf, "{:7}{:45} {formatted_time} {}", record.level(), location, record.args())
-        })
-        .filter(Some("salsa"), LevelFilter::Off)
-        .init();
+pub fn init_logging(level: Level) {
+    INIT.call_once(|| {
+        // Bridge log records to tracing so existing log macros still work via tracing-log
+        tracing_log::LogTracer::init().ok();
+
+        let env_filter = EnvFilter::try_from_default_env()
+            .or_else(|_| EnvFilter::try_new(level.to_string()))
+            .unwrap();
+
+        // Custom filter: filter out all events from the "salsa" crate unless CAIRO_UNMUTE_SALSA is
+        // set.
+        let salsa_filter = exclude_salsa();
+
+        let filter = env_filter.and_then(salsa_filter);
+
+        let timer = tracing_subscriber::fmt::time::SystemTime;
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .with_timer(timer)
+            .with_ansi(false)
+            .with_level(true)
+            .with_target(false)
+            .with_file(true)
+            .with_line_number(true);
+
+        // Avoid panicking if a global subscriber is already set (e.g., tests or another init).
+        let registry = tracing_subscriber::registry().with(filter);
+        if cfg!(test) {
+            let _ = registry.with(fmt_layer.with_test_writer()).try_init();
+        } else {
+            let _ = registry.with(fmt_layer).try_init();
+        }
+    });
+}
+
+/// Returns a filter that mutes all tracing events from the "salsa" crate unless the
+/// `CAIRO_UNMUTE_SALSA` environment variable is set.
+/// This is useful to reduce log noise from salsa internals during normal operation.
+pub fn exclude_salsa() -> tracing_subscriber::filter::DynFilterFn<
+    tracing_subscriber::Registry,
+    impl Fn(
+        &tracing::Metadata<'_>,
+        &tracing_subscriber::layer::Context<'_, tracing_subscriber::Registry>,
+    ) -> bool,
+> {
+    let salsa_unmuted = std::env::var("CAIRO_UNMUTE_SALSA").is_ok();
+    dynamic_filter_fn(move |meta, _ctx| {
+        if salsa_unmuted {
+            // If the env var is set, do not filter out salsa events.
+            true
+        } else {
+            // Filter out events whose target starts with "salsa"
+            !meta.target().starts_with("salsa")
+        }
+    })
 }

--- a/taplo.toml
+++ b/taplo.toml
@@ -13,5 +13,7 @@ keys = [
   "build-dependencies",
   "target.*.dependencies",
   "workspace.members",
+  "workspace.dependencies",
+  "features",
 ]
 formatting = { reorder_keys = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -28,7 +28,6 @@ cairo-lang-sierra-type-size = { path = "../crates/cairo-lang-sierra-type-size", 
 cairo-lang-syntax = { path = "../crates/cairo-lang-syntax" }
 cairo-lang-test-utils = { path = "../crates/cairo-lang-test-utils", features = ["testing"] }
 cairo-lang-utils = { path = "../crates/cairo-lang-utils" }
-env_logger.workspace = true
 itertools = { workspace = true, default-features = true }
 log.workspace = true
 num-bigint = { workspace = true, default-features = true }
@@ -37,6 +36,7 @@ rstest.workspace = true
 salsa.workspace = true
 starknet-types-core.workspace = true
 test-log.workspace = true
+tracing.workspace = true
 
 [[test]]
 name = "examples_test"


### PR DESCRIPTION
### TL;DR

Replace `env_logger` with `tracing` for improved logging capabilities across the codebase.

### What changed?

- Replaced `env_logger` dependency with `tracing`, `tracing-subscriber`, and `tracing-log` in the workspace.
- Updated the logging initialization code in `cairo-lang-utils/src/logging.rs` to use tracing-based implementation
- Added a custom filter to mute salsa events unless `CAIRO_UNMUTE_SALSA` environment variable is set
- Updated CI workflow to use the `tracing` feature instead of `env_logger` as it was renamed
- Added `tracing` feature to `test-log` dependency to ensure proper integration