### PR TITLE
docs: document missing cairo-run command-line options

### DIFF
--- a/crates/cairo-lang-runner/README.md
+++ b/crates/cairo-lang-runner/README.md
@@ -29,6 +29,14 @@ fn fib(a: u128, b: u128, n: u128) -> u128 {
 }
 ```
 
+# Command-Line Options
+
+- `--single-file` - Treat the path as a single file instead of a project directory.
+- `--available-gas <amount>` - Set the amount of gas available for execution.
+- `--print-full-memory` - Print the full memory state after execution.
+- `--allow-warnings` - Allow the compilation to succeed even with warnings.
+- `--run-profiler` - Run the profiler and display profiling information.
+
 # Additional Information
 
 - When compiling with --available-gas, if there are cycles in the code, calls to


### PR DESCRIPTION
Added documentation for --allow-warnings and --run-profiler flags that were missing from the cairo-run README. These options exist in the code but weren't documented anywhere, which could confuse users trying to figure out what's available.

Also added a dedicated "Command-Line Options" section listing all available flags in one place for better discoverability.