### PR TITLE
Improve version error message with details

### DIFF
--- a/crates/cairo-lang-sierra/src/program.rs
+++ b/crates/cairo-lang-sierra/src/program.rs
@@ -38,8 +38,11 @@ impl VersionedProgram {
 pub struct Version<const V: u8>;
 
 #[derive(Debug, Error)]
-#[error("Unsupported Sierra program version")]
-struct VersionError;
+#[error("Unsupported Sierra program version: got {got}, expected {expected}")]
+struct VersionError {
+    got: u8,
+    expected: u8,
+}
 
 impl<const V: u8> Serialize for Version<V> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -56,7 +59,11 @@ impl<'de, const V: u8> Deserialize<'de> for Version<V> {
         D: serde::Deserializer<'de>,
     {
         let value = u8::deserialize(deserializer)?;
-        if value == V { Ok(Version::<V>) } else { Err(serde::de::Error::custom(VersionError)) }
+        if value == V {
+            Ok(Version::<V>)
+        } else {
+            Err(serde::de::Error::custom(VersionError { got: value, expected: V }))
+        }
     }
 }
 


### PR DESCRIPTION
Enhances [VersionError](cci:2://file:///d:/friendly-project/cairo/crates/cairo-lang-sierra/src/program.rs:41:0-41:20) in [program.rs](cci:7://file:///d:/friendly-project/cairo/crates/cairo-lang-sierra/src/program.rs:0:0-0:0) to display both received and expected version numbers, making version mismatch issues immediately clear.

**Before:** `Unsupported Sierra program version`  
**After:** `Unsupported Sierra program version: got 2, expected 1`

