### PR TITLE
fix: correct set_nonce doc parameter name

### DIFF
--- a/corelib/src/starknet/testing.cairo
+++ b/corelib/src/starknet/testing.cairo
@@ -155,7 +155,7 @@ pub fn set_chain_id(chain_id: felt252) {
 ///
 /// # Arguments
 ///
-/// `non` - The nonce to set.
+/// `nonce` - The nonce to set.
 ///
 /// After a call to `set_nonce`, `starknet::get_execution_info().tx_info.nonce` will return the set
 /// value.


### PR DESCRIPTION
The doc comment for `set_nonce` incorrectly documented the parameter as `non` instead of `nonce`, which doesn't match the actual function signature.
