### PR TITLE
chore: remove unused VersionIdTooLongForSerialization error

### DIFF
--- a/crates/cairo-lang-starknet-classes/src/felt252_serde.rs
+++ b/crates/cairo-lang-starknet-classes/src/felt252_serde.rs
@@ -60,8 +60,6 @@ pub enum Felt252SerdeError {
     OutOfOrderUserFunctionDeclarationsForSerialization,
     #[error("Invalid function declaration for serialization.")]
     FunctionArgumentsMismatchInSerialization,
-    #[error("The sierra version is too long and cannot fit within a felt252.")]
-    VersionIdTooLongForSerialization,
 }
 
 /// Serializes a Sierra program and the current compiler and Sierra versions into a vector of


### PR DESCRIPTION
## Summary

The VersionIdTooLongForSerialization variant of Felt252SerdeError was never constructed anywhere in the codebase and there is no serialization logic that could trigger it. Keeping it around suggested a non-existent validation path for Sierra version encoding. This change removes the dead enum variant to better reflect the actual behavior and avoid misleading future readers. No observable behavior or serialization format is changed.

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change
