### PR TITLE
(feat): Adding module as context to diagnostic reporting

### DIFF
--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -335,7 +335,7 @@ impl<'db> DocumentationCommentParser<'db> {
         let syntax_node = item_id.stable_location(self.db)?.syntax_node(self.db);
         let containing_module = self.db.find_module_containing_node(syntax_node)?;
         let mut resolver = Resolver::new(self.db, containing_module, InferenceId::NoContext);
-        let mut diagnostics = SemanticDiagnostics::default();
+        let mut diagnostics = SemanticDiagnostics::new(containing_module);
         let segments = self.parse_comment_link_path(path)?;
         resolver
             .resolve_generic_path(

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::ops::{Deref, DerefMut};
 
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
@@ -9,8 +10,8 @@ use cairo_lang_defs::ids::{
 };
 use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_diagnostics::{
-    DiagnosticAdded, DiagnosticEntry, DiagnosticNote, DiagnosticsBuilder, ErrorCode, Severity,
-    error_code,
+    DiagnosticAdded, DiagnosticEntry, DiagnosticNote, Diagnostics, DiagnosticsBuilder, ErrorCode,
+    Severity, error_code,
 };
 use cairo_lang_filesystem::db::Edition;
 use cairo_lang_filesystem::ids::{SmolStrId, SpanInFile};
@@ -35,7 +36,48 @@ use crate::{ConcreteTraitId, semantic};
 #[path = "diagnostic_test.rs"]
 mod test;
 
-pub type SemanticDiagnostics<'db> = DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>;
+/// A diagnostics builder with module context for semantic diagnostics.
+pub struct SemanticDiagnostics<'db> {
+    builder: DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
+    context_module: ModuleId<'db>,
+}
+
+impl<'db> SemanticDiagnostics<'db> {
+    /// Create a new SemanticDiagnostics with the given context module.
+    pub fn new(context_module: ModuleId<'db>) -> Self {
+        Self { builder: DiagnosticsBuilder::default(), context_module }
+    }
+
+    /// Create a new SemanticDiagnostics from the given context module and diagnostics.
+    pub fn from_diagnostics(
+        context_module: ModuleId<'db>,
+        diagnostics: Diagnostics<'db, SemanticDiagnostic<'db>>,
+    ) -> Self {
+        let mut builder = DiagnosticsBuilder::default();
+        builder.extend(diagnostics);
+        Self { builder, context_module }
+    }
+
+    /// Build a Diagnostics object.
+    pub fn build(self) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
+        self.builder.build()
+    }
+}
+
+impl<'db> Deref for SemanticDiagnostics<'db> {
+    type Target = DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.builder
+    }
+}
+
+impl<'db> DerefMut for SemanticDiagnostics<'db> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.builder
+    }
+}
+
 pub trait SemanticDiagnosticsBuilder<'db> {
     /// Report a diagnostic in the location of the given ptr.
     fn report(
@@ -64,14 +106,22 @@ impl<'db> SemanticDiagnosticsBuilder<'db> for SemanticDiagnostics<'db> {
         stable_ptr: impl Into<SyntaxStablePtrId<'db>>,
         kind: SemanticDiagnosticKind<'db>,
     ) -> DiagnosticAdded {
-        self.add(SemanticDiagnostic::new(StableLocation::new(stable_ptr.into()), kind))
+        self.builder.add(SemanticDiagnostic::new(
+            StableLocation::new(stable_ptr.into()),
+            kind,
+            self.context_module,
+        ))
     }
     fn report_after(
         &mut self,
         stable_ptr: impl Into<SyntaxStablePtrId<'db>>,
         kind: SemanticDiagnosticKind<'db>,
     ) -> DiagnosticAdded {
-        self.add(SemanticDiagnostic::new_after(StableLocation::new(stable_ptr.into()), kind))
+        self.builder.add(SemanticDiagnostic::new_after(
+            StableLocation::new(stable_ptr.into()),
+            kind,
+            self.context_module,
+        ))
     }
     fn report_with_inner_span(
         &mut self,
@@ -79,9 +129,10 @@ impl<'db> SemanticDiagnosticsBuilder<'db> for SemanticDiagnostics<'db> {
         inner_span: (TextWidth, TextWidth),
         kind: SemanticDiagnosticKind<'db>,
     ) -> DiagnosticAdded {
-        self.add(SemanticDiagnostic::new(
+        self.builder.add(SemanticDiagnostic::new(
             StableLocation::with_inner_span(stable_ptr.into(), inner_span),
             kind,
+            self.context_module,
         ))
     }
 }
@@ -93,18 +144,25 @@ pub struct SemanticDiagnostic<'db> {
     /// true if the diagnostic should be reported *after* the given location. Normally false, in
     /// which case the diagnostic points to the given location (as-is).
     pub after: bool,
+    /// The module context in which this diagnostic was reported.
+    pub context_module: ModuleId<'db>,
 }
 impl<'db> SemanticDiagnostic<'db> {
     /// Create a diagnostic in the given location.
-    pub fn new(stable_location: StableLocation<'db>, kind: SemanticDiagnosticKind<'db>) -> Self {
-        SemanticDiagnostic { stable_location, kind, after: false }
+    pub fn new(
+        stable_location: StableLocation<'db>,
+        kind: SemanticDiagnosticKind<'db>,
+        context_module: ModuleId<'db>,
+    ) -> Self {
+        SemanticDiagnostic { stable_location, kind, after: false, context_module }
     }
     /// Create a diagnostic in the location after the given location (with width 0).
     pub fn new_after(
         stable_location: StableLocation<'db>,
         kind: SemanticDiagnosticKind<'db>,
+        context_module: ModuleId<'db>,
     ) -> Self {
-        SemanticDiagnostic { stable_location, kind, after: true }
+        SemanticDiagnostic { stable_location, kind, after: true, context_module }
     }
 }
 impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -741,7 +741,7 @@ fn expand_inline_macro<'db>(
     // We call the resolver with a new diagnostics, since the diagnostics should not be reported
     // if the macro was found as a plugin.
     let user_defined_macro = ctx.resolver.resolve_generic_path(
-        &mut Default::default(),
+        &mut SemanticDiagnostics::new(ctx.resolver.module_id),
         &macro_path,
         NotFoundItemType::Macro,
         ResolutionContext::Statement(&mut ctx.environment),
@@ -2820,7 +2820,7 @@ fn maybe_compute_pattern_semantic<'db>(
         }
         ast::Pattern::Path(path) => {
             let item_result = ctx.resolver.resolve_generic_path_with_args(
-                &mut Default::default(),
+                &mut SemanticDiagnostics::new(ctx.resolver.module_id),
                 path,
                 NotFoundItemType::Identifier,
                 ResolutionContext::Statement(&mut ctx.environment),
@@ -2831,7 +2831,7 @@ fn maybe_compute_pattern_semantic<'db>(
                 // Resolving as concrete path first might create vars which will not be inferred so
                 // we use the generic path first.
                 let item = ctx.resolver.resolve_concrete_path_ex(
-                    &mut Default::default(),
+                    &mut SemanticDiagnostics::new(ctx.resolver.module_id),
                     path,
                     NotFoundItemType::Identifier,
                     ResolutionContext::Statement(&mut ctx.environment),

--- a/crates/cairo-lang-semantic/src/items/enm.rs
+++ b/crates/cairo-lang-semantic/src/items/enm.rs
@@ -44,7 +44,7 @@ fn enum_declaration_data<'db>(
     db: &'db dyn Database,
     enum_id: EnumId<'db>,
 ) -> Maybe<EnumDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(enum_id.parent_module(db));
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
     // the item instead of all the module data.
@@ -76,7 +76,7 @@ fn enum_generic_params_data<'db>(
     enum_id: EnumId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = enum_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let enum_ast = db.module_enum_by_id(enum_id)?;
 
     // Generic params.
@@ -152,7 +152,7 @@ fn enum_definition_data<'db>(
 ) -> Maybe<EnumDefinitionData<'db>> {
     let module_id = enum_id.parent_module(db);
     let crate_id = module_id.owning_crate(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
     // the item instead of all the module data.
@@ -228,7 +228,8 @@ fn enum_definition_diagnostics<'db>(
     {
         return data.diagnostics.clone();
     }
-    let mut diagnostics = SemanticDiagnostics::from(data.diagnostics.clone());
+    let mut diagnostics =
+        SemanticDiagnostics::from_diagnostics(enum_id.parent_module(db), data.diagnostics.clone());
     for (_, variant) in data.variant_semantic.iter() {
         let stable_ptr = variant.id.stable_ptr(db);
         add_type_based_diagnostics(db, &mut diagnostics, variant.ty, stable_ptr);

--- a/crates/cairo-lang-semantic/src/items/extern_function.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_function.rs
@@ -38,7 +38,7 @@ fn extern_function_declaration_generic_params_data<'db>(
     extern_function_id: ExternFunctionId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = extern_function_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let extern_function_syntax = db.module_extern_function_by_id(extern_function_id)?;
     let declaration = extern_function_syntax.declaration(db);
 
@@ -70,7 +70,7 @@ fn priv_extern_function_declaration_data<'db>(
     db: &'db dyn Database,
     extern_function_id: ExternFunctionId<'db>,
 ) -> Maybe<FunctionDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(extern_function_id.parent_module(db));
     let extern_function_syntax = db.module_extern_function_by_id(extern_function_id)?;
 
     let declaration = extern_function_syntax.declaration(db);

--- a/crates/cairo-lang-semantic/src/items/extern_type.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_type.rs
@@ -39,7 +39,7 @@ fn extern_type_declaration_generic_params_data<'db>(
     extern_type_id: ExternTypeId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = extern_type_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let extern_type_syntax = db.module_extern_type_by_id(extern_type_id)?;
 
     let inference_id = InferenceId::LookupItemGenerics(LookupItemId::ModuleItem(
@@ -80,7 +80,7 @@ fn extern_type_declaration_data<'db>(
     db: &'db dyn Database,
     extern_type_id: ExternTypeId<'db>,
 ) -> Maybe<ExternTypeDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(extern_type_id.parent_module(db));
     let extern_type_syntax = db.module_extern_type_by_id(extern_type_id)?;
 
     // Generic params.

--- a/crates/cairo-lang-semantic/src/items/free_function.rs
+++ b/crates/cairo-lang-semantic/src/items/free_function.rs
@@ -38,7 +38,7 @@ fn free_function_generic_params_data<'db>(
     free_function_id: FreeFunctionId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = free_function_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let free_function_syntax = db.module_free_function_by_id(free_function_id)?;
     let declaration = free_function_syntax.declaration(db);
 
@@ -70,7 +70,7 @@ fn free_function_declaration_data<'db>(
     db: &'db dyn Database,
     free_function_id: FreeFunctionId<'db>,
 ) -> Maybe<FunctionDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(free_function_id.parent_module(db));
     let free_function_syntax = db.module_free_function_by_id(free_function_id)?;
     let declaration = free_function_syntax.declaration(db);
 
@@ -129,7 +129,7 @@ fn priv_free_function_body_data<'db>(
     db: &'db dyn Database,
     free_function_id: FreeFunctionId<'db>,
 ) -> Maybe<FunctionBodyData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(free_function_id.parent_module(db));
     let free_function_syntax = db.module_free_function_by_id(free_function_id)?;
     // Compute declaration semantic.
     let declaration = free_function_declaration_data(db, free_function_id).maybe_as_ref()?;

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -291,7 +291,7 @@ fn generic_impl_param_trait<'db>(
         }
     };
 
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let inference_id = InferenceId::GenericImplParamTrait(generic_param_id);
     // TODO(spapini): We should not create a new resolver -  we are missing the other generic params
     // in the context.
