### PR TITLE
docs: fix typo

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
@@ -83,7 +83,7 @@ fn test() {
 
 A variable can be introduced inside a match arm.
 
-for example:
+For example:
 [source]
 ----
 match opt {


### PR DESCRIPTION
Hello! I found a minor typo in `variables.adoc` in fixed it