### PR TITLE
fix: invalid `if let` syntax in `Goto` handling

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/validate.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/validate.rs
@@ -89,14 +89,15 @@ pub fn validate(lowered: &Lowered<'_>) -> Result<(), ValidationError> {
                     if !introductions.contains_key(&old_var.var_id) {
                         return Err(ValidationError::UnknownUsageInEnd(old_var.var_id, block_id));
                     }
+
                     let intro = Introduction::Remapping(block_id, *target_block_id);
-                    if let Some(prev) = introductions.insert(*new_var, intro)
-                        && !matches!(
+                    if let Some(prev) = introductions.insert(*new_var, intro) {
+                        if !matches!(
                             prev,
-                            Introduction::Remapping(_, target) if target == *target_block_id,
-                        )
-                    {
-                        return Err(ValidationError::DoubleIntroduction(*new_var, prev, intro));
+                            Introduction::Remapping(_, target) if target == *target_block_id
+                        ) {
+                            return Err(ValidationError::DoubleIntroduction(*new_var, prev, intro));
+                        }
                     }
                 }
                 stack.push(*target_block_id);


### PR DESCRIPTION
noticed that the existing conditional combined `if let` with a logical `&&`, which Rust doesn’t allow on the right-hand side of an `if let`. this caused a syntax error during compilation. i split the logic into two sequential `if` statements to preserve the intended behavior while keeping the code valid.

updated version now properly checks the `Introduction::Remapping` case and returns the appropriate `ValidationError` when needed.
