### PR TITLE
(feature): A new libfunc for calculating the pointer to temporary storage using a double call

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -20,7 +20,7 @@ use crate::{CairoHintProcessor, StarknetState, build_hints_dict};
 fn assembled(casm: CasmContext) -> AssembledCairoProgram {
     CairoProgram {
         instructions: casm.instructions,
-        consts_info: Default::default(),
+        segments_info: Default::default(),
         debug_info: CairoProgramDebugInfo { sierra_statement_info: vec![] },
     }
     .assemble()

--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -113,6 +113,10 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
             BoxConcreteLibfunc::Into(_) => vec![ApChange::Known(1)],
             BoxConcreteLibfunc::Unbox(_) => vec![ApChange::Known(0)],
             BoxConcreteLibfunc::ForwardSnapshot(_) => vec![ApChange::Known(0)],
+            BoxConcreteLibfunc::FromTempStore(_) => {
+                // Total: 2 calls * 2
+                vec![ApChange::Known(4)]
+            }
         },
         Cast(libfunc) => match libfunc {
             CastConcreteLibfunc::Downcast(libfunc) => {

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -371,6 +371,7 @@ pub fn core_libfunc_cost(
             BoxConcreteLibfunc::Unbox(_) | BoxConcreteLibfunc::ForwardSnapshot(_) => {
                 vec![ConstCost::default().into()]
             }
+            BoxConcreteLibfunc::FromTempStore(_) => vec![ConstCost::steps(4).into()],
         },
         Mem(libfunc) => match libfunc {
             StoreTemp(libfunc) => {

--- a/crates/cairo-lang-sierra-to-casm/src/compiler_test.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler_test.rs
@@ -760,6 +760,93 @@ indoc! {"
         dw 5;
     "};
     "Get builtin costs with a const segment.")]
+#[test_case(indoc! {"
+        type felt252 = felt252;
+        type Box<felt252> = Box<felt252>;
+
+        libfunc felt252_const<42> = felt252_const<42>;
+        libfunc store_temp<felt252> = store_temp<felt252>;
+        libfunc drop<felt252> = drop<felt252>;
+        libfunc box_from_temp_store<felt252> = box_from_temp_store<felt252>;
+        libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
+
+        felt252_const<42>() -> ([0]);
+        store_temp<felt252>([0]) -> ([0]);  // Allocate and store the constant felt252
+        drop<felt252>([0]) -> ();  // Drop the stored value
+        box_from_temp_store<felt252>() -> ([1]);  // Compute address for a felt252
+        store_temp<Box<felt252>>([1]) -> ([1]);
+        return([1]);
+
+        test_program@0() -> (Box<felt252>);
+    "},
+    false,
+    indoc! {"
+        [ap + 0] = 42, ap++;
+        call rel 5;
+        [ap + 0] = [ap + -2] + -1, ap++;
+        ret;
+        call rel 2;
+        ret;
+    "};
+    "box_from_temp_store with felt252 (size 1), after storing constant at [0].")]
+#[test_case(indoc! {"
+        type u128 = u128;
+        type felt252 = felt252;
+        type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128>;
+        type Box<core::integer::u256> = Box<core::integer::u256>;
+
+        libfunc u128_const<0> = u128_const<0>;
+        libfunc struct_construct<core::integer::u256> = struct_construct<core::integer::u256>;
+        libfunc store_temp<core::integer::u256> = store_temp<core::integer::u256>;
+        libfunc drop<core::integer::u256> = drop<core::integer::u256>;
+        libfunc box_from_temp_store<core::integer::u256> = box_from_temp_store<core::integer::u256>;
+        libfunc store_temp<Box<core::integer::u256>> = store_temp<Box<core::integer::u256>>;
+
+        u128_const<0>() -> ([0]);
+        u128_const<0>() -> ([1]);
+        struct_construct<core::integer::u256>([0], [1]) -> ([2]);
+        store_temp<core::integer::u256>([2]) -> ([2]);  // Store u256
+        drop<core::integer::u256>([2]) -> ();  // Drop the stored value
+        box_from_temp_store<core::integer::u256>() -> ([3]);  // Compute address for a u256
+        store_temp<Box<core::integer::u256>>([3]) -> ([3]);
+        return([3]);
+
+        test_program@0() -> (Box<core::integer::u256>);
+    "},
+    false,
+    indoc! {"
+        [ap + 0] = 0, ap++;
+        [ap + 0] = 0, ap++;
+        call rel 5;
+        [ap + 0] = [ap + -2] + -2, ap++;
+        ret;
+        call rel 2;
+        ret;
+    "};
+    "box_from_temp_store with u256 (size 2), after storing u256 at [0].")]
+#[test_case(indoc! {"
+        type Unit = Struct<ut@Tuple>;
+        type felt252 = felt252;
+        type Box<Unit> = Box<Unit>;
+
+        libfunc box_from_temp_store<Unit> = box_from_temp_store<Unit>;
+        libfunc store_temp<Box<Unit>> = store_temp<Box<Unit>>;
+
+        box_from_temp_store<Unit>() -> ([0]);  // No prior allocation for size 0 unit
+        store_temp<Box<Unit>>([0]) -> ([0]);
+        return([0]);
+
+        test_program@0() -> (Box<Unit>);
+    "},
+    false,
+    indoc! {"
+        call rel 5;
+        [ap + 0] = [ap + -2] + 0, ap++;
+        ret;
+        call rel 2;
+        ret;
+    "};
+    "box_from_temp_store with unit type (size 0), no prior allocation.")]
 fn sierra_to_casm(sierra_code: &str, gas_usage_check: bool, expected_casm: &str) {
     let program = ProgramParser::new().parse(sierra_code).unwrap();
     let program_info = ProgramRegistryInfo::new(&program).unwrap();

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
@@ -50,6 +50,7 @@ mod felt252_dict;
 mod function_call;
 mod gas;
 mod gas_reserve;
+
 mod int;
 mod mem;
 mod misc;

--- a/crates/cairo-lang-sierra-to-casm/src/relocations.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/relocations.rs
@@ -7,7 +7,7 @@ use cairo_lang_sierra::ids::ConcreteTypeId;
 use cairo_lang_sierra::program::StatementIdx;
 use cairo_lang_sierra_gas::objects::ConstCost;
 
-use crate::compiler::ConstsInfo;
+use crate::compiler::{SegmentsInfo, UtilityId};
 
 pub type CodeOffset = usize;
 
@@ -22,6 +22,8 @@ pub enum Relocation {
     ConstStart(u32, ConcreteTypeId),
     /// Adds the offset of the circuit with the given type.
     CircuitStart(ConcreteTypeId),
+    /// Adds the offset of the BoxFromTempStore utility segment.
+    UtilitySegment(UtilityId),
     /// Adds the offset between the current statement index and the end of the program code
     /// segment (which includes the const segment at its end).
     EndOfProgram,
@@ -32,29 +34,32 @@ impl Relocation {
         &self,
         instruction_offset: CodeOffset,
         statement_offsets: &[CodeOffset],
-        consts_info: &ConstsInfo,
+        segments_info: &SegmentsInfo,
         instruction: &mut Instruction,
     ) {
         let target_pc = match self {
             Relocation::RelativeStatementId(statement_idx) => statement_offsets[statement_idx.0],
             Relocation::SegmentStart(segment_index) => {
-                let segment = consts_info.segments.get(segment_index).expect("Segment not found.");
+                let segment =
+                    segments_info.const_segments.get(segment_index).expect("Segment not found.");
                 *statement_offsets.last().unwrap() + segment.segment_offset
             }
             Relocation::ConstStart(segment_index, ty) => {
-                let segment = consts_info.segments.get(segment_index).expect("Segment not found.");
+                let segment =
+                    segments_info.const_segments.get(segment_index).expect("Segment not found.");
                 *statement_offsets.last().unwrap()
                     + segment.segment_offset
                     + segment.const_offset.get(ty).expect("Const type not found in const segments.")
             }
             Relocation::EndOfProgram => {
-                *statement_offsets.last().unwrap() + consts_info.total_segments_size
+                *statement_offsets.last().unwrap() + segments_info.total_segments_size
             }
             Relocation::CircuitStart(circ_ty) => {
                 let segment_index =
-                    consts_info.circuit_segments.get(circ_ty).expect("Circuit not found");
+                    segments_info.circuit_segments.get(circ_ty).expect("Circuit not found");
 
-                let segment = consts_info.segments.get(segment_index).expect("Segment not found.");
+                let segment =
+                    segments_info.const_segments.get(segment_index).expect("Segment not found.");
 
                 *statement_offsets.last().unwrap()
                     + segment.segment_offset
@@ -62,6 +67,11 @@ impl Relocation {
                         .const_offset
                         .get(circ_ty)
                         .expect("Const type not found in const segments.")
+            }
+            Relocation::UtilitySegment(id) => {
+                let segment =
+                    segments_info.utility_segments.get(id).expect("Utility segment not found");
+                *statement_offsets.last().unwrap() + segment.offset
             }
         };
         match instruction {
@@ -125,7 +135,7 @@ pub struct RelocationEntry {
 pub fn relocate_instructions(
     relocations: &[RelocationEntry],
     statement_offsets: &[usize],
-    consts_info: &ConstsInfo,
+    segment_info: &SegmentsInfo,
     instructions: &mut [Instruction],
 ) {
     let mut program_offset = 0;
@@ -136,7 +146,7 @@ pub fn relocate_instructions(
             relocation_entry
         {
             if *relocation_idx == instruction_idx {
-                relocation.apply(program_offset, statement_offsets, consts_info, instruction);
+                relocation.apply(program_offset, statement_offsets, segment_info, instruction);
                 relocation_entry = relocations_iter.next();
             } else {
                 assert!(

--- a/crates/cairo-lang-sierra/src/extensions/modules/mod.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/mod.rs
@@ -30,6 +30,7 @@ pub mod felt252_dict;
 pub mod function_call;
 pub mod gas;
 pub mod gas_reserve;
+
 pub mod int;
 pub mod is_zero;
 pub mod mem;

--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -10,6 +10,7 @@ use super::LibfuncSimulationError;
 use super::value::CoreValue;
 use crate::extensions::array::ArrayConcreteLibfunc;
 use crate::extensions::boolean::BoolConcreteLibfunc;
+use crate::extensions::boxing::BoxConcreteLibfunc;
 use crate::extensions::core::CoreConcreteLibfunc;
 use crate::extensions::ec::EcConcreteLibfunc;
 use crate::extensions::enm::{EnumConcreteLibfunc, EnumInitConcreteLibfunc};
@@ -201,6 +202,9 @@ pub fn simulate<
         CoreConcreteLibfunc::Bool(libfunc) => simulate_bool_libfunc(libfunc, inputs)?,
         CoreConcreteLibfunc::Felt252(libfunc) => simulate_felt252_libfunc(libfunc, inputs)?,
         CoreConcreteLibfunc::UnwrapNonZero(_) => (inputs, 0),
+        CoreConcreteLibfunc::Box(BoxConcreteLibfunc::FromTempStore(_)) => {
+            unimplemented!("Simulation of Box::from_temp_store is not implemented yet.");
+        }
         CoreConcreteLibfunc::Mem(
             MemConcreteLibfunc::Rename(_) | MemConcreteLibfunc::StoreTemp(_),
         )

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
@@ -95,6 +95,7 @@
         "get_class_hash_at_syscall",
         "get_execution_info_syscall",
         "get_execution_info_v2_syscall",
+        "box_from_temp_store",
         "hades_permutation",
         "i128_const",
         "i128_diff",

--- a/crates/cairo-lang-starknet-classes/src/contract_segmentation.rs
+++ b/crates/cairo-lang-starknet-classes/src/contract_segmentation.rs
@@ -181,10 +181,11 @@ impl FunctionInfo {
 
 /// Returns the offsets of the const segments.
 fn consts_segments_offsets(cairo_program: &CairoProgram, bytecode_len: usize) -> Vec<usize> {
-    let const_segments_start_offset = bytecode_len - cairo_program.consts_info.total_segments_size;
+    let const_segments_start_offset =
+        bytecode_len - cairo_program.segments_info.total_segments_size;
     cairo_program
-        .consts_info
-        .segments
+        .segments_info
+        .const_segments
         .values()
         .map(|segment| const_segments_start_offset + segment.segment_offset)
         .collect()


### PR DESCRIPTION
### TL;DR

Added a new `get_temp_ptr` libfunc to compute addresses for variables based on type size, with utility segment support for code reuse.

### What changed?

- Added a new Sierra libfunc `get_temp_ptr<T>` that computes the address where a value of type T would be located
- Renamed `ConstsInfo` to `SegmentsInfo` and extended it to support utility segments for code reuse
- Implemented the CASM compilation for `get_temp_ptr` using a shared utility segment
- Added AP change and gas cost information for the new libfunc
- Added the libfunc to the Starknet allowed libfuncs list
