### PR TITLE
chore: remove unused vec import

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/starknet_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/starknet_libfunc_cost_base.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cairo_lang_sierra::extensions::starknet::StarknetConcreteLibfunc;
 use cairo_lang_sierra::extensions::starknet::secp256::{
     Secp256ConcreteLibfunc, Secp256OpConcreteLibfunc,


### PR DESCRIPTION
Remove the unused std::vec import from starknet_libfunc_cost_base.rs to clean up the module and silence the compiler's unused import warning, without changing any runtime behavior or gas cost logic.