### PR TITLE
fix: remove redundant DebugReplacer pass in cairo-run

### DIFF
--- a/crates/bin/cairo-run/src/main.rs
+++ b/crates/bin/cairo-run/src/main.rs
@@ -76,7 +76,6 @@ fn main() -> anyhow::Result<()> {
         .get_sierra_program(main_crate_ids.clone())
         .to_option()
         .context("Compilation failed without any diagnostics.")?
-        .clone();
     let replacer = DebugReplacer { db };
     if args.available_gas.is_none() && sierra_program.requires_gas_counter() {
         anyhow::bail!("Program requires gas counter, please provide `--available-gas` argument.");


### PR DESCRIPTION
The cairo-run binary was calling DebugReplacer::enrich_function_names on the Sierra program and then immediately applying DebugReplacer::apply, which already traverses all functions and updates their FunctionId debug names. This resulted in an unnecessary extra pass over the function list and redundant string allocations without changing behavior. The change drops the enrich_function_names call and relies solely on apply, keeping the observable semantics identical while reducing work.