### PR TITLE
Remove unused_variables allow from Analyzer trait defaults

### DIFF
--- a/crates/cairo-lang-lowering/src/borrow_check/analysis.rs
+++ b/crates/cairo-lang-lowering/src/borrow_check/analysis.rs
@@ -9,43 +9,48 @@ use crate::{Block, BlockEnd, BlockId, Lowered, MatchInfo, Statement, VarRemappin
 pub type StatementLocation = (BlockId, usize);
 
 /// Analyzer trait to implement for each specific analysis.
-#[allow(unused_variables)]
 pub trait Analyzer<'db, 'a> {
     type Info: Clone;
-    fn visit_block_start(&mut self, info: &mut Self::Info, block_id: BlockId, block: &Block<'db>) {}
+    fn visit_block_start(
+        &mut self,
+        _info: &mut Self::Info,
+        _block_id: BlockId,
+        _block: &Block<'db>,
+    ) {
+    }
     fn visit_stmt(
         &mut self,
-        info: &mut Self::Info,
-        statement_location: StatementLocation,
-        stmt: &'a Statement<'db>,
+        _info: &mut Self::Info,
+        _statement_location: StatementLocation,
+        _stmt: &'a Statement<'db>,
     ) {
     }
     fn visit_goto(
         &mut self,
-        info: &mut Self::Info,
-        statement_location: StatementLocation,
-        target_block_id: BlockId,
-        remapping: &'a VarRemapping<'db>,
+        _info: &mut Self::Info,
+        _statement_location: StatementLocation,
+        _target_block_id: BlockId,
+        _remapping: &'a VarRemapping<'db>,
     ) {
     }
     fn merge_match(
         &mut self,
-        statement_location: StatementLocation,
-        match_info: &'a MatchInfo<'db>,
-        infos: impl Iterator<Item = Self::Info>,
+        _statement_location: StatementLocation,
+        _match_info: &'a MatchInfo<'db>,
+        _infos: impl Iterator<Item = Self::Info>,
     ) -> Self::Info;
     fn info_from_return(
         &mut self,
-        statement_location: StatementLocation,
-        vars: &'a [VarUsage<'db>],
+        _statement_location: StatementLocation,
+        _vars: &'a [VarUsage<'db>],
     ) -> Self::Info;
 
     /// Default `info_from_panic` implementation for post 'lower_panics' phases.
     /// Earlier phases need to override this implementation.
     fn info_from_panic(
         &mut self,
-        statement_location: StatementLocation,
-        var: &VarUsage<'db>,
+        _statement_location: StatementLocation,
+        _var: &VarUsage<'db>,
     ) -> Self::Info {
         unreachable!("Panics should have been stripped in the `lower_panics` phase.");
     }


### PR DESCRIPTION
drop #[allow(unused_variables)] from Analyzer in cairo-lang-lowering
keep existing default impls by renaming params to _info, _statement_location, etc.
eliminate the redundant lint suppression without changing behaviour