### PR TITLE
Fix preposition in use item placement guidance

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/use.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/use.adoc
@@ -22,7 +22,7 @@ fn main() {
 The syntax for `use` is `use path::to::item;`, where `path::to::item` is as described in
 xref:path.adoc[Paths].
 The position of the `use` item does not matter (like any other item), but it is recommended to put
-them in the beginning of the module.
+them at the beginning of the module.
 
 == Aliasing
 


### PR DESCRIPTION
Aligns wording to “at the beginning of the module” in `use.adoc`.