### PR TITLE
Fix verb agreement in rustdoc comments

### DIFF
--- a/crates/cairo-lang-filesystem/src/db.rs
+++ b/crates/cairo-lang-filesystem/src/db.rs
@@ -517,7 +517,7 @@ fn crate_config_helper<'db>(
     }
 }
 
-/// Return a reference to the configuration of a crate.
+/// Returns a reference to the configuration of a crate.
 /// This is a wrapper around the tracked function `crate_config_helper` to return a
 /// reference to a type unsupported by salsa tracked functions.
 fn crate_config<'db>(
@@ -569,7 +569,7 @@ fn file_content<'db>(db: &'db dyn Database, file_id: FileId<'db>) -> Option<Arc<
     })
 }
 
-/// Return a reference to the content of a file as a string.
+/// Returns a reference to the content of a file as a string.
 /// This is a wrapper around the tracked function `file_summary_helper` to return a
 /// reference to a type unsupported by salsa tracked functions.
 fn file_summary<'db>(db: &'db dyn Database, file: FileId<'db>) -> Option<&'db FileSummary> {

--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -1322,7 +1322,7 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
         try_extract_matches!(self.var_info.get(&var_id)?, VarInfo::Const).copied()
     }
 
-    /// Return the const value as an int if it exists and is an integer.
+    /// Returns the const value as an int if it exists and is an integer.
     fn as_int(&self, var_id: VariableId) -> Option<&BigInt> {
         match self.as_const(var_id)?.long(self.db) {
             ConstValue::Int(value, _) => Some(value),

--- a/crates/cairo-lang-lowering/src/optimizations/dedup_blocks.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/dedup_blocks.rs
@@ -169,7 +169,7 @@ impl<'db, 'a> CanonicBlockBuilder<'db, 'a> {
 
 impl<'db> CanonicBlock<'db> {
     /// Tries to create a canonic block from a flat block.
-    /// Return the canonic representation of the block and the external inputs used in the block.
+    /// Returns the canonic representation of the block and the external inputs used in the block.
     /// Blocks that do not end in return do not have a canonic representation.
     fn try_from_block(
         variable: &VariableArena<'db>,


### PR DESCRIPTION
Changed `Return` to `Returns`, following third-person singular verb form for consistency with project documentation style.