### PR TITLE
docs: sync enum type derive traits with derive macro

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/enum-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/enum-types.adoc
@@ -84,6 +84,9 @@ Common traits that can be derived:
 * `PartialEq` — Equality comparison
 * `Serde` — Serialization and deserialization
 * `Debug` — Debug formatting
+* `Default` — Provides a default value for the enum
+* `Hash` — Allows computing a hash value for the enum
+* `PanicDestruct` — Allows safely destructing the enum during a panic
 
 Example with derived traits:
 


### PR DESCRIPTION
The enum type documentation listed only a subset of supported derive traits and was missing Default, Hash and PanicDestruct.

This change updates the Type properties section in enum-types.adoc to include the full set of derive traits supported by the derive macro, so the reference stays consistent and does not mislead users about available derives for enums.