### PR TITLE
fix: typo 

### DIFF
--- a/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/feedback_set_test.rs
@@ -74,7 +74,7 @@ fn test_connected_cycles() {
 
     // Make sure the cycle that's not in the SCC of the root is not covered.
     assert_eq!(feedback_set(0, graph.clone()), [0]);
-    // We do find in in the other case.
+    // We do find it in the other case.
     assert_eq!(feedback_set(5, graph), [5]);
 }
 


### PR DESCRIPTION
corrected `We do find in in` to `We do find it in`