### PR TITLE
perf: Avoid double token stream reconstruction

### DIFF
--- a/crates/cairo-lang-parser/src/utils.rs
+++ b/crates/cairo-lang-parser/src/utils.rs
@@ -86,9 +86,7 @@ impl SimpleParserDatabase {
             original_item_removed: false,
         })
         .intern(self);
-        let mut diagnostics = DiagnosticsBuilder::default();
-        let syntax = Parser::parse_token_stream(self, &mut diagnostics, file_id, token_stream);
-        (syntax.as_syntax_node(), diagnostics.build())
+        get_syntax_root_and_diagnostics(self, file_id)
     }
 
     /// Parses a token stream (based on a single expression).


### PR DESCRIPTION
## Summary

SimpleParserDatabase::parse_token_stream used Parser::parse_token_stream, which internally calls primitive_token_stream_content_and_offset again on the same token stream. In this context we already created a virtual file from the reconstructed content, so the second reconstruction and consistency check were redundant.

---

## Type of change


- [x] Performance improvement


## Why is this change needed?

Route the call through get_syntax_root_and_diagnostics instead, keeping the same public behaviour while avoiding an extra token stream traversal and string allocation.