### PR TITLE
fix: correct secp256r1 gas deduction for New and GetPointFromX syscalls

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -1608,7 +1608,7 @@ fn secp256r1_new(
     y: BigUint,
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
-    deduct_gas!(gas_counter, SECP256R1_GET_POINT_FROM_X);
+    deduct_gas!(gas_counter, SECP256R1_NEW);
     let modulus = <secp256r1::Fq as PrimeField>::MODULUS.into();
     if x >= modulus || y >= modulus {
         fail_syscall!(b"Coordinates out of range");
@@ -1671,7 +1671,7 @@ fn secp256r1_get_point_from_x(
     y_parity: bool,
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
-    deduct_gas!(gas_counter, SECP256R1_NEW);
+    deduct_gas!(gas_counter, SECP256R1_GET_POINT_FROM_X);
     if x >= <secp256r1::Fq as PrimeField>::MODULUS.into() {
         fail_syscall!(b"Coordinates out of range");
     }


### PR DESCRIPTION
The gas deduction constants for secp256r1 syscalls were swapped in crates/cairo-lang-runner/src/casm_run/mod.rs: 
secp256r1_new() was charging SECP256R1_GET_POINT_FROM_X and secp256r1_get_point_from_x() was charging. SECP256R1_NEW. This change aligns each syscall with its matching gas constant, mirroring the correct mapping used by the secp256k1 counterparts and the Sierra-to-syscall mapping in crates/cairo-lang-sierra-to-casm/src/invocations/starknet/secp256.rs. The fix ensures accurate gas accounting and consistency with the gas schedule definitions.