@@ -310,8 +310,7 @@ fn generic_impl_param_shallow_trait_generic_args<'db>(
 ) -> Maybe<Vec<(GenericParamId<'db>, ShallowGenericArg<'db>)>> {
     let db: &dyn Database = db;
     let module_id = generic_param_id.parent_module(db);
-    let mut diagnostics: cairo_lang_diagnostics::DiagnosticsBuilder<'_, SemanticDiagnostic<'_>> =
-        SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let parent_item_id = generic_param_id.generic_item(db);
     let lookup_item: LookupItemId<'_> = parent_item_id.into();
     let context_resolver_data = lookup_item.resolver_context(db)?;
@@ -412,8 +411,9 @@ fn generic_param_data<'db>(
     generic_param_id: GenericParamId<'db>,
     in_cycle: bool,
 ) -> Maybe<GenericParamData<'db>> {
+    let module_id = generic_param_id.parent_module(db);
     if in_cycle {
-        let mut diagnostics = SemanticDiagnostics::default();
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
         return Ok(GenericParamData {
             generic_param: Err(diagnostics.report(
                 generic_param_id.stable_ptr(db).untyped(),
@@ -426,8 +426,7 @@ fn generic_param_data<'db>(
             )),
         });
     }
-    let module_id = generic_param_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let parent_item_id = generic_param_id.generic_item(db);
     let lookup_item: LookupItemId<'_> = parent_item_id.into();
     let context_resolver_data = lookup_item.resolver_context(db)?;

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -15,7 +15,7 @@ use cairo_lang_defs::ids::{
     TraitId, TraitImplId, TraitTypeId, UseId,
 };
 use cairo_lang_diagnostics::{
-    DiagnosticAdded, Diagnostics, DiagnosticsBuilder, Maybe, MaybeAsRef, ToMaybe, skip_diagnostic,
+    DiagnosticAdded, Diagnostics, Maybe, MaybeAsRef, ToMaybe, skip_diagnostic,
 };
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CrateId, CrateLongId, SmolStrId, Tracked, UnstableSalsaId};
@@ -500,7 +500,7 @@ fn impl_def_generic_params_data<'db>(
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = impl_def_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
 
     let impl_ast = db.module_impl_by_id(impl_def_id)?;
     let inference_id =
