### PR TITLE
docs: fix step count in extract_comment_from_code_line comment

### DIFF
--- a/crates/cairo-lang-doc/src/db.rs
+++ b/crates/cairo-lang-doc/src/db.rs
@@ -211,7 +211,7 @@ fn extract_item_module_level_documentation_from_file<'db>(
     )
 }
 
-/// This function does 2 things to the line of comment:
+/// This function does 3 things to the line of comment:
 /// 1. Removes indentation
 /// 2. If it starts with one of the passed prefixes, removes the given prefixes (including the space
 ///    after the prefix).


### PR DESCRIPTION
Changed `does 2 things` to `does 3 things` to match the actual numberof steps listed in the function documentation.