### PR TITLE
Doc and Grammar Improvements

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -2029,7 +2029,8 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         }
     }
 
-    /// Parses a function call's argument, which contains possibly modifiers, and a argument clause.
+    /// Parses a function call's argument, which contains possibly modifiers, and an argument
+    /// clause.
     fn try_parse_function_argument(&mut self) -> TryParseResult<ArgGreen<'a>> {
         let modifiers_list = self.parse_modifier_list();
         let arg_clause = self.try_parse_argument_clause();

--- a/crates/cairo-lang-sierra/src/extensions/modules/is_zero.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/is_zero.rs
@@ -8,7 +8,7 @@ use crate::extensions::lib_func::{
 use crate::extensions::{NoGenericArgsGenericLibfunc, OutputVarReferenceInfo, SpecializationError};
 use crate::ids::GenericTypeId;
 
-/// Trait for implementing a IsZero library function for a type.
+/// Trait for implementing an IsZero library function for a type.
 pub trait IsZeroTraits: Default {
     /// The is_zero library function id.
     const IS_ZERO: &'static str;


### PR DESCRIPTION
 Correcting indefinite article usage ("a" to "an") before vowel-initial words in comments:
  - `an IsZero` in `cairo-lang-sierra`
  - `an argument` in `cairo-lang-parser`