### PR TITLE
fix(sierra): correct FromFelt252 input type for u8/u16

### DIFF
--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -502,7 +502,7 @@ fn simulate_u8_libfunc(
             (vec![CoreValue::Felt252(Felt252::from(value))], 0)
         }
         Uint8Concrete::FromFelt252(_) => {
-            take_inputs!(let [CoreValue::RangeCheck, CoreValue::Uint8(value)] = inputs);
+            take_inputs!(let [CoreValue::RangeCheck, CoreValue::Felt252(value)] = inputs);
             match value.to_u8() {
                 Some(value) => (vec![CoreValue::RangeCheck, CoreValue::Uint8(value)], 0),
                 None => (vec![CoreValue::RangeCheck], 1),
@@ -554,7 +554,7 @@ fn simulate_u16_libfunc(
             (vec![CoreValue::Felt252(Felt252::from(value))], 0)
         }
         Uint16Concrete::FromFelt252(_) => {
-            take_inputs!(let [CoreValue::RangeCheck, CoreValue::Uint16(value)] = inputs);
+            take_inputs!(let [CoreValue::RangeCheck, CoreValue::Felt252(value)] = inputs);
             match value.to_u16() {
                 Some(value) => (vec![CoreValue::RangeCheck, CoreValue::Uint16(value)], 0),
                 None => (vec![CoreValue::RangeCheck], 1),


### PR DESCRIPTION
## Summary

Fix copy-paste error in Sierra simulation: `Uint8Concrete::FromFelt252` and `Uint16Concrete::FromFelt252` incorrectly expected `Uint8`/`Uint16` input instead of `Felt252`.

## Type of change

- [x] Bug fix (fixes incorrect behavior)

## Why is this change needed?

`FromFelt252` should accept `Felt252` as input. The u8/u16 variants were inconsistent with u32/u64/u128 implementations due to copy-paste error.