### PR TITLE
docs: fix typo

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/implicit-arguments.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/implicit-arguments.adoc
@@ -77,7 +77,7 @@ The `System` implicit provides access to Starknet's state and operations.
 
 == Automatic propagation
 
-Implicit argument are automatically propagated through the call stack.
+Implicit arguments are automatically propagated through the call stack.
 When a function with implicits call another functions that requires the same implicit,
 they're passed automatically:
 


### PR DESCRIPTION
Changed `argument` to `arguments`