### PR TITLE
perf: avoid TypeId re-interning in storage analyzer

### DIFF
--- a/crates/cairo-lang-starknet/src/analyzer.rs
+++ b/crates/cairo-lang-starknet/src/analyzer.rs
@@ -185,8 +185,7 @@ fn analyze_storage_struct<'db>(
 
     for (member_name, member) in members.iter() {
         let member_ast = member.id.stable_ptr(db).lookup(db);
-        let member_type = member.ty.long(db).clone();
-        let concrete_trait_id = concrete_valid_storage_trait(db, TypeId::new(db, member_type));
+        let concrete_trait_id = concrete_valid_storage_trait(db, member.ty);
 
         let member_allows_invalid =
             member_ast.has_attr_with_arg(db, ALLOW_ATTR, ALLOW_INVALID_STORAGE_MEMBERS_ATTR);


### PR DESCRIPTION
Reuse the existing TypeId stored in Member::ty when building the ValidStorageTypeTrait instead of cloning the long type and calling TypeId::new again. The previous code performed an unnecessary round-trip through the salsa interner for each storage member, which added extra cloning and lookup work without changing semantics. The new code passes member.ty directly into concrete_valid_storage_trait, keeping behavior identical while removing redundant work.