### PR TITLE
fix: misleading comment in SierraCasmRunner::new about contract discovery

### DIFF
--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -189,8 +189,6 @@ impl SierraCasmRunner {
         starknet_contracts_info: OrderedHashMap<Felt252, ContractInfo>,
         run_profiler: Option<ProfilingInfoCollectionConfig>,
     ) -> Result<Self, RunnerError> {
-        // Receive precomputed contract info (class_hash -> ContractInfo). Discovery is performed by
-        // the caller.
         Ok(Self {
             builder: RunnableBuilder::new(sierra_program, metadata_config)?,
             starknet_contracts_info,


### PR DESCRIPTION
The previous comment stated that the constructor “Find[s] all contracts.”, but SierraCasmRunner::new does not perform any discovery. It takes a precomputed map of class_hash to ContractInfo and stores it. Contract discovery is implemented externally in cairo-lang-starknet (e.g., find_contracts + get_contracts_info) and callers such as the CLI and test runner supply the map. The updated comment clarifies this ownership boundary to prevent confusion and reflects the actual design and usages in casm_run where the runner only reads from starknet_contracts_info.