### PR TITLE
fix: grammar in AbiBuilder types field

### DIFF
--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -81,7 +81,7 @@ pub struct AbiBuilder<'db> {
     /// The constructed ABI.
     abi_items: OrderedHashSet<Item>,
 
-    /// List of type that were included abi.
+    /// List of types that were included in the abi.
     /// Used to avoid redundancy.
     types: HashSet<TypeId<'db>>,
 


### PR DESCRIPTION
Fixed two issues in the comment for the types field:
- `type` -> `types` (needs to be plural to match `were`)
- added missing `in` before `abi`