### PR TITLE
fix: remove redundant clone in sierra-generator utils

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/utils.rs
@@ -441,7 +441,7 @@ pub fn dummy_call_libfunc_id(
 
     let mut gargs = vec![];
 
-    gargs.push(GenericArg::UserFunc(function_id.clone()));
+    gargs.push(GenericArg::UserFunc(function_id));
 
     gargs.push(GenericArg::Value(
         match ap_change {


### PR DESCRIPTION
remove unnecessary `.clone()` call on `function_id` in `dummy_call_libfunc_id()`
all tests passed
