### PR TITLE
chore(scripts): add Bash shebang to release_crates.sh for portability

### DIFF
--- a/scripts/release_crates.sh
+++ b/scripts/release_crates.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # An optional argument, '-s | --skip-first <#num_to_skip>', can be passed to skip the first #num_to_skip crates, otherwise SKIP_FIRST is set to 0.
 if [ "$1" = "-s" ] || [ "$1" = "--skip-first" ]; then
     if [ -z "$2" ]; then


### PR DESCRIPTION


### Description
- Summary: Ensure `release_crates.sh` always runs under Bash.
- Rationale: Script uses Bash-specific arrays; without a shebang, environments invoking `/bin/sh` may fail.
- Change: Add `#!/usr/bin/env bash` as the first line.
