### PR TITLE
Clarify mutable variable wording in variables doc

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
@@ -26,7 +26,7 @@ let x = 5_u32;
 
 Variables are immutable unless declared otherwise.
 A variable can be declared as mutable using the `mut` keyword.
-A mutable variable can be link:assignment-statement.adoc[assigned] a different value after the initialization.
+A mutable variable can be link:assignment-statement.adoc[assigned] a different value after initialization.
 
 For example:
 [source]


### PR DESCRIPTION
 Fix the sentence about `mut` variables to remove the stray preposition.
