### PR TITLE
chore: fix MockTokenStream doc to reference ToPrimitiveTokenStream

### DIFF
--- a/crates/cairo-lang-parser/src/test_utils.rs
+++ b/crates/cairo-lang-parser/src/test_utils.rs
@@ -45,7 +45,7 @@ pub fn create_virtual_file<'a>(
     .intern(db)
 }
 
-/// Mocked struct which implements [crate::types::TokenStream]
+/// Mocked struct which implements [cairo_lang_primitive_token::ToPrimitiveTokenStream]
 /// Its main purpose is being used for testing the [crate::parser::Parser::parse_token_stream]
 #[derive(Debug, Clone)]
 pub struct MockTokenStream {


### PR DESCRIPTION
The previous doc link referenced a non-existent crate::types::TokenStream, which was misleading. The parser ecosystem uses cairo_lang_primitive_token::ToPrimitiveTokenStream as the canonical interface, and MockTokenStream implements that trait.