### PR TITLE
Remove inlining strategy from compiler config

### DIFF
--- a/crates/bin/cairo-compile/src/main.rs
+++ b/crates/bin/cairo-compile/src/main.rs
@@ -61,11 +61,8 @@ fn main() -> anyhow::Result<()> {
 
     let sierra_program = compile_cairo_project_at_path(
         &args.path,
-        CompilerConfig {
-            replace_ids: args.replace_ids,
-            inlining_strategy: args.inlining_strategy.into(),
-            ..CompilerConfig::default()
-        },
+        CompilerConfig { replace_ids: args.replace_ids, ..CompilerConfig::default() },
+        args.inlining_strategy.into(),
     )?;
 
     match args.output {

--- a/crates/bin/starknet-compile/src/main.rs
+++ b/crates/bin/starknet-compile/src/main.rs
@@ -64,6 +64,7 @@ fn main() -> anyhow::Result<()> {
             diagnostics_reporter,
             ..CompilerConfig::default()
         }),
+        Default::default(),
         Some(list_selector),
     )?;
     match args.output {

--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -46,9 +46,6 @@ pub struct CompilerConfig<'a> {
     /// Replaces Sierra IDs with human-readable ones.
     pub replace_ids: bool,
 
-    /// Disables inlining functions.
-    pub inlining_strategy: InliningStrategy,
-
     /// Adds a mapping used by [cairo-profiler](https://github.com/software-mansion/cairo-profiler) to
     /// [cairo_lang_sierra::debug_info::Annotations] in [cairo_lang_sierra::debug_info::DebugInfo].
     pub add_statements_functions: bool,
@@ -71,10 +68,11 @@ pub struct CompilerConfig<'a> {
 pub fn compile_cairo_project_at_path(
     path: &Path,
     compiler_config: CompilerConfig<'_>,
+    inlining_strategy: InliningStrategy,
 ) -> Result<Program> {
     let mut db = RootDatabase::builder()
         .with_optimizations(Optimizations::enabled_with_default_movable_functions(
-            compiler_config.inlining_strategy,
+            inlining_strategy,
         ))
         .detect_corelib()
         .build()?;
@@ -101,7 +99,7 @@ pub fn compile(
 ) -> Result<Program> {
     let db = RootDatabase::builder()
         .with_optimizations(Optimizations::enabled_with_default_movable_functions(
-            compiler_config.inlining_strategy,
+            InliningStrategy::Default,
         ))
         .with_project_config(project_config.clone())
         .build()?;

--- a/crates/cairo-lang-starknet/src/test_utils.rs
+++ b/crates/cairo-lang-starknet/src/test_utils.rs
@@ -7,7 +7,6 @@ use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::ProjectConfig;
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::Directory;
-use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use cairo_lang_test_utils::test_lock;
 use itertools::Itertools;
@@ -85,7 +84,6 @@ pub fn get_test_contract(example_file_name: &str) -> ContractClass {
             diagnostics_reporter,
             add_statements_functions: false,
             add_statements_code_locations: false,
-            inlining_strategy: InliningStrategy::Default,
         },
     )
     .expect("compile_path failed")


### PR DESCRIPTION
The pattern is to set everything in `RootDatabaseBuilder` anyways. The value in `compiler_config` was mostly unused