### PR TITLE
docs: fix grammar errors in comments

### DIFF
--- a/corelib/src/circuit.cairo
+++ b/corelib/src/circuit.cairo
@@ -685,7 +685,7 @@ impl CircuitOutputsImpl<
 /// been verified.
 extern type CircuitFailureGuarantee;
 
-/// A type that contain that is used to guarantee that a u384 is less than another u384.
+/// A type that is used to guarantee that a u384 is less than another u384.
 extern type U96LimbsLtGuarantee<const LIMB_COUNT: usize>;
 
 /// Helper trait for finding the value of a const minus 1.

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -2029,7 +2029,8 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         }
     }
 
-    /// Parses a function call's argument, which contains possibly modifiers, and a argument clause.
+      /// Parses a function call's argument, which contains possibly modifiers, and an argument
+      /// clause.
     fn try_parse_function_argument(&mut self) -> TryParseResult<ArgGreen<'a>> {
         let modifiers_list = self.parse_modifier_list();
         let arg_clause = self.try_parse_argument_clause();


### PR DESCRIPTION
 - Fix duplicate word 'that contain that' in circuit.cairo
 - Fix article error 'a argument' → 'an argument' in parser.rs"