### PR TITLE
chore: fix verb agreement in rustdoc comments

### DIFF
--- a/crates/cairo-lang-diagnostics/src/diagnostics.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics.rs
@@ -58,7 +58,7 @@ pub type PluginFileDiagnosticNotes<'a> = OrderedHashMap<FileId<'a>, DiagnosticNo
 
 // Helper trait to get the user location with plugin notes.
 pub trait UserLocationWithPluginNotes<'db> {
-    /// Get the location of the originating user code,
+    /// Gets the location of the originating user code,
     /// along with [`DiagnosticNote`]s for this translation.
     /// The notes are collected from the parent files of the originating location.
     fn user_location_with_plugin_notes(

--- a/crates/cairo-lang-filesystem/src/ids.rs
+++ b/crates/cairo-lang-filesystem/src/ids.rs
@@ -526,11 +526,11 @@ pub struct SpanInFile<'db> {
     pub span: TextSpan,
 }
 impl<'db> SpanInFile<'db> {
-    /// Get the location of right after this diagnostic's location (with width 0).
+    /// Gets the location of right after this diagnostic's location (with width 0).
     pub fn after(&self) -> Self {
         Self { file_id: self.file_id, span: self.span.after() }
     }
-    /// Get the location of the originating user code.
+    /// Gets the location of the originating user code.
     pub fn user_location(&self, db: &'db dyn Database) -> Self {
         get_originating_location(db, *self, None)
     }

--- a/crates/cairo-lang-filesystem/src/span.rs
+++ b/crates/cairo-lang-filesystem/src/span.rs
@@ -177,11 +177,11 @@ impl TextSpan {
     pub fn n_chars(self, content: &str) -> usize {
         self.take(content).chars().count()
     }
-    /// Get the span of width 0, located right after this span.
+    /// Gets the span of width 0, located right after this span.
     pub fn after(self) -> Self {
         Self::cursor(self.end)
     }
-    /// Get the span of width 0, located right at the beginning of this span.
+    /// Gets the span of width 0, located right at the beginning of this span.
     pub fn start_only(self) -> Self {
         Self::cursor(self.start)
     }

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1262,7 +1262,7 @@ fn compute_expr_binary_semantic<'db>(
     }
 }
 
-/// Get the function call expression of a binary operation that is defined in the corelib.
+/// Gets the function call expression of a binary operation that is defined in the corelib.
 fn call_core_binary_op<'db>(
     ctx: &mut ComputationContext<'db, '_>,
     syntax: &ast::ExprBinary<'db>,

--- a/crates/cairo-lang-semantic/src/items/attribute.rs
+++ b/crates/cairo-lang-semantic/src/items/attribute.rs
@@ -43,7 +43,7 @@ impl<'db> AttributeTrait<'db> for Attribute<'db> {
 
 /// Trait for querying attributes of semantic items.
 pub trait SemanticQueryAttrs<'db> {
-    /// Get the list of attributes attached to this node.
+    /// Gets the list of attributes attached to this node.
     ///
     /// Implementation detail, should not be used by this trait users.
     #[doc(hidden)]
@@ -63,7 +63,7 @@ pub trait SemanticQueryAttrs<'db> {
         Ok(self.query_attr(db, attr)?.next())
     }
 
-    /// Check if this node has an attribute whose name (without args) is exactly `attr`.
+    /// Checks if this node has an attribute whose name (without args) is exactly `attr`.
     fn has_attr(&self, db: &'db dyn Database, attr: &str) -> Maybe<bool> {
         Ok(self.find_attr(db, attr)?.is_some())
     }

--- a/crates/cairo-lang-semantic/src/items/function_with_body.rs
+++ b/crates/cairo-lang-semantic/src/items/function_with_body.rs
@@ -133,7 +133,7 @@ pub trait SemanticExprLookup<'db>: Database {
 }
 impl<'db, T: Database + ?Sized> SemanticExprLookup<'db> for T {}
 
-/// Get the inline configuration of the given function by parsing its attributes.
+/// Gets the inline configuration of the given function by parsing its attributes.
 pub fn get_inline_config<'db>(
     db: &'db dyn Database,
     diagnostics: &mut SemanticDiagnostics<'db>,

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -176,7 +176,7 @@ fn priv_macro_call_data_tracked<'db>(
 pub const EXPOSE_MACRO_NAME: &str = "expose";
 
 // TODO(eytan-starkware): Return SmolStrId
-/// Get the content and mappings for the `expose!` macro call.
+/// Gets the content and mappings for the `expose!` macro call.
 pub fn expose_content_and_mapping<'db>(
     db: &'db dyn Database,
     args: ast::TokenTreeNode<'db>,

--- a/crates/cairo-lang-semantic/src/items/module.rs
+++ b/crates/cairo-lang-semantic/src/items/module.rs
@@ -198,7 +198,7 @@ fn module_item_info_by_name_helper<'db>(
     module_item_info_by_name(db, module_id, name)
 }
 
-/// Get the imported global uses of a module, and their visibility.
+/// Gets the imported global uses of a module, and their visibility.
 pub fn get_module_global_uses<'db>(
     db: &'db dyn Database,
     module_id: ModuleId<'db>,