@@ -537,7 +537,7 @@ fn impl_def_substitution<'db>(
 #[salsa::tracked]
 fn impl_def_trait<'db>(db: &'db dyn Database, impl_def_id: ImplDefId<'db>) -> Maybe<TraitId<'db>> {
     let module_id = impl_def_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
 
     let impl_ast = db.module_impl_by_id(impl_def_id)?;
     let inference_id = InferenceId::ImplDefTrait(impl_def_id);
@@ -566,7 +566,7 @@ fn impl_def_shallow_trait_generic_args_helper<'db>(
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<Vec<(GenericParamId<'db>, ShallowGenericArg<'db>)>> {
     let module_id = impl_def_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
 
     let impl_ast = db.module_impl_by_id(impl_def_id)?;
     let inference_id = InferenceId::ImplDefTrait(impl_def_id);
@@ -649,7 +649,7 @@ fn impl_alias_trait_generic_args_helper<'db>(
     impl_alias_id: ImplAliasId<'db>,
 ) -> Maybe<Vec<(GenericParamId<'db>, ShallowGenericArg<'db>)>> {
     let module_id = impl_alias_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
 
     let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
     let inference_id = InferenceId::ImplAliasImplDef(impl_alias_id);
@@ -823,7 +823,7 @@ fn impl_declaration_data_inner<'db>(
     impl_def_id: ImplDefId<'db>,
     resolve_trait: bool,
 ) -> Maybe<ImplDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
 
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
@@ -948,7 +948,7 @@ fn impl_semantic_definition_diagnostics<'db>(
     db: &'db dyn Database,
     impl_def_id: ImplDefId<'db>,
 ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-    let mut diagnostics = DiagnosticsBuilder::default();
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
 
     let Ok(data) = impl_definition_data(db, impl_def_id) else {
         return Diagnostics::default();
@@ -1125,7 +1125,7 @@ fn deref_impl_diagnostics<'db>(
     db: &'db dyn Database,
     mut impl_def_id: ImplDefId<'db>,
     concrete_trait: ConcreteTraitId<'db>,
-    diagnostics: &mut DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
+    diagnostics: &mut SemanticDiagnostics<'db>,
 ) {
     let mut visited_impls: OrderedHashSet<ImplDefId<'_>> = OrderedHashSet::default();
     let deref_trait_id = concrete_trait.trait_id(db);
@@ -1408,7 +1408,7 @@ fn impl_definition_data<'db>(
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<ImplDefinitionData<'db>> {
     let module_id = impl_def_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
 
     let generic_params =
         impl_def_generic_params_data(db, impl_def_id).maybe_as_ref()?.generic_params.clone();
@@ -2442,7 +2442,8 @@ fn impl_type_semantic_data<'db>(
     impl_type_def_id: ImplTypeDefId<'db>,
     in_cycle: bool,
 ) -> Maybe<ImplItemTypeData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics =
+        SemanticDiagnostics::new(impl_type_def_id.impl_def_id(db).parent_module(db));
     let impl_type_def_ast = db.impl_type_by_id(impl_type_def_id)?;
     let generic_params_data =
         impl_type_def_generic_params_data(db, impl_type_def_id).maybe_as_ref()?.clone();
@@ -2621,8 +2622,8 @@ fn impl_constant_semantic_data<'db>(
     impl_constant_def_id: ImplConstantDefId<'db>,
     in_cycle: bool,
 ) -> Maybe<ImplItemConstantData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
     let impl_def_id = impl_constant_def_id.impl_def_id(db);
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
     let impl_constant_defs = db.impl_constants(impl_def_id)?;
     let impl_constant_def_ast = impl_constant_defs.get(&impl_constant_def_id).to_maybe()?;
     let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Constant(impl_constant_def_id));
