### PR TITLE
Remove incorrect article in tuple types docs (#9088)

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -24,7 +24,7 @@ use cairo_lang_utils::byte_array::BYTE_ARRAY_MAGIC;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
-use cairo_lang_utils::{Intern, extract_matches, try_extract_matches};
+use cairo_lang_utils::{Intern, extract_matches, require, try_extract_matches};
 use itertools::{chain, zip_eq};
 use num_bigint::BigInt;
 use num_integer::Integer;
@@ -1364,10 +1364,10 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
         unknown_vars: &mut Vec<VarUsage<'db>>,
         coerce: Option<&SpecializationArg<'db>>,
     ) -> Option<SpecializationArg<'db>> {
-        if self.db.type_size_info(ty).ok()? == TypeSizeInformation::ZeroSized {
-            // Skip zero-sized constants as they are not supported in sierra-gen.
-            return None;
-        }
+        // Skip zero-sized constants as they are not supported in sierra-gen.
+        require(self.db.type_size_info(ty).ok()? != TypeSizeInformation::ZeroSized)?;
+        // Skip specialization arguments if they are coerced to not be specialized.
+        require(!matches!(coerce, Some(SpecializationArg::NotSpecialized)))?;
 
         match var_info {
             VarInfo::Const(value) => {


### PR DESCRIPTION
Remove incorrect article in tuple types docs (#9088)

fix: resolve todo (#9089)

fix: grammar and articles in function and path expression docs (#9090)

docs: complete functions documentation (#9077)

docs: fix syntax typo (#9094)

docs: fix typo in `structs.adoc` (#9095)

fix: remove unused peekable call in patcher (#9096)

docs: document array iteration patterns (#9097)

Fix (docs) comment grammar for consistency (#9098)

fix grammar in type inference description (#9092)

docs: added box-type documentation (#9093)

Fix (docs) verb agreement in rustdoc comment (#9099)

Handled placeholders that weren't met during expansion as the expected empty repeatition. (#9082)

Make all functions debug info extraction parallel (#9102)

added specialization for tuples and fixed size arrays (#9087)

perf: use cached kind for terminal checks (#9103)

Added coercion of no-specialization.