### PR TITLE
Remove redundant clone in GasReserveCreateLibfunc

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/gas_reserve.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/gas_reserve.rs
@@ -65,7 +65,7 @@ impl NoGenericArgsGenericLibfunc for GasReserveCreateLibfunc {
                             ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                         },
                         OutputVarInfo {
-                            ty: gas_reserve_type.clone(),
+                            ty: gas_reserve_type,
                             ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 2 },
                         },
                     ],


### PR DESCRIPTION
Removed unnecessary `.clone()` call on `gas_reserve_type` in the success branchof `GasReserveCreateLibfunc::specialize_signature()`. The variable is moved and not used afterwards, making the clone operation redundant.