### PR TITLE
docs: update u256 integer types documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/integer-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/integer-types.adoc
@@ -18,7 +18,8 @@ The `usize` type is an alias to `u32`, and is used for array indexing.
 
 == Integer Creation
 
-All integer types can be created as literals using the appropriate suffix. For `u256`, you can also construct values from other types explicitly.
+All integer types can be created as literals using the appropriate suffix.
+For `u256`, you can also construct values from other types explicitly.
 [source,rust]
 ----
 fn main() {


### PR DESCRIPTION
The integer types reference was out of sync with the current corelib implementation. u256 now supports numeric literals and the standard division and modulo operators via the Div and Rem traits. This change updates the examples and the operations table so that the documentation matches the actual behavior of u256.