### PR TITLE
refactor: remove unnecessary clone in snapshot type construction

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/types.rs
+++ b/crates/cairo-lang-sierra-generator/src/types.rs
@@ -148,7 +148,7 @@ pub fn get_concrete_long_type_id<'db>(
             } else {
                 ConcreteTypeLongId {
                     generic_id: "Snapshot".into(),
-                    generic_args: vec![SierraGenericArg::Type(inner_ty.clone())],
+                    generic_args: vec![SierraGenericArg::Type(inner_ty)],
                 }
                 .into()
             }


### PR DESCRIPTION
Removes an unnecessary `clone()` call in `types.rs:151` where `inner_ty` is consumed immediately after, making the clone
   redundant since the variable is not used afterward.