### PR TITLE
Remove redundant clones when converting felt array bounds

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -2295,8 +2295,8 @@ fn read_array_result_as_vec(memory: &[Option<Felt252>], value: &[Felt252]) -> Ve
     let [res_start, res_end] = value else {
         panic!("Unexpected return value from contract call");
     };
-    let res_start: usize = res_start.clone().to_bigint().try_into().unwrap();
-    let res_end: usize = res_end.clone().to_bigint().try_into().unwrap();
+    let res_start: usize = res_start.to_bigint().try_into().unwrap();
+    let res_end: usize = res_end.to_bigint().try_into().unwrap();
     (res_start..res_end).map(|i| memory[i].unwrap()).collect()
 }
 


### PR DESCRIPTION
Drop the unnecessary clone() calls before to_bigint() in read_array_result_as_vec. Avoid the extra allocations while keeping the logic unchanged, since Felt252 is Copy.