### PR TITLE
refactor: remove redundant HashMap updates in SCC algorithm loop

### DIFF
--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
@@ -97,8 +97,8 @@ fn compute_scc_recursive<Node: GraphNode>(ctx: &mut SccAlgoContext<Node>, curren
             }
         };
 
-        // Update current_node in ctx.known_nodes.
-        ctx.known_nodes.insert(current_node_id.clone(), current_wrapper_node.clone());
+    // Update current_node in ctx.known_nodes after processing all neighbors.
+    ctx.known_nodes.insert(current_node_id.clone(), current_wrapper_node.clone());
     }
 
     if current_wrapper_node.lowlink != current_wrapper_node.index {


### PR DESCRIPTION
Optimizes the strongly connected components (SCC) algorithm by removing redundant HashMap updates inside the neighbor processing loop.