### PR TITLE
docs: fix minor grammar issue in security guidelines

### DIFF
--- a/docs/reference/src/components/cairo/modules/appendices/pages/security.adoc
+++ b/docs/reference/src/components/cairo/modules/appendices/pages/security.adoc
@@ -14,7 +14,7 @@ If there are any vulnerabilities in **Cairo**, don't hesitate to _report them_.
 
 3. We will evaluate the vulnerability and, if necessary, release a fix or mitigating steps to address it. We will contact you to let you know the outcome, and we will credit you in the report.
 
-   Please **do not disclose the vulnerability publicly** until a fix is released!
+   Please **do not disclose the vulnerability publicly** until a fix has been released!
 
 4. Once we have either a) published a fix, or b) declined to address the vulnerability for whatever reason, you are free to publicly disclose it.
 


### PR DESCRIPTION
Corrected a small grammar mistake in `security.adoc` to improve clarity in the vulnerability disclosure instructions.

