### PR TITLE
Remove warmup parallelism limit

### DIFF
--- a/crates/cairo-lang-test-plugin/src/lib.rs
+++ b/crates/cairo-lang-test-plugin/src/lib.rs
@@ -2,7 +2,7 @@ use std::default::Default;
 
 use anyhow::{Result, ensure};
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
-use cairo_lang_compiler::{DbWarmupContext, get_sierra_program_for_functions};
+use cairo_lang_compiler::{ensure_diagnostics, get_sierra_program_for_functions};
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{FreeFunctionId, FunctionWithBodyId, ModuleItemId};
@@ -103,8 +103,7 @@ pub fn compile_test_prepared_db<'db>(
         "Contract crate ids can be provided only when starknet is enabled."
     );
 
-    let context = DbWarmupContext::new();
-    context.ensure_diagnostics(db, &mut diagnostics_reporter)?;
+    ensure_diagnostics(db, &mut diagnostics_reporter)?;
 
     let contracts = tests_compilation_config.contract_declarations.unwrap_or_else(|| {
         find_contracts(
@@ -147,7 +146,7 @@ pub fn compile_test_prepared_db<'db>(
     .collect();
 
     let SierraProgramWithDebug { program: sierra_program, debug_info } =
-        get_sierra_program_for_functions(db, func_ids, context)?;
+        get_sierra_program_for_functions(db, func_ids)?;
 
     let function_set_costs: OrderedHashMap<FunctionId, CostTokenMap<i32>> = all_entry_points
         .iter()


### PR DESCRIPTION
With the new salsa, I don't see any benefit from having the limit anymore. 


OZ benchmarks:

Before:

Benchmark 1: SCARB_INCREMENTAL=false scarb build -w --test
  Time (mean ± σ):     106.724 s ±  4.403 s    [User: 313.918 s, System: 10.279 s]
  Range (min … max):   103.255 s … 111.678 s    3 runs

After:

Benchmark 1: SCARB_INCREMENTAL=false scarb build -w --test
  Time (mean ± σ):     92.257 s ±  2.130 s    [User: 420.124 s, System: 22.883 s]
  Range (min … max):   90.839 s … 94.707 s    3 runs