### PR TITLE
Add debug info annotations to executable struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
  "itertools 0.14.0",
  "salsa",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/cairo-lang-executable/Cargo.toml
+++ b/crates/cairo-lang-executable/Cargo.toml
@@ -25,6 +25,7 @@ cairo-vm.workspace = true
 itertools = { workspace = true, default-features = true }
 salsa.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 cairo-lang-compiler = { path = "../cairo-lang-compiler" }

--- a/crates/cairo-lang-executable/src/debug_info.rs
+++ b/crates/cairo-lang-executable/src/debug_info.rs
@@ -1,0 +1,35 @@
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use serde::{Deserialize, Serialize};
+
+/// Debug information for an Executable.
+#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
+pub struct DebugInfo {
+    /// Non-crucial information about the program, for use by external libraries and tools.
+    ///
+    /// See [`Annotations`] type documentation for more information about this field.
+    #[serde(default, skip_serializing_if = "Annotations::is_empty")]
+    pub annotations: Annotations,
+}
+
+/// Store for non-crucial information about the program, for use by external libraries and tools.
+///
+/// Keys represent tool namespaces, and values are tool-specific annotations themselves.
+/// Annotation values are JSON values, so they can be arbitrarily complex.
+///
+/// ## Namespaces
+///
+/// In order to avoid collisions between tools, namespaces should be URL-like, contain tool name.
+/// It is not required for namespace URLs to exist, but it is preferable nonetheless.
+///
+/// A single tool might want to use multiple namespaces, for example to group together annotations
+/// coming from different subcomponents of the tool. In such case, namespaces should use path-like
+/// notation (e.g. `example.com/sub-namespace`).
+///
+/// For future-proofing, it might be a good idea to version namespaces, e.g. `example.com/v1`.
+///
+/// ### Example well-formed namespaces
+///
+/// - `scarb.swmansion.com`
+/// - `scarb.swmansion.com/v1`
+/// - `scarb.swmansion.com/build-info/v1`
+pub type Annotations = OrderedHashMap<String, serde_json::Value>;

--- a/crates/cairo-lang-executable/src/executable.rs
+++ b/crates/cairo-lang-executable/src/executable.rs
@@ -5,6 +5,7 @@ use itertools::chain;
 use serde::{Deserialize, Serialize};
 
 use crate::compile::CompiledFunction;
+use crate::debug_info::DebugInfo;
 
 pub const NOT_RETURNING_HEADER_SIZE: usize = 6;
 
@@ -15,6 +16,9 @@ pub struct Executable {
     pub program: AssembledCairoProgram,
     /// The available entrypoints for the program.
     pub entrypoints: Vec<ExecutableEntryPoint>,
+    /// Debug information for the assembled program.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debug_info: Option<DebugInfo>,
 }
 
 impl Executable {
@@ -43,6 +47,7 @@ impl Executable {
                     kind: EntryPointKind::Bootloader,
                 },
             ],
+            debug_info: Default::default(),
         }
     }
 }

--- a/crates/cairo-lang-executable/src/lib.rs
+++ b/crates/cairo-lang-executable/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod compile;
 pub mod executable;
 
+mod debug_info;
+
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
Will be used to store info needed by the profiler (next pr).