### PR TITLE
Added `u128_bound` function removing some minor calculations.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/gas_reserve.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/gas_reserve.rs
@@ -1,9 +1,8 @@
 use cairo_lang_casm::builder::{CasmBuilder, Var};
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_sierra::extensions::gas_reserve::GasReserveConcreteLibfunc;
-use num_bigint::BigInt;
 
-use crate::invocations::int::SmallDiffHelper;
+use crate::invocations::int::{SmallDiffHelper, u128_bound};
 use crate::invocations::{
     CompiledInvocation, CompiledInvocationBuilder, InvocationError, add_input_variables,
 };
@@ -23,7 +22,7 @@ pub fn build(
 fn build_gas_reserve_create(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
-    let data = SmallDiffHelper::new(builder, BigInt::from(u128::MAX) + BigInt::from(1))?;
+    let data = SmallDiffHelper::new(builder, u128_bound().clone())?;
     let no_overflow_res: &[&[Var]] = &[&[data.range_check], &[data.a_minus_b], &[data.b]];
     let overflow_res: &[&[Var]] = &[&[data.range_check], &[data.a]];
     data.finalize(no_overflow_res, overflow_res)

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use cairo_lang_casm::builder::{CasmBuilder, Var};
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_casm::cell_expression::CellExpression;
@@ -18,6 +20,12 @@ pub mod unsigned;
 pub mod unsigned128;
 pub mod unsigned256;
 pub mod unsigned512;
+
+/// The value of 2^128.
+pub fn u128_bound() -> &'static BigInt {
+    static U128_BOUND: LazyLock<BigInt> = LazyLock::new(|| BigInt::from(1) << 128);
+    &U128_BOUND
+}
 
 /// Builds invocations for uint const values.
 fn build_const<TIntTraits: IntTraits>(
@@ -79,7 +87,7 @@ impl<'a> SmallDiffHelper<'a> {
             let orig_range_check = range_check;
             tempvar a_ge_b;
             tempvar a_minus_b = a - b;
-            const u128_limit = BigInt::from(u128::MAX) + BigInt::from(1);
+            const u128_limit = u128_bound().clone();
             const limit = limit;
             hint TestLessThan {lhs: a_minus_b, rhs: limit} into {dst: a_ge_b};
             jump NoOverflow if a_ge_b != 0;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed.rs
@@ -7,7 +7,7 @@ use cairo_lang_sierra::extensions::utils::Range;
 use cairo_lang_sierra::program::{BranchInfo, BranchTarget};
 use num_bigint::BigInt;
 
-use super::{add_input_variables, build_const, build_small_diff, build_small_wide_mul};
+use super::{add_input_variables, build_const, build_small_diff, build_small_wide_mul, u128_bound};
 use crate::invocations::range_reduction::build_felt252_range_reduction;
 use crate::invocations::{
     BuiltinInfo, CompiledInvocation, CompiledInvocationBuilder, CostValidationInfo,
@@ -77,7 +77,7 @@ pub fn build_sint_overflowing_operation(
         // Bound for addition or subtraction of any 2 numbers in [i128::MIN, i128::MAX].
         // max(2 * i128::MAX, i128::MAX - i128::MIN) + 1
         // ==> max(2*(2**127 - 1), 2**127 - 1 -(-2**127)) + 1 ==> 2**128
-        const above_bound = BigInt::from(u128::MAX) + BigInt::from(1);
+        const above_bound = u128_bound().clone();
         hint TestLessThan {lhs: value, rhs: above_bound} into {dst: is_above};
         jump IsAbove if is_above != 0;
         // Below range case.

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs
@@ -2,9 +2,9 @@ use cairo_lang_casm::builder::CasmBuilder;
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_sierra::extensions::gas::CostTokenType;
 use cairo_lang_sierra::extensions::range::IntRangeConcreteLibfunc;
-use num_bigint::BigInt;
 
 use super::{CompiledInvocation, CompiledInvocationBuilder, InvocationError};
+use crate::invocations::int::u128_bound;
 use crate::invocations::{
     BuiltinInfo, CostValidationInfo, add_input_variables, get_non_fallthrough_statement_id,
 };
@@ -39,7 +39,7 @@ fn build_try_new(
         let orig_range_check = range_check;
 
         tempvar diff = end - start;
-        const bound = BigInt::from(u128::MAX) + BigInt::from(1);
+        const bound = u128_bound().clone();
         tempvar is_valid_range;
         hint TestLessThan {lhs: diff, rhs: bound} into {dst: is_valid_range};
         jump Valid if is_valid_range != 0;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs
@@ -1,5 +1,3 @@
-use std::ops::Shl;
-
 use cairo_lang_casm::builder::CasmBuilder;
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_sierra::extensions::gas::CostTokenType;
@@ -11,6 +9,7 @@ use super::{
     CompiledInvocation, CompiledInvocationBuilder, InvocationError,
     get_non_fallthrough_statement_id,
 };
+use crate::invocations::int::u128_bound;
 use crate::invocations::misc::validate_under_limit;
 use crate::invocations::{BuiltinInfo, CostValidationInfo, add_input_variables};
 
@@ -89,7 +88,7 @@ pub fn build_felt252_range_reduction(
         maybe_tempvar rc_val = value + minus_range_lower;
         assert rc_val = *(range_check++);
     }
-    let rc_size = BigInt::from(1).shl(128);
+    let rc_size = u128_bound().clone();
     // If the out range is exactly `rc_size` the previous addition to the buffer validated this
     // case as well.
     if out_range.size() < rc_size {


### PR DESCRIPTION
## Summary

Introduced a `u128_bound()` function that returns a lazily initialized static reference to the value of 2^128, replacing multiple instances of `BigInt::from(u128::MAX) + BigInt::from(1)` throughout the codebase. This change improves code maintainability by centralizing this commonly used constant and avoids redundant computations.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The value 2^128 (u128::MAX + 1) is used in multiple places throughout the codebase. Each usage was creating a new BigInt instance and performing the same calculation. This change centralizes this constant computation behind a function that returns a reference to a lazily initialized static value, reducing redundant calculations and improving code consistency.

---

## What was the behavior or documentation before?

Previously, the code was creating new BigInt instances and performing the same calculation (`BigInt::from(u128::MAX) + BigInt::from(1)`) in multiple places.

---

## What is the behavior or documentation after?

Now, a single `u128_bound()` function returns a reference to a lazily initialized static BigInt with the value 2^128. This function is used consistently throughout the codebase, eliminating redundant calculations and improving code maintainability.

---

## Additional context

This change also makes the code more readable by giving a clear name to this commonly used constant. The use of `LazyLock` ensures the value is only computed once when first needed.