### PR TITLE
expose DocumentableItemSignatureData

### DIFF
--- a/crates/cairo-lang-doc/src/signature_data.rs
+++ b/crates/cairo-lang-doc/src/signature_data.rs
@@ -31,23 +31,75 @@ use crate::documentable_item::DocumentableItemId::Member;
 use crate::signature_errors::SignatureError;
 
 /// A helper struct gathering documentable item's signature data.
-pub(crate) struct DocumentableItemSignatureData<'db> {
-    pub(crate) item_id: DocumentableItemId<'db>,
-    pub(crate) name: SmolStrId<'db>,
-    pub(crate) visibility: Visibility,
-    pub(crate) generic_args: Option<Vec<GenericArgumentId<'db>>>,
-    pub(crate) generic_params: Option<Vec<GenericParam<'db>>>,
-    pub(crate) variants: Option<Vec<(SmolStrId<'db>, TypeId<'db>)>>,
-    pub(crate) members: Option<Vec<(SmolStrId<'db>, TypeId<'db>, Visibility)>>,
-    pub(crate) return_type: Option<TypeId<'db>>,
-    pub(crate) attributes: Option<Vec<Attribute<'db>>>,
-    pub(crate) params: Option<Vec<Parameter<'db>>>,
-    pub(crate) resolver_generic_params: Option<Vec<GenericParamId<'db>>>,
-    pub(crate) return_value_expr: Option<Expr<'db>>,
-    pub(crate) full_path: String,
+pub struct DocumentableItemSignatureData<'db> {
+    /// The item's identifier.
+    pub item_id: DocumentableItemId<'db>,
+    /// The item's simple name (last segment of its full path).
+    pub name: SmolStrId<'db>,
+    /// Visibility qualifier.
+    pub visibility: Visibility,
+    /// Concrete generic arguments applied to the item.
+    pub generic_args: Option<Vec<GenericArgumentId<'db>>>,
+    /// Generic parameters declared by the item.
+    pub generic_params: Option<Vec<GenericParam<'db>>>,
+    /// Enum variants for enum items: a list of pairs `(variant_name, variant_type)`.
+    pub variants: Option<Vec<(SmolStrId<'db>, TypeId<'db>)>>,
+    /// Struct members for struct items: a list of triples `(member_name, member_type,
+    /// visibility)`.
+    pub members: Option<Vec<(SmolStrId<'db>, TypeId<'db>, Visibility)>>,
+    /// Return type for function-like items.
+    pub return_type: Option<TypeId<'db>>,
+    /// Attributes attached to the item.
+    pub attributes: Option<Vec<Attribute<'db>>>,
+    /// Parameters for function-like items.
+    pub params: Option<Vec<Parameter<'db>>>,
+    /// Generic parameters coming from the resolver context.
+    pub resolver_generic_params: Option<Vec<GenericParamId<'db>>>,
+    /// The value expression for constant-like items.
+    pub return_value_expr: Option<Expr<'db>>,
+    /// Fully qualified path to the item.
+    pub full_path: String,
 }
 
