### PR TITLE
Fix verb agreement in rustdoc comments

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/return_optimization.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/return_optimization.rs
@@ -63,7 +63,7 @@ struct EarlyReturnContext<'db, 'a> {
 }
 
 impl<'db, 'a> EarlyReturnContext<'db, 'a> {
-    /// Return a vector of VarUsage's based on the input `ret_infos`.
+    /// Returns a vector of VarUsage's based on the input `ret_infos`.
     /// Adds `StructConstruct` and `EnumConstruct` statements to the block as needed.
     /// Assumes that early return is possible for the given `ret_infos`.
     fn prepare_early_return_vars(&mut self, ret_infos: &[ValueInfo<'db>]) -> Vec<VarUsage<'db>> {

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -2669,7 +2669,7 @@ fn compute_method_function_call_data<'db>(
     Ok((function_id, trait_function_id.trait_id(ctx.db), fixed_expr, first_param.mutability))
 }
 
-/// Return candidates for method functions that match the given arguments.
+/// Returns candidates for method functions that match the given arguments.
 /// Also returns the expression to be used as self for the method call, its type and whether deref
 /// was used.
 #[expect(clippy::too_many_arguments)]

--- a/crates/cairo-lang-semantic/src/inline_macros/panic.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/panic.rs
@@ -15,7 +15,7 @@ use indoc::{formatdoc, indoc};
 use salsa::Database;
 
 /// Try to generate a simple panic handling code.
-/// Return `Some(())` if successful and updates the builder if successful.
+/// Returns `Some(())` if successful and updates the builder if successful.
 fn try_handle_simple_panic(
     db: &dyn Database,
     builder: &mut PatchBuilder<'_>,


### PR DESCRIPTION
Changed `Return` to `Returns`, following third-person singular verb form for consistency with project documentation style.