### PR TITLE
fix: off-by-one error in array bounds check example

### DIFF
--- a/corelib/src/keyword_docs.cairo
+++ b/corelib/src/keyword_docs.cairo
@@ -290,7 +290,7 @@ mod keyword_return {}
 /// fn first_gt(xs: Array<u32>, cmp: u32) -> Option<u32> {
 ///     let mut i = 0;
 ///     let v = loop {
-///         if i > xs.len() {
+///         if i >= xs.len() {
 ///             return None;
 ///         }
 ///


### PR DESCRIPTION
Fixed the loop condition in first_gt example. Was checking `i > xs.len()` which would let i equal xs.len() through, causing a panic when accessing xs.at(i). Changed to `i >= xs.len()` to properly catch the boundary case since valid indices are 0 to len-1