### PR TITLE
chore: remove redundant whitespace equality assert in ast_test

### DIFF
--- a/crates/cairo-lang-syntax/src/node/ast_test.rs
+++ b/crates/cairo-lang-syntax/src/node/ast_test.rs
@@ -148,18 +148,17 @@ fn setup(db: &DatabaseForTesting) -> SyntaxNode<'_> {
     let token5 = TokenLiteralNumber::new_green(db, SmolStrId::from(db, "5"));
     assert_eq!(token_whitespace1, token_whitespace2);
     let no_trivia = Trivia::new_green(db, &[]);
-    let triviums = [token_whitespace1, token_whitespace2];
     let terminal_foo = TerminalIdentifier::new_green(
         db,
         no_trivia,
         token_foo,
-        Trivia::new_green(db, &[triviums[0].into()]),
+        Trivia::new_green(db, &[token_whitespace1.into()]),
     );
     let terminal_plus = TerminalPlus::new_green(
         db,
         no_trivia,
         token_plus,
-        Trivia::new_green(db, &[triviums[1].into()]),
+        Trivia::new_green(db, &[token_whitespace2.into()]),
     );
     let terminal5 = TerminalLiteralNumber::new_green(db, no_trivia, token5, no_trivia);
     let empty_dollar = OptionTerminalDollarEmpty::new_green(db).into();


### PR DESCRIPTION
## Summary

The second assert_eq! comparing triviums[0] and triviums[1] was fully implied by the first equality check between token_whitespace1 and token_whitespace2 and did not verify any additional behavior

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Removing it keeps the test semantics unchanged while reducing noise in the setup.