--- a/crates/cairo-lang-sierra-type-size/src/lib.rs
+++ b/crates/cairo-lang-sierra-type-size/src/lib.rs
@@ -24,12 +24,12 @@ impl ProgramRegistryInfo {
         Ok(Self { registry, type_sizes })
     }
 
-    /// Get a reference to the program registry.
+    /// Gets a reference to the program registry.
     pub fn registry(&self) -> &ProgramRegistry<CoreType, CoreLibfunc> {
         &self.registry
     }
 
-    /// Get a reference to the type size map.
+    /// Gets a reference to the type size map.
     pub fn type_sizes(&self) -> &TypeSizeMap {
         &self.type_sizes
     }

--- a/crates/cairo-lang-starknet/src/lib.rs
+++ b/crates/cairo-lang-starknet/src/lib.rs
@@ -15,7 +15,7 @@ pub mod contract;
 pub mod inline_macros;
 pub mod plugin;
 
-/// Get the suite of plugins for compilation with Starknet.
+/// Gets the suite of plugins for compilation with Starknet.
 pub fn starknet_plugin_suite() -> PluginSuite {
     let mut suite = PluginSuite::default();
     suite

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -116,12 +116,12 @@ impl<'db> cairo_lang_debug::DebugWithDb<'db> for SyntaxNode<'db> {
 }
 
 impl<'db> SyntaxNode<'db> {
-    /// Get the offset of this syntax node from the beginning of the file.
+    /// Gets the offset of this syntax node from the beginning of the file.
     pub fn offset(self, db: &'db dyn Database) -> TextOffset {
         self.data.offset(db)
     }
 
-    /// Get the parent syntax node, if any.
+    /// Gets the parent syntax node, if any.
     pub fn parent(self, db: &'db dyn Database) -> Option<SyntaxNode<'db>> {
         match self.data.id(db) {
             SyntaxNodeId::Child { parent, .. } => Some(*parent),
@@ -129,18 +129,18 @@ impl<'db> SyntaxNode<'db> {
         }
     }
 
-    /// Get the grandparent syntax node, if any.
+    /// Gets the grandparent syntax node, if any.
     /// This uses a cached parent when available, avoiding some database lookups.
     pub fn grandparent(self, db: &'db dyn Database) -> Option<SyntaxNode<'db>> {
         self.parent?.parent(db)
     }
 
-    /// Check if this syntax node is the root of the syntax tree.
+    /// Checks if this syntax node is the root of the syntax tree.
     pub fn is_root(self) -> bool {
         self.parent.is_none()
     }
 
-    /// Get the stable pointer for this syntax node.
+    /// Gets the stable pointer for this syntax node.
     pub fn stable_ptr(self, _db: &'db dyn Database) -> SyntaxStablePtrId<'db> {
         SyntaxStablePtrId(self)
     }
@@ -149,7 +149,7 @@ impl<'db> SyntaxNode<'db> {
         self.data.id(db)
     }
 
-    /// Get the key fields of this syntax node. These define the unique identifier of the node.
+    /// Gets the key fields of this syntax node. These define the unique identifier of the node.
     pub fn key_fields(self, db: &'db dyn Database) -> &'db [GreenId<'db>] {
         match self.data.id(db) {
             SyntaxNodeId::Child { key_fields, .. } => key_fields,
@@ -203,7 +203,7 @@ impl<'db> SyntaxNode<'db> {
     }
 }
 
-/// Create a new syntax node.
+/// Creates a new syntax node.
 pub fn new_syntax_node<'db>(
     db: &'db dyn Database,
     green: GreenId<'db>,
@@ -233,12 +233,12 @@ fn new_root_node<'db>(
 
 // Construction methods
 impl<'a> SyntaxNode<'a> {
-    /// Create a new root syntax node.
+    /// Creates a new root syntax node.
     pub fn new_root(db: &'a dyn Database, file_id: FileId<'a>, green: GreenId<'a>) -> Self {
         new_root_node(db, file_id, green, TextOffset::START)
     }
 
-    /// Create a new root syntax node with a custom initial offset.
+    /// Creates a new root syntax node with a custom initial offset.
     pub fn new_root_with_offset(
         db: &'a dyn Database,
         file_id: FileId<'a>,
@@ -250,17 +250,17 @@ impl<'a> SyntaxNode<'a> {
 
     // Basic accessors
 
-    /// Get the width of this syntax node.
+    /// Gets the width of this syntax node.
     pub fn width(&self, db: &dyn Database) -> TextWidth {
         self.green_node(db).width(db)
     }
 
-    /// Get the syntax kind of this node.
+    /// Gets the syntax kind of this node.
     pub fn kind(&self, _db: &dyn Database) -> SyntaxKind {
         self.kind
     }
 
-    /// Get the span of this syntax node.
+    /// Gets the span of this syntax node.
     pub fn span(&self, db: &dyn Database) -> TextSpan {
         TextSpan::new_with_width(self.offset(db), self.width(db))
     }


### PR DESCRIPTION
fix `Get` -> `Gets`.