### PR TITLE
docs(literals): correct u32 suffix type annotation from i32 to u32

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
@@ -40,7 +40,7 @@ Examples of numeric literals of various forms:
 | Literal         | Value | Type
 | `1234`          | 1234  | `felt252`
 | `1234_felt252`   | 1234  | `felt252`
-| `1234_u32`       | 1234  | `i32`
+| `1234_u32`       | 1234  | `u32`
 | `1234_u128`      | 1234  | `u128`
 | `0x4D2`         | 1234  | `felt252`
 | `0b10011010010` | 1234  | `felt252`


### PR DESCRIPTION
The literal `1234_u32` was mistakenly listed as producing type `i32` (signed)when it actually produces type `u32` (unsigned). The `_u32` suffix always creates an unsigned 32-bit integer type.