### PR TITLE
fix: alias example wording in impl aliases page

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/aliases.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/aliases.adoc
@@ -27,7 +27,7 @@ Examples:
 [source,cairo]
 ----
 // Pow implementation for any algebra.
-impl AnyAlgebraPow<A, impl AlgImp: Algebra<A>> of Pow<A> { ... }
+impl AnyAlgebraPow<A, impl AlgImpl: Algebra<A>> of Pow<A> { ... }
 
 // Impl alias for Pow of i32.
 impl Int32Pow = AnyAlgebraPow<i32, I32Algebra>;


### PR DESCRIPTION
correct the impl alias example to use a consistent AlgImpl name
