### PR TITLE
fix: fix typo

### DIFF
--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
@@ -58,7 +58,7 @@ fn test_root_points_to_cycle() {
 
     // Make sure the cycle that's not in the SCC of the root is not covered.
     assert!(feedback_set(10, graph.clone()).is_empty());
-    // We do find in in the other case.
+    // We do find it in the other case.
     assert_eq!(feedback_set(1, graph), [1]);
 }
 


### PR DESCRIPTION
Hello, i found typo in `feedback_set_test.rs` and fixed it