### PR TITLE
perf(sierra-generator): remove redundant cloning in executable collection

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/executables.rs
+++ b/crates/cairo-lang-sierra-generator/src/executables.rs
@@ -107,7 +107,7 @@ pub fn collect_executables(
             .drain()
             .map(|(key, functions)| {
                 let mut functions = functions.into_iter().collect::<Vec<_>>();
-                functions.sort_by_key(|(full_path, _)| full_path.clone());
+                functions.sort_by(|(full_path_a, _), (full_path_b, _)| full_path_a.cmp(full_path_b));
                 (key, functions.into_iter().map(|(_, function_id)| function_id).collect::<Vec<_>>())
             })
             .collect::<HashMap<String, Vec<FunctionId>>>()


### PR DESCRIPTION
Optimize executable function collection by eliminating unnecessary allocations and clones.