### PR TITLE
(feat): Reboxing now works recursivly and applies optimization at deconstruct statement

### DIFF
--- a/crates/cairo-lang-lowering/src/objects.rs
+++ b/crates/cairo-lang-lowering/src/objects.rs
@@ -4,7 +4,7 @@
 //! assigned once. It is also normal form: each function argument is a variable, rather than a
 //! compound expression.
 
-use std::ops::{Deref, DerefMut};
+use std::ops::{Deref, DerefMut, Index};
 
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
@@ -28,6 +28,7 @@ use salsa::Database;
 use semantic::MatchArmSelector;
 
 use self::blocks::Blocks;
+use crate::borrow_check::analysis::StatementLocation;
 use crate::diagnostic::LoweringDiagnostic;
 use crate::fmt::LoweredFormatter;
 use crate::ids::{FunctionId, LocationId, Signature};
@@ -151,6 +152,14 @@ pub struct Lowered<'db> {
     pub blocks: Blocks<'db>,
     /// function parameters, including implicits.
     pub parameters: Vec<VariableId>,
+}
+
+impl<'db> Index<StatementLocation> for Lowered<'db> {
+    type Output = Statement<'db>;
+
+    fn index(&self, location: StatementLocation) -> &Self::Output {
+        &self.blocks[location]
+    }
 }
 
 unsafe impl<'db> salsa::Update for Lowered<'db> {

--- a/crates/cairo-lang-lowering/src/objects/blocks.rs
+++ b/crates/cairo-lang-lowering/src/objects/blocks.rs
@@ -3,7 +3,8 @@ use std::ops::{Index, IndexMut};
 use cairo_lang_diagnostics::{DiagnosticAdded, Maybe};
 use cairo_lang_utils::require;
 
-use crate::Block;
+use crate::borrow_check::analysis::StatementLocation;
+use crate::{Block, Statement};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, salsa::Update)]
 pub struct BlockId(pub usize);
@@ -129,5 +130,12 @@ impl<'db> Index<BlockId> for Blocks<'db> {
 impl<'db> IndexMut<BlockId> for Blocks<'db> {
     fn index_mut(&mut self, index: BlockId) -> &mut Self::Output {
         &mut self.0[index.0]
+    }
+}
+impl<'db> Index<StatementLocation> for Blocks<'db> {
+    type Output = Statement<'db>;
+
+    fn index(&self, index: StatementLocation) -> &Self::Output {
+        &self[index.0].statements[index.1]
     }
 }

--- a/crates/cairo-lang-lowering/src/optimizations/reboxing.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/reboxing.rs
@@ -4,22 +4,34 @@ mod reboxing_test;
 
 use std::rc::Rc;
 
+use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::flag::FlagsGroup;
-use cairo_lang_semantic::items::structure::StructSemantic;
-use cairo_lang_semantic::types::{TypesSemantic, peel_snapshots, wrap_in_snapshots};
-use cairo_lang_semantic::{ConcreteTypeId, GenericArgumentId, TypeLongId};
+use cairo_lang_semantic::corelib::core_box_ty;
 use cairo_lang_utils::ordered_hash_map::{Entry, OrderedHashMap};
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::Itertools;
 use salsa::Database;
 
 use super::var_renamer::VarRenamer;
+use crate::blocks::Blocks;
 use crate::borrow_check::analysis::StatementLocation;
 use crate::utils::RebuilderEx;
 use crate::{
     BlockEnd, Lowered, Statement, StatementStructDestructure, VarUsage, Variable, VariableArena,
     VariableId,
 };
+
+/// Data for the MemberOfUnboxed variant.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MemberOfUnboxedData {
+    /// The source reboxing value.
+    pub source: Rc<ReboxingValue>,
+    /// The member index.
+    pub member: usize,
+    /// The location where the deconstruct statement occurs.
+    pub deconstruct_location: StatementLocation,
+}
 
 /// The possible values for the reboxing analysis.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -29,7 +41,7 @@ pub enum ReboxingValue {
     /// The variable is unboxed from a different variable.
     Unboxed(VariableId),
     /// The variable is a member of an unboxed variable.
