### PR TITLE
docs: fix misleading comment

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/interoperability.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/interoperability.rs
@@ -24,7 +24,7 @@ impl NoGenericArgsGenericType for ContractAddressType {
     const ZERO_SIZED: bool = false;
 }
 
-/// Libfunc for creating a constant storage address.
+/// Libfunc for creating a constant contract address.
 #[derive(Default)]
 pub struct ContractAddressConstLibfuncWrapped {}
 impl ConstGenLibfunc for ContractAddressConstLibfuncWrapped {


### PR DESCRIPTION
looks like a copy paste mistake, it seems to me the comment should say contract adress