### PR TITLE
fix: correct grammar in KeccakLibfunc documentation comment

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/syscalls.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/syscalls.rs
@@ -138,7 +138,7 @@ impl SyscallGenericLibfunc for ReplaceClassLibfunc {
 
 /// Libfunc for the keccak system call.
 /// The libfunc does not add any padding and the input needs to be a multiple of 1088 bits
-/// (== 17 u64 word).
+/// (== 17 u64 words).
 #[derive(Default)]
 pub struct KeccakLibfunc {}
 impl SyscallGenericLibfunc for KeccakLibfunc {


### PR DESCRIPTION
Change `17 u64 word` to `17 u64 words` to match proper English grammar for multiple items and maintain consistency with syscalls.cairo documentation