### PR TITLE
Removed `dup` and `drop` as functions from the corelib.

### DIFF
--- a/corelib/src/lib.cairo
+++ b/corelib/src/lib.cairo
@@ -260,10 +260,6 @@ impl Felt252Felt252DictValue of Felt252DictValue<felt252> {
     }
 }
 
-// TODO(spapini): Constraint using Copy and Drop traits.
-extern fn dup<T>(obj: T) -> (T, T) nopanic;
-extern fn drop<T>(obj: T) nopanic;
-
 pub mod blake;
 
 pub mod box;

--- a/corelib/src/prelude/v2023_01.cairo
+++ b/corelib/src/prelude/v2023_01.cairo
@@ -80,7 +80,7 @@ use crate::{
     BoolPartialEq, BoolSerde, Felt252Add, Felt252AddEq, Felt252Default, Felt252Felt252DictValue,
     Felt252Mul, Felt252MulEq, Felt252Neg, Felt252PartialEq, Felt252Serde, Felt252Sub, Felt252SubEq,
     Felt252TryIntoNonZero, RangeCheck, SegmentArena, assert, bool, bool_and_impl, bool_not_impl,
-    bool_or_impl, bool_to_felt252, bool_xor_impl, cmp, debug, drop, dup, ecdsa, felt252,
-    felt252_add, felt252_const, felt252_div, felt252_is_zero, felt252_mul, felt252_sub, hash,
-    internal, keccak, math, never, panic_with_felt252, testing, to_byte_array, usize,
+    bool_or_impl, bool_to_felt252, bool_xor_impl, cmp, debug, ecdsa, felt252, felt252_add,
+    felt252_const, felt252_div, felt252_is_zero, felt252_mul, felt252_sub, hash, internal, keccak,
+    math, never, panic_with_felt252, testing, to_byte_array, usize,
 };

--- a/crates/cairo-lang-sierra-generator/src/function_generator_test_data/stack_tracking
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test_data/stack_tracking
@@ -57,6 +57,8 @@ fn foo() -> (felt252, felt252) {
 foo
 
 //! > module_code
+extern fn drop<T, +Drop<T>>(value: T) nopanic;
+
 #[inline(never)]
 fn get_val() -> (felt252, felt252) {
     (13, 17)

--- a/crates/cairo-lang-sierra-generator/src/local_variables_test_data/e2e
+++ b/crates/cairo-lang-sierra-generator/src/local_variables_test_data/e2e
@@ -169,6 +169,8 @@ fn foo() -> felt252 {
 foo
 
 //! > module_code
+extern fn dup<T, +Copy<T>>(value: T) -> (T, T) nopanic;
+
 fn revoke_ap() -> felt252 {
     revoke_ap()
 }

--- a/crates/cairo-lang-sierra-generator/src/local_variables_test_data/simple
+++ b/crates/cairo-lang-sierra-generator/src/local_variables_test_data/simple
@@ -99,6 +99,8 @@ fn foo(x: felt252) -> felt252 {
 }
 
 //! > module_code
+extern fn dup<T, +Copy<T>>(value: T) -> (T, T) nopanic;
+
 // Revokes ap since this function is recursive.
 fn revoke_ap() -> felt252 {
     revoke_ap()
@@ -110,9 +112,9 @@ blk0 (root):
 Statements:
   (v1: core::felt252) <- core::felt252_add(v0, v0)
   (v2: core::felt252) <- core::felt252_add(v1, v1)
-  (v3: core::felt252, v4: core::felt252) <- core::dup::<core::felt252>(v2)
-  (v5: core::felt252, v6: core::felt252) <- core::dup::<core::felt252>(v4)
-  (v7: core::felt252, v8: core::felt252) <- core::dup::<core::felt252>(v5)
+  (v3: core::felt252, v4: core::felt252) <- test::dup::<core::felt252, core::felt252Copy>(v2)
+  (v5: core::felt252, v6: core::felt252) <- test::dup::<core::felt252, core::felt252Copy>(v4)
+  (v7: core::felt252, v8: core::felt252) <- test::dup::<core::felt252, core::felt252Copy>(v5)
   (v9: core::felt252) <- test::revoke_ap()
   (v10: core::felt252) <- core::felt252_add(v7, v8)
 End:


### PR DESCRIPTION
## Summary

Removed `dup` and `drop` external functions from the core library and moved them to specific test modules where they are needed. Updated the function signatures to include trait constraints (`+Copy<T>` for `dup` and `+Drop<T>` for `drop`).

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `dup` and `drop` functions were previously defined in the core library without proper trait constraints. This PR moves them to the specific test modules where they are actually used and adds the appropriate trait constraints (`+Copy<T>` for `dup` and `+Drop<T>` for `drop`), ensuring proper type safety and removing unnecessary dependencies from the core library.

---

## What was the behavior or documentation before?

The `dup` and `drop` functions were defined in the core library without trait constraints, and were imported in the prelude. This created unnecessary dependencies and lacked proper type safety.

---

## What is the behavior or documentation after?

The functions are now defined locally in the test modules where they are needed, with proper trait constraints. The core library and prelude no longer include these functions, making the code more modular and type-safe.

---

## Additional context

This change helps to enforce proper trait constraints for operations that should only be allowed on types that implement specific traits (Copy for duplication and Drop for dropping).