### PR TITLE
Fix preposition in module scope description

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/modules-and-source-files.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/modules-and-source-files.adoc
@@ -37,7 +37,7 @@ referred to using the `super` keyword. The root module of a crate has no parent.
 
 == Module scope
 Items defined inside a module are directly available within the module.
-In particular, items defined at outer modules are not directly available in inner modules, even when
+In particular, items defined in outer modules are not directly available in inner modules, even when
 inlined. To refer to an item defined in another module, the item must be either fully qualified or
 imported with the xref:use.adoc[`use`] keyword. For more information, see xref:path.adoc[Paths].
 


### PR DESCRIPTION
Description:
  - Updates wording to "items defined in outer modules" for correct preposition usage.
 