### PR TITLE
Clarify wording in array expressions docs

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc
@@ -29,8 +29,8 @@ Only one form is used at a time. Mixing both (e.g., `[a, b; 3]`) is not valid.
   repeating the single element expression.
 - The element expression in the repeat form is evaluated according to the language’s
   evaluation rules; refer to xref:expressions.adoc[Expressions] for general evaluation
-  order. Do not rely on side effects repeating unless guaranteed by the semantics of the
-  expression and compiler.
+  order. Do not rely on side effects being repeated unless guaranteed by the semantics of
+  the expression and compiler.
 - Empty arrays (`[]`) require type context to determine the element type. Where no such context
   exists, a type annotation is typically required.
 
@@ -68,4 +68,3 @@ Invalid examples (illustrative):
 - xref:array-types.adoc[Array types] (🚧)
 - xref:slice-types.adoc[Slice types] (🚧)
 - xref:tuple-expressions.adoc[Tuple expressions]
-


### PR DESCRIPTION
Description:
  - Refines the sentence about repeat-form side effects to use proper wording.
  