### PR TITLE
refactor(diagnostics): Inlined error code implementation.

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1165,7 +1165,16 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
     }
 
     fn error_code(&self) -> Option<ErrorCode> {
-        self.kind.error_code()
+        Some(match &self.kind {
+            SemanticDiagnosticKind::UnusedVariable => error_code!(E0001),
+            SemanticDiagnosticKind::CannotCallMethod { .. } => error_code!(E0002),
+            SemanticDiagnosticKind::MissingMember(_) => error_code!(E0003),
+            SemanticDiagnosticKind::MissingItemsInImpl(_) => error_code!(E0004),
+            SemanticDiagnosticKind::ModuleFileNotFound(_) => error_code!(E0005),
+            SemanticDiagnosticKind::PathNotFound(_) => error_code!(E0006),
+            SemanticDiagnosticKind::NoSuchTypeMember { .. } => error_code!(E0007),
+            _ => return None,
+        })
     }
 
     fn is_same_kind(&self, other: &Self) -> bool {
@@ -1570,23 +1579,6 @@ pub enum MultiArmExprKind {
     If,
     Match,
     Loop,
-}
-
-impl<'db> SemanticDiagnosticKind<'db> {
-    pub fn error_code(&self) -> Option<ErrorCode> {
-        Some(match &self {
-            Self::UnusedVariable => error_code!(E0001),
-            Self::CannotCallMethod { .. } => {
-                error_code!(E0002)
-            }
-            Self::MissingMember(_) => error_code!(E0003),
-            Self::MissingItemsInImpl(_) => error_code!(E0004),
-            Self::ModuleFileNotFound(_) => error_code!(E0005),
-            Self::PathNotFound(_) => error_code!(E0006),
-            Self::NoSuchTypeMember { .. } => error_code!(E0007),
-            _ => return None,
-        })
-    }
 }
 
 // TODO(Gil): It seems to have the same functionality as ElementKind, maybe we can merge them.


### PR DESCRIPTION
## Summary

Refactored error code handling in semantic diagnostics by moving the error code logic from `SemanticDiagnosticKind::error_code()` directly into `SemanticDiagnostic::error_code()`. This eliminates the separate implementation on the kind enum while maintaining the same functionality.

---

## Why is this change needed?

This refactoring simplifies the code structure by removing an unnecessary method implementation on `SemanticDiagnosticKind` and placing the error code logic directly where it's used in `SemanticDiagnostic`. This makes the code more maintainable by keeping related functionality together and reduces indirection.

---

## What was the behavior or documentation before?

Previously, `SemanticDiagnostic::error_code()` delegated to `SemanticDiagnosticKind::error_code()`, creating an unnecessary layer of indirection.

---

## What is the behavior or documentation after?

Now, `SemanticDiagnostic::error_code()` directly implements the error code mapping logic, eliminating the separate implementation on the kind enum while maintaining identical functionality.