### PR TITLE
Avoid redundant TokenStream clones in DebugWithDb derive

### DIFF
--- a/crates/cairo-lang-proc-macros/src/debug.rs
+++ b/crates/cairo-lang-proc-macros/src/debug.rs
@@ -23,7 +23,7 @@ pub fn derive_debug_with_db(input: TokenStream) -> TokenStream {
 
     // ── 2. Generate the body per kind ────────────────────────────────────────────
     let body = match &input.data {
-       syn::Data::Struct(s) => emit_struct_debug(name, generics, &db, s),
+        syn::Data::Struct(s) => emit_struct_debug(name, generics, &db, s),
         syn::Data::Enum(e) => emit_enum_debug(name, generics, &db, e),
         syn::Data::Union(_) => panic!("Unions are not supported"),
     };


### PR DESCRIPTION
pass the generated db token stream to helper routines by reference, eliminate the unnecessary TokenStream2::clone() calls highlighted by clippy