### PR TITLE
(opt): Libfunc for matching on a boxed enum for boxed variants results

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -15,7 +15,7 @@ use cairo_lang_sierra::extensions::const_type::ConstConcreteLibfunc;
 use cairo_lang_sierra::extensions::core::CoreConcreteLibfunc::{self, *};
 use cairo_lang_sierra::extensions::coupon::CouponConcreteLibfunc;
 use cairo_lang_sierra::extensions::ec::EcConcreteLibfunc;
-use cairo_lang_sierra::extensions::enm::EnumConcreteLibfunc;
+use cairo_lang_sierra::extensions::enm::{EnumBoxedMatchConcreteLibfunc, EnumConcreteLibfunc};
 use cairo_lang_sierra::extensions::felt252::{
     Felt252BinaryOperationConcrete, Felt252BinaryOperator, Felt252Concrete,
 };
@@ -32,6 +32,7 @@ use cairo_lang_sierra::extensions::int::unsigned256::Uint256Concrete;
 use cairo_lang_sierra::extensions::int::unsigned512::Uint512Concrete;
 use cairo_lang_sierra::extensions::int::{IntMulTraits, IntOperator};
 use cairo_lang_sierra::extensions::is_zero::IsZeroTraits;
+use cairo_lang_sierra::extensions::lib_func::SignatureOnlyConcreteLibfunc;
 use cairo_lang_sierra::extensions::mem::MemConcreteLibfunc;
 use cairo_lang_sierra::extensions::nullable::NullableConcreteLibfunc;
 use cairo_lang_sierra::extensions::pedersen::PedersenConcreteLibfunc;
@@ -293,8 +294,19 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
                 1 | 2 => vec![ApChange::Known(0)],
                 _ => vec![ApChange::Known(1)],
             },
-            EnumConcreteLibfunc::Match(libfunc) | EnumConcreteLibfunc::SnapshotMatch(libfunc) => {
-                vec![ApChange::Known(0); libfunc.signature.branch_signatures.len()]
+            EnumConcreteLibfunc::Match(SignatureOnlyConcreteLibfunc { signature, .. })
+            | EnumConcreteLibfunc::SnapshotMatch(SignatureOnlyConcreteLibfunc {
+                signature, ..
+            }) => {
+                vec![ApChange::Known(0); signature.branch_signatures.len()]
+            }
+            EnumConcreteLibfunc::BoxedMatch(EnumBoxedMatchConcreteLibfunc {
+                signature, ..
+            }) => {
+                // For zero or one variants, no instructions are generated (no branching needed)
+                // For other cases, we need 1 AP change for loading the variant selector
+                let n = signature.branch_signatures.len();
+                if n <= 1 { vec![ApChange::Known(0); n] } else { vec![ApChange::Known(1); n] }
             }
         },
         Struct(libfunc) => match libfunc {

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -1,10 +1,15 @@
+use std::iter;
+
+use cairo_lang_casm::ap_change::ApplyApChange;
 use cairo_lang_casm::builder::CasmBuilder;
-use cairo_lang_casm::cell_expression::CellExpression;
+use cairo_lang_casm::cell_expression::{CellExpression, CellOperator};
 use cairo_lang_casm::instructions::Instruction;
-use cairo_lang_casm::operand::CellRef;
+use cairo_lang_casm::operand::{CellRef, DerefOrImmediate, Register};
 use cairo_lang_casm::{casm, casm_build_extend, casm_extend};
 use cairo_lang_sierra::extensions::ConcreteLibfunc;
-use cairo_lang_sierra::extensions::enm::{EnumConcreteLibfunc, EnumInitConcreteLibfunc};
+use cairo_lang_sierra::extensions::enm::{
+    EnumBoxedMatchConcreteLibfunc, EnumConcreteLibfunc, EnumInitConcreteLibfunc,
+};
 use cairo_lang_sierra::ids::ConcreteTypeId;
 use cairo_lang_sierra::program::{BranchInfo, BranchTarget};
 use cairo_lang_utils::try_extract_matches;
@@ -34,6 +39,7 @@ pub fn build(
         EnumConcreteLibfunc::Match(_) | EnumConcreteLibfunc::SnapshotMatch(_) => {
             build_enum_match(builder)
         }
+        EnumConcreteLibfunc::BoxedMatch(libfunc) => build_enum_boxed_match(libfunc, builder),
     }
 }
 
