### PR TITLE
chore: remove outdated lifetime TODO in rewriter proc macro

### DIFF
--- a/crates/cairo-lang-proc-macros/src/rewriter.rs
+++ b/crates/cairo-lang-proc-macros/src/rewriter.rs
@@ -11,8 +11,6 @@ pub fn derive_semantic_object(input: TokenStream) -> TokenStream {
     let name = &input.ident;
     let generics = &input.generics;
 
-    // TODO(yuval/shahar): extract the lifetime here and use it instead of `'a` below.
-
     let body = match &input.data {
         syn::Data::Struct(structure) => emit_struct_semantic_object(name, generics, structure),
         syn::Data::Enum(enm) => emit_enum_semantic_object(name, generics, enm),


### PR DESCRIPTION
## Summary

This change removes an obsolete TODO comment in the derive_semantic_object implementation of the rewriter proc macro. The comment referred to extracting a 'a lifetime that is no longer present in the code, which made it misleading for readers and suggested work that is already obsolete

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Keeping comments in sync with the current implementation reduces noise and helps future maintainers trust the remaining TODOs.

---

