### PR TITLE
refactor(byte_array): delegate ByteArray iterator into ByteSpan iterator

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -705,27 +705,24 @@ pub(crate) impl ByteArrayIndexView of crate::traits::IndexView<ByteArray, usize,
     }
 }
 
-// TODO(giladchase): Delegate to byte span iterator instead of current at-based implementation.
 /// An iterator struct over a ByteArray.
 #[derive(Drop, Clone)]
 pub struct ByteArrayIter {
-    ba: ByteArray,
-    current_index: IntoIterator::<crate::ops::Range<usize>>::IntoIter,
+    inner: ByteSpanIter,
 }
 
 impl ByteArrayIterator of crate::iter::Iterator<ByteArrayIter> {
     type Item = u8;
 
     fn next(ref self: ByteArrayIter) -> Option<u8> {
-        self.ba.at(self.current_index.next()?)
+        self.inner.next()
     }
 }
 
 impl ByteArrayIntoIterator of crate::iter::IntoIterator<ByteArray> {
     type IntoIter = ByteArrayIter;
-    #[inline]
     fn into_iter(self: ByteArray) -> Self::IntoIter {
-        ByteArrayIter { current_index: (0..self.len()).into_iter(), ba: self }
+        ByteArrayIter { inner: self.span().into_iter() }
     }
 }
 


### PR DESCRIPTION
Faster than current approach, which uses `at`.