### PR TITLE
fix: correct typo in comment

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -4669,7 +4669,7 @@ pub fn compute_and_append_statement_semantic<'db>(
             )));
             Ok(())
         }
-        // Dianogstics reported on syntax level already.
+        // Diagnostics reported on syntax level already.
         ast::Statement::Missing(_) => return Err(skip_diagnostic()),
     };
     ctx.restore_features(feature_restore);


### PR DESCRIPTION
Corrected typo in the inline comment.
