### PR TITLE
Simplify OptionFrom Sized bound

### DIFF
--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -32,10 +32,7 @@ pub mod unordered_hash_map;
 pub mod unordered_hash_set;
 
 /// Similar to From / TryFrom, but returns an option.
-pub trait OptionFrom<T>
-where
-    Self: Sized,
-{
+pub trait OptionFrom<T>: Sized {
     fn option_from(other: T) -> Option<Self>;
 }
 


### PR DESCRIPTION
keep the OptionFrom trait constrained to sized implementors, drop the redundant where Self: Sized clause by expressing the bound directly on the trait