### PR TITLE
Complete impl parameter usage examples

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/method-calls.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/method-calls.adoc
@@ -30,6 +30,7 @@ impl DisplayUsize of Display<usize> {
 }
 
 fn bar<T: impl TDisplay: Display<T>>(value: T) {
+    let a = TDisplay::display(value);
     ...
     // Can be called as a method.
     let c = value.display();


### PR DESCRIPTION
Adds a missing example showing how to use TDisplay trait directly.

The documentation already shows calling `.display()` as a method, but doesn't demonstrate the trait usage pattern `TDisplay::display(value)`. 