### PR TITLE
refactor: Remove unused variable binding in lowering test

### DIFF
--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -60,7 +60,7 @@ fn test_lowering_consistency() {
         "core::poseidon::_poseidon_hash_span_inner".to_string(),
     )
     .unwrap();
-    let _unused = PhasesDisplay { db, function_id }.to_string();
+    PhasesDisplay { db, function_id }.to_string();
 }
 
 /// Prints the lowering of a concrete function:


### PR DESCRIPTION
Removes the unused `_unused` variable binding in `test_lowering_consistency()`.