### PR TITLE
fix(sierra-gen): remove unnecessary mut from KnownStack::get

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/store_variables/known_stack.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/known_stack.rs
@@ -43,7 +43,7 @@ impl KnownStack {
 
     /// Returns the slot `idx` of the stack in which the given variable appears, or `None` if it is
     /// not on the known stack.
-    pub fn get(&mut self, var: &cairo_lang_sierra::ids::VarId) -> Option<isize> {
+    pub fn get(&self, var: &cairo_lang_sierra::ids::VarId) -> Option<isize> {
         let ioffset: isize = self.offset.try_into().unwrap();
         let val: isize = (*self.variables_on_stack.get(var)?).try_into().unwrap();
         Some(val - ioffset)


### PR DESCRIPTION
## Summary

Remove unnecessary `&mut self` from `KnownStack::get` method - it only reads data, never mutates.

## Type of change

- [x] Bug fix (fixes incorrect behavior)

## Why is this change needed?

`KnownStack::get` takes `&mut self` but doesn't mutate anything internally. This is misleading and unnecessarily restricts callers.