### PR TITLE
Fix documentation syntax and formatting issues

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/boolean-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/boolean-types.adoc
@@ -1,10 +1,10 @@
 = Boolean types
 
-The boolean type represents a logical value of either true or false.
+The boolean type represents a logical value of either `true` or `false`.
 It is represented by the keyword `bool`. Values of this type are created using the
 keywords `true` and `false`.
 
-== Operators ==
+== Operators
 The following operators are defined for the boolean type:
 
 [options="header"]
@@ -18,7 +18,7 @@ The following operators are defined for the boolean type:
 | `!=`     | Inequality     | `x != y`
 |===
 
-== Examples ==
+== Examples
 [source,rust]
 ----
 fn main() {

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/integer-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/integer-types.adoc
@@ -25,7 +25,7 @@ fn main() {
     let x: u8 = 10_u8;
     let y = 0xff_u64;
     // let z = 10_u256; // Error: u256 literals are not supported
-    let z: u256 = u256 { high: 0_u128, low: 10_u128 } // 10 in u256 type
+    let z: u256 = u256 { high: 0_u128, low: 10_u128 }; // 10 in u256 type
 }
 ----
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/tuple-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/tuple-expressions.adoc
@@ -14,5 +14,5 @@ Examples:
 | ()                            | ()
 | (1_u32,)                      | (u32,)
 | (1_u32, Some(3_u8))           | (u32, Option<u8>)
-| (True, False, 'abc')          | (bool, bool, felt252)
+| (true, false, 'abc')          | (bool, bool, felt252)
 |===


### PR DESCRIPTION
Fixes 5 documentation issues identified in comprehensive scan:

- **boolean-types.adoc**: Added missing code formatting for `true`/`false` literals and corrected AsciiDoc header syntax
- **integer-types.adoc**: Added missing semicolon in u256 example code
- **tuple-expressions.adoc**: Fixed capitalized boolean literals (`True`/`False` → `true`/`false`)