### PR TITLE
fix(derive): use named format argument in hash struct generation

### DIFF
--- a/crates/cairo-lang-plugins/src/plugins/derive/hash.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/hash.rs
@@ -80,8 +80,8 @@ pub fn handle_hash(info: &PluginTypeInfo<'_>) -> String {
                     }),
                     info.members_info.iter().map(|member| {
                         format!(
-                            "let __hash_derive_state = {imp}::update_state(__hash_derive_state, {}.value);",
-                            member.name,
+                            "let __hash_derive_state = {imp}::update_state(__hash_derive_state, {member}.value);",
+                            member = member.name,
                             imp = member.impl_name(HASH_TRAIT),
                         )
                     })


### PR DESCRIPTION
## Summary

Replaced positional format argument with named argument in hash derive plugin's struct generation code. Changed `{}.value` to `{member}.value` and `member.name,` to `member = member.name,` for consistency with other derive plugins and the same file.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The hash derive plugin used a positional format argument (`{}`) in struct generation while the rest of the codebase (including other derive plugins like `clone.rs`, `serde.rs`, `default.rs`, and even the same file's enum variant) consistently uses named format arguments. This inconsistency reduces code readability and increases the risk of errors during refactoring when argument order matters.

---

## What was the behavior or documentation before?

In `crates/cairo-lang-plugins/src/plugins/derive/hash.rs` at line 83-84, the code used:
format!(
    "let __hash_derive_state = {imp}::update_state(__hash_derive_state, {}.value);",
    member.name,
    imp = member.impl_name(HASH_TRAIT),
)
## What is the behavior or documentation after?
The code now uses:
format!(    "let __hash_derive_state = {imp}::update_state(__hash_derive_state, {member}.value);",    member = member.name,    imp = member.impl_name(HASH_TRAIT),)
This matches the pattern used throughout the codebase, including line 76-78 in the same file and all other derive plugins.
## Related issue or discussion (if any)
<!-- None -->
## Additional context
This change maintains consistency with the established code style in the derive plugins module. All tests pass, and the generated code output remains functionally identical - only the formatting style is improved for better maintainability.
```