### PR TITLE
docs: clarify side-effect policy in early_unsafe_panic

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic.rs
@@ -62,7 +62,8 @@ pub struct UnsafePanicContext<'db> {
     /// The list of blocks where we can insert unsafe_panic.
     fixes: Vec<(StatementLocation, LocationId<'db>)>,
 
-    /// libfuncs with side effects that we need to ignore.
+    /// libfuncs with side effects that must be prevented from executing when return is
+    /// unreachable.
     libfuncs_with_sideffect: HashSet<ExternFunctionId<'db>>,
 }
 


### PR DESCRIPTION
The comment now explains that the listed libfuncs are considered side-effecting and must be prevented from executing when a return is unreachable. This aligns documentation with the existing logic in has_side_effects and visit_stmt, avoiding confusion for future maintainers.