### PR TITLE
docs(ecdsa): fix is_equivalent_to_zero modulo description

### DIFF
--- a/corelib/src/ecdsa.cairo
+++ b/corelib/src/ecdsa.cairo
@@ -200,7 +200,7 @@ pub fn recover_public_key(
     Some(state.finalize_nz()?.x())
 }
 
-/// Checks if `value != 0` (mod stark_curve::ORDER).
+/// Checks if `value == 0` (mod stark_curve::ORDER).
 fn is_equivalent_to_zero(value: felt252) -> bool {
     // Note that `2 * ec::stark_curve::ORDER` is larger than the felt252 PRIME.
     value == 0 || value == ec::stark_curve::ORDER


### PR DESCRIPTION
## Summary

The is_equivalent_to_zero helper was documented as checking value != 0 modulo stark_curve::ORDER, while the implementation actually detects values congruent to 0 (i.e. 0 or ORDER in felt252).

---

## Type of change


- [x] Style, wording, formatting, or typo-only change


---

## Why is this change needed?


This change updates the comment to accurately describe the behavior so that callers and readers of the ECDSA code are not misled when reasoning about the allowed ranges for signature scalars.
