### PR TITLE
fix(docs): correct impl generic parameter usage in traits example

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/traits.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/traits.adoc
@@ -37,7 +37,7 @@ an implementation of the `Display<T>` trait:
 [source,rust]
 ----
 fn foo<T, impl TDisplay: Display<T>>(value: T) {
-    let a = TDisplay::display(5_usize);
+    let a = TDisplay::display(value);
     let b = Display::display(value);
 }
 ----


### PR DESCRIPTION
Fixes traits doc example: use generic value parameter instead of concrete 5_usize when calling TDisplay::display().
