### PR TITLE
chore: fix documentation comment format in SHA256 example

### DIFF
--- a/corelib/src/sha256.cairo
+++ b/corelib/src/sha256.cairo
@@ -75,10 +75,10 @@ pub fn compute_sha256_u32_array(
 /// ```
 /// use core::sha256::compute_sha256_byte_array;
 ///
-//! let data = "Hello";
-//! let hash = compute_sha256_byte_array(@data);
-//! assert!(hash == [0x185f8db3, 0x2271fe25, 0xf561a6fc, 0x938b2e26, 0x4306ec30, 0x4eda5180,
-//! 0x7d17648, 0x26381969]);
+/// let data = "Hello";
+/// let hash = compute_sha256_byte_array(@data);
+/// assert!(hash == [0x185f8db3, 0x2271fe25, 0xf561a6fc, 0x938b2e26, 0x4306ec30, 0x4eda5180,
+/// 0x7d17648, 0x26381969]);
 /// ```
 pub fn compute_sha256_byte_array(arr: @ByteArray) -> [u32; 8] {
     let mut word_arr = array![];


### PR DESCRIPTION
Fixed documentation comment format in the SHA256 module by changing incorrect module-level comment symbols ( //! ) to proper function-level documentation symbols ( /// ) in the example code. 

This ensures proper parsing by documentation generation tools and maintains consistent documentation style throughout the codebase.