### PR TITLE
docs(eq-solver): fix const expression docs in Expr

### DIFF
--- a/crates/cairo-lang-eq-solver/src/expr.rs
+++ b/crates/cairo-lang-eq-solver/src/expr.rs
@@ -17,12 +17,12 @@ pub struct Expr<Var: Clone + Debug + Eq + Hash> {
     pub var_to_coef: OrderedHashMap<Var, i64>,
 }
 impl<Var: Clone + Debug + Eq + Hash> Expr<Var> {
-    /// Creates a cost expression based on const value only.
+    /// Creates a const expression based on const value only.
     pub fn from_const(const_term: i32) -> Self {
         Self { const_term, var_to_coef: Default::default() }
     }
 
-    /// Creates a cost expression based on variable only.
+    /// Creates a const expression based on variable only.
     pub fn from_var(var: Var) -> Self {
         Self { const_term: 0, var_to_coef: [(var, 1)].into_iter().collect() }
     }


### PR DESCRIPTION
The constructor doc comments used the term “cost expression”, which is misleading in this context and can be confused with cost modeling. Updated the wording to “const expression” to accurately describe what these helpers construct.