### PR TITLE
docs: clarify empty array type annotation syntax

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc
@@ -54,7 +54,8 @@ let grid = [[1, 2], [3, 4]];
 // Repeat form: repeat the element 0 four times.
 let zeros = [0; 4];
 
-// Using type context for an empty array (element type provided by the annotation).
+// Empty array using list form [] with type annotation [felt252; 0].
+// Note: [felt252; 0] is a type annotation syntax, not a repeat form expression.
 let empty: [felt252; 0] = [];
 
 ----
@@ -63,6 +64,7 @@ Invalid examples (illustrative):
 
 - Heterogeneous elements: `[1, true]`
 - Mixed forms: `[1, 2; 3]`
+- Repeat form with zero size: `[0; 0]` (size must be greater than 0)
 
 == Related
 


### PR DESCRIPTION
## Summary

Clarifies distinction between fixed-size array type annotation syntax `[T; N]` and repeat form expression syntax `[expr; size]`. Documents that repeat form with zero size is invalid.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The example `let empty: [felt252; 0] = [];` could be misinterpreted as using repeat form syntax `[expr; size]` with `size = 0`, which is invalid. The compiler rejects `[expr; 0]`, but this restriction wasn't documented.

---

## What was the behavior or documentation before?

The example comment didn't clarify that `[felt252; 0]` is type annotation syntax, not a repeat form expression. Invalid examples section didn't mention that repeat form with zero size is disallowed.

---

## What is the behavior or documentation after?

The example explicitly states that `[felt252; 0]` is a type annotation syntax, not a repeat form expression. Invalid examples section now includes `[0; 0]` as invalid with explanation that size must be greater than 0.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

The visual similarity between type annotation `[T; N]` and repeat form `[expr; size]` syntax can cause confusion, especially for empty arrays. This clarification helps users understand these are distinct syntactic constructs.