### PR TITLE
chore(sierra): avoid panic when simulation unexpectedly succeeds

### DIFF
--- a/crates/cairo-lang-sierra/src/simulation/test.rs
+++ b/crates/cairo-lang-sierra/src/simulation/test.rs
@@ -224,6 +224,10 @@ fn simulate_error(
     id: &str,
     generic_args: Vec<GenericArg>,
     inputs: Vec<CoreValue>,
-) -> LibfuncSimulationError {
-    simulate(id, generic_args, inputs).err().unwrap()
-}
+) -> LibfuncSimulationError  {
+        simulate(id, generic_args, inputs)
+            .expect_err("Expected simulation to fail, but it succeeded")
+    }
+    
+    
+


### PR DESCRIPTION
Replacing .unwrap() on expected Err with expect_err to avoid panic if the result is unexpectedly Ok.

