### PR TITLE
Fix incorrect parameter in storage read example

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/contracts.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/contracts.adoc
@@ -75,7 +75,7 @@ Another possibility is to get a read-only reference to the storage:
 ----
     #[external(v0)]
     fn view_example(self: @ContractState) -> felt252 {
-        x::read(value)
+        x::read()
     }
 ----
 This is a view function - it can only read from the storage.


### PR DESCRIPTION
Corrected the view_example function in contracts documentation. Changed x::read(value) to x::read() because storage variables are read without parameters. Only mappings (like m::read(key)) require a key parameter.