### PR TITLE
docs: fix grammar in ADR 003 simple trait system

### DIFF
--- a/adrs/003_simple_trait_system.md
+++ b/adrs/003_simple_trait_system.md
@@ -31,7 +31,7 @@ impl MyImpl<A> for MyTrait<A, felt252> {
 }
 ```
 This item introduces an implementation for this trait.
-Needs to implement exactly every associated type and function in the trait.
+It needs to implement exactly every associated type and function in the trait.
 
 ### Impl associated type and function
 ```


### PR DESCRIPTION


Fixed grammatical error in ADR documentation:
- Added missing subject `It` in implementation description

