### PR TITLE
test: expand invert_or_nullify test coverage with multiple moduli

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/circuit_test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/circuit_test.rs
@@ -52,6 +52,107 @@ use crate::casm_run::circuit::invert_or_nullify;
     7_u32;
     "invert_or_nullify(7, 8)"
 )]
+// Tests with prime modulus 7
+#[test_case(
+    1_u32,
+    7_u32,
+    1_u32;
+    "invert_or_nullify(1, 7) - prime modulus"
+)]
+#[test_case(
+    2_u32,
+    7_u32,
+    4_u32;
+    "invert_or_nullify(2, 7) - prime modulus"
+)]
+#[test_case(
+    3_u32,
+    7_u32,
+    5_u32;
+    "invert_or_nullify(3, 7) - prime modulus"
+)]
+#[test_case(
+    0_u32,
+    7_u32,
+    1_u32;
+    "invert_or_nullify(0, 7) - prime modulus, non-invertible"
+)]
+// Tests with prime modulus 11
+#[test_case(
+    3_u32,
+    11_u32,
+    4_u32;
+    "invert_or_nullify(3, 11) - prime modulus"
+)]
+#[test_case(
+    5_u32,
+    11_u32,
+    9_u32;
+    "invert_or_nullify(5, 11) - prime modulus"
+)]
+// Tests with composite modulus 9 (3^2)
+#[test_case(
+    1_u32,
+    9_u32,
+    1_u32;
+    "invert_or_nullify(1, 9) - composite modulus"
+)]
+#[test_case(
+    2_u32,
+    9_u32,
+    5_u32;
+    "invert_or_nullify(2, 9) - composite modulus"
+)]
+#[test_case(
+    3_u32,
+    9_u32,
+    3_u32;
+    "invert_or_nullify(3, 9) - composite modulus, non-invertible"
+)]
+#[test_case(
+    4_u32,
+    9_u32,
+    7_u32;
+    "invert_or_nullify(4, 9) - composite modulus"
+)]
+// Tests with composite modulus 12 (2^2 * 3)
+#[test_case(
+    1_u32,
+    12_u32,
+    1_u32;
+    "invert_or_nullify(1, 12) - composite modulus"
+)]
+#[test_case(
+    5_u32,
+    12_u32,
+    5_u32;
+    "invert_or_nullify(5, 12) - composite modulus"
+)]
+#[test_case(
+    2_u32,
+    12_u32,
+    6_u32;
+    "invert_or_nullify(2, 12) - composite modulus, non-invertible"
+)]
+// Tests with composite modulus 15 (3 * 5)
+#[test_case(
+    2_u32,
+    15_u32,
+    8_u32;
+    "invert_or_nullify(2, 15) - composite modulus"
+)]
+#[test_case(
+    7_u32,
+    15_u32,
+    13_u32;
+    "invert_or_nullify(7, 15) - composite modulus"
+)]
+#[test_case(
+    3_u32,
+    15_u32,
+    5_u32;
+    "invert_or_nullify(3, 15) - composite modulus, non-invertible"
+)]
 
 fn test_invert_or_nullify(input: u32, modulus: u32, output: u32) {
     let (success, nullifier) = invert_or_nullify(BigUint::from(input), &BigUint::from(modulus));


### PR DESCRIPTION
## Summary

Expands test coverage for `invert_or_nullify` by adding test cases with prime moduli (7, 11) and composite moduli (9, 12, 15). Previously, all tests used modulus 8.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The function works with `BigUint` and should handle any modulus, but tests only used modulus 8. This could miss issues with prime moduli (common in cryptography) and different composite moduli. Other tests in the codebase use varied moduli, and the current coverage doesn't reflect this.

---

## What was the behavior or documentation before?

All 8 test cases used `modulus = 8` only.

---

## What is the behavior or documentation after?

Added 16 test cases covering prime moduli (7, 11) and composite moduli (9, 12, 15). Original 8 tests preserved. Total: 24 test cases covering both invertible and non-invertible cases across different modulus types.

---

## Related issue or discussion (if any)

None.

---

## Additional context

The function uses the extended Euclidean algorithm. Added tests verify behavior with small primes, powers of primes, and products of distinct primes, aligning with patterns in other test files (`circuit_test.cairo`, `math_test.cairo`).