### PR TITLE
chore: Remove redundant Default trait import from test plugin

### DIFF
--- a/crates/cairo-lang-test-plugin/src/lib.rs
+++ b/crates/cairo-lang-test-plugin/src/lib.rs
@@ -1,5 +1,3 @@
-use std::default::Default;
-
 use anyhow::{Result, ensure};
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::{ensure_diagnostics, get_sierra_program_for_functions};


### PR DESCRIPTION
Remove unused `std::default::Default` import from `cairo-lang-test-plugin`.