### PR TITLE
fix: typos in cairo-lang-lowering comments

### DIFF
--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -352,7 +352,7 @@ pub trait LoweringGroup: Database {
         crate::inline::priv_never_inline(self.as_dyn_database(), function_id)
     }
 
-    /// Returns whether a function should be specalized.
+    /// Returns whether a function should be specialized.
     fn priv_should_specialize<'db>(
         &'db self,
         function_id: ids::ConcreteFunctionWithBodyId<'db>,

--- a/crates/cairo-lang-lowering/src/optimizations/dedup_blocks.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/dedup_blocks.rs
@@ -113,7 +113,7 @@ impl<'db, 'a> CanonicBlockBuilder<'db, 'a> {
         })
     }
 
-    /// Converts a statement to a cononic statement.
+    /// Converts a statement to a canonic statement.
     fn handle_statement(&mut self, statement: &Statement<'db>) -> CanonicStatement<'db> {
         match statement {
             Statement::Const(StatementConst { value, boxed, output }) => CanonicStatement::Const {


### PR DESCRIPTION
db.rs: Corrected "specalized" → "specialized" in function doc comment.

dedup_blocks.rs: Corrected "cononic" → "canonic" in comment describing statement conversion.