### PR TITLE
fix: grammar and articles in function and path expression docs

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/path-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/path-expressions.adoc
@@ -4,6 +4,6 @@ A path expression is a standalone xref:path.adoc[concrete path].
 It resolves to one of these items:
 
 * A local variable. In this case the path is a single identifier.
-* An xref:constant-items.adoc[constant item].
+* A xref:constant-items.adoc[constant item].
 * A generic const parameter. In this case the path is a single identifier.
   These are still unsupported.


### PR DESCRIPTION

  - Fixes article usage: `An xref:constant-items...` in `path-expressions.adoc`.
  - Improves wording: `See an example of calling it below` in `functions.adoc`.
