### PR TITLE
docs: update types overview links

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/types.adoc
@@ -10,6 +10,7 @@ In this section, we'll cover the different types available in Cairo.
 * xref:never-type.adoc[Never type]
 * xref:unit-type.adoc[Unit type]
 * xref:error-type.adoc[Error type]
+* xref:snapshot-type.adoc[`Snapshot`]
 
 == Sequence types
 * xref:tuple-types.adoc[Tuple]
@@ -20,7 +21,7 @@ In this section, we'll cover the different types available in Cairo.
 
 == Pointer types
 * xref:box-type.adoc[`Box`]
-* xref:snapshot-type.adoc[`Snapshot`]
+* `Nullable`
 
 == User-defined types
 * xref:struct-types.adoc[Struct]


### PR DESCRIPTION
The types overview page contained an outdated TODO about adding links and still listed several types without proper cross references. This change removes the obsolete TODO and adds xref links for Array, Box, Snapshot, slices, strings, and the error type, so the page now serves as a consistent entry point to the individual type documentation