### PR TITLE
docs: correct numeric match threshold flag comment

### DIFF
--- a/crates/cairo-lang-filesystem/src/flag.rs
+++ b/crates/cairo-lang-filesystem/src/flag.rs
@@ -57,7 +57,8 @@ fn flag_add_withdraw_gas(db: &dyn Database) -> bool {
     extract_flag_value!(db, ADD_WITHDRAW_GAS, AddWithdrawGas).unwrap_or(true)
 }
 
-/// Returns the value of the `unsafe_panic` flag, or `None` if the flag is not set.
+/// Returns the value of the `numeric_match_optimization_min_arms_threshold` flag, or `None` if the
+/// flag is not set.
 #[salsa::tracked]
 fn flag_numeric_match_optimization_min_arms_threshold(db: &dyn salsa::Database) -> Option<usize> {
     extract_flag_value!(


### PR DESCRIPTION
## Summary

Fixed reference in comments

---

## Type of change

Please check **one**:

- [x] Documentation change with concrete technical impact

---

## Why is this change needed?


- A behavior was undocumented or unclear in a way that caused real confusion

---

## What was the behavior or documentation before?

Docs incorrectly referenced `unsafe_panic` instead of  `numeric_match_optimization_min_arms_threshold`

## What is the behavior or documentation after?

Docs now reference `numeric_match_optimization_min_arms_threshold` as it should be

---
