### PR TITLE
docs: improve wording in statements documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/statements.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/statements.adoc
@@ -2,8 +2,8 @@
 
 Cairo is an expression-oriented language, where most syntax productions producing values or
 causing effects when evaluated are _expressions_.
-Many expressions can nest within each other, and the sequence of evaluation is driven by precedence
-and associativity rules.
+Many expressions can nest within each other, and the sequence of evaluation is driven by
+precedence and associativity rules.
 
 There are not a lot of statement kinds, whose role is limited to containing explicitly sequential
 xref:expression-statement.adoc[expression evaluation] and declaring xref:items.adoc[items]


### PR DESCRIPTION


## Changes

- Clarified the sentence about evaluation order by adding the missing article (`the sequence of evaluation`)
- Corrected `statements kinds, which role is` to the grammatically correct `statement kinds, whose role is`
