### PR TITLE
Avoid redundant Sierra program clone in cairo-lang-test-plugin

### DIFF
--- a/crates/cairo-lang-test-plugin/src/lib.rs
+++ b/crates/cairo-lang-test-plugin/src/lib.rs
@@ -143,7 +143,7 @@ pub fn compile_test_prepared_db<'db>(
     )
     .collect();
 
-    let SierraProgramWithDebug { program: sierra_program, debug_info } =
+   let SierraProgramWithDebug { program: mut sierra_program, debug_info } =
         get_sierra_program_for_functions(db, func_ids)?;
 
     let function_set_costs: OrderedHashMap<FunctionId, CostTokenMap<i32>> = all_entry_points
@@ -157,7 +157,6 @@ pub fn compile_test_prepared_db<'db>(
         .collect();
 
     let replacer = DebugReplacer { db };
-    let mut sierra_program = sierra_program.clone();
     replacer.enrich_function_names(&mut sierra_program);
 
     let mut annotations = Annotations::default();


### PR DESCRIPTION
take sierra_program as mut directly from SierraProgramWithDebug
drop the extra clone() and reuse the original buffer when enriching debug info

