### PR TITLE
fix: write sierra statement locations to formatter

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/program_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator.rs
@@ -250,7 +250,7 @@ impl<'db> DebugWithDb<'db> for SierraProgramWithDebug<'db> {
                     &self.debug_info.statements_locations.locations.get(&StatementIdx(i))
                 {
                     let loc = get_location_marks(db, &loc.first().unwrap().span_in_file(db), true);
-                    println!("{}", loc.split('\n').map(|l| format!("// {l}")).join("\n"));
+                    writeln!(f, "{}", loc.split('\n').map(|l| format!("// {l}")).join("\n"))?;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Route the statement location comments in DebugWithDb through the provided formatter instead of printing them to stdout. 

---

## Type of change

- [x] Style, wording, formatting, or typo-only change


---

## Why is this change needed?

This keeps all debug output of the Sierra program in a single, composable stream (e.g. when using format!("{:?}", ..)) and avoids polluting global stdout during tests and tooling runs.

---


