### PR TITLE
perf: use cached kind for terminal checks

### DIFF
--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -488,7 +488,7 @@ impl<'a> SyntaxNode<'a> {
     /// Gets all the leaves of the SyntaxTree, where the self node is the root of a tree.
     pub fn tokens(&self, db: &'a dyn Database) -> impl Iterator<Item = Self> + 'a {
         self.preorder(db).filter_map(|event| match event {
-            WalkEvent::Enter(node) if node.green_node(db).kind.is_terminal() => Some(node),
+            WalkEvent::Enter(node) if node.kind(db).is_terminal() => Some(node),
             _ => None,
         })
     }

--- a/crates/cairo-lang-syntax/src/node/with_db.rs
+++ b/crates/cairo-lang-syntax/src/node/with_db.rs
@@ -58,7 +58,7 @@ impl<'a> Iterator for SyntaxNodeWithDbIterator<'a> {
             // This represents a single step of the depth-first traversal of a syntax tree.
             // If the node is a terminal, it creates and saves token representation of it.
             // Otherwise, it pushes all children of the node onto the iteration stack.
-            if node.green_node(self.db).kind.is_terminal() {
+            if node.kind(self.db).is_terminal() {
                 token_from_syntax_node(node, self.db, &mut self.buffer);
             } else {
                 self.iter_stack.extend(node.get_children(self.db).iter().rev());


### PR DESCRIPTION
Replace terminal checks based on green_node(db).kind with SyntaxNode::kind(db) to rely on the cached kind field instead of querying Salsa each time. This keeps the behavior identical while avoiding unnecessary database lookups during syntax tree traversal.