### PR TITLE
fix: correct SyntaxNode::nth_parent documentation

### DIFF
--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -174,7 +174,7 @@ impl<'db> SyntaxNode<'db> {
         }
     }
 
-    /// Returns the stable pointer of the `n`th parent of this stable pointer.
+    /// Returns the `n`th parent of this syntax node.
     /// n = 0: returns itself.
     /// n = 1: return the parent.
     /// n = 2: return the grand parent.


### PR DESCRIPTION
The doc comment for SyntaxNode::nth_parent incorrectly referred to returning a stable pointer, while the method actually returns a SyntaxNode. This change aligns the documentation with the method’s signature and the stable pointer API, which is built on top of this node-level helper.