### PR TITLE
fix: correct doc comment for function_inline_config

### DIFF
--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -92,7 +92,7 @@ pub fn priv_never_inline<'db>(
     Ok(matches!(function_inline_config(db, function_id)?, InlineConfiguration::Never(_)))
 }
 
-/// Query implementation of [LoweringGroup::priv_never_inline].
+/// Query implementation of [LoweringGroup::function_inline_config].
 pub fn function_inline_config<'db>(
     db: &'db dyn Database,
     function_id: ConcreteFunctionWithBodyId<'db>,


### PR DESCRIPTION
correct doc comment reference for function_inline_config