### PR TITLE
performance(sierra-gas): Not copying full `Function` structure on gas calc.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost.rs
@@ -4,7 +4,9 @@ use cairo_lang_sierra::program::StatementIdx;
 use cairo_lang_utils::collection_arithmetics::{AddCollection, SubCollection};
 use itertools::zip_eq;
 
-use crate::core_libfunc_cost_base::{CostOperations, core_libfunc_postcost, core_libfunc_precost};
+use crate::core_libfunc_cost_base::{
+    CostOperations, FunctionCostInfo, core_libfunc_postcost, core_libfunc_precost,
+};
 pub use crate::core_libfunc_cost_base::{
     DICT_SQUASH_FIXED_COST, DICT_SQUASH_REPEATED_ACCESS_COST, DICT_SQUASH_UNIQUE_KEY_COST,
     InvocationCostInfoProvider, SEGMENT_ARENA_ALLOCATION_COST,
@@ -26,7 +28,7 @@ impl CostOperations for Ops<'_> {
 
     fn function_token_cost(
         &mut self,
-        function: &cairo_lang_sierra::program::Function,
+        function: &FunctionCostInfo,
         token_type: CostTokenType,
     ) -> Self::CostType {
         if let Some(function_cost) = self.gas_info.function_costs.get(&function.id)

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_expr.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_expr.rs
@@ -5,7 +5,8 @@ use cairo_lang_sierra::program::StatementIdx;
 use cairo_lang_utils::collection_arithmetics::{AddCollection, SubCollection};
 
 use crate::core_libfunc_cost_base::{
-    CostOperations, InvocationCostInfoProvider, core_libfunc_postcost, core_libfunc_precost,
+    CostOperations, FunctionCostInfo, InvocationCostInfoProvider, core_libfunc_postcost,
+    core_libfunc_precost,
 };
 use crate::cost_expr::{CostExpr, Var};
 use crate::generate_equations::StatementFutureCost;
@@ -27,7 +28,7 @@ impl CostOperations for Ops<'_> {
 
     fn function_token_cost(
         &mut self,
-        function: &cairo_lang_sierra::program::Function,
+        function: &FunctionCostInfo,
         token_type: CostTokenType,
     ) -> Self::CostType {
         Self::CostType::from_iter([(

--- a/crates/cairo-lang-sierra-gas/src/objects.rs
+++ b/crates/cairo-lang-sierra-gas/src/objects.rs
@@ -1,9 +1,10 @@
 use cairo_lang_sierra::extensions::circuit::CircuitInfo;
 use cairo_lang_sierra::extensions::gas::{BuiltinCostsType, CostTokenMap, CostTokenType};
 use cairo_lang_sierra::ids::ConcreteTypeId;
-use cairo_lang_sierra::program::Function;
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::collection_arithmetics::{AddCollection, SubCollection};
+
+use crate::core_libfunc_cost_base::FunctionCostInfo;
 
 /// Represents constant cost.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -110,7 +111,7 @@ pub enum BranchCost {
     /// A cost of a function.
     /// `sign` controls whether the cost (the function cost as well as `const_cost`) is added
     /// to or reduced from the wallet.
-    FunctionCost { const_cost: ConstCost, function: Function, sign: BranchCostSign },
+    FunctionCost { const_cost: ConstCost, function: FunctionCostInfo, sign: BranchCostSign },
     /// The cost of the `branch_align` libfunc.
     BranchAlign,
     /// The cost of `withdraw_gas` and `withdraw_gas_all` libfuncs.


### PR DESCRIPTION
Introduced a new `FunctionCostInfo` struct to optimize function cost calculations by reducing cloning of entire `Function` objects.