### PR TITLE
fix: correct grammar in compute.rs

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -2835,7 +2835,7 @@ fn maybe_compute_pattern_semantic<'db>(
             if let Ok(ResolvedGenericItem::Variant(_)) = item_result {
                 // If the path resolves to a variant, it might still be a generic param, so we
                 // resolve it as a concrete path.
-                // Resolveing as concrete path first might create vars which will not be inferred so
+                // Resolving as concrete path first might create vars which will not be inferred so
                 // we use the generic path first.
                 let item = ctx.resolver.resolve_concrete_path_ex(
                     &mut Default::default(),


### PR DESCRIPTION

- Fixed typo: `Resolveing` → `Resolving`


