### PR TITLE
refactor: remove redundant dereference in UnorderedHashMap::into_iter_sorted

### DIFF
--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -261,7 +261,7 @@ impl<Key: Eq + Hash, Value, BH: BuildHasher> UnorderedHashMap<Key, Value, BH> {
     where
         Key: Ord + Clone,
     {
-        self.0.into_iter().sorted_by_key(|(key, _)| (*key).clone())
+        self.0.into_iter().sorted_by_key(|(key, _)| key.clone())
     }
 
     /// Iterates the map in an ascending order of the keys produced by the given function `f`.


### PR DESCRIPTION
Removes redundant explicit dereference in `into_iter_sorted` method closure.