### PR TITLE
fix: remove unnecessary clone in consteval_int macro

### DIFF
--- a/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
@@ -24,7 +24,7 @@ impl InlineMacroExprPlugin for ConstevalIntMacro {
         syntax: &ast::ExprInlineMacro<'db>,
         metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
-        let Some(legacy_inline_macro) = syntax.clone().as_legacy_inline_macro(db) else {
+        let Some(legacy_inline_macro) = syntax.as_legacy_inline_macro(db) else {
             return InlinePluginResult::diagnostic_only(not_legacy_macro_diagnostic(
                 syntax.as_syntax_node().stable_ptr(db),
             ));


### PR DESCRIPTION
This change removes an unnecessary clone of the syntax node before calling as_legacy_inline_macro(db) in 
ConstevalIntMacro::generate_code(). The clone provided no functional benefit because as_legacy_inline_macro accepts a reference and other inline macros (e.g., array.rs) already call it without cloning. Avoiding the clone reduces minor overhead and aligns the implementation with neighboring macros for consistency without altering behavior.