### PR TITLE
Fix incorrect assertion in variables documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
@@ -51,7 +51,7 @@ fn test() {
     let x = 1;
     let y = 2;
     assert(add(x, y) == 3, 'Should be equal.');
-    assert(y == 1, 'Should be equal.');
+    assert(y == 2, 'Should be equal.');
 }
 ----
 


### PR DESCRIPTION
Correct assertion in function parameter example, value should remain 2 since `mut` parameter does not modify caller's variable.