### PR TITLE
Fix numeric literal example in path documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/path.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/path.adoc
@@ -42,10 +42,10 @@ Examples:
 fn foo<A, B>(a: A, b: B) { ... }
 
 fn main() {
-    foo::<bool, bool>(false, 3_u2); // OK
-    foo::<bool, _>(false, 3_u2);    // OK, B is inferred to be u32
-    foo::<bool>(false, 3_u2);       // OK, B is inferred to be u32
-    foo(false, 3_u2);               // OK, A, B are inferred as bool and u32 respectively
+    foo::<bool, bool>(false, 3_u32); // OK
+    foo::<bool, _>(false, 3_u32);    // OK, B is inferred to be u32
+    foo::<bool>(false, 3_u32);       // OK, B is inferred to be u32
+    foo(false, 3_u32);               // OK, A, B are inferred as bool and u32 respectively
 }
 ----
 


### PR DESCRIPTION
Correct the example generic call in `path.adoc` to use the valid `u32` suffix instead of `u2`.
