### PR TITLE
docs: fix incorrect 'array' references in Span method documentation

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -468,7 +468,7 @@ impl SpanSerde<T, +Serde<T>, +Drop<T>, -TypeEqual<felt252, T>> of Serde<Span<T>>
 #[generate_trait]
 pub impl SpanImpl<T> of SpanTrait<T> {
     /// Pops a value from the front of the span.
-    /// Returns `Some(@value)` if the array is not empty, `None` otherwise.
+    /// Returns `Some(@value)` if the span is not empty, `None` otherwise.
     ///
     /// # Examples
     ///
@@ -488,7 +488,7 @@ pub impl SpanImpl<T> of SpanTrait<T> {
     }
 
     /// Pops a value from the back of the span.
-    /// Returns `Some(@value)` if the array is not empty, `None` otherwise.
+    /// Returns `Some(@value)` if the span is not empty, `None` otherwise.
     ///
     /// # Examples
     /// ```


### PR DESCRIPTION
## Summary
Fixed incorrect terminology in `Span` method documentation that referred to "array" instead of "span".

## Type of change
- [x] Documentation change with concrete technical impact

## Why is this change needed?
The `pop_front()` and `pop_back()` methods in `SpanTrait` incorrectly stated "if the array is not empty" in their documentation, while they operate on `Span` type, not `Array`. This creates confusion about which type the methods work with.