### PR TITLE
Adding support to felt add mul and sub in constant propogation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "pretty_assertions",
  "salsa",
  "serde",
+ "starknet-types-core",
  "thiserror",
 ]
 

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -26,6 +26,7 @@ num-integer = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
 serde = { workspace = true, default-features = true }
+starknet-types-core.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/cairo-lang-lowering/src/lower/test_data/closure
+++ b/crates/cairo-lang-lowering/src/lower/test_data/closure
@@ -307,7 +307,7 @@ test_generated_function
 fn foo(a: u32) {
     let f = |a: felt252| {
         let mut b = @0;
-        if 1 == 2 {
+        if 1 == bar(2) {
             b = @a;
         } else {
             b = @a;
@@ -320,6 +320,10 @@ fn foo(a: u32) {
 foo
 
 //! > module_code
+#[inline(never)]
+fn bar(a: felt252) -> felt252 {
+    a + 1
+}
 
 //! > semantic_diagnostics
 
@@ -330,11 +334,11 @@ Main:
 Parameters: v0: core::integer::u32
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:2:13: 2:25}) <- struct_construct()
-  (v2: {closure@lib.cairo:2:13: 2:25}, v3: @{closure@lib.cairo:2:13: 2:25}) <- snapshot(v1)
+  (v1: {closure@lib.cairo:6:13: 6:25}) <- struct_construct()
+  (v2: {closure@lib.cairo:6:13: 6:25}, v3: @{closure@lib.cairo:6:13: 6:25}) <- snapshot(v1)
   (v4: core::felt252) <- 0
   (v5: (core::felt252,)) <- struct_construct(v4)
-  (v6: ()) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:2:13: 2:25}(v3, v5)
+  (v6: ()) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:6:13: 6:25}(v3, v5)
   (v7: ()) <- struct_construct()
 End:
   Return(v7)
@@ -344,13 +348,14 @@ Final lowering:
 Parameters: v0: core::integer::u32
 blk0 (root):
 Statements:
-  (v1: core::felt252) <- 1
-  (v2: core::felt252) <- 2
-  (v3: core::felt252) <- core::felt252_sub(v1, v2)
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- test::bar(v1)
+  (v3: core::felt252) <- 1
+  (v4: core::felt252) <- core::felt252_sub(v3, v2)
 End:
-  Match(match core::felt252_is_zero(v3) {
+  Match(match core::felt252_is_zero(v4) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v4) => blk2,
+    IsZeroResult::NonZero(v5) => blk2,
   })
 
 blk1:
@@ -368,7 +373,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
     let f = |a: felt252| {
             ^^^^^^^^^^^^
 
-Parameters: v0: {closure@lib.cairo:2:13: 2:25}
+Parameters: v0: {closure@lib.cairo:6:13: 6:25}
 blk0 (root):
 Statements:
   () <- struct_destructure(v0)
@@ -378,7 +383,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:2:13: 2:25}
+Parameters: v0: {closure@lib.cairo:6:13: 6:25}
 blk0 (root):
 Statements:
 End:
@@ -389,10 +394,10 @@ Generated core::ops::function::Fn::call lowering for source location:
     let f = |a: felt252| {
             ^^^^^^^^^^^^
 
-Parameters: v0: @{closure@lib.cairo:2:13: 2:25}, v2: (core::felt252,)
+Parameters: v0: @{closure@lib.cairo:6:13: 6:25}, v2: (core::felt252,)
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:2:13: 2:25}) <- desnap(v0)
+  (v1: {closure@lib.cairo:6:13: 6:25}) <- desnap(v0)
   () <- struct_destructure(v1)
   (v3: core::felt252) <- struct_destructure(v2)
   (v4: core::felt252) <- 0
@@ -400,44 +405,46 @@ Statements:
   (v7: core::felt252) <- 1
   (v8: core::felt252, v9: @core::felt252) <- snapshot(v7)
   (v10: core::felt252) <- 2
-  (v11: core::felt252, v12: @core::felt252) <- snapshot(v10)
-  (v13: core::bool) <- core::Felt252PartialEq::eq(v9, v12)
+  (v11: core::felt252) <- test::bar(v10)
+  (v12: core::felt252, v13: @core::felt252) <- snapshot(v11)
+  (v14: core::bool) <- core::Felt252PartialEq::eq(v9, v13)
 End:
