### PR TITLE
Сhore(get-lowering): remove unused ImplSemantic import

### DIFF
--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -29,7 +29,6 @@ use cairo_lang_semantic::items::functions::{
     ConcreteFunctionWithBody, GenericFunctionWithBodyId, ImplFunctionBodyId,
     ImplGenericFunctionWithBodyId,
 };
-use cairo_lang_semantic::items::imp::ImplSemantic;
 use cairo_lang_starknet::starknet_plugin_suite;
 use cairo_lang_test_plugin::test_plugin_suite;
 use cairo_lang_utils::Intern;


### PR DESCRIPTION
Drop the unused ImplSemantic import from crates/bin/get-lowering/src/main.rs silence the associated compiler warning and keep the binary free of dead dependencies