### PR TITLE
feat(ops): add get, SliceIndex and impl for ByteSpan

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -55,6 +55,7 @@ use crate::cmp::min;
 use crate::integer::{U32TryIntoNonZero, u128_safe_divmod};
 #[feature("bounded-int-utils")]
 use crate::internal::bounded_int::{self, BoundedInt, downcast, upcast};
+use crate::num::traits::CheckedSub;
 #[allow(unused_imports)]
 use crate::serde::Serde;
 use crate::traits::{Into, TryInto};
@@ -837,6 +838,16 @@ pub impl ByteSpanImpl of ByteSpanTrait {
         ba.append_from_parts(self.data, self.remainder_word, upcast(self.remainder_len));
         ba
     }
+
+    /// Gets the element(s) at the given index.
+    /// Accepts ranges (returns Option<ByteSpan>), and (to-be-implemented) single indices (returns
+    /// Option<u8>).
+    #[feature("corelib-get-trait")]
+    fn get<I, impl TGet: crate::ops::Get<ByteSpan, I>, +Drop<I>>(
+        self: @ByteSpan, index: I,
+    ) -> Option<TGet::Output> {
+        TGet::get(self, index)
+    }
 }
 
 impl ByteSpanDefault of Default<ByteSpan> {
@@ -844,6 +855,59 @@ impl ByteSpanDefault of Default<ByteSpan> {
         ByteSpan {
             data: [].span(), first_char_start_offset: 0, remainder_word: 0, remainder_len: 0,
         }
+    }
+}
+
+
+impl ByteSpanGetRange of crate::ops::Get<ByteSpan, crate::ops::Range<usize>> {
+    type Output = ByteSpan;
+
+    /// Returns a slice for the given range `[start, end)`.
+    /// If span is consumed by the slice: returns the default object.
+    /// If out of bounds: returns `None`.
+    fn get(self: @ByteSpan, index: crate::ops::Range<usize>) -> Option<ByteSpan> {
+        let range = index;
+        let len = (range.end).checked_sub(range.start)?;
+        if len == 0 {
+            return Some(Default::default());
+        }
+        if range.end > self.len() {
+            return None;
+        }
+
+        let abs_start = range.start + upcast(*self.first_char_start_offset);
+        let (start_word, start_offset) = DivRem::div_rem(abs_start, BYTES_IN_BYTES31_NONZERO);
+        let (end_word, end_offset) = DivRem::div_rem(abs_start + len, BYTES_IN_BYTES31_NONZERO);
+        let data_len = self.data.len();
+
+        let remainder_with_end_offset_trimmed = if end_word < data_len {
+            let word = (*self.data[end_word]).into();
+            shift_right(word, BYTES_IN_BYTES31, BYTES_IN_BYTES31 - end_offset)
+        } else {
+            let remainder_len = upcast(*self.remainder_len);
+            shift_right(*self.remainder_word, remainder_len, remainder_len - end_offset)
+        };
+
+        Some(
+            ByteSpan {
+                data: self.data.slice(start_word, min(end_word, data_len) - start_word),
+                first_char_start_offset: downcast(start_offset).unwrap(),
+                remainder_word: remainder_with_end_offset_trimmed,
+                remainder_len: downcast(end_offset).unwrap(),
+            },
+        )
+    }
+}
+
+impl ByteSpanGetRangeInclusive of crate::ops::Get<ByteSpan, crate::ops::RangeInclusive<usize>> {
+    type Output = ByteSpan;
+
+    /// Returns a slice for the given range `[start, end]`.
+    /// If span is consumed by the slice: returns the default object.
+    /// If out of bounds: returns `None`.
+    fn get(self: @ByteSpan, index: crate::ops::RangeInclusive<usize>) -> Option<ByteSpan> {
+        let end_exclusive = crate::num::traits::CheckedAdd::checked_add(index.end, 1)?;
+        ByteSpanTrait::get(self, index.start..end_exclusive)
     }
 }
 
