### PR TITLE
fix: remove incorrect underflow mention from CheckedMul docs

### DIFF
--- a/corelib/src/num/traits/ops/checked.cairo
+++ b/corelib/src/num/traits/ops/checked.cairo
@@ -64,7 +64,7 @@ pub trait CheckedSub<T> {
     fn checked_sub(self: T, v: T) -> Option<T>;
 }
 
-/// Performs multiplication that returns `None` instead of wrapping around on underflow or
+/// Performs multiplication that returns `None` instead of wrapping around on
 /// overflow.
 ///
 /// # Examples
@@ -79,8 +79,8 @@ pub trait CheckedSub<T> {
 /// assert!(result == None); // Overflow
 /// ```
 pub trait CheckedMul<T> {
-    /// Multiplies two numbers, checking for underflow or overflow. If underflow
-    /// or overflow happens, `None` is returned.
+    /// Multiplies two numbers, checking for overflow. If overflow happens,
+    /// `None` is returned.
     fn checked_mul(self: T, v: T) -> Option<T>;
 }
 


### PR DESCRIPTION
## Summary

Removed incorrect "underflow" mention from `CheckedMul` trait documentation. Multiplication of unsigned integers can only overflow, not underflow.

## Type of change

- [x] Bug fix (fixes incorrect behavior)

## Why is this change needed?

The documentation incorrectly stated that multiplication can cause "underflow or overflow". This is mathematically incorrect: multiplication of unsigned integers can only overflow, never underflow.