### PR TITLE
(optimization): felt252_div constant propogation support

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -499,8 +499,8 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
             {
                 self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[0]));
                 None
-            } else if let (Some(lhs), Some(rhs)) =
-                (self.as_int(stmt.inputs[0].var_id), self.as_int(stmt.inputs[1].var_id))
+            } else if let Some(lhs) = self.as_int(stmt.inputs[0].var_id)
+                && let Some(rhs) = self.as_int(stmt.inputs[1].var_id)
             {
                 let value = Felt252::from(lhs - rhs).to_bigint();
                 Some(self.propagate_const_and_get_statement(value, stmt.outputs[0], false))
@@ -518,8 +518,8 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
             {
                 self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[0]));
                 None
-            } else if let (Some(lhs), Some(rhs)) =
-                (self.as_int(stmt.inputs[0].var_id), self.as_int(stmt.inputs[1].var_id))
+            } else if let Some(lhs) = self.as_int(stmt.inputs[0].var_id)
+                && let Some(rhs) = self.as_int(stmt.inputs[1].var_id)
             {
                 let value = Felt252::from(lhs + rhs).to_bigint();
                 Some(self.propagate_const_and_get_statement(value, stmt.outputs[0], false))
@@ -543,10 +543,38 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
             {
                 self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[1]));
                 None
-            } else if let (Some((lhs_val, lhs_nz)), Some((rhs_val, rhs_nz))) = (lhs, rhs) {
+            } else if let Some((lhs_val, lhs_nz)) = lhs
+                && let Some((rhs_val, rhs_nz)) = rhs
+            {
                 let value = Felt252::from(lhs_val * rhs_val).to_bigint();
                 let nz_ty = lhs_nz && rhs_nz;
                 Some(self.propagate_const_and_get_statement(value, stmt.outputs[0], nz_ty))
+            } else {
+                None
+            }
+        } else if id == self.felt_div {
+            // Note that divisor is never 0, due to NonZero type always being the divisor.
+            if let Some(rhs) = self.as_int(stmt.inputs[1].var_id)
+                // Returns the original value when dividing by 1.
+                && rhs.is_one()
+            {
+                self.var_info.insert(stmt.outputs[0], VarInfo::Var(stmt.inputs[0]));
+                None
+            } else if let Some(lhs) = self.as_int(stmt.inputs[0].var_id)
+                // If the value is 0, result is 0 regardless of the divisor.
+                && lhs.is_zero()
+            {
+                Some(self.propagate_zero_and_get_statement(stmt.outputs[0]))
+            } else if let Some(lhs) = self.as_int(stmt.inputs[0].var_id)
+                && let Some(rhs) = self.as_int(stmt.inputs[1].var_id)
+                && let Ok(rhs_nonzero) = Felt252::from(rhs).try_into()
+            {
+                // Constant fold when both operands are constants
+
+                // Use field_div for Felt252 division
+                let lhs_felt = Felt252::from(lhs);
+                let value = lhs_felt.field_div(&rhs_nonzero).to_bigint();
+                Some(self.propagate_const_and_get_statement(value, stmt.outputs[0], false))
             } else {
                 None
             }
@@ -1266,6 +1294,8 @@ pub struct ConstFoldingLibfuncInfo<'db> {
     felt_add: ExternFunctionId<'db>,
     /// The `felt252_mul` libfunc.
     felt_mul: ExternFunctionId<'db>,
+    /// The `felt252_div` libfunc.
+    felt_div: ExternFunctionId<'db>,
     /// The `into_box` libfunc.
     into_box: ExternFunctionId<'db>,
     /// The `unbox` libfunc.
@@ -1437,6 +1467,7 @@ impl<'db> ConstFoldingLibfuncInfo<'db> {
             felt_sub: core.extern_function_id("felt252_sub"),
             felt_add: core.extern_function_id("felt252_add"),
             felt_mul: core.extern_function_id("felt252_mul"),
+            felt_div: core.extern_function_id("felt252_div"),
             into_box: box_module.extern_function_id("into_box"),
             unbox: box_module.extern_function_id("unbox"),
             box_forward_snapshot: box_module.generic_function_id("box_forward_snapshot"),

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
@@ -6493,3 +6493,127 @@ End:
   Return(v6)
 
 //! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 div const fold.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo() -> felt252 {
+    let x = core::felt252_div(6, 30);
+    x * 5
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 6
+  (v1: core::zeroable::NonZero::<core::felt252>) <- NonZero(30)
+  (v2: core::felt252) <- core::felt252_div(v0, v1)
+  (v3: core::felt252) <- 5
+  (v4: core::felt252) <- core::felt252_mul(v2, v3)
+End:
+  Return(v4)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 6
+  (v1: core::zeroable::NonZero::<core::felt252>) <- NonZero(30)
+  (v2: core::felt252) <- 2894802230932904970957858226476056084498485772265277359978473644908697616385
+  (v3: core::felt252) <- 5
+  (v4: core::felt252) <- 1
+End:
+  Return(v4)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 div by one.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo(a: felt252) -> felt252 {
+    core::felt252_div(a, 1)
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+  (v1: core::zeroable::NonZero::<core::felt252>) <- NonZero(1)
+  (v2: core::felt252) <- core::felt252_div(v0, v1)
+End:
+  Return(v2)
+
+//! > after
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+  (v1: core::zeroable::NonZero::<core::felt252>) <- NonZero(1)
+  (v2: core::felt252) <- core::felt252_div(v0, v1)
+End:
+  Return(v0)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Felt252 zero div.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function
+fn foo(a: NonZero<felt252>) -> felt252 {
+    core::felt252_div(0, a)
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters: v0: core::zeroable::NonZero::<core::felt252>
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 0
+  (v2: core::felt252) <- core::felt252_div(v1, v0)
+End:
+  Return(v2)
+
+//! > after
+Parameters: v0: core::zeroable::NonZero::<core::felt252>
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 0
+  (v2: core::felt252) <- 0
+End:
+  Return(v2)
+
+//! > lowering_diagnostics


### PR DESCRIPTION
### TL;DR

Add constant folding support for the `felt252_div` libfunc in the lowering phase.

### What changed?

- Added constant folding for the `felt252_div` libfunc with three optimization cases:
  1. Division by 1 returns the original value
  2. Division of 0 by any non-zero value returns 0
  3. Division of two constants is computed at compile time
- Updated the `ConstFoldingLibfuncInfo` struct to include the `felt_div` field
- Refactored some if-let patterns to use let chains
- Improved error handling in the test runner to provide better diagnostics when lowering fails
- Added test cases for all three optimization scenarios
