### PR TITLE
fix(docs): replace felt252 with i32 in sign function example

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/if-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/if-expressions.adoc
@@ -182,7 +182,7 @@ If expressions can be nested:
 
 [source,cairo]
 ----
-fn sign(x: felt252) -> felt252 {
+fn sign(x: i32) -> i32 {
     if x == 0 {
         0
     } else {


### PR DESCRIPTION
## Summary

Fixes the `sign` function example by replacing `felt252` with `i32`. The original example used comparison operators with `felt252`, which doesn't implement `PartialOrd` and causes a compilation error.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The example doesn't compile. `felt252` doesn't implement `PartialOrd`, so using `>` and `<` with it results in error `E2311: Trait has no implementation in context: core::traits::PartialOrd::<core::felt252>`.

---

## What was the behavior or documentation before?
airo
fn sign(x: felt252) -> felt252 {
    if x > 0 { ... }  // Compilation error
}---

## What is the behavior or documentation after?

fn sign(x: i32) -> i32 {
    if x > 0 { ... }  // Works correctly
}---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

`felt252` is a field element type without meaningful sign semantics. For sign checking, use signed integer types like `i32`, `i64`, or `i128`.