### PR TITLE
Fix typos in comments

### DIFF
--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -573,7 +573,7 @@ fn module_file<'db>(
     Ok(db.module_files(module_file_id.0)?[module_file_id.1.0])
 }
 
-// TODO(eytan-starkware): This doesnt really need to be tracked.
+// TODO(eytan-starkware): This doesn't really need to be tracked.
 #[salsa::tracked(returns(ref))]
 fn module_dir_helper<'db>(
     db: &'db dyn Database,

--- a/crates/cairo-lang-semantic/src/items/function_with_body.rs
+++ b/crates/cairo-lang-semantic/src/items/function_with_body.rs
@@ -177,7 +177,7 @@ pub struct FunctionBody<'db> {
 unsafe impl<'db> salsa::Update for FunctionBody<'db> {
     unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
         // The function body contains both the arena and the expr id, so a change will be detected.
-        // The comparison should still be safe to do as we wont follow expired references.
+        // The comparison should still be safe to do as we won't follow expired references.
         let old_value = unsafe { &mut *old_pointer };
 
         if old_value != &new_value {


### PR DESCRIPTION


Minor typographical corrections in code comments:

- **`crates/cairo-lang-defs/src/db.rs`**: Fixed "doesnt" → "doesn't" in TODO comment
- **`crates/cairo-lang-semantic/src/items/function_with_body.rs`**: Fixed "wont" → "won't" in safety comment

