### PR TITLE
perf: avoid extra Arc clone in lexer

### DIFF
--- a/crates/cairo-lang-parser/src/lexer.rs
+++ b/crates/cairo-lang-parser/src/lexer.rs
@@ -314,10 +314,7 @@ impl Lexer {
         };
 
         let span = self.consume_text_span();
-        let text = {
-            let text_slice = span.take(&self.text);
-            SmolStrId::from(db, text_slice)
-        };
+        let text = SmolStrId::from(db, span.take(&self.text));
         let trailing_trivia = self.match_trivia(db, false);
         let terminal_kind = token_kind_to_terminal_syntax_kind(kind);
 


### PR DESCRIPTION
## Summary

Use the existing Arc<str> inside Lexer when extracting the token text span instead of cloning it on every token.

---

## Type of change

Please check **one**:

- [x] Performance improvement

---

## Why is this change needed?

This removes a redundant atomic reference count update in the hot path of tokenization without changing any observable behavior.

---

