### PR TITLE
fix: grammar in expr::compute module documentation

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1,4 +1,4 @@
-//! This module is responsible of computing the semantic model of expressions and statements in
+//! This module is responsible for computing the semantic model of expressions and statements in
 //! the code, while type checking.
 //! It is invoked by queries for function bodies and other code blocks.
 


### PR DESCRIPTION
Updated the module-level documentation in `crates/cairo-lang-semantic/src/expr/compute.rs` to use the correct phrase `responsible for computing` instead of `responsible of computing`
