### PR TITLE
Make `read_felts` and `format_for_debug` public

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -2271,7 +2271,7 @@ pub fn execute_core_hint(
 }
 
 /// Reads a range of `Felt252`s from the VM.
-fn read_felts(
+pub fn read_felts(
     vm: &mut VirtualMachine,
     start: &ResOperand,
     end: &ResOperand,


### PR DESCRIPTION
Needed to capture + save printed output in `scarb execute`:
- https://github.com/software-mansion/scarb/pull/2869