### PR TITLE
Fixed cost of `local_into_box` cost.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -370,9 +370,7 @@ pub fn core_libfunc_cost(
                     std::cmp::max(1, info_provider.type_size(&libfunc.ty).try_into().unwrap());
                 vec![ConstCost::steps(n_steps).into()]
             }
-            BoxConcreteLibfunc::LocalInto(_) => {
-                vec![ConstCost::steps(3).into()]
-            }
+            BoxConcreteLibfunc::LocalInto(_) => vec![ConstCost::steps(2).into()],
             BoxConcreteLibfunc::Unbox(_) | BoxConcreteLibfunc::ForwardSnapshot(_) => {
                 vec![ConstCost::default().into()]
             }

--- a/tests/e2e_test_data/libfuncs/box
+++ b/tests/e2e_test_data/libfuncs/box
@@ -746,7 +746,7 @@ call rel 5;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap({Const: 300})
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -781,7 +781,7 @@ call rel 4;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap({Const: 300})
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -833,7 +833,7 @@ return([1]);
 test::foo@F0() -> (Box<Unit>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap({Const: 300})
 
 //! > ==========================================================================
 
@@ -854,7 +854,7 @@ call rel 5;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap({Const: 300})
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -904,7 +904,7 @@ ret;
 
 //! > function_costs
 test::bar: SmallOrderedMap({Const: 100})
-test::foo: SmallOrderedMap({Const: 900})
+test::foo: SmallOrderedMap({Const: 800})
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -966,7 +966,7 @@ call rel 5;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap({Const: 300})
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];


### PR DESCRIPTION
## Summary

Reduced the gas cost for the `box::local_into` libfunc from 3 steps to 2 steps. This change is reflected in the core libfunc cost calculation and updates the expected function costs in the box e2e tests.

---

## Type of change

Please check **one**:

- [x] Performance improvement
- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `box::local_into` libfunc was using more gas steps than necessary. After analysis, it was determined that 2 steps is sufficient for this operation, which will reduce the gas cost for functions using this libfunc.

---

## What was the behavior or documentation before?

The `box::local_into` libfunc was costing 3 gas steps, which resulted in higher function costs in the e2e tests.

---

## What is the behavior or documentation after?

The `box::local_into` libfunc now costs 2 gas steps, reducing the overall gas cost for functions that use this operation. The e2e test function costs have been updated to reflect this change, with most functions seeing a 100-unit reduction in cost.