### PR TITLE
Remove redundant Clone implementation for EcState

### DIFF
--- a/corelib/src/ec.cairo
+++ b/corelib/src/ec.cairo
@@ -127,18 +127,7 @@ impl EcPointTryIntoNonZero of TryInto<EcPoint, NonZeroEcPoint> {
 pub extern type EcState;
 
 impl EcStateDrop of Drop<EcState>;
-
-mod internal {
-    impl EcStateCopy of Copy<super::EcState>;
-    pub impl EcStateClone of Clone<super::EcState> {
-        #[inline]
-        fn clone(self: @super::EcState) -> super::EcState {
-            *self
-        }
-    }
-}
-
-impl EcStateClone = internal::EcStateClone;
+impl EcStateCopy of Copy<EcState>;
 
 /// Initializes an EC computation with the zero point.
 extern fn ec_state_init() -> EcState nopanic;


### PR DESCRIPTION
Removes redundant manual `Clone` implementation for `EcState` type in favor of the automatic implementation provided by `TCopyClone`.