### PR TITLE
perf(semantic): remove unnecessary clones in mapper rewriters

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
@@ -588,7 +588,7 @@ impl<'db> SemanticRewriter<ImplLongId<'db>, MapperError> for Mapper<'db, '_> {
             .get(&var.id)
             .copied()
             .ok_or(MapperError(InferenceVar::Impl(var.id)))?;
-        let var = ImplVar { id, inference_id: self.mapping.target_inference_id, ..var.clone() };
+        let var = ImplVar { id, inference_id: self.mapping.target_inference_id, ..var };
 
         *value = ImplLongId::ImplVar(var.intern(self.get_db()));
         Ok(RewriteResult::Modified)
@@ -620,8 +620,7 @@ impl<'db> SemanticRewriter<NegativeImplLongId<'db>, MapperError> for Mapper<'db,
             .get(&var.id)
             .copied()
             .ok_or(MapperError(InferenceVar::NegativeImpl(var.id)))?;
-        let var =
-            NegativeImplVar { id, inference_id: self.mapping.target_inference_id, ..var.clone() };
+        let var = NegativeImplVar { id, inference_id: self.mapping.target_inference_id, ..var };
 
         *value = NegativeImplLongId::NegativeImplVar(var.intern(self.get_db()));
         Ok(RewriteResult::Modified)


### PR DESCRIPTION
Replaced struct update clones with moves in Mapper::internal_rewrite() and Mapper::internal_rewrite() in canonic.rs. long() returns owned ImplVar/NegativeImplVar, so using ..var is safe and avoids redundant allocations. No behavior change; reduces copies and slightly improves performance.