### PR TITLE
feat: add `VariableTracker` to `ComputationContext`

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/objects.rs
+++ b/crates/cairo-lang-semantic/src/expr/objects.rs
@@ -4,7 +4,6 @@ use cairo_lang_diagnostics::DiagnosticAdded;
 use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
-use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use id_arena::{Arena, ArenaBehavior};
 use num_bigint::BigInt;
 use salsa::Database;
@@ -225,20 +224,6 @@ impl<'db> Expr<'db> {
             Expr::Var(expr) => Some(ExprVarMemberPath::Var(expr.clone())),
             Expr::MemberAccess(expr) => expr.member_path.clone(),
             _ => None,
-        }
-    }
-
-    /// Returns true if the expression is a variable or a member access of a mutable variable.
-    pub fn is_mutable_var(
-        &self,
-        semantic_defs: &UnorderedHashMap<semantic::VarId<'db>, semantic::Binding<'db>>,
-    ) -> bool {
-        if let Some(base_var) = self.as_member_path().map(|path| path.base_var())
-            && let Some(var_def) = semantic_defs.get(&base_var)
-        {
-            var_def.is_mut()
-        } else {
-            false
         }
     }
 }


### PR DESCRIPTION
Motivation:
- Reduces coupling with environment.variables (but not completely).
- VariableTracker will also include upcoming metadata for supporting the
experimental `&T` feature.