### PR TITLE
Use diagnostics.is_empty to avoid extra allocation in macro_helpers

### DIFF
--- a/crates/cairo-lang-parser/src/macro_helpers.rs
+++ b/crates/cairo-lang-parser/src/macro_helpers.rs
@@ -35,7 +35,7 @@ pub fn token_tree_as_wrapped_arg_list<'a>(
         );
     };
     let diagnostics = diagnostics.build();
-    if !diagnostics.get_all().is_empty() {
+    if !diagnostics.is_empty() {
         return None;
     }
     Some(wrapped_arg_list_green)


### PR DESCRIPTION
replace get_all().is_empty() with is_empty() in token_tree_as_wrapped_arg_list to skip building a Vec, keeps the same behavior while removing redundant work and allocations