### PR TITLE
docs: sync derive traits list with DerivePlugin

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/derive-macro.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/derive-macro.adoc
@@ -34,7 +34,8 @@ See xref:linear-types.adoc[linear types] for more information.
 * `Debug` - Implements the `Debug` trait to allow formatting the type for debugging.
 All members of the type must also be `Debug`.
 * `Default` - Implements the `Default` trait to provide a default value for the type.
-All members of the type must also be `Default`.
+For structs, all members of the type must also be `Default`.
+For enums, only the variant marked with `#[default]` must have all its members implement `Default`.
 * `Destruct` - Implements the destruct method to explicitly destroy the type.
 All members of the type must also be `Destruct`.
 See xref:linear-types.adoc[linear types] for more information.


### PR DESCRIPTION
I updated the derive macro documentation to reflect the actual set of traits supported by DerivePlugin in the compiler. The list now includes Debug, Default, Hash and PanicDestruct in addition to the previously documented traits, so users have an accurate view of which derives are available and won’t assume a trait is unsupported just because it is missing from the docs.