### PR TITLE
fix(utils): correct docs for BigInt/BigUint hex wrappers

### DIFF
--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -15,7 +15,7 @@ use num_traits::{Num, Signed};
 #[derive(Clone, Default, Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 pub struct BigUintAsHex {
-    /// The underlying big integer value serialized as a hex string.
+    /// The underlying big integer value.
     #[cfg_attr(
         feature = "serde",
         serde(serialize_with = "serialize_big_uint", deserialize_with = "deserialize_big_uint")
@@ -65,7 +65,7 @@ where
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BigIntAsHex {
-    /// The underlying signed big integer value serialized as a hex string.
+    /// The underlying signed big integer value.
     #[cfg_attr(
         feature = "serde",
         serde(serialize_with = "serialize_big_int", deserialize_with = "deserialize_big_int")


### PR DESCRIPTION
The comments on BigUintAsHex::value and BigIntAsHex::value incorrectly described these fields as function selectors. In practice these wrappers are generic big integer containers serialized as hex and are used across the codebase for various values (felt252s, indices, cheatcode selectors, etc.).