### PR TITLE
Using MiMallocator for better performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "cairo-lang-utils",
  "clap",
  "log",
+ "mimalloc",
  "tracing",
 ]
 
@@ -432,6 +433,7 @@ dependencies = [
  "cairo-lang-sierra-generator",
  "cairo-vm",
  "clap",
+ "mimalloc",
  "num-bigint",
  "salsa",
  "serde_json",
@@ -447,6 +449,7 @@ dependencies = [
  "colored",
  "ignore",
  "log",
+ "mimalloc",
  "tracing",
 ]
 
@@ -1167,6 +1170,7 @@ dependencies = [
  "cairo-lang-sierra-generator",
  "cairo-lang-starknet",
  "clap",
+ "mimalloc",
 ]
 
 [[package]]
@@ -1190,6 +1194,7 @@ dependencies = [
  "cairo-lang-utils",
  "clap",
  "itertools 0.14.0",
+ "mimalloc",
  "salsa",
 ]
 
@@ -1202,6 +1207,7 @@ dependencies = [
  "cairo-lang-runner",
  "cairo-lang-test-runner",
  "clap",
+ "mimalloc",
 ]
 
 [[package]]
@@ -1843,6 +1849,7 @@ dependencies = [
  "clap",
  "convert_case",
  "itertools 0.14.0",
+ "mimalloc",
  "salsa",
 ]
 
@@ -2441,6 +2448,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2535,15 @@ checksum = "51d1790c73b93164ff65868f63164497cb32339458a9297e17e212d91df62258"
 dependencies = [
  "log",
  "sprs",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3553,6 +3579,7 @@ dependencies = [
  "clap",
  "indoc",
  "log",
+ "mimalloc",
  "tracing",
 ]
 
@@ -3642,6 +3669,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "clap",
+ "mimalloc",
 ]
 
 [[package]]
@@ -3681,6 +3709,7 @@ dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "clap",
+ "mimalloc",
  "serde",
  "serde_json",
 ]
@@ -3692,6 +3721,7 @@ dependencies = [
  "anyhow",
  "cairo-lang-starknet-classes",
  "clap",
+ "mimalloc",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ opt-level = 3
 opt-level = 3
 [profile.ci-dev.package."vector-map"]
 opt-level = 3
+[profile.ci-dev.package."mimalloc"]
+opt-level = 3
+[profile.ci-dev.package."libmimalloc-sys"]
+opt-level = 3
 
 [workspace]
 resolver = "2"
@@ -123,6 +127,7 @@ itertools = { version = "0.14.0", default-features = false }
 keccak = "0.1.5"
 lalrpop-util = { version = "0.22.2", features = ["lexer"] }
 log = "0.4.27"
+mimalloc = { version = "0.1.48" }
 num-bigint = { version = "0.4.6", default-features = false }
 num-integer = "0.1.46"
 num-traits = { version = "0.2.19", default-features = false }

--- a/crates/bin/cairo-compile/Cargo.toml
+++ b/crates/bin/cairo-compile/Cargo.toml
@@ -10,8 +10,12 @@ description = "Cairo compiler executable for the Cairo programming language"
 anyhow.workspace = true
 clap.workspace = true
 log.workspace = true
+mimalloc = { workspace = true, optional = true }
 tracing.workspace = true
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "~2.13.0" }
 cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "~2.13.0" }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.13.0", features = ["tracing"] }
+
+[features]
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -7,6 +7,10 @@ use cairo_lang_compiler::{CompilerConfig, compile_cairo_project_at_path};
 use cairo_lang_utils::logging::init_logging;
 use clap::Parser;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Options for the `inlining-strategy` arguments.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum InliningStrategy {

--- a/crates/bin/cairo-execute/Cargo.toml
+++ b/crates/bin/cairo-execute/Cargo.toml
@@ -19,6 +19,11 @@ cairo-lang-runner = { path = "../../cairo-lang-runner", version = "~2.13.0" }
 cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "~2.13.0" }
 cairo-vm = { workspace = true, features = ["clap"] }
 clap.workspace = true
+mimalloc = { workspace = true, features = ["secure"], optional = true }
 num-bigint.workspace = true
 salsa.workspace = true
 serde_json.workspace = true
+
+[features]
+
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/cairo-execute/src/main.rs
+++ b/crates/bin/cairo-execute/src/main.rs
@@ -30,6 +30,10 @@ use clap::Parser;
 use num_bigint::BigInt;
 use salsa::Database;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Compiles a Cairo project and runs a function marked `#[executable]`.
 /// Exits with 1 if the compilation or run fails, otherwise 0.
 #[derive(Parser, Debug)]

