### PR TITLE
chore: remove unused PreCostMetadataNotSupported error

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
@@ -92,9 +92,6 @@ pub enum InvocationError {
     IntegerOverflow,
     #[error(transparent)]
     FrameStateError(#[from] FrameStateError),
-    // TODO(lior): Remove this error once not used.
-    #[error("This libfunc does not support pre-cost metadata yet.")]
-    PreCostMetadataNotSupported,
     #[error("{output_ty} is not contained in the circuit {circuit_ty}.")]
     InvalidCircuitOutput { output_ty: ConcreteTypeId, circuit_ty: ConcreteTypeId },
 }


### PR DESCRIPTION
## Summary

Removes the unused `PreCostMetadataNotSupported` error variant from `InvocationError` enum, fulfilling the TODO comment request to remove it once not used.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `PreCostMetadataNotSupported` error variant is no longer used anywhere in the codebase. The TODO comment explicitly states "Remove this error once not used." A codebase-wide search confirms that no code returns this error variant. The error became obsolete after commit 0b4d15a97 (January 2024) "Enabled redeposit for all cost types" removed the code path that used this error.

---

## What was the behavior or documentation before?

The `InvocationError` enum contained an unused error variant:
```rust
// TODO(lior): Remove this error once not used.
#[error("This libfunc does not support pre-cost metadata yet.")]
PreCostMetadataNotSupported,
```
This variant was defined but never returned by any code path.


---
What is the behavior or documentation after?

The unused error variant has been removed from the enum, reducing dead code and fulfilling the TODO request.

---
Related issue or discussion (if any)

N/A

---
Additional context

N/A