### PR TITLE
Remove outdated TODO comments in gas test file

### DIFF
--- a/tests/e2e_test_data/libfuncs/gas
+++ b/tests/e2e_test_data/libfuncs/gas
@@ -4,7 +4,6 @@
 SmallE2ETestRunnerSkipAddGas
 
 //! > cairo_code
-// TODO(lior): Use gas::redeposit_gas once it's there.
 extern fn redeposit_gas() implicits(GasBuiltin) nopanic;
 
 fn foo(x: felt252) {
@@ -86,7 +85,6 @@ test::bar@F1() -> ();
 SmallE2ETestRunnerSkipAddGas
 
 //! > cairo_code
-// TODO(lior): Use gas::redeposit_gas once it's there.
 extern fn redeposit_gas() implicits(GasBuiltin) nopanic;
 
 fn foo(x: felt252) {


### PR DESCRIPTION

Removed outdated TODO comments in `tests/e2e_test_data/libfuncs/gas` that referenced non-existent `gas::redeposit_gas` function.

## Rationale
The `gas::redeposit_gas` function already exists in `corelib/src/gas.cairo`, making these TODO comments misleading and contributing to technical debt. Removing them improves code readability and reduces confusion for contributors.

