### PR TITLE
chore: remove unused std::vec import

### DIFF
--- a/crates/cairo-lang-lowering/src/specialization.rs
+++ b/crates/cairo-lang-lowering/src/specialization.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_proc_macros::HeapSize;


### PR DESCRIPTION
## Summary

Removed the unused std::vec import from specialization.rs to keep the import list minimal and accurate.

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This avoids suggesting that the std::vec module is used in this file and slightly improves readability without changing behavior.

---
