### PR TITLE
fix: add missing #[test] attribute to test_snapshot_array_into_iter

### DIFF
--- a/corelib/src/test/array_test.cairo
+++ b/corelib/src/test/array_test.cairo
@@ -215,6 +215,7 @@ fn test_empty_snapshot_fixed_size_array_iterator() {
     assert!(iter.next().is_none());
 }
 
+#[test]
 fn test_snapshot_array_into_iter() {
     let mut iter = (@array![1, 2, 3, 4, 5]).into_iter();
     assert_eq!(iter.next(), Some(@1));


### PR DESCRIPTION
## Summary

Add missing `#[test]` attribute to `test_snapshot_array_into_iter` function.

## Type of change

- [x] Bug fix (fixes incorrect behavior)

## Why is this change needed?

The test function `test_snapshot_array_into_iter` was missing the `#[test]` attribute, so it was never executed by the test runner.

## What was the behavior before?

Test was silently skipped.

## What is the behavior after?

Test runs as intended.