### PR TITLE
refactor(utils): Remove unnecessary `BH: Clone` bound from `UnorderedHashMap::merge`

### DIFF
--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -323,7 +323,6 @@ impl<Key: Eq + Hash, Value, BH: BuildHasher> UnorderedHashMap<Key, Value, BH> {
     /// function is used to combine the values.
     pub fn merge<HandleDuplicate>(&mut self, other: &Self, handle_duplicate: HandleDuplicate)
     where
-        BH: Clone,
         HandleDuplicate: Fn(OccupiedEntry<'_, Key, Value>, &Value),
         Key: Clone,
         Value: Clone,


### PR DESCRIPTION
Removes the unnecessary `BH: Clone` trait bound from the `UnorderedHashMap::merge` method.