### PR TITLE
(debug): Adding test_name attribute to test runners input

### DIFF
--- a/crates/cairo-lang-test-utils/src/parse_test_file.rs
+++ b/crates/cairo-lang-test-utils/src/parse_test_file.rs
@@ -14,6 +14,7 @@ use colored::Colorize;
 const TAG_PREFIX: &str = "//! > ";
 const TEST_SEPARATOR: &str =
     "==========================================================================";
+const TEST_NAME: &str = "test_name";
 
 #[derive(Default)]
 struct Tag {
@@ -102,12 +103,14 @@ pub fn dump_to_test_file(
     for (test_name, test) in tests {
         let mut tag_strings = vec![TAG_PREFIX.to_string() + &test_name];
         for (tag, content) in test.attributes {
-            tag_strings.push(
-                TAG_PREFIX.to_string()
-                    + &tag
-                    + if content.is_empty() { "" } else { "\n" }
-                    + &content,
-            );
+            if tag != TEST_NAME {
+                tag_strings.push(
+                    TAG_PREFIX.to_string()
+                        + &tag
+                        + if content.is_empty() { "" } else { "\n" }
+                        + &content,
+                );
+            }
         }
         test_strings.push(tag_strings.join("\n\n"));
     }
@@ -139,8 +142,11 @@ impl TestBuilder {
     }
 
     fn set_test_name(&mut self, line: String, line_num: usize) {
-        self.current_test_name = Some(line);
-        self.current_test = Some(Test { attributes: OrderedHashMap::default(), line_num });
+        self.current_test_name = Some(line.clone());
+        self.current_test = Some(Test {
+            attributes: OrderedHashMap::from([(TEST_NAME.to_string(), line)]),
+            line_num,
+        });
     }
 
     fn add_content_line(&mut self, line: String) {


### PR DESCRIPTION
# Store test name in test attributes

This PR modifies the test file parsing to store the test name as an attribute in the test attribute map. The test name attribute is excluded when using CAIRO_FIX_TESTS.