--- a/crates/bin/cairo-format/Cargo.toml
+++ b/crates/bin/cairo-format/Cargo.toml
@@ -11,7 +11,11 @@ clap.workspace = true
 colored.workspace = true
 ignore.workspace = true
 log.workspace = true
+mimalloc = { workspace = true, optional = true }
 tracing.workspace = true
 
 cairo-lang-formatter = { path = "../../cairo-lang-formatter", version = "~2.13.0" }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.13.0", features = ["tracing"] }
+
+[features]
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/cairo-format/src/main.rs
+++ b/crates/bin/cairo-format/src/main.rs
@@ -11,6 +11,10 @@ use ignore::WalkState::Continue;
 use ignore::{DirEntry, Error, ParallelVisitor, ParallelVisitorBuilder, WalkState};
 use log::warn;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Outputs a string to stderr if the verbose flag is true.
 fn eprintln_if_verbose(s: &str, verbose: bool) {
     if verbose {

--- a/crates/bin/cairo-run/Cargo.toml
+++ b/crates/bin/cairo-run/Cargo.toml
@@ -9,6 +9,7 @@ description = "Runner executable for the Cairo programming language"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+mimalloc = { workspace = true, optional = true }
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "~2.13.0" }
 cairo-lang-diagnostics = { path = "../../cairo-lang-diagnostics", version = "~2.13.0" }
@@ -16,3 +17,6 @@ cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "~2.13
 cairo-lang-runner = { path = "../../cairo-lang-runner", version = "~2.13.0" }
 cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "~2.13.0" }
 cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "~2.13.0" }
+
+[features]
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/cairo-run/src/main.rs
+++ b/crates/bin/cairo-run/src/main.rs
@@ -18,6 +18,10 @@ use cairo_lang_sierra_generator::replace_ids::{DebugReplacer, SierraIdReplacer};
 use cairo_lang_starknet::contract::{find_contracts, get_contracts_info};
 use clap::Parser;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Compiles a Cairo project and runs the function `main`.
 /// Exits with 1 if the compilation or run fails, otherwise 0.
 #[derive(Parser, Debug)]

--- a/crates/bin/cairo-size-profiler/Cargo.toml
+++ b/crates/bin/cairo-size-profiler/Cargo.toml
@@ -9,6 +9,7 @@ description = "Runner executable for the Cairo programming language"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+mimalloc = { workspace = true, optional = true }
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "~2.13.0" }
 cairo-lang-defs = { path = "../../cairo-lang-defs", version = "~2.13.0" }
@@ -26,3 +27,7 @@ cairo-lang-syntax = { path = "../../cairo-lang-syntax", version = "~2.13.0" }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.13.0" }
 itertools = { workspace = true, default-features = true }
 salsa.workspace = true
+
+[features]
+
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/cairo-size-profiler/src/main.rs
+++ b/crates/bin/cairo-size-profiler/src/main.rs
@@ -38,6 +38,10 @@ use clap::Parser;
 use itertools::{Itertools, chain};
 use salsa::Database;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Compiles a Cairo project and analyzes the size-related costs of its components.
 /// Exits with a status code of 1 if compilation or analysis fails, and 0 otherwise.
 #[derive(Parser, Debug)]

--- a/crates/bin/cairo-test/Cargo.toml
+++ b/crates/bin/cairo-test/Cargo.toml
@@ -9,7 +9,11 @@ description = "Test runner for the Cairo programming language"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+mimalloc = { workspace = true, optional = true }
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "~2.13.0" }
 cairo-lang-runner = { path = "../../cairo-lang-runner", version = "~2.13.0" }
 cairo-lang-test-runner = { path = "../../cairo-lang-test-runner", version = "~2.13.0" }
+
+[features]
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/cairo-test/src/main.rs
+++ b/crates/bin/cairo-test/src/main.rs
@@ -7,6 +7,10 @@ use cairo_lang_runner::clap::RunProfilerConfigArg;
 use cairo_lang_test_runner::{TestRunConfig, TestRunner};
 use clap::Parser;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Compiles a Cairo project and runs all the functions marked as `#[test]`.
 /// Exits with 1 if the compilation or run fails, otherwise 0.
 #[derive(Parser, Debug)]

--- a/crates/bin/get-lowering/Cargo.toml
+++ b/crates/bin/get-lowering/Cargo.toml
@@ -22,4 +22,9 @@ cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.13.0" }
 clap.workspace = true
 convert_case.workspace = true
 itertools.workspace = true
+mimalloc = { workspace = true, optional = true }
 salsa.workspace = true
