### PR TITLE
fix(corelib): correct append_byte documentation example

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -178,8 +178,8 @@ pub impl ByteArrayImpl of ByteArrayTrait {
     ///
     /// ```
     /// let mut ba = "";
-    /// ba.append_byte(0);
-    /// assert!(ba == "0");
+    /// ba.append_byte('A');
+    /// assert!(ba == "A");
     /// ```
     fn append_byte(ref self: ByteArray, byte: u8) {
         if self.pending_word_len == 0 {


### PR DESCRIPTION
The doc example for `append_byte` was using `append_byte(0)` and asserting equality with `"0"`, which would never be true.

`append_byte(0)` adds a NULL byte (0x00), not the character '0' (0x30). The assert would always fail since the byte array would contain a null character, not the string "0".

Fixed by using the char literal `'A'` which is more readable and idiomatic.