### PR TITLE
Convert relative paths to GitHub URLs in docs

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/constant-evaluation.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/constant-evaluation.adoc
@@ -99,7 +99,7 @@ solved or finalized for consts; unresolved or mismatched types result in diagnos
 
 The semantic rules above define what is valid and how values are computed for consts. Separately,
 the lowering/IR optimizer performs constant folding and related simplifications on lowered code
-(`crates/cairo-lang-lowering/src/optimizations/const_folding.rs`). Those optimizations do not alter
+(link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-lowering/src/optimizations/const_folding.rs[crates/cairo-lang-lowering/src/optimizations/const_folding.rs]). Those optimizations do not alter
 language semantics.
 
 == Related sources

--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/memory-model.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/memory-model.adoc
@@ -101,6 +101,7 @@ Language semantics and constructs:
 
 Snapshots, desnap, and types:
 
+<<<<<<< Updated upstream
 - link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-semantic/src/expr/compute.rs[unary Reference/Desnap handling]
 - link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-semantic/src/types.rs[type resolution for `Snapshot(T)` and `*`]
 
@@ -108,12 +109,21 @@ Lowering representation:
 
 - link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-lowering/src/lower/context.rs[`LoweredExpr`, snapshots, variable arena]
 - link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-lowering/src/objects.rs[lowered structures, blocks, variables]
+=======
+- link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-semantic/src/expr/compute.rs[crates/cairo-lang-semantic/src/expr/compute.rs] (unary Reference/Desnap handling)
+- link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-semantic/src/types.rs[crates/cairo-lang-semantic/src/types.rs] (type resolution for `Snapshot(T)` and `*`)
+
+Lowering representation:
+
+- link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-lowering/src/lower/context.rs[crates/cairo-lang-lowering/src/lower/context.rs] (`LoweredExpr`, snapshots, variable arena)
+- link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-lowering/src/objects.rs[crates/cairo-lang-lowering/src/objects.rs] (lowered structures, blocks, variables)
+>>>>>>> Stashed changes
 
 Execution-time memory model:
 
-- `crates/cairo-lang-casm/src/assembler.rs` (instruction reps, `ApUpdate`, `FpUpdate`)
-- `crates/cairo-lang-runner/src/casm_run/mod.rs` (segments, memory buffers, VM helpers)
-- `crates/cairo-lang-runner/src/lib.rs` (VM initialization, builtin cost segment)
+- link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-casm/src/assembler.rs[crates/cairo-lang-casm/src/assembler.rs] (instruction reps, `ApUpdate`, `FpUpdate`)
+- link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-runner/src/casm_run/mod.rs[crates/cairo-lang-runner/src/casm_run/mod.rs] (segments, memory buffers, VM helpers)
+- link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-runner/src/lib.rs[crates/cairo-lang-runner/src/lib.rs] (VM initialization, builtin cost segment)
 
 == Related reading
 


### PR DESCRIPTION
Fixes broken source references in the documentation by linking to GitHub instead of internal paths.

The docs were referencing files like `crates/cairo-lang-parser/src/operators.rs` which don't help anyone actually reading them. Now they link straight to the code on GitHub so people can click through and see what we're talking about.