@@ -396,4 +402,90 @@ fn get_enum_size(
     concrete_enum_type: &ConcreteTypeId,
 ) -> Option<i16> {
     Some(program_info.type_sizes.get(concrete_enum_type)?.to_owned())
+}
+
+/// Generates CASM instructions for matching a boxed enum into individual boxed variants.
+///
+/// This function takes a boxed enum (stored in a single memory cell containing the address)
+/// and branches based on the variant selector, returning a box pointing to the appropriate variant.
+fn build_enum_boxed_match(
+    libfunc: &EnumBoxedMatchConcreteLibfunc,
+    builder: CompiledInvocationBuilder<'_>,
+) -> Result<CompiledInvocation, InvocationError> {
+    let num_branches = builder.invocation.branches.len();
+
+    // Handle zero variants case - no instructions needed for uninhabited type
+    if num_branches == 0 {
+        return Ok(builder.build(
+            vec![],
+            vec![],
+            iter::empty::<iter::Empty<ReferenceExpression>>(),
+        ));
+    }
+
+    let [cell] = builder.try_get_single_cells()?;
+    let cell_ref = cell.to_deref().ok_or(InvocationError::InvalidReferenceExpressionForArgument)?;
+
+    // Calculate the size of each variant
+    let mut variant_sizes: Vec<i16> = Vec::new();
+    for variant_ty in &libfunc.variants {
+        let variant_size = *builder
+            .program_info
+            .type_sizes
+            .get(variant_ty)
+            .ok_or(InvocationError::InvalidReferenceExpressionForArgument)?;
+        variant_sizes.push(variant_size);
+    }
+
+    // The enum size is 1 (selector) + max(variant_sizes)
+    let max_variant_size = variant_sizes.iter().max().copied().unwrap_or(0);
+
+    let output_cellref = if num_branches > 1 {
+        let mut adjusted = cell_ref;
+        assert!(adjusted.apply_known_ap_change(1));
+        adjusted
+    } else {
+        cell_ref
+    };
+
+    // For each branch, we need to create a reference to Box<Variant>
+    // The variant data starts at offset 1 + padding to skip to the variant
+    let output_expressions_for_branches = variant_sizes.iter().map(|&variant_size| {
+        // Calculate padding: the variant is right-aligned in the enum's value space
+        let padding = max_variant_size - variant_size;
+        // The box should point to: base_addr + 1 (selector) + padding
+        let variant_offset = 1 + padding;
+        let variant_box = CellExpression::BinOp {
+            op: CellOperator::Add,
+            a: output_cellref,
+            b: DerefOrImmediate::Immediate(variant_offset.into()),
+        };
+
+        vec![ReferenceExpression::from_cell(variant_box)].into_iter()
+    });
+
+    // For single variant enums, no branching is needed - just return the variant box
+    if num_branches == 1 {
+        return Ok(builder.build(vec![], vec![], output_expressions_for_branches));
+    }
+
+    // Load the variant selector into a temporary - this is a double deref
+    let instructions = casm! { [ap] = [[&cell_ref]], ap++; }.instructions;
+    let variant_selector_cell = CellRef { register: Register::AP, offset: -1 };
+
+    if num_branches == 2 {
+        build_enum_match_short_ex(
+            builder,
+            variant_selector_cell,
+            output_expressions_for_branches.into_iter().map(|v| v.into_iter()),
+            instructions,
+        )
+    } else {
+        build_enum_match_long_ex(
+            builder,
+            variant_selector_cell,
+            output_expressions_for_branches.into_iter().map(|v| v.into_iter()),
+            instructions,
+        )
+    }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/enm.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/enm.rs
@@ -20,9 +20,10 @@ use num_traits::Signed;
 
 use super::snapshot::snapshot_ty;
 use super::structure::StructType;
-use super::utils::reinterpret_cast_signature;
+use super::utils::{boxed_ty_with_optional_snapshot, peel_snapshot, reinterpret_cast_signature};
 use crate::define_libfunc_hierarchy;
 use crate::extensions::bounded_int::bounded_int_ty;
+use crate::extensions::boxing::box_ty;
 use crate::extensions::lib_func::{
     BranchSignature, DeferredOutputKind, LibfuncSignature, OutputVarInfo, ParamSignature,
     SierraApChange, SignatureOnlyGenericLibfunc, SignatureSpecializationContext,
@@ -126,6 +127,7 @@ define_libfunc_hierarchy! {
         FromBoundedInt(EnumFromBoundedIntLibfunc),
         Match(EnumMatchLibfunc),
         SnapshotMatch(EnumSnapshotMatchLibfunc),
+        BoxedMatch(EnumBoxedMatchLibfunc),
     }, EnumConcreteLibfunc
 }
 
@@ -321,7 +323,7 @@ impl SignatureOnlyGenericLibfunc for EnumMatchLibfunc {
         Ok(LibfuncSignature {
             param_signatures: vec![enum_type.clone().into()],
             branch_signatures,
-            fallthrough: if is_empty { None } else { Some(0) },
+            fallthrough: (!is_empty).then_some(0),
         })
     }
 }
@@ -363,5 +365,100 @@ impl SignatureOnlyGenericLibfunc for EnumSnapshotMatchLibfunc {
             branch_signatures,
             fallthrough: Some(0),
         })
