### PR TITLE
perf: inline span.take calls in lexer

### DIFF
--- a/crates/cairo-lang-parser/src/lexer.rs
+++ b/crates/cairo-lang-parser/src/lexer.rs
@@ -84,16 +84,14 @@ impl Lexer {
     fn match_trivium_whitespace<'a>(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
         self.take_while(|s| matches!(s, ' ' | '\r' | '\t'));
         let span = self.consume_text_span();
-        let text = span.take(&self.text);
-        TokenWhitespace::new_green(db, SmolStrId::from(db, text)).into()
+        TokenWhitespace::new_green(db, SmolStrId::from(db, span.take(&self.text))).into()
     }
 
     /// Assumes the next character is '\n'.
     fn match_trivium_newline<'a>(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
         self.take();
         let span = self.consume_text_span();
-        let text = span.take(&self.text);
-        TokenNewline::new_green(db, SmolStrId::from(db, text)).into()
+        TokenNewline::new_green(db, SmolStrId::from(db, span.take(&self.text))).into()
     }
 
     /// Assumes the next 2 characters are "//".
@@ -102,20 +100,17 @@ impl Lexer {
             Some('/') => {
                 self.take_while(|c| c != '\n');
                 let span = self.consume_text_span();
-                let text = span.take(&self.text);
-                TokenSingleLineDocComment::new_green(db, SmolStrId::from(db, text)).into()
+                TokenSingleLineDocComment::new_green(db, SmolStrId::from(db, span.take(&self.text))).into()
             }
             Some('!') => {
                 self.take_while(|c| c != '\n');
                 let span = self.consume_text_span();
-                let text = span.take(&self.text);
-                TokenSingleLineInnerComment::new_green(db, SmolStrId::from(db, text)).into()
+                TokenSingleLineInnerComment::new_green(db, SmolStrId::from(db, span.take(&self.text))).into()
             }
             _ => {
                 self.take_while(|c| c != '\n');
                 let span = self.consume_text_span();
-                let text = span.take(&self.text);
-                TokenSingleLineComment::new_green(db, SmolStrId::from(db, text)).into()
+                TokenSingleLineComment::new_green(db, SmolStrId::from(db, span.take(&self.text))).into()
             }
         }
     }


### PR DESCRIPTION
 Eliminates 5 unnecessary intermediate `text` variables in trivium matching functions by inlining `span.take(&self.text)` directly into `SmolStrId::from()` calls.

  - Reduces code by 5 lines
  - No behavioral changes, pure refactoring
  - Applies to: `match_trivium_whitespace`, `match_trivium_newline`, and three branches in `match_trivium_single_line_comment`