### PR TITLE
fix: Implement proper unordered comparison in SmallOrderedMap::eq_unordered

### DIFF
--- a/crates/cairo-lang-utils/src/small_ordered_map.rs
+++ b/crates/cairo-lang-utils/src/small_ordered_map.rs
@@ -16,7 +16,15 @@ impl<Key: Eq, Value> SmallOrderedMap<Key, Value> {
 impl<Key: Eq, Value: Eq> SmallOrderedMap<Key, Value> {
     /// Checks if the two maps have the same keys and values.
     pub fn eq_unordered(&self, other: &Self) -> bool {
-        self.0 == other.0
+        if self.len() != other.len() {
+            return false;
+        }
+
+        self.iter()
+            .all(|(key, value)| match other.get(key) {
+                Some(other_value) => other_value == value,
+                None => false,
+            })
     }
 }
 impl<Key: Eq, Value: Eq> PartialEq for SmallOrderedMap<Key, Value> {


### PR DESCRIPTION


The `eq_unordered` method in `SmallOrderedMap` was misleading: it called `VecMap::==`, which compares maps with insertion order taken into account. This meant the method was functionally identical to `PartialEq::eq`, contradicting its name and potentially causing bugs when developers expected true unordered comparison.