@@ -2877,8 +2878,8 @@ fn impl_impl_semantic_data<'db>(
     impl_impl_def_id: ImplImplDefId<'db>,
     in_cycle: bool,
 ) -> Maybe<ImplItemImplData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
     let impl_def_id = impl_impl_def_id.impl_def_id(db);
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
     let impl_impl_defs = db.impl_impls(impl_def_id)?;
     let impl_impl_def_ast = impl_impl_defs.get(&impl_impl_def_id).to_maybe()?;
     let generic_params_data =
@@ -3020,7 +3021,7 @@ fn implicit_impl_impl_semantic_data<'db>(
     trait_impl_id: TraitImplId<'db>,
     in_cycle: bool,
 ) -> Maybe<ImplicitImplImplData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
     if in_cycle {
         let err = Err(diagnostics.report(impl_def_id.stable_ptr(db).untyped(), ImplAliasCycle));
         return Ok(ImplicitImplImplData {
@@ -3232,7 +3233,7 @@ fn impl_function_generic_params_data<'db>(
     impl_function_id: ImplFunctionId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = impl_function_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let impl_def_id = impl_function_id.impl_def_id(db);
     let data = impl_definition_data(db, impl_def_id).maybe_as_ref()?;
     let function_syntax = &data.function_asts[&impl_function_id];
@@ -3264,8 +3265,8 @@ fn impl_function_declaration_data<'db>(
     db: &'db dyn Database,
     impl_function_id: ImplFunctionId<'db>,
 ) -> Maybe<ImplFunctionDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
     let impl_def_id = impl_function_id.impl_def_id(db);
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
     let data = impl_definition_data(db, impl_def_id).maybe_as_ref()?;
     let function_syntax = &data.function_asts[&impl_function_id];
     let declaration = function_syntax.declaration(db);
@@ -3588,8 +3589,8 @@ fn priv_impl_function_body_data<'db>(
     db: &'db dyn Database,
     impl_function_id: ImplFunctionId<'db>,
 ) -> Maybe<FunctionBodyData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
     let impl_def_id = impl_function_id.impl_def_id(db);
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
     let data = impl_definition_data(db, impl_def_id).maybe_as_ref()?;
     let function_syntax = &data.function_asts[&impl_function_id];
     // Compute declaration semantic.
@@ -3792,27 +3793,28 @@ fn uninferred_impl_trait_dependency<'db>(
     trait_deps: &mut OrderedHashMap<TraitId<'db>, OrderedHashSet<TraitId<'db>>>,
 ) -> Maybe<()> {
     if let Ok(imp_trait_id) = impl_id.trait_id(db) {
-        let mut diagnostics = SemanticDiagnostics::default();
-        let (mut resolver, module_id, generic_params) = match impl_id {
+        let (mut resolver, module_id, generic_params, mut diagnostics) = match impl_id {
             UninferredImpl::Def(impl_def_id) => {
                 let module_id = impl_def_id.parent_module(db);
+                let mut diagnostics = SemanticDiagnostics::new(module_id);
 
                 let impl_ast = db.module_impl_by_id(impl_def_id)?;
                 let inference_id = InferenceId::ImplDefTrait(impl_def_id);
 
                 let mut resolver = Resolver::new(db, module_id, inference_id);
                 resolver.set_feature_config(&impl_def_id, &impl_ast, &mut diagnostics);
-                (resolver, module_id, impl_ast.generic_params(db))
+                (resolver, module_id, impl_ast.generic_params(db), diagnostics)
             }
             UninferredImpl::ImplAlias(impl_alias_id) => {
                 let module_id = impl_alias_id.parent_module(db);
+                let mut diagnostics = SemanticDiagnostics::new(module_id);
 
                 let impl_ast = db.module_impl_alias_by_id(impl_alias_id)?;
                 let inference_id = InferenceId::ImplAliasImplDef(impl_alias_id);
 
                 let mut resolver = Resolver::new(db, module_id, inference_id);
                 resolver.set_feature_config(&impl_alias_id, &impl_ast, &mut diagnostics);
-                (resolver, module_id, impl_ast.generic_params(db))
+                (resolver, module_id, impl_ast.generic_params(db), diagnostics)
             }
             _ => {
                 return Ok(());

--- a/crates/cairo-lang-semantic/src/items/impl_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/impl_alias.rs
@@ -66,7 +66,7 @@ pub fn impl_alias_semantic_data_helper<'db>(
     lookup_item_id: LookupItemId<'db>,
     generic_params_data: GenericParamsData<'db>,
 ) -> Maybe<ImplAliasData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(lookup_item_id.parent_module(db));
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
     // the item instead of all the module data.
@@ -116,7 +116,7 @@ pub fn impl_alias_semantic_data_cycle_helper<'db>(
     lookup_item_id: LookupItemId<'db>,
     generic_params_data: GenericParamsData<'db>,
 ) -> Maybe<ImplAliasData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(lookup_item_id.parent_module(db));
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
     // the item instead of all the module data.
@@ -160,7 +160,7 @@ pub fn impl_alias_generic_params_data_helper<'db>(
     lookup_item_id: LookupItemId<'db>,
     parent_resolver_data: Option<Arc<ResolverData<'db>>>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
 
     let mut resolver = match parent_resolver_data {
@@ -193,7 +193,7 @@ fn impl_alias_impl_def<'db>(
     impl_alias_id: ImplAliasId<'db>,
 ) -> Maybe<ImplDefId<'db>> {
     let module_id = impl_alias_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
     let inference_id = InferenceId::ImplAliasImplDef(impl_alias_id);
 

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -76,7 +76,7 @@ fn priv_macro_call_data<'db>(
             parent_macro_call_data,
         });
     }
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(callsite_module_id);
     let macro_declaration_id = match resolver.resolve_generic_path(
         &mut diagnostics,
         &macro_call_path,
@@ -217,7 +217,8 @@ fn priv_macro_call_data_initial<'db>(
 ) -> Maybe<MacroCallData<'db>> {
     // If we are in a cycle, we return an empty MacroCallData with no diagnostics.
     // This is to prevent infinite recursion in case of cyclic macro calls.
