### PR TITLE
 Fix outdated cross-module

### DIFF
--- a/docs/reference/src/components/cairo/modules/ROOT/pages/how-to-contribute.adoc
+++ b/docs/reference/src/components/cairo/modules/ROOT/pages/how-to-contribute.adoc
@@ -2,7 +2,7 @@
 
 First off, thanks for taking the time to contribute! Contributions are what make the open-source community such an amazing place to learn, inspire, and create. Any contributions you make will benefit everyone else and are **greatly appreciated**.
 
-Please read xref:appendices:contribution-guidelines.adoc[our contribution guidelines], and thank you for being
+Please read xref:../appendices/pages/contribution-guidelines.adoc[our contribution guidelines], and thank you for being
 involved!
 
 == Documentation contributions needed
@@ -12,38 +12,38 @@ See a full list of content and what is currently missing below:
 // Language constructs
 === Language Constructs
 
-* xref:language_constructs:modules-and-source-files.adoc[3. Modules and source files]
-* xref:language_constructs:type-aliases.adoc[4.4 Type aliases]
-* xref:language_constructs:impl-aliases.adoc[4.5 Impl aliases]
-* xref:language_constructs:constant-items.adoc[4.8 Constant items]
-* xref:language_constructs:namespaces.adoc[5.2 Namespaces]
-* xref:language_constructs:visibility.adoc[5.3 Visibility]
-* xref:language_constructs:item-statement.adoc[6.3 Item statement]
-* xref:language_constructs:path-expressions.adoc[7.2 Path expressions]
-* xref:language_constructs:arithmetic-and-logical-operators.adoc[7.4.2 Arithmetic and logical operators]
-* xref:language_constructs:equality-operators.adoc[7.4.3 Equality operators]
-* xref:language_constructs:comparison-operators.adoc[7.4.4 Comparison operators]
-* xref:language_constructs:boolean-operators.adoc[7.4.5 Boolean operators]
-* xref:language_constructs:error-propagation-operator.adoc[7.4.6 Error propagation operator]
-* xref:language_constructs:function-calls.adoc[7.6 Function calls]
-* xref:language_constructs:method-calls.adoc[7.7 Method calls]
-* xref:language_constructs:member-access-expressions.adoc[7.8 Member access expressions]
-* xref:language_constructs:struct-expressions.adoc[7.10 Struct expressions]
-* xref:language_constructs:if-expressions.adoc[7.11 If expressions]
-* xref:language_constructs:match-expressions.adoc[7.12 Match expressions]
-* xref:language_constructs:for-loop-expressions.adoc[7.13 For loop expressions]
-* xref:language_constructs:patterns.adoc[8. Patterns]
-* xref:language_constructs:felt252-type.adoc[9.1.2 Felt252 type]
-* xref:language_constructs:string-types.adoc[9.1.4 String types]
-* xref:language_constructs:struct-types.adoc[9.1.8 Struct types]
-* xref:language_constructs:enum-types.adoc[9.1.9 Enum types]
-* xref:language_constructs:array-types.adoc[9.1.10 Array types]
+* xref:../language_constructs/pages/modules-and-source-files.adoc[3. Modules and source files]
+* xref:../language_constructs/pages/type-aliases.adoc[4.4 Type aliases]
+* xref:../language_constructs/pages/impl-aliases.adoc[4.5 Impl aliases]
+* xref:../language_constructs/pages/constant-items.adoc[4.8 Constant items]
+* xref:../language_constructs/pages/namespaces.adoc[5.2 Namespaces]
+* xref:../language_constructs/pages/visibility.adoc[5.3 Visibility]
+* xref:../language_constructs/pages/item-statement.adoc[6.3 Item statement]
+* xref:../language_constructs/pages/path-expressions.adoc[7.2 Path expressions]
+* xref:../language_constructs/pages/arithmetic-and-logical-operators.adoc[7.4.2 Arithmetic and logical operators]
+* xref:../language_constructs/pages/equality-operators.adoc[7.4.3 Equality operators]
+* xref:../language_constructs/pages/comparison-operators.adoc[7.4.4 Comparison operators]
+* xref:../language_constructs/pages/boolean-operators.adoc[7.4.5 Boolean operators]
+* xref:../language_constructs/pages/error-propagation-operator.adoc[7.4.6 Error propagation operator]
+* xref:../language_constructs/pages/function-calls.adoc[7.6 Function calls]
+* xref:../language_constructs/pages/method-calls.adoc[7.7 Method calls]
+* xref:../language_constructs/pages/member-access-expressions.adoc[7.8 Member access expressions]
+* xref:../language_constructs/pages/struct-expressions.adoc[7.10 Struct expressions]
+* xref:../language_constructs/pages/if-expressions.adoc[7.11 If expressions]
+* xref:../language_constructs/pages/match-expressions.adoc[7.12 Match expressions]
+* xref:../language_constructs/pages/for-loop-expressions.adoc[7.13 For loop expressions]
+* xref:../language_constructs/pages/patterns.adoc[8. Patterns]
+* xref:../language_constructs/pages/felt252-type.adoc[9.1.2 Felt252 type]
+* xref:../language_constructs/pages/string-types.adoc[9.1.4 String types]
+* xref:../language_constructs/pages/struct-types.adoc[9.1.8 Struct types]
+* xref:../language_constructs/pages/enum-types.adoc[9.1.9 Enum types]
+* xref:../language_constructs/pages/array-types.adoc[9.1.10 Array types]
 
 === Language Semantics