-    MemberOfUnboxed { source: Rc<ReboxingValue>, member: usize },
+    MemberOfUnboxed(MemberOfUnboxedData),
 }
 
 /// Represents a candidate for reboxing optimization.
@@ -53,7 +65,7 @@ pub struct ReboxCandidate {
 /// Returns candidates that can be optimized with struct_boxed_deconstruct libfunc calls.
 pub fn find_reboxing_candidates<'db>(lowered: &Lowered<'db>) -> OrderedHashSet<ReboxCandidate> {
     if lowered.blocks.is_empty() {
-        return OrderedHashSet::default();
+        return Default::default();
     }
 
     trace!("Running reboxing analysis...");
@@ -89,6 +101,10 @@ pub fn find_reboxing_candidates<'db>(lowered: &Lowered<'db>) -> OrderedHashSet<R
                     }
                 }
                 Statement::StructDestructure(destructure_stmt) => {
+                    let info = &lowered.variables[destructure_stmt.input.var_id].info;
+                    if info.copyable.is_err() || info.droppable.is_err() {
+                        continue;
+                    }
                     let input_state = current_state
                         .get(&destructure_stmt.input.var_id)
                         .cloned()
@@ -99,10 +115,11 @@ pub fn find_reboxing_candidates<'db>(lowered: &Lowered<'db>) -> OrderedHashSet<R
                             for (member_idx, output_var) in
                                 destructure_stmt.outputs.iter().enumerate()
                             {
-                                let res = ReboxingValue::MemberOfUnboxed {
+                                let res = ReboxingValue::MemberOfUnboxed(MemberOfUnboxedData {
                                     source: Rc::new(input_state.clone()),
+                                    deconstruct_location: (block_id, stmt_idx),
                                     member: member_idx,
-                                };
+                                });
 
                                 current_state.insert(*output_var, res);
                             }
@@ -146,46 +163,140 @@ fn update_reboxing_variable_join(
     }
 }
 
+/// Represents an operation to apply to the lowered function.
+#[derive(Debug)]
+enum ReboxingOperation<'db> {
+    Add { location: StatementLocation, statement: Statement<'db> },
+    Remove { location: StatementLocation },
+}
+
+impl<'db> ReboxingOperation<'db> {
+    /// Applies this operation to the lowered function, adding or removing statements as specified.
+    /// Note: This function modifies the lowered object, and applying multiple operations may
+    /// require applying in reverse order to statement location.
+    fn apply(self, lowered: &mut Lowered<'db>) {
+        match self {
+            ReboxingOperation::Add { location: (block_id, stmt_idx), statement } => {
+                lowered.blocks[block_id].statements.insert(stmt_idx, statement);
+            }
+            ReboxingOperation::Remove { location: (block_id, stmt_idx) } => {
+                lowered.blocks[block_id].statements.remove(stmt_idx);
+            }
+        }
+    }
+
+    /// Returns the statement location associated with this operation.
+    fn location(&self) -> StatementLocation {
+        match self {
+            ReboxingOperation::Add { location, .. } => *location,
+            ReboxingOperation::Remove { location } => *location,
+        }
+    }
+}
+
 /// Applies reboxing optimizations to the lowered function using the provided candidates.
 pub fn apply_reboxing_candidates<'db>(
     db: &'db dyn Database,
     lowered: &mut Lowered<'db>,
     candidates: &OrderedHashSet<ReboxCandidate>,
