### PR TITLE
fix variable name conflict in cairo

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/felt252dict-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/felt252dict-type.adoc
@@ -17,7 +17,7 @@ let mut dict = Felt252DictTrait::new();
     let val11 = dict[11]; // 111
     let val12 = dict[12]; // 0
     dict.insert(10, 120);
-    let val10 = dict[10]; // 120
+    let new_val10 = dict[10]; // 120
 ----
 
 == Dictionary Entry


### PR DESCRIPTION
ran into an issue where a variable was declared twice within the same scope.
unlike some languages, Cairo (similar to Rust) doesn’t allow redeclaring a name - the old one isn’t shadowed.
to resolve this, I renamed the second variable so the code compiles cleanly and behaves as intended.
