### PR TITLE
fix: avoid duplicated diagnostics context for executable compilation

### DIFF
--- a/crates/cairo-lang-executable/src/compile.rs
+++ b/crates/cairo-lang-executable/src/compile.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::setup_project;
@@ -210,8 +210,7 @@ pub fn compile_executable_function_in_prepared_db<'db>(
     config: ExecutableConfig,
 ) -> Result<CompileExecutableResult<'db>> {
     let SierraProgramWithDebug { program: sierra_program, debug_info } =
-        get_sierra_program_for_functions(db, vec![executable])
-            .with_context(|| "Compilation failed without any diagnostics.")?;
+        get_sierra_program_for_functions(db, vec![executable])?;
     if !config.allow_syscalls {
         // Finding if any syscall libfuncs are used in the program.
         // If any are found, the compilation will fail, as syscalls are not proved in executables.


### PR DESCRIPTION
`compile_executable_function_in_prepared_db` was wrapping `get_sierra_program_for_functions` with an additional with_context("Compilation failed without any diagnostics.") even though the compiler helper already attaches the same message. This resulted in duplicated text in error reports without adding any useful information. The extra context wrapper was removed and the unused anyhow::Context import was cleaned up to keep diagnostics output concise and consistent with other call sites.