### PR TITLE
fix: Cache in salsa loading of the incremental cache

### DIFF
--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -1071,6 +1071,7 @@ pub(crate) fn module_data<'db>(
 pub type ModuleDataCacheAndLoadingData<'db> =
     (Arc<OrderedHashMap<ModuleId<'db>, ModuleData<'db>>>, Arc<DefCacheLoadingData<'db>>);
 
+#[salsa::tracked]
 fn cached_crate_modules<'db>(
     db: &'db dyn Database,
     crate_id: CrateId<'db>,


### PR DESCRIPTION
Incremental compilation right now seems broken, as any query that should use the cache spends time loading it over and over again.

<img width="3032" height="264" alt="image" src="https://github.com/user-attachments/assets/f4e207ec-94d3-4e55-9141-1c7d342899d9" />