### PR TITLE
fix: Improve error message grammar

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/error.rs
+++ b/crates/cairo-lang-sierra/src/extensions/error.rs
@@ -15,7 +15,7 @@ pub enum SpecializationError {
     WrongNumberOfGenericArgs,
     #[error("Provided generic argument is unsupported")]
     UnsupportedGenericArg,
-    #[error("index is out of a relevant range")]
+    #[error("index is out of the relevant range")]
     IndexOutOfRange {
         index: BigInt,
         /// Range is [0, range_size - 1]


### PR DESCRIPTION
Changed `"out of a relevant range"` → `"out of the relevant range"` for better grammar.