### PR TITLE
docs: fix typos and improve consistency in Cairo reference

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/generics.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/generics.adoc
@@ -78,7 +78,7 @@ impl Triple<u32> of MulTrait::<u32> {
         x * 3
     }
 }
-fn foo<T, impl MyImpl: MyTrait::<T>>(x: T) -> T {
+fn foo<T, impl MyImpl: MulTrait::<T>>(x: T) -> T {
     MyImpl::mul(x)
 }
 fn main() {


### PR DESCRIPTION

This PR fixes minor documentation issues in the Cairo reference:

- Corrects an inconsistent trait name in the generics example (`MulTrait` usage).
