### PR TITLE
feat: implement ToSpanTrait for Span<T> to return self

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -645,6 +645,15 @@ pub trait ToSpanTrait<C, T> {
     fn span(self: @C) -> Span<T>;
 }
 
+
+impl SpanToSpan<T> of ToSpanTrait<Span<T>, T> {
+    /// Returns self. Useful for generic code.
+    #[inline]
+    fn span(self: @Span<T>) -> Span<T> {
+        *self
+    }
+}
+
 impl ArrayToSpan<T> of ToSpanTrait<Array<T>, T> {
     /// Returns a `Span<T>` corresponding to a view into an `Array<T>`.
     #[inline]


### PR DESCRIPTION
Gave Span the ToSpanTrait to help with generics eg:

```rust
    fn do_something_on_many<TS, T, +ToSpanTrait<TS, T>>(collection: TS){
        collection.to_span().into_iter().map(|c| c.do_something())
   }
```

Where `do_something_on_many` can take `Span<T>`, `Array<T>` or `[T; N]` and in some cases of `[T; N]` It can solve the Non zero complier issues  
