### PR TITLE
Fix incorrect type usage in documentation examples

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/constant-items.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/constant-items.adoc
@@ -103,7 +103,7 @@ Cross-type constants (casts validated at compile time):
 [source,cairo]
 ----
 const MAX_U8: u8 = 255;
-const NEG_ONE: felt252 = -1;
+const NEG_ONE: i32 = -1;
 ----
 
 == Diagnostics

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/return-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/return-expressions.adoc
@@ -19,11 +19,11 @@ remaining code in the function body.
 
 [source,cairo]
 ----
-fn check_positive(x: i32) -> felt252 {
+fn check_positive(x: i32) -> u32 {
     if x < 0 {
         return 0;  // Exit early if negative
     }
-    x.into()
+    x.try_into().unwrap()
 }
 ----
 


### PR DESCRIPTION
 **Changes:**
  1. `return-expressions.adoc`: Changed return type from `felt252` to `u32` in `check_positive()` - the function checks for positivity and returns unsigned values, so `felt252` (a field element) is semantically incorrect.

  2. `constant-items.adoc`: Changed `NEG_ONE` constant from `felt252` to `i32` - negative values should use signed integer types. The name `NEG_ONE` explicitly indicates a negative value, making `felt252` inappropriate.