### PR TITLE
fix(parser): add missing SyntaxKind variants to is_missing_kind

### DIFF
--- a/crates/cairo-lang-parser/src/colored_printer.rs
+++ b/crates/cairo-lang-parser/src/colored_printer.rs
@@ -38,7 +38,15 @@ impl ColoredPrinter<'_> {
 
 // TODO(yuval): autogenerate both.
 fn is_missing_kind(kind: SyntaxKind) -> bool {
-    matches!(kind, SyntaxKind::ExprMissing | SyntaxKind::StatementMissing)
+    matches!(
+        kind,
+        SyntaxKind::ExprMissing
+            | SyntaxKind::WrappedArgListMissing
+            | SyntaxKind::StatementMissing
+            | SyntaxKind::ModuleItemMissing
+            | SyntaxKind::TraitItemMissing
+            | SyntaxKind::ImplItemMissing
+    )
 }
 
 // TODO(yuval): Move to SyntaxKind.


### PR DESCRIPTION
## Summary

Fixed incomplete `is_missing_kind` implementation in `colored_printer.rs`. Added 4 missing variants (`WrappedArgListMissing`, `ModuleItemMissing`, `TraitItemMissing`, `ImplItemMissing`) to match `printer.rs` and ensure all missing nodes are detected in verbose mode.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

`is_missing_kind` in `colored_printer.rs` only checked 2 missing node types, while `printer.rs` checks 6. This caused some missing nodes to be incorrectly handled in colored verbose output.

---

## What was the behavior or documentation before?

`is_missing_kind` only detected `ExprMissing` and `StatementMissing`, missing 4 other types that `printer.rs` correctly handles.

---

## What is the behavior or documentation after?

`is_missing_kind` now detects all 6 missing node types, matching `printer.rs` and ensuring consistent behavior.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

Addresses the TODO about autogenerating this function. This change ensures correctness until autogeneration is implemented.