### PR TITLE
fix (doc): mismatched closing quote

### DIFF
--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -178,7 +178,7 @@ impl<'a> DiagnosticEntry<'a> for ParserDiagnostic<'a> {
                 };
                 format!(
                     "Expected a '!' after the identifier '{identifier}' to start an inline macro.
-Did you mean to write `{identifier}!{left}...{right}'?",
+Did you mean to write '{identifier}!{left}...{right}'?",
                 )
             }
             ParserDiagnosticKind::ReservedIdentifier { identifier } => {


### PR DESCRIPTION
spotted a mismatched quote in the `ItemInlineMacroWithoutBang` message.  
the snippet started with a backtick and ended with a single quote.  
made them match. nothing else changed.
