### PR TITLE
AGENTS.md to prevent bots from reading ast.rs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Do not read or grep crates/cairo-lang-syntax/src/node/ast.rs. Instead read crates/cairo-lang-syntax-codegen/src/generator.rs.


### PR DESCRIPTION
Added a new file `AGENTS.md` with instructions for AI agents to avoid directly reading or grepping the AST implementation file. Instead instruction direct it to look at the code of generator.rs.
