### PR TITLE
docs: complete functions documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
@@ -185,6 +185,8 @@ fn add_one(x: u32) -> u32 {
 
 Inline behavior:
 
+* `#[inline(always)]` — Always inline this function
+* `#[inline(never)]` — Never inline this function
 * `#[inline]` — Attempt to inline - but compiler may decide to not do so.
 * No annotation - Let the compiler decide based on optimization heuristics.
 


### PR DESCRIPTION
Removed TODO comments and added sections on methods/self parameters, function attributes (inline, implicits, nopanic) and local compilability with examples from corelib.