### PR TITLE
Refactored EC-point point calculations.

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -10,6 +10,7 @@ use cairo_lang_casm::hints::{CoreHint, DeprecatedHint, ExternalHint, Hint, Stark
 use cairo_lang_casm::operand::{
     BinOpOperand, CellRef, DerefOrImmediate, Operation, Register, ResOperand,
 };
+use cairo_lang_sierra::extensions::ec::EcPointType;
 use cairo_lang_sierra::ids::FunctionId;
 use cairo_lang_utils::bigint::BigIntAsHex;
 use cairo_lang_utils::byte_array::{BYTE_ARRAY_MAGIC, BYTES_IN_WORD};
@@ -1819,12 +1820,7 @@ pub fn random_ec_point<R: rand::RngCore>(
         // TODO(orizi): Use `Felt252` random implementation when exists.
         let x_bytes: [u8; 31] = rng.random();
         let random_x = Felt252::from_bytes_be_slice(&x_bytes);
-        /// The Beta value of the Starkware elliptic curve.
-        pub const BETA: Felt252 = Felt252::from_hex_unchecked(
-            "0x6f21413efbe40de150e596d72f7a8c5609ad26c15c915c1f4cdfcb99cee9e89",
-        );
-        let random_y_squared = random_x * random_x * random_x + random_x + BETA;
-        if let Some(random_y) = random_y_squared.sqrt() {
+        if let Some(random_y) = EcPointType::calc_lhs(random_x).sqrt() {
             break (random_x, random_y);
         }
     };

--- a/crates/cairo-lang-sierra/src/extensions/modules/ec.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/ec.rs
@@ -1,3 +1,5 @@
+use starknet_types_core::felt::Felt as Felt252;
+
 use super::felt252::Felt252Type;
 use super::non_zero::nonzero_ty;
 use super::range_check::RangeCheckType;
@@ -26,6 +28,25 @@ impl NoGenericArgsGenericType for EcOpType {
 /// An EC point is a pair (x,y) on the curve.
 #[derive(Default)]
 pub struct EcPointType {}
+impl EcPointType {
+    /// The beta parameter of the curve.
+    const BETA: Felt252 = Felt252::from_hex_unchecked(
+        "0x6f21413efbe40de150e596d72f7a8c5609ad26c15c915c1f4cdfcb99cee9e89",
+    );
+    /// Returns the left hand side of the curve equation.
+    pub fn calc_lhs(x: Felt252) -> Felt252 {
+        x * x * x + x + Self::BETA
+    }
+    /// Returns the right hand side of the curve equation.
+    fn calc_rhs(y: Felt252) -> Felt252 {
+        y * y
+    }
+    /// Checks if a point is on the curve.
+    pub fn is_on_curve(x: Felt252, y: Felt252) -> bool {
+        Self::calc_lhs(x) == Self::calc_rhs(y)
+    }
+}
+
 impl NoGenericArgsGenericType for EcPointType {
     const ID: GenericTypeId = GenericTypeId::new_inline("EcPoint");
     const STORABLE: bool = true;

--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -11,7 +11,7 @@ use super::value::CoreValue;
 use crate::extensions::array::ArrayConcreteLibfunc;
 use crate::extensions::boolean::BoolConcreteLibfunc;
 use crate::extensions::core::CoreConcreteLibfunc;
-use crate::extensions::ec::EcConcreteLibfunc;
+use crate::extensions::ec::{EcConcreteLibfunc, EcPointType};
 use crate::extensions::enm::{EnumConcreteLibfunc, EnumInitConcreteLibfunc};
 use crate::extensions::felt252::{
     Felt252BinaryOpConcreteLibfunc, Felt252BinaryOperationConcrete, Felt252BinaryOperator,
@@ -70,12 +70,8 @@ pub fn simulate<
             match libfunc {
                 EcConcreteLibfunc::TryNew(_) => {
                     take_inputs!(let [CoreValue::Felt252(x), CoreValue::Felt252(y)] = inputs);
-                    const BETA: Felt252 = Felt252::from_hex_unchecked(
-                        "0x6f21413efbe40de150e596d72f7a8c5609ad26c15c915c1f4cdfcb99cee9e89",
-                    );
-                    // If the point is on the curve use the fallthrough branch and return the
-                    // point.
-                    if y * y == x * x * x + x + BETA {
+                    // If the point is on the curve use the fallthrough branch and return the point.
+                    if EcPointType::is_on_curve(x, y) {
                         (vec![CoreValue::EcPoint(x, y)], 0)
                     } else {
                         (vec![], 1)


### PR DESCRIPTION
## Summary

Refactored EC point validation and curve operations by extracting common elliptic curve functionality into the `EcPointType` struct. Added utility methods for calculating curve points and validating if a point lies on the curve, replacing duplicated curve equation implementations across the codebase.

---

## Type of change

Please check **one**:

- [x] Performance improvement

---

## Why is this change needed?

The code had multiple implementations of the same elliptic curve operations scattered across different modules. This created maintenance issues and potential inconsistencies when working with EC points. By centralizing these operations in the `EcPointType` struct, we ensure consistent behavior and make the code more maintainable.

---

## What was the behavior or documentation before?

Previously, the curve equation and validation logic was duplicated in multiple places, with hardcoded constants for the curve parameters appearing in both the runner and simulation code. This made it difficult to ensure consistent behavior across different parts of the codebase.

---

## What is the behavior or documentation after?

Now all EC point operations use a centralized implementation in the `EcPointType` struct, which provides methods for:
- Calculating the left-hand side of the curve equation
- Calculating the right-hand side of the curve equation
- Checking if a point is on the curve

This ensures consistent behavior across the codebase and simplifies maintenance.

---

## Additional context

This refactoring improves code organization without changing functionality. The centralized implementation makes it easier to update curve operations if needed in the future.