### PR TITLE
refactor(runner): remove incorrect dead_code suppression from DictTrackerExecScope

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
+++ b/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
@@ -8,7 +8,6 @@ use starknet_types_core::felt::Felt as Felt252;
 pub struct DictTrackerExecScope {
     /// The data of the dictionary.
     data: HashMap<Felt252, MaybeRelocatable>,
-    /// The index of the dictionary in the dict_infos segment.
     idx: usize,
 }
 


### PR DESCRIPTION
Removes an incorrect #[allow(dead_code)] attribute from the idx field in DictTrackerExecScope. This field is actively used and the suppression attribute was misleading.While reviewing code quality attributes, identified that DictTrackerExecScope::idx is incorrectly marked with #[allow(dead_code)]. The field is:Initialized in the constructor (new(), L25)Publicly accessed via get_dict_infos_index() (L72).This false suppression masks legitimate compiler warnings and misleads contributors about the field's usage.