### PR TITLE
Fix (docs) AST specification wording

### DIFF
--- a/crates/cairo-lang-syntax-codegen/src/spec.rs
+++ b/crates/cairo-lang-syntax-codegen/src/spec.rs
@@ -36,7 +36,7 @@ pub struct Variant {
     pub kind: String,
 }
 
-// Helpers to build AST specification.
+// Helpers to build AST specifications.
 
 /// Builds a spec for a struct node.
 pub struct StructBuilder {


### PR DESCRIPTION
this refers to one spec as a concept, so it’s now *AST specification* instead of *AST specifications*.
