### PR TITLE
docs: fix grammar in enum documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/enums.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/enums.adoc
@@ -64,7 +64,7 @@ let blue_hatchback = Car::Hatchback((Color::blue(()), 5));
 
 To inspect an enum variable, it can be matched using the `match` keyword.
 A match expression must have an arm for each variant of the enum, that specifies the logic that
-should happen in the case the enum variable holds that variant.
+should happen when the enum variable holds that variant.
 For example:
 
 [source,cairo]


### PR DESCRIPTION


Fixed a grammatical error in the enum documentation by replacing `in the case the enum variable` with `when the enum variable` for better readability and clarity.

