### PR TITLE
chore: remove unused std::vec imports

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_diagnostics::{Diagnostics, Maybe};

--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cairo_lang_defs::patcher::PatchBuilder;
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,

--- a/crates/cairo-lang-sierra-generator/src/types.rs
+++ b/crates/cairo-lang-sierra-generator/src/types.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::vec;
 
 use cairo_lang_defs::ids::NamedLanguageElementId;
 use cairo_lang_diagnostics::Maybe;


### PR DESCRIPTION
Removes unused `use std::vec;` statements across three files. These imports serve no purpose since `Vec` is already in the prelude and none of the removed lines were actually used in their respective modules. 