### PR TITLE
docs: fix incorrect underflow mention in CheckedMul trait

### DIFF
--- a/corelib/src/num/traits/ops/checked.cairo
+++ b/corelib/src/num/traits/ops/checked.cairo
@@ -64,8 +64,7 @@ pub trait CheckedSub<T> {
     fn checked_sub(self: T, v: T) -> Option<T>;
 }
 
-/// Performs multiplication that returns `None` instead of wrapping around on underflow or
-/// overflow.
+/// Performs multiplication that returns `None` instead of wrapping around on overflow.
 ///
 /// # Examples
 ///
@@ -79,8 +78,8 @@ pub trait CheckedSub<T> {
 /// assert!(result == None); // Overflow
 /// ```
 pub trait CheckedMul<T> {
-    /// Multiplies two numbers, checking for underflow or overflow. If underflow
-    /// or overflow happens, `None` is returned.
+    /// Multiplies two numbers, checking for overflow. If overflow happens,
+    /// `None` is returned.
     fn checked_mul(self: T, v: T) -> Option<T>;
 }
 


### PR DESCRIPTION
Remove "underflow" from CheckedMul documentation since multiplication of unsigned integers can only overflow, never underflow. The trait is only implemented for unsigned types (u8, u16, u32, u64, u128, u256).