-/// A utility function, retrieves [`ModuleItemInfo`] for [`ModuleItemId`].
+pub trait SignatureDataRetriever<'db, T> {
+    fn retrieve_signature_data(
+        db: &'db dyn Database,
+        item_id: T,
+    ) -> Result<DocumentableItemSignatureData<'db>, SignatureError>;
+}
+
+macro_rules! implement_signature_data_retriever {
+    ($t:ty, $function:expr) => {
+        impl<'db> SignatureDataRetriever<'db, $t> for $t {
+            fn retrieve_signature_data(
+                db: &'db dyn Database,
+                item_id: $t,
+            ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
+                $function(db, item_id)
+            }
+        }
+    };
+}
+
+implement_signature_data_retriever!(ExternTypeId<'db>, get_extern_type_full_signature);
+implement_signature_data_retriever!(ConstantId<'db>, get_constant_signature_data);
+implement_signature_data_retriever!(EnumId<'db>, get_enum_signature_data);
+implement_signature_data_retriever!(FreeFunctionId<'db>, get_free_function_signature_data);
+implement_signature_data_retriever!(ImplFunctionId<'db>, get_impl_function_signature_data);
+implement_signature_data_retriever!(MemberId<'db>, get_member_signature_data);
+implement_signature_data_retriever!(StructId<'db>, get_struct_signature_data);
+implement_signature_data_retriever!(TraitFunctionId<'db>, get_trait_function_signature_data);
+implement_signature_data_retriever!(TraitId<'db>, get_trait_signature_data);
+implement_signature_data_retriever!(ImplTypeDefId<'db>, get_impl_type_def_full_signature);
+implement_signature_data_retriever!(ModuleTypeAliasId<'db>, get_module_type_alias_full_signature);
+implement_signature_data_retriever!(TraitConstantId<'db>, get_trait_const_signature_data);
+implement_signature_data_retriever!(TraitTypeId<'db>, get_trait_type_full_signature);
+implement_signature_data_retriever!(ImplDefId<'db>, get_impl_def_signature_data);
+implement_signature_data_retriever!(ImplAliasId<'db>, get_impl_alias_signature_data);
+implement_signature_data_retriever!(ExternFunctionId<'db>, get_extern_function_full_signature);
+implement_signature_data_retriever!(ImplConstantDefId<'db>, get_impl_constant_signature_data);
+
+/// A utility function that retrieves [`ModuleItemInfo`] for [`ModuleItemId`].
 fn get_module_item_info<'db>(
     db: &'db dyn Database,
     module_item_id: ModuleItemId<'db>,
@@ -66,7 +118,7 @@ fn get_module_item_info<'db>(
 
 /// Retrieves data for enum signature formatting. Returns [`SignatureError`] if any relevant data
 /// could not be retrieved from db.
-pub(crate) fn get_enum_signature_data<'db>(
+fn get_enum_signature_data<'db>(
     db: &'db dyn Database,
     item_id: EnumId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -102,7 +154,7 @@ pub(crate) fn get_enum_signature_data<'db>(
 }
 
 /// Retrieves data for struct signature formatting.
-pub(crate) fn get_struct_signature_data<'db>(
+fn get_struct_signature_data<'db>(
     db: &'db dyn Database,
     item_id: StructId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -142,7 +194,7 @@ pub(crate) fn get_struct_signature_data<'db>(
 }
 
 /// Retrieves data for member signature formatting.
-pub(crate) fn get_member_signature_data<'db>(
+fn get_member_signature_data<'db>(
     db: &'db dyn Database,
     item_id: MemberId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -175,7 +227,7 @@ pub(crate) fn get_member_signature_data<'db>(
 }
 
 /// Retrieves data for free function signature formatting.
-pub(crate) fn get_free_function_signature_data<'db>(
+fn get_free_function_signature_data<'db>(
     db: &'db dyn Database,
     item_id: FreeFunctionId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -214,7 +266,7 @@ pub(crate) fn get_free_function_signature_data<'db>(
 }
 
 /// Retrieves data for trait function signature formatting.
-pub(crate) fn get_trait_function_signature_data<'db>(
+fn get_trait_function_signature_data<'db>(
     db: &'db dyn Database,
     item_id: TraitFunctionId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -263,7 +315,7 @@ pub(crate) fn get_trait_function_signature_data<'db>(
 }
 
 /// Retrieves data for impl function signature formatting.
-pub(crate) fn get_impl_function_signature_data<'db>(
+fn get_impl_function_signature_data<'db>(
     db: &'db dyn Database,
     item_id: ImplFunctionId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -293,7 +345,7 @@ pub(crate) fn get_impl_function_signature_data<'db>(
 }
 
 /// Retrieves data for constant signature formatting.
-pub(crate) fn get_constant_signature_data<'db>(
+fn get_constant_signature_data<'db>(
     db: &'db dyn Database,
     item_id: ConstantId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -324,7 +376,7 @@ pub(crate) fn get_constant_signature_data<'db>(
 }
 
 /// Retrieves data for impl constant signature formatting.
-pub(crate) fn get_impl_constant_signature_data<'db>(
+fn get_impl_constant_signature_data<'db>(
     db: &'db dyn Database,
     item_id: ImplConstantDefId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -352,7 +404,7 @@ pub(crate) fn get_impl_constant_signature_data<'db>(
 }
 
 /// Retrieves data for trait signature formatting.
-pub(crate) fn get_trait_signature_data<'db>(
+fn get_trait_signature_data<'db>(
     db: &'db dyn Database,
     item_id: TraitId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -381,7 +433,7 @@ pub(crate) fn get_trait_signature_data<'db>(
 }
 
 /// Retrieves data for trait const signature formatting.
-pub(crate) fn get_trait_const_signature_data<'db>(
+fn get_trait_const_signature_data<'db>(
     db: &'db dyn Database,
     item_id: TraitConstantId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -411,7 +463,7 @@ pub(crate) fn get_trait_const_signature_data<'db>(
 }
 
 /// Retrieves data for implementation signature formatting.
-pub(crate) fn get_impl_def_signature_data<'db>(
+fn get_impl_def_signature_data<'db>(
     db: &'db dyn Database,
     item_id: ImplDefId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -445,7 +497,7 @@ pub(crate) fn get_impl_def_signature_data<'db>(
 }
 
 /// Retrieves data for alias signature formatting.
-pub(crate) fn get_impl_alias_signature_data<'db>(
+fn get_impl_alias_signature_data<'db>(
     db: &'db dyn Database,
     item_id: ImplAliasId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -472,7 +524,7 @@ pub(crate) fn get_impl_alias_signature_data<'db>(
 }
 
 /// Retrieves data for type alias signature formatting.
-pub(crate) fn get_module_type_alias_full_signature<'db>(
+fn get_module_type_alias_full_signature<'db>(
     db: &'db dyn Database,
     item_id: ModuleTypeAliasId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -507,7 +559,7 @@ pub(crate) fn get_module_type_alias_full_signature<'db>(
 }
 
 /// Retrieves data for trait type signature formatting.
-pub(crate) fn get_trait_type_full_signature<'db>(
+fn get_trait_type_full_signature<'db>(
     db: &'db dyn Database,
     item_id: TraitTypeId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -533,7 +585,7 @@ pub(crate) fn get_trait_type_full_signature<'db>(
 }
 
 /// Retrieves data for type signature formatting.
-pub(crate) fn get_impl_type_def_full_signature<'db>(
+fn get_impl_type_def_full_signature<'db>(
     db: &'db dyn Database,
     item_id: ImplTypeDefId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -563,7 +615,7 @@ pub(crate) fn get_impl_type_def_full_signature<'db>(
 }
 
 /// Retrieves data for extern type signature formatting.
-pub(crate) fn get_extern_type_full_signature<'db>(
+fn get_extern_type_full_signature<'db>(
     db: &'db dyn Database,
     item_id: ExternTypeId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {
@@ -594,7 +646,7 @@ pub(crate) fn get_extern_type_full_signature<'db>(
 }
 
 /// Retrieves data for extern function signature formatting.
-pub(crate) fn get_extern_function_full_signature<'db>(
+fn get_extern_function_full_signature<'db>(
     db: &'db dyn Database,
     item_id: ExternFunctionId<'db>,
 ) -> Result<DocumentableItemSignatureData<'db>, SignatureError> {


### PR DESCRIPTION
partially closes https://github.com/software-mansion/scarb/issues/2840

This is a Scarb task but it turned out that LS also faces the problem where in some cases the custom logic needs to implemented for building an item signature. 
This PR aims at: 
- exposing some compiler logic so the same methods can be used by Scarb and LS,
- brings some minor redability improvements 