### PR TITLE
perf(borrow_check): avoid temp Vec in enrich_as_notes by iter().cloned()

### DIFF
--- a/crates/cairo-lang-lowering/src/borrow_check/mod.rs
+++ b/crates/cairo-lang-lowering/src/borrow_check/mod.rs
@@ -78,7 +78,7 @@ impl<'db> DropPosition<'db> {
             text.into(),
             location.stable_location.span_in_file(db),
         ));
-        notes.extend(location.notes.clone());
+        notes.extend(location.notes.iter().cloned());
     }
 }
 


### PR DESCRIPTION
Replace notes.extend(location.notes.clone()) with notes.extend(location.notes.iter().cloned()) in 
borrow_check/mod.rs. LocationId::long() returns a borrowed &Location, so moving notes isn’t possible. Cloning via iterator avoids allocating a temporary Vec and re-copying its contents. This matches common patterns in the codebase (e.g., extending from iter().cloned() in objects.rs) and reduces minor overhead on diagnostics assembly paths.