### PR TITLE
docs: fix Get trait documentation to include usize index type

### DIFF
--- a/corelib/src/ops/get.cairo
+++ b/corelib/src/ops/get.cairo
@@ -10,9 +10,9 @@
 ///
 /// # Examples
 ///
-/// The following example shows how `ByteSpan` implements `Get` for both `Range<usize>`
-/// and `RangeInclusive<usize>`, enabling safe slicing operations that return `None` when
-/// out of bounds.
+/// The following example shows how `ByteSpan` implements `Get` for `usize`, `Range<usize>`,
+/// and `RangeInclusive<usize>`, enabling safe indexing and slicing operations that return `None`
+/// when out of bounds.
 ///
 /// ```
 /// use core::byte_array::{ByteSpan, ByteSpanTrait};
@@ -36,7 +36,6 @@
 /// assert!(span.get(10).is_none());
 /// assert!(span.get(10..20).is_none());
 /// ```
-// TODO(giladchase): add examples for `usize` once supported.
 #[unstable(feature: "corelib-get-trait")]
 pub trait Get<C, I> {
     /// The returned type after indexing.


### PR DESCRIPTION
## Summary

Updates the `Get` trait documentation to correctly state that `ByteSpan` implements `Get` for `usize`, `Range<usize>`, and `RangeInclusive<usize>`. The previous documentation only mentioned `Range<usize>` and `RangeInclusive<usize>`, despite examples and implementation already supporting `usize`. Also removes an outdated TODO comment.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The Examples section stated that `ByteSpan` implements `Get` for "both `Range<usize>` and `RangeInclusive<usize>`", but the implementation and examples already support `usize` as well. This discrepancy could confuse developers. An outdated TODO comment also suggested `usize` examples were missing, contradicting the existing code.

---

## What was the behavior or documentation before?

The Examples section only mentioned `Range<usize>` and `RangeInclusive<usize>`, despite `usize` examples being present (lines 23-25) and `ByteSpanGetUsize` implementation existing. A TODO comment incorrectly suggested `usize` support was pending.

---

## What is the behavior or documentation after?

The Examples section now correctly mentions all three index types: `usize`, `Range<usize>`, and `RangeInclusive<usize>`. The outdated TODO comment has been removed.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

This aligns the documentation with the main trait description (which mentions all three types) and the actual implementation in `byte_array.cairo`.