### PR TITLE
(refactor): Removed module_id from TopLevelLanguageElement and using just parent_module which is equivalent

### DIFF
--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -1743,7 +1743,7 @@ impl LanguageElementCached {
         ctx: &mut DefCacheSavingContext<'db>,
     ) -> Self {
         Self {
-            module_id: ModuleIdCached::new(language_element.module_id(ctx.db), ctx),
+            module_id: ModuleIdCached::new(language_element.parent_module(ctx.db), ctx),
             stable_ptr: SyntaxStablePtrIdCached::new(
                 language_element.untyped_stable_ptr(ctx.db),
                 ctx,

--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -42,12 +42,8 @@ use crate::plugin::{InlineMacroExprPlugin, MacroPlugin};
 
 // A trait for an id for a language element.
 pub trait LanguageElementId<'db> {
-    fn module_id(&self, db: &'db dyn Database) -> ModuleId<'db>;
+    fn parent_module(&self, db: &'db dyn Database) -> ModuleId<'db>;
     fn untyped_stable_ptr(&self, db: &'db dyn Database) -> SyntaxStablePtrId<'db>;
-
-    fn parent_module(&self, db: &'db dyn Database) -> ModuleId<'db> {
-        self.module_id(db)
-    }
 
     fn stable_location(&self, db: &'db dyn Database) -> StableLocation<'db>;
 
@@ -155,7 +151,7 @@ macro_rules! define_language_element_id_basic {
             }
         }
         impl<'db> LanguageElementId<'db> for $short_id<'db> {
-            fn module_id(&self, db: &'db dyn Database) -> ModuleId<'db> {
+            fn parent_module(&self, db: &'db dyn Database) -> ModuleId<'db> {
                 self.long(db).0
             }
             fn untyped_stable_ptr(&self, db: &'db dyn Database) -> SyntaxStablePtrId<'db> {
@@ -218,10 +214,10 @@ macro_rules! define_language_element_id_as_enum {
             }
         }
         impl<'db> LanguageElementId<'db> for $enum_name<'db> {
-            fn module_id(&self, db: &'db dyn Database) -> ModuleId<'db> {
+            fn parent_module(&self, db: &'db dyn Database) -> ModuleId<'db> {
                 match self {
                     $(
-                        $enum_name::$variant(id) => id.module_id(db),
+                        $enum_name::$variant(id) => id.parent_module(db),
                     )*
                 }
             }

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -333,7 +333,7 @@ pub fn constant_semantic_data_helper<'db>(
         Some(parent_resolver_data) => {
             Resolver::with_data(db, parent_resolver_data.clone_with_inference_id(db, inference_id))
         }
-        None => Resolver::new(db, element_id.module_id(db), inference_id),
+        None => Resolver::new(db, element_id.parent_module(db), inference_id),
     };
     resolver.set_feature_config(element_id, constant_ast, &mut diagnostics);
 
@@ -376,7 +376,7 @@ pub fn constant_semantic_data_cycle_helper<'db>(
         Some(parent_resolver_data) => {
             Resolver::with_data(db, parent_resolver_data.clone_with_inference_id(db, inference_id))
         }
-        None => Resolver::new(db, element_id.module_id(db), inference_id),
+        None => Resolver::new(db, element_id.parent_module(db), inference_id),
     };
 
     let resolver_data = Arc::new(resolver.data);

--- a/crates/cairo-lang-semantic/src/items/enm.rs
+++ b/crates/cairo-lang-semantic/src/items/enm.rs
@@ -75,7 +75,7 @@ fn enum_generic_params_data<'db>(
     db: &'db dyn Database,
     enum_id: EnumId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = enum_id.module_id(db);
+    let module_id = enum_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let enum_ast = db.module_enum_by_id(enum_id)?;
 
@@ -150,7 +150,7 @@ fn enum_definition_data<'db>(
     db: &'db dyn Database,
     enum_id: EnumId<'db>,
 ) -> Maybe<EnumDefinitionData<'db>> {
-    let module_id = enum_id.module_id(db);
+    let module_id = enum_id.parent_module(db);
     let crate_id = module_id.owning_crate(db);
     let mut diagnostics = SemanticDiagnostics::default();
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path

--- a/crates/cairo-lang-semantic/src/items/extern_function.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_function.rs
@@ -37,7 +37,7 @@ fn extern_function_declaration_generic_params_data<'db>(
     db: &'db dyn Database,
     extern_function_id: ExternFunctionId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = extern_function_id.module_id(db);
+    let module_id = extern_function_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let extern_function_syntax = db.module_extern_function_by_id(extern_function_id)?;
     let declaration = extern_function_syntax.declaration(db);

--- a/crates/cairo-lang-semantic/src/items/extern_type.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_type.rs
@@ -38,7 +38,7 @@ fn extern_type_declaration_generic_params_data<'db>(
     db: &'db dyn Database,
     extern_type_id: ExternTypeId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = extern_type_id.module_id(db);
+    let module_id = extern_type_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let extern_type_syntax = db.module_extern_type_by_id(extern_type_id)?;
 

--- a/crates/cairo-lang-semantic/src/items/free_function.rs
+++ b/crates/cairo-lang-semantic/src/items/free_function.rs
@@ -37,7 +37,7 @@ fn free_function_generic_params_data<'db>(
     db: &'db dyn Database,
     free_function_id: FreeFunctionId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = free_function_id.module_id(db);
+    let module_id = free_function_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let free_function_syntax = db.module_free_function_by_id(free_function_id)?;
     let declaration = free_function_syntax.declaration(db);

--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -183,14 +183,14 @@ impl<'db> GenericFunctionId<'db> {
     /// Returns the ModuleId of the function's definition if possible.
     pub fn module_id(&self, db: &'db dyn Database) -> Option<ModuleId<'db>> {
         match self {
-            GenericFunctionId::Free(free_function) => Some(free_function.module_id(db)),
-            GenericFunctionId::Extern(extern_function) => Some(extern_function.module_id(db)),
+            GenericFunctionId::Free(free_function) => Some(free_function.parent_module(db)),
+            GenericFunctionId::Extern(extern_function) => Some(extern_function.parent_module(db)),
             GenericFunctionId::Impl(impl_generic_function_id) => {
                 // Return the module file of the impl containing the function.
                 if let ImplLongId::Concrete(concrete_impl_id) =
                     impl_generic_function_id.impl_id.long(db)
                 {
-                    Some(concrete_impl_id.impl_def_id(db).module_id(db))
+                    Some(concrete_impl_id.impl_def_id(db).parent_module(db))
                 } else {
                     None
                 }

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -264,7 +264,7 @@ fn generic_impl_param_trait<'db>(
     db: &'db dyn Database,
     generic_param_id: GenericParamId<'db>,
 ) -> Maybe<TraitId<'db>> {
-    let module_id = generic_param_id.module_id(db);
+    let module_id = generic_param_id.parent_module(db);
     let option_generic_params_syntax = generic_param_generic_params_list(db, generic_param_id)?;
     let generic_params_syntax = extract_matches!(
         option_generic_params_syntax,
@@ -305,7 +305,7 @@ fn generic_impl_param_shallow_trait_generic_args<'db>(
     generic_param_id: GenericParamId<'db>,
 ) -> Maybe<Vec<(GenericParamId<'db>, ShallowGenericArg<'db>)>> {
     let db: &dyn Database = db;
-    let module_id = generic_param_id.module_id(db);
+    let module_id = generic_param_id.parent_module(db);
     let mut diagnostics: cairo_lang_diagnostics::DiagnosticsBuilder<'_, SemanticDiagnostic<'_>> =
         SemanticDiagnostics::default();
     let parent_item_id = generic_param_id.generic_item(db);
@@ -363,7 +363,7 @@ fn generic_impl_param_shallow_trait_generic_args<'db>(
         .trait_generic_params_ids(trait_id)?
         .iter()
         .map(|param_syntax| {
-            GenericParamLongId(trait_id.module_id(db), param_syntax.stable_ptr(db)).intern(db)
+            GenericParamLongId(trait_id.parent_module(db), param_syntax.stable_ptr(db)).intern(db)
         })
         .collect::<Vec<_>>();
 
@@ -420,12 +420,12 @@ fn generic_param_data<'db>(
             )),
             diagnostics: diagnostics.build(),
             resolver_data: Arc::new(ResolverData::new(
-                generic_param_id.module_id(db),
+                generic_param_id.parent_module(db),
                 InferenceId::GenericParam(generic_param_id),
             )),
         });
     }
-    let module_id = generic_param_id.module_id(db);
+    let module_id = generic_param_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let parent_item_id = generic_param_id.generic_item(db);
     let lookup_item: LookupItemId<'_> = parent_item_id.into();

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -499,7 +499,7 @@ fn impl_def_generic_params_data<'db>(
     db: &'db dyn Database,
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = impl_def_id.module_id(db);
+    let module_id = impl_def_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
 
     let impl_ast = db.module_impl_by_id(impl_def_id)?;
@@ -536,7 +536,7 @@ fn impl_def_substitution<'db>(
 /// Implementation of [ImplSemantic::impl_def_trait].
 #[salsa::tracked]
 fn impl_def_trait<'db>(db: &'db dyn Database, impl_def_id: ImplDefId<'db>) -> Maybe<TraitId<'db>> {
-    let module_id = impl_def_id.module_id(db);
+    let module_id = impl_def_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
 
     let impl_ast = db.module_impl_by_id(impl_def_id)?;
@@ -565,7 +565,7 @@ fn impl_def_shallow_trait_generic_args_helper<'db>(
     db: &'db dyn Database,
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<Vec<(GenericParamId<'db>, ShallowGenericArg<'db>)>> {
-    let module_id = impl_def_id.module_id(db);
+    let module_id = impl_def_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
 
     let impl_ast = db.module_impl_by_id(impl_def_id)?;
@@ -598,7 +598,7 @@ fn impl_def_shallow_trait_generic_args_helper<'db>(
         .trait_generic_params_ids(trait_id)?
         .iter()
         .map(|param_syntax| {
-            GenericParamLongId(trait_id.module_id(db), param_syntax.stable_ptr(db)).intern(db)
+            GenericParamLongId(trait_id.parent_module(db), param_syntax.stable_ptr(db)).intern(db)
         })
         .collect::<Vec<_>>();
 
@@ -651,7 +651,7 @@ fn impl_alias_trait_generic_args_helper<'db>(
     db: &'db dyn Database,
     impl_alias_id: ImplAliasId<'db>,
 ) -> Maybe<Vec<(GenericParamId<'db>, ShallowGenericArg<'db>)>> {
-    let module_id = impl_alias_id.module_id(db);
+    let module_id = impl_alias_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
 
     let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
@@ -689,8 +689,11 @@ fn impl_alias_trait_generic_args_helper<'db>(
                     .generic_params(db)
                     .elements(db)
                     .map(|param_syntax| {
-                        GenericParamLongId(impl_def_id.module_id(db), param_syntax.stable_ptr(db))
-                            .intern(db)
+                        GenericParamLongId(
+                            impl_def_id.parent_module(db),
+                            param_syntax.stable_ptr(db),
+                        )
+                        .intern(db)
                     })
                     .collect::<Vec<_>>(),
             )
@@ -708,8 +711,11 @@ fn impl_alias_trait_generic_args_helper<'db>(
                     .generic_params(db)
                     .elements(db)
                     .map(|param_syntax| {
-                        GenericParamLongId(impl_alias.module_id(db), param_syntax.stable_ptr(db))
-                            .intern(db)
+                        GenericParamLongId(
+                            impl_alias.parent_module(db),
+                            param_syntax.stable_ptr(db),
+                        )
+                        .intern(db)
                     })
                     .collect::<Vec<_>>(),
             )
@@ -1203,7 +1209,7 @@ fn get_impl_based_on_single_impl_type<'db>(
     }
     let ty = db.impl_type_def_resolved_type(*impl_item_type_id).unwrap();
 
-    let module_id = impl_def_id.module_id(db);
+    let module_id = impl_def_id.parent_module(db);
     let generic_params = db.impl_def_generic_params(impl_def_id).unwrap();
     let generic_params_ids =
         generic_params.iter().map(|generic_param| generic_param.id()).collect();
@@ -1405,7 +1411,7 @@ fn impl_definition_data<'db>(
     db: &'db dyn Database,
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<ImplDefinitionData<'db>> {
-    let module_id = impl_def_id.module_id(db);
+    let module_id = impl_def_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
 
     let generic_params =
@@ -2492,7 +2498,7 @@ fn impl_type_def_generic_params_data<'db>(
     db: &'db dyn Database,
     impl_type_def_id: ImplTypeDefId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = impl_type_def_id.module_id(db);
+    let module_id = impl_type_def_id.parent_module(db);
     let impl_type_def_ast = db.impl_type_by_id(impl_type_def_id)?;
     let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Type(impl_type_def_id));
 
@@ -2921,7 +2927,7 @@ fn impl_impl_def_generic_params_data<'db>(
     db: &'db dyn Database,
     impl_impl_def_id: ImplImplDefId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = impl_impl_def_id.module_id(db);
+    let module_id = impl_impl_def_id.parent_module(db);
     let impl_impl_def_ast = db.impl_impl_by_id(impl_impl_def_id)?;
     let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Impl(impl_impl_def_id));
 
@@ -3219,7 +3225,7 @@ fn impl_function_generic_params_data<'db>(
     db: &'db dyn Database,
     impl_function_id: ImplFunctionId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = impl_function_id.module_id(db);
+    let module_id = impl_function_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let impl_def_id = impl_function_id.impl_def_id(db);
     let data = impl_definition_data(db, impl_def_id).maybe_as_ref()?;
@@ -3783,7 +3789,7 @@ fn uninferred_impl_trait_dependency<'db>(
         let mut diagnostics = SemanticDiagnostics::default();
         let (mut resolver, module_id, generic_params) = match impl_id {
             UninferredImpl::Def(impl_def_id) => {
-                let module_id = impl_def_id.module_id(db);
+                let module_id = impl_def_id.parent_module(db);
 
                 let impl_ast = db.module_impl_by_id(impl_def_id)?;
                 let inference_id = InferenceId::ImplDefTrait(impl_def_id);
@@ -3793,7 +3799,7 @@ fn uninferred_impl_trait_dependency<'db>(
                 (resolver, module_id, impl_ast.generic_params(db))
             }
             UninferredImpl::ImplAlias(impl_alias_id) => {
-                let module_id = impl_alias_id.module_id(db);
+                let module_id = impl_alias_id.parent_module(db);
 
                 let impl_ast = db.module_impl_alias_by_id(impl_alias_id)?;
                 let inference_id = InferenceId::ImplAliasImplDef(impl_alias_id);
@@ -3873,7 +3879,7 @@ fn module_global_impls<'db>(
                             global_impls_insert_generic_impls(
                                 db,
                                 &impl_ast.generic_params(db),
-                                impl_def_id.module_id(db),
+                                impl_def_id.parent_module(db),
                                 &mut module_impls.globals_by_trait,
                             );
                         }
@@ -3892,7 +3898,7 @@ fn module_global_impls<'db>(
                             global_impls_insert_generic_impls(
                                 db,
                                 &declaration.generic_params(db),
-                                free_function_id.module_id(db),
+                                free_function_id.parent_module(db),
                                 &mut module_impls.globals_by_trait,
                             );
                         }

--- a/crates/cairo-lang-semantic/src/items/impl_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/impl_alias.rs
@@ -140,7 +140,7 @@ fn impl_alias_generic_params_data<'db>(
     db: &'db dyn Database,
     impl_alias_id: ImplAliasId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = impl_alias_id.module_id(db);
+    let module_id = impl_alias_id.parent_module(db);
     let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
     impl_alias_generic_params_data_helper(
         db,
@@ -191,7 +191,7 @@ fn impl_alias_impl_def<'db>(
     db: &'db dyn Database,
     impl_alias_id: ImplAliasId<'db>,
 ) -> Maybe<ImplDefId<'db>> {
-    let module_id = impl_alias_id.module_id(db);
+    let module_id = impl_alias_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
     let inference_id = InferenceId::ImplAliasImplDef(impl_alias_id);
@@ -245,7 +245,7 @@ pub trait ImplAliasSemantic<'db>: Database {
     /// Returns the resolved type of a type alias.
     fn impl_alias_resolved_impl(&'db self, id: ImplAliasId<'db>) -> Maybe<ImplId<'db>> {
         let db = self.as_dyn_database();
-        if let Some(data) = db.cached_crate_semantic_data(id.module_id(db).owning_crate(db)) {
+        if let Some(data) = db.cached_crate_semantic_data(id.parent_module(db).owning_crate(db)) {
             if let Some(resolved_impl) = data.impl_aliases_resolved_impls.get(&id) {
                 return Ok(*resolved_impl);
             } else {

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -40,7 +40,7 @@ fn priv_macro_call_data<'db>(
     macro_call_id: MacroCallId<'db>,
 ) -> Maybe<MacroCallData<'db>> {
     let inference_id = InferenceId::MacroCall(macro_call_id);
-    let module_id = macro_call_id.module_id(db);
+    let module_id = macro_call_id.parent_module(db);
     let mut resolver = Resolver::new(db, module_id, inference_id);
     let macro_call_syntax = db.module_macro_call_by_id(macro_call_id)?;
     // Resolve the macro call path, and report diagnostics if it finds no match or

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -111,7 +111,7 @@ fn priv_macro_declaration_data<'db>(
 ) -> Maybe<MacroDeclarationData<'db>> {
     let mut diagnostics = SemanticDiagnostics::default();
 
-    let module_id = macro_declaration_id.module_id(db);
+    let module_id = macro_declaration_id.parent_module(db);
     let macro_declaration_syntax = db.module_macro_declaration_by_id(macro_declaration_id)?;
     if !are_user_defined_inline_macros_enabled(db, module_id) {
         diagnostics.report(

--- a/crates/cairo-lang-semantic/src/items/module_type_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/module_type_alias.rs
@@ -77,7 +77,7 @@ fn module_type_alias_generic_params_data<'db>(
     db: &'db dyn Database,
     module_type_alias_id: ModuleTypeAliasId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = module_type_alias_id.module_id(db);
+    let module_id = module_type_alias_id.parent_module(db);
     let type_alias_ast = db.module_type_alias_by_id(module_type_alias_id)?;
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::TypeAlias(module_type_alias_id));
 

--- a/crates/cairo-lang-semantic/src/items/structure.rs
+++ b/crates/cairo-lang-semantic/src/items/structure.rs
@@ -77,7 +77,7 @@ fn struct_generic_params_data<'db>(
     db: &'db dyn Database,
     struct_id: StructId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = struct_id.module_id(db);
+    let module_id = struct_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
@@ -127,7 +127,7 @@ fn struct_definition_data<'db>(
     db: &'db dyn Database,
     struct_id: StructId<'db>,
 ) -> Maybe<StructDefinitionData<'db>> {
-    let module_id = struct_id.module_id(db);
+    let module_id = struct_id.parent_module(db);
     let crate_id = module_id.owning_crate(db);
     let mut diagnostics = SemanticDiagnostics::default();
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -295,7 +295,7 @@ fn trait_generic_params_data<'db>(
     trait_id: TraitId<'db>,
     in_cycle: bool,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = trait_id.module_id(db);
+    let module_id = trait_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let trait_ast = db.module_trait_by_id(trait_id)?;
 
@@ -347,7 +347,7 @@ fn trait_generic_params_ids<'db>(
     db: &'db dyn Database,
     trait_id: TraitId<'db>,
 ) -> Maybe<Vec<GenericParamId<'db>>> {
-    let module_id = trait_id.module_id(db);
+    let module_id = trait_id.parent_module(db);
     let trait_ast = db.module_trait_by_id(trait_id)?;
 
     let generic_params = &trait_ast.generic_params(db);
@@ -595,7 +595,7 @@ fn priv_trait_definition_data<'db>(
     db: &'db dyn Database,
     trait_id: TraitId<'db>,
 ) -> Maybe<TraitDefinitionData<'db>> {
-    let module_id = trait_id.module_id(db);
+    let module_id = trait_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
 
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
@@ -734,7 +734,7 @@ fn priv_trait_type_generic_params_data<'db>(
     db: &'db dyn Database,
     trait_type_id: TraitTypeId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = trait_type_id.module_id(db);
+    let module_id = trait_type_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let trait_id = trait_type_id.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;
@@ -939,7 +939,7 @@ fn priv_trait_function_generic_params_data<'db>(
     db: &'db dyn Database,
     trait_function_id: TraitFunctionId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = trait_function_id.module_id(db);
+    let module_id = trait_function_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let trait_id = trait_function_id.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;

--- a/crates/cairo-lang-semantic/src/items/us.rs
+++ b/crates/cairo-lang-semantic/src/items/us.rs
@@ -53,7 +53,7 @@ fn priv_use_semantic_data<'db>(
     db: &'db dyn Database,
     use_id: UseId<'db>,
 ) -> Maybe<Arc<UseData<'db>>> {
-    let module_id = use_id.module_id(db);
+    let module_id = use_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let module_item_id = ModuleItemId::Use(use_id);
     let inference_id = InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(module_item_id));
@@ -180,7 +180,7 @@ fn priv_use_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     use_id: UseId<'db>,
 ) -> Maybe<Arc<UseData<'db>>> {
-    let module_id = use_id.module_id(db);
+    let module_id = use_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let use_ast = db.module_use_by_id(use_id)?;
     let err = Err(diagnostics.report(use_ast.stable_ptr(db), UseCycle));
@@ -260,7 +260,7 @@ fn priv_global_use_semantic_data<'db>(
     db: &'db dyn Database,
     global_use_id: GlobalUseId<'db>,
 ) -> Maybe<UseGlobalData<'db>> {
-    let module_id = global_use_id.module_id(db);
+    let module_id = global_use_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::default();
     let inference_id = InferenceId::GlobalUseStar(global_use_id);
     let star_ast = ast::UsePath::Star(db.module_global_use_by_id(global_use_id)?);

--- a/crates/cairo-lang-semantic/src/lookup_item.rs
+++ b/crates/cairo-lang-semantic/src/lookup_item.rs
@@ -65,7 +65,7 @@ impl<'db> LookupItemEx<'db> for LookupItemId<'db> {
             }
             LookupItemId::ModuleItem(item) => {
                 // Top level does not have an outer context, create an empty resolver data.
-                let module_id = item.module_id(db);
+                let module_id = item.parent_module(db);
                 let resolver_data = Arc::new(ResolverData::new(module_id, InferenceId::NoContext));
                 Ok(resolver_data)
             }
@@ -144,7 +144,7 @@ impl<'db> HasResolverData<'db> for ExternTypeId<'db> {
         let inference_id = InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(
             ModuleItemId::ExternType(*self),
         ));
-        Ok(Arc::new(ResolverData::new(self.module_id(db), inference_id)))
+        Ok(Arc::new(ResolverData::new(self.parent_module(db), inference_id)))
     }
 }
 

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -657,7 +657,7 @@ impl<'db> ShallowGenericArg<'db> {
     pub fn module_id(&self, db: &'db dyn Database) -> Option<ModuleId<'db>> {
         match self {
             ShallowGenericArg::GenericParameter(_) => None,
-            ShallowGenericArg::GenericType(ty) => Some(ty.module_id(db)),
+            ShallowGenericArg::GenericType(ty) => Some(ty.parent_module(db)),
             ShallowGenericArg::Snapshot(inner) => inner.module_id(db),
             ShallowGenericArg::Tuple => TypeLongId::Tuple(vec![]).module_id(db),
             ShallowGenericArg::FixedSizeArray => TypeLongId::FixedSizeArray {

--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -864,7 +864,7 @@ fn fetch_event_data<'db>(db: &'db dyn Database, event_type_id: TypeId<'db>) -> O
     let impl_def_id = concrete_event_impl.impl_def_id(db);
 
     // Attempt to extract the event data from the aux data from the impl generation.
-    let module_file = impl_def_id.module_id(db);
+    let module_file = impl_def_id.parent_module(db);
     let all_aux_data = module_file.module_data(db).ok()?.generated_file_aux_data(db);
     let aux_data = all_aux_data.get(&impl_def_id.stable_ptr(db).untyped().file_id(db))?.as_ref()?;
     Some(aux_data.0.as_any().downcast_ref::<StarknetEventAuxData>()?.event_data.clone())


### PR DESCRIPTION
Refactored `module_id()` to `parent_module()` in the language element ID trait to improve clarity and consistency.