### PR TITLE
 chore(utils): remove unused itertools import

### DIFF
--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -22,7 +22,6 @@ use std::vec;
 use hashbrown::HashMap;
 #[cfg(not(feature = "std"))]
 pub use hashbrown::hash_map::Entry;
-use itertools::Itertools;
 
 #[cfg(feature = "std")]
 type BHImpl = RandomState;


### PR DESCRIPTION
 remove the unused `itertools::Itertools` import from `unordered_hash_map.rs` keep the module free of dead imports and avoid clippy/CI warnings