### PR TITLE
Convert remaining file paths to GitHub links

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
@@ -29,7 +29,7 @@ type error (trait resolution fails).
 == Precedence and associativity
 
 Arithmetic operators have different precedence levels defined in
-`crates/cairo-lang-parser/src/operators.rs`:
+link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs]:
 
 - `*`, `/`, `%` share precedence level 2
 - `+`, `-` share precedence level 3

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/bitwise-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/bitwise-operators.adoc
@@ -27,7 +27,7 @@ type error (trait resolution fails).
 == Precedence and associativity
 
 Bitwise operators have different precedence levels defined in
-`crates/cairo-lang-parser/src/operators.rs`:
+link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs]:
 
 - `&` has precedence level 4
 - `^` has precedence level 5


### PR DESCRIPTION
Replaced raw file path (`crates/cairo-lang-parser/src/operators.rs`) with a direct GitHub link in arithmetic/logical + bitwise operators docs. Ensures readers can instantly access the source code (instead of manually navigating repos), improving doc usability.