### PR TITLE
(bug-fix): Reenabling reboxing analysis

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/reboxing_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/reboxing_test.rs
@@ -41,7 +41,7 @@ fn test_reboxing_analysis(
         let formatter = LoweredFormatter::new(db, &after.variables);
         trace!("Lowering input to Reboxing:\n{:?}", after.debug(&formatter));
 
-        let candidates = find_reboxing_candidates(db, &after);
+        let candidates = find_reboxing_candidates(&after);
 
         let candidates_str = candidates
             .iter()

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/reboxing
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/reboxing
@@ -23,6 +23,7 @@ fn main(a: Box<A>) -> Box<felt252> {
 //! > lowering_diagnostics
 
 //! > candidates
+v4
 
 //! > before
 Parameters: v0: core::box::Box::<test::A>
@@ -40,7 +41,7 @@ blk0 (root):
 Statements:
   (v1: test::A) <- unbox(v0)
   (v2: core::felt252, v3: core::felt252) <- struct_destructure(v1)
-  (v4: core::box::Box::<core::felt252>) <- into_box(v3)
+  (v5: core::box::Box::<core::felt252>, v4: core::box::Box::<core::felt252>) <- struct_destructure(v0)
 End:
   Return(v4)
 
@@ -74,6 +75,7 @@ fn multi_member(p: Box<Point>) -> (Box<u32>, Box<u32>) {
 //! > lowering_diagnostics
 
 //! > candidates
+v5, v10
 
 //! > before
 Parameters: v0: core::box::Box::<test::Point>
@@ -95,10 +97,10 @@ blk0 (root):
 Statements:
   (v1: test::Point) <- unbox(v0)
   (v2: core::integer::u32, v3: core::integer::u32, v4: core::integer::u32) <- struct_destructure(v1)
-  (v5: core::box::Box::<core::integer::u32>) <- into_box(v2)
+  (v5: core::box::Box::<core::integer::u32>, v12: core::box::Box::<core::integer::u32>, v13: core::box::Box::<core::integer::u32>) <- struct_destructure(v0)
   (v6: test::Point) <- unbox(v0)
   (v7: core::integer::u32, v8: core::integer::u32, v9: core::integer::u32) <- struct_destructure(v6)
-  (v10: core::box::Box::<core::integer::u32>) <- into_box(v9)
+  (v14: core::box::Box::<core::integer::u32>, v15: core::box::Box::<core::integer::u32>, v10: core::box::Box::<core::integer::u32>) <- struct_destructure(v0)
   (v11: (core::box::Box::<core::integer::u32>, core::box::Box::<core::integer::u32>)) <- struct_construct(v5, v10)
 End:
   Return(v11)
@@ -137,6 +139,7 @@ fn nested_struct(o: Box<Outer>) -> Box<felt252> {
 //! > lowering_diagnostics
 
 //! > candidates
+v5
 
 //! > before
 Parameters: v0: core::box::Box::<test::Outer>
@@ -194,6 +197,7 @@ fn with_snapshot(data: Box<@Data>) -> Box<@NonCopy> {
 //! > lowering_diagnostics
 
 //! > candidates
+v4
 
 //! > before
 Parameters: v0: core::box::Box::<@test::Data>
@@ -211,7 +215,7 @@ blk0 (root):
 Statements:
   (v1: @test::Data) <- unbox(v0)
   (v2: @test::NonCopy, v3: @core::felt252) <- struct_destructure(v1)
-  (v4: core::box::Box::<@test::NonCopy>) <- into_box(v2)
+  (v4: core::box::Box::<@test::NonCopy>, v5: core::box::Box::<@core::felt252>) <- struct_destructure(v0)
 End:
   Return(v4)
 
@@ -240,6 +244,7 @@ fn rebox_whole(s: Box<Simple>) -> Box<Simple> {
 //! > lowering_diagnostics
 
 //! > candidates
+v2
 
 //! > before
 Parameters: v0: core::box::Box::<test::Simple>
@@ -255,9 +260,8 @@ Parameters: v0: core::box::Box::<test::Simple>
 blk0 (root):
 Statements:
   (v1: test::Simple) <- unbox(v0)
-  (v2: core::box::Box::<test::Simple>) <- into_box(v1)
 End:
-  Return(v2)
+  Return(v0)
 
 //! > ==========================================================================
 
@@ -413,6 +417,7 @@ fn tuple_rebox(t: Box<(u32, felt252, u64)>) -> Box<felt252> {
 //! > lowering_diagnostics
 
 //! > candidates
+v5
 
 //! > before
 Parameters: v0: core::box::Box::<(core::integer::u32, core::felt252, core::integer::u64)>
@@ -430,7 +435,7 @@ blk0 (root):
 Statements:
   (v1: (core::integer::u32, core::felt252, core::integer::u64)) <- unbox(v0)
   (v2: core::integer::u32, v3: core::felt252, v4: core::integer::u64) <- struct_destructure(v1)
-  (v5: core::box::Box::<core::felt252>) <- into_box(v3)
+  (v6: core::box::Box::<core::integer::u32>, v5: core::box::Box::<core::felt252>, v7: core::box::Box::<core::integer::u64>) <- struct_destructure(v0)
 End:
   Return(v5)
 
@@ -463,6 +468,7 @@ fn non_copy_struct_rebox(s: Box<NonCopyStruct>) -> Box<felt252> {
 //! > lowering_diagnostics
 
 //! > candidates
+v4
 
 //! > before
 Parameters: v0: core::box::Box::<test::NonCopyStruct>
@@ -507,6 +513,7 @@ fn non_copy_tuple_rebox(t: Box<(Array<felt252>, felt252)>) -> Box<felt252> {
 //! > lowering_diagnostics
 
 //! > candidates
+v4
 
 //! > before
 Parameters: v0: core::box::Box::<(core::array::Array::<core::felt252>, core::felt252)>
@@ -657,6 +664,7 @@ fn main(a: Box<A>) -> (Box<felt252>, NonDrop) {
 //! > lowering_diagnostics
 
 //! > candidates
+v4
 
 //! > before
 Parameters: v0: core::box::Box::<test::A>
@@ -715,6 +723,7 @@ fn main(a: Box<@A>) -> (Box<@felt252>, @NonDrop) {
 //! > lowering_diagnostics
 
 //! > candidates
+v4
 
 //! > before
 Parameters: v0: core::box::Box::<@test::A>
@@ -734,7 +743,7 @@ blk0 (root):
 Statements:
   (v1: @test::A) <- unbox(v0)
   (v2: @core::felt252, v3: @test::NonDrop) <- struct_destructure(v1)
-  (v4: core::box::Box::<@core::felt252>) <- into_box(v2)
+  (v4: core::box::Box::<@core::felt252>, v8: core::box::Box::<@test::NonDrop>) <- struct_destructure(v0)
   (v5: @core::felt252, v6: @test::NonDrop) <- struct_destructure(v1)
   (v7: (core::box::Box::<@core::felt252>, @test::NonDrop)) <- struct_construct(v4, v6)
 End:
@@ -775,6 +784,7 @@ fn mixed_reboxing(p: Box<Point>, flag: bool) -> Box<felt252> {
 }
 
 //! > candidates
+v5, v9, v14
 
 //! > before
 Parameters: v0: core::box::Box::<test::Point>, v1: core::bool
@@ -822,10 +832,9 @@ End:
 blk1:
 Statements:
   (v4: test::Point) <- unbox(v0)
-  (v5: core::box::Box::<test::Point>) <- into_box(v4)
-  (v6: test::Point) <- unbox(v5)
+  (v6: test::Point) <- unbox(v0)
   (v7: core::felt252, v8: core::felt252) <- struct_destructure(v6)
-  (v9: core::box::Box::<core::felt252>) <- into_box(v8)
+  (v15: core::box::Box::<core::felt252>, v9: core::box::Box::<core::felt252>) <- struct_destructure(v0)
 End:
   Goto(blk3, {v9 -> v10})
 
@@ -833,7 +842,7 @@ blk2:
 Statements:
   (v11: test::Point) <- unbox(v0)
   (v12: core::felt252, v13: core::felt252) <- struct_destructure(v11)
-  (v14: core::box::Box::<core::felt252>) <- into_box(v12)
+  (v14: core::box::Box::<core::felt252>, v16: core::box::Box::<core::felt252>) <- struct_destructure(v0)
 End:
   Goto(blk3, {v14 -> v10})
 

--- a/crates/cairo-lang-sierra-generator/src/function_generator_test_data/struct
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test_data/struct
@@ -52,12 +52,10 @@ foo
 
 //! > sierra_code
 label_test::foo::0:
-unbox<core::integer::u256>([0]) -> ([1])
-struct_deconstruct<core::integer::u256>([1]) -> ([2], [3])
-drop<u128>([2]) -> ()
-store_temp<u128>([3]) -> ([3])
-into_box<u128>([3]) -> ([4])
-return([4])
+struct_boxed_deconstruct<core::integer::u256>([0]) -> ([1], [2])
+drop<Box<u128>>([1]) -> ()
+store_temp<Box<u128>>([2]) -> ([2])
+return([2])
 
 //! > ==========================================================================
 
@@ -83,12 +81,10 @@ foo
 //! > sierra_code
 label_test::foo::0:
 rename<Box<core::integer::u256>>([0]) -> ([1])
-unbox<core::integer::u256>([1]) -> ([2])
-struct_deconstruct<core::integer::u256>([2]) -> ([3], [4])
-drop<u128>([3]) -> ()
-store_temp<u128>([4]) -> ([4])
-into_box<u128>([4]) -> ([5])
-return([5])
+struct_boxed_deconstruct<core::integer::u256>([1]) -> ([2], [3])
+drop<Box<u128>>([2]) -> ()
+store_temp<Box<u128>>([3]) -> ([3])
+return([3])
 
 //! > ==========================================================================
 
@@ -118,12 +114,10 @@ struct A {
 
 //! > sierra_code
 label_test::foo::0:
-unbox<Snapshot<test::A>>([0]) -> ([1])
-store_temp<Snapshot<test::A>>([1]) -> ([1])
-struct_snapshot_deconstruct<test::A>([1]) -> ([2], [3])
-drop<Snapshot<Array<felt252>>>([3]) -> ()
-into_box<Snapshot<Array<felt252>>>([2]) -> ([4])
-return([4])
+struct_boxed_deconstruct<Snapshot<test::A>>([0]) -> ([1], [2])
+drop<Box<Snapshot<Array<felt252>>>>([2]) -> ()
+store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1])
+return([1])
 
 //! > ==========================================================================
 
@@ -153,12 +147,10 @@ struct A {
 
 //! > sierra_code
 label_test::foo::0:
-unbox<Snapshot<test::A>>([0]) -> ([1])
-store_temp<Snapshot<test::A>>([1]) -> ([1])
-struct_snapshot_deconstruct<test::A>([1]) -> ([2], [3])
-drop<Snapshot<Array<felt252>>>([3]) -> ()
-into_box<Snapshot<Array<felt252>>>([2]) -> ([4])
-return([4])
+struct_boxed_deconstruct<Snapshot<test::A>>([0]) -> ([1], [2])
+drop<Box<Snapshot<Array<felt252>>>>([2]) -> ()
+store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1])
+return([1])
 
 //! > ==========================================================================
 
@@ -188,9 +180,7 @@ struct A {
 
 //! > sierra_code
 label_test::foo::0:
-unbox<Snapshot<test::A>>([0]) -> ([1])
-store_temp<Snapshot<test::A>>([1]) -> ([1])
-struct_snapshot_deconstruct<test::A>([1]) -> ([2], [3])
-drop<Snapshot<Array<felt252>>>([3]) -> ()
-into_box<Snapshot<Array<felt252>>>([2]) -> ([4])
-return([4])
+struct_boxed_deconstruct<Snapshot<test::A>>([0]) -> ([1], [2])
+drop<Box<Snapshot<Array<felt252>>>>([2]) -> ()
+store_temp<Box<Snapshot<Array<felt252>>>>([1]) -> ([1])
+return([1])


### PR DESCRIPTION
## Summary

Refactored the reboxing optimization to use dedicated `Statement::Unbox` and `Statement::IntoBox` statements as it was nullified by their addition to `Statement`.

---

## Type of change

Please check **one**:

- [X] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

---

## What was the behavior or documentation before?

---

## What is the behavior or documentation after?

---

## Additional context

