### PR TITLE
Save program offset in executable debug info annotations

### DIFF
--- a/crates/cairo-lang-executable/src/debug_info.rs
+++ b/crates/cairo-lang-executable/src/debug_info.rs
@@ -33,3 +33,22 @@ pub struct DebugInfo {
 /// - `scarb.swmansion.com/v1`
 /// - `scarb.swmansion.com/build-info/v1`
 pub type Annotations = OrderedHashMap<String, serde_json::Value>;
+
+/// Program offsets information, for use by the profiler.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProgramInformation {
+    /// The bytecode offset of the first CASM instruction after all added headers.
+    /// It is the offset of the first CASM instruction of the original CASM program (the one that
+    /// is a direct result of Sierra compilation).
+    pub program_offset: usize,
+}
+
+impl From<ProgramInformation> for Annotations {
+    fn from(value: ProgramInformation) -> Self {
+        let mapping = serde_json::to_value(value).unwrap();
+        OrderedHashMap::from([(
+            "github.com/software-mansion/cairo-profiler".to_string(),
+            serde_json::Value::from_iter([("program_info", mapping)]),
+        )])
+    }
+}

--- a/crates/cairo-lang-executable/src/executable.rs
+++ b/crates/cairo-lang-executable/src/executable.rs
@@ -5,7 +5,7 @@ use itertools::chain;
 use serde::{Deserialize, Serialize};
 
 use crate::compile::CompiledFunction;
-use crate::debug_info::DebugInfo;
+use crate::debug_info::{Annotations, DebugInfo, ProgramInformation};
 
 pub const NOT_RETURNING_HEADER_SIZE: usize = 6;
 
@@ -47,7 +47,17 @@ impl Executable {
                     kind: EntryPointKind::Bootloader,
                 },
             ],
-            debug_info: Default::default(),
+            debug_info: Some(DebugInfo {
+                annotations: Annotations::from(ProgramInformation {
+                    program_offset: NOT_RETURNING_HEADER_SIZE
+                        + compiled
+                            .wrapper
+                            .header
+                            .iter()
+                            .map(|inst| inst.body.op_size())
+                            .sum::<usize>(),
+                }),
+            }),
         }
     }
 }


### PR DESCRIPTION
Will be used by the profiler to skip headers. 