### PR TITLE
docs: document string literals in reference

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/literal-expressions.adoc
@@ -78,3 +78,14 @@ Cairo doesn't have a string type at the moment.
 
 The short string's first character is the most significant byte of the integer (big endian
 representation).
+
+== String literals
+
+A string literal is a sequence of characters enclosed in double quotes ("...").
+String literals support escape sequences (for example, for newlines or quotes) and are
+limited to ASCII characters.
+
+Unlike short string literals, string literals do not have a numeric representation and
+cannot be suffixed with a type like `_u8` or `_felt252`.
+They are primarily used in language features and tooling that consume string values,
+while the core language still does not define a built-in `string` type.


### PR DESCRIPTION
## Summary

Previously the literal expressions reference only documented numeric, boolean and short string literals, even though the language and parser support full string literals. This patch adds a dedicated “String literals” section that describes double-quoted ASCII strings with escape sequences and clarifies that they do not have a numeric representation and cannot use type suffixes.

---

## Type of change

Please check **one**:

- [x] Documentation change with concrete technical impact

---

## Why is this change needed?

This brings the documentation in line with the actual behavior of TerminalString validation and reduces confusion between short strings and regular string literals.
