### PR TITLE
docs: update expression-statement.adoc examples to Cairo

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/expression-statement.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/expression-statement.adoc
@@ -6,19 +6,17 @@ Its purpose is to trigger side effects of expression evaluation only.
 When an expression that ends with a block (i.e. '}') is used in a context where a statement is
 permitted, the trailing semicolon can be omitted without changing the semantic meaning.
 This is different from omitting the semicolon after a non-block expression.
-// TODO(spapini) Add links to the relevant expressions when they are written.
-This can include if, match, for, etc.
+This can include xref:if-expressions.adoc[if], xref:match-expressions.adoc[match], xref:for-loop-expressions.adoc[for], etc.
 This can cause an ambiguity between it being parsed as a standalone statement and as a part of
 another expression; in this case, it is parsed as a statement.
 
-// TODO(spapini): Use cairo syntax highlighting.
-[source,rust]
+[source,cairo]
 ----
-v.pop();          // Ignore the element returned from pop
+v.pop_front();    // Ignore the element returned from pop_front
 if v.is_empty() {
-    v.push(5);
+    v.append(5);
 } else {
-    v.remove(0);
+    v.pop_front();  // Remove the first element
 }                 // Semicolon can be omitted.
 [1];              // Separate expression statement, not an indexing expression
 ----
@@ -26,18 +24,18 @@ if v.is_empty() {
 When the trailing semicolon is omitted, the result return type of the expression must be
 the xref:unit-type.adoc[unit type].
 
-[source,rust]
+[source,cairo]
 ----
 // bad: the block's type is i32, not ()
 // Error: expected `()` because of default return type
 // if true {
-//   1
+//   1_i32
 // }
 
 // good: the block's type is i32
 if true {
-  1
+  1_i32
 } else {
-  2
+  2_i32
 };
 ----


### PR DESCRIPTION
Completes TODO tasks by adding cross-references to related expression documents, replaces Rust syntax and APIs with Cairo equivalents.