-) {
+) -> Maybe<()> {
     if candidates.is_empty() {
         trace!("No reboxing candidates to apply.");
-        return;
+        return Ok(());
     }
 
     trace!("Applying {} reboxing optimization(s).", candidates.len());
 
     let mut renamer = VarRenamer::default();
-    let mut stmts_to_remove = Vec::new();
+    let mut operations = Vec::new();
+    let mut added_boxes = UnorderedHashMap::default();
 
-    for candidate in candidates {
-        match &candidate.source {
-            ReboxingValue::Revoked => {}
-            ReboxingValue::Unboxed(id) => {
-                renamer.renamed_vars.insert(candidate.reboxed_var, *id);
-                stmts_to_remove.push(candidate.into_box_location);
+    for candidate in candidates.iter() {
+        let box_var_to_use = match &candidate.source {
+            ReboxingValue::Revoked => unreachable!("Revoked reboxing candidate should not exist"),
+            ReboxingValue::Unboxed(id) => *id,
+            ReboxingValue::MemberOfUnboxed(data) => {
+                // Create output variables for all members (all will be Box<MemberType>), or get
+                // existing ones.
+                create_deconstruct_statements(
+                    db,
+                    &mut lowered.variables,
+                    &lowered.blocks,
+                    &mut operations,
+                    &mut added_boxes,
+                    data,
+                )
             }
-            ReboxingValue::MemberOfUnboxed { source, member } => {
-                replace_into_box_call(db, lowered, candidate, source, *member);
-            }
-        }
+        };
+        renamer.renamed_vars.insert(candidate.reboxed_var, box_var_to_use);
+        operations.push(ReboxingOperation::Remove { location: candidate.into_box_location });
     }
 
-    // We sort the candidates such that removal of statements can be done in reverse order.
-    // Statements are expected to be in order due to analysis being forward, but we do not require
-    // the ordered assumption.
-    stmts_to_remove.sort_by_key(|(block_id, stmt_idx)| (block_id.0, *stmt_idx));
-    for (block_id, stmt_idx) in stmts_to_remove.into_iter().rev() {
-        lowered.blocks[block_id].statements.remove(stmt_idx);
-    }
+    // Sort operations by location in reverse order (highest block_id, highest stmt_idx first)
+    // This ensures that an operation index won't change before it is updated.
+    operations.sort_by_key(|op| {
+        let (block_id, stmt_idx) = op.location();
+        (std::cmp::Reverse(block_id.0), std::cmp::Reverse(stmt_idx))
+    });
+
+    operations.into_iter().for_each(|operation| operation.apply(lowered));
 
     for block in lowered.blocks.iter_mut() {
         *block = renamer.rebuild_block(block);
     }
+    Ok(())
+}
+
+/// Recursively allocate boxed variables for a deconstruct statement and its original deconstruct
+/// creation. Add the boxed_deconstruct operations (recursively) to the operations vector.
+#[allow(clippy::too_many_arguments)]
+fn create_deconstruct_statements<'db>(
+    db: &'db dyn Database,
+    variables: &mut VariableArena<'db>,
+    blocks: &Blocks<'db>,
+    operations: &mut Vec<ReboxingOperation<'db>>,
+    added_boxes: &mut UnorderedHashMap<VariableId, Vec<VariableId>>,
+    data: &MemberOfUnboxedData,
+) -> VariableId {
+    let deconstruct_statement = &blocks[data.deconstruct_location];
+    let deconstruct_outputs = deconstruct_statement.outputs();
+    let input_var = deconstruct_statement.inputs()[0];
+    if let Some(boxed_vars) = added_boxes.get(&input_var.var_id) {
+        return boxed_vars[data.member];
+    }
+
+    let source_box = match data.source.as_ref() {
+        ReboxingValue::Revoked => {
+            unreachable!("A Revoked reboxing state should be blocked before.")
+        }
+        ReboxingValue::Unboxed(id) => {
+            // We are at top of the recursion and found our source var.
+            *id
+        }
+        ReboxingValue::MemberOfUnboxed(data) => {
+            // Recurse to find the source var.
+            create_deconstruct_statements(db, variables, blocks, operations, added_boxes, data)
+        }
+    };
+    let outputs = deconstruct_outputs
+        .iter()
+        .map(|out_var_id| {
+            let out_var = &variables[*out_var_id];
+            let box_ty = core_box_ty(db, out_var.ty);
+            let out_location = out_var.location;
+            variables.alloc(Variable::with_default_context(db, box_ty, out_location))
+        })
+        .collect_vec();
+
+    operations.push(ReboxingOperation::Add {
+        location: data.deconstruct_location,
+        statement: Statement::StructDestructure(StatementStructDestructure {
+            input: VarUsage { var_id: source_box, location: input_var.location },
+            outputs: outputs.clone(),
+        }),
+    });
+    added_boxes.insert(input_var.var_id, outputs);
+    added_boxes[&input_var.var_id][data.member]
 }
 
 /// Applies the reboxing optimization to the lowered function.
@@ -196,119 +307,11 @@ pub fn apply_reboxing_candidates<'db>(
 /// 3. Box one of the members back
 ///
 /// And replaces it with a direct struct_boxed_deconstruct libfunc call.
-pub fn apply_reboxing<'db>(db: &'db dyn Database, lowered: &mut Lowered<'db>) {
+pub fn apply_reboxing<'db>(db: &'db dyn Database, lowered: &mut Lowered<'db>) -> Maybe<()> {
     if db.flag_future_sierra() {
         let candidates = find_reboxing_candidates(lowered);
-        apply_reboxing_candidates(db, lowered, &candidates);
+        apply_reboxing_candidates(db, lowered, &candidates)
+    } else {
+        Ok(())
     }
-}
-
-/// Replaces the call to `into_box` with a call to `struct_boxed_deconstruct`.
-fn replace_into_box_call<'db>(
-    db: &'db dyn Database,
-    lowered: &mut Lowered<'db>,
-    candidate: &ReboxCandidate,
-    source: &Rc<ReboxingValue>,
-    member: usize,
-) {
-    trace!(
-        "Applying optimization: candidate={:?}, reboxed={}",
-        candidate.source,
-        candidate.reboxed_var.index()
-    );
-
-    let ReboxingValue::Unboxed(source_var) = **source else {
-        // When source of the value is not `Unboxes`, it is a nested MemberOfUnboxed, which is not
-        // supported yet.
-        return;
-    };
-    // Create the struct_boxed_deconstruct call
-    let (into_box_block, into_box_stmt_idx) = candidate.into_box_location;
-    if let Some(new_stmt) = create_struct_boxed_deconstruct_call(
-        db,
-        &mut lowered.variables,
-        source_var,
-        member,
-        candidate.reboxed_var,
-        &lowered.blocks[into_box_block].statements[into_box_stmt_idx],
-    ) {
-        lowered.blocks[into_box_block].statements[into_box_stmt_idx] = new_stmt;
-        trace!("Successfully applied reboxing optimization.");
-    }
-}
-
-/// Creates a struct_boxed_deconstruct call statement.
-/// Returns None if the call cannot be created.
-fn create_struct_boxed_deconstruct_call<'db>(
-    db: &'db dyn Database,
-    variables: &mut VariableArena<'db>,
-    boxed_struct_var: VariableId,
-    member_index: usize,
-    output_var: VariableId,
-    old_stmt: &Statement<'db>,
-) -> Option<Statement<'db>> {
-    let boxed_struct_ty = variables[boxed_struct_var].ty;
-    trace!("Creating struct_boxed_deconstruct call for type {:?}", boxed_struct_ty);
-
-    // Extract the struct type from Box<Struct>
-    // The boxed type should be Box<T>, we need to get T
-    let TypeLongId::Concrete(concrete_box) = boxed_struct_ty.long(db) else {
-        unreachable!("Unbox should always be called on a box type (which is concrete).");
-    };
-
-    let generic_args = concrete_box.generic_args(db);
-    let GenericArgumentId::Type(inner_ty) = generic_args.first()? else {
-        unreachable!("Box unbox call should always have a generic arg");
-    };
-
-    if db.copyable(*inner_ty).is_err() {
-        return None;
-    }
-    let (n_snapshots, struct_ty) = peel_snapshots(db, *inner_ty);
-
-    trace!("Extracted struct or tuple type: {:?}", struct_ty);
-    let member_types = match struct_ty {
-        TypeLongId::Concrete(ConcreteTypeId::Struct(struct_id)) => db
-            .concrete_struct_members(struct_id)
-            .ok()?
-            .iter()
-            .map(|(_, member)| wrap_in_snapshots(db, member.ty, n_snapshots))
-            .collect_vec(),
-        TypeLongId::Tuple(inner_types) => {
-            inner_types.into_iter().map(|ty| wrap_in_snapshots(db, ty, n_snapshots)).collect()
-        }
-        _ => {
-            trace!("Unsupported type for reboxing: {:?}", struct_ty);
-            return None;
-        }
-    };
-
-    if member_types.iter().any(|ty| db.droppable(*ty).is_err()) {
-        trace!("Type contains droppable members. Currently unsupported, skipping.");
-        return None;
-    }
-    trace!("Type has {} members, accessing member {}", member_types.len(), member_index);
-
-    if member_index >= member_types.len() {
-        unreachable!("Member index out of bounds");
-    }
-
-    // Create output variables for all members (all will be Box<MemberType>)
-    // We'll create new variables except for the one we're interested in
-    let mut outputs = Vec::new();
-    for (idx, member_ty) in member_types.into_iter().enumerate() {
-        if idx == member_index {
-            outputs.push(output_var);
-        } else {
-            let box_ty = cairo_lang_semantic::corelib::core_box_ty(db, member_ty);
-            let out_location = variables[output_var].location;
-            let var = variables.alloc(Variable::with_default_context(db, box_ty, out_location));
-            outputs.push(var);
-        }
-    }
-
-    Some(Statement::StructDestructure(StatementStructDestructure {
-        input: VarUsage { var_id: boxed_struct_var, location: old_stmt.inputs()[0].location },
-        outputs,
-    }))
 }

