### PR TITLE
Warmup diagnostics before ensure in sierra artifact compilation

### DIFF
--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -282,7 +282,7 @@ pub fn compile_prepared_db_program_artifact<'db>(
     let add_statements_functions = compiler_config.add_statements_functions;
     let add_statements_code_locations = compiler_config.add_statements_code_locations;
 
-    compiler_config.diagnostics_reporter.ensure(db)?;
+    ensure_diagnostics(db, &mut compiler_config.diagnostics_reporter)?;
 
     let executable_functions = find_executable_function_ids(db, main_crate_ids.clone());
 


### PR DESCRIPTION
vide supra


Before: 
<img width="616" height="109" alt="image" src="https://github.com/user-attachments/assets/ce81c61c-d825-415c-a761-1beb563d233a" />

Benchmark 1: SCARB_INCREMENTAL=false scarb build -w
  Time (mean ± σ):     214.500 s ±  0.722 s    [User: 234.829 s, System: 5.950 s]
  Range (min … max):   213.680 s … 215.043 s    3 runs

After:
<img width="387" height="104" alt="image" src="https://github.com/user-attachments/assets/ff6a8534-c532-4d4c-9a79-0f315ec8d1c5" />

Benchmark 1: SCARB_INCREMENTAL=false scarb build -w
  Time (mean ± σ):     84.480 s ±  1.135 s    [User: 365.572 s, System: 17.896 s]
  Range (min … max):   83.793 s … 85.790 s    3 runs
