### PR TITLE
chore: remove outdated path parsing TODO from 2022

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -3103,7 +3103,6 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                     self.create_and_report_missing::<PathSegment<'_>>(
                         ParserDiagnosticKind::MissingPathSegment,
                     ),
-                    // TODO(ilya, 10/10/2022): Should we continue parsing the path here?
                     None,
                 );
             }
@@ -3137,7 +3136,6 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                     self.create_and_report_missing::<PathSegment<'_>>(
                         ParserDiagnosticKind::MissingPathSegment,
                     ),
-                    // TODO(ilya, 10/10/2022): Should we continue parsing the path here?
                     None,
                 );
             }


### PR DESCRIPTION
## Summary

Removes two identical TODO comments from 2022 questioning whether to continue parsing paths after encountering missing segments, as the current behavior has been stable and working correctly for over 3 years.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

These TODO comments dated October 10, 2022 (over 3 years old) question whether the parser should continue parsing paths after encountering a missing path segment. The current implementation returns `None` to stop parsing, and this behavior has been stable for 3+ years without issues. Recent path-related changes in 2024 (commits 4e2f21926, 66c8c1f21, a38e8cb83) all preserved this behavior, indicating it is correct. The question has been implicitly answered by time and practice.

---

## What was the behavior or documentation before?

Two identical TODO comments appeared in the path parsing logic:
```rust
// TODO(ilya, 10/10/2022): Should we continue parsing the path here?
None,
```

---
What is the behavior or documentation after?

The TODO comments have been removed. 

---
Related issue or discussion (if any)

N/A

---
Additional context

N/A