### PR TITLE
chore: remove obsolete TODO from location marks

### DIFF
--- a/crates/cairo-lang-filesystem/src/location_marks.rs
+++ b/crates/cairo-lang-filesystem/src/location_marks.rs
@@ -35,7 +35,6 @@ pub fn get_location_marks(
 
 /// Given a single line diagnostic location, returns a string with the location marks.
 fn get_single_line_location_marks(db: &dyn Database, location: &SpanInFile<'_>) -> String {
-    // TODO(ilya, 10/10/2023): Handle locations which spread over a few lines.
     let content = db.file_content(location.file_id).expect("File missing from DB.");
     let summary = db.file_summary(location.file_id).expect("File missing from DB.");
     let span = &location.span;


### PR DESCRIPTION
Remove an outdated TODO comment in get_single_line_location_marks which incorrectly states that multiline locations are not handled. Multiline spans are already supported via get_multiple_lines_location_marks and invoked from get_location_marks,
so the comment is misleading and no longer accurate.