### PR TITLE
drop redundant Sized bound from IntoOrPanic

### DIFF
--- a/crates/cairo-lang-utils/src/casts.rs
+++ b/crates/cairo-lang-utils/src/casts.rs
@@ -1,4 +1,4 @@
-pub trait IntoOrPanic: Sized + Copy + core::fmt::Debug {
+pub trait IntoOrPanic: Copy + core::fmt::Debug {
     fn into_or_panic<T>(self) -> T
     where
         T: TryFrom<Self> + core::fmt::Debug,


### PR DESCRIPTION
remove the unnecessary Sized constraint from IntoOrPanic since Copy already implies it