### PR TITLE
fix(proc-macros): fix inaccurate comment about enum pattern bindings

### DIFF
--- a/crates/cairo-lang-proc-macros/src/heap_size.rs
+++ b/crates/cairo-lang-proc-macros/src/heap_size.rs
@@ -96,7 +96,9 @@ fn emit_variant_heap_size(fields: &syn::Fields) -> (TokenStream2, TokenStream2) 
         pattern = quote! { #pattern #field_ident, };
 
         if !should_skip {
-            // In enum patterns, the bindings are already references, so we don't need &
+            // In enum patterns when matching on &self, bindings for non-Copy types
+            // are automatically references. For Copy types, Rust automatically borrows
+            // them when passed to methods expecting &T, so we don't need & here.
             calls = quote! {
                 #calls + #crt::HeapSize::heap_size(#field_ident)
             };


### PR DESCRIPTION
## Summary

Fixes inaccurate comment in `HeapSize` derive macro that incorrectly stated enum pattern bindings are always references. Updated to accurately describe Rust's automatic borrowing behavior.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The comment incorrectly stated bindings are always references. In reality, non-Copy types are auto-referenced, while Copy types are auto-borrowed when passed to `&T` methods. The inaccurate comment could mislead developers maintaining this macro.

---

## What was the behavior or documentation before?

// In enum patterns, the bindings are already references, so we don't need &---

## What is the behavior or documentation after?
t
// In enum patterns when matching on &self, bindings for non-Copy types
// are automatically references. For Copy types, Rust automatically borrows
// them when passed to methods expecting &T, so we don't need & here.---

## Related issue or discussion (if any)

<!-- None -->

---

## Additional context

The code was already correct. This only fixes the documentation to accurately reflect Rust's automatic borrowing semantics.