### PR TITLE
Merged `SmallDiffHelper` and `build_128bit_diff` fns.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/mod.rs
@@ -95,6 +95,7 @@ impl<'a> SmallDiffHelper<'a> {
             deref a;
             deref b;
         };
+        let same_limit = u128_bound() == &limit;
         casm_build_extend! {casm_builder,
             let orig_range_check = range_check;
             tempvar a_ge_b;
@@ -121,7 +122,7 @@ impl<'a> SmallDiffHelper<'a> {
             a,
             b,
             a_minus_b,
-            wrapping_a_minus_b,
+            wrapping_a_minus_b: if same_limit { fixed_a_minus_b } else { wrapping_a_minus_b },
         })
     }
 
@@ -160,48 +161,4 @@ fn build_small_diff(
     let no_overflow_res: &[&[Var]] = &[&[data.range_check], &[data.a_minus_b]];
     let overflow_res: &[&[Var]] = &[&[data.range_check], &[data.wrapping_a_minus_b]];
     data.finalize(no_overflow_res, overflow_res)
-}
-
-/// Handles a 128 bit diff operation.
-fn build_128bit_diff(
-    builder: CompiledInvocationBuilder<'_>,
-) -> Result<CompiledInvocation, InvocationError> {
-    let failure_handle_statement_id = get_non_fallthrough_statement_id(&builder);
-    let [range_check, a, b] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
-    add_input_variables! {casm_builder,
-        buffer(0) range_check;
-        deref a;
-        deref b;
-    };
-    casm_build_extend! {casm_builder,
-        let orig_range_check = range_check;
-        tempvar a_ge_b;
-        tempvar a_minus_b = a - b;
-        const u128_limit = BigInt::from(u128::MAX) + BigInt::from(1);
-        hint TestLessThan {lhs: a_minus_b, rhs: u128_limit} into {dst: a_ge_b};
-        jump NoOverflow if a_ge_b != 0;
-        // Overflow (negative):
-        // Here we know that 0 - (2**128 - 1) <= a - b < 0.
-        tempvar wrapping_a_minus_b = a_minus_b + u128_limit;
-        assert wrapping_a_minus_b = *(range_check++);
-        jump Target;
-    NoOverflow:
-        assert a_minus_b = *(range_check++);
-    };
-    Ok(builder.build_from_casm_builder(
-        casm_builder,
-        [
-            ("Fallthrough", &[&[range_check], &[a_minus_b]], None),
-            ("Target", &[&[range_check], &[wrapping_a_minus_b]], Some(failure_handle_statement_id)),
-        ],
-        CostValidationInfo {
-            builtin_infos: vec![BuiltinInfo {
-                cost_token_ty: CostTokenType::RangeCheck,
-                start: orig_range_check,
-                end: range_check,
-            }],
-            extra_costs: None,
-        },
-    ))
 }

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed128.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed128.rs
@@ -2,7 +2,8 @@ use cairo_lang_sierra::extensions::int::signed128::Sint128Concrete;
 
 use super::signed::{build_sint_from_felt252, build_sint_overflowing_operation};
 use super::{
-    CompiledInvocation, CompiledInvocationBuilder, InvocationError, build_128bit_diff, build_const,
+    CompiledInvocation, CompiledInvocationBuilder, InvocationError, build_const, build_small_diff,
+    u128_bound,
 };
 use crate::invocations::misc;
 
@@ -19,6 +20,6 @@ pub fn build(
         Sint128Concrete::Operation(libfunc) => {
             build_sint_overflowing_operation(builder, i128::MIN, i128::MAX, libfunc.operator)
         }
-        Sint128Concrete::Diff(_) => build_128bit_diff(builder),
+        Sint128Concrete::Diff(_) => build_small_diff(builder, u128_bound().clone()),
     }
 }

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs
@@ -7,7 +7,7 @@ use cairo_lang_sierra::extensions::utils::Range;
 use num_bigint::BigInt;
 use num_traits::{Num, One};
 
-use super::{bounded, build_128bit_diff, build_const, u128_bound};
+use super::{bounded, build_const, build_small_diff, u128_bound};
 use crate::invocations::{
     BuiltinInfo, CompiledInvocation, CompiledInvocationBuilder, CostValidationInfo,
     InvocationError, add_input_variables, bitwise, get_non_fallthrough_statement_id, misc,
@@ -21,7 +21,7 @@ pub fn build(
     match libfunc {
         Uint128Concrete::Operation(libfunc) => match libfunc.operator {
             IntOperator::OverflowingAdd => build_u128_overflowing_add(builder),
-            IntOperator::OverflowingSub => build_128bit_diff(builder),
+            IntOperator::OverflowingSub => build_small_diff(builder, u128_bound().clone()),
         },
         Uint128Concrete::Divmod(_) => bounded::build_div_rem(
             builder,


### PR DESCRIPTION
## Summary

Refactored the integer difference operation implementation by consolidating the `build_128bit_diff` function into the more general `build_small_diff` function. This change eliminates code duplication by reusing the same implementation for both signed and unsigned 128-bit integer subtraction operations.

The PR adds an optimization that avoids redundant computation when the limit value is the same as the u128 bound by reusing the already calculated `fixed_a_minus_b` variable.

---

## Type of change

Please check **one**:

- [x] Performance improvement
- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The code had duplicate implementations for integer difference operations. By consolidating the implementation into a single function, we reduce code duplication and improve maintainability. Additionally, the optimization to reuse the already calculated value when possible improves performance by avoiding redundant computation.

---

## What was the behavior or documentation before?

Previously, there were separate implementations for integer difference operations, with `build_128bit_diff` handling 128-bit differences specifically. This led to code duplication and missed optimization opportunities.

---

## What is the behavior or documentation after?

Now, both signed and unsigned 128-bit integer subtraction operations use the same `build_small_diff` function, eliminating code duplication. When the limit value matches the u128 bound, the code reuses the already calculated `fixed_a_minus_b` value instead of recalculating it, improving performance.

---

## Additional context

This refactoring is part of ongoing efforts to improve the efficiency and maintainability of the Sierra-to-CASM compiler by consolidating similar operations and eliminating redundant computations.