### PR TITLE
docs: correct panic message in extract_matches! macro example

### DIFF
--- a/crates/cairo-lang-utils/src/extract_matches.rs
+++ b/crates/cairo-lang-utils/src/extract_matches.rs
@@ -44,7 +44,7 @@ macro_rules! try_extract_matches {
 /// let Point { x, y: _ } = extract_matches!(p, MyEnum::Point);
 /// assert_eq!(x, 3);
 ///
-/// // Would panic with 'assertion failed: `Point(Point { x: 3, y: 5 })` does not match `MyEnum::Value`:
+/// // Would panic with 'Variant extract failed: `Point(Point { x: 3, y: 5 })` is not of variant `MyEnum::Value`:
 /// // Expected a point!'
 /// // let _value = extract_matches!(p, MyEnum::Value, "Expected a point!");
 /// ```


### PR DESCRIPTION
Fix documentation to match actual panic message format. Changed `assertion failed: ... does not match` to `Variant extract failed: ... is not of variant` as per the actual implementation in lines 57 and 64-65.