### PR TITLE
Extended `SmallDiffHelper` documentation.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/mod.rs
@@ -61,17 +61,29 @@ pub fn build_small_wide_mul(
 
 /// Helper struct for creating libfuncs that handle small integer diff operations.
 pub struct SmallDiffHelper<'a> {
+    /// The invocation builder for the current Sierra instruction.
     builder: CompiledInvocationBuilder<'a>,
+    /// The CASM builder.
     casm_builder: CasmBuilder,
+    /// Var for range check pointer before running the code.
     orig_range_check: Var,
+    /// Var for range check pointer during the code (the final value, after the code).
     pub range_check: Var,
+    /// Var for the LHS of the comparison.
     pub a: Var,
+    /// Var for the RHS of the comparison.
     pub b: Var,
+    /// Var for the diff result.
     pub a_minus_b: Var,
+    /// Var for the diff result, with a wraparound around `limit` if negative, or larger than
+    /// `limit`.
     pub wrapping_a_minus_b: Var,
 }
 impl<'a> SmallDiffHelper<'a> {
     /// Constructs the helper.
+    /// This assumes `|a - b| < limit`, and `limit <= 2^128`.
+    /// The diff itself may wrap around the felt252 prime, although there are currently no such
+    /// usages. Assumes nothing about the values of `a` and `b`.
     pub fn new(
         builder: CompiledInvocationBuilder<'a>,
         limit: BigInt,


### PR DESCRIPTION
## Summary

Added detailed documentation to the `SmallDiffHelper` struct in the Sierra-to-CASM compiler. The PR adds comprehensive documentation for all fields in the struct and enhances the constructor documentation with important assumptions about the operation, specifically that it assumes `|a - b| < limit` and `limit <= 2^128`, and that the diff may wrap around the felt252 prime.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Documentation change with concrete technical impact
- [ ] Performance improvement
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `SmallDiffHelper` struct lacked proper documentation about its fields and the assumptions made by its constructor. This documentation is important for developers working with the Sierra-to-CASM compiler to understand the constraints and behavior of integer difference operations.

---

## What was the behavior or documentation before?

The struct had minimal documentation, with no explanation of the fields or the mathematical constraints of the operations it performs.

---

## What is the behavior or documentation after?

Each field now has clear documentation explaining its purpose, and the constructor includes important mathematical constraints and assumptions that are critical for correct usage.