### PR TITLE
fix: casm inline syscall hint type

### DIFF
--- a/crates/cairo-lang-casm/src/inline.rs
+++ b/crates/cairo-lang-casm/src/inline.rs
@@ -199,7 +199,7 @@ macro_rules! casm_extend {
         $crate::casm_extend!($ctx, $($tok)*)
     };
     ($ctx:ident, %{ syscall_handler.syscall(syscall_ptr=memory $addr:tt + $offset:tt) %} $($tok:tt)*) => {
-        $ctx.current_hints.push($crate::hints::CoreHint::SystemCall {
+        $ctx.current_hints.push($crate::hints::StarknetHint::SystemCall {
             system: $crate::operand::ResOperand::BinOp($crate::operand::BinOpOperand {
                 op: cairo_lang_casm::operand::Operation::Add,
                 a: $crate::deref!($addr),
@@ -208,7 +208,7 @@ macro_rules! casm_extend {
         $crate::casm_extend!($ctx, $($tok)*)
     };
     ($ctx:ident, %{ syscall_handler.syscall(syscall_ptr=memory $addr:tt) %} $($tok:tt)*) => {
-        $ctx.current_hints.push($crate::hints::CoreHint::SystemCall {
+        $ctx.current_hints.push($crate::hints::StarknetHint::SystemCall {
             system: $crate::operand::ResOperand::Deref($crate::deref!($addr))
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)


### PR DESCRIPTION
## Summary

The casm! inline DSL was constructing CoreHint::SystemCall for syscall_handler.syscall hints, but SystemCall is defined only on StarknetHint. The runner and hint formatting logic both expect StarknetHint::SystemCall, and sierra-to-casm already emits that variant for system calls.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)


---

## Why is this change needed?

This change switches the inline macro to push StarknetHint::SystemCall instead, keeping the constructed ResOperand unchanged so that syscall execution and pythonic formatting stay consistent with the rest of the pipeline.