-    let mut diagnostics = SemanticDiagnostics::default();
+    let module_id = macro_call_id.parent_module(db);
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let macro_call_syntax = db.module_macro_call_by_id(macro_call_id)?;
     let macro_call_path = macro_call_syntax.path(db);
     let macro_name = macro_call_path.as_syntax_node().get_text_without_trivia(db);
@@ -226,7 +227,6 @@ fn priv_macro_call_data_initial<'db>(
         macro_call_id.stable_ptr(db).untyped(),
         SemanticDiagnosticKind::InlineMacroNotFound(macro_name),
     );
-    let module_id = macro_call_id.parent_module(db);
 
     Ok(MacroCallData {
         macro_call_module: Err(diag_added),

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -109,9 +109,9 @@ fn priv_macro_declaration_data<'db>(
     db: &'db dyn Database,
     macro_declaration_id: MacroDeclarationId<'db>,
 ) -> Maybe<MacroDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
-
     let module_id = macro_declaration_id.parent_module(db);
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
+
     let macro_declaration_syntax = db.module_macro_declaration_by_id(macro_declaration_id)?;
     if !are_user_defined_inline_macros_enabled(db, module_id) {
         diagnostics.report(

--- a/crates/cairo-lang-semantic/src/items/module.rs
+++ b/crates/cairo-lang-semantic/src/items/module.rs
@@ -3,7 +3,7 @@ use cairo_lang_defs::ids::{
     GlobalUseId, LanguageElementId, LookupItemId, ModuleId, ModuleItemId, NamedLanguageElementId,
     TraitId, UseId,
 };
-use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder, Maybe, MaybeAsRef};
+use cairo_lang_diagnostics::{Diagnostics, Maybe, MaybeAsRef};
 use cairo_lang_filesystem::db::CrateSettings;
 use cairo_lang_filesystem::ids::{SmolStrId, Tracked};
 use cairo_lang_syntax::attribute::structured::{Attribute, AttributeListStructurize};
@@ -20,7 +20,7 @@ use super::visibility::{Visibility, peek_visible_in};
 use crate::SemanticDiagnostic;
 use crate::corelib::{core_submodule, get_submodule};
 use crate::db::{SemanticGroup, get_resolver_data_options};
-use crate::diagnostic::{SemanticDiagnosticKind, SemanticDiagnosticsBuilder};
+use crate::diagnostic::{SemanticDiagnosticKind, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::items::feature_kind::HasFeatureKind;
 use crate::items::imp::ImplSemantic;
 use crate::items::impl_alias::ImplAliasSemantic;
@@ -60,7 +60,7 @@ fn priv_module_semantic_data<'db>(
         }
     };
     // We use the builder here since the items can come from different file_ids.
-    let mut diagnostics = DiagnosticsBuilder::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let mut items = OrderedHashMap::default();
     let module_data = module_id.module_data(db)?;
     for item_id in module_data.items(db).iter().copied() {

--- a/crates/cairo-lang-semantic/src/items/module_type_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/module_type_alias.rs
@@ -41,7 +41,7 @@ fn module_type_alias_semantic_data<'db>(
         module_type_alias_generic_params_data(db, module_type_alias_id).maybe_as_ref()?.clone();
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::TypeAlias(module_type_alias_id));
 
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let type_alias_data = if in_cycle {
         type_alias_semantic_data_cycle_helper(
             db,

--- a/crates/cairo-lang-semantic/src/items/structure.rs
+++ b/crates/cairo-lang-semantic/src/items/structure.rs
@@ -43,7 +43,7 @@ fn struct_declaration_data<'db>(
     db: &'db dyn Database,
     struct_id: StructId<'db>,
 ) -> Maybe<StructDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(struct_id.parent_module(db));
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
     // the item instead of all the module data.
@@ -78,7 +78,7 @@ fn struct_generic_params_data<'db>(
     struct_id: StructId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = struct_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
     // the item instead of all the module data.
@@ -129,7 +129,7 @@ fn struct_definition_data<'db>(
 ) -> Maybe<StructDefinitionData<'db>> {
     let module_id = struct_id.parent_module(db);
     let crate_id = module_id.owning_crate(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
     // the item instead of all the module data.
@@ -196,7 +196,10 @@ fn struct_definition_diagnostics<'db>(
     {
         return data.diagnostics.clone();
     }
-    let mut diagnostics = SemanticDiagnostics::from(data.diagnostics.clone());
+    let mut diagnostics = SemanticDiagnostics::from_diagnostics(
+        struct_id.parent_module(db),
+        data.diagnostics.clone(),
+    );
     for (_, member) in data.members.iter() {
         let stable_ptr = member.id.stable_ptr(db);
         add_type_based_diagnostics(db, &mut diagnostics, member.ty, stable_ptr);

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -304,7 +304,7 @@ fn trait_generic_params_data<'db>(
     in_cycle: bool,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = trait_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let trait_ast = db.module_trait_by_id(trait_id)?;
 
     // Generic params.
@@ -380,7 +380,7 @@ fn priv_trait_declaration_data<'db>(
     db: &'db dyn Database,
     trait_id: TraitId<'db>,
 ) -> Maybe<TraitDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(trait_id.parent_module(db));
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
     // the item instead of all the module data.
@@ -605,7 +605,7 @@ fn priv_trait_definition_data<'db>(
     trait_id: TraitId<'db>,
 ) -> Maybe<TraitDefinitionData<'db>> {
     let module_id = trait_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
 
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
@@ -744,7 +744,7 @@ fn priv_trait_type_generic_params_data<'db>(
     trait_type_id: TraitTypeId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = trait_type_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let trait_id = trait_type_id.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;
     let trait_type_ast = &data.item_type_asts[&trait_type_id];
@@ -789,7 +789,7 @@ fn priv_trait_type_data<'db>(
     db: &'db dyn Database,
     trait_type_id: TraitTypeId<'db>,
 ) -> Maybe<TraitItemTypeData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(trait_type_id.parent_module(db));
     let trait_id = trait_type_id.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;
     let type_syntax = &data.item_type_asts[&trait_type_id];
