### PR TITLE
fix: align EnumView docs with CellExpression layout

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -311,11 +311,12 @@ fn build_enum_match_long(
 /// A struct representing an actual enum value in the Sierra program.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EnumView {
-    /// This would be ReferenceExpression::Immediate after enum_init, and would be
-    /// ReferenceExpression::Deref after store_*.
+    /// The selector of the active variant.
+    /// It is `CellExpression::Immediate` right after `enum_init`, and `CellExpression::Deref`
+    /// after the enum value is stored in memory.
     pub variant_selector: CellExpression,
     /// The inner value of the enum (a flat vector of cell expressions), padded with
-    /// CellExpression::Padding to match the size of the largest variant.
+    /// zero `CellExpression::Immediate` cells to match the size of the largest variant.
     pub inner_value: Vec<CellExpression>,
 }
 


### PR DESCRIPTION
## Summary

This change updates the EnumView documentation to reflect its actual runtime representation. The comments now describe variant_selector as a CellExpression that is Immediate after enum_init and Deref after storing the enum, and inner_value as padded with zero Immediate cells instead of a non-existent Padding variant.

---

## Type of change

Please check **one**:


- [x] Documentation change with concrete technical impact


---

## Why is this change needed?


This removes misleading references to ReferenceExpression and CellExpression::Padding, making the enum encoding clearer and reducing the risk of future logic changes being based on outdated docs.
