### PR TITLE
chore: remove unused std::vec import from split_structs

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/split_structs.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/split_structs.rs
@@ -2,8 +2,6 @@
 #[path = "split_structs_test.rs"]
 mod test;
 
-use std::vec;
-
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::{Itertools, zip_eq};


### PR DESCRIPTION
The split_structs optimization module was importing std::vec but never using the vec module directly (no vec::Vec, vec::IntoIter, etc.). Vec and the vec! macro come from the standard prelude in this workspace (Rust 2024 edition, no no_std or no_implicit_prelude), so this import was effectively dead code. Removing it cleans up the imports without changing behavior or semantics of the optimization.