### PR TITLE
fix(lowering): correct unreachable! message in lower_while_body_expr

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/flow_control/lower_graph/lower_node.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/lower_graph/lower_node.rs
@@ -160,7 +160,7 @@ fn lower_while_body_expr<'db>(
     mut builder: BlockBuilder<'db>,
 ) -> Maybe<()> {
     let semantic::Expr::Block(expr) = ctx.ctx.function_body.arenas.exprs[node.body].clone() else {
-        unreachable!("WhileLet expression should be a block");
+        unreachable!("WhileBody expression should be a block");
     };
     let block_expr = lower_expr_block(ctx.ctx, &mut builder, &expr).and_then(|_| {
         recursively_call_loop_func(ctx.ctx, &mut builder, node.loop_expr_id, node.loop_stable_ptr)


### PR DESCRIPTION
The panic message mentioned "WhileLet" even though this code path handles WhileBody. This was likely a copy-paste mistake. The new message accurately reflects the context, improving debugging clarity without changing any behavior.