### PR TITLE
docs: clarify core_libfunc_ap_change unknown semantics

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -57,7 +57,7 @@ pub trait InvocationApChangeInfoProvider {
 }
 
 /// Returns the ap change for a core libfunc.
-/// Values with unknown values will return as None.
+/// Unknown ap changes are represented as `ApChange::Unknown`.
 pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
     libfunc: &CoreConcreteLibfunc,
     info_provider: &InfoProvider,


### PR DESCRIPTION
Clarified the documentation above core_libfunc_ap_change to describe unknown AP changes as ApChange::Unknown instead of mentioning None. The function has always returned Vec<ApChange>, and the old comment was a leftover from a previous API shape, which could mislead readers into expecting an Option-based interface.