### PR TITLE
docs: fix grammar and wording issues in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 When contributing to this repository, please first discuss the change you wish to make via issue,
 email, or any other method with the owners of this repository before making a change.
-Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your
+Please note that we have a [code of conduct](CODE_OF_CONDUCT.md); please follow it in all your
 interactions with the project.
 
 ## Development environment setup
@@ -51,9 +51,9 @@ cargo run --bin cairo-test -- --single-file tests/test.cairo
 
 Three projects within the Compiler repository are tested with cairo-test:
 
-1. The Cairo core library: Run by running `cargo run --bin cairo-test -- corelib`.
-2. Bug samples: Run by running `cargo run --bin cairo-test -- tests/bug_samples --starknet`.
-3. Starknet features: Run by running: `cargo run --bin cairo-test -- crates/cairo-lang-starknet/cairo_level_tests --starknet`.
+1. The Cairo core library: Run `cargo run --bin cairo-test -- corelib`.
+2. Bug samples: Run `cargo run --bin cairo-test -- tests/bug_samples --starknet`.
+3. Starknet features: Run `cargo run --bin cairo-test -- crates/cairo-lang-starknet/cairo_level_tests --starknet`.
 
 ### Running Rust Tests
 


### PR DESCRIPTION


- **Grammar fix**: Added missing `that` and corrected punctuation in the code of conduct notice
  - Before: `Please note we have a [code of conduct], please follow it...`
  - After: `Please note that we have a [code of conduct]; please follow it...`

- **Wording improvement**: Removed redundant repetition in test running instructions
  - Before: `Run by running cargo run...`
  - After: `Run cargo run...`

