### PR TITLE
refactor(proc-macros): remove redundant variable in heap_size test

### DIFF
--- a/crates/cairo-lang-proc-macros/tests/heap_size.rs
+++ b/crates/cairo-lang-proc-macros/tests/heap_size.rs
@@ -50,6 +50,5 @@ fn test_heap_size_derive() {
     assert_eq!(test_enum2.heap_size(), 5);
 
     let test_enum3 = TestEnum::Variant3;
-    let size3 = test_enum3.heap_size();
-    assert_eq!(size3, 0);
+    assert_eq!(test_enum3.heap_size(), 0);
 }


### PR DESCRIPTION
Remove unnecessary intermediate variable `size3` in `test_heap_size_derive()` test function.