### PR TITLE
 Remove unnecessary clone operations

### DIFF
--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -456,7 +456,7 @@ pub fn update_file_overrides_input_helper(
     let db_ref: &dyn Database = db;
     let mut overrides = files_group_input(db_ref).file_overrides(db_ref).clone().unwrap();
     match content {
-        Some(content) => overrides.insert(file.clone(), content),
+        Some(content) => overrides.insert(file, content),
         None => overrides.swap_remove(&file),
     };
     overrides

--- a/crates/cairo-lang-filesystem/src/db_test.rs
+++ b/crates/cairo-lang-filesystem/src/db_test.rs
@@ -41,7 +41,7 @@ fn test_flags() {
 
     let add_withdraw_gas_flag_id = FlagLongId("add_withdraw_gas".into());
     db.set_flag(add_withdraw_gas_flag_id.clone(), Some(Arc::new(Flag::AddWithdrawGas(false))));
-    let id = add_withdraw_gas_flag_id.clone().intern(&db);
+    let id = add_withdraw_gas_flag_id.intern(&db);
 
     assert_eq!(*db.get_flag(id).unwrap(), Flag::AddWithdrawGas(false));
     assert!(db.get_flag(FlagId::new(&db, FlagLongId("non_existing_flag".into()))).is_none());

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -296,7 +296,7 @@ fn run_e2e_test(
             .iter()
             .map(|(func_id, cost)| format!("{func_id}: {cost:?}"))
             .join("\n");
-        res.insert("function_costs".into(), function_costs_str.to_string());
+        res.insert("function_costs".into(), function_costs_str);
     }
 
     TestRunnerResult::success(res)


### PR DESCRIPTION
Eliminates redundant clone operations across the codebase. The removed clones were not contributing any value and were creating unnecessary allocations. This improves performance slightly and makes the code cleaner.