### PR TITLE
Remove redundant clone in GenStatement::map

### DIFF
--- a/crates/cairo-lang-sierra/src/program.rs
+++ b/crates/cairo-lang-sierra/src/program.rs
@@ -275,7 +275,7 @@ impl<StatementId> GenStatement<StatementId> {
                     })
                     .collect(),
             }),
-            GenStatement::Return(results) => GenStatement::Return(results.clone()),
+            GenStatement::Return(results) => GenStatement::Return(results),
         }
     }
 }


### PR DESCRIPTION
eliminate an unnecessary Vec<VarId> clone when mapping GenStatement::Return, keeping the original allocation intact retain existing behavior because self is consumed and we still return the owned results vector reduces avoidable allocation/copy in the hot path