-  Match(match_enum(v13) {
-    bool::False(v15) => blk2,
-    bool::True(v14) => blk1,
+  Match(match_enum(v14) {
+    bool::False(v16) => blk2,
+    bool::True(v15) => blk1,
   })
 
 blk1:
 Statements:
-  (v18: core::felt252, v19: @core::felt252) <- snapshot(v3)
+  (v19: core::felt252, v20: @core::felt252) <- snapshot(v3)
 End:
-  Goto(blk3, {v18 -> v20, v19 -> v21})
+  Goto(blk3, {v19 -> v21, v20 -> v22})
 
 blk2:
 Statements:
-  (v16: core::felt252, v17: @core::felt252) <- snapshot(v3)
+  (v17: core::felt252, v18: @core::felt252) <- snapshot(v3)
 End:
-  Goto(blk3, {v16 -> v20, v17 -> v21})
+  Goto(blk3, {v17 -> v21, v18 -> v22})
 
 blk3:
 Statements:
-  (v22: ()) <- struct_construct()
+  (v23: ()) <- struct_construct()
 End:
-  Return(v22)
+  Return(v23)
 
 
 Final lowering:
-Parameters: v0: @{closure@lib.cairo:2:13: 2:25}, v1: (core::felt252,)
+Parameters: v0: @{closure@lib.cairo:6:13: 6:25}, v1: (core::felt252,)
 blk0 (root):
 Statements:
-  (v2: core::felt252) <- 1
-  (v3: core::felt252) <- 2
-  (v4: core::felt252) <- core::felt252_sub(v2, v3)
+  (v2: core::felt252) <- 2
+  (v3: core::felt252) <- test::bar(v2)
+  (v4: core::felt252) <- 1
+  (v5: core::felt252) <- core::felt252_sub(v4, v3)
 End:
-  Match(match core::felt252_is_zero(v4) {
+  Match(match core::felt252_is_zero(v5) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v5) => blk2,
+    IsZeroResult::NonZero(v6) => blk2,
   })
 
 blk1:

--- a/crates/cairo-lang-lowering/src/lower/test_data/for
+++ b/crates/cairo-lang-lowering/src/lower/test_data/for
@@ -55,7 +55,7 @@ Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
   (v2: core::felt252) <- 1
-  (v3: core::felt252) <- core::felt252_add(v2, v2)
+  (v3: core::felt252) <- 2
   (v4: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
   (v5: core::felt252) <- 10
   (v6: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v4, v5)

--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -29,6 +29,7 @@ use num_integer::Integer;
 use num_traits::cast::ToPrimitive;
 use num_traits::{Num, One, Zero};
 use salsa::Database;
+use starknet_types_core::felt::Felt as Felt252;
 
 use crate::db::LoweringGroup;
 use crate::ids::{
@@ -493,12 +494,62 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
         }
         let (id, _generic_args) = stmt.function.get_extern(db)?;
         if id == self.felt_sub {
-            // (a - 0) can be replaced by a.
-            let val = self.as_int(stmt.inputs[1].var_id)?;
-            if val.is_zero() {
+            if let Some(rhs) = self.as_int(stmt.inputs[1].var_id)
+                && rhs.is_zero()
+            {
                 self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[0]));
+                None
+            } else if let (Some(lhs), Some(rhs)) =
+                (self.as_int(stmt.inputs[0].var_id), self.as_int(stmt.inputs[1].var_id))
+            {
+                let value = Felt252::from(lhs - rhs).to_bigint();
+                Some(self.propagate_const_and_get_statement(value, stmt.outputs[0], false))
+            } else {
+                None
             }
-            None
+        } else if id == self.felt_add {
+            if let Some(lhs) = self.as_int(stmt.inputs[0].var_id)
+                && lhs.is_zero()
+            {
+                self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[1]));
+                None
+            } else if let Some(rhs) = self.as_int(stmt.inputs[1].var_id)
+                && rhs.is_zero()
+            {
+                self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[0]));
+                None
+            } else if let (Some(lhs), Some(rhs)) =
+                (self.as_int(stmt.inputs[0].var_id), self.as_int(stmt.inputs[1].var_id))
+            {
+                let value = Felt252::from(lhs + rhs).to_bigint();
+                Some(self.propagate_const_and_get_statement(value, stmt.outputs[0], false))
+            } else {
+                None
+            }
+        } else if id == self.felt_mul {
+            let lhs = self.as_int_ex(stmt.inputs[0].var_id);
+            let rhs = self.as_int_ex(stmt.inputs[1].var_id);
+            if lhs.map(|(v, _)| v.is_zero()).unwrap_or(false)
+                || rhs.map(|(v, _)| v.is_zero()).unwrap_or(false)
+            {
+                Some(self.propagate_zero_and_get_statement(stmt.outputs[0]))
+            } else if let Some(rhs) = self.as_int(stmt.inputs[1].var_id)
+                && rhs.is_one()
+            {
+                self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[0]));
+                None
+            } else if let Some(lhs) = self.as_int(stmt.inputs[0].var_id)
+                && lhs.is_one()
+            {
+                self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[1]));
+                None
+            } else if let (Some((lhs_val, lhs_nz)), Some((rhs_val, rhs_nz))) = (lhs, rhs) {
+                let value = Felt252::from(lhs_val * rhs_val).to_bigint();
+                let nz_ty = lhs_nz && rhs_nz;
+                Some(self.propagate_const_and_get_statement(value, stmt.outputs[0], nz_ty))
+            } else {
+                None
+            }
         } else if self.wide_mul_fns.contains(&id) {
             let lhs = self.as_int_ex(stmt.inputs[0].var_id);
             let rhs = self.as_int(stmt.inputs[1].var_id);
@@ -1211,6 +1262,10 @@ fn priv_const_folding_info<'db>(
 pub struct ConstFoldingLibfuncInfo<'db> {
     /// The `felt252_sub` libfunc.
     felt_sub: ExternFunctionId<'db>,
+    /// The `felt252_add` libfunc.
+    felt_add: ExternFunctionId<'db>,
+    /// The `felt252_mul` libfunc.
+    felt_mul: ExternFunctionId<'db>,
     /// The `into_box` libfunc.
     into_box: ExternFunctionId<'db>,
     /// The `unbox` libfunc.
@@ -1380,6 +1435,8 @@ impl<'db> ConstFoldingLibfuncInfo<'db> {
             );
         Self {
             felt_sub: core.extern_function_id("felt252_sub"),
+            felt_add: core.extern_function_id("felt252_add"),
+            felt_mul: core.extern_function_id("felt252_mul"),
             into_box: box_module.extern_function_id("into_box"),
             unbox: box_module.extern_function_id("unbox"),
             box_forward_snapshot: box_module.generic_function_id("box_forward_snapshot"),

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
@@ -42,6 +42,177 @@ End:
 
 //! > ==========================================================================
 
+//! > Felt252 add overflow const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    PRIME_MINUS_1 + 2
+}
+
+//! > function_name
+foo
+
+//! > module_code
+const PRIME_MINUS_1: felt252 = -1;
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- -1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- core::felt252_add(v0, v1)
+End:
+  Return(v2)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- -1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- 1
+End:
+  Return(v2)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 sub overflow const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    0 - 1
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 0
+  (v1: core::felt252) <- 1
+  (v2: core::felt252) <- core::felt252_sub(v0, v1)
+End:
+  Return(v2)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 0
+  (v1: core::felt252) <- 1
+  (v2: core::felt252) <- 3618502788666131213697322783095070105623107215331596699973092056135872020480
+End:
+  Return(v2)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 mul overflow const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    PRIME_MINUS_1 * 2
+}
+
+//! > function_name
+foo
+
+//! > module_code
+const PRIME_MINUS_1: felt252 = -1;
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- -1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- core::felt252_mul(v0, v1)
+End:
+  Return(v2)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- -1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- 3618502788666131213697322783095070105623107215331596699973092056135872020479
+End:
+  Return(v2)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 combined overflow const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    (PRIME_MINUS_1 + 2) * 2
+}
+
+//! > function_name
+foo
+
+//! > module_code
+const PRIME_MINUS_1: felt252 = -1;
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- -1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- core::felt252_add(v0, v1)
+  (v3: core::felt252) <- 2
+  (v4: core::felt252) <- core::felt252_mul(v2, v3)
+End:
+  Return(v4)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- -1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- 1
+  (v3: core::felt252) <- 2
+  (v4: core::felt252) <- core::felt252_mul(v2, v3)
+End:
+  Return(v3)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
 //! > Basic box const folding.
 
 //! > test_runner_name
@@ -6148,5 +6319,177 @@ blk3:
 Statements:
 End:
   Return(v7)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 add const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    1 + 2
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- core::felt252_add(v0, v1)
+End:
+  Return(v2)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- 3
+End:
+  Return(v2)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 sub const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    5 - 3
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 5
+  (v1: core::felt252) <- 3
+  (v2: core::felt252) <- core::felt252_sub(v0, v1)
+End:
+  Return(v2)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 5
+  (v1: core::felt252) <- 3
+  (v2: core::felt252) <- 2
+End:
+  Return(v2)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 mul const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    2 * 3
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 2
+  (v1: core::felt252) <- 3
+  (v2: core::felt252) <- core::felt252_mul(v0, v1)
+End:
+  Return(v2)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 2
+  (v1: core::felt252) <- 3
+  (v2: core::felt252) <- 6
+End:
+  Return(v2)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 combined operations const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    1 + 2 * 3 - 4
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- 3
+  (v3: core::felt252) <- core::felt252_mul(v1, v2)
+  (v4: core::felt252) <- core::felt252_add(v0, v3)
+  (v5: core::felt252) <- 4
+  (v6: core::felt252) <- core::felt252_sub(v4, v5)
+End:
+  Return(v6)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 1
+  (v1: core::felt252) <- 2
+  (v2: core::felt252) <- 3
+  (v3: core::felt252) <- 6
+  (v4: core::felt252) <- 7
+  (v5: core::felt252) <- 4
+  (v6: core::felt252) <- 3
+End:
+  Return(v6)
 
 //! > lowering_diagnostics

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/reorder_statements
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/reorder_statements
@@ -4,7 +4,7 @@
 test_reorder_statements
 
 //! > function
