### PR TITLE
fix: avoid repeated allocation of unknown cairo function name

### DIFF
--- a/crates/cairo-lang-runner/src/profiling.rs
+++ b/crates/cairo-lang-runner/src/profiling.rs
@@ -655,14 +655,14 @@ impl<'a> ProfilingInfoProcessor<'a> {
         require(params.process_by_cairo_function)?;
 
         let mut cairo_functions = UnorderedHashMap::<_, _>::default();
-        let unknown_function_identifier = "unknown".to_string();
         for (statement_idx, weight) in sierra_statement_weights {
             // TODO(Gil): Fill all the `Unknown functions` in the Cairo functions profiling.
             let function_identifier = self
                 .statements_functions
                 .get(statement_idx)
-                .unwrap_or(&unknown_function_identifier)
-                .clone();
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+
             *(cairo_functions.entry(function_identifier).or_insert(0)) += weight;
         }
 


### PR DESCRIPTION
Use a single preallocated "unknown" String as the fallback function identifier in process_cairo_function_weights instead of calling unwrap_or(&"unknown".to_string()). unwrap_or evaluates its argument eagerly, which previously caused an extra heap allocation on every iteration even when a real function name was present. Reusing one String preserves the existing behavior while removing unnecessary allocations in the profiling hot path.