### PR TITLE
perf: avoid cloning other.variable_values in GasInfo::assert_eq_variables

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/gas_info.rs
+++ b/crates/cairo-lang-sierra-gas/src/gas_info.rs
@@ -66,8 +66,10 @@ impl GasInfo {
             (fd.long_id.generic_id.0 == BranchAlignLibfunc::STR_ID).then_some(&fd.id)
         });
         let mut fail = false;
-        for ((idx, token), val) in
-            self.variable_values.clone().sub_collection(other.variable_values.clone())
+        for ((idx, token), val) in self
+            .variable_values
+            .clone()
+            .sub_collection(other.variable_values.iter().map(|(k, v)| (*k, *v)))
         {
             if val != 0
                 && !matches!(


### PR DESCRIPTION
## Summary

Use an iterator over other.variable_values instead of cloning the whole map
when calling sub_collection. This keeps the same subtraction semantics but
avoids an extra allocation and full copy of the map.

---

## Type of change

- [x] Performance improvement

---

## Why is this change needed?

The change mirrors the existing pattern in assert_eq_functions and only
affects the diagnostic comparison path used when non-linear solver
comparisons are enabled, so behavior is preserved while reducing overhead.