--- a/crates/cairo-lang-lowering/src/optimizations/reboxing_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/reboxing_test.rs
@@ -50,7 +50,7 @@ fn test_reboxing_analysis(
             .join(", ");
 
         // Apply reboxing optimizations to create "after" state
-        apply_reboxing_candidates(db, &mut after, &candidates);
+        apply_reboxing_candidates(db, &mut after, &candidates).unwrap();
 
         TestRunnerResult::success(OrderedHashMap::from([
             ("candidates".into(), candidates_str),

--- a/crates/cairo-lang-lowering/src/optimizations/reorder_statements.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/reorder_statements.rs
@@ -44,7 +44,7 @@ pub fn reorder_statements(db: &dyn Database, lowered: &mut Lowered<'_>) {
         changes_by_block.entry(src.0).or_insert_with(Vec::new).push((src.1, None));
 
         if let Some(dst) = opt_dst {
-            let statement = lowered.blocks[src.0].statements[src.1].clone();
+            let statement = lowered[src].clone();
             changes_by_block.entry(dst.0).or_insert_with(Vec::new).push((dst.1, Some(statement)));
         }
     }

--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -86,7 +86,7 @@ impl<'db> OptimizationPhase<'db> {
             OptimizationPhase::DedupBlocks => dedup_blocks(lowered),
             OptimizationPhase::OptimizeMatches => optimize_matches(lowered),
             OptimizationPhase::OptimizeRemappings => optimize_remappings(lowered),
-            OptimizationPhase::Reboxing => apply_reboxing(db, lowered),
+            OptimizationPhase::Reboxing => apply_reboxing(db, lowered)?,
             OptimizationPhase::ReorderStatements => reorder_statements(db, lowered),
             OptimizationPhase::ReorganizeBlocks => reorganize_blocks(lowered),
             OptimizationPhase::ReturnOptimization => return_optimization(db, lowered),

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/reboxing
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/reboxing
@@ -40,10 +40,10 @@ Parameters: v0: core::box::Box::<test::A>
 blk0 (root):
 Statements:
   (v1: test::A) <- unbox(v0)
+  (v5: core::box::Box::<core::felt252>, v6: core::box::Box::<core::felt252>) <- struct_destructure(v0)
   (v2: core::felt252, v3: core::felt252) <- struct_destructure(v1)
-  (v5: core::box::Box::<core::felt252>, v4: core::box::Box::<core::felt252>) <- struct_destructure(v0)
 End:
-  Return(v4)
+  Return(v6)
 
 //! > ==========================================================================
 
@@ -54,8 +54,6 @@ test_reboxing_analysis
 
 //! > function_name
 multi_member
-
-//! > TODO(eytan-starkware): Support multiple members by unboxing each member separately.
 
 //! > module_code
 #[derive(Drop, Copy)]
@@ -96,12 +94,12 @@ Parameters: v0: core::box::Box::<test::Point>
 blk0 (root):
 Statements:
   (v1: test::Point) <- unbox(v0)
+  (v12: core::box::Box::<core::integer::u32>, v13: core::box::Box::<core::integer::u32>, v14: core::box::Box::<core::integer::u32>) <- struct_destructure(v0)
   (v2: core::integer::u32, v3: core::integer::u32, v4: core::integer::u32) <- struct_destructure(v1)
-  (v5: core::box::Box::<core::integer::u32>, v12: core::box::Box::<core::integer::u32>, v13: core::box::Box::<core::integer::u32>) <- struct_destructure(v0)
   (v6: test::Point) <- unbox(v0)
+  (v15: core::box::Box::<core::integer::u32>, v16: core::box::Box::<core::integer::u32>, v17: core::box::Box::<core::integer::u32>) <- struct_destructure(v0)
   (v7: core::integer::u32, v8: core::integer::u32, v9: core::integer::u32) <- struct_destructure(v6)
-  (v14: core::box::Box::<core::integer::u32>, v15: core::box::Box::<core::integer::u32>, v10: core::box::Box::<core::integer::u32>) <- struct_destructure(v0)
-  (v11: (core::box::Box::<core::integer::u32>, core::box::Box::<core::integer::u32>)) <- struct_construct(v5, v10)
+  (v11: (core::box::Box::<core::integer::u32>, core::box::Box::<core::integer::u32>)) <- struct_construct(v12, v17)
 End:
   Return(v11)
 
@@ -114,8 +112,6 @@ test_reboxing_analysis
 
 //! > function_name
 nested_struct
-
-//! > TODO(eytan-starkware): Add nesting support
 
 //! > module_code
 #[derive(Drop, Copy)]
@@ -157,11 +153,12 @@ Parameters: v0: core::box::Box::<test::Outer>
 blk0 (root):
 Statements:
   (v1: test::Outer) <- unbox(v0)
+  (v6: core::box::Box::<test::Inner>, v7: core::box::Box::<core::felt252>) <- struct_destructure(v0)
   (v2: test::Inner, v3: core::felt252) <- struct_destructure(v1)
+  (v8: core::box::Box::<core::felt252>) <- struct_destructure(v6)
   (v4: core::felt252) <- struct_destructure(v2)
-  (v5: core::box::Box::<core::felt252>) <- into_box(v4)
 End:
-  Return(v5)
+  Return(v8)
 
 //! > ==========================================================================
 
@@ -172,8 +169,6 @@ test_reboxing_analysis
 
 //! > function_name
 with_snapshot
-
-//! > TODO(eytan-starkware): Add snapshot support
 
 //! > module_code
 #[derive(Drop)]
@@ -214,10 +209,10 @@ Parameters: v0: core::box::Box::<@test::Data>
 blk0 (root):
 Statements:
   (v1: @test::Data) <- unbox(v0)
+  (v5: core::box::Box::<@test::NonCopy>, v6: core::box::Box::<@core::felt252>) <- struct_destructure(v0)
   (v2: @test::NonCopy, v3: @core::felt252) <- struct_destructure(v1)
-  (v4: core::box::Box::<@test::NonCopy>, v5: core::box::Box::<@core::felt252>) <- struct_destructure(v0)
 End:
-  Return(v4)
+  Return(v5)
 
 //! > ==========================================================================
 
@@ -434,10 +429,10 @@ Parameters: v0: core::box::Box::<(core::integer::u32, core::felt252, core::integ
 blk0 (root):
 Statements:
   (v1: (core::integer::u32, core::felt252, core::integer::u64)) <- unbox(v0)
+  (v6: core::box::Box::<core::integer::u32>, v7: core::box::Box::<core::felt252>, v8: core::box::Box::<core::integer::u64>) <- struct_destructure(v0)
   (v2: core::integer::u32, v3: core::felt252, v4: core::integer::u64) <- struct_destructure(v1)
-  (v6: core::box::Box::<core::integer::u32>, v5: core::box::Box::<core::felt252>, v7: core::box::Box::<core::integer::u64>) <- struct_destructure(v0)
 End:
-  Return(v5)
+  Return(v7)
 
 //! > ==========================================================================
 
@@ -468,7 +463,6 @@ fn non_copy_struct_rebox(s: Box<NonCopyStruct>) -> Box<felt252> {
 //! > lowering_diagnostics
 
 //! > candidates
-v4
 
 //! > before
 Parameters: v0: core::box::Box::<test::NonCopyStruct>
@@ -513,7 +507,6 @@ fn non_copy_tuple_rebox(t: Box<(Array<felt252>, felt252)>) -> Box<felt252> {
 //! > lowering_diagnostics
 
 //! > candidates
-v4
 
 //! > before
 Parameters: v0: core::box::Box::<(core::array::Array::<core::felt252>, core::felt252)>
@@ -664,7 +657,6 @@ fn main(a: Box<A>) -> (Box<felt252>, NonDrop) {
 //! > lowering_diagnostics
 
 //! > candidates
-v4
 
 //! > before
 Parameters: v0: core::box::Box::<test::A>
@@ -742,10 +734,10 @@ Parameters: v0: core::box::Box::<@test::A>
 blk0 (root):
 Statements:
   (v1: @test::A) <- unbox(v0)
+  (v8: core::box::Box::<@core::felt252>, v9: core::box::Box::<@test::NonDrop>) <- struct_destructure(v0)
   (v2: @core::felt252, v3: @test::NonDrop) <- struct_destructure(v1)
-  (v4: core::box::Box::<@core::felt252>, v8: core::box::Box::<@test::NonDrop>) <- struct_destructure(v0)
   (v5: @core::felt252, v6: @test::NonDrop) <- struct_destructure(v1)
-  (v7: (core::box::Box::<@core::felt252>, @test::NonDrop)) <- struct_construct(v4, v6)
+  (v7: (core::box::Box::<@core::felt252>, @test::NonDrop)) <- struct_construct(v8, v6)
 End:
   Return(v7)
 
@@ -833,18 +825,18 @@ blk1:
 Statements:
   (v4: test::Point) <- unbox(v0)
   (v6: test::Point) <- unbox(v0)
+  (v15: core::box::Box::<core::felt252>, v16: core::box::Box::<core::felt252>) <- struct_destructure(v0)
   (v7: core::felt252, v8: core::felt252) <- struct_destructure(v6)
-  (v15: core::box::Box::<core::felt252>, v9: core::box::Box::<core::felt252>) <- struct_destructure(v0)
 End:
-  Goto(blk3, {v9 -> v10})
+  Goto(blk3, {v16 -> v10})
 
 blk2:
 Statements:
   (v11: test::Point) <- unbox(v0)
+  (v17: core::box::Box::<core::felt252>, v18: core::box::Box::<core::felt252>) <- struct_destructure(v0)
   (v12: core::felt252, v13: core::felt252) <- struct_destructure(v11)
-  (v14: core::box::Box::<core::felt252>, v16: core::box::Box::<core::felt252>) <- struct_destructure(v0)
 End:
-  Goto(blk3, {v14 -> v10})
+  Goto(blk3, {v17 -> v10})
 
 blk3:
 Statements:


### PR DESCRIPTION
## Summary

Refactored the reboxing optimization to properly handle nested struct deconstructing. This implementation now correctly handles cases where a boxed struct is deconstructed and one of its members is boxed again, including support for nested access.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [X] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation of reboxing optimization had limitations when handling nested struct deconstructing.

---

## What was the behavior or documentation before?

Previously, the reboxing optimization could only handle simple cases where a struct was unboxed and immediately reboxed. It couldn't handle nested struct destructuring, as noted in several TODOs in the test file.

---

## What is the behavior or documentation after?

---

## Additional context

The implementation adds an `Index` trait implementation for `Lowered` to simplify accessing statements by location. It also introduces a more structured approach to tracking and applying operations with the `ReboxingOperation` enum, which helps maintain correct statement indices during transformation.