### PR TITLE
docs: fix grammar in statements.adoc

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/statements.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/statements.adoc
@@ -5,7 +5,7 @@ causing effects when evaluated are _expressions_.
 Many expressions can nest within each other, and the sequence of evaluation is driven by
 precedence and associativity rules.
 
-There are not a lot of statement kinds, whose role is limited to containing explicitly sequential
+There are not many statement kinds, and their role is limited to containing explicitly sequential
 xref:expression-statement.adoc[expression evaluation] and declaring xref:items.adoc[items]
 and xref:let-statement.adoc[variables] in xref:block-expression.adoc[code blocks].
 


### PR DESCRIPTION

Fix grammatical error in statements documentation:

- Replace `a lot of` with `many` (more formal)
- Fix incorrect use of `whose` → `and their` (proper pronoun reference)

**Before:**
> There are not a lot of statement kinds, whose role is limited...

**After:**
> There are not many statement kinds, and their role is limited...