-* xref:language_semantics:memory-model.adoc[Memory model]
-* xref:language_semantics:constant-evaluation.adoc[Constant evaluation]
-* xref:language_semantics:application-binary-interface.adoc[Application binary interface]
-* xref:language_semantics:runtime.adoc[Runtime]
+* xref:../language_semantics/pages/memory-model.adoc[Memory model]
+* xref:../language_semantics/pages/constant-evaluation.adoc[Constant evaluation]
+* xref:../language_semantics/pages/application-binary-interface.adoc[Application binary interface]
+* xref:../language_semantics/pages/runtime.adoc[Runtime]
 
 ## Support
 

--- a/docs/reference/src/components/cairo/modules/ROOT/pages/index.adoc
+++ b/docs/reference/src/components/cairo/modules/ROOT/pages/index.adoc
@@ -23,7 +23,7 @@ This documentation site is a work in progress. You are very welcome to contribut
 documentation by link:https://github.com/starkware-libs/cairo/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22[submitting a pull request].
 
 Please see xref:how-to-contribute.adoc[here] for a list of missing content and learn more about
-how to contribute by reading the xref:appendices:contribution-guidelines.adoc[Contribution guidelines] of this
+how to contribute by reading the xref:../appendices/pages/contribution-guidelines.adoc[Contribution guidelines] of this
 site.
 
 |===

--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/application-binary-interface.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/application-binary-interface.adoc
@@ -10,7 +10,7 @@ interact with contracts in a consistent way.
 
 This page explains what the ABI contains, its JSON representation, how it is generated and
 validated by the compiler, and how events are serialized. For how entry points are authored in
-contracts, see xref:language_constructs:contracts.adoc[Contracts].
+contracts, see xref:../../language_constructs/pages/contracts.adoc[Contracts].
 
 == What the ABI contains
 
@@ -142,7 +142,7 @@ Key invariants and diagnostics include (non‑exhaustive):
 - Exactly one constructor at most; having more than one is rejected.
 - Contracts must define exactly one `Storage` struct.
 - Entry points must have a `self` first parameter with the correct mutability (`ref` for external,
-  `@` for view), see xref:language_constructs:contracts.adoc[Contracts].
+  `@` for view), see xref:../../language_constructs/pages/contracts.adoc[Contracts].
 - Events must derive `starknet::Event`; flattened variants marked with `#[flat]` must be enums.
 - Duplicate entry point names/selectors and duplicate event selectors are rejected.
 - Interfaces embedded into a contract must be marked with the correct attributes, and interface
@@ -175,7 +175,7 @@ tooling.
 
 == Related documentation and sources
 
-- xref:language_constructs:contracts.adoc[Contracts]
+- xref:../../language_constructs/pages/contracts.adoc[Contracts]
 - ABI model and JSON serialization live in the codebase:
   * link:{cairo-repo}/crates/cairo-lang-starknet-classes/src/abi.rs[crates/cairo-lang-starknet-classes/src/abi.rs]
   * link:{cairo-repo}/crates/cairo-lang-starknet/src/abi.rs[crates/cairo-lang-starknet/src/abi.rs]

--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/memory-model.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/memory-model.adoc
@@ -21,7 +21,7 @@ At the language semantics level, memory is immutable. Assigning to an lvalue doe
 existing memory; instead, a variable is a logical placeholder that can point to a different value
 after assignment. See the language constructs reference for the canonical wording.
 
-xref:language_constructs:lvalue.adoc#_mutability_in_an_immutable_world[Mutability in an immutable world]
+xref:../../language_constructs/pages/lvalue.adoc#_mutability_in_an_immutable_world[Mutability in an immutable world]
 
 == Struct member updates and copying
 
@@ -29,7 +29,7 @@ Assigning to a member (e.g. `s.x = ...`) is defined as producing a new struct va
 structs, this may copy the entire struct logically; compilers may optimize to reduce copies when
 possible. The language constructs docs explain this performance aspect.
 
-xref:language_constructs:structs.adoc[Structs] (copy behavior notes)
+xref:../../language_constructs/pages/structs.adoc[Structs] (copy behavior notes)
 
 == Linear types, Copy and Drop
 

--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/runtime.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/runtime.adoc
@@ -64,7 +64,7 @@ Builtins provide optimized implementations of common operations:
 Builtins are accessed through core library functions and passed between functions
 using implicit arguments.
 
-See xref:language_constructs:implicit-arguments.adoc[Implicit arguments] for
+See xref:../../language_constructs/pages/implicit-arguments.adoc[Implicit arguments] for
 how builtins are threaded through function calls.
 
 == See also


### PR DESCRIPTION
Updates xref links to use relative `../../` paths instead of absolute `xref:module_name:` prefixes, ensuring doc references work correctly regardless of build location.

Fixed 38 instances across:
- ROOT/pages/index.adoc  
- ROOT/pages/how-to-contribute.adoc
- language_semantics/pages/runtime.adoc
- language_semantics/pages/memory-model.adoc
- language_semantics/pages/application-binary-interface.adoc