### PR TITLE
fix: clarify profiling footer accounting comment

### DIFF
--- a/crates/cairo-lang-runner/src/profiling.rs
+++ b/crates/cairo-lang-runner/src/profiling.rs
@@ -91,8 +91,7 @@ impl ProfilingInfo {
         let mut end_of_program_reached = false;
         // The total weight of each Sierra statement.
         // Note the header and footer (CASM instructions added for running the program by the
-        // runner). The header is not counted, and the footer is, but then the relevant
-        // entry is removed.
+        // runner). Both header and footer are not counted when collecting the weights.
         let mut sierra_statement_weights = UnorderedHashMap::default();
         // Total weight of Sierra statements grouped by the respective (collapsed) user function
         // call stack.


### PR DESCRIPTION
## Summary

The comment above sierra_statement_weights in ProfilingInfo::from_trace claimed that the footer was counted and later removed from the weights. In reality both header and footer CASM instructions are fully skipped when collecting statement weights.

## Type of change

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This change updates the comment to match the actual behavior without modifying any runtime logic.