### PR TITLE
Remove obsolete pattern TODO comments from cairo_spec

### DIFF
--- a/crates/cairo-lang-syntax-codegen/src/cairo_spec.rs
+++ b/crates/cairo-lang-syntax-codegen/src/cairo_spec.rs
@@ -291,8 +291,6 @@ pub fn get_spec() -> Vec<Node> {
     )
     .add_struct(StructBuilder::new("WrappedArgListMissing"))
     // ---Patterns ---
-    // TODO(spapini): Support "Or" patterns (e.g. 1 | 2).
-    // TODO(spapini): Support tuple patterns (e.g. (x, _)).
     .add_enum(EnumBuilder::new("Pattern")
         .node_with_explicit_kind("Underscore", "TerminalUnderscore")
         .node_with_explicit_kind("Literal", "TerminalLiteralNumber")


### PR DESCRIPTION
Delete outdated TODOs about Or and tuple patterns in cairo_spec.rs, since both pattern kinds are already fully supported and exercised in parser, semantic, and lowering tests.