### PR TITLE
docs: fix invalid Rust nightly date

### DIFF
--- a/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
@@ -36,5 +36,5 @@ You can install the nightly version by running.
 
 [source,bash]
 ----
-rustup install nightly-2025-11-17
+rustup install nightly
 ----


### PR DESCRIPTION
updated the command to use the correct form `rustup install nightly` for actual Rust release behavior.
