### PR TITLE
docs: fix grammar in comments

### DIFF
--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -911,7 +911,7 @@ define_language_element_id_as_enum! {
 }
 define_language_element_id_as_enum! {
     #[toplevel]
-    /// The ID of a impl item with generic parameters.
+    /// The ID of an impl item with generic parameters.
     pub enum GenericImplItemId<'db> {
         Type(ImplTypeDefId<'db>),
     }

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -924,7 +924,7 @@ impl<'db> ImplDefinitionData<'db> {
         self.item_id_by_name.get(&item_name).cloned()
     }
 }
-/// Stores metadata for a impl item, including its ID and feature kind.
+/// Stores metadata for an impl item, including its ID and feature kind.
 #[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
 pub struct ImplItemInfo<'db> {
     /// The unique identifier of the impl item.

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -237,7 +237,7 @@ impl<'db> ConcreteTraitConstantId<'db> {
     }
 }
 
-/// The ID of a impl item in a concrete trait.
+/// The ID of an impl item in a concrete trait.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, DebugWithDb, SemanticObject)]
 #[debug_db(dyn Database)]
 pub struct ConcreteTraitImplLongId<'db> {


### PR DESCRIPTION
 ## Problem
  Documentation comments use incorrect grammar: "a impl" instead of "an impl".
 
  ## Changes   
  Fixed 3 occurrences across the codebase:
  - `crates/cairo-lang-defs/src/ids.rs:914`
  - `crates/cairo-lang-semantic/src/items/imp.rs:927`
  - `crates/cairo-lang-semantic/src/items/trt.rs:240`
  