### PR TITLE
Remove unused `core::panic` import from runnable-utils

### DIFF
--- a/crates/cairo-lang-runnable-utils/src/builder.rs
+++ b/crates/cairo-lang-runnable-utils/src/builder.rs
@@ -1,5 +1,3 @@
-use core::panic;
-
 use cairo_lang_casm::assembler::AssembledCairoProgram;
 use cairo_lang_casm::builder::{CasmBuilder, Var};
 use cairo_lang_casm::cell_expression::CellExpression;


### PR DESCRIPTION
Removes an unused import of core::panic from cairo-lang-runnable-utils/src/builder.rs.