### PR TITLE
Initialize default plugin inputs in defs group setup

### DIFF
--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -374,7 +374,9 @@ impl<T: Database + ?Sized> DefsGroup for T {}
 
 /// Initializes the [`DefsGroup`] database to a proper state.
 pub fn init_defs_group(db: &mut dyn Database) {
+    defs_group_input(db).set_default_macro_plugins(db).to(Some(Vec::new()));
     defs_group_input(db).set_macro_plugin_overrides(db).to(Some(OrderedHashMap::default()));
+    defs_group_input(db).set_default_inline_macro_plugins(db).to(Some(OrderedHashMap::default()));
     defs_group_input(db).set_inline_macro_plugin_overrides(db).to(Some(OrderedHashMap::default()));
 }
 


### PR DESCRIPTION
Initialize default_macro_plugins with an empty vector in init_defs_group. Initialize default_inline_macro_plugins with an empty OrderedHashMap. Keep existing overrides initialization so all tracked inputs have safe defaults.