### PR TITLE
fix: remove unused peekable call in patcher

### DIFF
--- a/crates/cairo-lang-defs/src/patcher.rs
+++ b/crates/cairo-lang-defs/src/patcher.rs
@@ -155,7 +155,7 @@ impl<'db> RewriteNode<'db> {
         code: &str,
         patches: &UnorderedHashMap<String, RewriteNode<'db>>,
     ) -> RewriteNode<'db> {
-        let mut chars = code.chars().peekable();
+        let mut chars = code.chars();
         let mut pending_text = String::new();
         let mut children = Vec::new();
         while let Some(c) = chars.next() {


### PR DESCRIPTION
Remove unnecessary `.peekable()` call in `RewriteNode::interpolate_patched`.

The iterator was converted to `Peekable` but `.peek()` was never called - only `.next()` and `.by_ref()` are used.