### PR TITLE
Override mapping from generated function name to attribute

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/entry_point.rs
+++ b/crates/cairo-lang-starknet/src/plugin/entry_point.rs
@@ -158,13 +158,12 @@ pub fn handle_entry_point<'db, 'a>(
     }
 
     let params = declaration.signature(db).parameters(db);
-    let function_name = RewriteNode::from_ast_trimmed(&name_node);
-    let wrapper_function_name = RewriteNode::Text(format!("{WRAPPER_PREFIX}{wrapper_identifier}"));
+    let wrapper_function_name = &format!("{WRAPPER_PREFIX}{wrapper_identifier}");
     match generate_entry_point_wrapper(
         db,
         item_function,
         wrapped_function_path,
-        wrapper_function_name.clone(),
+        RewriteNode::text(wrapper_function_name),
         generic_params,
         unsafe_new_contract_state_prefix,
     ) {
@@ -180,15 +179,11 @@ pub fn handle_entry_point<'db, 'a>(
                 }
                 EntryPointKind::External => &mut data.external_functions,
             };
+            let function_name = name_node.text(db).long(db);
             generated.push(
-                RewriteNode::interpolate_patched(
-                    "\n    pub use super::$wrapper_function_name$ as $function_name$;",
-                    &[
-                        ("wrapper_function_name".into(), wrapper_function_name),
-                        ("function_name".into(), function_name),
-                    ]
-                    .into(),
-                )
+                RewriteNode::text(&format!(
+                    "\n    pub use super::{wrapper_function_name} as {function_name};",
+                ))
                 .mapped(db, &trigger_attribute),
             );
         }


### PR DESCRIPTION
Semantically it's not the same function, therefore it should not be mapped back to the original function's name