### PR TITLE
docs: document panic_with_felt252 in const evaluation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/constant-evaluation.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/constant-evaluation.adoc
@@ -49,6 +49,8 @@ Calls are permitted if one of the following holds (see `is_function_const` and
 - The function is marked `is_const` in its signature and depth limits are respected.
 - The call resolves to a trait implementation in the core library for specific const-enabled
   traits (see below).
+- The function is `core::panic_with_felt252`; such calls are permitted in const context but
+  always result in a `FailedConstantCalculation` during evaluation.
 - Specific extern functions enumerated in `ConstCalcInfo` are allowed.
 
 Const-enabled traits (corelib):


### PR DESCRIPTION
## Summary

The const evaluation docs did not mention core::panic_with_felt252 as an allowed function call, even though the implementation treats it as const-eligible via is_function_const and always produces FailedConstantCalculation at runtime.

---

## Type of change

Please check **one**:

- [x] Documentation change with concrete technical impact

---

## Why is this change needed?

This change documents that special case so that the language semantics reference matches the current compiler behavior and makes the error behavior of const panics explicit.

---



