### PR TITLE
Eliminate unnecessary allocation in parser diagnostics path

### DIFF
--- a/crates/cairo-lang-parser/src/db.rs
+++ b/crates/cairo-lang-parser/src/db.rs
@@ -98,5 +98,5 @@ fn file_syntax_diagnostics<'db>(
     db: &'db dyn Database,
     file_id: FileId<'db>,
 ) -> Diagnostics<'db, ParserDiagnostic<'db>> {
-    file_syntax_data(db, file_id).diagnostics(db).clone()
+    file_syntax_data(db, file_id).diagnostics(db)
 }


### PR DESCRIPTION
The file_syntax_diagnostics function was performing a redundant cloneon diagnostic data that's already returned by reference via salsa'stracked query system. This removes the superfluous allocation without any behavioral changes.

All existing tests pass with this change.