### PR TITLE
Made all cairo code examples marked as cairo instead of rust.

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/block-expression.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/block-expression.adoc
@@ -18,7 +18,7 @@ Otherwise, if the last statement is a xref:never-type.adoc[never type] emitting 
 return, break) the block's type is the xref:never-type.adoc[never type], otherwise it is the
 xref:unit-type.adoc[unit type].
 
-[source,rust]
+[source,cairo]
 ----
 // Evaluated to unit-type.
 let _: () = {

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/boolean-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/boolean-operators.adoc
@@ -29,7 +29,7 @@ Both operands and the result are of type `bool`.
 |===
 
 [#logical-examples]
-[source,rust]
+[source,cairo]
 ----
 fn expensive() -> bool { true }
 
@@ -65,7 +65,7 @@ short-circuit: both operands are always evaluated.
 |===
 
 [#bitwise-examples]
-[source,rust]
+[source,cairo]
 ----
 fn side_effect() -> bool { /* ... */ false }
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/boolean-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/boolean-types.adoc
@@ -19,7 +19,7 @@ The following operators are defined for the boolean type:
 |===
 
 == Examples
-[source,rust]
+[source,cairo]
 ----
 fn main() {
     let x: bool = true;

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/comments.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/comments.adoc
@@ -4,7 +4,7 @@ Comments follow the general C++/Rust style of line (`//`) comments.
 
 == Example
 
-[source,rust]
+[source,cairo]
 ----
 // Comment.
 ----

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/contracts.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/contracts.adoc
@@ -6,7 +6,7 @@ Starknet contracts can be written in Cairo.
 
 == Example
 
-[source,rust]
+[source,cairo]
 ----
 #[starknet::contract]
 mod my_contract {
@@ -66,7 +66,7 @@ Starknet contracts have no main() function. Instead, each function may be annota
 function using one of the attributes below:
 
 - `#[external(v0)]` functions may be called by Starknet users or by other contracts. For example:
-[source]
+[source,cairo]
 ----
     #[external(v0)]
     fn external_example(ref self: ContractState, value: felt252) {
@@ -76,7 +76,7 @@ function using one of the attributes below:
 Note the first parameter. It represents the state of the contract storage.
 The `ref` modifier means that the state may change - by writing to storage, for example.
 Another possibility is to get a read-only reference to the storage:
-[source]
+[source,cairo]
 ----
     #[external(v0)]
     fn view_example(self: @ContractState) -> felt252 {
@@ -87,7 +87,7 @@ This is a view function - it can only read from the storage.
 - `#[constructor]` function is called when the contract is deployed. There may be only one such
 function and it must be called `constructor`. If it is not defined, the contract is deployed with
 all storage variables default-initialized. For example:
-[source]
+[source,cairo]
 ----
     #[constructor]
     fn constructor() {
@@ -95,7 +95,7 @@ all storage variables default-initialized. For example:
     }
 ----
 - `#[l1_handler]` functions are called when the contract receives a message from L1. For example:
-[source]
+[source,cairo]
 ----
     #[l1_handler]
     fn l1_handler_example(from_address: felt252) {
@@ -105,7 +105,7 @@ all storage variables default-initialized. For example:
 ----
 - Functions without any of the above attributes are private functions, and may only be called by
 other functions in the same contract. They are not entry points. For example:
-[source]
+[source,cairo]
 ----
     fn private_helper_add(a: felt252, b: felt252) -> felt252 {
         a + b
@@ -120,7 +120,7 @@ Events are defined by creating an `enum` named `Event` annotated with `#[event]`
 Each variant represents a different event type and must be a struct deriving `starknet::Event`.
 
 For example:
-[source,rust]
+[source,cairo]
 ----
     #[derive(Drop, starknet::Event)]
     pub struct MyEvent {
@@ -135,7 +135,7 @@ For example:
 ----
 
 Events are emitted using `self.emit()`:
-[source,rust]
+[source,cairo]
 ----
     #[external(v0)]
     fn trigger_event(ref self: ContractState, value: u128) {
@@ -160,7 +160,7 @@ You can also write a contract interface manually, for contracts that are not imp
 your code.
 
 For example, the contract interface for `my_contract` above can be manually written as:
-[source,rust]
+[source,cairo]
 ----
 #[starknet::interface]
 trait IMyContract {
@@ -177,7 +177,7 @@ That is, for every contract you implement or contract interface you manually add
 You can use another contract interface contract-dispatcher to call another contract
 in the following way:
 
-[source,rust]
+[source,cairo]
 ----
 #[starknet::interface]
 trait IMyContract<TContractState> {
@@ -206,7 +206,7 @@ You can also call a function from another contract class as a library function.
 This means the function's logic is executed from the caller contract's context.
 This can be done using the library-dispatcher in the following way:
 
-[source,rust]
+[source,cairo]
 ----
 #[starknet::interface]
 trait IMyContract {
@@ -241,7 +241,7 @@ deserialize yourself.
 You also need to compute the selector of the function you want to call, which is the
 keccak hash of the function name - in this case `starknet_keccak("foo")`.
 
-[source,rust]
+[source,cairo]
 ----
 #[starknet::contract]
 mod my_second_contract {

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/derive-macro.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/derive-macro.adoc
@@ -5,8 +5,7 @@ The derive macro is used to implement traits for structs and enums automatically
 The compiler will generate implementations for the requested traits.
 Note this is supported for generic types as well.
 
-// TODO(spapini): Use cairo syntax highlighting.
-[source,rust]
+[source,cairo]
 ----
 #[derive(Copy, Drop, PartialEq)]
 struct Foo {

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/felt252-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/felt252-type.adoc
@@ -6,7 +6,7 @@ specified range, using modular arithmetic.
 == Code Example
 The following example demonstrates how the maximum value of `felt252` behaves when adding `1`.
 
-[source, rust]
+[source,cairo]
 ----
 fn main() {
     // max value of felt252
@@ -20,7 +20,7 @@ fn main() {
 Since `felt252` is the default data type, there's no need to explicitly specify it in simple cases.
 Here’s the simplified version:
 
-[source, rust]
+[source,cairo]
 ----
 fn main() {
     // max value of felt252

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/felt252dict-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/felt252dict-type.adoc
@@ -8,7 +8,7 @@ By default, the value `0`, or value logically equivalent to `0`, is returned for
 
 Here is a simple usage example for a dictionary:
 
-[source,rust]
+[source,cairo]
 ----
 let mut dict: Felt252Dict<u128> = Default::default();
 dict.insert(10, 110);
@@ -31,7 +31,7 @@ value of the given key. The `Felt252DictEntry` object is a temporary owner of th
 and can only be destructed by calling `finalize(new_value)` on it, which returns ownership of
 the dictionary. This ensures that the dictionary is not used while it is being modified.
 
-[source,rust]
+[source,cairo]
 ----
 let mut dict: Felt252Dict<u128> = Default::default();
 dict.insert(10, 110);
@@ -48,7 +48,7 @@ process of a dictionary is not trivial, and the `Destruct` trait is implemented 
 This means that `Destruct` must be derived for any type that contains a dictionary. For more
 information, see the xref:linear-types.adoc#Destructors[Destructors] section.
 
-[source,rust]
+[source,cairo]
 ----
 #[derive(Destruct)]
 struct MyStruct {

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/function-calls.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/function-calls.adoc
@@ -3,14 +3,14 @@
 A call expression calls a xref:functions.adoc[function]. The syntax for a call expression is the
 xref:path.adoc[concrete path] of the function followed by a list of arguments.
 The list of arguments is a comma-separated list of expressions enclosed in parentheses.
-[source,rust]
+[source,cairo]
 ----
 <concrete_path>(<arg0>,<arg1>,...)
 ----
 
 Examples:
 
-[source,rust]
+[source,cairo]
 ----
 cmp::max(a: 5, b: 1)
 get_info()
@@ -43,7 +43,7 @@ xref:assignment-statement.adoc[assignment].
 `lvalue` is passed to the function and then reassigned when the function returns.
 Example: `increment(ref a.b)`.
 
-[source,rust]
+[source,cairo]
 ----
 fn main() {
     let x = 3;

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
@@ -3,7 +3,7 @@
 A function is a unit of code that performs some logic. It is defined using the `fn` keyword.
 
 Examples of functions are:
-[source]
+[source,cairo]
 ----
 fn main() {
     let x = 3;
@@ -16,7 +16,7 @@ fn inc(x: u32) -> u32 {
 
 A function consists of 2 main parts: the function signature and the function body.
 For example,
-[source]
+[source,cairo]
 ----
 // Function signature |         | Body starts here
 //                    V         V
@@ -30,7 +30,7 @@ fn inc_n<T, const N>(x: T) -> T {
 The function signature defines the function name, the xref:generics.adoc[generic parameters],
 the parameters and the return type.
 
-[source,rust]
+[source,cairo]
 ----
 fn <name>[<<generic_parameters>>](<parameters>) [-> <return_type>]
 ----
@@ -63,7 +63,7 @@ and can be modified in the function.
 A parameter that is defined with the `ref` modifier, simulates a reference to the
 value passed to the function. It behaves similarly to a mutable variable, but mutating
 it also affects its value in the caller function. For example:
-[source,rust]
+[source,cairo]
 ----
     fn foo(mut x: u32, ref y: u32) {
         x *= 3;

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/generics.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/generics.adoc
@@ -3,7 +3,7 @@
 Generic programming is a way to define "recipes" for creating concrete xref:items.adoc[items].
 This recipe has parameters called "generic parameters" (in addition to the "normal" parameters).
 For example:
-[source,rust]
+[source,cairo]
 ----
 fn foo<T>(x: T) -> T { x }
 ----
@@ -18,7 +18,7 @@ If an item doesn't require generic parameters, the whole `<...>` clause can be o
 Each generic parameter has a name that is used to refer to it in the item's body.
 
 For example, the generic struct `Box` below defines a type that can hold any type of data:
-[source,rust]
+[source,cairo]
 ----
 fn main() {
     struct Box<T> {
@@ -63,7 +63,7 @@ which impl will be actually used.
 
 For example:
 
-[source,rust]
+[source,cairo]
 ----
 trait MulTrait<T> {
     fn mul(x: T) -> T;
@@ -102,7 +102,7 @@ For example, `foo` from the above example can't have a concrete form in which `T
 as there is no impl of `MulTrait` for `u128`.
 
 In this case, you can also use anonymous impl generic parameters:
-[source,rust]
+[source,cairo]
 ----
 fn foo<T, +MyTrait<T>>(x: T) -> T {
     MyTrait::mul(x)
@@ -132,7 +132,7 @@ Each kind of generic parameter has its own kind of generic arguments:
 Generic arguments can be named.
 This allows specifying them in any order, and also allows specifying only some of them.
 For example, the following two statements are equivalent:
-[source,rust]
+[source,cairo]
 ----
 let x = foo::<T: u32, S: u64>(5);
 let x = foo::<S: u64, T: u32>(5);

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/integer-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/integer-types.adoc
@@ -20,7 +20,7 @@ The `usize` type is an alias to `u32`, and is used for array indexing.
 
 All integer types can be created as literals using the appropriate suffix.
 For `u256`, you can also construct values from other types explicitly.
-[source,rust]
+[source,cairo]
 ----
 fn main() {
     let x: u8 = 10_u8;

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/lexical-structure.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/lexical-structure.adoc
@@ -64,7 +64,7 @@ See the xref:punctuation.adoc[punctuation page] for a complete reference.
 
 Cairo supports xref:comments.adoc[line comments] using the `//` syntax:
 
-[source,rust]
+[source,cairo]
 ----
 // This is a line comment
 let x = 42;  // Comment after code

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
@@ -10,7 +10,7 @@ The supported literal expressions are described next.
 The two values of the xref:boolean-types.adoc[boolean] type are `true` and `false`.
 
 example
-[source]
+[source,cairo]
 ----
 let a = true;
 let b = false;

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/method-calls.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/method-calls.adoc
@@ -17,7 +17,7 @@ It must be the first parameter of the function.
 
 A function defined in such a way can be called as a method on the value:
 
-[source,rust]
+[source,cairo]
 ----
 trait Display<T> {
     fn display(self: T) -> Array<u8>;

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/naming-conventions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/naming-conventions.adoc
@@ -36,7 +36,7 @@ Language implementations can emit warnings when names do not follow these rules.
 
 The name of an unused variable must start with an _ (a common example is simply "_").
 
-[source,rust]
+[source,cairo]
 ----
 let _unused = compute_something();
 ----

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
@@ -10,7 +10,7 @@ and valid.
 
 The basic function that all panic stems from is the `panic` function.
 It is defined as:
-[source,rust]
+[source,cairo]
 ----
 extern fn panic(data: Array<felt252>) -> never;
 ----
@@ -45,7 +45,7 @@ This macro takes two arguments: the data that is passed as the panic reason as w
 name for a wrapping function.
 If the function returns `None` or `Err`, _panic_ function will be called with the given data.
 
-[source,rust]
+[source,cairo]
 ----
 #[panic_with('got none value', unwrap)]
 fn identity(value: Option<u128>) -> Option<u128> { value }

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/parentheses.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/parentheses.adoc
@@ -5,7 +5,7 @@ multiple operators.
 
 An example of a parenthesized expression:
 
-[source,rust]
+[source,cairo]
 ----
  2 + 2  * 2 // == 6
 (2 + 2) * 2 // == 8

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/patterns.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/patterns.adoc
@@ -4,7 +4,7 @@ Patterns are used to match values to specific structures.
 They can be used in xref:let-statement.adoc[`let` statements] and xref:match-expressions.adoc[`match`] arms.
 == Pattern examples
 
-[source]
+[source,cairo]
 ----
 MyStruct {a: a, b : _b, c: _}
 MyEnum(a, b, c)

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/traits.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/traits.adoc
@@ -6,7 +6,7 @@ functions. This feature promotes code reusability and modular design.
 
 == Example
 
-[source,rust]
+[source,cairo]
 ----
 trait Display<T> {
     fn display(x: T) -> Array<u8>;
@@ -34,7 +34,7 @@ Note that unlike Rust, impls have names, so that they can be explicitly specifie
 In Cairo, impls can be used as generic parameters, allowing for a more flexible and modular design.
 For example, the following code defines a function that takes a generic parameter `T` and
 an implementation of the `Display<T>` trait:
-[source,rust]
+[source,cairo]
 ----
 fn foo<T, impl TDisplay: Display<T>>(value: T) {
     let a = TDisplay::display(value);

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/variables.adoc
@@ -10,7 +10,7 @@ There are several ways to introduce variables in a Cairo program.
 == Let statement
 
 Variables can be defined using the xref:let-statement.adoc[`let`] keyword with the following syntax:
-[source]
+[source,cairo]
 ----
 let x: u32 = 5_u32;
 ----
@@ -19,7 +19,7 @@ declares a variable named `x` of type `u32` with an initial value of `5`.
 The type annotation can be omitted in cases where the type can be deduced.
 
 For example:
-[source]
+[source,cairo]
 ----
 let x = 5_u32;
 ----
@@ -29,7 +29,7 @@ A variable can be declared as mutable using the `mut` keyword.
 A mutable variable can be xref:assignment-statement.adoc[assigned] a different value after initialization.
 
 For example:
-[source]
+[source,cairo]
 ----
 let mut x = 17;
 x = x + 3;
@@ -40,7 +40,7 @@ x = x + 3;
 Every function parameter introduces a variable that is accessible in the body of a function.
 
 For example:
-[source]
+[source,cairo]
 ----
 fn add(x: u32, mut y: u32) -> u32 {
    y += x;
@@ -66,7 +66,7 @@ Note that `ref` parameters are mutable. Using both modifiers on the same paramet
 allowed.
 
 For example:
-[source]
+[source,cairo]
 ----
 fn inc_by_one(ref x: u32) {
    x = x + 1;
@@ -84,7 +84,7 @@ fn test() {
 A variable can be introduced inside a match arm.
 
 For example:
-[source]
+[source,cairo]
 ----
 match opt {
     Some(x) => x,
@@ -101,7 +101,7 @@ In this case, the variable shadows the variable in the outer scope,
 but it does not change the variable in the outer scope.
 
 For example:
-[source]
+[source,cairo]
 ----
 let x = 5;
 {
@@ -113,7 +113,7 @@ assert(x == 5, 'Should be equal.');
 In contrast, when a mutable variable is assigned in an inner scope, it also changes in the outer
 scope.
 
-[source]
+[source,cairo]
 ----
 let mut x = 5;
 {


### PR DESCRIPTION
## Summary

Updated syntax highlighting in documentation from `rust` to `cairo` across multiple files to ensure proper code block rendering.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The documentation was using `rust` syntax highlighting for Cairo code examples, which could lead to incorrect highlighting of Cairo-specific syntax. This change ensures that code blocks are properly highlighted according to Cairo's syntax rules, improving readability and accuracy of the documentation.

---

## What was the behavior or documentation before?

Code blocks in the documentation were using `[source,rust]` tags, which applied Rust syntax highlighting to Cairo code examples.

---

## What is the behavior or documentation after?

All code blocks now use `[source,cairo]` tags, ensuring proper Cairo-specific syntax highlighting for all examples, when supported. Currently mostly fallbacks to rust.

---

## Additional context

This change affects multiple documentation files in the language constructs section, ensuring consistent syntax highlighting throughout the reference documentation. Proper syntax highlighting helps users better understand Cairo code examples by visually distinguishing language-specific elements.