### PR TITLE
Refactored `Box` getting libfuncs by `CellExpression::add_with_const`.

### DIFF
--- a/crates/cairo-lang-casm/src/cell_expression.rs
+++ b/crates/cairo-lang-casm/src/cell_expression.rs
@@ -99,6 +99,20 @@ impl CellExpression {
             })
         }
     }
+
+    /// Returns a cell expression which is the sum of `cell` and `value`.
+    /// If the value is zero, returns the cell itself.
+    pub fn add_with_const(cell: CellRef, value: i16) -> CellExpression {
+        if value == 0 {
+            CellExpression::Deref(cell)
+        } else {
+            CellExpression::BinOp {
+                op: CellOperator::Add,
+                a: cell,
+                b: DerefOrImmediate::Immediate(value.into()),
+            }
+        }
+    }
 }
 
 impl ApplyApChange for CellExpression {


### PR DESCRIPTION
## Summary

Added a new utility method `add_with_const` to `CellExpression` that creates a cell expression representing the sum of a cell reference and a constant value, with an optimization to return the cell directly when the value is zero. This method is then used to simplify and improve the implementation of boxed struct operations in the Sierra-to-CASM compiler.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The code for handling boxed structs and local-to-box conversions contained duplicated logic for adding offsets to cell references. This PR extracts this common pattern into a reusable utility method, making the code more maintainable and less error-prone. Additionally, it refactors the struct boxed deconstruct implementation to handle offsets more consistently.

---

## What was the behavior or documentation before?

Before this change, offset calculations for boxed structs were implemented directly in each function that needed them, with duplicated logic for handling the special case of zero offsets.

---

## What is the behavior or documentation after?

After this change, a new utility method `add_with_const` handles offset calculations consistently, with proper optimization for zero offsets. The boxed struct deconstruction logic has been refactored into a separate helper function that uses this new utility.

---

## Additional context

This refactoring improves code maintainability while preserving the same functionality. The new `boxed_members_cell_exprs` helper function also provides better error handling and documentation for the boxed struct deconstruction process.