### PR TITLE
fix: correct indexing link in array-expressions documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc
@@ -36,8 +36,7 @@ Only one form is used at a time. Mixing both (e.g., `[a, b; 3]`) is not valid.
 
 [NOTE]
 ====
-Indexing uses the general indexing expression form `array[index]`. See
-xref:pages/operator-precedence.adoc[Operator precedence] for operator precedence information.
+Indexing uses the general indexing expression form `array[index]`.
 ====
 
 == Examples


### PR DESCRIPTION
## Description
Fixes an incorrect cross-reference in the array expressions documentation. The note about array indexing incorrectly linked to the member access expressions page, which only covers dot notation (.), not the [] indexing operator.
## Changes
Replaced the link to member-access-expressions.adoc with a reference to operator-precedence.adoc, where the [] operator is documented as a postfix unary operator.