### PR TITLE
perf: remove redundant clone in get_concrete_long_type_id

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/types.rs
+++ b/crates/cairo-lang-sierra-generator/src/types.rs
@@ -144,7 +144,7 @@ pub fn get_concrete_long_type_id<'db>(
             let ty =
                 snapshot_ty(&SierraSignatureSpecializationContext(db), inner_ty.clone()).unwrap();
             if ty == *inner_ty {
-                return sierra_concrete_long_id(db, ty.clone());
+                return sierra_concrete_long_id(db, ty);
             } else {
                 ConcreteTypeLongId {
                     generic_id: "Snapshot".into(),


### PR DESCRIPTION
Removed redundant .clone() operation in get_concrete_long_type_id function when returning a ConcreteTypeId. The variable ty is already an owned value and can be moved directly without cloning.