### PR TITLE
docs: document Cairo error types

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/error-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/error-type.adoc
@@ -136,11 +136,16 @@ type. See the dedicated page for detailed semantics and examples.
 == References (source)
 
 Error type and methods:
+
 - `corelib/src/result.cairo` (`Result<T, E>`)
 - `corelib/src/option.cairo` (`Option<T>` helpers)
+
 Panic infrastructure:
+
 - `corelib/src/panics.cairo` (`Panic`, `PanicResult<T>`, `panic`)
 - `corelib/src/lib.cairo` (`panic_with_felt252`, `assert`, etc.)
+
 Language features:
+
 - xref:panic.adoc[Panic]
 - xref:error-propagation-operator.adoc[Error propagation operator]


### PR DESCRIPTION
Added a dedicated reference page for error types in Cairo.

The new documentation explains how recoverable errors are modeled with Result<T, E> and Option<T>, how unrecoverable errors are represented by panic and Panic/PanicResult, and how these types interact with the `?` operator. This replaces the previous WIP placeholder and gives users a consistent overview of error-carrying types in the language.