### PR TITLE
refactor(casm): Remove redundant intermediate conversion in DerefOrImmediate

### DIFF
--- a/crates/cairo-lang-casm/src/assembler.rs
+++ b/crates/cairo-lang-casm/src/assembler.rs
@@ -276,14 +276,13 @@ impl Operation {
 }
 
 impl DerefOrImmediate {
-    fn to_res_operand(&self) -> ResOperand {
-        match self {
-            DerefOrImmediate::Deref(operand) => ResOperand::Deref(*operand),
-            DerefOrImmediate::Immediate(operand) => ResOperand::Immediate(operand.clone()),
-        }
-    }
     fn to_res_description(&self) -> ResDescription {
-        self.to_res_operand().to_res_description()
+        match self {
+            DerefOrImmediate::Deref(operand) => ResOperand::Deref(*operand).to_res_description(),
+            DerefOrImmediate::Immediate(operand) => {
+                ResOperand::Immediate(operand.clone()).to_res_description()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Remove unnecessary intermediate method to_res_operand() that creates redundant allocations and adds no value to the codebase.