### PR TITLE
 chore: remove unused cairo-lang imports from ensure-no_std harness

### DIFF
--- a/ensure-no_std/src/main.rs
+++ b/ensure-no_std/src/main.rs
@@ -17,8 +17,3 @@ pub extern "C" fn _start() -> ! {
 #[global_allocator]
 // NOTE: this should be initialized before use
 static ALLOC: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
-
-#[expect(unused_imports)]
-use cairo_lang_casm;
-#[expect(unused_imports)]
-use cairo_lang_utils;


### PR DESCRIPTION
drop the unused cairo_lang_casm and cairo_lang_utils imports from the no-std entry point
keep the minimal no-std bootstrap free of unnecessary dependencies
