### PR TITLE
fix: clarify profiler option doc comment

### DIFF
--- a/crates/cairo-lang-runner/src/clap.rs
+++ b/crates/cairo-lang-runner/src/clap.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use crate::profiling::ProfilerConfig;
 
-/// A clap-arg wrapper for Option<ProfilerConfig>.
+/// A clap-arg wrapper for `Option<ProfilerConfig>`.
 #[derive(ValueEnum, Clone, Default, Debug, Serialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum RunProfilerConfigArg {


### PR DESCRIPTION
Aligned the clap doc comment with the actual `Option<ProfilerConfig>` type so the CLI help no longer implies a slice is returned.