### PR TITLE
docs: fix minor typo

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/implicit-arguments.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/implicit-arguments.adoc
@@ -16,7 +16,7 @@ They're commonly used for:
 
 == Syntax
 
-Functions declare implicit argument using the `implicits()` attribute:
+Functions declare implicit arguments using the `implicits()` attribute:
 
 [source,cairo]
 ----


### PR DESCRIPTION
Should be `arguments` instead `argument`