### PR TITLE
refactor: Replace unused variable `_iife` with explicit discard pattern

### DIFF
--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -395,7 +395,8 @@ fn add_unused_import_diagnostics<'db>(
     use_id: UseId<'db>,
     diagnostics: &mut DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
 ) {
-    let _iife = (|| {
+    // Explicitly discard the result of the IIFE to satisfy must_use and improve readability.
+    let _ = (|| {
         let item = db.use_resolved_item(use_id).ok()?;
         // TODO(orizi): Properly handle usages of impls, and than add warnings on their usages as
         // well.


### PR DESCRIPTION

## Summary

Improves code readability by replacing an unused variable assignment with the idiomatic `let _ = ...` pattern for explicitly discarding values.

## Motivation

The variable `_iife` was created solely to suppress `must_use` warnings but wasn't actually used. This creates a false impression that the value is being utilized, reducing code clarity.

## Benefits

- **Improved readability:** `let _ = ...` is the idiomatic Rust pattern for explicitly discarding values
- **Clear intent:** Makes it obvious that we're intentionally ignoring the result

