### PR TITLE
refactor: use Text instead of interpolate_patched for wrapper name

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/entry_point.rs
+++ b/crates/cairo-lang-starknet/src/plugin/entry_point.rs
@@ -159,10 +159,7 @@ pub fn handle_entry_point<'db, 'a>(
 
     let params = declaration.signature(db).parameters(db);
     let function_name = RewriteNode::from_ast_trimmed(&name_node);
-    let wrapper_function_name = RewriteNode::interpolate_patched(
-        &format!("{WRAPPER_PREFIX}{}", wrapper_identifier),
-        &[("function_name".into(), function_name.clone())].into(),
-    );
+    let wrapper_function_name = RewriteNode::Text(format!("{WRAPPER_PREFIX}{wrapper_identifier}"));
     match generate_entry_point_wrapper(
         db,
         item_function,


### PR DESCRIPTION
Replaced RewriteNode::interpolate_patched with RewriteNode::Text for wrapper_function_name construction. The previous code passed an unused mapping entry and performed unnecessary interpolation and allocation while the value had no placeholders. The new code preserves behavior and reduces overhead.