### PR TITLE
Upgraded typos check version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: crate-ci/typos@v1.39.0
+      - uses: crate-ci/typos@v1.41.0
 
   docs:
     runs-on: ubuntu-latest

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,4 +1,5 @@
 [default.extend-words]
 # Don't correct the shorthand for ByteArray.
 ba = "ba"
+bimap = "bimap"
 compilability = "compilability"


### PR DESCRIPTION
## Summary

Upgrade the `crate-ci/typos` GitHub Action from v1.39.0 to v1.41.0 and add "bimap" to the list of words to ignore in the typo checker configuration.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The typo checker was incorrectly flagging "bimap" as a typo, which is actually a valid term in our codebase referring to a bidirectional map data structure. Additionally, updating the typo checker to the latest version ensures we have the most recent fixes and improvements.

---

## What was the behavior or documentation before?

The CI would flag "bimap" as a typo, potentially causing false positives in the typo check workflow. The typo checker was also running on an older version (v1.39.0).

---

## What is the behavior or documentation after?

"bimap" is now properly recognized as a valid term and won't be flagged as a typo. The typo checker is updated to the latest version (v1.41.0) with all its improvements and fixes.

---

## Additional context

Prevented nightly failure of typos.