### PR TITLE
docs: clarify eval_circuit libfunc comment

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/circuit.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/circuit.rs
@@ -648,7 +648,7 @@ fn get_u384_type(
 pub type GetCircuitDescriptorLibFunc =
     WrapSignatureAndTypeGenericLibfunc<GetCircuitDescriptorLibFuncWrapped>;
 
-/// A zero-input function that returns a handle to the offsets of a circuit.
+/// Evaluates a circuit instance using the given descriptor, input data and modulus.
 #[derive(Default)]
 pub struct EvalCircuitLibFuncWrapped {}
 impl SignatureAndTypeGenericLibfunc for EvalCircuitLibFuncWrapped {


### PR DESCRIPTION
Updated the documentation comment for EvalCircuitLibFuncWrapped so it accurately describes the eval_circuit libfunc inputs and behavior instead of the copied description of a zero-input descriptor function.