### PR TITLE
docs: clarify LegacyMap deprecation and recommend Map

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/contracts.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/contracts.adoc
@@ -47,6 +47,9 @@ For example, for the storage member `x` above, access is done using `x::read()` 
 Defining a mapping storage member is done using the `LegacyMap` "type" that is expanded by
 the Starknet plugin. The keys must implement the `Hash` trait and the values must implement the
 `starknet::Store` trait.
+Note that `LegacyMap` is a deprecated alias for `starknet::storage::Map`. For new contracts you
+should use `starknet::storage::Map` directly. The example above still uses `LegacyMap` for
+backward compatibility.
 Accessing such storage members is done using the `::read(key)` and
 `::write(key, value)` functions which are also automatically created by the Starknet plugin.
 For example, for the storage member `m` above, access is done using `m::read(key)` and


### PR DESCRIPTION
LegacyMap is now a deprecated alias for starknet::storage::Map in the Starknet plugin, but the contracts documentation still presented it as the primary mapping type. This patch updates the text around the example to explicitly mention the deprecation and recommend using starknet::storage::Map directly for new contracts, while keeping the existing example for backward compatibility.