### PR TITLE
refactor: simplify type construction in sierra generator

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/expr_generator_context.rs
+++ b/crates/cairo-lang-sierra-generator/src/expr_generator_context.rs
@@ -141,7 +141,7 @@ impl<'db, 'a> ExprGeneratorContext<'db, 'a> {
                 self.db.intern_concrete_type(crate::db::SierraGeneratorTypeLongId::Regular(
                     ConcreteTypeLongId {
                         generic_id: UninitializedType::ID,
-                        generic_args: vec![GenericArg::Type(inner_type.clone())],
+                        generic_args: vec![GenericArg::Type(inner_type)],
                     }
                     .into(),
                 ))


### PR DESCRIPTION
Pass `inner_type` directly to `GenericArg::Type()` instead of cloning, as it's not used afterward.