### PR TITLE
Fix quote style in code examples

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/lvalue.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/lvalue.adoc
@@ -2,7 +2,7 @@
 
 An `lvalue` is a syntax element that represents a target that can be assigned values.
 The syntax of an `lvalue` is a member-path: A sequence of identifiers separated by dots.
-Example: 'a', `foo.bar.baz`.
+Example: `a`, `foo.bar.baz`.
 
 The first identifier must be a mutable xref:let-statement.adoc[local variable]
 (defined with the `mut` keyword).

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/match-expressions.adoc
@@ -58,4 +58,4 @@ match felt_var {
 ----
 
 Where `felt_var` is a xref:felt252-type.adoc[felt252] and the match patterns are the
-xref:literal-expressions.adoc[literal] '0' and wildcard '_' (which matches any value).
+xref:literal-expressions.adoc[literal] `0` and wildcard `_` (which matches any value).


### PR DESCRIPTION
Replace single quotes with backticks for code literals, maintaining consistent inline code formatting.