### PR TITLE
fix: correct error message in bool conversion test

### DIFF
--- a/corelib/src/test/bool_test.cairo
+++ b/corelib/src/test/bool_test.cairo
@@ -25,5 +25,5 @@ fn test_bool_operators() {
 #[test]
 fn test_bool_conversion() {
     assert_eq(@false.into(), @0, 'f.into() != 0');
-    assert_eq(@true.into(), @1, 'f.into() != 1');
+    assert_eq(@true.into(), @1, 't.into() != 1');
 }


### PR DESCRIPTION
## Summary

Fix error in `bool_test.cairo`: error message says `'f.into() != 1'` but should be `'t.into() != 1'` since it tests `true`, not `false`.

---

## Type of change

- [x] Bug fix (fixes incorrect behavior)

---

## Why is this change needed?

Misleading error message during debugging — suggests problem with `false` when actually testing `true`.