### PR TITLE
fix: polish path documentation examples

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/path.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/path.adoc
@@ -60,8 +60,8 @@ Option::<bool>::Some(true) // Enum variant expression
 ----
 
 * Type expressions
-- `let x: Option<bool> = None; // Let statement type clause`
-- `Option::<Option::<bool>>    // Generic type argument`
+- `let x: Option<bool> = None;` // Let statement type clause
+- `Option::<Option::<bool>>`    // Generic type argument
 
 * Trait expressions
 +


### PR DESCRIPTION
fix backticks in `path.adoc`.  
