### PR TITLE
fix: rename test parameter from `modules` to `modulus` in circuit_test

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/circuit_test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/circuit_test.rs
@@ -53,8 +53,8 @@ use crate::casm_run::circuit::invert_or_nullify;
     "invert_or_nullify(7, 8)"
 )]
 
-fn test_invert_or_nullify(input: u32, modules: u32, output: u32) {
-    let (success, nullifier) = invert_or_nullify(BigUint::from(input), &BigUint::from(modules));
-    assert_eq!(success, (input * output).mod_floor(&modules) == 1_u32);
+fn test_invert_or_nullify(input: u32, modulus: u32, output: u32) {
+    let (success, nullifier) = invert_or_nullify(BigUint::from(input), &BigUint::from(modulus));
+    assert_eq!(success, (input * output).mod_floor(&modulus) == 1_u32);
     assert_eq!(nullifier, BigUint::from(output));
 }


### PR DESCRIPTION
Fixed a parameter naming inconsistency in the test_invert_or_nullify function. The parameter was incorrectly named `modules` (plural, suggesting program modules) but should be `modulus` (singular, the mathematical term used in modular arithmetic).

This matches the original invert_or_nullify function signature which uses `modulus` as the parameter name, and is semantically correct since we're doing modular inversion where the second argument is the modulus for the mod operation.