### PR TITLE
fix: avoid duplicate ClosureInGlobalScope diagnostics

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -2397,9 +2397,6 @@ fn compute_expr_closure_semantic<'db>(
         }
         ContextFunction::Function(function_id) => function_id,
     };
-    if matches!(ctx.function_id, ContextFunction::Global) {
-        ctx.diagnostics.report(syntax.stable_ptr(db), ClosureInGlobalScope);
-    }
 
     let mut usages = Usages { usages: Default::default() };
     let usage = usages.handle_closure(&ctx.arenas, &params, body);


### PR DESCRIPTION
## Summary

compute_expr_closure_semantic
 reported ClosureInGlobalScope twice for closures in the global scope: once when storing the error in parent_function: Maybe<FunctionId>, and once again via a separate diagnostics.report call. This resulted in duplicated diagnostics for the same source location.

---

## Type of change


- [x] Performance improvement


---

## Why is this change needed?


Now we rely solely on the error stored in parent_function, preserving the existing error propagation behavior while emitting the diagnostic only once.
