### PR TITLE
Use --edition 2024 in the VS Code rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -27,7 +27,7 @@ wrap_comments = true
 #         "--",
 #         "rustfmt",
 #         "--edition",
-#         "2021",
+#         "2024",
 #         "--"
 #     ]
 # and run "rustup toolchain install nightly-2025-08-05".


### PR DESCRIPTION
The workspace already targets edition 2024 (both edition and style_edition) but the sample VS Code override in rustfmt.toml still passes --edition 2021. This mismatch can mislead contributors who copy the snippet, causing editor-side formatting drift or confusing warnings.