### PR TITLE
fix: grammar and formatting in contribution guidelines

### DIFF
--- a/docs/reference/src/components/cairo/modules/appendices/pages/contribution-guidelines.adoc
+++ b/docs/reference/src/components/cairo/modules/appendices/pages/contribution-guidelines.adoc
@@ -3,13 +3,13 @@
 When contributing to the Cairo repository, please first discuss the change you wish to make via
 issue, email, or any other method with the owners of this repository before making a change.
 
-Please note we have a link:https://github.com/starkware-libs/cairo/blob/main/docs/CODE_OF_CONDUCT.md[code of conduct], please follow it in all your
+Please note that we have a link:https://github.com/starkware-libs/cairo/blob/main/docs/CODE_OF_CONDUCT.md[code of conduct]; please follow it in all your
 interactions with the project.
 
 == Issues and feature requests
 
-You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new
-feature? Take a look at link:https://github.com/starkware-libs/cairo/discussions[GitHub Discussions] to see if it's already being discussed.  You can
+You've found a bug in the source code, a mistake in the documentation, or maybe you'd like a new
+feature? Take a look at link:https://github.com/starkware-libs/cairo/discussions[GitHub Discussions] to see if it's already being discussed. You can
 help us by link:https://github.com/starkware-libs/cairo/issues[submitting an issue on GitHub].
 Before you create an issue, make sure to search
 the issue archive - your issue may have already been addressed!


### PR DESCRIPTION


Fixed grammatical errors and formatting in contribution guidelines:
- Added missing `that` and proper punctuation
- Added missing comma before `or maybe`
- Removed double spaces