@@ -872,6 +936,21 @@ impl ByteSpanToByteSpan of ToByteSpanTrait<ByteSpan> {
     fn span(self: @ByteSpan) -> ByteSpan {
         *self
     }
+}
+
+/// Shifts a word right by `n_bytes`.
+/// The input `bytes31` and the output `bytes31`s are represented using `felt252`s to improve
+/// performance.
+///
+/// Note: this function assumes that:
+/// 1. `word` is validly convertible to a `bytes31` which has no more than `word_len` bytes of data.
+/// 2. `n_bytes <= word_len`.
+/// 3. `word_len <= BYTES_IN_BYTES31`.
+/// If these assumptions are not met, it can corrupt the result. Thus, this should be a
+/// private function. We could add masking/assertions but it would be more expensive.
+fn shift_right(word: felt252, word_len: usize, n_bytes: usize) -> felt252 {
+    let (_shifted_out, after_shift_right) = split_bytes31(word, word_len, n_bytes);
+    after_shift_right
 }
 
 mod helpers {

--- a/corelib/src/ops.cairo
+++ b/corelib/src/ops.cairo
@@ -73,3 +73,8 @@ pub use range::{
 // `RangeOp` and `RangeInclusiveOp` are used internally by the compiler.
 #[allow(unused_imports)]
 use range::{RangeInclusiveOp, RangeOp};
+
+#[unstable(feature: "corelib-get-trait")]
+pub mod get;
+#[feature("corelib-get-trait")]
+pub use get::Get;

--- a/corelib/src/ops/get.cairo
+++ b/corelib/src/ops/get.cairo
@@ -1,0 +1,42 @@
+/// A trait for fallible indexing operations with different index types.
+///
+/// Unlike [`IndexView`] and [`Index`] which panic on out-of-bounds access, `Get`
+/// returns an `Option`, providing safe indexing operations. This trait enables containers
+/// to support multiple index types (e.g., `Range<usize>`, `RangeInclusive<usize>`,
+/// or `usize`) through a unified interface.
+///
+/// [`IndexView`]: crate::ops::IndexView
+/// [`Index`]: crate::ops::Index
+///
+/// # Examples
+///
+/// The following example shows how `ByteSpan` implements `Get` for both `Range<usize>`
+/// and `RangeInclusive<usize>`, enabling safe slicing operations that return `None` when
+/// out of bounds.
+///
+/// ```
+/// use core::byte_array::{ByteSpan, ByteSpanTrait};
+///
+/// let ba: ByteArray = "hello";
+/// let span = ba.span();
+///
+/// // Using Range<usize>.
+/// let slice = span.get(1..4).unwrap();
+/// assert_eq!(slice.to_byte_array(), "ell");
+///
+/// // Using RangeInclusive<usize>.
+/// let slice = span.get(1..=3).unwrap();
+/// assert_eq!(slice.to_byte_array(), "ell");
+///
+/// // Out of bounds returns None.
+/// assert!(span.get(10..20).is_none());
+/// ```
+// TODO(giladchase): add examples for `usize` once supported.
+#[unstable(feature: "corelib-get-trait")]
+pub trait Get<C, I> {
+    /// The returned type after indexing.
+    type Output;
+
+    /// Returns the output at this index, if in bounds.
+    fn get(self: @C, index: I) -> Option<Self::Output>;
+}

--- a/corelib/src/ops/index.cairo
+++ b/corelib/src/ops/index.cairo
@@ -6,6 +6,9 @@
 //! * [`IndexView`] - For snapshot-based access
 //! * [`Index`] - For reference-based access
 //!
+//! For safe indexing operations that return `Option`, see the unstable [`Get`] trait
+//! in the [`get`] module.
+//!
 //! # When to use which trait
 //!
 //! - Use [`IndexView`] when the collection can be accessed in a read-only context and is not
@@ -17,6 +20,8 @@
 //! Only one of these traits should be implemented for any given type, not both.
 //!
 //! [`Felt252Dict`]: core::dict::Felt252Dict
+//! [`Get`]: crate::ops::get::Get
+//! [`get`]: crate::ops::get
 
 #[feature("deprecated-index-traits")]
 use crate::traits::{Index as DeprecatedIndex, IndexView as DeprecatedIndexView};


### PR DESCRIPTION
Implementation notes for ByteSpan:

1. When a slice ends before a word boundary (it's last word isn't a full 31 bytes long)
, it's last word is copied into the remainder word.
Rationale: this is consistent with `ByteArray`'s `pending word`, and allows slices of full bytes31
that include an end_suffix to be shifted-right without allocating a new array.
2. When slices include a start-offset, the offset is applied lazily only upon `into`ing into a
`ByteArray`, otherwise it's only recorded in the `first_char_start_offset` field.