### PR TITLE
fix: refine wording in never-type documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/never-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/never-type.adoc
@@ -1,4 +1,4 @@
 = Never type
 
-A _never type_ is a type of an expression that should not be evaluated in the encapsulating block,
+A _never type_ is a type of an expression that should not be evaluated within the enclosing block,
 but should cause a flow control change - this may be caused by `return` or `break` statements.


### PR DESCRIPTION
Clarify phrasing about evaluation context for the `never` type.
