### PR TITLE
refactor(cairo-lang-utils): remove unused `borrow_as_box` helper

### DIFF
--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -68,29 +68,6 @@ impl<T> OptionHelper for Option<T> {
     }
 }
 
-/// Borrows a mutable reference as Box for the lifespan of this function.
-///
-/// Runs the given closure with the boxed value as a parameter.
-/// The closure is expected to return a boxed value, whose changes will be reflected on the mutable
-/// reference.
-/// Example:
-/// ```
-/// use cairo_lang_utils::borrow_as_box;
-/// let mut x = 5;
-/// borrow_as_box(&mut x, |mut x: Box<usize>| {
-///     *x += 1;
-///     ((), x)
-/// });
-/// assert_eq!(x, 6);
-/// ```
-pub fn borrow_as_box<T: Default, R, F: FnOnce(Box<T>) -> (R, Box<T>)>(ptr: &mut T, f: F) -> R {
-    // TODO(spapini): Consider replacing take with something that leaves the memory dangling,
-    // instead of filling with default().
-    let (res, boxed) = f(Box::new(core::mem::take(ptr)));
-    *ptr = *boxed;
-    res
-}
-
 #[cfg(feature = "std")]
 pub trait Intern<'db, Target> {
     fn intern(self, db: &'db dyn salsa::Database) -> Target;


### PR DESCRIPTION
Remove dead code: `borrow_as_box` helper function and its documentation.