### PR TITLE
cairo-lang-executable: borrow the target Sierra function instead of cloning

### DIFF
--- a/crates/cairo-lang-executable/src/compile.rs
+++ b/crates/cairo-lang-executable/src/compile.rs
@@ -228,7 +228,7 @@ pub fn compile_executable_function_in_prepared_db<'db>(
 
     // Since we build the entry point asking for a single function - we know it will be first, and
     // that it will be available.
-    let executable_func = sierra_program.funcs[0].clone();
+    let executable_func = &sierra_program.funcs[0];
     assert_eq!(executable_func.id, db.intern_sierra_function(executable.function_id(db).unwrap()));
     let builder = RunnableBuilder::new(sierra_program.clone(), None).map_err(|err| {
         let mut locs = vec![];
@@ -245,7 +245,7 @@ pub fn compile_executable_function_in_prepared_db<'db>(
     // If syscalls are allowed it means we allow for unsound programs.
     let allow_unsound = config.allow_syscalls;
     let wrapper = builder
-        .create_wrapper_info(&executable_func, EntryCodeConfig::executable(allow_unsound))?;
+        .create_wrapper_info(executable_func, EntryCodeConfig::executable(allow_unsound))?;
     let compiled_function = CompiledFunction { program: builder.casm_program().clone(), wrapper };
     Ok(CompileExecutableResult { compiled_function, builder, debug_info: debug_info.clone() })
 }


### PR DESCRIPTION
Stop cloning the first Sierra function when setting up the executable wrapper. Reuse the borrowed function reference when creating the wrapper info, keeping behaviour identical while avoiding redundant work.