### PR TITLE
Fix dead cross-module documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/boolean-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/boolean-operators.adoc
@@ -36,7 +36,7 @@ fn main() {
 ----
 
 Const evaluation: logical `&&` / `\|\|` are supported and preserve short-circuit semantics
-in const contexts. See xref:language_semantics:constant-evaluation.adoc[Constant evaluation].
+in const contexts. See xref:../../language_semantics/pages/constant-evaluation.adoc[Constant evaluation].
 
 == Bitwise boolean operators on `bool` (`&`, `\|`, `^`)
 


### PR DESCRIPTION
Fixes broken xref link to constant evaluation documentation. The old path `xref:language_semantics:constant-evaluation.adoc` was incorrect. Updated to the correct relative path `../../language_semantics/pages/constant-evaluation.adoc`.