### PR TITLE
docs: fix incorrect function documentation comment

### DIFF
--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs.rs
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs.rs
@@ -88,7 +88,7 @@ pub const BUILTIN_EXPERIMENTAL_LIBFUNCS_LIST: &str = "experimental";
 /// The experimental list contains all the libfuncs and is currently used for development.
 pub const BUILTIN_ALL_LIBFUNCS_LIST: &str = "all";
 
-/// Returns the Sierra version corresponding to the given version id.
+/// Returns the list of allowed Sierra libfuncs based on the provided list selector.
 pub fn lookup_allowed_libfuncs_list(
     list_selector: ListSelector,
 ) -> Result<AllowedLibfuncs, AllowedLibfuncsError> {


### PR DESCRIPTION
## Summary

Fix incorrect doc comment for `lookup_allowed_libfuncs_list`. The comment incorrectly stated it returns a Sierra version, but it actually returns a list of allowed libfuncs.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The doc comment was factually incorrect and misleading. It stated the function returns a Sierra version, but the function signature returns `Result<AllowedLibfuncs, AllowedLibfuncsError>`.

---

## What was the behavior or documentation before?
ust
/// Returns the Sierra version corresponding to the given version id.
---

## What is the behavior or documentation after?

/// Returns the list of allowed Sierra libfuncs based on the provided list selector.---

## Related issue or discussion (if any)

<!-- None -->

---

## Additional context

The function is used throughout the codebase to retrieve allowed libfunc lists, confirming the previous comment was incorrect.