### PR TITLE
fix: grammar in ADR 002 documentation

### DIFF
--- a/adrs/002_let_and_assign.md
+++ b/adrs/002_let_and_assign.md
@@ -57,9 +57,9 @@ Some non-trivial interactions to consider with other syntax elements:
 
 - `if` branches.
 - `for` loop bodies. In particular, assignment is the "only way" to change something inside
-  a loop for next iterations. Using a "let" in this context will define a "new" variable that
-  will go out of scope at the end of the iteration, and the next iteration will use the "old"
-  variable. This is similar to other programming languages.
+  a loop for the next iterations. Using a "let" in this context will define a "new" variable
+  that will go out of scope at the end of the iteration, and the next iteration will use the
+  "old" variable. This is similar to other programming languages.
 
 Advantages:
 


### PR DESCRIPTION


Fixed a minor grammatical issue in the `for` loop section of ADR 002 (Let and Assign syntax).