@@ -829,7 +829,7 @@ fn priv_trait_constant_data<'db>(
     db: &'db dyn Database,
     trait_constant: TraitConstantId<'db>,
 ) -> Maybe<TraitItemConstantData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(trait_constant.parent_module(db));
     let trait_id = trait_constant.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;
     let constant_syntax = &data.item_constant_asts[&trait_constant];
@@ -888,7 +888,7 @@ fn priv_trait_impl_data<'db>(
     db: &'db dyn Database,
     trait_impl: TraitImplId<'db>,
 ) -> Maybe<TraitItemImplData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(trait_impl.parent_module(db));
     let trait_id = trait_impl.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;
     let impl_syntax = &data.item_impl_asts[&trait_impl];
@@ -949,7 +949,7 @@ fn priv_trait_function_generic_params_data<'db>(
     trait_function_id: TraitFunctionId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = trait_function_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let trait_id = trait_function_id.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;
     let function_syntax = &data.function_asts[&trait_function_id];
@@ -986,7 +986,7 @@ fn priv_trait_function_declaration_data<'db>(
     db: &'db dyn Database,
     trait_function_id: TraitFunctionId<'db>,
 ) -> Maybe<FunctionDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(trait_function_id.parent_module(db));
     let trait_id = trait_function_id.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;
     let function_syntax = &data.function_asts[&trait_function_id];
