### PR TITLE
fix: Box type documentation implementation path

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/box-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/box-type.adoc
@@ -101,5 +101,5 @@ let value: u32 = boxed_value.deref();  // Extracts the value
 
 == See also
 
-* xref:pages/linear-types.adoc[Linear types system] — Move semantics and Copy/Drop
+* xref:linear-types.adoc[Linear types system] — Move semantics and Copy/Drop
 * Implementation: `corelib/src/box.cairo`


### PR DESCRIPTION
Update the Box type reference documentation to point to the correct corelib implementation file (corelib/src/box.cairo instead of the outdated crates/cairo-lang-corelib/src/box.cairo path).