+    }
+}
+
+/// Concrete implementation of the boxed enum match libfunc.
+pub struct EnumBoxedMatchConcreteLibfunc {
+    /// The concrete types of the enum variants (no additional snapshots and boxing) that will be
+    /// extracted as boxed values.
+    pub variants: Vec<ConcreteTypeId>,
+    pub signature: LibfuncSignature,
+}
+
+impl SignatureBasedConcreteLibfunc for EnumBoxedMatchConcreteLibfunc {
+    fn signature(&self) -> &LibfuncSignature {
+        &self.signature
+    }
+}
+
+/// Libfunc for matching a boxed enum into boxes of its variants.
+#[derive(Default)]
+pub struct EnumBoxedMatchLibfunc {}
+
+impl EnumBoxedMatchLibfunc {
+    /// Extracts variant types and snapshot status from an enum type.
+    fn analyze_enum_type(
+        context: &dyn SignatureSpecializationContext,
+        ty: ConcreteTypeId,
+    ) -> Result<(Vec<ConcreteTypeId>, bool), SpecializationError> {
+        let type_info = context.get_type_info(&ty)?;
+        let (inner_ty, is_snapshot) = peel_snapshot(&ty, &type_info)?;
+        let enum_type = EnumConcreteType::try_from_concrete_type(context, inner_ty)?;
+        Ok((enum_type.variants, is_snapshot))
+    }
+
+    /// Builds the libfunc signature for boxed enum match.
+    fn create_signature(
+        context: &dyn SignatureSpecializationContext,
+        ty: ConcreteTypeId,
+        variant_types: impl IntoIterator<Item = ConcreteTypeId>,
+        is_snapshot: bool,
+    ) -> Result<LibfuncSignature, SpecializationError> {
+        let variants: Vec<ConcreteTypeId> = variant_types.into_iter().collect();
+        let is_empty = variants.is_empty();
+        let no_ap_change = variants.len() <= 1;
+        let branch_signatures = variants
+            .into_iter()
+            .map(|variant_ty| {
+                let ref_info = OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst);
+                Ok(BranchSignature {
+                    vars: vec![OutputVarInfo {
+                        ty: boxed_ty_with_optional_snapshot(context, variant_ty, is_snapshot)?,
+                        ref_info,
+                    }],
+                    ap_change: SierraApChange::Known { new_vars_only: no_ap_change },
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(LibfuncSignature {
+            param_signatures: vec![
+                ParamSignature::new(box_ty(context, ty)?).with_allow_add_const(),
+            ],
+            branch_signatures,
+            fallthrough: (!is_empty).then_some(0),
+        })
+    }
+}
+
+impl NamedLibfunc for EnumBoxedMatchLibfunc {
+    type Concrete = EnumBoxedMatchConcreteLibfunc;
+    const STR_ID: &'static str = "enum_boxed_match";
+
+    fn specialize_signature(
+        &self,
+        context: &dyn SignatureSpecializationContext,
+        args: &[GenericArg],
+    ) -> Result<LibfuncSignature, SpecializationError> {
+        let enum_type = args_as_single_type(args)?;
+        let (variant_types, is_snapshot) = Self::analyze_enum_type(context, enum_type.clone())?;
+        Self::create_signature(context, enum_type.clone(), variant_types, is_snapshot)
+    }
+
+    fn specialize(
+        &self,
+        context: &dyn SpecializationContext,
+        args: &[GenericArg],
+    ) -> Result<Self::Concrete, SpecializationError> {
+        let enum_type = args_as_single_type(args)?;
+        let (variants, is_snapshot) = Self::analyze_enum_type(context, enum_type.clone())?;
+        let signature = Self::create_signature(
+            context,
+            enum_type.clone(),
+            variants.iter().cloned(),
+            is_snapshot,
+        )?;
+        Ok(EnumBoxedMatchConcreteLibfunc { variants, signature })
     }
 }

--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -231,7 +231,9 @@ pub fn simulate<
             (vec![CoreValue::Enum { value: Box::new(value), index: *index }], 0)
         }
         CoreConcreteLibfunc::Enum(
-            EnumConcreteLibfunc::Match(_) | EnumConcreteLibfunc::SnapshotMatch(_),
+            EnumConcreteLibfunc::Match(_)
+            | EnumConcreteLibfunc::SnapshotMatch(_)
+            | EnumConcreteLibfunc::BoxedMatch(_),
         ) => {
             take_inputs!(let [CoreValue::Enum { value, index }] = inputs);
             (vec![*value], index)

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
@@ -67,6 +67,7 @@
         "ec_state_try_finalize_nz",
         "emit_event_syscall",
         "enable_ap_tracking",
+        "enum_boxed_match",
         "enum_from_bounded_int",
         "enum_init",
         "enum_match",

--- a/tests/e2e_test_data/libfuncs/enum
+++ b/tests/e2e_test_data/libfuncs/enum
@@ -495,3 +495,804 @@ store_temp<test::IndexEnum1>([1]) -> ([1]);
 return([1]);
 
 test::foo@F0([0]: BoundedInt<0, 0>) -> (test::IndexEnum1);
+
+//! > ==========================================================================
+
+//! > boxed match enum with 1 variant (libfunc only)
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+enum Single {
+    Value: felt252,
+}
+
+enum BoxedSingle {
+    Value: Box<felt252>,
+}
+
+extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedSingle nopanic;
+
+fn foo(e: Box<Single>) -> BoxedSingle {
+    enum_boxed_match(e)
+}
+
+//! > casm
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -3] + 1, ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 200})
+
+//! > sierra_code
+type Box<test::Single> = Box<test::Single> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::BoxedSingle = Enum<ut@test::BoxedSingle, Box<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Single = Enum<ut@test::Single, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_boxed_match<test::Single> = enum_boxed_match<test::Single>;
+libfunc branch_align = branch_align;
+libfunc enum_init<test::BoxedSingle, 0> = enum_init<test::BoxedSingle, 0>;
+libfunc store_temp<test::BoxedSingle> = store_temp<test::BoxedSingle>;
+
+F0:
+enum_boxed_match<test::Single>([0]) -> ([1]);
+branch_align() -> ();
+enum_init<test::BoxedSingle, 0>([1]) -> ([2]);
+store_temp<test::BoxedSingle>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: Box<test::Single>) -> (test::BoxedSingle);
+
+//! > ==========================================================================
+
+//! > boxed match enum with 2 variants (libfunc only)
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+enum BoxedOption {
+    Some: Box<felt252>,
+    None: Box<()>,
+}
+
+extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedOption nopanic;
+
+fn foo(e: Box<Option<felt252>>) -> BoxedOption {
+    enum_boxed_match(e)
+}
+
+//! > casm
+[ap + 0] = [[fp + -3] + 0], ap++;
+jmp rel 7 if [ap + -1] != 0;
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -3] + 1, ap++;
+ret;
+[ap + 0] = 1, ap++;
+[ap + 0] = [fp + -3] + 2, ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 400})
+
+//! > sierra_code
+type Box<core::option::Option::<core::felt252>> = Box<core::option::Option::<core::felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Unit> = Box<Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::BoxedOption = Enum<ut@test::BoxedOption, Box<felt252>, Box<Unit>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::option::Option::<core::felt252> = Enum<ut@core::option::Option::<core::felt252>, felt252, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_boxed_match<core::option::Option::<core::felt252>> = enum_boxed_match<core::option::Option::<core::felt252>>;
+libfunc branch_align = branch_align;
+libfunc enum_init<test::BoxedOption, 0> = enum_init<test::BoxedOption, 0>;
+libfunc store_temp<test::BoxedOption> = store_temp<test::BoxedOption>;
+libfunc enum_init<test::BoxedOption, 1> = enum_init<test::BoxedOption, 1>;
+
+F0:
+enum_boxed_match<core::option::Option::<core::felt252>>([0]) { fallthrough([1]) F0_B0([2]) };
+branch_align() -> ();
+enum_init<test::BoxedOption, 0>([1]) -> ([3]);
+store_temp<test::BoxedOption>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+enum_init<test::BoxedOption, 1>([2]) -> ([4]);
+store_temp<test::BoxedOption>([4]) -> ([4]);
+return([4]);
+
+test::foo@F0([0]: Box<core::option::Option::<core::felt252>>) -> (test::BoxedOption);
+
+//! > ==========================================================================
+
+//! > boxed match enum with 3 variants (libfunc only)
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+enum Color {
+    Red: felt252,
+    Green: felt252,
+    Blue: felt252,
+}
+
+enum BoxedColor {
+    Red: Box<felt252>,
+    Green: Box<felt252>,
+    Blue: Box<felt252>,
+}
+
+extern fn enum_boxed_match<Color>(e: Box<Color>) -> BoxedColor nopanic;
+
+fn foo(e: Box<Color>) -> BoxedColor {
+    enum_boxed_match(e)
+}
+
+//! > casm
+[ap + 0] = [[fp + -3] + 0], ap++;
+jmp rel [ap + -1];
+jmp rel 14;
+jmp rel 7;
+[ap + 0] = 5, ap++;
+[ap + 0] = [fp + -3] + 1, ap++;
+ret;
+[ap + 0] = 3, ap++;
+[ap + 0] = [fp + -3] + 1, ap++;
+ret;
+[ap + 0] = 1, ap++;
+[ap + 0] = [fp + -3] + 1, ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 500})
+
+//! > sierra_code
+type Box<test::Color> = Box<test::Color> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::BoxedColor = Enum<ut@test::BoxedColor, Box<felt252>, Box<felt252>, Box<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Color = Enum<ut@test::Color, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_boxed_match<test::Color> = enum_boxed_match<test::Color>;
+libfunc branch_align = branch_align;
+libfunc enum_init<test::BoxedColor, 0> = enum_init<test::BoxedColor, 0>;
+libfunc store_temp<test::BoxedColor> = store_temp<test::BoxedColor>;
+libfunc enum_init<test::BoxedColor, 1> = enum_init<test::BoxedColor, 1>;
+libfunc enum_init<test::BoxedColor, 2> = enum_init<test::BoxedColor, 2>;
+
+F0:
+enum_boxed_match<test::Color>([0]) { fallthrough([1]) F0_B0([2]) F0_B1([3]) };
+branch_align() -> ();
+enum_init<test::BoxedColor, 0>([1]) -> ([4]);
+store_temp<test::BoxedColor>([4]) -> ([4]);
+return([4]);
+F0_B0:
+branch_align() -> ();
+enum_init<test::BoxedColor, 1>([2]) -> ([5]);
+store_temp<test::BoxedColor>([5]) -> ([5]);
+return([5]);
+F0_B1:
+branch_align() -> ();
+enum_init<test::BoxedColor, 2>([3]) -> ([6]);
+store_temp<test::BoxedColor>([6]) -> ([6]);
+return([6]);
+
+test::foo@F0([0]: Box<test::Color>) -> (test::BoxedColor);
+
+//! > ==========================================================================
+
+//! > boxed match enum with padding (libfunc only)
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+enum Data {
+    Small: felt252,
+    Large: (felt252, felt252, felt252),
+}
+
+enum BoxedData {
+    Small: Box<felt252>,
+    Large: Box<(felt252, felt252, felt252)>,
+}
+
+extern fn enum_boxed_match<Data>(e: Box<Data>) -> BoxedData nopanic;
+
+fn foo(e: Box<Data>) -> BoxedData {
+    enum_boxed_match(e)
+}
+
+//! > casm
+[ap + 0] = [[fp + -3] + 0], ap++;
+jmp rel 7 if [ap + -1] != 0;
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -3] + 3, ap++;
+ret;
+[ap + 0] = 1, ap++;
+[ap + 0] = [fp + -3] + 1, ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 400})
+
+//! > sierra_code
+type Box<test::Data> = Box<test::Data> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Tuple<felt252, felt252, felt252>> = Box<Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::BoxedData = Enum<ut@test::BoxedData, Box<felt252>, Box<Tuple<felt252, felt252, felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252, felt252> = Struct<ut@Tuple, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Data = Enum<ut@test::Data, felt252, Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_boxed_match<test::Data> = enum_boxed_match<test::Data>;
+libfunc branch_align = branch_align;
+libfunc enum_init<test::BoxedData, 0> = enum_init<test::BoxedData, 0>;
+libfunc store_temp<test::BoxedData> = store_temp<test::BoxedData>;
+libfunc enum_init<test::BoxedData, 1> = enum_init<test::BoxedData, 1>;
+
+F0:
+enum_boxed_match<test::Data>([0]) { fallthrough([1]) F0_B0([2]) };
+branch_align() -> ();
+enum_init<test::BoxedData, 0>([1]) -> ([3]);
+store_temp<test::BoxedData>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+enum_init<test::BoxedData, 1>([2]) -> ([4]);
+store_temp<test::BoxedData>([4]) -> ([4]);
+return([4]);
+
+test::foo@F0([0]: Box<test::Data>) -> (test::BoxedData);
+
+//! > ==========================================================================
+
+//! > boxed match enum with 1 variant
+
+//! > test_runner_name
+SmallE2ETestRunner(test_data_function: add_123, test_data_input: 5, test_data_output: 128)
+
+//! > cairo_code
+enum Single {
+    Value: felt252,
+}
+
+enum BoxedSingle {
+    Value: Box<felt252>,
+}
+
+extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedSingle nopanic;
+
+fn add_123(x: felt252) -> felt252 {
+    let boxed = BoxTrait::new(Single::Value(x));
+    match enum_boxed_match(boxed) {
+        BoxedSingle::Value(boxed_x) => boxed_x.unbox() + 123,
+    }
+}
+
+//! > casm
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -3], ap++;
+%{
+if '__boxed_segment' not in globals():
+    __boxed_segment = segments.add()
+memory[ap + 0] = __boxed_segment
+__boxed_segment += 2
+%}
+[ap + -2] = [[ap + 0] + 0], ap++;
+[ap + -2] = [[ap + -1] + 1];
+[ap + 0] = [ap + -1] + 1, ap++;
+[ap + 0] = [[ap + -1] + 0], ap++;
+[ap + 0] = [ap + -1] + 123, ap++;
+ret;
+
+//! > function_costs
+test::add_123: SmallOrderedMap({Const: 700})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 123> = Const<felt252, 123> [storable: false, drop: false, dup: false, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<test::Single> = Box<test::Single> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Single = Enum<ut@test::Single, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_init<test::Single, 0> = enum_init<test::Single, 0>;
+libfunc store_temp<test::Single> = store_temp<test::Single>;
+libfunc into_box<test::Single> = into_box<test::Single>;
+libfunc enum_boxed_match<test::Single> = enum_boxed_match<test::Single>;
+libfunc branch_align = branch_align;
+libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
+libfunc unbox<felt252> = unbox<felt252>;
+libfunc const_as_immediate<Const<felt252, 123>> = const_as_immediate<Const<felt252, 123>>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc felt252_add = felt252_add;
+
+F0:
+enum_init<test::Single, 0>([0]) -> ([1]);
+store_temp<test::Single>([1]) -> ([1]);
+into_box<test::Single>([1]) -> ([2]);
+enum_boxed_match<test::Single>([2]) -> ([3]);
+branch_align() -> ();
+store_temp<Box<felt252>>([3]) -> ([3]);
+unbox<felt252>([3]) -> ([4]);
+const_as_immediate<Const<felt252, 123>>() -> ([5]);
+store_temp<felt252>([4]) -> ([4]);
+felt252_add([4], [5]) -> ([6]);
+store_temp<felt252>([6]) -> ([6]);
+return([6]);
+
+test::add_123@F0([0]: felt252) -> (felt252);
+
+//! > ==========================================================================
+
+//! > boxed match enum with 2 variants
+
+//! > test_runner_name
+SmallE2ETestRunner(test_data_function: add_123, test_data_input: 5, test_data_output: 128)
+
+//! > cairo_code
+enum BoxedOption {
+    Some: Box<felt252>,
+    None: Box<()>,
+}
+
+extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedOption nopanic;
+
+fn add_123(x: felt252) -> felt252 {
+    let boxed = BoxTrait::new(Some(x));
+    match enum_boxed_match(boxed) {
+        BoxedOption::Some(boxed_x) => boxed_x.unbox() + 123,
+        _ => 999,
+    }
+}
+
+//! > casm
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -3], ap++;
+%{
+if '__boxed_segment' not in globals():
+    __boxed_segment = segments.add()
+memory[ap + 0] = __boxed_segment
+__boxed_segment += 2
+%}
+[ap + -2] = [[ap + 0] + 0], ap++;
+[ap + -2] = [[ap + -1] + 1];
+[ap + 0] = [[ap + -1] + 0], ap++;
+jmp rel 8 if [ap + -1] != 0;
+[ap + 0] = [ap + -2] + 1, ap++;
+[ap + 0] = [[ap + -1] + 0], ap++;
+[ap + 0] = [ap + -1] + 123, ap++;
+ret;
+ap += 2;
+[ap + 0] = 999, ap++;
+ret;
+
+//! > function_costs
+test::add_123: SmallOrderedMap({Const: 900})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 999> = Const<felt252, 999> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 123> = Const<felt252, 123> [storable: false, drop: false, dup: false, zero_sized: false];
+type Box<Unit> = Box<Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Box<core::option::Option::<core::felt252>> = Box<core::option::Option::<core::felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::option::Option::<core::felt252> = Enum<ut@core::option::Option::<core::felt252>, felt252, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_init<core::option::Option::<core::felt252>, 0> = enum_init<core::option::Option::<core::felt252>, 0>;
+libfunc store_temp<core::option::Option::<core::felt252>> = store_temp<core::option::Option::<core::felt252>>;
+libfunc into_box<core::option::Option::<core::felt252>> = into_box<core::option::Option::<core::felt252>>;
+libfunc enum_boxed_match<core::option::Option::<core::felt252>> = enum_boxed_match<core::option::Option::<core::felt252>>;
+libfunc branch_align = branch_align;
+libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
+libfunc unbox<felt252> = unbox<felt252>;
+libfunc const_as_immediate<Const<felt252, 123>> = const_as_immediate<Const<felt252, 123>>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc felt252_add = felt252_add;
+libfunc drop<Box<Unit>> = drop<Box<Unit>>;
+libfunc const_as_immediate<Const<felt252, 999>> = const_as_immediate<Const<felt252, 999>>;
+
+F0:
+enum_init<core::option::Option::<core::felt252>, 0>([0]) -> ([1]);
+store_temp<core::option::Option::<core::felt252>>([1]) -> ([1]);
+into_box<core::option::Option::<core::felt252>>([1]) -> ([2]);
+enum_boxed_match<core::option::Option::<core::felt252>>([2]) { fallthrough([3]) F0_B0([4]) };
+branch_align() -> ();
+store_temp<Box<felt252>>([3]) -> ([3]);
+unbox<felt252>([3]) -> ([5]);
+const_as_immediate<Const<felt252, 123>>() -> ([6]);
+store_temp<felt252>([5]) -> ([5]);
+felt252_add([5], [6]) -> ([7]);
+store_temp<felt252>([7]) -> ([7]);
+return([7]);
+F0_B0:
+branch_align() -> ();
+drop<Box<Unit>>([4]) -> ();
+const_as_immediate<Const<felt252, 999>>() -> ([8]);
+store_temp<felt252>([8]) -> ([8]);
+return([8]);
+
+test::add_123@F0([0]: felt252) -> (felt252);
+
+//! > ==========================================================================
+
+//! > boxed match enum with 3 variants
+
+//! > test_runner_name
+SmallE2ETestRunner(test_data_function: test_blue, test_data_input: 5, test_data_output: 1004)
+
+//! > cairo_code
+enum Color {
+    Red: felt252,
+    Green: felt252,
+    Blue: felt252,
+}
+
+enum BoxedColor {
+    Red: Box<felt252>,
+    Green: Box<felt252>,
+    Blue: Box<felt252>,
+}
+
+extern fn enum_boxed_match<Color>(e: Box<Color>) -> BoxedColor nopanic;
+
+fn test_blue(x: felt252) -> felt252 {
+    let boxed = BoxTrait::new(Color::Blue(x));
+    match enum_boxed_match(boxed) {
+        BoxedColor::Red(_) => 777,
+        BoxedColor::Green(_) => 888,
+        BoxedColor::Blue(boxed_x) => 999 + boxed_x.unbox(),
+    }
+}
+
+//! > casm
+[ap + 0] = 1, ap++;
+[ap + 0] = [fp + -3], ap++;
+%{
+if '__boxed_segment' not in globals():
+    __boxed_segment = segments.add()
+memory[ap + 0] = __boxed_segment
+__boxed_segment += 2
+%}
+[ap + -2] = [[ap + 0] + 0], ap++;
+[ap + -2] = [[ap + -1] + 1];
+[ap + 0] = [[ap + -1] + 0], ap++;
+jmp rel [ap + -1];
+jmp rel 14;
+jmp rel 7;
+ap += 3;
+[ap + 0] = 777, ap++;
+ret;
+ap += 3;
+[ap + 0] = 888, ap++;
+ret;
+[ap + 0] = [ap + -2] + 1, ap++;
+[ap + 0] = 999, ap++;
+[ap + 0] = [[ap + -2] + 0], ap++;
+[ap + 0] = [ap + -2] + [ap + -1], ap++;
+ret;
+
+//! > function_costs
+test::test_blue: SmallOrderedMap({Const: 1100})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 999> = Const<felt252, 999> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 888> = Const<felt252, 888> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 777> = Const<felt252, 777> [storable: false, drop: false, dup: false, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<test::Color> = Box<test::Color> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Color = Enum<ut@test::Color, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_init<test::Color, 2> = enum_init<test::Color, 2>;
+libfunc store_temp<test::Color> = store_temp<test::Color>;
+libfunc into_box<test::Color> = into_box<test::Color>;
+libfunc enum_boxed_match<test::Color> = enum_boxed_match<test::Color>;
+libfunc branch_align = branch_align;
+libfunc drop<Box<felt252>> = drop<Box<felt252>>;
+libfunc const_as_immediate<Const<felt252, 777>> = const_as_immediate<Const<felt252, 777>>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc const_as_immediate<Const<felt252, 888>> = const_as_immediate<Const<felt252, 888>>;
+libfunc const_as_immediate<Const<felt252, 999>> = const_as_immediate<Const<felt252, 999>>;
+libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
+libfunc unbox<felt252> = unbox<felt252>;
+libfunc felt252_add = felt252_add;
+
+F0:
+enum_init<test::Color, 2>([0]) -> ([1]);
+store_temp<test::Color>([1]) -> ([1]);
+into_box<test::Color>([1]) -> ([2]);
+enum_boxed_match<test::Color>([2]) { fallthrough([3]) F0_B0([4]) F0_B1([5]) };
+branch_align() -> ();
+drop<Box<felt252>>([3]) -> ();
+const_as_immediate<Const<felt252, 777>>() -> ([6]);
+store_temp<felt252>([6]) -> ([6]);
+return([6]);
+F0_B0:
+branch_align() -> ();
+drop<Box<felt252>>([4]) -> ();
+const_as_immediate<Const<felt252, 888>>() -> ([7]);
+store_temp<felt252>([7]) -> ([7]);
+return([7]);
+F0_B1:
+branch_align() -> ();
+const_as_immediate<Const<felt252, 999>>() -> ([8]);
+store_temp<Box<felt252>>([5]) -> ([5]);
+unbox<felt252>([5]) -> ([9]);
+store_temp<felt252>([8]) -> ([8]);
+store_temp<felt252>([9]) -> ([9]);
+felt252_add([8], [9]) -> ([10]);
+store_temp<felt252>([10]) -> ([10]);
+return([10]);
+
+test::test_blue@F0([0]: felt252) -> (felt252);
+
+//! > ==========================================================================
+
+//! > boxed match enum with padding small (different sized variants)
+
+//! > test_runner_name
+SmallE2ETestRunner(test_data_function: test_small, test_data_input: 7, test_data_output: 7)
+
+//! > cairo_code
+enum Data {
+    Small: felt252,
+    Large: (felt252, felt252, felt252),
+}
+
+enum BoxedData {
+    Small: Box<felt252>,
+    Large: Box<(felt252, felt252, felt252)>,
+}
+
+extern fn enum_boxed_match<Data>(e: Box<Data>) -> BoxedData nopanic;
+
+fn test_small(x: felt252) -> felt252 {
+    let boxed = BoxTrait::new(Data::Small(x));
+    match enum_boxed_match(boxed) {
+        BoxedData::Small(boxed_x) => boxed_x.unbox(),
+        BoxedData::Large(_) => 999,
+    }
+}
+
+//! > casm
+[ap + 0] = 0, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -3], ap++;
+%{
+if '__boxed_segment' not in globals():
+    __boxed_segment = segments.add()
+memory[ap + 0] = __boxed_segment
+__boxed_segment += 4
+%}
+[ap + -4] = [[ap + 0] + 0], ap++;
+[ap + -4] = [[ap + -1] + 1];
+[ap + -3] = [[ap + -1] + 2];
+[ap + -2] = [[ap + -1] + 3];
+[ap + 0] = [[ap + -1] + 0], ap++;
+jmp rel 6 if [ap + -1] != 0;
+[ap + 0] = [ap + -2] + 3, ap++;
+[ap + 0] = [[ap + -1] + 0], ap++;
+ret;
+ap += 1;
+[ap + 0] = 999, ap++;
+ret;
+
+//! > function_costs
+test::test_small: SmallOrderedMap({Const: 1210})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 999> = Const<felt252, 999> [storable: false, drop: false, dup: false, zero_sized: false];
+type Box<Tuple<felt252, felt252, felt252>> = Box<Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252, felt252> = Struct<ut@Tuple, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<test::Data> = Box<test::Data> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Data = Enum<ut@test::Data, felt252, Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_init<test::Data, 0> = enum_init<test::Data, 0>;
+libfunc store_temp<test::Data> = store_temp<test::Data>;
+libfunc into_box<test::Data> = into_box<test::Data>;
+libfunc enum_boxed_match<test::Data> = enum_boxed_match<test::Data>;
+libfunc branch_align = branch_align;
+libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
+libfunc unbox<felt252> = unbox<felt252>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc drop<Box<Tuple<felt252, felt252, felt252>>> = drop<Box<Tuple<felt252, felt252, felt252>>>;
+libfunc const_as_immediate<Const<felt252, 999>> = const_as_immediate<Const<felt252, 999>>;
+
+F0:
+enum_init<test::Data, 0>([0]) -> ([1]);
+store_temp<test::Data>([1]) -> ([1]);
+into_box<test::Data>([1]) -> ([2]);
+enum_boxed_match<test::Data>([2]) { fallthrough([3]) F0_B0([4]) };
+branch_align() -> ();
+store_temp<Box<felt252>>([3]) -> ([3]);
+unbox<felt252>([3]) -> ([5]);
+store_temp<felt252>([5]) -> ([5]);
+return([5]);
+F0_B0:
+branch_align() -> ();
+drop<Box<Tuple<felt252, felt252, felt252>>>([4]) -> ();
+const_as_immediate<Const<felt252, 999>>() -> ([6]);
+store_temp<felt252>([6]) -> ([6]);
+return([6]);
+
+test::test_small@F0([0]: felt252) -> (felt252);
+
+//! > ==========================================================================
+
+//! > boxed match enum with padding large (different sized variants)
+
+//! > test_runner_name
+SmallE2ETestRunner(test_data_function: test_large, test_data_input: 7, test_data_output: 21)
+
+//! > cairo_code
+enum Data {
+    Small: felt252,
+    Large: (felt252, felt252, felt252),
+}
+
+enum BoxedData {
+    Small: Box<felt252>,
+    Large: Box<(felt252, felt252, felt252)>,
+}
+
+extern fn enum_boxed_match<Data>(e: Box<Data>) -> BoxedData nopanic;
+
+fn test_large(x: felt252) -> felt252 {
+    let boxed = BoxTrait::new(Data::Large((x, x, x)));
+    match enum_boxed_match(boxed) {
+        BoxedData::Small(_) => 999,
+        BoxedData::Large(t) => {
+            let (x, y, z) = *t;
+            x + y + z
+        },
+    }
+}
+
+//! > casm
+[ap + 0] = 1, ap++;
+[ap + 0] = [fp + -3], ap++;
+[ap + 0] = [fp + -3], ap++;
+[ap + 0] = [fp + -3], ap++;
+%{
+if '__boxed_segment' not in globals():
+    __boxed_segment = segments.add()
+memory[ap + 0] = __boxed_segment
+__boxed_segment += 4
+%}
+[ap + -4] = [[ap + 0] + 0], ap++;
+[ap + -4] = [[ap + -1] + 1];
+[ap + -3] = [[ap + -1] + 2];
+[ap + -2] = [[ap + -1] + 3];
+[ap + 0] = [[ap + -1] + 0], ap++;
+jmp rel 7 if [ap + -1] != 0;
+ap += 5;
+[ap + 0] = 999, ap++;
+ret;
+[ap + 0] = [ap + -2] + 1, ap++;
+[ap + 0] = [[ap + -1] + 0], ap++;
+[ap + 0] = [[ap + -2] + 1], ap++;
+[ap + 0] = [ap + -2] + [ap + -1], ap++;
+[ap + 0] = [[ap + -4] + 2], ap++;
+[ap + 0] = [ap + -2] + [ap + -1], ap++;
+ret;
+
+//! > function_costs
+test::test_large: SmallOrderedMap({Const: 1600})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 999> = Const<felt252, 999> [storable: false, drop: false, dup: false, zero_sized: false];
+type Box<Tuple<felt252, felt252, felt252>> = Box<Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<test::Data> = Box<test::Data> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252, felt252, felt252> = Struct<ut@Tuple, felt252, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::Data = Enum<ut@test::Data, felt252, Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc dup<felt252> = dup<felt252>;
+libfunc struct_construct<Tuple<felt252, felt252, felt252>> = struct_construct<Tuple<felt252, felt252, felt252>>;
+libfunc enum_init<test::Data, 1> = enum_init<test::Data, 1>;
+libfunc store_temp<test::Data> = store_temp<test::Data>;
+libfunc into_box<test::Data> = into_box<test::Data>;
+libfunc enum_boxed_match<test::Data> = enum_boxed_match<test::Data>;
+libfunc branch_align = branch_align;
+libfunc drop<Box<felt252>> = drop<Box<felt252>>;
+libfunc const_as_immediate<Const<felt252, 999>> = const_as_immediate<Const<felt252, 999>>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc store_temp<Box<Tuple<felt252, felt252, felt252>>> = store_temp<Box<Tuple<felt252, felt252, felt252>>>;
+libfunc unbox<Tuple<felt252, felt252, felt252>> = unbox<Tuple<felt252, felt252, felt252>>;
+libfunc struct_deconstruct<Tuple<felt252, felt252, felt252>> = struct_deconstruct<Tuple<felt252, felt252, felt252>>;
+libfunc felt252_add = felt252_add;
+
+F0:
+dup<felt252>([0]) -> ([0], [1]);
+dup<felt252>([0]) -> ([0], [2]);
+struct_construct<Tuple<felt252, felt252, felt252>>([1], [2], [0]) -> ([3]);
+enum_init<test::Data, 1>([3]) -> ([4]);
+store_temp<test::Data>([4]) -> ([4]);
+into_box<test::Data>([4]) -> ([5]);
+enum_boxed_match<test::Data>([5]) { fallthrough([6]) F0_B0([7]) };
+branch_align() -> ();
+drop<Box<felt252>>([6]) -> ();
+const_as_immediate<Const<felt252, 999>>() -> ([8]);
+store_temp<felt252>([8]) -> ([8]);
+return([8]);
+F0_B0:
+branch_align() -> ();
+store_temp<Box<Tuple<felt252, felt252, felt252>>>([7]) -> ([7]);
+unbox<Tuple<felt252, felt252, felt252>>([7]) -> ([9]);
+struct_deconstruct<Tuple<felt252, felt252, felt252>>([9]) -> ([10], [11], [12]);
+store_temp<felt252>([10]) -> ([10]);
+store_temp<felt252>([11]) -> ([11]);
+felt252_add([10], [11]) -> ([13]);
+store_temp<felt252>([13]) -> ([13]);
+store_temp<felt252>([12]) -> ([12]);
+felt252_add([13], [12]) -> ([14]);
+store_temp<felt252>([14]) -> ([14]);
+return([14]);
+
+test::test_large@F0([0]: felt252) -> (felt252);
+
+//! > ==========================================================================
+
+//! > boxed match snapshot enum with array variant (Box<@Array<...>>)
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+enum SingleArray {
+    Value: Array<felt252>,
+}
+
+enum BoxedSingleArray {
+    Value: Box<@Array<felt252>>,
+}
+
+extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedSingleArray nopanic;
+
+fn foo(e: Box<@SingleArray>) -> BoxedSingleArray {
+    enum_boxed_match(e)
+}
+
+//! > casm
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -3] + 1, ap++;
+ret;
+
+//! > sierra_code
+type Box<Snapshot<test::SingleArray>> = Box<Snapshot<test::SingleArray>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Snapshot<Array<felt252>>> = Box<Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::BoxedSingleArray = Enum<ut@test::BoxedSingleArray, Box<Snapshot<Array<felt252>>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type test::SingleArray = Enum<ut@test::SingleArray, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<test::SingleArray> = Snapshot<test::SingleArray> [storable: true, drop: true, dup: true, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_boxed_match<Snapshot<test::SingleArray>> = enum_boxed_match<Snapshot<test::SingleArray>>;
+libfunc branch_align = branch_align;
+libfunc enum_init<test::BoxedSingleArray, 0> = enum_init<test::BoxedSingleArray, 0>;
+libfunc store_temp<test::BoxedSingleArray> = store_temp<test::BoxedSingleArray>;
+
+F0:
+enum_boxed_match<Snapshot<test::SingleArray>>([0]) -> ([1]);
+branch_align() -> ();
+enum_init<test::BoxedSingleArray, 0>([1]) -> ([2]);
+store_temp<test::BoxedSingleArray>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: Box<Snapshot<test::SingleArray>>) -> (test::BoxedSingleArray);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 200})


### PR DESCRIPTION
## Summary

Added support for `enum_boxed_match` libfunc that allows matching on boxed enums, returning boxes of the variant types. This complements the existing `struct_boxed_deconstruct` functionality and enables more efficient handling of boxed enum types.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When working with boxed enums, there was no direct way to match on the enum and get boxed variants without unboxing and reboxing. This implementation allows for more efficient handling of boxed enum types by providing a direct way to match on a boxed enum and get boxes of the variant types.

---

## What was the behavior or documentation before?

Previously, to match on a boxed enum and work with its variants as boxes, you would need to unbox the enum, match on it, and then box each variant again. This was inefficient and required more code.

---

## What is the behavior or documentation after?

Now, the `enum_boxed_match` libfunc allows directly matching on a boxed enum and getting boxes of the variant types. This is similar to how `struct_boxed_deconstruct` works for structs. The implementation handles different variant sizes correctly, including padding for right-aligned variants.

---

## Additional context

The implementation includes refactoring of the box unpacking functionality to reduce code duplication between struct and enum implementations. The `BoxUnpackLibfunc` trait was introduced to share common logic between `struct_boxed_deconstruct` and `enum_boxed_match`.