### PR TITLE
Avoid redundant cloning in SCC context updates

### DIFF
--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
@@ -97,8 +97,9 @@ fn compute_scc_recursive<Node: GraphNode>(ctx: &mut SccAlgoContext<Node>, curren
             }
         };
 
-        // Update current_node in ctx.known_nodes.
-        ctx.known_nodes.insert(current_node_id.clone(), current_wrapper_node.clone());
+        // Update current_node in ctx.known_nodes without re-cloning the wrapper node.
+        let wrapper_node = ctx.known_nodes.get_mut(&current_node_id).unwrap();
+        wrapper_node.lowlink = current_wrapper_node.lowlink;
     }
 
     if current_wrapper_node.lowlink != current_wrapper_node.index {


### PR DESCRIPTION
update compute_scc_recursive to refresh lowlink in-place via get_mut, remove the per-iteration clone of the wrapper node and node id