### PR TITLE
fix(corelib): correct method name in SquashedFelt252Dict example

### DIFF
--- a/corelib/src/dict.cairo
+++ b/corelib/src/dict.cairo
@@ -300,7 +300,7 @@ pub impl SquashedFelt252DictImpl<T> of SquashedFelt252DictTrait<T> {
     /// # Example
     /// ```
     /// let squashed_dict = dict.squash();
-    /// let entries = squashed_dict.entries();
+    /// let entries = squashed_dict.into_entries();
     /// ```
     #[inline]
     fn into_entries(self: SquashedFelt252Dict<T>) -> Array<(felt252, T, T)> {


### PR DESCRIPTION
## Summary

Fix incorrect method name in documentation example: `entries()` → `into_entries()` for `SquashedFelt252DictTrait`.

## Type of change

- [x] Bug fix (fixes incorrect behavior)