### PR TITLE
docs: fix CfgSet::iter() documentation order description

### DIFF
--- a/crates/cairo-lang-filesystem/src/cfg.rs
+++ b/crates/cairo-lang-filesystem/src/cfg.rs
@@ -107,7 +107,9 @@ impl CfgSet {
         Self(self.0.union(&other.0).cloned().collect())
     }
 
-    /// An iterator visiting all elements in insertion order.
+    /// An iterator visiting all elements in ascending sorted order.
+    ///
+    /// Elements are returned in order according to the `Ord` implementation of `Cfg`.
     pub fn iter(&self) -> impl Iterator<Item = &Cfg> {
         self.0.iter()
     }


### PR DESCRIPTION
The documentation incorrectly stated that iter() returns elements in insertion order, but BTreeSet actually returns them in sorted order according to Cfg's Ord implementation. 
Updated the docs to accurately reflect the sorted iteration behavior.