### PR TITLE
remove unused `env_logger` feature flag

### DIFF
--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -32,7 +32,6 @@ tracing.workspace = true
 
 [features]
 default = ["std", "tracing"]
-env_logger = ["tracing"]
 parity-scale-codec = ["dep:parity-scale-codec"]
 schemars = ["dep:schemars", "serde", "std"]
 serde = ["dep:serde", "indexmap/serde", "num-bigint/serde", "smol_str/serde"]


### PR DESCRIPTION
Remove unused `env_logger` feature flag from `cairo-lang-utils` package.