### PR TITLE
Fixes the declared returned location of box-deconstruct.

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
@@ -298,10 +298,7 @@ impl StructBoxedDeconstructLibfunc {
         let arg_type_info = context.get_type_info(ty.clone())?;
         let is_snapshot = arg_type_info.long_id.generic_id == SnapshotType::id();
         if is_snapshot {
-            ty = match &arg_type_info.long_id.generic_args[0] {
-                GenericArg::Type(ty) => ty.clone(),
-                _ => return Err(SpecializationError::UnsupportedGenericArg),
-            }
+            ty = args_as_single_type(&arg_type_info.long_id.generic_args)?;
         }
         let struct_type = StructConcreteType::try_from_concrete_type(context, &ty)?;
         Ok((struct_type.members, is_snapshot))
@@ -321,22 +318,26 @@ impl StructBoxedDeconstructLibfunc {
         &self,
         context: &dyn SignatureSpecializationContext,
         ty: ConcreteTypeId,
-        member_types: Vec<ConcreteTypeId>,
+        member_types: impl IntoIterator<Item = ConcreteTypeId>,
         is_snapshot: bool,
     ) -> Result<LibfuncSignature, SpecializationError> {
+        let mut is_shifted = false;
         Ok(LibfuncSignature::new_non_branch_ex(
             vec![ParamSignature::new(box_ty(context, ty)?).with_allow_add_const()],
             member_types
                 .into_iter()
                 .map(|member_ty| {
+                    let ref_info = if is_shifted {
+                        OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
+                            param_idx: 0,
+                        })
+                    } else {
+                        is_shifted = !context.get_type_info(member_ty.clone())?.zero_sized;
+                        OutputVarReferenceInfo::SameAsParam { param_idx: 0 }
+                    };
                     let inner_type =
                         if is_snapshot { snapshot_ty(context, member_ty)? } else { member_ty };
-                    Ok(OutputVarInfo {
-                        ty: box_ty(context, inner_type)?,
-                        ref_info: OutputVarReferenceInfo::Deferred(
-                            crate::extensions::lib_func::DeferredOutputKind::Generic,
-                        ),
-                    })
+                    Ok(OutputVarInfo { ty: box_ty(context, inner_type)?, ref_info })
                 })
                 .collect::<Result<Vec<_>, _>>()?,
             SierraApChange::Known { new_vars_only: true },
@@ -367,7 +368,7 @@ impl NamedLibfunc for StructBoxedDeconstructLibfunc {
         let ty = args_as_single_type(args)?;
         let (members, is_snapshot) = self.analyze_struct_type(context, ty.clone())?;
         let signature =
-            self.inner_specialize_signature(context, ty, members.clone(), is_snapshot)?;
+            self.inner_specialize_signature(context, ty, members.iter().cloned(), is_snapshot)?;
         Ok(ConcreteStructBoxedDeconstructLibfunc { members, signature })
     }
 }


### PR DESCRIPTION
## Summary

Improved the `StructBoxedDeconstructLibfunc` to optimize memory usage by changing how output variable references are handled. The first output now uses `SameAsParam` reference info, while subsequent outputs use `AddConst` deferred output kind. This change allows better reuse of memory when deconstructing boxed structs.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] Performance improvement
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation used generic deferred output references for all struct members during deconstruction, which wasn't optimal for memory usage. By specifying that the first output reuses the same memory as the input parameter and subsequent outputs use address offsets, we can achieve better memory efficiency.

---

## What was the behavior or documentation before?

When deconstructing a boxed struct, all output variables used generic deferred references, which didn't take advantage of potential memory reuse opportunities.

---

## What is the behavior or documentation after?

Now when deconstructing a boxed struct:
- The first member uses `SameAsParam` reference info, directly reusing the input parameter's memory
- Subsequent members use `AddConst` deferred output kind, which allows for more efficient memory addressing

---

## Additional context

This change also includes a small API improvement, changing the `member_types` parameter in `inner_specialize_signature` from `Vec<ConcreteTypeId>` to `impl IntoIterator<Item = ConcreteTypeId>` for more flexibility.