### PR TITLE
Remove redundant cache existence check in flow-control graph cache

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/cache.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/cache.rs
@@ -25,7 +25,6 @@ impl<Input: std::hash::Hash + Eq + Clone> Cache<Input> {
         }
 
         let node_id = callback(graph, input.clone(), path);
-        assert!(!self.cache.contains_key(&input));
         self.cache.insert(input, node_id);
         node_id
     }


### PR DESCRIPTION
Delete the contains_key assert in Cache::get_or_compute since prior get already guarantees the key is absent on the miss path; avoids an extra hash lookup.
Keeps memoization behavior unchanged while removing redundant work.