### PR TITLE
perf(lowering-cache): avoid unnecessary Arc and clone in crate cache

### DIFF
--- a/crates/cairo-lang-lowering/src/cache/mod.rs
+++ b/crates/cairo-lang-lowering/src/cache/mod.rs
@@ -159,14 +159,14 @@ pub fn generate_crate_cache<'db>(
         .iter()
         .filter_map(|id| {
             db.function_body(*id).ok()?;
-            let multi = match lower_semantic_function(db, *id).map(Arc::new) {
+            let multi = match lower_semantic_function(db, *id) {
                 Ok(multi) => multi,
                 Err(err) => return Some(Err(err)),
             };
 
             Some(Ok((
                 DefsFunctionWithBodyIdCached::new(*id, &mut ctx.semantic_ctx),
-                MultiLoweringCached::new((*multi).clone(), &mut ctx),
+                MultiLoweringCached::new(multi, &mut ctx),
             )))
         })
         .collect::<Maybe<Vec<_>>>()?;


### PR DESCRIPTION
Remove the redundant Arc::new + clone around MultiLowering in generate_crate_cache and pass MultiLowering by value directly into MultiLoweringCached::new. This avoids an extra heap allocation and a full deep clone of the lowering data per function while preserving the same behavior and error handling.