### PR TITLE
fix: clarify should_inline doc comment

### DIFF
--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -332,8 +332,8 @@ fn inner_apply_inlining<'db>(
     Ok(())
 }
 
-/// Rewrites a statement and either appends it to self.statements or adds new statements to
-/// self.statements_rewrite_stack.
+/// Inspects a statement and, when it is an inlinable call, returns the call statement and
+/// the callee function id.
 fn should_inline<'db, 'r>(
     db: &'db dyn Database,
     calling_function_id: ConcreteFunctionWithBodyId<'db>,


### PR DESCRIPTION
The previous documentation for should_inline no longer matched its behavior and mentioned rewriting statements and managing a rewrite stack. The helper now only inspects a statement and, when it is an inlinable call, returns the call statement together with the callee function id. This update aligns the comment with the current implementation and makes the inlining logic easier to understand for future readers.