### PR TITLE
 docs: fix grammatical errors and typos in comments

### DIFF
--- a/corelib/src/starknet/storage.cairo
+++ b/corelib/src/starknet/storage.cairo
@@ -31,7 +31,7 @@
 //! }
 //! ```
 //!
-//! Any type that implements the `Store` trait (or it's optimized `StorePacked` variant) can be used
+//! Any type that implements the `Store` trait (or its optimized `StorePacked` variant) can be used
 //! in storage.  This type can simply be derived using `#[derive(Store)]` - provided that all of the
 //! members of the type also implement `Store`.
 //!

--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -1267,7 +1267,7 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
         try_extract_matches!(self.var_info.get(&var_id)?, VarInfo::Const).copied()
     }
 
-    /// Return the const value as a int if it exists and is an integer.
+    /// Return the const value as an int if it exists and is an integer.
     fn as_int(&self, var_id: VariableId) -> Option<&BigInt> {
         match self.as_const(var_id)?.long(self.db) {
             ConstValue::Int(value, _) => Some(value),

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -394,7 +394,7 @@ fn add_unused_import_diagnostics<'db>(
 ) {
     let _iife = (|| {
         let item = db.use_resolved_item(use_id).ok()?;
-        // TODO(orizi): Properly handle usages of impls, and than add warnings on their usages as
+        // TODO(orizi): Properly handle usages of impls, and then add warnings on their usages as
         // well.
         require(!matches!(
             item,

--- a/crates/cairo-lang-semantic/src/expr/inference/solver.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/solver.rs
@@ -247,7 +247,7 @@ fn solve_candidate<'db>(
     let Ok(candidate_concrete_trait) = candidate.concrete_trait(db) else {
         return Err(super::ErrorSet);
     };
-    // If the candidate is fully concrete, or its a generic which is var free, there is nothing
+    // If the candidate is fully concrete, or it's a generic which is var free, there is nothing
     // to substitute. A generic param may not be var free, if it contains impl types.
     let candidate_final = matches!(candidate, UninferredImpl::GenericParam(_))
         && candidate_concrete_trait.is_var_free(db)


### PR DESCRIPTION
 Fixes common grammatical mistakes:
- 'as a int' -> 'as an int' (vowel sound)
- 'its' -> 'it's' confusion (possessive vs contraction)
- 'than' -> 'then' (sequence vs comparison)