### PR TITLE
Revert "Remove redundant is_empty method" - Method required for serde

### DIFF
--- a/crates/cairo-lang-utils/src/ordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_map.rs
@@ -81,6 +81,13 @@ impl<Key, Value, BH> OrderedHashMap<Key, Value, BH> {
     }
 }
 
+impl<Key, Value, BH> OrderedHashMap<Key, Value, BH> {
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 impl<Key: Eq + Hash, Value, BH: BuildHasher> OrderedHashMap<Key, Value, BH> {
     /// Returns true if the maps are equal, ignoring the order of the entries.
     pub fn eq_unordered(&self, other: &Self) -> bool


### PR DESCRIPTION
This reverts the removal of `OrderedHashMap::is_empty()` method.