### PR TITLE
fix typo in TODO comment

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
@@ -107,4 +107,4 @@ See xref:function-calls.adoc[Function calls].
 // TODO(yuval): mention methods/self?
 // TODO(yuval): mention panics/implicits? (it's part of the signature).
 // TODO(yuval): mention inline.
-// TODO(yuval): mention local compilability.
+// TODO(yuval): mention local compatibility.


### PR DESCRIPTION

- **File:** `docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc`
- **Line 110:** Changed `// TODO (yuval): mention local compilability.` → `// TODO (yuval): mention local compatibility.`

