### PR TITLE
chore: remove unnecessary dead_code attribute from DictTrackerExecScope::idx

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
+++ b/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
@@ -9,7 +9,6 @@ pub struct DictTrackerExecScope {
     /// The data of the dictionary.
     data: HashMap<Felt252, MaybeRelocatable>,
     /// The index of the dictionary in the dict_infos segment.
-    #[allow(dead_code)]
     idx: usize,
 }
 


### PR DESCRIPTION
Removed unnecessary #[allow(dead_code)] attribute from the idx field in DictTrackerExecScope struct. The field is actively used in the public method get_dict_infos_index() and is not dead code.