### PR TITLE
Made `is_missing` part of the code generation.

### DIFF
--- a/crates/cairo-lang-parser/src/colored_printer.rs
+++ b/crates/cairo-lang-parser/src/colored_printer.rs
@@ -22,7 +22,7 @@ impl ColoredPrinter<'_> {
                 }
             }
             GreenNodeDetails::Node { .. } => {
-                if self.verbose && is_missing_kind(node.kind) {
+                if self.verbose && node.kind.is_missing() {
                     self.result.push_str(&format!("{}", "<m>".red()));
                 } else if self.verbose && is_empty_kind(node.kind) {
                     self.result.push_str(&format!("{}", "<e>".red()));
@@ -34,11 +34,6 @@ impl ColoredPrinter<'_> {
             }
         }
     }
-}
-
-// TODO(yuval): autogenerate both.
-fn is_missing_kind(kind: SyntaxKind) -> bool {
-    matches!(kind, SyntaxKind::ExprMissing | SyntaxKind::StatementMissing)
 }
 
 // TODO(yuval): Move to SyntaxKind.

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/item_inline_macro
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/item_inline_macro
@@ -464,7 +464,7 @@ a_macro!
     │   │           └── ident (kind: TokenIdentifier): 'a_macro'
     │   ├── bang (kind: TokenNot): '!'
     │   ├── arguments (kind: TokenTreeNode)
-    │   │   └── subtree (kind: WrappedTokenTreeMissing) []
+    │   │   └── subtree: Missing []
     │   └── semicolon: Missing
     └── child #1 (kind: FunctionWithBody) <ignored>
 

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/macro_declaration
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/macro_declaration
@@ -232,7 +232,7 @@ error[E1008]: Missing tokens. Expected a macro rule parameter kind.
     │       │       │   │   │   ├── name (kind: TokenIdentifier): 'x'
     │       │       │   │   │   └── kind (kind: ParamKind)
     │       │       │   │   │       ├── colon (kind: TokenColon): ':'
-    │       │       │   │   │       └── kind (kind: MacroParamKindMissing) []
+    │       │       │   │   │       └── kind: Missing []
     │       │       │   │   └── child #1 (kind: TokenTreeLeaf)
     │       │       │   │       └── leaf (kind: TokenIdentifier): 'unknown'
     │       │       │   └── rparen (kind: TokenRParen): ')'

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees_with_trivia/attribute_errors
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees_with_trivia/attribute_errors
@@ -732,7 +732,7 @@ error[E1023]: Missing tokens. Expected an item after attributes.
         │               │   │   │       │   └── trailing_trivia (kind: Trivia)
         │               │   │   │       │       └── child #0 (kind: TokenNewline).
         │               │   │   │       └── segments (kind: ExprPathInner)
-        │               │   │   │           └── item #0 (kind: PathSegmentMissing)
+        │               │   │   │           └── item #0: Missing
         │               │   │   │               └── ident (kind: TerminalIdentifier)
         │               │   │   │                   ├── leading_trivia (kind: Trivia) []
         │               │   │   │                   ├── token: Missing

--- a/crates/cairo-lang-parser/src/printer.rs
+++ b/crates/cairo-lang-parser/src/printer.rs
@@ -163,7 +163,7 @@ impl<'a> Printer<'a> {
             return;
         }
 
-        let extra_info = if is_missing_kind(kind) {
+        let extra_info = if kind.is_missing() {
             format!(": {}", self.red("Missing".into()))
         } else {
             format!(" (kind: {kind:?})")
@@ -287,17 +287,4 @@ impl<'a> Printer<'a> {
     fn bright_purple(&self, text: ColoredString) -> ColoredString {
         if self.print_colors { text.bright_purple() } else { text }
     }
-}
-
-// TODO(yuval): autogenerate.
-fn is_missing_kind(kind: SyntaxKind) -> bool {
-    matches!(
-        kind,
-        SyntaxKind::ExprMissing
-            | SyntaxKind::WrappedArgListMissing
-            | SyntaxKind::StatementMissing
-            | SyntaxKind::ModuleItemMissing
-            | SyntaxKind::TraitItemMissing
-            | SyntaxKind::ImplItemMissing
-    )
 }

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -32,7 +32,6 @@ use cairo_lang_syntax::node::ast::{
 };
 use cairo_lang_syntax::node::helpers::{GetIdentifier, PathSegmentEx, QueryAttrs};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
-use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::ordered_hash_map::{Entry, OrderedHashMap};
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
@@ -736,20 +735,7 @@ fn expand_inline_macro<'db>(
     let macro_path = syntax.path(db);
     let crate_id = ctx.resolver.owning_crate_id;
     // Skipping expanding an inline macro if it had a parser error.
-    if syntax.as_syntax_node().descendants(db).any(|node| {
-        matches!(
-            node.kind(db),
-            SyntaxKind::ExprMissing
-                | SyntaxKind::WrappedArgListMissing
-                | SyntaxKind::StatementMissing
-                | SyntaxKind::ModuleItemMissing
-                | SyntaxKind::TraitItemMissing
-                | SyntaxKind::ImplItemMissing
-                | SyntaxKind::TokenMissing
-                | SyntaxKind::TokenSkipped
-                | SyntaxKind::WrappedTokenTreeMissing
-        )
-    }) {
+    if syntax.as_syntax_node().descendants(db).any(|node| node.kind(db).is_missing()) {
         return Err(skip_diagnostic());
     }
     // We call the resolver with a new diagnostics, since the diagnostics should not be reported

--- a/crates/cairo-lang-syntax/src/node/kind.rs
+++ b/crates/cairo-lang-syntax/src/node/kind.rs
@@ -618,6 +618,22 @@ impl SyntaxKind {
                 | SyntaxKind::TerminalPub
         )
     }
+    pub fn is_missing(&self) -> bool {
+        matches!(
+            *self,
+            SyntaxKind::ExprMissing
+                | SyntaxKind::PathSegmentMissing
+                | SyntaxKind::WrappedArgListMissing
+                | SyntaxKind::StatementMissing
+                | SyntaxKind::ModuleItemMissing
+                | SyntaxKind::TraitItemMissing
+                | SyntaxKind::ImplItemMissing
+                | SyntaxKind::TokenTreeMissing
+                | SyntaxKind::WrappedTokenTreeMissing
+                | SyntaxKind::MacroRepetitionOperatorMissing
+                | SyntaxKind::MacroParamKindMissing
+        )
+    }
 }
 impl fmt::Display for SyntaxKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
## Summary

Added a `is_missing()` method to `SyntaxKind` to centralize the detection of missing syntax nodes, replacing scattered implementations across the codebase. The method is now auto-generated from the syntax specification, making it more maintainable and consistent.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, the code had multiple implementations of functions to detect missing syntax nodes (`is_missing_kind`), which were scattered across different files. This led to inconsistencies and maintenance issues. By centralizing this logic in a method on `SyntaxKind` itself and auto-generating it from the syntax specification, we ensure consistency and make the code more maintainable.

---

## What was the behavior or documentation before?

Before this change, there were multiple implementations of `is_missing_kind()` functions in different files, each with slightly different logic for detecting missing syntax nodes. This was error-prone and difficult to maintain.

---

## What is the behavior or documentation after?

Now, `SyntaxKind` has a single, auto-generated `is_missing()` method that provides a consistent way to check if a syntax node is missing. All code that previously used custom implementations now uses this centralized method.

---

## Additional context

This change improves code maintainability by reducing duplication and centralizing logic. It also ensures that all missing syntax kinds are properly detected throughout the codebase.