### PR TITLE
docs: fix typos

### DIFF
--- a/crates/cairo-lang-syntax/src/attribute/consts.rs
+++ b/crates/cairo-lang-syntax/src/attribute/consts.rs
@@ -1,4 +1,4 @@
-// Attributes which does not invoke any plugin, and thus are not declared in the plugin crate.
+// Attributes which do not invoke any plugin, and thus are not declared in the plugin crate.
 
 /// An attribute that can be used to make the formatter ignore the formatting of a statement or an
 /// item, and keep the user defined formatting.

--- a/crates/cairo-lang-test-plugin/src/lib.rs
+++ b/crates/cairo-lang-test-plugin/src/lib.rs
@@ -55,7 +55,7 @@ pub struct TestsCompilationConfig<'db> {
     pub starknet: bool,
 
     /// Contracts to compile.
-    /// If defined, only this contacts will be available in tests.
+    /// If defined, only these contracts will be available in tests.
     /// If not, all contracts from `contract_crate_ids` will be compiled.
     pub contract_declarations: Option<Vec<ContractDeclaration<'db>>>,
 


### PR DESCRIPTION
Attributes which does not -> Attributes which do not
    /// Contracts to compile.
    /// If defined, only this contacts ->
    /// Contracts to compile.
    /// If defined, only these contracts