### PR TITLE
fix: clarify ap_cell_ref comment

### DIFF
--- a/crates/cairo-lang-casm/src/operand.rs
+++ b/crates/cairo-lang-casm/src/operand.rs
@@ -89,7 +89,7 @@ impl Display for CellRef {
     }
 }
 
-/// Returns an AP DerefOperand with the given offset.
+/// Returns a CellRef referencing AP with the given offset.
 pub fn ap_cell_ref(offset: i16) -> CellRef {
     CellRef { register: Register::AP, offset }
 }


### PR DESCRIPTION
The comment above ap_cell_ref still referred to an old DerefOperand name, while the function actually returns a CellRef. This mismatch could confuse readers and contributors when they navigate the CASM operand helpers. The comment was updated to explicitly state that the helper returns a CellRef referencing AP with the given offset, without changing any runtime behavior.