### PR TITLE
Turn remaining file paths into GitHub links

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/comparison-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/comparison-operators.adoc
@@ -34,7 +34,7 @@ Relational operators share the same precedence level as equality operators (`==`
 - Looser than bitwise `&`, `^`, `|`, arithmetic `+`, `-`, `*`, `/`, `%`, indexing `[]`, and
   member access `.`.
 
-This is defined in `crates/cairo-lang-parser/src/operators.rs`.
+This is defined in link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs].
 
 == Examples
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/equality-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/equality-operators.adoc
@@ -29,7 +29,7 @@
  - Looser than bitwise `&`, `^`, `|`, arithmetic `+`, `-`, `*`, `/`, `%`,
    indexing `[]`, and member access `.`.
  
- This is defined in `crates/cairo-lang-parser/src/operators.rs`.
+ This is defined in link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs].
  
  == Examples
  
@@ -99,6 +99,6 @@
  
  == References (source)
  
- - Lexer tokens: `crates/cairo-lang-parser/src/lexer.rs` (`EqEq`, `Neq`).
- - Operator precedence: `crates/cairo-lang-parser/src/operators.rs`.
+ - Lexer tokens: link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/lexer.rs[crates/cairo-lang-parser/src/lexer.rs] (`EqEq`, `Neq`).
+ - Operator precedence: link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs].
  - Trait and behavior: `corelib/src/traits.cairo` (`PartialEq`).


### PR DESCRIPTION
Updates internal file path references to external GitHub links in the Cairo language documentation.

The original references (`crates/cairo-lang-parser/src/...`) were relative paths that don't work for external users viewing the documentation. Changed to direct GitHub URLs pointing to the starkware-libs/cairo repository, making the documentation actually useful for readers who want to verify operator precedence and lexer token definitions in the source code.

Affects:
- `comparison-operators.adoc` 
- `equality-operators.adoc`
- References section with lexer tokens and operator precedence links