### PR TITLE
(refactoring): Removed getting prelude submodule code duplication

### DIFF
--- a/crates/cairo-lang-semantic/src/lsp_helpers.rs
+++ b/crates/cairo-lang-semantic/src/lsp_helpers.rs
@@ -16,8 +16,6 @@ use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 use itertools::chain;
 use salsa::Database;
 
-use crate::Variant;
-use crate::corelib::{self, core_submodule, get_submodule};
 use crate::expr::inference::InferenceId;
 use crate::items::constant::ConstantSemantic;
 use crate::items::enm::EnumSemantic;
@@ -32,6 +30,7 @@ use crate::items::us::SemanticUseEx;
 use crate::keyword::SELF_PARAM_KW;
 use crate::resolve::{ResolvedGenericItem, Resolver};
 use crate::types::TypeHead;
+use crate::{Variant, corelib};
 
 /// A filter for types.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -375,10 +374,8 @@ pub fn visible_importables_from_module<'db>(
     module_id: ModuleId<'db>,
 ) -> Option<Arc<OrderedHashMap<ImportableId<'db>, String>>> {
     let current_crate_id = module_id.owning_crate(db);
-    let prelude_submodule_name =
-        db.crate_config(current_crate_id)?.settings.edition.prelude_submodule_name(db);
-    let core_prelude_submodule = core_submodule(db, SmolStrId::from(db, "prelude"));
-    let prelude_submodule = get_submodule(db, core_prelude_submodule, prelude_submodule_name)?;
+    let prelude_submodule =
+        db.get_prelude_submodule(&db.crate_config(current_crate_id)?.settings)?;
 
     let mut module_visible_importables = Vec::new();
     // Collect importables from the prelude.

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -32,7 +32,7 @@ use salsa::Database;
 use syntax::node::TypedStablePtr;
 use syntax::node::helpers::QueryAttrs;
 
-use crate::corelib::{CorelibSemantic, core_submodule, get_submodule};
+use crate::corelib::CorelibSemantic;
 use crate::diagnostic::SemanticDiagnosticKind::{self, *};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::compute::{
@@ -856,16 +856,12 @@ impl<'db> Resolver<'db> {
     /// Returns the crate's `prelude` submodule.
     fn prelude_submodule_ex(&self, info: &MacroResolutionInfo<'db>) -> ModuleId<'db> {
         let active_settings = self.active_settings(info);
-        let prelude_submodule_name = active_settings.edition.prelude_submodule_name(self.db);
-        let core_prelude_submodule = core_submodule(self.db, SmolStrId::from(self.db, "prelude"));
-        get_submodule(self.db, core_prelude_submodule, prelude_submodule_name).unwrap_or_else(
-            || {
-                panic!(
-                    "expected prelude submodule `{}` not found in `core::prelude`.",
-                    prelude_submodule_name.long(self.db)
-                )
-            },
-        )
+        self.db.get_prelude_submodule(active_settings).unwrap_or_else(|| {
+            panic!(
+                "expected prelude submodule `{}` not found in `core::prelude`.",
+                active_settings.edition.prelude_submodule_name(self.db).long(self.db)
+            )
+        })
     }
 
     /// Specializes a trait.


### PR DESCRIPTION
Refactored prelude submodule resolution into a dedicated method on the `ModuleSemantic` trait.

