### PR TITLE
chore: remove obsolete TODO about attribute repetition check

### DIFF
--- a/crates/cairo-lang-syntax/src/attribute/structured.rs
+++ b/crates/cairo-lang-syntax/src/attribute/structured.rs
@@ -121,7 +121,6 @@ pub trait AttributeListStructurize<'a> {
 
 impl<'a> AttributeListStructurize<'a> for ast::AttributeList<'a> {
     fn structurize(self, db: &'a dyn Database) -> Vec<Attribute<'a>> {
-        // TODO(ilya): Consider checking for attribute repetitions.
         self.elements(db).map(|attr| attr.structurize(db)).collect()
     }
 }


### PR DESCRIPTION
## Summary

Removed obsolete TODO comment about checking attribute repetitions in `AttributeListStructurize::structurize`. Duplicate validation is intentionally handled at the plugin level, not in the structurization method.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The TODO comment suggests checking for attribute repetitions in `structurize`, but this validation is intentionally performed at the plugin level where attribute semantics are known. The structurization method should remain a neutral AST transformation. The TODO is misleading and should be removed.

---

## What was the behavior or documentation before?

The code contained a TODO comment: `// TODO(ilya): Consider checking for attribute repetitions.`

---

## What is the behavior or documentation after?

The TODO comment is removed. Behavior is unchanged—duplicate validation continues to be handled by plugins (e.g., `storage_interfaces.rs`, `feature_kind.rs`).

---

## Related issue or discussion (if any)

<!-- None -->

---

## Additional context

This is a code cleanup. The structurization layer should not perform validation; plugins handle duplicate checks based on attribute-specific rules.