### PR TITLE
docs: fix link to xref

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/inference.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/inference.adoc
@@ -7,7 +7,7 @@ Inference applies to types, impls and generic arguments.
 
 Places where inference is enabled:
 
-* Type inference on link:let-statement.adoc[`let`] statements with missing type clauses.
+* Type inference on xref:let-statement.adoc[`let`] statements with missing type clauses.
 * Impl inference on method calls.
 * Impl inference when calling by trait.
 * Generic argument inference.


### PR DESCRIPTION
link:let-statement.adoc -> xref:let-statement.adoc