### PR TITLE
(debug): Adding debug information for test runner and optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "serde",
  "starknet-types-core",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -4180,6 +4181,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -28,6 +28,8 @@ salsa.workspace = true
 serde = { workspace = true, default-features = true }
 starknet-types-core.workspace = true
 thiserror.workspace = true
+tracing = { workspace = true, features = ["log"] }
+
 
 [dev-dependencies]
 cairo-lang-plugins = { path = "../cairo-lang-plugins" }

--- a/crates/cairo-lang-lowering/src/optimizations/mod.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/mod.rs
@@ -1,3 +1,23 @@
+/// Macro for debug logging with "optimization" target.
+#[allow(unused)]
+macro_rules! debug {
+    ($($arg:tt)*) => {
+        tracing::debug!(target: "optimization", $($arg)*)
+    };
+}
+#[allow(unused_imports)]
+pub(crate) use debug;
+
+/// Macro for trace logging with "optimization" target.
+#[allow(unused)]
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        tracing::trace!(target: "optimization", $($arg)*)
+    };
+}
+#[allow(unused_imports)]
+pub(crate) use trace;
+
 pub mod branch_inversion;
 pub mod cancel_ops;
 pub mod config;

--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -69,6 +69,8 @@ impl<'db> OptimizationPhase<'db> {
         function: ConcreteFunctionWithBodyId<'db>,
         lowered: &mut Lowered<'db>,
     ) -> Maybe<()> {
+        debug!("Applying optimization: {self:?}");
+
         match self {
             OptimizationPhase::ApplyInlining { enable_const_folding } => {
                 apply_inlining(db, function, lowered, enable_const_folding)?


### PR DESCRIPTION
# Add Tracing to Lowering Optimizations

### TL;DR

Added tracing support to the lowering optimization phase to improve debugging capabilities.

### What changed?

- Added `tracing` dependency to `cairo-lang-lowering` crate
- Created debug and trace macros in the optimizations module with an "optimization" target
- Added debug logging for optimization phase application
- Updated Cargo.lock with the new dependency

### How to test?

Run the compiler with tracing enabled to see optimization logs:
```
RUST_LOG=optimization=debug cargo run -- compile <file>
```

### Why make this change?

This change improves the observability of the optimization process, making it easier to debug and understand which optimizations are being applied during compilation. The targeted logging will help developers track optimization behavior without cluttering logs with unrelated information.