### PR TITLE
Clean Up lowering_test Fixture Usage

### DIFF
--- a/tests/examples_test.rs
+++ b/tests/examples_test.rs
@@ -41,8 +41,7 @@ fn example_dir_data() -> ExampleDirData {
 }
 
 #[rstest]
-#[expect(unused_variables)]
-fn lowering_test(example_dir_data: &ExampleDirData) {}
+fn lowering_test(_example_dir_data: &ExampleDirData) {}
 
 /// Returns the path of the relevant test file.
 fn get_test_data_path(name: &str, test_type: &str) -> PathBuf {


### PR DESCRIPTION
remove the redundant #[expect(unused_variables)] on lowering_test
keep the fixture wiring intact by renaming the parameter to _example_dir_data

Testing: cargo test --package tests --test examples_test --workspace