@@ -1114,7 +1114,7 @@ fn priv_trait_function_body_data<'db>(
     db: &'db dyn Database,
     trait_function_id: TraitFunctionId<'db>,
 ) -> Maybe<Option<FunctionBodyData<'db>>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(trait_function_id.parent_module(db));
     let trait_id = trait_function_id.trait_id(db);
     let data = db.priv_trait_definition_data(trait_id)?;
     let function_syntax = &data.function_asts[&trait_function_id];

--- a/crates/cairo-lang-semantic/src/items/type_aliases.rs
+++ b/crates/cairo-lang-semantic/src/items/type_aliases.rs
@@ -33,7 +33,7 @@ pub fn type_alias_generic_params_data_helper<'db>(
     lookup_item_id: LookupItemId<'db>,
     parent_resolver_data: Option<Arc<ResolverData<'db>>>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
 
     let mut resolver = match parent_resolver_data {

--- a/crates/cairo-lang-semantic/src/items/us.rs
+++ b/crates/cairo-lang-semantic/src/items/us.rs
@@ -54,7 +54,7 @@ fn priv_use_semantic_data<'db>(
     use_id: UseId<'db>,
 ) -> Maybe<Arc<UseData<'db>>> {
     let module_id = use_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let module_item_id = ModuleItemId::Use(use_id);
     let inference_id = InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(module_item_id));
     let mut resolver = Resolver::new(db, module_id, inference_id);
