### PR TITLE
Added validation of error_code! not being duplicated.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,14 @@ jobs:
       - if: needs.parallel-cairo-tests.result != 'success'
         run: exit 1
 
+  # Checks that error codes are not duplicated.
+  error-code-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: >
+          scripts/validate_error_codes.sh
+
   # Check for unnecessary dependencies.
   udeps:
     runs-on: ubuntu-latest

--- a/scripts/validate_error_codes.sh
+++ b/scripts/validate_error_codes.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Validate that each error_code! appears at most once in diagnostic.rs files
+
+# Find all error_code! usages in diagnostic.rs files
+usages=$(find crates -name diagnostic.rs -exec grep "error_code!(E[0-9]\+)" {} \; | sed 's/.*error_code!(\(E[0-9]\+\)).*/\1/')
+
+duplicates=$(echo "$usages" | sort | uniq -d)
+
+if [ -n "$duplicates" ]; then
+    echo "Duplicate error codes found in diagnostic.rs files:"
+    echo "$duplicates"
+    exit 1
+else
+    echo "All error codes in diagnostic.rs files are unique."
+fi


### PR DESCRIPTION
## Summary

Added a CI check to validate that error codes are not duplicated across diagnostic.rs files. The PR introduces a new GitHub workflow job called `error-code-check` that runs a shell script to find and report any duplicate error codes.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Duplicate error codes can cause confusion when debugging issues, as the same error code would point to different problems. This validation ensures that each error code is unique across the codebase, making error identification and resolution more straightforward.

---

## What was the behavior or documentation before?

There was no automated check to prevent duplicate error codes from being introduced. Developers had to manually ensure uniqueness.

---

## What is the behavior or documentation after?

The CI pipeline now automatically checks for duplicate error codes in all diagnostic.rs files. If duplicates are found, the CI job fails with a clear error message listing the duplicated codes.

---

## Additional context

The validation script works by:
1. Finding all `error_code!(EXXXX)` patterns in diagnostic.rs files
2. Extracting the error code identifiers
3. Checking for duplicates using sort and uniq
4. Failing the build if any duplicates are found