### PR TITLE
fix: remove redundant "//" from comment in cairo-lang-defs test

### DIFF
--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -420,7 +420,7 @@ fn test_first_plugin_removes() {
 }
 
 // Verify that if the first plugin generates new code, the later plugins don't act on the
-// original // item.
+// original item.
 #[test]
 fn test_first_plugin_generates() {
     let mut db_val = DatabaseForTesting::default();


### PR DESCRIPTION

Remove extra `//` characters from comment on line 423 in test.rs, changing `original // item` to `original item` for clarity