-fn foo() -> felt252 {
+fn foo(x: felt252) -> felt252 {
     let opt = get_option();
 
     let _unused = 17;
@@ -12,14 +12,14 @@ fn foo() -> felt252 {
 
     let one = 1;
     let two = 2;
-    let three = 3;
+    let threex = 3 + x;
 
     match opt {
         Some(_) => one + two,
         None => {
             let four = 4;
             match opt {
-                Some(_) => three + four,
+                Some(_) => threex + four,
                 None => one,
             }
         },
@@ -37,146 +37,147 @@ extern fn get_option() -> Option<u16> nopanic;
 //! > lowering_diagnostics
 
 //! > before
-Parameters:
+Parameters: v0: core::felt252
 blk0 (root):
 Statements:
 End:
   Match(match test::get_option() {
-    Option::Some(v0) => blk1,
+    Option::Some(v1) => blk1,
     Option::None => blk2,
   })
 
 blk1:
 Statements:
-  (v1: core::option::Option::<core::integer::u16>) <- Option::Some(v0)
+  (v2: core::option::Option::<core::integer::u16>) <- Option::Some(v1)
 End:
-  Goto(blk3, {v1 -> v2})
+  Goto(blk3, {v2 -> v3})
 
 blk2:
 Statements:
-  (v3: ()) <- struct_construct()
-  (v4: core::option::Option::<core::integer::u16>) <- Option::None(v3)
+  (v4: ()) <- struct_construct()
+  (v5: core::option::Option::<core::integer::u16>) <- Option::None(v4)
 End:
-  Goto(blk3, {v4 -> v2})
+  Goto(blk3, {v5 -> v3})
 
 blk3:
 Statements:
-  (v5: core::felt252) <- 17
-  (v6: ()) <- struct_construct()
-  (v7: core::felt252) <- 1
-  (v8: core::felt252) <- 2
-  (v9: core::felt252) <- 3
+  (v6: core::felt252) <- 17
+  (v7: ()) <- struct_construct()
+  (v8: core::felt252) <- 1
+  (v9: core::felt252) <- 2
+  (v10: core::felt252) <- 3
+  (v11: core::felt252) <- core::felt252_add(v10, v0)
 End:
-  Match(match_enum(v2) {
-    Option::Some(v10) => blk4,
-    Option::None(v11) => blk5,
+  Match(match_enum(v3) {
+    Option::Some(v12) => blk4,
+    Option::None(v13) => blk5,
   })
 
 blk4:
 Statements:
-  (v12: core::felt252) <- core::felt252_add(v7, v8)
+  (v14: core::felt252) <- 3
 End:
-  Goto(blk9, {v12 -> v13})
+  Goto(blk9, {v14 -> v15})
 
 blk5:
 Statements:
-  (v14: core::felt252) <- 4
+  (v16: core::felt252) <- 4
 End:
-  Match(match_enum(v2) {
-    Option::Some(v15) => blk6,
-    Option::None(v16) => blk7,
+  Match(match_enum(v3) {
+    Option::Some(v17) => blk6,
+    Option::None(v18) => blk7,
   })
 
 blk6:
 Statements:
-  (v17: core::felt252) <- core::felt252_add(v9, v14)
+  (v19: core::felt252) <- core::felt252_add(v11, v16)
 End:
-  Goto(blk8, {v17 -> v18})
+  Goto(blk8, {v19 -> v20})
 
 blk7:
 Statements:
 End:
-  Goto(blk8, {v7 -> v18})
+  Goto(blk8, {v8 -> v20})
 
 blk8:
 Statements:
 End:
-  Goto(blk9, {v18 -> v13})
+  Goto(blk9, {v20 -> v15})
 
 blk9:
 Statements:
 End:
-  Return(v13)
+  Return(v15)
 
 //! > after
-Parameters:
+Parameters: v0: core::felt252
 blk0 (root):
 Statements:
 End:
   Match(match test::get_option() {
-    Option::Some(v0) => blk1,
+    Option::Some(v1) => blk1,
     Option::None => blk2,
   })
 
 blk1:
 Statements:
-  (v1: core::option::Option::<core::integer::u16>) <- Option::Some(v0)
+  (v2: core::option::Option::<core::integer::u16>) <- Option::Some(v1)
 End:
-  Goto(blk3, {v1 -> v2})
+  Goto(blk3, {v2 -> v3})
 
 blk2:
 Statements:
-  (v3: ()) <- struct_construct()
-  (v4: core::option::Option::<core::integer::u16>) <- Option::None(v3)
+  (v4: ()) <- struct_construct()
+  (v5: core::option::Option::<core::integer::u16>) <- Option::None(v4)
 End:
-  Goto(blk3, {v4 -> v2})
+  Goto(blk3, {v5 -> v3})
 
 blk3:
 Statements:
-  (v7: core::felt252) <- 1
 End:
-  Match(match_enum(v2) {
-    Option::Some(v10) => blk4,
-    Option::None(v11) => blk5,
+  Match(match_enum(v3) {
+    Option::Some(v12) => blk4,
+    Option::None(v13) => blk5,
   })
 
 blk4:
 Statements:
-  (v8: core::felt252) <- 2
-  (v12: core::felt252) <- core::felt252_add(v7, v8)
+  (v14: core::felt252) <- 3
 End:
-  Goto(blk9, {v12 -> v13})
+  Goto(blk9, {v14 -> v15})
 
 blk5:
 Statements:
 End:
-  Match(match_enum(v2) {
-    Option::Some(v15) => blk6,
-    Option::None(v16) => blk7,
+  Match(match_enum(v3) {
+    Option::Some(v17) => blk6,
+    Option::None(v18) => blk7,
   })
 
 blk6:
 Statements:
-  (v9: core::felt252) <- 3
-  (v14: core::felt252) <- 4
-  (v17: core::felt252) <- core::felt252_add(v9, v14)
+  (v10: core::felt252) <- 3
+  (v11: core::felt252) <- core::felt252_add(v10, v0)
+  (v16: core::felt252) <- 4
+  (v19: core::felt252) <- core::felt252_add(v11, v16)
 End:
-  Goto(blk8, {v17 -> v18})
+  Goto(blk8, {v19 -> v20})
 
 blk7:
 Statements:
+  (v8: core::felt252) <- 1
 End:
-  Goto(blk8, {v7 -> v18})
+  Goto(blk8, {v8 -> v20})
 
 blk8:
 Statements:
 End:
-  Goto(blk9, {v18 -> v13})
+  Goto(blk9, {v20 -> v15})
 
 blk9:
 Statements:
 End:
-  Return(v13)
+  Return(v15)
 
 //! > ==========================================================================
 
@@ -356,7 +357,7 @@ Statements:
   (v2: core::felt252) <- 5
   (v3: ()) <- struct_construct()
   (v4: core::felt252) <- 3
-  (v5: core::felt252) <- core::felt252_add(v2, v4)
+  (v5: core::felt252) <- 8
 End:
   Return(v5)
 
@@ -364,8 +365,6 @@ End:
 Parameters:
 blk0 (root):
 Statements:
-  (v2: core::felt252) <- 5
-  (v4: core::felt252) <- 3
-  (v5: core::felt252) <- core::felt252_add(v2, v4)
+  (v5: core::felt252) <- 8
 End:
   Return(v5)

--- a/crates/cairo-lang-lowering/src/test_data/closure
+++ b/crates/cairo-lang-lowering/src/test_data/closure
@@ -24,11 +24,9 @@ foo
 Parameters: v0: core::felt252
 blk0 (root):
 Statements:
-  (v1: core::felt252) <- 2
-  (v2: core::felt252) <- 3
-  (v3: core::felt252) <- core::felt252_add(v1, v2)
+  (v1: core::felt252) <- 5
 End:
-  Return(v3)
+  Return(v1)
 
 //! > ==========================================================================
 
@@ -60,11 +58,6 @@ foo
 Parameters:
 blk0 (root):
 Statements:
-  (v0: core::felt252) <- 8
-  (v1: core::felt252) <- 2
-  (v2: core::felt252) <- 3
-  (v3: core::felt252) <- core::felt252_add(v1, v2)
-  (v4: core::felt252) <- core::felt252_mul(v0, v3)
-  (v5: core::felt252) <- core::felt252_add(v4, v0)
+  (v0: core::felt252) <- 48
 End:
-  Return(v5)
+  Return(v0)

--- a/crates/cairo-lang-lowering/src/test_data/for
+++ b/crates/cairo-lang-lowering/src/test_data/for
@@ -49,15 +49,14 @@ End:
 blk1:
 Statements:
   (v20: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v16)
-  (v21: core::felt252) <- 1
-  (v22: core::felt252) <- core::felt252_add(v21, v21)
-  (v23: (core::felt252,)) <- struct_construct(v22)
-  (v24: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Ok(v23)
+  (v21: core::felt252) <- 2
+  (v22: (core::felt252,)) <- struct_construct(v21)
+  (v23: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Ok(v22)
 End:
-  Return(v15, v20, v24)
+  Return(v15, v20, v23)
 
 blk2:
 Statements:
-  (v25: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v19)
+  (v24: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v19)
 End:
-  Return(v15, v16, v25)
+  Return(v15, v16, v24)

--- a/crates/cairo-lang-lowering/src/test_data/generics
+++ b/crates/cairo-lang-lowering/src/test_data/generics
@@ -75,11 +75,9 @@ struct Query<V> {
 Parameters:
 blk0 (root):
 Statements:
-  (v0: core::felt252) <- 1
-  (v1: core::felt252) <- 2
-  (v2: core::felt252) <- core::felt252_add(v1, v0)
+  (v0: core::felt252) <- 3
 End:
-  Return(v2)
+  Return(v0)
 
 //! > ==========================================================================
 
@@ -213,14 +211,9 @@ fn bar<const N: felt252>() -> felt252 {
 Parameters:
 blk0 (root):
 Statements:
-  (v0: core::felt252) <- 5
-  (v1: core::felt252) <- 3
-  (v2: core::felt252) <- core::felt252_add(v1, v0)
-  (v3: core::felt252) <- 2
-  (v4: core::felt252) <- core::felt252_add(v3, v0)
-  (v5: core::felt252) <- core::felt252_add(v2, v4)
+  (v0: core::felt252) <- 15
 End:
-  Return(v5)
+  Return(v0)
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-lowering/src/test_data/if
+++ b/crates/cairo-lang-lowering/src/test_data/if
@@ -361,9 +361,8 @@ End:
 
 blk1:
 Statements:
-  (v2: core::felt252) <- core::felt252_add(v0, v1)
 End:
-  Goto(blk5, {v2 -> v3})
+  Goto(blk5, {v1 -> v2})
 
 blk2:
 Statements:
@@ -378,14 +377,14 @@ End:
 blk4:
 Statements:
 End:
-  Goto(blk5, {v0 -> v3})
+  Goto(blk5, {v0 -> v2})
 
 blk5:
 Statements:
-  (v4: core::felt252) <- 1
-  (v5: core::felt252) <- core::felt252_add(v3, v4)
+  (v3: core::felt252) <- 1
+  (v4: core::felt252) <- core::felt252_add(v2, v3)
 End:
-  Return(v5)
+  Return(v4)
 
 //! > ==========================================================================
 
@@ -395,9 +394,9 @@ End:
 test_function_lowering(expect_diagnostics: false)
 
 //! > function
-fn foo() -> felt252 {
+fn foo(z: felt252) -> felt252 {
     let mut y = 0;
-    if let (MyEnum::A(x), true) = (a(), 5 == 6) {
+    if let (MyEnum::A(x), true) = (a(), z == 6) {
         y = y + x
     }
     y = y + 1;
@@ -420,13 +419,12 @@ extern fn a() -> MyEnum nopanic;
 //! > lowering_diagnostics
 
 //! > lowering_flat
-Parameters:
+Parameters: v0: core::felt252
 blk0 (root):
 Statements:
-  (v0: core::felt252) <- 0
-  (v1: core::felt252) <- 5
+  (v1: core::felt252) <- 0
   (v2: core::felt252) <- 6
-  (v3: core::felt252) <- core::felt252_sub(v1, v2)
+  (v3: core::felt252) <- core::felt252_sub(v0, v2)
 End:
   Match(match core::felt252_is_zero(v3) {
     IsZeroResult::Zero => blk1,
@@ -471,9 +469,8 @@ End:
 
 blk6:
 Statements:
-  (v13: core::felt252) <- core::felt252_add(v0, v10)
 End:
-  Goto(blk10, {v13 -> v14})
+  Goto(blk10, {v10 -> v13})
 
 blk7:
 Statements:
@@ -488,14 +485,14 @@ End:
 blk9:
 Statements:
 End:
-  Goto(blk10, {v0 -> v14})
+  Goto(blk10, {v1 -> v13})
 
 blk10:
 Statements:
-  (v15: core::felt252) <- 1
-  (v16: core::felt252) <- core::felt252_add(v14, v15)
+  (v14: core::felt252) <- 1
+  (v15: core::felt252) <- core::felt252_add(v13, v14)
 End:
-  Return(v16)
+  Return(v15)
 
 //! > ==========================================================================
 
@@ -505,9 +502,9 @@ End:
 test_function_lowering(expect_diagnostics: false)
 
 //! > function
-fn foo() -> felt252 {
+fn foo(z: felt252) -> felt252 {
     let mut y = 0;
-    if let (MyEnum::A(x), 3) = (a(), 3) {
+    if let (MyEnum::A(x), 3) = (a(), z) {
         y = y + x
     }
     y = y + 1;
@@ -530,32 +527,31 @@ extern fn a() -> MyEnum nopanic;
 //! > lowering_diagnostics
 
 //! > lowering_flat
-Parameters:
+Parameters: v0: core::felt252
 blk0 (root):
 Statements:
-  (v0: core::felt252) <- 0
+  (v1: core::felt252) <- 0
 End:
   Match(match test::a() {
-    MyEnum::A(v1) => blk1,
+    MyEnum::A(v2) => blk1,
     MyEnum::B => blk4,
     MyEnum::C => blk5,
   })
 
 blk1:
 Statements:
-  (v2: core::felt252) <- 3
-  (v3: core::felt252) <- core::felt252_sub(v2, v2)
+  (v3: core::felt252) <- 3
+  (v4: core::felt252) <- core::felt252_sub(v0, v3)
 End:
-  Match(match core::felt252_is_zero(v3) {
+  Match(match core::felt252_is_zero(v4) {
     IsZeroResult::Zero => blk2,
-    IsZeroResult::NonZero(v4) => blk3,
+    IsZeroResult::NonZero(v5) => blk3,
   })
 
 blk2:
 Statements:
-  (v5: core::felt252) <- core::felt252_add(v0, v1)
 End:
-  Goto(blk7, {v5 -> v6})
+  Goto(blk7, {v2 -> v6})
 
 blk3:
 Statements:
@@ -575,7 +571,7 @@ End:
 blk6:
 Statements:
 End:
-  Goto(blk7, {v0 -> v6})
+  Goto(blk7, {v1 -> v6})
 
 blk7:
 Statements:
@@ -614,12 +610,9 @@ foo
 Parameters:
 blk0 (root):
 Statements:
-  (v0: core::felt252) <- 0
-  (v1: core::felt252) <- core::felt252_add(v0, v0)
-  (v2: core::felt252) <- 1
-  (v3: core::felt252) <- core::felt252_add(v1, v2)
+  (v0: core::felt252) <- 1
 End:
-  Return(v3)
+  Return(v0)
 
 //! > ==========================================================================
 
@@ -657,13 +650,9 @@ enum MyEnum {
 Parameters: v0: test::MyEnum
 blk0 (root):
 Statements:
-  (v1: core::felt252) <- 0
-  (v2: core::felt252) <- 5
-  (v3: core::felt252) <- core::felt252_add(v1, v2)
-  (v4: core::felt252) <- 1
-  (v5: core::felt252) <- core::felt252_add(v3, v4)
+  (v1: core::felt252) <- 6
 End:
-  Return(v5)
+  Return(v1)
 
 //! > ==========================================================================
 
@@ -710,13 +699,9 @@ warning: Unreachable clause.
 Parameters: v0: test::MyEnum
 blk0 (root):
 Statements:
-  (v1: core::felt252) <- 0
-  (v2: core::felt252) <- 5
-  (v3: core::felt252) <- core::felt252_add(v1, v2)
-  (v4: core::felt252) <- 1
-  (v5: core::felt252) <- core::felt252_add(v3, v4)
+  (v1: core::felt252) <- 6
 End:
-  Return(v5)
+  Return(v1)
 
 //! > ==========================================================================
 
@@ -845,13 +830,9 @@ warning: Unreachable clause.
 Parameters: v0: core::option::Option::<core::felt252>
 blk0 (root):
 Statements:
-  (v1: core::felt252) <- 0
-  (v2: core::felt252) <- 5
-  (v3: core::felt252) <- core::felt252_add(v1, v2)
-  (v4: core::felt252) <- 1
-  (v5: core::felt252) <- core::felt252_add(v3, v4)
+  (v1: core::felt252) <- 6
 End:
-  Return(v5)
+  Return(v1)
 
 //! > ==========================================================================
 
@@ -885,50 +866,47 @@ foo
 Parameters: v0: core::option::Option::<core::result::Result::<core::felt252, core::felt252>>
 blk0 (root):
 Statements:
-  (v1: core::felt252) <- 0
 End:
   Match(match_enum(v0) {
-    Option::Some(v2) => blk1,
-    Option::None(v3) => blk5,
+    Option::Some(v1) => blk1,
+    Option::None(v2) => blk5,
   })
 
 blk1:
 Statements:
 End:
-  Match(match_enum(v2) {
-    Result::Ok(v4) => blk2,
-    Result::Err(v5) => blk3,
+  Match(match_enum(v1) {
+    Result::Ok(v3) => blk2,
+    Result::Err(v4) => blk3,
   })
 
 blk2:
 Statements:
 End:
-  Goto(blk4, {v4 -> v6})
+  Goto(blk4, {v3 -> v5})
 
 blk3:
 Statements:
 End:
-  Goto(blk4, {v5 -> v6})
+  Goto(blk4, {v4 -> v5})
 
 blk4:
 Statements:
-  (v7: core::felt252) <- core::felt252_add(v1, v6)
 End:
-  Goto(blk6, {v7 -> v8})
+  Goto(blk6, {v5 -> v6})
 
 blk5:
 Statements:
-  (v9: core::felt252) <- 8
-  (v10: core::felt252) <- core::felt252_add(v1, v9)
+  (v7: core::felt252) <- 8
 End:
-  Goto(blk6, {v10 -> v8})
+  Goto(blk6, {v7 -> v6})
 
 blk6:
 Statements:
-  (v11: core::felt252) <- 1
-  (v12: core::felt252) <- core::felt252_add(v8, v11)
+  (v8: core::felt252) <- 1
+  (v9: core::felt252) <- core::felt252_add(v6, v8)
 End:
-  Return(v12)
+  Return(v9)
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-lowering/src/test_data/tests
+++ b/crates/cairo-lang-lowering/src/test_data/tests
@@ -175,7 +175,7 @@ fn foo(a: felt252) -> felt252 {
     {
         x;
     }
-    let _y = if 1 == 1 {
+    let _y = if a == 1 {
         6
     } else {
         7
@@ -208,7 +208,7 @@ End:
 blk1:
 Statements:
   (v7: core::felt252) <- 1
-  (v8: core::felt252) <- core::felt252_sub(v7, v7)
+  (v8: core::felt252) <- core::felt252_sub(v2, v7)
 End:
   Match(match core::felt252_is_zero(v8) {
     IsZeroResult::Zero => blk2,
@@ -242,27 +242,25 @@ Statements:
   (v19: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v15)
   (v20: core::felt252) <- struct_destructure(v17)
   (v21: core::felt252) <- 5
-  (v22: core::felt252) <- 0
-  (v23: core::felt252) <- core::felt252_add(v2, v22)
-  (v24: core::felt252) <- core::felt252_mul(v21, v23)
-  (v25: core::felt252) <- core::felt252_add(v20, v24)
-  (v26: (core::felt252,)) <- struct_construct(v25)
-  (v27: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Ok(v26)
+  (v22: core::felt252) <- core::felt252_mul(v21, v2)
+  (v23: core::felt252) <- core::felt252_add(v20, v22)
+  (v24: (core::felt252,)) <- struct_construct(v23)
+  (v25: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Ok(v24)
 End:
-  Return(v14, v19, v27)
+  Return(v14, v19, v25)
 
 blk6:
 Statements:
-  (v28: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v18)
+  (v26: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v18)
 End:
-  Return(v14, v15, v28)
+  Return(v14, v15, v26)
 
 blk7:
 Statements:
-  (v29: (core::panics::Panic, core::array::Array::<core::felt252>)) <- core::panic_with_const_felt252::<375233589013918064796019>()
-  (v30: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v29)
+  (v27: (core::panics::Panic, core::array::Array::<core::felt252>)) <- core::panic_with_const_felt252::<375233589013918064796019>()
+  (v28: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v27)
 End:
-  Return(v5, v6, v30)
+  Return(v5, v6, v28)
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-sierra-generator/src/local_variables_test_data/match_enum
+++ b/crates/cairo-lang-sierra-generator/src/local_variables_test_data/match_enum
@@ -57,37 +57,35 @@ blk0 (root):
 Statements:
   (v0: test::MyEnum) <- test::bar()
   (v1: core::felt252) <- test::non_literal()
-  (v2: core::felt252) <- 2
 End:
   Match(match_enum(v0) {
-    MyEnum::A(v3) => blk1,
-    MyEnum::B(v4) => blk2,
+    MyEnum::A(v2) => blk1,
+    MyEnum::B(v3) => blk2,
   })
 
 blk1:
 Statements:
-  (v5: core::felt252) <- test::revoke_ap()
-  (v6: core::felt252) <- core::felt252_add(v3, v3)
+  (v4: core::felt252) <- test::revoke_ap()
+  (v5: core::felt252) <- core::felt252_add(v2, v2)
 End:
-  Goto(blk3, {v6 -> v7})
+  Goto(blk3, {v5 -> v6})
 
 blk2:
 Statements:
-  (v8: core::felt252) <- core::felt252_add(v4, v4)
-  (v9: core::felt252) <- core::felt252_add(v8, v4)
+  (v7: core::felt252) <- core::felt252_add(v3, v3)
+  (v8: core::felt252) <- core::felt252_add(v7, v3)
 End:
-  Goto(blk3, {v9 -> v7})
+  Goto(blk3, {v8 -> v6})
 
 blk3:
 Statements:
-  (v10: core::felt252) <- core::felt252_add(v1, v1)
-  (v11: core::felt252) <- core::felt252_add(v2, v2)
-  (v12: core::felt252) <- test::revoke_ap()
+  (v9: core::felt252) <- core::felt252_add(v1, v1)
+  (v10: core::felt252) <- test::revoke_ap()
 End:
-  Return(v7)
+  Return(v6)
 
 //! > local_variables
-v7, v1, v3
+v6, v1, v2
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-sierra-generator/src/statement_location_test_data/simple
+++ b/crates/cairo-lang-sierra-generator/src/statement_location_test_data/simple
@@ -838,84 +838,9 @@ foo
 label_test::foo::0:
 alloc_local<BoundedInt<0, 30>>() -> ([1])
 alloc_local<felt252>() -> ([3])
-alloc_local<BoundedInt<0, 30>>() -> ([5])
-alloc_local<felt252>() -> ([7])
 finalize_locals() -> ()
 disable_ap_tracking() -> ()
-const_as_immediate<Const<felt252, 10>>() -> ([8])
-const_as_immediate<Const<felt252, 20>>() -> ([9])
-store_temp<felt252>([8]) -> ([8])
-Originating location:
-        felt252_sub(lhs, rhs)
-        ^^^^^^^^^^^^^^^^^^^^^
-In function: core::Felt252Sub::sub
-Inlined at:
-        match *lhs - *rhs {
-              ^^^^^^^^^^^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-felt252_sub([8], [9]) -> ([10])
-Originating location:
-        felt252_sub(lhs, rhs)
-        ^^^^^^^^^^^^^^^^^^^^^
-In function: core::Felt252Sub::sub
-Inlined at:
-        match *lhs - *rhs {
-              ^^^^^^^^^^^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-store_temp<felt252>([10]) -> ([10])
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-felt252_is_zero([10]) { fallthrough() label_test::foo::1([11]) }
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-branch_align() -> ()
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-drop<Uninitialized<BoundedInt<0, 30>>>([1]) -> ()
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-drop<Uninitialized<felt252>>([3]) -> ()
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-array_new<bytes31>() -> ([12])
+array_new<bytes31>() -> ([4])
 Originating location:
         array_new()
         ^^^^^^^^^^^
@@ -936,7 +861,7 @@ Inlined at:
     let mut __formatter_for_print_macros__: core::fmt::Formatter = core::traits::Default::default();
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-drop<Array<bytes31>>([12]) -> ()
+drop<Array<bytes31>>([4]) -> ()
 Originating location:
         array_new()
         ^^^^^^^^^^^
@@ -957,7 +882,7 @@ Inlined at:
     let mut __formatter_for_print_macros__: core::fmt::Formatter = core::traits::Default::default();
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-function_call<user@core::byte_array::InternalImpl::append_word_ex{{ array![], 0, 0 }, 33812444595910922, 7, }>() -> ([13])
+function_call<user@core::byte_array::InternalImpl::append_word_ex{{ array![], 0, 0 }, 33812324336826634, 7, }>() -> ([5])
 Originating location:
             Some(len) => self.append_word_ex(word, len),
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -970,20 +895,20 @@ Inlined at:
 |_____^
 In function: core::byte_array::ByteArrayImpl::append_word
 Inlined at:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
+    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
-enum_match<core::panics::PanicResult::<(core::byte_array::ByteArray, ())>>([13]) { fallthrough([14]) label_test::foo::3([15]) }
+enum_match<core::panics::PanicResult::<(core::byte_array::ByteArray, ())>>([5]) { fallthrough([6]) label_test::foo::1([7]) }
 Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
+    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
 branch_align() -> ()
 Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
+    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
-array_new<felt252>() -> ([16])
+array_new<felt252>() -> ([8])
 Originating location:
         array_new()
         ^^^^^^^^^^^
@@ -996,7 +921,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-const_as_immediate<Const<felt252, 1997209042069643135709344952807065910992472029923670688473712229447419591075>>() -> ([17])
+const_as_immediate<Const<felt252, 1997209042069643135709344952807065910992472029923670688473712229447419591075>>() -> ([9])
 Originating location:
         array_new()
         ^^^^^^^^^^^
@@ -1009,7 +934,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-store_temp<felt252>([17]) -> ([17])
+store_temp<felt252>([9]) -> ([9])
 Originating location:
         array_append(ref self, value)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1022,7 +947,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-array_append<felt252>([16], [17]) -> ([18])
+array_append<felt252>([8], [9]) -> ([10])
 Originating location:
         array_append(ref self, value)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1035,27 +960,27 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-struct_deconstruct<Tuple<core::byte_array::ByteArray, Unit>>([14]) -> ([19], [20])
+struct_deconstruct<Tuple<core::byte_array::ByteArray, Unit>>([6]) -> ([11], [12])
 Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
+    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
-drop<Unit>([20]) -> ()
+drop<Unit>([12]) -> ()
 Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
+    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
-snapshot_take<core::byte_array::ByteArray>([19]) -> ([21], [22])
+snapshot_take<core::byte_array::ByteArray>([11]) -> ([13], [14])
 Originating location:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-drop<core::byte_array::ByteArray>([21]) -> ()
+drop<core::byte_array::ByteArray>([13]) -> ()
 Originating location:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-struct_snapshot_deconstruct<core::byte_array::ByteArray>([22]) -> ([23], [6], [4])
+struct_snapshot_deconstruct<core::byte_array::ByteArray>([14]) -> ([15], [2], [0])
 Originating location:
         Serde::serialize(self.data, ref output);
                          ^^^^
@@ -1068,7 +993,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-dup<Snapshot<Array<bytes31>>>([23]) -> ([23], [24])
+dup<Snapshot<Array<bytes31>>>([15]) -> ([15], [16])
 Originating location:
         array_len(self)
         ^^^^^^^^^^^^^^^
@@ -1089,7 +1014,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-array_len<bytes31>([24]) -> ([25])
+array_len<bytes31>([16]) -> ([17])
 Originating location:
         array_len(self)
         ^^^^^^^^^^^^^^^
@@ -1110,7 +1035,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-u32_to_felt252([25]) -> ([26])
+u32_to_felt252([17]) -> ([18])
 Originating location:
         u32_to_felt252(self)
         ^^^^^^^^^^^^^^^^^^^^
@@ -1135,7 +1060,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-store_temp<felt252>([26]) -> ([26])
+store_temp<felt252>([18]) -> ([18])
 Originating location:
         array_append(ref self, value)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1160,7 +1085,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-array_append<felt252>([18], [26]) -> ([27])
+array_append<felt252>([10], [18]) -> ([19])
 Originating location:
         array_append(ref self, value)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1185,7 +1110,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-struct_construct<core::array::Span::<core::bytes_31::bytes31>>([23]) -> ([28])
+struct_construct<core::array::Span::<core::bytes_31::bytes31>>([15]) -> ([20])
 Originating location:
         array_append(ref self, value)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1210,7 +1135,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-store_temp<core::array::Span::<core::bytes_31::bytes31>>([28]) -> ([28])
+store_temp<core::array::Span::<core::bytes_31::bytes31>>([20]) -> ([20])
 Originating location:
         serialize_array_helper(self.span(), ref output);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1227,596 +1152,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-store_temp<Array<felt252>>([27]) -> ([27])
-Originating location:
-        serialize_array_helper(self.span(), ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-store_local<felt252>([7], [6]) -> ([6])
-Originating location:
-        serialize_array_helper(self.span(), ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-store_local<BoundedInt<0, 30>>([5], [4]) -> ([4])
-Originating location:
-        serialize_array_helper(self.span(), ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-function_call<user@core::array::serialize_array_helper::<core::bytes_31::bytes31, core::serde::into_felt252_based::SerdeImpl::<core::bytes_31::bytes31, core::bytes_31::bytes31Copy, core::bytes_31::Bytes31IntoFelt252, core::bytes_31::Felt252TryIntoBytes31>, core::bytes_31::bytes31Drop>>([28], [27]) -> ([29])
-Originating location:
-        serialize_array_helper(self.span(), ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-rename<felt252>([6]) -> ([30])
-Originating location:
-        output.append(*self);
-                       ^^^^
-In function: core::Felt252Serde::serialize
-Inlined at:
-        Serde::serialize(self.pending_word, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-array_append<felt252>([29], [30]) -> ([31])
-Originating location:
-        array_append(ref self, value)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::append
-Inlined at:
-        output.append(*self);
-        ^^^^^^^^^^^^^^^^^^^^
-In function: core::Felt252Serde::serialize
-Inlined at:
-        Serde::serialize(self.pending_word, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-rename<BoundedInt<0, 30>>([4]) -> ([32])
-Originating location:
-            output.append((*self).into());
-                            ^^^^
-In function: core::serde::into_felt252_based::SerdeImpl::serialize
-Inlined at:
-        Serde::serialize(self.pending_word_len, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-upcast<BoundedInt<0, 30>, felt252>([32]) -> ([33])
-Originating location:
-        upcast(self)
-        ^^^^^^^^^^^^
-In function: core::internal::bounded_int::BoundedIntIntoFelt252::into
-Inlined at:
-            output.append((*self).into());
-                          ^^^^^^^^^^^^^^
-In function: core::serde::into_felt252_based::SerdeImpl::serialize
-Inlined at:
-        Serde::serialize(self.pending_word_len, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-array_append<felt252>([31], [33]) -> ([34])
-Originating location:
-        array_append(ref self, value)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::append
-Inlined at:
-            output.append((*self).into());
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::serde::into_felt252_based::SerdeImpl::serialize
-Inlined at:
-        Serde::serialize(self.pending_word_len, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-store_temp<Array<felt252>>([34]) -> ([34])
-Originating location:
-    print(serialized)
-    ^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-print([34]) -> ()
-Originating location:
-    print(serialized)
-    ^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-jump() { label_test::foo::5() }
-Originating location:
-    print(serialized)
-    ^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-label_test::foo::3:
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-branch_align() -> ()
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-drop<Uninitialized<BoundedInt<0, 30>>>([5]) -> ()
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-drop<Uninitialized<felt252>>([7]) -> ()
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-enum_init<core::panics::PanicResult::<((),)>, 1>([15]) -> ([35])
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x78203d3d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-store_temp<core::panics::PanicResult::<((),)>>([35]) -> ([35])
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-return([35])
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-label_test::foo::4:
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-label_test::foo::1:
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-branch_align() -> ()
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-drop<NonZero<felt252>>([11]) -> ()
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-drop<Uninitialized<BoundedInt<0, 30>>>([5]) -> ()
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-drop<Uninitialized<felt252>>([7]) -> ()
-Originating location:
-            0 => true,
-            ^
-In function: core::Felt252PartialEq::eq
-Inlined at:
-    if x == y { // highlighted
-       ^^^^^^
-In function: lib.cairo::foo
-array_new<bytes31>() -> ([36])
-Originating location:
-        array_new()
-        ^^^^^^^^^^^
-In function: core::array::ArrayImpl::new
-Inlined at:
-        ArrayTrait::new()
-        ^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayDefault::default
-Inlined at:
-        ByteArray { data: Default::default(), pending_word: 0, pending_word_len: 0 }
-                          ^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArrayDefault::default
-Inlined at:
-        let buffer = core::internal::InferDestruct::<ByteArray> { value: core::traits::Default::<ByteArray>::default() };
-                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::fmt::FormatterDefault::default
-Inlined at:
-    let mut __formatter_for_print_macros__: core::fmt::Formatter = core::traits::Default::default();
-                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-drop<Array<bytes31>>([36]) -> ()
-Originating location:
-        array_new()
-        ^^^^^^^^^^^
-In function: core::array::ArrayImpl::new
-Inlined at:
-        ArrayTrait::new()
-        ^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayDefault::default
-Inlined at:
-        ByteArray { data: Default::default(), pending_word: 0, pending_word_len: 0 }
-                          ^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArrayDefault::default
-Inlined at:
-        let buffer = core::internal::InferDestruct::<ByteArray> { value: core::traits::Default::<ByteArray>::default() };
-                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::fmt::FormatterDefault::default
-Inlined at:
-    let mut __formatter_for_print_macros__: core::fmt::Formatter = core::traits::Default::default();
-                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-function_call<user@core::byte_array::InternalImpl::append_word_ex{{ array![], 0, 0 }, 33812324336826634, 7, }>() -> ([37])
-Originating location:
-            Some(len) => self.append_word_ex(word, len),
-                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArrayImpl::append_word
-Inlined at:
-      fn append_word(ref self: ByteArray, word: felt252, len: usize) {
- _____^
-| ...
-|     }
-|_____^
-In function: core::byte_array::ByteArrayImpl::append_word
-Inlined at:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-enum_match<core::panics::PanicResult::<(core::byte_array::ByteArray, ())>>([37]) { fallthrough([38]) label_test::foo::6([39]) }
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-branch_align() -> ()
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-array_new<felt252>() -> ([40])
-Originating location:
-        array_new()
-        ^^^^^^^^^^^
-In function: core::array::ArrayImpl::new
-Inlined at:
-            let mut __array_builder_macro_result__ = core::array::ArrayTrait::new();
-                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::array_inline_macro
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-const_as_immediate<Const<felt252, 1997209042069643135709344952807065910992472029923670688473712229447419591075>>() -> ([41])
-Originating location:
-        array_new()
-        ^^^^^^^^^^^
-In function: core::array::ArrayImpl::new
-Inlined at:
-            let mut __array_builder_macro_result__ = core::array::ArrayTrait::new();
-                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::array_inline_macro
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-store_temp<felt252>([41]) -> ([41])
-Originating location:
-        array_append(ref self, value)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::append
-Inlined at:
-            core::array::ArrayTrait::append(ref __array_builder_macro_result__,crate::byte_array::BYTE_ARRAY_MAGIC);
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::array_inline_macro
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-array_append<felt252>([40], [41]) -> ([42])
-Originating location:
-        array_append(ref self, value)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::append
-Inlined at:
-            core::array::ArrayTrait::append(ref __array_builder_macro_result__,crate::byte_array::BYTE_ARRAY_MAGIC);
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::array_inline_macro
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-struct_deconstruct<Tuple<core::byte_array::ByteArray, Unit>>([38]) -> ([43], [44])
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-drop<Unit>([44]) -> ()
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-snapshot_take<core::byte_array::ByteArray>([43]) -> ([45], [46])
-Originating location:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-drop<core::byte_array::ByteArray>([45]) -> ()
-Originating location:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-struct_snapshot_deconstruct<core::byte_array::ByteArray>([46]) -> ([47], [2], [0])
-Originating location:
-        Serde::serialize(self.data, ref output);
-                         ^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-dup<Snapshot<Array<bytes31>>>([47]) -> ([47], [48])
-Originating location:
-        array_len(self)
-        ^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::len
-Inlined at:
-        self.len().serialize(ref output);
-        ^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-array_len<bytes31>([48]) -> ([49])
-Originating location:
-        array_len(self)
-        ^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::len
-Inlined at:
-        self.len().serialize(ref output);
-        ^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-u32_to_felt252([49]) -> ([50])
-Originating location:
-        u32_to_felt252(self)
-        ^^^^^^^^^^^^^^^^^^^^
-In function: core::integer::U32IntoFelt252::into
-Inlined at:
-            output.append((*self).into());
-                          ^^^^^^^^^^^^^^
-In function: core::serde::into_felt252_based::SerdeImpl::serialize
-Inlined at:
-        self.len().serialize(ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-store_temp<felt252>([50]) -> ([50])
-Originating location:
-        array_append(ref self, value)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::append
-Inlined at:
-            output.append((*self).into());
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::serde::into_felt252_based::SerdeImpl::serialize
-Inlined at:
-        self.len().serialize(ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-array_append<felt252>([42], [50]) -> ([51])
-Originating location:
-        array_append(ref self, value)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::append
-Inlined at:
-            output.append((*self).into());
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::serde::into_felt252_based::SerdeImpl::serialize
-Inlined at:
-        self.len().serialize(ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-struct_construct<core::array::Span::<core::bytes_31::bytes31>>([47]) -> ([52])
-Originating location:
-        array_append(ref self, value)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArrayImpl::append
-Inlined at:
-            output.append((*self).into());
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::serde::into_felt252_based::SerdeImpl::serialize
-Inlined at:
-        self.len().serialize(ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-store_temp<core::array::Span::<core::bytes_31::bytes31>>([52]) -> ([52])
-Originating location:
-        serialize_array_helper(self.span(), ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::array::ArraySerde::serialize
-Inlined at:
-        Serde::serialize(self.data, ref output);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::byte_array::ByteArraySerde::serialize
-Inlined at:
-    self.serialize(ref serialized);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-store_temp<Array<felt252>>([51]) -> ([51])
+store_temp<Array<felt252>>([19]) -> ([19])
 Originating location:
         serialize_array_helper(self.span(), ref output);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1867,7 +1203,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-function_call<user@core::array::serialize_array_helper::<core::bytes_31::bytes31, core::serde::into_felt252_based::SerdeImpl::<core::bytes_31::bytes31, core::bytes_31::bytes31Copy, core::bytes_31::Bytes31IntoFelt252, core::bytes_31::Felt252TryIntoBytes31>, core::bytes_31::bytes31Drop>>([52], [51]) -> ([53])
+function_call<user@core::array::serialize_array_helper::<core::bytes_31::bytes31, core::serde::into_felt252_based::SerdeImpl::<core::bytes_31::bytes31, core::bytes_31::bytes31Copy, core::bytes_31::Bytes31IntoFelt252, core::bytes_31::Felt252TryIntoBytes31>, core::bytes_31::bytes31Drop>>([20], [19]) -> ([21])
 Originating location:
         serialize_array_helper(self.span(), ref output);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1884,7 +1220,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-rename<felt252>([2]) -> ([54])
+rename<felt252>([2]) -> ([22])
 Originating location:
         output.append(*self);
                        ^^^^
@@ -1901,7 +1237,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-array_append<felt252>([53], [54]) -> ([55])
+array_append<felt252>([21], [22]) -> ([23])
 Originating location:
         array_append(ref self, value)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1922,7 +1258,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-rename<BoundedInt<0, 30>>([0]) -> ([56])
+rename<BoundedInt<0, 30>>([0]) -> ([24])
 Originating location:
             output.append((*self).into());
                             ^^^^
@@ -1939,7 +1275,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-upcast<BoundedInt<0, 30>, felt252>([56]) -> ([57])
+upcast<BoundedInt<0, 30>, felt252>([24]) -> ([25])
 Originating location:
         upcast(self)
         ^^^^^^^^^^^^
@@ -1960,7 +1296,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-array_append<felt252>([55], [57]) -> ([58])
+array_append<felt252>([23], [25]) -> ([26])
 Originating location:
         array_append(ref self, value)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1981,7 +1317,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-store_temp<Array<felt252>>([58]) -> ([58])
+store_temp<Array<felt252>>([26]) -> ([26])
 Originating location:
     print(serialized)
     ^^^^^^^^^^^^^^^^^
@@ -1990,7 +1326,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-print([58]) -> ()
+print([26]) -> ()
 Originating location:
     print(serialized)
     ^^^^^^^^^^^^^^^^^
@@ -1999,7 +1335,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-label_test::foo::5:
+struct_construct<Unit>() -> ([27])
 Originating location:
     print(serialized)
     ^^^^^^^^^^^^^^^^^
@@ -2008,7 +1344,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-struct_construct<Unit>() -> ([59])
+struct_construct<Tuple<Unit>>([27]) -> ([28])
 Originating location:
     print(serialized)
     ^^^^^^^^^^^^^^^^^
@@ -2017,16 +1353,7 @@ Inlined at:
     core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: println_macro::println_macro
-struct_construct<Tuple<Unit>>([59]) -> ([60])
-Originating location:
-    print(serialized)
-    ^^^^^^^^^^^^^^^^^
-In function: core::debug::print_byte_array_as_string
-Inlined at:
-    core::debug::print_byte_array_as_string(@__formatter_for_print_macros__.buffer);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: println_macro::println_macro
-enum_init<core::panics::PanicResult::<((),)>, 0>([60]) -> ([61])
+enum_init<core::panics::PanicResult::<((),)>, 0>([28]) -> ([29])
 Originating location:
   fn foo() {
  __________^
@@ -2034,7 +1361,7 @@ Originating location:
 | }
 |_^
 In function: lib.cairo::foo
-store_temp<core::panics::PanicResult::<((),)>>([61]) -> ([61])
+store_temp<core::panics::PanicResult::<((),)>>([29]) -> ([29])
 Originating location:
   fn foo() {
  __________^
@@ -2042,7 +1369,7 @@ Originating location:
 | }
 |_^
 In function: lib.cairo::foo
-return([61])
+return([29])
 Originating location:
   fn foo() {
  __________^
@@ -2050,7 +1377,7 @@ Originating location:
 | }
 |_^
 In function: lib.cairo::foo
-label_test::foo::6:
+label_test::foo::1:
 Originating location:
     core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2070,22 +1397,17 @@ Originating location:
     core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
-enum_init<core::panics::PanicResult::<((),)>, 1>([39]) -> ([62])
+enum_init<core::panics::PanicResult::<((),)>, 1>([7]) -> ([30])
 Originating location:
     core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
-store_temp<core::panics::PanicResult::<((),)>>([62]) -> ([62])
+store_temp<core::panics::PanicResult::<((),)>>([30]) -> ([30])
 Originating location:
     core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
-return([62])
-Originating location:
-    core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: writeln_macro::writeln_macro
-label_test::foo::7:
+return([30])
 Originating location:
     core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
@@ -112,7 +112,7 @@ fn test_validate_gas_cost() {
     assert!(
         call_building_gas_usage == 3930
             && serialization_gas_usage == 27670
-            && entry_point_gas_usage == 105430,
+            && entry_point_gas_usage == 105130,
         "Unexpected gas_usage:
      call_building: `{call_building_gas_usage}`.
      serialization: `{serialization_gas_usage}`.


### PR DESCRIPTION
Added constant folding for felt252 arithmetic operations (add, sub, mul) to improve compiler optimization.

### What changed?

- Implemented constant folding for `felt252_add` and `felt252_mul` operations
- Enhanced the existing `felt252_sub` constant folding to handle more cases
- Added utility functions undet utils crate in `bigint.rs` to support felt252 modular arithmetic:
  - Added `CAIRO_PRIME_BIGINT` as a static constant
  - Added `felt252_mod()` function to handle modular arithmetic properly
- Added test cases to verify the constant folding behavior for all operations
- Updated existing test files to reflect the new optimized output
