### PR TITLE
feat(semantic): add experimental support for &T

### DIFF
--- a/corelib/src/box.cairo
+++ b/corelib/src/box.cairo
@@ -53,8 +53,7 @@ extern fn unbox<T>(box: Box<T>) -> T nopanic;
 extern fn box_forward_snapshot<T>(value: @Box<T>) -> Box<@T> nopanic;
 
 /// Basic trait for the `Box` type.
-#[generate_trait]
-pub impl BoxImpl<T> of BoxTrait<T> {
+pub trait BoxTrait<T> {
     /// Creates a new `Box` with the given value.
     ///
     /// Allocates space in the boxed segment for the provided value
@@ -65,12 +64,7 @@ pub impl BoxImpl<T> of BoxTrait<T> {
     /// let x = 42;
     /// let boxed_x = BoxTrait::new(x);
     /// ```
-    #[inline]
-    #[must_use]
-    fn new(value: T) -> Box<T> nopanic {
-        into_box(value)
-    }
-
+    fn new(value: T) -> Box<T> nopanic;
     /// Unboxes the given `Box` and returns the wrapped value.
     ///
     /// # Examples
@@ -79,12 +73,7 @@ pub impl BoxImpl<T> of BoxTrait<T> {
     /// let boxed = BoxTrait::new(42);
     /// assert!(boxed.unbox() == 42);
     /// ```
-    #[inline]
-    #[must_use]
-    fn unbox(self: Box<T>) -> T nopanic {
-        unbox(self)
-    }
-
+    fn unbox(self: Box<T>) -> T nopanic;
     /// Converts the given snapshot of a `Box` into a `Box` of a snapshot.
     /// Useful for structures that aren't copyable.
     ///
@@ -95,6 +84,21 @@ pub impl BoxImpl<T> of BoxTrait<T> {
     /// let boxed_snap_arr = snap_boxed_arr.as_snapshot();
     /// let snap_arr = boxed_snap_arr.unbox();
     /// ```
+    fn as_snapshot(self: @Box<T>) -> Box<@T> nopanic;
+}
+pub impl BoxImpl<T> of BoxTrait<T> {
+    #[inline]
+    #[must_use]
+    fn new(value: T) -> Box<T> nopanic {
+        into_box(value)
+    }
+
+    #[inline]
+    #[must_use]
+    fn unbox(self: Box<T>) -> T nopanic {
+        unbox(self)
+    }
+
     #[must_use]
     fn as_snapshot(self: @Box<T>) -> Box<@T> nopanic {
         box_forward_snapshot(self)

--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -205,6 +205,9 @@ pub struct ExperimentalFeaturesConfig {
     /// Allows using user defined inline macros.
     #[serde(default)]
     pub user_defined_inline_macros: bool,
+    /// Allows using reference types (&T), which desugar to BoxTrait<@T>.
+    #[serde(default)]
+    pub references: bool,
 }
 
 /// Function to get a virtual file from an external id.
@@ -410,6 +413,7 @@ pub fn init_dev_corelib(db: &mut dyn salsa::Database, core_lib_dir: PathBuf) {
                 associated_item_constraints: true,
                 coupons: true,
                 user_defined_inline_macros: true,
+                references: true,
             },
         },
         cache_file: None,

--- a/crates/cairo-lang-project/src/test.rs
+++ b/crates/cairo-lang-project/src/test.rs
@@ -47,6 +47,7 @@ fn test_serde() {
                             associated_item_constraints: false,
                             coupons: false,
                             user_defined_inline_macros: false,
+                            references: false,
                         },
                         cfg_set: Default::default(),
                     },
@@ -75,6 +76,7 @@ fn test_serde() {
             associated_item_constraints = false
             coupons = false
             user_defined_inline_macros = false
+            references = false
 
             [config.override.crate1]
             edition = "2023_10"
@@ -86,6 +88,7 @@ fn test_serde() {
             associated_item_constraints = false
             coupons = false
             user_defined_inline_macros = false
+            references = false
 
             [config.override.crate3]
             edition = "2023_01"
@@ -97,6 +100,7 @@ fn test_serde() {
             associated_item_constraints = false
             coupons = false
             user_defined_inline_macros = false
+            references = false
         "# }
     );
     assert_eq!(config, toml::from_str(&serialized).unwrap());
@@ -129,6 +133,7 @@ fn test_serde_defaults() {
         associated_item_constraints = false
         coupons = false
         user_defined_inline_macros = false
+        references = false
 
         [config.override]
     "# };

--- a/crates/cairo-lang-semantic/src/corelib.rs
+++ b/crates/cairo-lang-semantic/src/corelib.rs
@@ -960,6 +960,7 @@ pub struct CoreInfo<'db> {
     pub fn_once_trt: TraitId<'db>,
     pub type_eq_trt: TraitId<'db>,
     pub felt252_dict_value_trt: TraitId<'db>,
+    pub box_trt: TraitId<'db>,
     // Trait fns.
     pub deref_fn: TraitFunctionId<'db>,
     pub deref_mut_fn: TraitFunctionId<'db>,
@@ -994,6 +995,7 @@ pub struct CoreInfo<'db> {
     pub next_fn: TraitFunctionId<'db>,
     pub call_fn: TraitFunctionId<'db>,
     pub call_once_fn: TraitFunctionId<'db>,
+    pub box_new_fn: TraitFunctionId<'db>,
     pub upcast_fn: GenericFunctionId<'db>,
     pub downcast_fn: GenericFunctionId<'db>,
     pub tuple_submodule: ModuleId<'db>,
@@ -1041,6 +1043,8 @@ impl<'db> CoreInfo<'db> {
         let fn_module = ops.submodule("function");
         let fn_trt = fn_module.trait_id("Fn");
         let fn_once_trt = fn_module.trait_id("FnOnce");
+        let box_module = core.submodule("box");
+        let box_trt = box_module.trait_id("BoxTrait");
         let index_module = ops.submodule("index");
         let starknet = core.submodule("starknet");
         let bounded_int = core.submodule("internal").submodule("bounded_int");
@@ -1102,6 +1106,7 @@ impl<'db> CoreInfo<'db> {
             fn_once_trt,
             type_eq_trt: core.submodule("metaprogramming").trait_id("TypeEqual"),
             felt252_dict_value_trt: traits.trait_id("Felt252DictValue"),
+            box_trt,
             deref_fn: trait_fn(deref_trt, "deref"),
             deref_mut_fn: trait_fn(deref_mut_trt, "deref_mut"),
             destruct_fn: trait_fn(destruct_trt, "destruct"),
@@ -1135,6 +1140,7 @@ impl<'db> CoreInfo<'db> {
             next_fn: trait_fn(iterator_trt, "next"),
             call_fn: trait_fn(fn_trt, "call"),
             call_once_fn: trait_fn(fn_once_trt, "call"),
+            box_new_fn: trait_fn(box_trt, "new"),
             upcast_fn: bounded_int.generic_function_id("upcast"),
             downcast_fn: bounded_int.generic_function_id("downcast"),
             tuple_submodule,

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -16,7 +16,7 @@ use cairo_lang_defs::ids::{
     StatementUseLongId, TraitFunctionId, TraitId, VarId,
 };
 use cairo_lang_defs::plugin::{InlineMacroExprPlugin, MacroPluginMetadata};
-use cairo_lang_diagnostics::{Maybe, skip_diagnostic};
+use cairo_lang_diagnostics::{DiagnosticNote, Maybe, skip_diagnostic};
 use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{
@@ -461,6 +461,8 @@ impl<'ctx, 'mt> ComputationContext<'ctx, 'mt> {
 pub struct VariableTracker<'ctx> {
     /// Definitions of semantic variables.
     semantic_defs: UnorderedHashMap<semantic::VarId<'ctx>, Binding<'ctx>>,
+    /// Mutable variables that have been referenced (lost mutability).
+    referenced_mut_vars: UnorderedHashMap<semantic::VarId<'ctx>, SyntaxStablePtrId<'ctx>>,
 }
 
 impl<'ctx> VariableTracker<'ctx> {
@@ -475,14 +477,58 @@ impl<'ctx> VariableTracker<'ctx> {
         self.semantic_defs.insert(var.id(), var)
     }
 
-    /// Checks if a variable is mutable.
+    /// Returns true if the variable is currently mutable.
+    /// A variable is mutable only if declared mutable AND not referenced.
     pub fn is_mut(&self, var_id: &semantic::VarId<'ctx>) -> bool {
-        self.semantic_defs.get(var_id).is_some_and(|def| def.is_mut())
+        self.semantic_defs
+            .get(var_id)
+            .is_some_and(|def| def.is_mut() && !self.referenced_mut_vars.contains_key(var_id))
     }
 
     /// Returns true if the expression is a variable or a member access of a mutable variable.
     pub fn is_mut_expr(&self, expr: &ExprAndId<'ctx>) -> bool {
         expr.as_member_path().is_some_and(|var| self.is_mut(&var.base_var()))
+    }
+
+    /// Reports a mutability error if the variable cannot be modified.
+    pub fn report_var_mutability_error(
+        &self,
+        db: &'ctx dyn Database,
+        diagnostics: &mut SemanticDiagnostics<'ctx>,
+        var_id: &semantic::VarId<'ctx>,
+        error_ptr: impl Into<SyntaxStablePtrId<'ctx>>,
+        immutable_diagnostic: SemanticDiagnosticKind<'ctx>,
+    ) {
+        let Some(def) = self.semantic_defs.get(var_id) else {
+            return;
+        };
+
+        if !def.is_mut() {
+            diagnostics.report(error_ptr, immutable_diagnostic);
+            return;
+        }
+
+        if let Some(&referenced_at) = self.referenced_mut_vars.get(var_id) {
+            let note = DiagnosticNote::with_location(
+                "variable was referenced here".into(),
+                StableLocation::new(referenced_at).diagnostic_location(db),
+            );
+            diagnostics.report(error_ptr, AssignmentToReferencedVariable(vec![note]));
+        }
+    }
+
+    /// Marks an expression as referenced if it refers to a mutable variable.
+    pub fn mark_referenced(
+        &mut self,
+        expr: &ExprAndId<'ctx>,
+        reference_location: SyntaxStablePtrId<'ctx>,
+    ) {
+        if let Some(base_var) = expr.as_member_path().map(|path| path.base_var())
+            && self.is_mut(&base_var)
+        {
+            // This insert happens only once, since `is_mut` returns false if already referenced.
+            let _ = self.referenced_mut_vars.insert(base_var, reference_location);
+        }
     }
 }
 
@@ -1012,6 +1058,69 @@ fn compute_expr_unary_semantic<'db>(
                 stable_ptr: syntax.stable_ptr(db).into(),
             }))
         }
+        (UnaryOperator::Reference(_), inner) => {
+            let stable_ptr = syntax.stable_ptr(db);
+            if !crate::types::are_references_enabled(ctx.db, ctx.resolver.module_id) {
+                return Err(ctx.diagnostics.report(stable_ptr, ReferencesDisabled));
+            }
+            let inner_expr = compute_expr_semantic(ctx, inner);
+
+            // Disable mutability from referenced variable.
+            ctx.variable_tracker.mark_referenced(&inner_expr, stable_ptr.untyped());
+
+            // Snapshot inner expression.
+            let inner_ty = inner_expr.ty();
+            let snapshot_ty = TypeLongId::Snapshot(inner_ty).intern(ctx.db);
+            let snapshot_expr = ExprSnapshot {
+                inner: inner_expr.id,
+                ty: snapshot_ty,
+                stable_ptr: stable_ptr.into(),
+            };
+            let snapshot_expr_id = ctx.arenas.exprs.alloc(Expr::Snapshot(snapshot_expr.clone()));
+
+            // Get BoxTrait::<@T>::new
+            let info = ctx.db.core_info();
+            let generic_args = vec![GenericArgumentId::Type(snapshot_ty)];
+            let concrete_trait_id =
+                crate::ConcreteTraitLongId { trait_id: info.box_trt, generic_args }.intern(ctx.db);
+            let concrete_trait_function =
+                crate::items::trt::ConcreteTraitGenericFunctionLongId::new(
+                    ctx.db,
+                    concrete_trait_id,
+                    info.box_new_fn,
+                )
+                .intern(ctx.db);
+
+            // Resolve which BoxTrait implementation applies to this type.
+            let impl_lookup_context = ctx.resolver.impl_lookup_context();
+            let mut inference = ctx.resolver.inference();
+            let function = inference
+                .infer_trait_function(
+                    concrete_trait_function,
+                    impl_lookup_context,
+                    Some(stable_ptr.untyped()),
+                )
+                .map_err(|err_set| {
+                    inference.report_on_pending_error(
+                        err_set,
+                        ctx.diagnostics,
+                        stable_ptr.untyped(),
+                    )
+                })?;
+
+            // Call BoxTrait::new(@x).
+            expr_function_call(
+                ctx,
+                function,
+                vec![NamedArg(
+                    ExprAndId { expr: Expr::Snapshot(snapshot_expr), id: snapshot_expr_id },
+                    None,
+                    Mutability::Immutable,
+                )],
+                stable_ptr,
+                stable_ptr.into(),
+            )
+        }
         (_, inner) => {
             let expr = compute_expr_semantic(ctx, inner);
 
@@ -1093,10 +1202,13 @@ fn compute_expr_binary_semantic<'db>(
                 || rhs_syntax.stable_ptr(db).untyped(),
                 |actual_ty, expected_ty| WrongArgumentType { expected_ty, actual_ty },
             )?;
-            // Verify the variable argument is mutable.
-            if !ctx.variable_tracker.is_mut(&member_path.base_var()) {
-                ctx.diagnostics.report(syntax.stable_ptr(db), AssignmentToImmutableVar);
-            }
+            ctx.variable_tracker.report_var_mutability_error(
+                db,
+                ctx.diagnostics,
+                &member_path.base_var(),
+                syntax.stable_ptr(db),
+                AssignmentToImmutableVar,
+            );
             Ok(Expr::Assignment(ExprAssignment {
                 ref_arg: member_path,
                 rhs: rexpr.id,
@@ -4080,10 +4192,14 @@ fn expr_function_call<'db>(
             let Some(ref_arg) = arg.as_member_path() else {
                 return Err(ctx.diagnostics.report(arg.deref(), RefArgNotAVariable));
             };
-            // Verify the variable argument is mutable.
-            if !ctx.variable_tracker.is_mut(&ref_arg.base_var()) {
-                ctx.diagnostics.report(arg.deref(), RefArgNotMutable);
-            }
+            // Verify the variable is mutable and hasn't been referenced.
+            ctx.variable_tracker.report_var_mutability_error(
+                ctx.db,
+                ctx.diagnostics,
+                &ref_arg.base_var(),
+                arg.deref(),
+                RefArgNotMutable,
+            );
             // Verify that it is passed explicitly as 'ref'.
             if mutability != Mutability::Reference {
                 ctx.diagnostics.report(arg.deref(), RefArgNotExplicit);

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/reference
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/reference
@@ -1,0 +1,564 @@
+//! > Test reference type desugaring to Box<@T>
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > expr_code
+&5_u32
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: core::box::BoxImpl::<@core::integer::u32>::new,
+        args: [
+            Value(
+                Snapshot(
+                    ExprSnapshot {
+                        inner: Literal(
+                            ExprLiteral {
+                                value: 5,
+                                ty: core::integer::u32,
+                            },
+                        ),
+                        ty: @core::integer::u32,
+                    },
+                ),
+            ),
+        ],
+        coupon_arg: None,
+        ty: core::box::Box::<@core::integer::u32>,
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test double reference & &x
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > expr_code
+& &5_u32
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: core::box::BoxImpl::<@core::box::Box::<@core::integer::u32>>::new,
+        args: [
+            Value(
+                Snapshot(
+                    ExprSnapshot {
+                        inner: FunctionCall(
+                            ExprFunctionCall {
+                                function: core::box::BoxImpl::<@core::integer::u32>::new,
+                                args: [
+                                    Value(
+                                        Snapshot(
+                                            ExprSnapshot {
+                                                inner: Literal(
+                                                    ExprLiteral {
+                                                        value: 5,
+                                                        ty: core::integer::u32,
+                                                    },
+                                                ),
+                                                ty: @core::integer::u32,
+                                            },
+                                        ),
+                                    ),
+                                ],
+                                coupon_arg: None,
+                                ty: core::box::Box::<@core::integer::u32>,
+                            },
+                        ),
+                        ty: @core::box::Box::<@core::integer::u32>,
+                    },
+                ),
+            ),
+        ],
+        coupon_arg: None,
+        ty: core::box::Box::<@core::box::Box::<@core::integer::u32>>,
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test reference of snapshot &@x
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > expr_code
+&@5_u32
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: core::box::BoxImpl::<@@core::integer::u32>::new,
+        args: [
+            Value(
+                Snapshot(
+                    ExprSnapshot {
+                        inner: Snapshot(
+                            ExprSnapshot {
+                                inner: Literal(
+                                    ExprLiteral {
+                                        value: 5,
+                                        ty: core::integer::u32,
+                                    },
+                                ),
+                                ty: @core::integer::u32,
+                            },
+                        ),
+                        ty: @@core::integer::u32,
+                    },
+                ),
+            ),
+        ],
+        coupon_arg: None,
+        ty: core::box::Box::<@@core::integer::u32>,
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test snapshot of reference @&x
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > expr_code
+@&5_u32
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+Snapshot(
+    ExprSnapshot {
+        inner: FunctionCall(
+            ExprFunctionCall {
+                function: core::box::BoxImpl::<@core::integer::u32>::new,
+                args: [
+                    Value(
+                        Snapshot(
+                            ExprSnapshot {
+                                inner: Literal(
+                                    ExprLiteral {
+                                        value: 5,
+                                        ty: core::integer::u32,
+                                    },
+                                ),
+                                ty: @core::integer::u32,
+                            },
+                        ),
+                    ),
+                ],
+                coupon_arg: None,
+                ty: core::box::Box::<@core::integer::u32>,
+            },
+        ),
+        ty: @core::box::Box::<@core::integer::u32>,
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test bitwise AND with reference operator
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > function_body
+let a = &3_u32;
+let b = 5_u32;
+
+//! > expr_code
+a & &b
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: ?1::bitand,
+        args: [
+            Value(
+                Var(
+                    LocalVarId(test::a),
+                ),
+            ),
+            Value(
+                FunctionCall(
+                    ExprFunctionCall {
+                        function: core::box::BoxImpl::<@core::integer::u32>::new,
+                        args: [
+                            Value(
+                                Snapshot(
+                                    ExprSnapshot {
+                                        inner: Var(
+                                            LocalVarId(test::b),
+                                        ),
+                                        ty: @core::integer::u32,
+                                    },
+                                ),
+                            ),
+                        ],
+                        coupon_arg: None,
+                        ty: core::box::Box::<@core::integer::u32>,
+                    },
+                ),
+            ),
+        ],
+        coupon_arg: None,
+        ty: core::box::Box::<@core::integer::u32>,
+    },
+)
+
+//! > expected_diagnostics
+error: Trait has no implementation in context: core::traits::BitAnd::<core::box::Box::<@core::integer::u32>>.
+ --> lib.cairo:3:1
+a & &b
+^^^^^^
+
+//! > ==========================================================================
+
+//! > Test reference to struct
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > module_code
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+struct PPoint {
+    point: Point,
+}
+
+//! > function_body
+let p = PPoint { point: Point { x: 1, y: 2 } };
+
+//! > expr_code
+&p.point.x
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: core::box::BoxImpl::<@core::integer::u32>::new,
+        args: [
+            Value(
+                Snapshot(
+                    ExprSnapshot {
+                        inner: MemberAccess(
+                            ExprMemberAccess {
+                                expr: MemberAccess(
+                                    ExprMemberAccess {
+                                        expr: Var(
+                                            LocalVarId(test::p),
+                                        ),
+                                        concrete_struct_id: test::PPoint,
+                                        member: MemberId(test::point),
+                                        ty: test::Point,
+                                    },
+                                ),
+                                concrete_struct_id: test::Point,
+                                member: MemberId(test::x),
+                                ty: core::integer::u32,
+                            },
+                        ),
+                        ty: @core::integer::u32,
+                    },
+                ),
+            ),
+        ],
+        coupon_arg: None,
+        ty: core::box::Box::<@core::integer::u32>,
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test reference to array
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > function_body
+let arr = array![1_u32, 2_u32, 3_u32];
+
+//! > expr_code
+&arr[1]
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: core::box::BoxImpl::<@@core::integer::u32>::new,
+        args: [
+            Value(
+                Snapshot(
+                    ExprSnapshot {
+                        inner: FunctionCall(
+                            ExprFunctionCall {
+                                function: core::ops::index::DeprecatedIndexViewImpl::<core::array::Array::<core::integer::u32>, core::integer::u32, @core::integer::u32, core::array::ArrayIndex::<core::integer::u32>>::index,
+                                args: [
+                                    Value(
+                                        Snapshot(
+                                            ExprSnapshot {
+                                                inner: Var(
+                                                    LocalVarId(test::arr),
+                                                ),
+                                                ty: @core::array::Array::<core::integer::u32>,
+                                            },
+                                        ),
+                                    ),
+                                    Value(
+                                        Literal(
+                                            ExprLiteral {
+                                                value: 1,
+                                                ty: core::integer::u32,
+                                            },
+                                        ),
+                                    ),
+                                ],
+                                coupon_arg: None,
+                                ty: @core::integer::u32,
+                            },
+                        ),
+                        ty: @@core::integer::u32,
+                    },
+                ),
+            ),
+        ],
+        coupon_arg: None,
+        ty: core::box::Box::<@@core::integer::u32>,
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test reference in function call
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > module_code
+fn takes_box(b: Box<@u32>) {}
+
+//! > function_body
+let x = 42_u32;
+
+//! > expr_code
+takes_box(&x)
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: test::takes_box,
+        args: [
+            Value(
+                FunctionCall(
+                    ExprFunctionCall {
+                        function: core::box::BoxImpl::<@core::integer::u32>::new,
+                        args: [
+                            Value(
+                                Snapshot(
+                                    ExprSnapshot {
+                                        inner: Var(
+                                            LocalVarId(test::x),
+                                        ),
+                                        ty: @core::integer::u32,
+                                    },
+                                ),
+                            ),
+                        ],
+                        coupon_arg: None,
+                        ty: core::box::Box::<@core::integer::u32>,
+                    },
+                ),
+            ),
+        ],
+        coupon_arg: None,
+        ty: (),
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test reference in assignment
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > function_body
+let x = 42_u32;
+let y = &x;
+
+//! > expr_code
+y
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+Var(
+    LocalVarId(test::y),
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test ref parameter after reference taken
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > module_code
+fn modify_value(ref x: u32) {
+    x = x + 1;
+}
+
+//! > function_body
+let mut value = 5_u32;
+// Take a reference - this should prevent mutation through ref parameter.
+let r = &value;
+
+//! > expr_code
+modify_value(ref value)
+
+//! > crate_settings
+edition = "2023_01"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = false
+references = true
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: test::modify_value,
+        args: [
+            Reference(
+                LocalVarId(test::value),
+            ),
+        ],
+        coupon_arg: None,
+        ty: (),
+    },
+)
+
+//! > expected_diagnostics
+error: Cannot assign to a variable that has been referenced
+ --> lib.cairo:7:18
+modify_value(ref value)
+                 ^^^^^
+note: variable was referenced here:
+  --> lib.cairo:6:9
+let r = &value; {
+        ^^^^^^
+
+warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:6:5
+let r = &value; {
+    ^

--- a/crates/cairo-lang-semantic/src/expr/test.rs
+++ b/crates/cairo-lang-semantic/src/expr/test.rs
@@ -91,6 +91,7 @@ cairo_lang_test_utils::test_file_test!(
         range: "range",
         const_: "const",
         use_: "use",
+        reference: "reference",
     },
     test_expr_semantics
 );

--- a/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
+++ b/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
@@ -225,3 +225,74 @@ error: `test::ImplIssue::Index` type mismatch: `@core::felt252` and `core::felt2
  --> lib.cairo:13:15
     1_felt252.issue(@2_felt252);
               ^^^^^
+
+//! > ==========================================================================
+
+//! > Type mismatch diagnostics of reference expressions.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo() {
+    let _: Box<u32> =  &3_u32;
+    let _: Box<@felt252> =  &3_u32;
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error: Unexpected argument type. Expected: "core::box::Box::<core::integer::u32>", found: "core::box::Box::<@core::integer::u32>".
+ --> lib.cairo:2:24
+    let _: Box<u32> =  &3_u32;
+                       ^^^^^^
+
+error: Unexpected argument type. Expected: "core::box::Box::<@core::felt252>", found: "core::box::Box::<@core::integer::u32>".
+ --> lib.cairo:3:29
+    let _: Box<@felt252> =  &3_u32;
+                            ^^^^^^
+
+//! > ==========================================================================
+
+//! > Cannot assign to mutable variable after referencing it.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function
+fn foo(mut param: u32) {
+    let mut x = 3_u32;
+    let _r =  &x;
+    x = 5;
+
+    let mut y = 2_felt252;
+    let _s =  &y;
+    y = 10;
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error: Cannot assign to a variable that has been referenced
+ --> lib.cairo:4:5
+    x = 5;
+    ^^^^^
+note: variable was referenced here:
+  --> lib.cairo:3:15
+    let _r =  &x;
+              ^^
+
+error: Cannot assign to a variable that has been referenced
+ --> lib.cairo:8:5
+    y = 10;
+    ^^^^^^
+note: variable was referenced here:
+  --> lib.cairo:7:15
+    let _s =  &y;
+              ^^

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -119,6 +119,7 @@ pub fn setup_test_crate_ex<'a>(
                 associated_item_constraints: true,
                 coupons: true,
                 user_defined_inline_macros: true,
+                references: true,
             },
             cfg_set: Default::default(),
         }


### PR DESCRIPTION
- Desugars `&T` into `BoxTrait<@T>`.
- Once referenced, a mutable variable may no longer be mutated. Consequently, once referenced, a
  mutable variable CAN be captured by closures.

Implementation notes:
- `BoxTrait` is now defined explicitely instead of via `generate_trait`: this is necessary since
  `CoreInfo` may be used before the `generate_trait` macro is processed, depending on the order
  in which modules are processed. See also #7294 which de-sugared `..` into `Range`.