### PR TITLE
refactor(semantic): Removed unused generic-params kept at definitions.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/extern_function.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_function.rs
@@ -218,7 +218,6 @@ fn priv_extern_function_declaration_data<'db>(
     // Generic params.
     let generic_params_data =
         db.extern_function_declaration_generic_params_data(extern_function_id)?;
-    let generic_params = generic_params_data.generic_params;
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::ExternFunction(extern_function_id));
     let inference_id = InferenceId::LookupItemDeclaration(lookup_item_id);
     let mut resolver = Resolver::with_data(
@@ -270,13 +269,11 @@ fn priv_extern_function_declaration_data<'db>(
     inference.finalize(&mut diagnostics, extern_function_syntax.stable_ptr(db).untyped());
 
     let signature = inference.rewrite(signature).no_err();
-    let generic_params = inference.rewrite(generic_params).no_err();
 
     Ok(FunctionDeclarationData {
         diagnostics: diagnostics.build(),
         signature,
         environment,
-        generic_params,
         attributes,
         resolver_data: Arc::new(resolver.data),
         inline_config,

--- a/crates/cairo-lang-semantic/src/items/free_function.rs
+++ b/crates/cairo-lang-semantic/src/items/free_function.rs
@@ -77,7 +77,7 @@ fn free_function_declaration_data<'db>(
     // Generic params.
     let generic_params_data =
         free_function_generic_params_data(db, free_function_id).maybe_as_ref()?;
-    let generic_params = generic_params_data.generic_params.clone();
+    let generic_params = &generic_params_data.generic_params;
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::FreeFunction(free_function_id));
     let inference_id = InferenceId::LookupItemDeclaration(lookup_item_id);
     let mut resolver = Resolver::with_data(
@@ -101,7 +101,7 @@ fn free_function_declaration_data<'db>(
 
     let inline_config = get_inline_config(db, &mut diagnostics, &attributes)?;
 
-    forbid_inline_always_with_impl_generic_param(&mut diagnostics, &generic_params, &inline_config);
+    forbid_inline_always_with_impl_generic_param(&mut diagnostics, generic_params, &inline_config);
 
     let (implicit_precedence, _) =
         get_implicit_precedence(db, &mut diagnostics, &mut resolver, &attributes);
@@ -111,13 +111,11 @@ fn free_function_declaration_data<'db>(
 
     inference.finalize(&mut diagnostics, declaration.stable_ptr(db).untyped());
     let signature = inference.rewrite(signature).no_err();
-    let generic_params = inference.rewrite(generic_params).no_err();
 
     Ok(FunctionDeclarationData {
         diagnostics: diagnostics.build(),
         signature,
         environment,
-        generic_params,
         attributes,
         resolver_data: Arc::new(resolver.data),
         inline_config,

--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -974,7 +974,6 @@ pub struct FunctionDeclarationData<'db> {
     pub signature: semantic::Signature<'db>,
     /// The environment induced by the function's signature.
     pub environment: Environment<'db>,
-    pub generic_params: Vec<semantic::GenericParam<'db>>,
     pub attributes: Vec<Attribute<'db>>,
     pub resolver_data: Arc<ResolverData<'db>>,
     pub inline_config: InlineConfiguration<'db>,

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -485,7 +485,6 @@ pub enum ImplHead<'db> {
 #[debug_db(dyn Database)]
 pub struct ImplDeclarationData<'db> {
     diagnostics: Diagnostics<'db, SemanticDiagnostic<'db>>,
-    generic_params: Vec<semantic::GenericParam<'db>>,
     /// The concrete trait this impl implements, or Err if cannot be resolved.
     concrete_trait: Maybe<ConcreteTraitId<'db>>,
     attributes: Vec<Attribute<'db>>,
@@ -970,7 +969,6 @@ fn priv_impl_declaration_data_inner<'db>(
 
     // Generic params.
     let generic_params_data = db.impl_def_generic_params_data(impl_def_id)?;
-    let generic_params = generic_params_data.generic_params;
     let mut resolver = Resolver::with_data(
         db,
         (*generic_params_data.resolver_data).clone_with_inference_id(db, inference_id),
@@ -1018,14 +1016,12 @@ fn priv_impl_declaration_data_inner<'db>(
 
     let concrete_trait: Result<ConcreteTraitId<'_>, DiagnosticAdded> =
         inference.rewrite(concrete_trait).no_err();
-    let generic_params: Vec<GenericParam<'_>> = inference.rewrite(generic_params).no_err();
 
     let attributes = impl_ast.attributes(db).structurize(db);
     let mut resolver_data = resolver.data;
     resolver_data.trait_or_impl_ctx = TraitOrImplContext::Impl(impl_def_id);
     Ok(ImplDeclarationData {
         diagnostics: diagnostics.build(),
-        generic_params,
         concrete_trait,
         attributes,
         resolver_data: Arc::new(resolver_data),
@@ -4270,14 +4266,12 @@ fn priv_impl_function_declaration_data<'db>(
     forbid_inline_always_with_impl_generic_param(&mut diagnostics, &generic_params, &inline_config);
 
     let signature = inference.rewrite(signature).no_err();
-    let generic_params = inference.rewrite(generic_params).no_err();
 
     let resolver_data = Arc::new(resolver.data);
     Ok(ImplFunctionDeclarationData {
         function_declaration_data: FunctionDeclarationData {
             diagnostics: diagnostics.build(),
             signature,
-            generic_params,
             environment,
             attributes,
             resolver_data,

--- a/crates/cairo-lang-semantic/src/items/module_type_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/module_type_alias.rs
@@ -111,9 +111,8 @@ pub trait ModuleTypeAliasSemantic<'db>: Database {
         &'db self,
         id: ModuleTypeAliasId<'db>,
     ) -> Maybe<Vec<GenericParam<'db>>> {
-        Ok(module_type_alias_semantic_data(self.as_dyn_database(), id, false)
+        Ok(module_type_alias_generic_params_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
-            .type_alias_data
             .generic_params
             .clone())
     }


### PR DESCRIPTION
As it already exists and rewritten at params data.
In some cases needed to change the calling query.