### PR TITLE
fix: swap error descriptions for InvalidGenericArg and IntegerOverflow

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
@@ -86,9 +86,9 @@ pub enum InvocationError {
     UnknownTypeData,
     #[error("Expected variable data for statement not found.")]
     UnknownVariableData,
-    #[error("An integer overflow occurred.")]
-    InvalidGenericArg,
     #[error("Invalid generic argument for libfunc.")]
+    InvalidGenericArg,
+    #[error("An integer overflow occurred.")]
     IntegerOverflow,
     #[error(transparent)]
     FrameStateError(#[from] FrameStateError),


### PR DESCRIPTION
The error messages were mixed up - InvalidGenericArg was saying "An integer overflow occurred" while IntegerOverflow was saying "Invalid generic argument for libfunc". Found this when checking actual usage in enm.rs where IntegerOverflow is clearly used for checked_mul overflow scenarios. Simple swap to make the error descriptions match what they actually represent.