### PR TITLE
docs: fix Box deref example to show automatic dereferencing

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/box-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/box-type.adoc
@@ -91,13 +91,24 @@ This is useful when working with non-copyable types.
 
 == Dereferencing
 
-`Box<T>` implements the `Deref` trait, allowing automatic dereferencing:
+`Box<T>` implements the `Deref` trait, allowing automatic dereferencing
+for field and method access:
 
 [source,cairo]
 ----
-let boxed_value: Box<u32> = BoxTrait::new(42);
-let value: u32 = boxed_value.deref();  // Extracts the value
+#[derive(Copy, Drop)]
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+let boxed_point: Box<Point> = BoxTrait::new(Point { x: 10, y: 20 });
+let x_value = boxed_point.x;  // Automatic dereferencing for field access
+let value: Point = boxed_point.deref();  // Explicit deref to get the value
 ----
+
+Note: Automatic dereferencing works for field and method access,
+but not for implicit type conversion when passing arguments to functions.
 
 == See also
 


### PR DESCRIPTION
## Summary

Updates Box dereferencing docs to show automatic dereferencing with a concrete example. The previous example only showed explicit `.deref()` calls, which didn't demonstrate the automatic behavior.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The docs mentioned "automatic dereferencing" but only showed explicit `.deref()` calls. This was misleading since automatic dereferencing works for field/method access, not just explicit calls.

---

## What was the behavior or documentation before?

Only showed explicit dereferencing:airo
let boxed_value: Box<u32> = BoxTrait::new(42);
let value: u32 = boxed_value.deref();---

## What is the behavior or documentation after?

Now demonstrates automatic field access:
let boxed_point: Box<Point> = BoxTrait::new(Point { x: 10, y: 20 });
let x_value = boxed_point.x;  // Automatic dereferencingIncludes a note that automatic deref works for fields/methods but not for implicit type conversion.

---

## Related issue or discussion (if any)

<!-- None -->

---

## Additional context

Aligns with behavior shown in `corelib/src/ops/deref.cairo` and test cases that demonstrate automatic field access through deref.