### PR TITLE
docs: fix wrong import in u256_div_mod_n example

### DIFF
--- a/corelib/src/math.cairo
+++ b/corelib/src/math.cairo
@@ -199,7 +199,7 @@ pub fn u256_inv_mod(a: u256, n: NonZero<u256>) -> Option<NonZero<u256>> {
 /// # Examples
 ///
 /// ```
-/// use core::math::u256_inv_mod;
+/// use core::math::u256_div_mod_n;
 ///
 /// let result = u256_div_mod_n(17, 7, 29);
 /// assert!(result == Some(19));


### PR DESCRIPTION
The doc example for `u256_div_mod_n` was importing `u256_inv_mod` instead of `u256_div_mod_n`. Copy-paste error from the function above it.