### PR TITLE
docs: clarify type and impl aliases are not new types/impls

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/aliases.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/aliases.adoc
@@ -1,7 +1,8 @@
 = Type and impl aliases
 
-A type alias is a new name for an existing type. It is not a new type. This means that the alias and the original type are treated as the same type by the compiler and can be used interchangeably. Type aliases are created with
-the type keyword:
+A type alias is a new name for an existing type. It is not a new type. This means that the alias and
+the original type are treated as the same type by the compiler and can be used interchangeably.
+Type aliases are created with the type keyword:
 [source,cairo]
 ----
 type NewName<Generics> = ConcreteType;
@@ -16,8 +17,9 @@ type BoxOption<T> = Box<Option<T>>;
 ----
 
 An impl alias is similar to a type alias, but for impls.
-An impl alias is a new name for an existing impl. It is not a new impl. This means that the alias refers to the same implementation and can be used wherever the original impl is expected. Impl aliases are created
-with the impl keyword:
+An impl alias is a new name for an existing impl. It is not a new impl. This means that the alias
+refers to the same implementation and can be used wherever the original impl is expected. Impl
+aliases are created with the impl keyword:
 [source,cairo]
 ----
 impl NewName<Generics> = ConcreteImpl;


### PR DESCRIPTION
### Description
Adds brief explanations clarifying that type and impl aliases are not new types/impls.
### Changes
- Clarifies that type aliases are treated as the same type by the compiler and are interchangeable
- Clarifies that impl aliases refer to the same implementation and can be used wherever the original impl is expected