+
+[features]
+
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -39,6 +39,10 @@ use convert_case::Casing;
 use itertools::Itertools;
 use salsa::Database;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Tests that `PhasesFormatter` is consistent with the lowering phases.
 #[test]
 fn test_lowering_consistency() {

--- a/crates/bin/sierra-compile/Cargo.toml
+++ b/crates/bin/sierra-compile/Cargo.toml
@@ -11,9 +11,13 @@ anyhow.workspace = true
 clap.workspace = true
 indoc.workspace = true
 log.workspace = true
+mimalloc = { workspace = true, optional = true }
 tracing.workspace = true
 
 cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "~2.13.0" }
 cairo-lang-sierra-to-casm = { path = "../../cairo-lang-sierra-to-casm", version = "~2.13.0" }
 cairo-lang-sierra-type-size = { path = "../../cairo-lang-sierra-type-size", version = "~2.13.0" }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.13.0", features = ["tracing"] }
+
+[features]
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/sierra-compile/src/main.rs
+++ b/crates/bin/sierra-compile/src/main.rs
@@ -9,6 +9,10 @@ use cairo_lang_utils::logging::init_logging;
 use clap::Parser;
 use indoc::formatdoc;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Compiles a Sierra file to CASM.
 /// Exits with 0/1 if the compilation succeeds/fails.
 #[derive(Parser, Debug)]

--- a/crates/bin/starknet-compile/Cargo.toml
+++ b/crates/bin/starknet-compile/Cargo.toml
@@ -9,7 +9,11 @@ description = "Compiler executable for the Cairo programming language with the S
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+mimalloc = { workspace = true, optional = true }
 
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "~2.13.0" }
 cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "~2.13.0" }
 cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "~2.13.0" }
+
+[features]
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/starknet-compile/src/main.rs
+++ b/crates/bin/starknet-compile/src/main.rs
@@ -9,6 +9,10 @@ use cairo_lang_starknet::compile::starknet_compile;
 use cairo_lang_starknet_classes::allowed_libfuncs::ListSelector;
 use clap::Parser;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Compiles the specified contract from a Cairo project, into a contract class file.
 /// Exits with 0/1 if the compilation succeeds/fails.
 #[derive(Parser, Debug)]

--- a/crates/bin/starknet-sierra-compile/Cargo.toml
+++ b/crates/bin/starknet-sierra-compile/Cargo.toml
@@ -9,9 +9,13 @@ description = "Compiler executable for the Sierra intermediate representation wi
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+mimalloc = { workspace = true, optional = true }
 serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 
 cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "~2.13.0" }
 cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "~2.13.0" }
 cairo-lang-utils = { path = "../../cairo-lang-utils", version = "~2.13.0", features = ["serde"] }
+
+[features]
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/starknet-sierra-compile/src/main.rs
+++ b/crates/bin/starknet-sierra-compile/src/main.rs
@@ -8,6 +8,10 @@ use cairo_lang_utils::bigint::BigUintAsHex;
 use clap::Parser;
 use serde::Deserialize;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Compiles a Sierra contract class into CASM contract class.
 /// Exits with 0/1 if the compilation succeeds/fails.
 #[derive(Parser, Debug)]

--- a/crates/bin/starknet-sierra-extract-code/Cargo.toml
+++ b/crates/bin/starknet-sierra-extract-code/Cargo.toml
@@ -11,4 +11,9 @@ publish = false
 anyhow.workspace = true
 cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "~2.13.0" }
 clap.workspace = true
+mimalloc = { workspace = true, optional = true }
 serde_json.workspace = true
+
+[features]
+
+mimalloc = ["dep:mimalloc"]

--- a/crates/bin/starknet-sierra-extract-code/src/main.rs
+++ b/crates/bin/starknet-sierra-extract-code/src/main.rs
@@ -4,6 +4,10 @@ use anyhow::Context;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use clap::Parser;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Extracts Sierra code from a contract class file.
 /// Exits with 0/1 if the extraction succeeds/fails.
 #[derive(Parser, Debug)]


### PR DESCRIPTION
### TL;DR

Added mimalloc as the global allocator for all Cairo binaries to improve memory management.

### What changed?

- Added mimalloc as a dependency in the workspace Cargo.toml
- Configured mimalloc as the global allocator in all binary crates:
  - cairo-compile
  - cairo-execute
  - cairo-format
  - cairo-size-profiler
  - cairo-test
  - get-lowering
  - sierra-compile
  - starknet-compile
  - starknet-sierra-compile
  - starknet-sierra-extract-code
- Using secure feature in cairo-execute