### PR TITLE
Make all functions debug info extraction parallel

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info.rs
+++ b/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info.rs
@@ -29,7 +29,8 @@ use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use salsa::Database;
+use itertools::Itertools;
+use salsa::{Database, par_map};
 
 use crate::debug_info::function_debug_info::serializable::{
     CairoVariableName, SerializableAllFunctionsDebugInfo, SerializableFunctionDebugInfo,
@@ -52,17 +53,15 @@ impl<'db> AllFunctionsDebugInfo<'db> {
         &self,
         db: &'db dyn Database,
     ) -> SerializableAllFunctionsDebugInfo {
-        SerializableAllFunctionsDebugInfo(
-            self.0
-                .iter()
-                .filter_map(|(function_id, function_debug_info)| {
-                    Some((
-                        SierraFunctionId(function_id.id),
-                        function_debug_info.extract_serializable_debug_info(db)?,
-                    ))
-                })
-                .collect(),
-        )
+        let all_functions_debug_info: Vec<
+            Option<(SierraFunctionId, SerializableFunctionDebugInfo)>,
+        > = par_map(db, self.0.iter().collect_vec(), |db, (function_id, function_debug_info)| {
+            Some((
+                SierraFunctionId(function_id.id),
+                function_debug_info.extract_serializable_debug_info(db)?,
+            ))
+        });
+        SerializableAllFunctionsDebugInfo(all_functions_debug_info.into_iter().flatten().collect())
     }
 }
 


### PR DESCRIPTION
On OZ presets: 

Before:
<img width="916" height="188" alt="image" src="https://github.com/user-attachments/assets/9484ea57-a596-43cf-87b7-81ef95da2b00" />


After: 
<img width="1324" height="506" alt="image" src="https://github.com/user-attachments/assets/c4f69b16-7eaa-494c-8a15-fceecdcba102" />
