### PR TITLE
Fix macOS release asset suffix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
             target: x86_64-unknown-linux-musl
           - os: macos-latest
             artifact_name: aarch64-apple-darwin.tar.gz
-            asset_name: release-aarch64-apple-darwin.tar
+            asset_name: release-aarch64-apple-darwin.tar.gz
             target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
The macOS release asset name used `.tar` while the build script (`scripts/release_tar.sh`) produces `.tar.gz`. 