### PR TITLE
perf(parser): avoid String clone in MockTokenStream Display

### DIFF
--- a/crates/cairo-lang-parser/src/test_utils.rs
+++ b/crates/cairo-lang-parser/src/test_utils.rs
@@ -90,7 +90,7 @@ impl MockTokenStream {
 impl Display for MockTokenStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for token in &self.tokens {
-            write!(f, "{}", token.content.clone())?;
+            f.write_str(&token.content)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Replace write!(f, "{}", token.content.clone()) with f.write_str(&token.content) in test_utils.rs. This removes an unnecessary allocation per token and avoids formatting overhead while preserving output behavior. Cloning in to_primitive_token_stream remains, since 
PrimitiveToken requires owned String.