### PR TITLE
Chore: remove unused rand::Rng import from CASM runner

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -39,7 +39,6 @@ use itertools::Itertools;
 use num_bigint::{BigInt, BigUint};
 use num_integer::{ExtendedGcd, Integer};
 use num_traits::{Signed, ToPrimitive, Zero};
-use rand::Rng;
 use starknet_types_core::felt::{Felt as Felt252, NonZeroFelt};
 use {ark_secp256k1 as secp256k1, ark_secp256r1 as secp256r1};
 


### PR DESCRIPTION
remove the unused rand::Rng import from crates/cairo-lang-runner/src/casm_run/mod.rs silence the unused import warning and keep the runner dependency surface minimal