### PR TITLE
Remove unused std::vec imports

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cairo_lang_casm::builder::{CasmBuildResult, CasmBuilder, Var};
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_sierra::extensions::felt252_dict::{

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/mod.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/mod.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
     DynGeneratedFileAuxData, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile,


### PR DESCRIPTION
Removes unused `use std::vec;` imports from three files. `Vec` is already available in the prelude, making these statements redundant.