### PR TITLE
(optimization): libfunc for destructuring a Box<T> into Box<Ti> for each member

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -299,7 +299,8 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
         Struct(libfunc) => match libfunc {
             StructConcreteLibfunc::Construct(_)
             | StructConcreteLibfunc::Deconstruct(_)
-            | StructConcreteLibfunc::SnapshotDeconstruct(_) => {
+            | StructConcreteLibfunc::SnapshotDeconstruct(_)
+            | StructConcreteLibfunc::BoxedDeconstruct(_) => {
                 vec![ApChange::Known(0)]
             }
         },

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -412,7 +412,8 @@ pub fn core_libfunc_cost(
         Struct(
             StructConcreteLibfunc::Construct(_)
             | StructConcreteLibfunc::Deconstruct(_)
-            | StructConcreteLibfunc::SnapshotDeconstruct(_),
+            | StructConcreteLibfunc::SnapshotDeconstruct(_)
+            | StructConcreteLibfunc::BoxedDeconstruct(_),
         ) => {
             vec![ConstCost::default().into()]
         }

--- a/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
@@ -13,7 +13,8 @@
 
 use cairo_lang_utils::try_extract_matches;
 
-use super::snapshot::snapshot_ty;
+use super::boxing::box_ty;
+use super::snapshot::{SnapshotType, snapshot_ty};
 use crate::define_libfunc_hierarchy;
 use crate::extensions::lib_func::{
     DeferredOutputKind, LibfuncSignature, OutputVarInfo, ParamSignature, SierraApChange,
@@ -22,7 +23,8 @@ use crate::extensions::lib_func::{
 use crate::extensions::type_specialization_context::TypeSpecializationContext;
 use crate::extensions::types::TypeInfo;
 use crate::extensions::{
-    ConcreteType, NamedType, OutputVarReferenceInfo, SpecializationError, args_as_single_type,
+    ConcreteType, NamedLibfunc, NamedType, OutputVarReferenceInfo, SignatureBasedConcreteLibfunc,
+    SpecializationError, args_as_single_type,
 };
 use crate::ids::{ConcreteTypeId, GenericTypeId};
 use crate::program::{ConcreteTypeLongId, GenericArg};
@@ -126,6 +128,7 @@ define_libfunc_hierarchy! {
         Construct(StructConstructLibfunc),
         Deconstruct(StructDeconstructLibfunc),
         SnapshotDeconstruct(StructSnapshotDeconstructLibfunc),
+        BoxedDeconstruct(StructBoxedDeconstructLibfunc),
     }, StructConcreteLibfunc
 }
 
@@ -256,5 +259,115 @@ impl SignatureOnlyGenericLibfunc for StructSnapshotDeconstructLibfunc {
                 .collect::<Result<Vec<_>, _>>()?,
             SierraApChange::Known { new_vars_only: true },
         ))
+    }
+}
+
+/// Concrete implementation of the boxed struct deconstruct libfunc.
+pub struct ConcreteStructBoxedDeconstructLibfunc {
+    /// The concrete types of the struct members (no additional snapshots and boxing) that will be
+    /// extracted as boxed values.
+    pub members: Vec<ConcreteTypeId>,
+    signature: LibfuncSignature,
+}
+
+impl SignatureBasedConcreteLibfunc for ConcreteStructBoxedDeconstructLibfunc {
+    fn signature(&self) -> &LibfuncSignature {
+        &self.signature
+    }
+}
+
+/// Libfunc for deconstructing a boxed struct into boxes of its members.
+#[derive(Default)]
+pub struct StructBoxedDeconstructLibfunc {}
+
+impl StructBoxedDeconstructLibfunc {
+    /// Analyzes a struct type to extract member types and snapshot information.
+    ///
+    /// This method handles both regular structs and snapshot-wrapped structs. For snapshot-wrapped
+    /// structs (e.g., `@StructType`), it unwraps the snapshot to get the underlying struct type,
+    /// then extracts the member types and indicates the snapshot status.
+    ///
+    /// # Returns
+    /// - `Vec<ConcreteTypeId>`: The concrete types of each struct member
+    /// - `bool`: Whether the input struct was wrapped in a snapshot
+    fn analyze_struct_type(
+        &self,
+        context: &dyn SignatureSpecializationContext,
+        mut ty: ConcreteTypeId,
+    ) -> Result<(Vec<ConcreteTypeId>, bool), SpecializationError> {
+        let arg_type_info = context.get_type_info(ty.clone())?;
+        let is_snapshot = arg_type_info.long_id.generic_id == SnapshotType::id();
+        if is_snapshot {
+            ty = match &arg_type_info.long_id.generic_args[0] {
+                GenericArg::Type(ty) => ty.clone(),
+                _ => return Err(SpecializationError::UnsupportedGenericArg),
+            }
+        }
+        let struct_type = StructConcreteType::try_from_concrete_type(context, &ty)?;
+        Ok((struct_type.members, is_snapshot))
+    }
+
+    /// Creates the libfunc signature for boxed struct deconstruction.
+    ///
+    /// # Parameters
+    /// - `ty`: The concrete type ID of the struct being deconstructed
+    /// - `member_types`: The concrete types of each struct member
+    /// - `is_snapshot`: Whether the struct was originally wrapped in a snapshot
+    ///
+    /// # Returns
+    /// A libfunc signature that takes a boxed struct as input and returns boxed versions
+    /// of each member. If `is_snapshot` is true, the members are also wrapped in snapshots.
+    fn inner_specialize_signature(
+        &self,
+        context: &dyn SignatureSpecializationContext,
+        ty: ConcreteTypeId,
+        member_types: Vec<ConcreteTypeId>,
+        is_snapshot: bool,
+    ) -> Result<LibfuncSignature, SpecializationError> {
+        Ok(LibfuncSignature::new_non_branch_ex(
+            vec![ParamSignature::new(box_ty(context, ty)?).with_allow_add_const()],
+            member_types
+                .into_iter()
+                .map(|member_ty| {
+                    let inner_type =
+                        if is_snapshot { snapshot_ty(context, member_ty)? } else { member_ty };
+                    Ok(OutputVarInfo {
+                        ty: box_ty(context, inner_type)?,
+                        ref_info: OutputVarReferenceInfo::Deferred(
+                            crate::extensions::lib_func::DeferredOutputKind::Generic,
+                        ),
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            SierraApChange::Known { new_vars_only: true },
+        ))
+    }
+}
+
+impl NamedLibfunc for StructBoxedDeconstructLibfunc {
+    type Concrete = ConcreteStructBoxedDeconstructLibfunc;
+
+    const STR_ID: &'static str = "struct_boxed_deconstruct";
+
+    fn specialize_signature(
+        &self,
+        context: &dyn SignatureSpecializationContext,
+        args: &[GenericArg],
+    ) -> Result<LibfuncSignature, SpecializationError> {
+        let ty = args_as_single_type(args)?;
+        let (member_types, is_snapshot) = self.analyze_struct_type(context, ty.clone())?;
+        self.inner_specialize_signature(context, ty, member_types, is_snapshot)
+    }
+
+    fn specialize(
+        &self,
+        context: &dyn crate::extensions::lib_func::SpecializationContext,
+        args: &[GenericArg],
+    ) -> Result<Self::Concrete, SpecializationError> {
+        let ty = args_as_single_type(args)?;
+        let (members, is_snapshot) = self.analyze_struct_type(context, ty.clone())?;
+        let signature =
+            self.inner_specialize_signature(context, ty, members.clone(), is_snapshot)?;
+        Ok(ConcreteStructBoxedDeconstructLibfunc { members, signature })
     }
 }

--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -201,6 +201,10 @@ pub fn simulate<
         CoreConcreteLibfunc::Bool(libfunc) => simulate_bool_libfunc(libfunc, inputs)?,
         CoreConcreteLibfunc::Felt252(libfunc) => simulate_felt252_libfunc(libfunc, inputs)?,
         CoreConcreteLibfunc::UnwrapNonZero(_) => (inputs, 0),
+        CoreConcreteLibfunc::Struct(StructConcreteLibfunc::BoxedDeconstruct(_)) => {
+            take_inputs!(let [CoreValue::Struct(members)] = inputs);
+            (members, 0)
+        }
         CoreConcreteLibfunc::Mem(
             MemConcreteLibfunc::Rename(_) | MemConcreteLibfunc::StoreTemp(_),
         )

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
@@ -31,6 +31,7 @@
         "bounded_int_trim_min",
         "bounded_int_wrap_non_zero",
         "box_forward_snapshot",
+        "struct_boxed_deconstruct",
         "branch_align",
         "bytes31_const",
         "bytes31_to_felt252",

--- a/tests/e2e_test_data/libfuncs/box
+++ b/tests/e2e_test_data/libfuncs/box
@@ -302,3 +302,429 @@ store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1]);
 return([1]);
 
 test::foo@F0([0]: Snapshot<Box<Array<felt252>>>) -> (Box<Snapshot<Array<felt252>>>);
+
+//! > ==========================================================================
+
+//! > struct_boxed_deconstruct libfunc
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+fn foo(value: Box<A>) -> (Box<u256>, Box<u256>) {
+    struct_boxed_deconstruct(value)
+}
+
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u256>, Box<u256>) nopanic;
+
+struct A {
+    a: u256,
+    b: u256,
+}
+
+//! > casm
+[ap + 0] = [fp + -3], ap++;
+[ap + 0] = [fp + -3] + 2, ap++;
+ret;
+
+//! > sierra_code
+type Box<test::A> = Box<test::A> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::integer::u256> = Box<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<Box<core::integer::u256>, Box<core::integer::u256>> = Struct<ut@Tuple, Box<core::integer::u256>, Box<core::integer::u256>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::A = Struct<ut@test::A, core::integer::u256, core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<test::A> = struct_boxed_deconstruct<test::A>;
+libfunc struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>> = struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>;
+libfunc store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>> = store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>;
+
+F0:
+struct_boxed_deconstruct<test::A>([0]) -> ([1], [2]);
+struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>([1], [2]) -> ([3]);
+store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>([3]) -> ([3]);
+return([3]);
+
+test::foo@F0([0]: Box<test::A>) -> (Tuple<Box<core::integer::u256>, Box<core::integer::u256>>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 200})
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc for struct with single member
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+fn foo(value: Box<Single>) -> (Box<Array<felt252>>,) {
+    struct_boxed_deconstruct(value)
+}
+
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<Array<felt252>>,) nopanic;
+
+struct Single {
+    x: Array<felt252>,
+}
+
+//! > casm
+[ap + 0] = [fp + -3], ap++;
+ret;
+
+//! > sierra_code
+type Box<test::Single> = Box<test::Single> [storable: true, drop: true, dup: false, zero_sized: false];
+type Box<Array<felt252>> = Box<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Tuple<Box<Array<felt252>>> = Struct<ut@Tuple, Box<Array<felt252>>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type test::Single = Struct<ut@test::Single, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<test::Single> = struct_boxed_deconstruct<test::Single>;
+libfunc struct_construct<Tuple<Box<Array<felt252>>>> = struct_construct<Tuple<Box<Array<felt252>>>>;
+libfunc store_temp<Tuple<Box<Array<felt252>>>> = store_temp<Tuple<Box<Array<felt252>>>>;
+
+F0:
+struct_boxed_deconstruct<test::Single>([0]) -> ([1]);
+struct_construct<Tuple<Box<Array<felt252>>>>([1]) -> ([2]);
+store_temp<Tuple<Box<Array<felt252>>>>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: Box<test::Single>) -> (Tuple<Box<Array<felt252>>>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 100})
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc for struct with many members
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+fn foo(value: Box<Many>) -> (Box<u256>, Box<felt252>, Box<Array<felt252>>, Box<u256>) {
+    struct_boxed_deconstruct(value)
+}
+
+extern fn struct_boxed_deconstruct<T>(
+    value: Box<T>,
+) -> (Box<u256>, Box<felt252>, Box<Array<felt252>>, Box<u256>) nopanic;
+
+struct Many {
+    a: u256,
+    b: felt252,
+    c: Array<felt252>,
+    d: u256,
+}
+
+//! > casm
+[ap + 0] = [fp + -3], ap++;
+[ap + 0] = [fp + -3] + 2, ap++;
+[ap + 0] = [fp + -3] + 3, ap++;
+[ap + 0] = [fp + -3] + 5, ap++;
+ret;
+
+//! > sierra_code
+type Box<test::Many> = Box<test::Many> [storable: true, drop: true, dup: false, zero_sized: false];
+type Box<core::integer::u256> = Box<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Array<felt252>> = Box<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>> = Struct<ut@Tuple, Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>> [storable: true, drop: true, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type test::Many = Struct<ut@test::Many, core::integer::u256, felt252, Array<felt252>, core::integer::u256> [storable: true, drop: true, dup: false, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<test::Many> = struct_boxed_deconstruct<test::Many>;
+libfunc struct_construct<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>>> = struct_construct<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>>>;
+libfunc store_temp<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>>> = store_temp<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>>>;
+
+F0:
+struct_boxed_deconstruct<test::Many>([0]) -> ([1], [2], [3], [4]);
+struct_construct<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>>>([1], [2], [3], [4]) -> ([5]);
+store_temp<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>>>([5]) -> ([5]);
+return([5]);
+
+test::foo@F0([0]: Box<test::Many>) -> (Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 400})
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc for empty struct
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+fn foo(value: Box<Empty>) -> () {
+    struct_boxed_deconstruct(value)
+}
+
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> () nopanic;
+
+struct Empty {}
+
+//! > casm
+ret;
+
+//! > sierra_code
+type Box<test::Empty> = Box<test::Empty> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Empty = Struct<ut@test::Empty> [storable: true, drop: true, dup: true, zero_sized: true];
+
+libfunc struct_boxed_deconstruct<test::Empty> = struct_boxed_deconstruct<test::Empty>;
+
+F0:
+struct_boxed_deconstruct<test::Empty>([0]) -> ();
+return();
+
+test::foo@F0([0]: Box<test::Empty>) -> ();
+
+//! > function_costs
+test::foo: SmallOrderedMap({})
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc for Box<@A>
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+fn foo(value: Box<@A>) -> (Box<@u256>, Box<@u256>) {
+    struct_boxed_deconstruct(value)
+}
+
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<@u256>, Box<@u256>) nopanic;
+
+struct A {
+    a: u256,
+    b: u256,
+}
+
+//! > casm
+[ap + 0] = [fp + -3], ap++;
+[ap + 0] = [fp + -3] + 2, ap++;
+ret;
+
+//! > sierra_code
+type Box<test::A> = Box<test::A> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::integer::u256> = Box<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<Box<core::integer::u256>, Box<core::integer::u256>> = Struct<ut@Tuple, Box<core::integer::u256>, Box<core::integer::u256>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::A = Struct<ut@test::A, core::integer::u256, core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<test::A> = struct_boxed_deconstruct<test::A>;
+libfunc struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>> = struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>;
+libfunc store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>> = store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>;
+
+F0:
+struct_boxed_deconstruct<test::A>([0]) -> ([1], [2]);
+struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>([1], [2]) -> ([3]);
+store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>([3]) -> ([3]);
+return([3]);
+
+test::foo@F0([0]: Box<test::A>) -> (Tuple<Box<core::integer::u256>, Box<core::integer::u256>>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 200})
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc for Box<@Single>
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+fn foo(value: Box<@Single>) -> (Box<@Array<felt252>>,) {
+    struct_boxed_deconstruct(value)
+}
+
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<@Array<felt252>>,) nopanic;
+
+struct Single {
+    x: Array<felt252>,
+}
+
+//! > casm
+[ap + 0] = [fp + -3], ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 100})
+
+//! > sierra_code
+type Box<Snapshot<test::Single>> = Box<Snapshot<test::Single>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<Box<Snapshot<Array<felt252>>>> = Struct<ut@Tuple, Box<Snapshot<Array<felt252>>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type test::Single = Struct<ut@test::Single, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<test::Single> = Snapshot<test::Single> [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<Snapshot<test::Single>> = struct_boxed_deconstruct<Snapshot<test::Single>>;
+libfunc struct_construct<Tuple<Box<Snapshot<Array<felt252>>>>> = struct_construct<Tuple<Box<Snapshot<Array<felt252>>>>>;
+libfunc store_temp<Tuple<Box<Snapshot<Array<felt252>>>>> = store_temp<Tuple<Box<Snapshot<Array<felt252>>>>>;
+
+F0:
+struct_boxed_deconstruct<Snapshot<test::Single>>([0]) -> ([1]);
+struct_construct<Tuple<Box<Snapshot<Array<felt252>>>>>([1]) -> ([2]);
+store_temp<Tuple<Box<Snapshot<Array<felt252>>>>>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: Box<Snapshot<test::Single>>) -> (Tuple<Box<Snapshot<Array<felt252>>>>);
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc for Box<@Many>
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+fn foo(value: Box<@Many>) -> (Box<@u256>, Box<@felt252>, Box<@Array<felt252>>, Box<@u256>) {
+    struct_boxed_deconstruct(value)
+}
+
+extern fn struct_boxed_deconstruct<T>(
+    value: Box<T>,
+) -> (Box<@u256>, Box<@felt252>, Box<@Array<felt252>>, Box<@u256>) nopanic;
+
+struct Many {
+    a: u256,
+    b: felt252,
+    c: Array<felt252>,
+    d: u256,
+}
+
+//! > casm
+[ap + 0] = [fp + -3], ap++;
+[ap + 0] = [fp + -3] + 2, ap++;
+[ap + 0] = [fp + -3] + 3, ap++;
+[ap + 0] = [fp + -3] + 5, ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 400})
+
+//! > sierra_code
+type Box<Snapshot<test::Many>> = Box<Snapshot<test::Many>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::integer::u256> = Box<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>> = Struct<ut@Tuple, Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type test::Many = Struct<ut@test::Many, core::integer::u256, felt252, Array<felt252>, core::integer::u256> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<test::Many> = Snapshot<test::Many> [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<Snapshot<test::Many>> = struct_boxed_deconstruct<Snapshot<test::Many>>;
+libfunc struct_construct<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>>> = struct_construct<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>>>;
+libfunc store_temp<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>>> = store_temp<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>>>;
+
+F0:
+struct_boxed_deconstruct<Snapshot<test::Many>>([0]) -> ([1], [2], [3], [4]);
+struct_construct<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>>>([1], [2], [3], [4]) -> ([5]);
+store_temp<Tuple<Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>>>([5]) -> ([5]);
+return([5]);
+
+test::foo@F0([0]: Box<Snapshot<test::Many>>) -> (Tuple<Box<core::integer::u256>, Box<felt252>, Box<Snapshot<Array<felt252>>>, Box<core::integer::u256>>);
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc with non-zero offset (non-recursive call)
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+#[inline(never)]
+pub fn helper() -> Box<A> {
+    BoxTrait::new(A { a: 1, b: 2 })
+}
+
+fn foo() -> (Box<u256>, Box<u256>) {
+    let b = helper();
+    struct_boxed_deconstruct::<A>(b)
+}
+
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u256>, Box<u256>) nopanic;
+
+struct A {
+    a: u256,
+    b: u256,
+}
+
+//! > casm
+[ap + 0] = 1, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = 2, ap++;
+[ap + 0] = 0, ap++;
+%{
+if '__boxed_segment' not in globals():
+    __boxed_segment = segments.add()
+memory[ap + 0] = __boxed_segment
+__boxed_segment += 4
+%}
+[ap + -4] = [[ap + 0] + 0], ap++;
+[ap + -4] = [[ap + -1] + 1];
+[ap + -3] = [[ap + -1] + 2];
+[ap + -2] = [[ap + -1] + 3];
+ret;
+call rel -13;
+[ap + 0] = [ap + -1], ap++;
+[ap + 0] = [ap + -2] + 2, ap++;
+ret;
+
+//! > function_costs
+test::helper: SmallOrderedMap({Const: 800})
+test::foo: SmallOrderedMap({Const: 1200})
+
+//! > sierra_code
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::integer::u256> = Box<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<Box<core::integer::u256>, Box<core::integer::u256>> = Struct<ut@Tuple, Box<core::integer::u256>, Box<core::integer::u256>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<test::A> = Box<test::A> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::A = Struct<ut@test::A, core::integer::u256, core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<core::integer::u256, Const<u128, 2>, Const<u128, 0>> = Const<core::integer::u256, Const<u128, 2>, Const<u128, 0>> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<core::integer::u256, Const<u128, 1>, Const<u128, 0>> = Const<core::integer::u256, Const<u128, 1>, Const<u128, 0>> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u128, 0> = Const<u128, 0> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u128, 1> = Const<u128, 1> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u128, 2> = Const<u128, 2> [storable: false, drop: false, dup: false, zero_sized: false];
+
+libfunc const_as_immediate<Const<core::integer::u256, Const<u128, 1>, Const<u128, 0>>> = const_as_immediate<Const<core::integer::u256, Const<u128, 1>, Const<u128, 0>>>;
+libfunc const_as_immediate<Const<core::integer::u256, Const<u128, 2>, Const<u128, 0>>> = const_as_immediate<Const<core::integer::u256, Const<u128, 2>, Const<u128, 0>>>;
+libfunc struct_construct<test::A> = struct_construct<test::A>;
+libfunc store_temp<test::A> = store_temp<test::A>;
+libfunc into_box<test::A> = into_box<test::A>;
+libfunc function_call<user@test::helper> = function_call<user@test::helper>;
+libfunc struct_boxed_deconstruct<test::A> = struct_boxed_deconstruct<test::A>;
+libfunc struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>> = struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>;
+libfunc store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>> = store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>;
+
+F0:
+const_as_immediate<Const<core::integer::u256, Const<u128, 1>, Const<u128, 0>>>() -> ([0]);
+const_as_immediate<Const<core::integer::u256, Const<u128, 2>, Const<u128, 0>>>() -> ([1]);
+struct_construct<test::A>([0], [1]) -> ([2]);
+store_temp<test::A>([2]) -> ([2]);
+into_box<test::A>([2]) -> ([3]);
+return([3]);
+F1:
+function_call<user@test::helper>() -> ([0]);
+struct_boxed_deconstruct<test::A>([0]) -> ([1], [2]);
+struct_construct<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>([1], [2]) -> ([3]);
+store_temp<Tuple<Box<core::integer::u256>, Box<core::integer::u256>>>([3]) -> ([3]);
+return([3]);
+
+test::helper@F0() -> (Box<test::A>);
+test::foo@F1() -> (Tuple<Box<core::integer::u256>, Box<core::integer::u256>>);


### PR DESCRIPTION
Added a new `boxed_struct_deconstruct` libfunc to extract boxed members from a boxed struct.

The libfunc works by taking a boxed struct (which is a pointer to a memory location) and returning individual boxed references to each member by calculating their offsets in memory.

