### PR TITLE
Removed `HashMap` usages in cairo-lang-sierra.

### DIFF
--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -300,7 +300,7 @@ pub fn compile_prepared_db_program_artifact<'db>(
             .context("Compilation failed without any diagnostics.")?
     } else {
         // Compile for executable functions only.
-        executable_functions.clone().into_keys().collect()
+        executable_functions.keys().cloned().collect()
     };
 
     let mut program_artifact =

--- a/crates/cairo-lang-sierra/src/debug_info.rs
+++ b/crates/cairo-lang-sierra/src/debug_info.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::hash::Hash;
 
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -20,25 +19,25 @@ pub struct DebugInfo {
         serialize_with = "serialize_map::<ConcreteTypeId, _>",
         deserialize_with = "deserialize_map::<ConcreteTypeId, _>"
     )]
-    pub type_names: HashMap<ConcreteTypeId, SmolStr>,
+    pub type_names: OrderedHashMap<ConcreteTypeId, SmolStr>,
     #[serde(
         serialize_with = "serialize_map::<ConcreteLibfuncId, _>",
         deserialize_with = "deserialize_map::<ConcreteLibfuncId, _>"
     )]
-    pub libfunc_names: HashMap<ConcreteLibfuncId, SmolStr>,
+    pub libfunc_names: OrderedHashMap<ConcreteLibfuncId, SmolStr>,
     #[serde(
         serialize_with = "serialize_map::<FunctionId, _>",
         deserialize_with = "deserialize_map::<FunctionId, _>"
     )]
-    pub user_func_names: HashMap<FunctionId, SmolStr>,
+    pub user_func_names: OrderedHashMap<FunctionId, SmolStr>,
     /// Non-crucial information about the program, for use by external libraries and tools.
     ///
     /// See [`Annotations`] type documentation for more information about this field.
     #[serde(default, skip_serializing_if = "Annotations::is_empty")]
     pub annotations: Annotations,
     /// List of functions marked as executable.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub executables: HashMap<String, Vec<FunctionId>>,
+    #[serde(default, skip_serializing_if = "OrderedHashMap::is_empty")]
+    pub executables: OrderedHashMap<String, Vec<FunctionId>>,
 }
 
 /// Store for non-crucial information about the program, for use by external libraries and tools.
@@ -200,7 +199,7 @@ impl IdAsHashKey for FunctionId {
 }
 
 fn serialize_map<Id: IdAsHashKey, S: serde::Serializer>(
-    m: &HashMap<Id, SmolStr>,
+    m: &OrderedHashMap<Id, SmolStr>,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     let v: Vec<_> = m.iter().map(|(id, name)| (id.get(), name)).sorted().collect();
@@ -209,7 +208,7 @@ fn serialize_map<Id: IdAsHashKey, S: serde::Serializer>(
 
 fn deserialize_map<'de, Id: IdAsHashKey, D: serde::Deserializer<'de>>(
     deserializer: D,
-) -> Result<HashMap<Id, SmolStr>, D::Error> {
+) -> Result<OrderedHashMap<Id, SmolStr>, D::Error> {
     Ok(Vec::<(u64, SmolStr)>::deserialize(deserializer)?
         .into_iter()
         .map(|(id, name)| (Id::new(id), name))

--- a/crates/cairo-lang-sierra/src/debug_info_test.rs
+++ b/crates/cairo-lang-sierra/src/debug_info_test.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use indoc::indoc;
 
 use super::DebugInfo;
@@ -22,16 +20,16 @@ fn test_extract_names() {
                 .unwrap(),
         ),
         DebugInfo {
-            type_names: HashMap::from([
+            type_names: From::from([
                 ("u128".into(), "u128".into()),
                 ("GasBuiltin".into(), "GasBuiltin".into()),
                 ("NonZeroInt".into(), "NonZeroInt".into())
             ]),
-            libfunc_names: HashMap::from([
+            libfunc_names: From::from([
                 ("rename_u128".into(), "rename_u128".into()),
                 ("rename_gb".into(), "rename_gb".into())
             ]),
-            user_func_names: HashMap::from([
+            user_func_names: From::from([
                 ("Func1".into(), "Func1".into()),
                 ("Func2".into(), "Func2".into())
             ]),
@@ -60,16 +58,16 @@ fn test_populate_names() {
     "})
         .unwrap();
     DebugInfo {
-        type_names: HashMap::from([
+        type_names: From::from([
             (0.into(), "u128".into()),
             (1.into(), "GasBuiltin".into()),
             (2.into(), "NonZeroInt".into()),
         ]),
-        libfunc_names: HashMap::from([
+        libfunc_names: From::from([
             (0.into(), "rename_u128".into()),
             (1.into(), "rename_gb".into()),
         ]),
-        user_func_names: HashMap::from([(0.into(), "Func1".into()), (1.into(), "Func2".into())]),
+        user_func_names: From::from([(0.into(), "Func1".into()), (1.into(), "Func2".into())]),
         annotations: Default::default(),
         executables: Default::default(),
     }


### PR DESCRIPTION
## Summary

Removes direct usage of `HashMap` in the `sierra` crate.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

We avoid using HashMap as much as possible, and use {Ordered,Unordered}HashMap instead, for better result stability.
