### PR TITLE
docs: Fix typo in felt252_downcast test comment

### DIFF
--- a/tests/e2e_test_data/libfuncs/felt252_downcast
+++ b/tests/e2e_test_data/libfuncs/felt252_downcast
@@ -432,7 +432,7 @@ test::foo: SmallOrderedMap({Const: 1510})
 //! > downcast::<BoundedInt<1-PRIME, 0>, BoundedInt<0, 10>> libfunc
 
 //! > Comments
-Validiting the basic shrinking of a destination type.
+Validating the basic shrinking of a destination type.
 
 //! > test_runner_name
 SmallE2ETestRunner


### PR DESCRIPTION
Fixed spelling error: "Validiting" → "Validating" in test comment.