@@ -182,7 +182,7 @@ fn priv_use_semantic_data_cycle<'db>(
     use_id: UseId<'db>,
 ) -> Maybe<Arc<UseData<'db>>> {
     let module_id = use_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let use_ast = db.module_use_by_id(use_id)?;
     let err = Err(diagnostics.report(use_ast.stable_ptr(db), UseCycle));
     let inference_id =
@@ -263,7 +263,7 @@ fn priv_global_use_semantic_data<'db>(
     global_use_id: GlobalUseId<'db>,
 ) -> Maybe<UseGlobalData<'db>> {
     let module_id = global_use_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
     let inference_id = InferenceId::GlobalUseStar(global_use_id);
     let star_ast = ast::UsePath::Star(db.module_global_use_by_id(global_use_id)?);
     let mut resolver = Resolver::new(db, module_id, inference_id);
@@ -327,7 +327,7 @@ fn priv_global_use_semantic_data_tracked_initial<'db>(
     _id: salsa::Id,
     global_use_id: GlobalUseId<'db>,
 ) -> Maybe<UseGlobalData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(global_use_id.parent_module(db));
     let global_use_ast = db.module_global_use_by_id(global_use_id)?;
     let star_ast = ast::UsePath::Star(db.module_global_use_by_id(global_use_id)?);
     let segments = get_use_path_segments(db, star_ast)?;

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -568,7 +568,7 @@ impl<'db> Resolver<'db> {
         path: &ast::ExprPath<'db>,
         ctx: ResolutionContext<'db, '_>,
     ) -> Option<InlineMacroExprPluginId<'db>> {
-        let mut diagnostics = SemanticDiagnostics::default();
+        let mut diagnostics = SemanticDiagnostics::new(self.module_id);
         let resolution =
             Resolution::new(self, &mut diagnostics, path, NotFoundItemType::Macro, ctx).ok()?;
         let macro_name = resolution.segments.exactly_one().ok()?;

--- a/crates/cairo-lang-starknet/src/contract.rs
+++ b/crates/cairo-lang-starknet/src/contract.rs
@@ -173,7 +173,7 @@ fn get_impl_aliases_abi_functions<'db>(
     module_prefix: SmolStrId<'db>,
 ) -> anyhow::Result<Vec<Aliased<SemanticConcreteFunctionWithBodyId<'db>>>> {
     let generated_module_id = get_generated_contract_module(db, contract)?;
-    let mut diagnostics = SemanticDiagnostics::default();
+    let mut diagnostics = SemanticDiagnostics::new(generated_module_id);
     let mut all_abi_functions = vec![];
     for (impl_alias_id, impl_alias) in generated_module_id
         .module_data(db)


### PR DESCRIPTION
## Summary

Add module context to semantic diagnostics to enable better error reporting. This change introduces a `SemanticDiagnostics` struct that carries the module context in which diagnostics are reported, replacing the previous approach of using a generic `DiagnosticsBuilder`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Semantic diagnostics previously lacked module context information, which made it difficult to properly report and handle errors in certain scenarios. By adding module context to diagnostics, we can provide more accurate error messages and better track where errors originate from.

---

## What was the behavior or documentation before?

Previously, semantic diagnostics were created using a generic `DiagnosticsBuilder` without module context. This made it difficult to associate diagnostics with their originating modules and limited the ability to provide contextual error information.

---

## What is the behavior or documentation after?

Now, semantic diagnostics are created with a `SemanticDiagnostics` struct that carries the module context. This allows for better error reporting and tracking of where diagnostics originate from. All diagnostic creation points have been updated to include the appropriate module context.

---

## Additional context

This change is primarily internal to the compiler and improves error reporting capabilities. It required updating numerous call sites throughout the codebase to provide the appropriate module context when creating diagnostics.