### PR TITLE
docs: fix past time verb

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
@@ -45,7 +45,7 @@ match enum_var {
 ----
 
 Where `enum_var` is an instance of some xref:enums.adoc[enum] and `variant_0`, `variant_1`, ...,
-`variant_k` are all the variants of the said enum, order in the way that they were declared.
+`variant_k` are all the variants of the said enum, ordered in the way that they were declared.
 
 === Match on an felt252.
 


### PR DESCRIPTION
Minor typo 
order -> ordered