### PR TITLE
refactor: remove unused storage_name arg from component impl template

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
@@ -119,7 +119,6 @@ impl<'db> ComponentsGenerationData<'db> {
                 &[
                     ("component_name".to_string(), RewriteNode::from_ast_trimmed(&component_name)),
                     ("component_path".to_string(), RewriteNode::from_ast_trimmed(component_path)),
-                    ("storage_name".to_string(), RewriteNode::from_ast_trimmed(storage_name)),
                     ("event_name".to_string(), RewriteNode::from_ast_trimmed(event_name)),
                 ]
                 .into(),


### PR DESCRIPTION
## Summary

The storage_name RewriteNode was passed into the HasComponentImpl_* interpolate_patched call but had no corresponding placeholder in the template. This made the component! macro arguments and the generated impl look inconsistent and added redundant work during code generation.

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Removing the unused argument keeps the template parameters aligned with the actual placeholders without changing the generated Cairo code.

---


