### PR TITLE
fix: outdated function name in PushValues panic

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/program_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator.rs
@@ -52,7 +52,10 @@ fn collect_and_generate_libfunc_declarations<'db>(
             pre_sierra::Statement::Sierra(program::GenStatement::Return(_))
             | pre_sierra::Statement::Label(_) => None,
             pre_sierra::Statement::PushValues(_) => {
-                panic!("Unexpected pre_sierra::Statement::PushValues in collect_used_libfuncs().")
+                panic!(
+                    "Unexpected pre_sierra::Statement::PushValues in \
+                     collect_and_generate_libfunc_declarations()."
+                )
             }
         })
         .collect()


### PR DESCRIPTION
Update the panic message in collect_and_generate_libfunc_declarations to reference the current function name instead of the old collect_used_libfuncs. This keeps diagnostics consistent with the implementation and makes it easier to trace unexpected PushValues handling back to the correct function during debugging.