### PR TITLE
fix(parser): better handling for multi-reference objects (&&T, &&&T, etc)

### DIFF
--- a/crates/cairo-lang-formatter/src/node_properties.rs
+++ b/crates/cairo-lang-formatter/src/node_properties.rs
@@ -758,7 +758,9 @@ impl<'a> SyntaxNodeFormat for SyntaxNode<'a> {
                         true,
                     ))
                 }
-                SyntaxKind::TerminalAnd => {
+                SyntaxKind::TerminalAnd
+                    if matches!(self.parent_kind(db), Some(SyntaxKind::ExprBinary)) =>
+                {
                     BreakLinePointsPositions::Leading(BreakLinePointProperties::new(
                         13,
                         BreakLinePointIndentation::Indented,

--- a/crates/cairo-lang-parser/src/operators.rs
+++ b/crates/cairo-lang-parser/src/operators.rs
@@ -4,6 +4,7 @@ pub fn get_unary_operator_precedence(kind: SyntaxKind) -> Option<usize> {
     match kind {
         SyntaxKind::TerminalAt
         | SyntaxKind::TerminalAnd
+        | SyntaxKind::TerminalAndAnd
         | SyntaxKind::TerminalNot
         | SyntaxKind::TerminalBitNot
         | SyntaxKind::TerminalMul

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/reference
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/reference
@@ -4,7 +4,7 @@
 test_partial_parser_tree(expect_diagnostics: false)
 
 //! > cairo_code
-fn f(x: &u32) {}
+fn f(x: &u32, y: &&u32, z: &&&u32) {}
 
 //! > top_level_kind
 ExprUnary
@@ -21,6 +21,26 @@ ExprUnary
         └── segments (kind: ExprPathInner)
             └── item #0 (kind: PathSegmentSimple)
                 └── ident (kind: TokenIdentifier): 'u32'
+└── Top level kind: ExprUnary
+    ├── op (kind: TokenAnd): '&'
+    └── expr (kind: ExprUnary)
+        ├── op (kind: TokenAnd): '&'
+        └── expr (kind: ExprPath)
+            ├── dollar (kind: OptionTerminalDollarEmpty) []
+            └── segments (kind: ExprPathInner)
+                └── item #0 (kind: PathSegmentSimple)
+                    └── ident (kind: TokenIdentifier): 'u32'
+└── Top level kind: ExprUnary
+    ├── op (kind: TokenAnd): '&'
+    └── expr (kind: ExprUnary)
+        ├── op (kind: TokenAnd): '&'
+        └── expr (kind: ExprUnary)
+            ├── op (kind: TokenAnd): '&'
+            └── expr (kind: ExprPath)
+                ├── dollar (kind: OptionTerminalDollarEmpty) []
+                └── segments (kind: ExprPathInner)
+                    └── item #0 (kind: PathSegmentSimple)
+                        └── ident (kind: TokenIdentifier): 'u32'
 
 //! > ==========================================================================
 
@@ -30,7 +50,7 @@ ExprUnary
 test_partial_parser_tree(expect_diagnostics: false)
 
 //! > cairo_code
-fn f(x: &@u32, y: @ &u32) {}
+fn f(x: &@u32, y: @&u32) {}
 
 //! > top_level_kind
 ParamList
@@ -79,7 +99,7 @@ ParamList
 test_partial_parser_tree(expect_diagnostics: false)
 
 //! > cairo_code
-fn f() -> Option< &u64> {}
+fn f() -> Option<&u64> {}
 
 //! > top_level_kind
 ExprUnary
@@ -99,42 +119,16 @@ ExprUnary
 
 //! > ==========================================================================
 
-//! > Test double reference &&x
-
-//! > test_runner_name
-test_partial_parser_tree(expect_diagnostics: false)
-
-//! > cairo_code
-fn f(x: & &u32) {}
-
-//! > top_level_kind
-ExprUnary
-
-//! > ignored_kinds
-
-//! > expected_diagnostics
-
-//! > expected_tree
-└── Top level kind: ExprUnary
-    ├── op (kind: TokenAnd): '&'
-    └── expr (kind: ExprUnary)
-        ├── op (kind: TokenAnd): '&'
-        └── expr (kind: ExprPath)
-            ├── dollar (kind: OptionTerminalDollarEmpty) []
-            └── segments (kind: ExprPathInner)
-                └── item #0 (kind: PathSegmentSimple)
-                    └── ident (kind: TokenIdentifier): 'u32'
-
-//! > ==========================================================================
-
-//! > Test double &T as expr
+//! > Test double reference with literal &&5_u32
 
 //! > test_runner_name
 test_partial_parser_tree(expect_diagnostics: false)
 
 //! > cairo_code
 fn f() {
-    let x =  &1_u32;
+    let x = &1_u32;
+    let y = &&2_u32;
+    let z = &&&3_u32;
 }
 
 //! > top_level_kind
@@ -148,3 +142,15 @@ ExprUnary
 └── Top level kind: ExprUnary
     ├── op (kind: TokenAnd): '&'
     └── expr (kind: TokenLiteralNumber): '1_u32'
+└── Top level kind: ExprUnary
+    ├── op (kind: TokenAnd): '&'
+    └── expr (kind: ExprUnary)
+        ├── op (kind: TokenAnd): '&'
+        └── expr (kind: TokenLiteralNumber): '2_u32'
+└── Top level kind: ExprUnary
+    ├── op (kind: TokenAnd): '&'
+    └── expr (kind: ExprUnary)
+        ├── op (kind: TokenAnd): '&'
+        └── expr (kind: ExprUnary)
+            ├── op (kind: TokenAnd): '&'
+            └── expr (kind: TokenLiteralNumber): '3_u32'

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/reference
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/reference
@@ -4,39 +4,157 @@
 test_expr_semantics
 
 //! > expr_code
-&5_u32
-
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
+{
+    let _x= & 1_u32;
+    let _y= && 2_u32;
+    let _z= &&& 3_u32;
+}
 
 //! > expected_semantics
-FunctionCall(
-    ExprFunctionCall {
-        function: core::box::BoxImpl::<@core::integer::u32>::new,
-        args: [
-            Value(
-                Snapshot(
-                    ExprSnapshot {
-                        inner: Literal(
-                            ExprLiteral {
-                                value: 5,
-                                ty: core::integer::u32,
-                            },
-                        ),
-                        ty: @core::integer::u32,
-                    },
-                ),
+Block(
+    ExprBlock {
+        statements: [
+            Let(
+                StatementLet {
+                    pattern: Variable(
+                        _x,
+                    ),
+                    expr: FunctionCall(
+                        ExprFunctionCall {
+                            function: core::box::BoxImpl::<@core::integer::u32>::new,
+                            args: [
+                                Value(
+                                    Snapshot(
+                                        ExprSnapshot {
+                                            inner: Literal(
+                                                ExprLiteral {
+                                                    value: 1,
+                                                    ty: core::integer::u32,
+                                                },
+                                            ),
+                                            ty: @core::integer::u32,
+                                        },
+                                    ),
+                                ),
+                            ],
+                            coupon_arg: None,
+                            ty: core::box::Box::<@core::integer::u32>,
+                        },
+                    ),
+                    else_clause: None,
+                },
+            ),
+            Let(
+                StatementLet {
+                    pattern: Variable(
+                        _y,
+                    ),
+                    expr: FunctionCall(
+                        ExprFunctionCall {
+                            function: core::box::BoxImpl::<@core::box::Box::<@core::integer::u32>>::new,
+                            args: [
+                                Value(
+                                    Snapshot(
+                                        ExprSnapshot {
+                                            inner: FunctionCall(
+                                                ExprFunctionCall {
+                                                    function: core::box::BoxImpl::<@core::integer::u32>::new,
+                                                    args: [
+                                                        Value(
+                                                            Snapshot(
+                                                                ExprSnapshot {
+                                                                    inner: Literal(
+                                                                        ExprLiteral {
+                                                                            value: 2,
+                                                                            ty: core::integer::u32,
+                                                                        },
+                                                                    ),
+                                                                    ty: @core::integer::u32,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ],
+                                                    coupon_arg: None,
+                                                    ty: core::box::Box::<@core::integer::u32>,
+                                                },
+                                            ),
+                                            ty: @core::box::Box::<@core::integer::u32>,
+                                        },
+                                    ),
+                                ),
+                            ],
+                            coupon_arg: None,
+                            ty: core::box::Box::<@core::box::Box::<@core::integer::u32>>,
+                        },
+                    ),
+                    else_clause: None,
+                },
+            ),
+            Let(
+                StatementLet {
+                    pattern: Variable(
+                        _z,
+                    ),
+                    expr: FunctionCall(
+                        ExprFunctionCall {
+                            function: core::box::BoxImpl::<@core::box::Box::<@core::box::Box::<@core::integer::u32>>>::new,
+                            args: [
+                                Value(
+                                    Snapshot(
+                                        ExprSnapshot {
+                                            inner: FunctionCall(
+                                                ExprFunctionCall {
+                                                    function: core::box::BoxImpl::<@core::box::Box::<@core::integer::u32>>::new,
+                                                    args: [
+                                                        Value(
+                                                            Snapshot(
+                                                                ExprSnapshot {
+                                                                    inner: FunctionCall(
+                                                                        ExprFunctionCall {
+                                                                            function: core::box::BoxImpl::<@core::integer::u32>::new,
+                                                                            args: [
+                                                                                Value(
+                                                                                    Snapshot(
+                                                                                        ExprSnapshot {
+                                                                                            inner: Literal(
+                                                                                                ExprLiteral {
+                                                                                                    value: 3,
+                                                                                                    ty: core::integer::u32,
+                                                                                                },
+                                                                                            ),
+                                                                                            ty: @core::integer::u32,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            ],
+                                                                            coupon_arg: None,
+                                                                            ty: core::box::Box::<@core::integer::u32>,
+                                                                        },
+                                                                    ),
+                                                                    ty: @core::box::Box::<@core::integer::u32>,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ],
+                                                    coupon_arg: None,
+                                                    ty: core::box::Box::<@core::box::Box::<@core::integer::u32>>,
+                                                },
+                                            ),
+                                            ty: @core::box::Box::<@core::box::Box::<@core::integer::u32>>,
+                                        },
+                                    ),
+                                ),
+                            ],
+                            coupon_arg: None,
+                            ty: core::box::Box::<@core::box::Box::<@core::box::Box::<@core::integer::u32>>>,
+                        },
+                    ),
+                    else_clause: None,
+                },
             ),
         ],
-        coupon_arg: None,
-        ty: core::box::Box::<@core::integer::u32>,
+        tail: None,
+        ty: (),
     },
 )
 
@@ -44,23 +162,13 @@ FunctionCall(
 
 //! > ==========================================================================
 
-//! > Test double reference & &x
+//! > Test double reference & &x with space
 
 //! > test_runner_name
 test_expr_semantics
 
 //! > expr_code
 & &5_u32
-
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
 
 //! > expected_semantics
 FunctionCall(
@@ -106,6 +214,155 @@ FunctionCall(
 
 //! > ==========================================================================
 
+//! > Test double and triple reference in function parameter types
+
+//! > test_runner_name
+test_expr_semantics
+
+//! > module_code
+fn f(x: &u32, y: &&u32, z: &&&u32) {}
+
+//! > function_body
+
+//! > expr_code
+f(&1,&&2, &&&3)
+
+
+//! > expected_semantics
+FunctionCall(
+    ExprFunctionCall {
+        function: test::f,
+        args: [
+            Value(
+                FunctionCall(
+                    ExprFunctionCall {
+                        function: core::box::BoxImpl::<@core::integer::u32>::new,
+                        args: [
+                            Value(
+                                Snapshot(
+                                    ExprSnapshot {
+                                        inner: Literal(
+                                            ExprLiteral {
+                                                value: 1,
+                                                ty: core::integer::u32,
+                                            },
+                                        ),
+                                        ty: @core::integer::u32,
+                                    },
+                                ),
+                            ),
+                        ],
+                        coupon_arg: None,
+                        ty: core::box::Box::<@core::integer::u32>,
+                    },
+                ),
+            ),
+            Value(
+                FunctionCall(
+                    ExprFunctionCall {
+                        function: core::box::BoxImpl::<@core::box::Box::<@core::integer::u32>>::new,
+                        args: [
+                            Value(
+                                Snapshot(
+                                    ExprSnapshot {
+                                        inner: FunctionCall(
+                                            ExprFunctionCall {
+                                                function: core::box::BoxImpl::<@core::integer::u32>::new,
+                                                args: [
+                                                    Value(
+                                                        Snapshot(
+                                                            ExprSnapshot {
+                                                                inner: Literal(
+                                                                    ExprLiteral {
+                                                                        value: 2,
+                                                                        ty: core::integer::u32,
+                                                                    },
+                                                                ),
+                                                                ty: @core::integer::u32,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                coupon_arg: None,
+                                                ty: core::box::Box::<@core::integer::u32>,
+                                            },
+                                        ),
+                                        ty: @core::box::Box::<@core::integer::u32>,
+                                    },
+                                ),
+                            ),
+                        ],
+                        coupon_arg: None,
+                        ty: core::box::Box::<@core::box::Box::<@core::integer::u32>>,
+                    },
+                ),
+            ),
+            Value(
+                FunctionCall(
+                    ExprFunctionCall {
+                        function: core::box::BoxImpl::<@core::box::Box::<@core::box::Box::<@core::integer::u32>>>::new,
+                        args: [
+                            Value(
+                                Snapshot(
+                                    ExprSnapshot {
+                                        inner: FunctionCall(
+                                            ExprFunctionCall {
+                                                function: core::box::BoxImpl::<@core::box::Box::<@core::integer::u32>>::new,
+                                                args: [
+                                                    Value(
+                                                        Snapshot(
+                                                            ExprSnapshot {
+                                                                inner: FunctionCall(
+                                                                    ExprFunctionCall {
+                                                                        function: core::box::BoxImpl::<@core::integer::u32>::new,
+                                                                        args: [
+                                                                            Value(
+                                                                                Snapshot(
+                                                                                    ExprSnapshot {
+                                                                                        inner: Literal(
+                                                                                            ExprLiteral {
+                                                                                                value: 3,
+                                                                                                ty: core::integer::u32,
+                                                                                            },
+                                                                                        ),
+                                                                                        ty: @core::integer::u32,
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        ],
+                                                                        coupon_arg: None,
+                                                                        ty: core::box::Box::<@core::integer::u32>,
+                                                                    },
+                                                                ),
+                                                                ty: @core::box::Box::<@core::integer::u32>,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                coupon_arg: None,
+                                                ty: core::box::Box::<@core::box::Box::<@core::integer::u32>>,
+                                            },
+                                        ),
+                                        ty: @core::box::Box::<@core::box::Box::<@core::integer::u32>>,
+                                    },
+                                ),
+                            ),
+                        ],
+                        coupon_arg: None,
+                        ty: core::box::Box::<@core::box::Box::<@core::box::Box::<@core::integer::u32>>>,
+                    },
+                ),
+            ),
+        ],
+        coupon_arg: None,
+        ty: (),
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
 //! > Test reference of snapshot &@x
 
 //! > test_runner_name
@@ -114,15 +371,6 @@ test_expr_semantics
 //! > expr_code
 &@5_u32
 
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
 
 //! > expected_semantics
 FunctionCall(
@@ -165,15 +413,6 @@ test_expr_semantics
 //! > expr_code
 @&5_u32
 
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
 
 //! > expected_semantics
 Snapshot(
@@ -220,15 +459,6 @@ let b = 5_u32;
 //! > expr_code
 a & &b
 
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
 
 //! > expected_semantics
 FunctionCall(
@@ -296,15 +526,6 @@ let p = PPoint { point: Point { x: 1, y: 2 } };
 //! > expr_code
 &p.point.x
 
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
 
 //! > expected_semantics
 FunctionCall(
@@ -356,16 +577,6 @@ let arr = array![1_u32, 2_u32, 3_u32];
 //! > expr_code
 &arr[1]
 
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
-
 //! > expected_semantics
 FunctionCall(
     ExprFunctionCall {
@@ -415,66 +626,6 @@ FunctionCall(
 
 //! > ==========================================================================
 
-//! > Test reference in function call
-
-//! > test_runner_name
-test_expr_semantics
-
-//! > module_code
-fn takes_box(b: Box<@u32>) {}
-
-//! > function_body
-let x = 42_u32;
-
-//! > expr_code
-takes_box(&x)
-
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
-
-//! > expected_semantics
-FunctionCall(
-    ExprFunctionCall {
-        function: test::takes_box,
-        args: [
-            Value(
-                FunctionCall(
-                    ExprFunctionCall {
-                        function: core::box::BoxImpl::<@core::integer::u32>::new,
-                        args: [
-                            Value(
-                                Snapshot(
-                                    ExprSnapshot {
-                                        inner: Var(
-                                            LocalVarId(test::x),
-                                        ),
-                                        ty: @core::integer::u32,
-                                    },
-                                ),
-                            ),
-                        ],
-                        coupon_arg: None,
-                        ty: core::box::Box::<@core::integer::u32>,
-                    },
-                ),
-            ),
-        ],
-        coupon_arg: None,
-        ty: (),
-    },
-)
-
-//! > expected_diagnostics
-
-//! > ==========================================================================
-
 //! > Test reference in assignment
 
 //! > test_runner_name
@@ -486,16 +637,6 @@ let y = &x;
 
 //! > expr_code
 y
-
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
 
 //! > expected_semantics
 Var(
@@ -524,15 +665,6 @@ let r = &value;
 //! > expr_code
 modify_value(ref value)
 
-//! > crate_settings
-edition = "2023_01"
-
-[experimental_features]
-negative_impls = false
-associated_item_constraints = false
-coupons = false
-user_defined_inline_macros = false
-references = true
 
 //! > expected_semantics
 FunctionCall(

--- a/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
+++ b/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
@@ -235,8 +235,8 @@ test_function_diagnostics(expect_diagnostics: true)
 
 //! > function
 fn foo() {
-    let _: Box<u32> =  &3_u32;
-    let _: Box<@felt252> =  &3_u32;
+    let _: Box<u32> = &3_u32;
+    let _: Box<@felt252> = &3_u32;
 }
 
 //! > function_name
@@ -246,14 +246,14 @@ foo
 
 //! > expected_diagnostics
 error: Unexpected argument type. Expected: "core::box::Box::<core::integer::u32>", found: "core::box::Box::<@core::integer::u32>".
- --> lib.cairo:2:24
-    let _: Box<u32> =  &3_u32;
-                       ^^^^^^
+ --> lib.cairo:2:23
+    let _: Box<u32> = &3_u32;
+                      ^^^^^^
 
 error: Unexpected argument type. Expected: "core::box::Box::<@core::felt252>", found: "core::box::Box::<@core::integer::u32>".
- --> lib.cairo:3:29
-    let _: Box<@felt252> =  &3_u32;
-                            ^^^^^^
+ --> lib.cairo:3:28
+    let _: Box<@felt252> = &3_u32;
+                           ^^^^^^
 
 //! > ==========================================================================
 
@@ -265,11 +265,11 @@ test_function_diagnostics(expect_diagnostics: true)
 //! > function
 fn foo(mut param: u32) {
     let mut x = 3_u32;
-    let _r =  &x;
+    let _r = &x;
     x = 5;
 
     let mut y = 2_felt252;
-    let _s =  &y;
+    let _s = &y;
     y = 10;
 }
 
@@ -284,15 +284,15 @@ error: Cannot assign to a variable that has been referenced
     x = 5;
     ^^^^^
 note: variable was referenced here:
-  --> lib.cairo:3:15
-    let _r =  &x;
-              ^^
+  --> lib.cairo:3:14
+    let _r = &x;
+             ^^
 
 error: Cannot assign to a variable that has been referenced
  --> lib.cairo:8:5
     y = 10;
     ^^^^^^
 note: variable was referenced here:
-  --> lib.cairo:7:15
-    let _s =  &y;
-              ^^
+  --> lib.cairo:7:14
+    let _s = &y;
+             ^^


### PR DESCRIPTION
- Formatter no longer inserts breakline before & in an unary & (or &&), meaning &&T isn't coerced
  into & &T. This also had the effect of removing excess whitespace in some other cases (see tests).
- Implementation: parser consumes && and pushes two & into the token queue, which is then
parsed similarly to &(&T).
- consolidated tests and added triple &&&T test