### PR TITLE
refactor: drop unnecessary clone in lifetime analysis

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/lifetime.rs
+++ b/crates/cairo-lang-sierra-generator/src/lifetime.rs
@@ -237,8 +237,7 @@ impl<'db> Analyzer<'db, '_> for VariableLifetimeContext<'_> {
         infos: impl Iterator<Item = Self::Info>,
     ) -> Self::Info {
         let arm_demands = zip_eq(match_info.arms(), infos)
-            .map(|(arm, demand)| {
-                let mut demand = demand;
+            .map(|(arm, mut demand)| {
                 self.introduce(
                     &mut demand,
                     &arm.var_ids,


### PR DESCRIPTION
`demand` is already owned from the iterator, no need to clone before mutating
