### PR TITLE
Avoid cloning type sizes in enum invocations

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -360,5 +360,5 @@ fn get_enum_size(
     program_info: &ProgramInfo<'_>,
     concrete_enum_type: &ConcreteTypeId,
 ) -> Option<i16> {
-    Some(program_info.type_sizes.get(concrete_enum_type)?.copied())
+    Some(program_info.type_sizes.get(concrete_enum_type).copied())
 }


### PR DESCRIPTION
Use copied() instead of to_owned() when reading TypeSizeMap entries in enm.rs, removing redundant cloning of i16 values. Keeps enum size lookups leaner with no behavior change.