### PR TITLE
refactor: avoid redundant String allocation

### DIFF
--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs.rs
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs.rs
@@ -106,7 +106,7 @@ pub fn lookup_allowed_libfuncs_list(
             }
             _ => {
                 return Err(AllowedLibfuncsError::UnexpectedAllowedLibfuncsList {
-                    allowed_libfuncs_list_name: list_name.to_string(),
+                    allowed_libfuncs_list_name: list_name,
                 });
             }
         },


### PR DESCRIPTION
## Summary

This change removes an unnecessary String allocation when constructing the UnexpectedAllowedLibfuncsList error in 
lookup_allowed_libfuncs_list

---

## Type of change

Please check **one**:

- [x] Performance improvement

---

## Why is this change needed?

The code now moves the existing list_name String instead of calling to_string(), which keeps the behavior identical while avoiding a pointless allocation in the error path.

---
