### PR TITLE
Remove unused Debug import from cairo-format main

### DIFF
--- a/crates/bin/cairo-format/src/main.rs
+++ b/crates/bin/cairo-format/src/main.rs
@@ -1,4 +1,3 @@
-use std::fmt::Debug;
 use std::path::Path;
 use std::process::ExitCode;
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
- drop the unused `std::fmt::Debug` import from `crates/bin/cairo-format/src/main.rs`
- rely on the derive-generated Debug impl without redundant wiring
- keep the module free of unused-import noise
