### PR TITLE
Make file_syntax_data function public

### DIFF
--- a/crates/cairo-lang-parser/src/db.rs
+++ b/crates/cairo-lang-parser/src/db.rs
@@ -50,7 +50,7 @@ struct SyntaxData<'db> {
 
 /// Parses a file and returns the result and the generated [ParserDiagnostic].
 #[salsa::tracked(returns(ref))]
-fn file_syntax_data<'db>(db: &'db dyn Database, file_id: FileId<'db>) -> SyntaxData<'db> {
+pub fn file_syntax_data<'db>(db: &'db dyn Database, file_id: FileId<'db>) -> SyntaxData<'db> {
     let mut diagnostics = DiagnosticsBuilder::default();
     let syntax = db.file_content(file_id).to_maybe().map(|s| match file_id.kind(db) {
         FileKind::Module => Parser::parse_file(db, &mut diagnostics, file_id, s).as_syntax_node(),

--- a/crates/cairo-lang-semantic/src/expr/pattern.rs
+++ b/crates/cairo-lang-semantic/src/expr/pattern.rs
@@ -5,9 +5,9 @@ use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
+use salsa::Database;
 
 use super::fmt::ExprFormatter;
-use crate::db::SemanticGroup;
 use crate::items::function_with_body::FunctionWithBodySemantic;
 use crate::{
     ConcreteStructId, ExprLiteral, ExprStringLiteral, LocalVariable, PatternArena, PatternId,
@@ -123,7 +123,7 @@ impl<'a> PatternVariablesQueryable<'a> for PatternArena<'a> {
 /// This is a wrapper over [`SemanticGroup`] that takes [`FunctionWithBodyId`]
 /// and relays queries to [`FunctionWithBodySemantic::pattern_semantic`].
 pub struct QueryPatternVariablesFromDb<'a>(
-    pub &'a (dyn SemanticGroup + 'static),
+    pub &'a (dyn Database + 'static),
     pub FunctionWithBodyId<'a>,
 );
 


### PR DESCRIPTION
1. We make it public as we need it in the cairo-lint and LS.
2. We change the type to `dyn Database`, as we want to use this struct in LS, where we use the `Database` type from salsa already