### PR TITLE
fix(semantic): incorrect diagnostics for var redefinition in patterns

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -404,6 +404,9 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::MissingVariableInPattern => {
                 "Missing variable in pattern.".into()
             }
+            SemanticDiagnosticKind::VariableDefinedMultipleTimesInPattern(name) => {
+                format!(r#"Redefinition of variable name "{}" in pattern."#, name.long(db))
+            }
             SemanticDiagnosticKind::StructMemberRedefinition { struct_id, member_name } => {
                 format!(
                     r#"Redefinition of member "{}" on struct "{}"."#,
@@ -1293,6 +1296,7 @@ pub enum SemanticDiagnosticKind<'db> {
     },
     VariableNotFound(SmolStrId<'db>),
     MissingVariableInPattern,
+    VariableDefinedMultipleTimesInPattern(SmolStrId<'db>),
     StructMemberRedefinition {
         struct_id: StructId<'db>,
         member_name: SmolStrId<'db>,

--- a/crates/cairo-lang-semantic/src/expr/test_data/for
+++ b/crates/cairo-lang-semantic/src/expr/test_data/for
@@ -63,7 +63,7 @@ error[E0006]: Identifier not found.
 //! > Test for loop with duplicate variables in pattern.
 
 //! > test_runner_name
-test_function_diagnostics(expect_diagnostics: false)
+test_function_diagnostics(expect_diagnostics: true)
 
 //! > function
 fn foo() {
@@ -76,3 +76,7 @@ foo
 //! > module_code
 
 //! > expected_diagnostics
+error: Redefinition of variable name "_a" in pattern.
+ --> lib.cairo:2:14
+    for (_a, _a) in array![(1, 2)] {}
+             ^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/pattern
+++ b/crates/cairo-lang-semantic/src/expr/test_data/pattern
@@ -276,7 +276,7 @@ error: Wrong number of tuple elements in pattern. Expected: 0. Got: 1.
 //! > Test duplicate variables in tuple pattern let.
 
 //! > test_runner_name
-test_function_diagnostics(expect_diagnostics: false)
+test_function_diagnostics(expect_diagnostics: true)
 
 //! > function
 fn foo() {
@@ -289,6 +289,10 @@ foo
 //! > module_code
 
 //! > expected_diagnostics
+error: Redefinition of variable name "_a" in pattern.
+ --> lib.cairo:2:14
+    let (_a, _a) = (1, 2);
+             ^^
 
 //! > ==========================================================================
 
@@ -314,12 +318,12 @@ foo
 //! > module_code
 
 //! > expected_diagnostics
-error: Missing variable in pattern.
- --> lib.cairo:3:9
+error: Redefinition of variable name "_a" in pattern.
+ --> lib.cairo:3:14
         (_a, _a) => (),
-        ^^^^^^^^
+             ^^
 
-error: Missing variable in pattern.
- --> lib.cairo:7:9
+error: Redefinition of variable name "_b" in pattern.
+ --> lib.cairo:7:19
         ((_b, _), _b) => (),
-        ^^^^^^^^^^^^^
+                  ^^


### PR DESCRIPTION
fix(semantic): incorrect diagnostics for var redefinition in patterns

Either no diagnostics was printed, or an incorrect diagnostic "Missing variable in pattern."
was printed.

fix(semantic): add diagnostic for duplicate var names in pattern