### PR TITLE
fix: add missing doc block closure in RangeTrait::contains

### DIFF
--- a/corelib/src/ops/range.cairo
+++ b/corelib/src/ops/range.cairo
@@ -53,6 +53,7 @@ pub impl RangeImpl<T, +Destruct<T>, +PartialOrd<@T>> of RangeTrait<T> {
     ///
     /// assert!(!(3..3).contains(@3));
     /// assert!(!(3..2).contains(@3));
+    /// ```
     fn contains(self: @Range<T>, item: @T) -> bool {
         self.start <= item && item < self.end
     }


### PR DESCRIPTION
Missing closing ``` in documentation for `contains` method in `RangeTrait`. All other doc blocks in the file were properly closed except this one.