### PR TITLE
docs(inline_macros): remove stale comment in get_dep_component

### DIFF
--- a/crates/cairo-lang-starknet/src/inline_macros/get_dep_component.rs
+++ b/crates/cairo-lang-starknet/src/inline_macros/get_dep_component.rs
@@ -81,8 +81,6 @@ fn get_dep_component_generate_code_helper<'db>(
 
         // Verify the first element has only a `ref` modifier.
         if !matches!(contract_arg_modifiers, Some([ast::Modifier::Ref(_)])) {
-            // TODO(Gil): The generated diagnostics points to the whole inline macro, it should
-            // point to the arg.
             let diagnostics = vec![PluginDiagnostic::error_with_inner_span(
                 db,
                 syntax.stable_ptr(db),


### PR DESCRIPTION
Removed the outdated TODO about diagnostic span placement. The implementation already uses error_with_inner_span to anchor the error on the argument, so the comment was misleading. No functional changes.