### PR TITLE
Removed various TODOs.

### DIFF
--- a/corelib/src/box.cairo
+++ b/corelib/src/box.cairo
@@ -45,9 +45,8 @@ impl BoxCopy<T, +Copy<T>> of Copy<Box<T>>;
 impl BoxDrop<T, +Drop<T>> of Drop<Box<T>>;
 
 
-// These functions are only exposed in the corelib through the trait below, since calling them
+// These functions must only be exposed in the corelib through the trait below, since calling them
 // directly with tuples panics due to auto-unpacking of the tuple.
-// TODO(Gil): Expose in the core lib when the described behaviour is fixed.
 extern fn into_box<T>(value: T) -> Box<T> nopanic;
 extern fn unbox<T>(box: Box<T>) -> T nopanic;
 extern fn box_forward_snapshot<T>(value: @Box<T>) -> Box<@T> nopanic;

--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -72,7 +72,6 @@ pub const BYTE_ARRAY_MAGIC: felt252 =
 const BYTES_IN_U128: usize = 16;
 const BYTES_IN_BYTES31_MINUS_ONE: usize = BYTES_IN_BYTES31 - 1;
 
-// TODO(yuval): don't allow creation of invalid ByteArray?
 /// Byte array type.
 #[derive(Drop, Clone, PartialEq)]
 pub struct ByteArray {

--- a/corelib/src/ec.cairo
+++ b/corelib/src/ec.cairo
@@ -376,7 +376,6 @@ impl NonZeroEcPointNeg of Neg<NonZeroEcPoint> {
 #[cfg(not(sierra: "future"))]
 impl NonZeroEcPointNeg of Neg<NonZeroEcPoint> {
     fn neg(a: NonZeroEcPoint) -> NonZeroEcPoint {
-        // TODO(orizi): Have a `ec_neg` for NonZeroEcPoint as well.
         let p: EcPoint = a.into();
         (-p).try_into().unwrap()
     }
@@ -384,15 +383,12 @@ impl NonZeroEcPointNeg of Neg<NonZeroEcPoint> {
 
 impl EcPointAdd of Add<EcPoint> {
     /// Computes the sum of two points on the curve.
-    // TODO(lior): Implement using a libfunc to make it more efficient.
     fn add(lhs: EcPoint, rhs: EcPoint) -> EcPoint {
-        let lhs_nz = match lhs.try_into() {
-            Some(pt) => pt,
-            None => { return rhs; },
+        let Some(lhs_nz) = lhs.try_into() else {
+            return rhs;
         };
-        let rhs_nz = match rhs.try_into() {
-            Some(pt) => pt,
-            None => { return lhs; },
+        let Some(rhs_nz) = rhs.try_into() else {
+            return lhs;
         };
         let mut state = ec_state_init();
         state.add(lhs_nz);

--- a/corelib/src/num/traits/ops/pow.cairo
+++ b/corelib/src/num/traits/ops/pow.cairo
@@ -80,117 +80,32 @@ mod mul_based {
         }
     }
 
-    // TODO(gil): Use a macro for it instead of copy-paste.
-    // TODO(orizi): Consider extracting this for other corelib const calculations.
-    // Not using a trait for the implementation to allow `fn` to be `const`.
-
-    impl ConstPowHelperFelt252 of ConstPowHelper<felt252> {
-        const fn one() -> felt252 {
-            1
-        }
-        const fn mul(lhs: felt252, rhs: felt252) -> felt252 {
-            lhs * rhs
-        }
+    /// Macro for generating an implementation for `ConstPowHelper`.
+    /// Not using a trait for the implementation to allow `fn` to be `const`.
+    macro impl_const_pow_helper {
+        ($impl_name: ident, $ty: ident) => {
+            impl $impl_name of $defsite::ConstPowHelper<$ty> {
+                const fn one() -> $ty {
+                    1
+                }
+                const fn mul(lhs: $ty, rhs: $ty) -> $ty {
+                    lhs * rhs
+                }
+            }
+        };
     }
-
-    impl ConstPowHelperI8 of ConstPowHelper<i8> {
-        const fn one() -> i8 {
-            1
-        }
-        const fn mul(lhs: i8, rhs: i8) -> i8 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperU8 of ConstPowHelper<u8> {
-        const fn one() -> u8 {
-            1
-        }
-        const fn mul(lhs: u8, rhs: u8) -> u8 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperI16 of ConstPowHelper<i16> {
-        const fn one() -> i16 {
-            1
-        }
-        const fn mul(lhs: i16, rhs: i16) -> i16 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperU16 of ConstPowHelper<u16> {
-        const fn one() -> u16 {
-            1
-        }
-        const fn mul(lhs: u16, rhs: u16) -> u16 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperI32 of ConstPowHelper<i32> {
-        const fn one() -> i32 {
-            1
-        }
-        const fn mul(lhs: i32, rhs: i32) -> i32 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperU32 of ConstPowHelper<u32> {
-        const fn one() -> u32 {
-            1
-        }
-        const fn mul(lhs: u32, rhs: u32) -> u32 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperI64 of ConstPowHelper<i64> {
-        const fn one() -> i64 {
-            1
-        }
-        const fn mul(lhs: i64, rhs: i64) -> i64 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperU64 of ConstPowHelper<u64> {
-        const fn one() -> u64 {
-            1
-        }
-        const fn mul(lhs: u64, rhs: u64) -> u64 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperI128 of ConstPowHelper<i128> {
-        const fn one() -> i128 {
-            1
-        }
-        const fn mul(lhs: i128, rhs: i128) -> i128 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperU128 of ConstPowHelper<u128> {
-        const fn one() -> u128 {
-            1
-        }
-        const fn mul(lhs: u128, rhs: u128) -> u128 {
-            lhs * rhs
-        }
-    }
-
-    impl ConstPowHelperU256 of ConstPowHelper<u256> {
-        const fn one() -> u256 {
-            1
-        }
-        const fn mul(lhs: u256, rhs: u256) -> u256 {
-            lhs * rhs
-        }
-    }
+    impl_const_pow_helper!(ConstPowHelperFelt252, felt252);
+    impl_const_pow_helper!(ConstPowHelperI8, i8);
+    impl_const_pow_helper!(ConstPowHelperU8, u8);
+    impl_const_pow_helper!(ConstPowHelperI16, i16);
+    impl_const_pow_helper!(ConstPowHelperU16, u16);
+    impl_const_pow_helper!(ConstPowHelperI32, i32);
+    impl_const_pow_helper!(ConstPowHelperU32, u32);
+    impl_const_pow_helper!(ConstPowHelperI64, i64);
+    impl_const_pow_helper!(ConstPowHelperU64, u64);
+    impl_const_pow_helper!(ConstPowHelperI128, i128);
+    impl_const_pow_helper!(ConstPowHelperU128, u128);
+    impl_const_pow_helper!(ConstPowHelperU256, u256);
 }
 
 impl PowFelt252 = mul_based::PowByMul<felt252>;

--- a/corelib/src/ops/get.cairo
+++ b/corelib/src/ops/get.cairo
@@ -36,7 +36,6 @@
 /// assert!(span.get(10).is_none());
 /// assert!(span.get(10..20).is_none());
 /// ```
-// TODO(giladchase): add examples for `usize` once supported.
 #[unstable(feature: "corelib-get-trait")]
 pub trait Get<C, I> {
     /// The returned type after indexing.

--- a/crates/cairo-lang-casm/src/assembler.rs
+++ b/crates/cairo-lang-casm/src/assembler.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use num_bigint::{BigInt, ToBigInt};
+use num_bigint::BigInt;
 
 use crate::hints::Hint;
 use crate::instructions::{Instruction, InstructionBody};
@@ -318,8 +318,7 @@ impl ResOperand {
             ResOperand::Immediate(operand) => ResDescription {
                 off1: -1,
                 off2: 1,
-                // TODO(alon): Change immediate to always work with bigint.
-                imm: operand.value.to_bigint(),
+                imm: Some(operand.value.clone()),
                 op0_register: Register::FP,
                 op1_addr: Op1Addr::Imm,
                 res: Res::Op1,

--- a/crates/cairo-lang-casm/src/inline.rs
+++ b/crates/cairo-lang-casm/src/inline.rs
@@ -244,8 +244,6 @@ pub struct CasmContext {
     pub current_code_offset: usize,
     pub current_hints: Vec<Hint>,
     pub instructions: Vec<Instruction>,
-    // TODO(spapini): Branches.
-    // TODO(spapini): Relocations.
 }
 
 #[macro_export]

--- a/crates/cairo-lang-casm/src/instructions.rs
+++ b/crates/cairo-lang-casm/src/instructions.rs
@@ -23,7 +23,6 @@ pub enum InstructionBody {
 }
 impl InstructionBody {
     pub fn op_size(&self) -> usize {
-        // TODO(spapini): Make this correct.
         match self {
             InstructionBody::AddAp(insn) => insn.op_size(),
             InstructionBody::AssertEq(insn) | InstructionBody::QM31AssertEq(insn) => insn.op_size(),

--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -1138,7 +1138,6 @@ define_language_element_id_as_enum! {
         Struct(StructId<'db>),
         Enum(EnumId<'db>),
         Extern(ExternTypeId<'db>),
-        // TODO(spapini): associated types in impls.
     }
 }
 impl<'db> GenericTypeId<'db> {

--- a/crates/cairo-lang-defs/src/plugin.rs
+++ b/crates/cairo-lang-defs/src/plugin.rs
@@ -179,7 +179,6 @@ pub struct MacroPluginMetadata<'a> {
     pub edition: Edition,
 }
 
-// TODO(spapini): Move to another place.
 /// A trait for a macro plugin: an external plugin that generates additional code for items.
 pub trait MacroPlugin: std::fmt::Debug + Sync + Send + Any {
     /// Generates code for an item. If no code should be generated returns None.

--- a/crates/cairo-lang-diagnostics/src/diagnostics.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics.rs
@@ -48,8 +48,6 @@ pub trait DiagnosticEntry<'db>: Clone + fmt::Debug + Eq + Hash {
     /// Returns true if the two should be regarded as the same kind when filtering duplicate
     /// diagnostics.
     fn is_same_kind(&self, other: &Self) -> bool;
-
-    // TODO(spapini): Add a way to inspect the diagnostic programmatically, e.g, downcast.
 }
 
 /// Diagnostic notes for diagnostics originating in the plugin generated files identified by

--- a/crates/cairo-lang-formatter/src/test.rs
+++ b/crates/cairo-lang-formatter/src/test.rs
@@ -7,7 +7,6 @@ use test_case::test_case;
 
 use crate::{FormatterConfig, get_formatted_file};
 
-// TODO(Gil): Add tests
 #[test_case(
     "test_data/cairo_files/test1.cairo",
     "test_data/expected_results/test1.cairo",


### PR DESCRIPTION
## Summary

This PR cleans up TODOs and improves code quality in several ways:

1. Clarified comments in `box.cairo` about function exposure
2. Refactored `EcPointAdd` implementation by replacing nested match statements with more concise `if let` syntax
3. Replaced repetitive `ConstPowHelper` implementations with a macro to reduce code duplication
4. Removed outdated TODOs that are no longer relevant
5. Fixed `ResOperand::to_res_description()` to properly handle BigInt values

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This PR addresses several issues:
1. The `EcPointAdd` implementation had verbose and potentially error-prone nested match statements
2. The `ConstPowHelper` implementations were duplicated for each numeric type, making maintenance difficult
3. Several TODOs were outdated and no longer applicable to the current codebase

---

## What was the behavior or documentation before?

- `EcPointAdd` used nested match statements for control flow
- `ConstPowHelper` had separate, duplicated implementations for each numeric type
- Several outdated TODOs were scattered throughout the codebase

---

## What is the behavior or documentation after?

- `EcPointAdd` now uses cleaner `if let` syntax
- `ConstPowHelper` implementations are generated using a macro
- Outdated TODOs have been removed

---

## Additional context

This PR is primarily focused on code cleanup and maintenance, removing technical debt and improving code quality without changing functionality.