### PR TITLE
Remove unused hash import from SCC util module

### DIFF
--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
@@ -1,7 +1,5 @@
 //! Logic for computing the strongly connected component of a node in a graph.
 
-use core::hash::Hash;
-
 use super::graph_node::GraphNode;
 use crate::unordered_hash_map::UnorderedHashMap;
 


### PR DESCRIPTION
drop the unused core::hash::Hash import from strongly_connected_components.rs to keep the module tidy