### PR TITLE
refactor: remove redundant clones in sierra-generator

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/specialization_context.rs
+++ b/crates/cairo-lang-sierra-generator/src/specialization_context.rs
@@ -35,10 +35,7 @@ impl SignatureSpecializationContext for SierraSignatureSpecializationContext<'_>
         &self,
         function_id: &cairo_lang_sierra::ids::FunctionId,
     ) -> Option<cairo_lang_sierra::program::FunctionSignature> {
-        self.0
-            .get_function_signature(function_id.clone())
-            .cloned()
-            .to_option()
+        self.0.get_function_signature(function_id.clone()).cloned().to_option()
     }
 
     fn try_get_function_ap_change(


### PR DESCRIPTION
This PR removes unnecessary clone operations in the cairo-lang-sierra-generator crate, improving performance without changing behavior.