### PR TITLE
Fix documentation links to point to GitHub repository

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/error-propagation-operator.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/error-propagation-operator.adoc
@@ -40,7 +40,7 @@ type error.
 == Precedence and associativity
 
 The error propagation operator has high precedence (level 1 in
-`crates/cairo-lang-parser/src/operators.rs`), binding:
+link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs]), binding:
 
 - Tighter than all binary operators
 - Looser than member access `.`
@@ -99,7 +99,7 @@ fn process_empty() -> Option<u8> {
 
 == References (source)
 
-- Syntax tree: `crates/cairo-lang-syntax-codegen/src/cairo_spec.rs` (`ExprErrorPropagate`)
-- Operator precedence: `crates/cairo-lang-parser/src/operators.rs` (line 18)
-- Lexer token: `crates/cairo-lang-parser/src/lexer.rs` (`TerminalQuestionMark`)
+- Syntax tree: link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-syntax-codegen/src/cairo_spec.rs[crates/cairo-lang-syntax-codegen/src/cairo_spec.rs] (`ExprErrorPropagate`)
+- Operator precedence: link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs] (line 18)
+- Lexer token: link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-parser/src/lexer.rs[crates/cairo-lang-parser/src/lexer.rs] (`TerminalQuestionMark`)
 - Error types: `corelib/src/result.cairo` (`Result`), `corelib/src/option.cairo` (`Option`)

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/expressions.adoc
@@ -4,7 +4,7 @@ Expressions produce values. They are used in variable initializers, function arg
 flow constructs, and other contexts where evaluation yields a result.
  
 This overview mirrors the language syntax as specified in
-`crates/cairo-lang-syntax-codegen/src/cairo_spec.rs` (the `Expr` enum and its variants), and links
+link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-syntax-codegen/src/cairo_spec.rs[crates/cairo-lang-syntax-codegen/src/cairo_spec.rs] (the `Expr` enum and its variants), and links
 to detailed subpages where available.
  
 == Categories of expressions


### PR DESCRIPTION
Replaces internal crate paths with clickable GitHub links in Cairo documentation.

Previously referenced files like `crates/cairo-lang-parser/src/operators.rs` which are meaningless to external readers. Now links directly to the source on GitHub (starkware-libs/cairo), allowing users to actually navigate to the referenced code.

Changes apply to operator precedence, lexer tokens, and syntax tree references across multiple documentation pages.