### PR TITLE
feat: add cairo-metrics benchmark harness + CI tracking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,121 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  # Run cairo-metrics and post a non-blocking comment on the PR if spotted regressions.
+  benchmark:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: '0'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Get SHAs
+        id: shas
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA=$(git rev-parse origin/${{ github.base_ref }})
+          else
+            BASE_SHA=$(git rev-parse HEAD~1 || echo "")
+          fi
+          echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
+          echo "pr_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+
+      - name: Restore cached baseline
+        if: steps.shas.outputs.base_sha != ''
+        id: cache-baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: results.db
+          key: benchmark-${{ steps.shas.outputs.base_sha }}
+
+      - name: Build cairo-metrics
+        run: cargo build --profile=ci-dev -p cairo-metrics
+
+      - name: Benchmark baseline
+        if: steps.shas.outputs.base_sha != '' && steps.cache-baseline.outputs.cache-hit != 'true'
+        run: |
+          git checkout ${{ steps.shas.outputs.base_sha }}
+          ./target/ci-dev/cairo-metrics run ${{ steps.shas.outputs.base_sha }}
+          git checkout -
+
+      - name: Cache baseline results
+        if: steps.shas.outputs.base_sha != '' && steps.cache-baseline.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: results.db
+          key: benchmark-${{ steps.shas.outputs.base_sha }}
+
+      - name: Benchmark current
+        run: ./target/ci-dev/cairo-metrics run
+
+      - name: Cache current results (current can be base of stacked PR)
+        uses: actions/cache/save@v4
+        with:
+          path: results.db
+          key: benchmark-${{ steps.shas.outputs.pr_sha }}
+
+      - name: Compare
+        if: github.event_name == 'pull_request' && steps.shas.outputs.base_sha != ''
+        id: compare
+        run: |
+          ./target/ci-dev/cairo-metrics compare \
+            ${{ steps.shas.outputs.base_sha }} \
+            ${{ steps.shas.outputs.pr_sha }} \
+            > comparison.txt 2>&1 || true
+          cat comparison.txt
+
+      - name: Post comparison comment
+        if: github.event_name == 'pull_request' && steps.shas.outputs.base_sha != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let output = '';
+            try {
+              output = fs.readFileSync('comparison.txt', 'utf8');
+            } catch (e) { return; }
+
+            const body = `## Benchmark Comparison
+
+            \`\`\`
+            ${output}
+            \`\`\`
+            `;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Benchmark Comparison')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 .DS_Store
 perf.data*
 flamegraph.svg
+results.db*
 
 ensure-no_std/Cargo.lock
 ensure-no_std/target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-metrics"
+version = "2.15.0"
+dependencies = [
+ "anyhow",
+ "cairo-lang-compiler",
+ "cairo-lang-lowering",
+ "cairo-lang-utils",
+ "clap",
+ "crossterm",
+ "ratatui",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "time",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "cairo-run"
 version = "2.15.0"
 dependencies = [
@@ -1256,6 +1275,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1367,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,7 +1398,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1458,6 +1506,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1549,41 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1666,6 +1774,18 @@ dependencies = [
  "dissimilar",
  "once_cell",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1871,7 +1991,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1949,6 +2069,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1970,6 +2099,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2209,6 +2347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,7 +2426,7 @@ checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
 ]
@@ -2294,6 +2438,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2465,6 +2622,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2713,6 +2888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3072,6 +3256,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3255,6 +3460,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,6 +3500,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -3288,7 +3520,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3347,7 +3579,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "intrusive-collections",
  "inventory",
@@ -3590,6 +3822,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3769,6 +4022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3785,6 +4044,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "subtle"
@@ -3870,7 +4151,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -3992,7 +4273,9 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4315,10 +4598,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -4514,6 +4814,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4521,6 +4837,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,12 @@ opt-level = 3
 opt-level = 3
 
 [workspace]
-resolver = "2"
+exclude = ["ensure-no_std"]
 members = [
   "crates/bin/cairo-compile",
   "crates/bin/cairo-execute",
   "crates/bin/cairo-format",
+  "crates/bin/cairo-metrics",
   "crates/bin/cairo-run",
   "crates/bin/cairo-size-profiler",
   "crates/bin/cairo-test",
@@ -87,7 +88,7 @@ members = [
   "crates/cairo-lang-utils",
   "tests",
 ]
-exclude = ["ensure-no_std"]
+resolver = "2"
 
 [workspace.package]
 edition = "2024"
@@ -113,6 +114,7 @@ colored = "3.0.0"
 const-fnv1a-hash = "1.1.0"
 const_format = "0.2.34"
 convert_case = "0.10.0"
+crossterm = "0.28"
 derivative = "2.2.0"
 diffy = "0.4.2"
 genco = "0.19.0"
@@ -137,8 +139,10 @@ pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.95"
 quote = "1.0.40"
 rand = "0.9.2"
+ratatui = "0.29"
 rayon = "1.10.0"
 rstest = "0.26.1"
+rusqlite = { version = "0.32", features = ["bundled"] }
 salsa = "0.25.2"
 schemars = "1.0.4"
 semver = { version = "1.0.26", features = ["serde"] }

--- a/crates/bin/cairo-metrics/Cargo.toml
+++ b/crates/bin/cairo-metrics/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cairo-metrics"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "Walltime benchmark harness for the Cairo compiler."
+
+[dependencies]
+anyhow.workspace = true
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.15.0" }
+cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "=2.15.0" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.15.0", features = ["tracing"] }
+clap.workspace = true
+crossterm.workspace = true
+ratatui.workspace = true
+rusqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+time.workspace = true
+toml.workspace = true
+tracing.workspace = true

--- a/crates/bin/cairo-metrics/README.md
+++ b/crates/bin/cairo-metrics/README.md
@@ -1,0 +1,82 @@
+# cairo-metrics
+
+A benchmark harness for the Cairo compiler.
+
+## Features
+
+- Walltime benchmarks using `cairo-compile`
+- Robust statistics (median, MAD) for noisy CI environments
+- SQLite storage for historical tracking
+- Baseline comparison with TUI
+- Optional hyperfine backend for enhanced timing accuracy
+
+## Quick Start
+
+```bash
+# Run all benchmarks (results stored in results.db)
+cargo run -p cairo-metrics -- run
+
+# Run specific benchmarks
+cargo run -p cairo-metrics -- run --include corelib
+
+# Force builtin engine (for CI without hyperfine)
+cargo run -p cairo-metrics -- run --engine builtin
+
+# Compare two runs (interactive TUI if no args)
+cargo run -p cairo-metrics -- compare baseline-sha current-sha
+
+# List stored runs
+cargo run -p cairo-metrics -- list
+
+# Show history for a benchmark
+cargo run -p cairo-metrics -- history corelib-clean-full-walltime
+```
+
+## Adding Benchmarks
+
+Benchmarks are discovered from subdirectories containing a `benchmark.toml`:
+
+```
+benchmarks/
+  corelib/
+    benchmark.toml
+  myproject/
+    benchmark.toml
+```
+
+### benchmark.toml
+
+```toml
+# Path to the Cairo project (relative to repo root)
+path = "corelib/"
+
+# Optional: mark as library project
+library = true
+```
+
+| Field     | Required | Description                        |
+| --------- | -------- | ---------------------------------- |
+| `path`    | yes      | Path to Cairo project directory    |
+| `library` | no       | Mark as library project (optional) |
+
+## Timing Engines
+
+Two timing backends are available:
+
+- **builtin**: Direct process execution with Rust timing
+- **hyperfine**: Uses hyperfine for shell calibration and statistics
+
+By default, hyperfine is used if installed. Use `--engine builtin` to force the builtin engine.
+
+## Output
+
+Results stored in SQLite include:
+
+- Metadata (timestamp, git commit)
+- Per-benchmark timing stats (median, mean, stddev, MAD, min, max)
+- Raw timing data for each run
+
+## Future Work
+
+- Incremental compilation benchmarks (requires cairo compiler support)
+- Additional metrics beyond walltime

--- a/crates/bin/cairo-metrics/benchmarks/corelib/benchmark.toml
+++ b/crates/bin/cairo-metrics/benchmarks/corelib/benchmark.toml
@@ -1,0 +1,3 @@
+path = "corelib/"
+# Corelib is a library project: no incremental benchmarks, no casm phase.
+library = true

--- a/crates/bin/cairo-metrics/src/compare.rs
+++ b/crates/bin/cairo-metrics/src/compare.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+
+use crate::model::{BenchmarkResult, RunResult};
+
+/// Compare two runs and identify regressions.
+pub fn diff_runs(baseline: &RunResult, current: &RunResult) -> RunDiff {
+    let mut entries = Vec::new();
+
+    // Build a map of baseline benchmarks by display name.
+    let base_map: HashMap<String, &BenchmarkResult> =
+        baseline.benchmarks.iter().map(|b| (b.display_name(), b)).collect();
+
+    for cur in &current.benchmarks {
+        let cur_name = cur.display_name();
+        let Some(base) = base_map.get(&cur_name) else {
+            // New benchmark, no baseline to compare.
+            continue;
+        };
+
+        let base_median = base.timing.median_ns;
+        let current_median = cur.timing.median_ns;
+
+        // Compute delta percentage using f64 for precision.
+        let delta_pct = if base_median > 0 {
+            (current_median as f64 - base_median as f64) / base_median as f64 * 100.0
+        } else {
+            0.0
+        };
+
+        entries.push(DiffEntry { name: cur_name, base_median, current_median, delta_pct });
+    }
+
+    RunDiff { entries }
+}
+
+/// Result of comparing two runs.
+#[derive(Debug, Clone)]
+pub struct RunDiff {
+    pub entries: Vec<DiffEntry>,
+}
+
+/// A single comparison entry (medians in nanoseconds).
+#[derive(Debug, Clone)]
+pub struct DiffEntry {
+    pub name: String,
+    pub base_median: u64,
+    pub current_median: u64,
+    pub delta_pct: f64,
+}
+
+#[cfg(test)]
+#[path = "compare_test.rs"]
+mod tests;

--- a/crates/bin/cairo-metrics/src/compare_test.rs
+++ b/crates/bin/cairo-metrics/src/compare_test.rs
@@ -1,0 +1,76 @@
+use crate::compare::diff_runs;
+use crate::model::{BenchmarkResult, RunMeta, RunResult, TimingStats};
+
+fn make_benchmark(name: &str, median_ns: u64) -> BenchmarkResult {
+    BenchmarkResult {
+        benchmark: name.to_string(),
+        scenario: "clean".to_string(),
+        patch: String::new(),
+        phase: "sierra".to_string(),
+        metric: "walltime".to_string(),
+        timing: TimingStats {
+            runs: 3,
+            warmup: 1,
+            times_ns: vec![median_ns],
+            mean_ns: median_ns,
+            stddev_ns: 0,
+            median_ns,
+            mad_ns: 0,
+            min_ns: median_ns,
+            max_ns: median_ns,
+        },
+        success: true,
+    }
+}
+
+fn make_run(benchmarks: Vec<BenchmarkResult>) -> RunResult {
+    RunResult {
+        meta: RunMeta { timestamp_utc: "2025-01-01T00:00:00Z".into(), git_commit: None },
+        benchmarks,
+    }
+}
+
+#[test]
+fn test_no_regression() {
+    let baseline = make_run(vec![make_benchmark("a", 1_000_000)]);
+    let current = make_run(vec![make_benchmark("a", 1_000_000)]);
+    let diff = diff_runs(&baseline, &current);
+    assert_eq!(diff.entries[0].delta_pct, 0.0);
+}
+
+#[test]
+fn test_regression_detected() {
+    let baseline = make_run(vec![make_benchmark("a", 1_000_000)]);
+    let current = make_run(vec![make_benchmark("a", 1_100_000)]);
+    let diff = diff_runs(&baseline, &current);
+    assert!(diff.entries[0].delta_pct > 0.0);
+    assert!((diff.entries[0].delta_pct - 10.0).abs() < 0.01);
+}
+
+#[test]
+fn test_improvement_not_regression() {
+    let baseline = make_run(vec![make_benchmark("a", 1_000_000)]);
+    let current = make_run(vec![make_benchmark("a", 500_000)]);
+    let diff = diff_runs(&baseline, &current);
+    assert!(diff.entries[0].delta_pct < 0.0);
+    assert!((diff.entries[0].delta_pct - (-50.0)).abs() < 0.01);
+}
+
+#[test]
+fn test_new_benchmark_ignored() {
+    let baseline = make_run(vec![make_benchmark("a", 1_000_000)]);
+    let current = make_run(vec![make_benchmark("a", 1_000_000), make_benchmark("b", 2_000_000)]);
+    let diff = diff_runs(&baseline, &current);
+    // Only "a" should be compared.
+    assert_eq!(diff.entries.len(), 1);
+    assert_eq!(diff.entries[0].name, "a-clean-sierra-walltime");
+}
+
+#[test]
+fn test_zero_baseline() {
+    let baseline = make_run(vec![make_benchmark("a", 0)]);
+    let current = make_run(vec![make_benchmark("a", 1_000_000)]);
+    let diff = diff_runs(&baseline, &current);
+    // Division by zero should result in 0% delta.
+    assert_eq!(diff.entries[0].delta_pct, 0.0);
+}

--- a/crates/bin/cairo-metrics/src/config.rs
+++ b/crates/bin/cairo-metrics/src/config.rs
@@ -1,0 +1,166 @@
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::{cmp, fs};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[cfg(test)]
+#[path = "config_test.rs"]
+mod tests;
+
+/// Top-level configuration.
+#[derive(Debug, Clone)]
+pub struct MetricsConfig {
+    pub defaults: Defaults,
+    pub benchmarks: Vec<Benchmark>,
+}
+
+impl MetricsConfig {
+    /// Discover benchmarks from a flat directory structure.
+    /// Each immediate subdirectory with a benchmark.toml is a benchmark.
+    pub fn discover(benchmarks_dir: &Path) -> Result<Self> {
+        let mut benchmarks = BTreeSet::new();
+        for entry in fs::read_dir(benchmarks_dir)? {
+            let dir = entry?.path();
+            let config_path = dir.join("benchmark.toml");
+
+            let content = fs::read_to_string(&config_path)?;
+            let config: BenchmarkConfig = toml::from_str(&content)?;
+            benchmarks.insert(config.into_benchmark(&dir)?);
+        }
+
+        Ok(MetricsConfig {
+            defaults: Defaults::default(),
+            benchmarks: benchmarks.into_iter().collect(),
+        })
+    }
+}
+
+/// A benchmark with its name and configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Benchmark {
+    pub name: String,
+    pub config: BenchmarkConfig,
+    pub patches: Vec<Patch>,
+}
+
+impl Benchmark {
+    /// Get the path to the Cairo project source directory.
+    pub fn path(&self) -> &Path {
+        &self.config.path
+    }
+}
+
+impl PartialOrd for Benchmark {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Benchmark {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+/// Configuration loaded from benchmark.toml.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct BenchmarkConfig {
+    /// Path to the Cairo project to benchmark (relative to repo root).
+    pub path: PathBuf,
+    /// Whether this benchmark is a library project (like corelib).
+    #[serde(default)]
+    pub library: bool,
+}
+
+impl BenchmarkConfig {
+    /// Consume config and create a Benchmark with name derived from directory.
+    pub fn into_benchmark(self, dir: &Path) -> Result<Benchmark> {
+        let name = dir.file_name().unwrap().to_string_lossy().into_owned();
+        let patches = discover_patches(dir)?;
+        Ok(Benchmark { name, config: self, patches })
+    }
+}
+
+/// Default values for benchmarks.
+#[derive(Debug, Clone)]
+pub struct Defaults {
+    pub runs: usize,
+    pub warmup: usize,
+}
+
+impl Default for Defaults {
+    fn default() -> Self {
+        Self { runs: 5, warmup: 1 }
+    }
+}
+
+/// A git patch file for incremental benchmarks, for deterministic incremental benchmarks.
+/// This is applied on top of a fresh copy of the example project, after a full build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Patch {
+    /// Index for ordering (parsed from filename like "0-name.patch").
+    pub index: u32,
+    /// Human-readable name (parsed from filename).
+    pub name: String,
+    /// Absolute path to the .patch file.
+    pub path: PathBuf,
+}
+
+impl Patch {
+    /// Parse a patch from a filename like "0-println.patch".
+    pub fn from_path(path: PathBuf) -> Option<Self> {
+        let filename = path.file_stem()?.to_str()?;
+        let (index_str, name) = filename.split_once('-')?;
+        let index = index_str.parse().ok()?;
+        Some(Self { index, name: name.to_string(), path })
+    }
+
+    /// Apply this patch to a benchmark project sourcecode using `patch -p1`.
+    // Unused until cairo compiler adds incremental compilation support.
+    #[allow(dead_code)]
+    pub fn apply(&self, dir: &Path) -> Result<()> {
+        let status = Command::new("patch")
+            .arg("-p1")
+            .arg("-i")
+            .arg(&self.path)
+            .current_dir(dir)
+            .status()
+            .with_context(|| format!("failed to run patch: {}", self.path.display()))?;
+
+        anyhow::ensure!(status.success(), "patch failed: {}", self.path.display());
+        Ok(())
+    }
+}
+
+impl PartialOrd for Patch {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Patch {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.index.cmp(&other.index)
+    }
+}
+
+fn discover_patches(dir: &Path) -> Result<Vec<Patch>> {
+    let abs_dir = &dir
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize benchmark dir: {}", dir.display()))?;
+    let mut patches = BTreeSet::new();
+    for entry in fs::read_dir(abs_dir)? {
+        let path = entry?.path();
+        if path.extension() == Some(OsStr::new("patch")) {
+            let patch = Patch::from_path(path.clone()).with_context(|| {
+                format!("invalid patch filename '{}': expected N-name.patch", path.display())
+            })?;
+            patches.insert(patch);
+        }
+    }
+    Ok(patches.into_iter().collect())
+}

--- a/crates/bin/cairo-metrics/src/config_test.rs
+++ b/crates/bin/cairo-metrics/src/config_test.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use crate::config::{BenchmarkConfig, Defaults, Patch};
+
+#[test]
+fn test_parse_minimal_benchmark() {
+    let toml = r#"
+path = "corelib/"
+"#;
+    let benchmark: BenchmarkConfig = toml::from_str(toml).unwrap();
+    assert_eq!(benchmark.path, PathBuf::from("corelib/"));
+}
+
+#[test]
+fn test_defaults() {
+    let defaults = Defaults::default();
+    assert_eq!(defaults.runs, 5);
+    assert_eq!(defaults.warmup, 1);
+}
+
+#[test]
+fn test_patch_discovery() {
+    let temp_dir = std::env::temp_dir().join("cairo-metrics-test-patches");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
+
+    // Create some patch files.
+    std::fs::write(temp_dir.join("0-first.patch"), "patch content").unwrap();
+    std::fs::write(temp_dir.join("1-second.patch"), "patch content").unwrap();
+    std::fs::write(temp_dir.join("not-a-patch.txt"), "ignore me").unwrap();
+
+    let config = BenchmarkConfig { path: PathBuf::from("corelib"), library: false };
+    let benchmark = config.into_benchmark(&temp_dir).unwrap();
+
+    assert_eq!(benchmark.patches.len(), 2);
+    assert_eq!(benchmark.patches[0].index, 0);
+    assert_eq!(benchmark.patches[0].name, "first");
+    assert_eq!(benchmark.patches[1].index, 1);
+    assert_eq!(benchmark.patches[1].name, "second");
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn test_patch_from_path() {
+    let path = PathBuf::from("/tmp/0-example.patch");
+    let patch = Patch::from_path(path.clone()).unwrap();
+    assert_eq!(patch.index, 0);
+    assert_eq!(patch.name, "example");
+    assert_eq!(patch.path, path);
+}
+
+#[test]
+fn test_patch_from_path_invalid() {
+    assert!(Patch::from_path(PathBuf::from("/tmp/invalid.patch")).is_none());
+    assert!(Patch::from_path(PathBuf::from("/tmp/notapatch.txt")).is_none());
+}

--- a/crates/bin/cairo-metrics/src/database.rs
+++ b/crates/bin/cairo-metrics/src/database.rs
@@ -1,0 +1,316 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+
+use crate::model::{BenchmarkResult, RunMeta, RunResult, TimingStats};
+
+/// Database operations for storing and retrieving benchmark results.
+pub trait Database {
+    /// Store a run result (append-only, does not delete existing benchmarks).
+    fn store_run(&self, id: &str, result: &RunResult) -> Result<()>;
+
+    /// Load a run result by ID.
+    fn load_run(&self, id: &str) -> Result<RunResult>;
+
+    /// List all run IDs, ordered by timestamp (newest first).
+    fn list_runs(&self, limit: u32) -> Result<Vec<RunInfo>>;
+
+    /// Get history for a specific benchmark across runs.
+    fn history(&self, benchmark: &str, limit: u32) -> Result<Vec<HistoryEntry>>;
+
+    /// List all unique benchmark names.
+    fn list_benchmarks(&self) -> Result<Vec<String>>;
+
+    /// List benchmark names that have cached results for a specific run.
+    fn list_benchmarks_for_run(&self, run_id: &str) -> Result<Vec<String>>;
+
+    /// Delete all results for a run.
+    fn purge_run(&self, run_id: &str) -> Result<()>;
+
+    /// Delete only failed benchmarks for a run. Returns number deleted.
+    fn purge_failed_benchmarks(&self, run_id: &str) -> Result<usize>;
+}
+
+/// SQLite implementation of the database.
+pub struct SqliteDatabase {
+    conn: Connection,
+}
+
+impl SqliteDatabase {
+    /// Open or create a SQLite database at the given path.
+    pub fn open(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create database directory: {}", parent.display())
+            })?;
+        }
+
+        let conn = Connection::open(path)
+            .with_context(|| format!("failed to open database: {}", path.display()))?;
+
+        let db = Self { conn };
+        db.init_schema()?;
+        Ok(db)
+    }
+
+    fn init_schema(&self) -> Result<()> {
+        self.conn
+            .execute_batch(
+                "
+            CREATE TABLE IF NOT EXISTS runs (
+                id TEXT PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                git_commit TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS benchmark_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+                benchmark TEXT NOT NULL,
+                scenario TEXT NOT NULL,
+                patch TEXT NOT NULL DEFAULT '',
+                phase TEXT NOT NULL,
+                metric TEXT NOT NULL,
+                mean_ns INTEGER NOT NULL,
+                stddev_ns INTEGER NOT NULL,
+                median_ns INTEGER NOT NULL,
+                min_ns INTEGER NOT NULL,
+                max_ns INTEGER NOT NULL,
+                mad_ns INTEGER NOT NULL,
+                runs INTEGER NOT NULL,
+                warmup INTEGER NOT NULL,
+                success INTEGER NOT NULL,
+                times_json TEXT,
+                UNIQUE (run_id, benchmark, scenario, patch, phase, metric)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_runs_timestamp ON runs(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_benchmark_results_benchmark ON \
+                 benchmark_results(benchmark);
+            CREATE INDEX IF NOT EXISTS idx_benchmark_results_phase ON benchmark_results(phase);
+            ",
+            )
+            .context("failed to initialize database schema")?;
+        Ok(())
+    }
+
+    /// Create an in-memory database (for testing).
+    #[cfg(test)]
+    pub fn in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        let db = Self { conn };
+        db.init_schema()?;
+        Ok(db)
+    }
+}
+
+impl Database for SqliteDatabase {
+    fn store_run(&self, id: &str, result: &RunResult) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+
+        tx.execute(
+            "INSERT OR IGNORE INTO runs (id, timestamp, git_commit) VALUES (?1, ?2, ?3)",
+            params![id, result.meta.timestamp_utc, result.meta.git_commit],
+        )
+        .with_context(|| format!("failed to store run '{}'", id))?;
+
+        for bench in &result.benchmarks {
+            let times_json = serde_json::to_string(&bench.timing.times_ns)
+                .context("failed to serialize times")?;
+            tx.execute(
+                "INSERT OR REPLACE INTO benchmark_results
+                 (run_id, benchmark, scenario, patch, phase, metric,
+                  mean_ns, stddev_ns, median_ns, min_ns, max_ns, mad_ns,
+                  runs, warmup, success, times_json)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                params![
+                    id,
+                    bench.benchmark,
+                    bench.scenario,
+                    bench.patch,
+                    bench.phase,
+                    bench.metric,
+                    bench.timing.mean_ns,
+                    bench.timing.stddev_ns,
+                    bench.timing.median_ns,
+                    bench.timing.min_ns,
+                    bench.timing.max_ns,
+                    bench.timing.mad_ns,
+                    bench.timing.runs,
+                    bench.timing.warmup,
+                    bench.success,
+                    times_json,
+                ],
+            )?;
+        }
+
+        tx.commit()?;
+        Ok(())
+    }
+
+    fn load_run(&self, id: &str) -> Result<RunResult> {
+        let (timestamp, git_commit): (String, Option<String>) = self
+            .conn
+            .query_row("SELECT timestamp, git_commit FROM runs WHERE id = ?1", params![id], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .with_context(|| format!("failed to load run '{}': not found", id))?;
+
+        let mut stmt = self.conn.prepare(
+            "SELECT benchmark, scenario, patch, phase, metric,
+                    mean_ns, stddev_ns, median_ns, min_ns, max_ns,
+                    mad_ns, runs, warmup, success, times_json
+             FROM benchmark_results WHERE run_id = ?1",
+        )?;
+
+        let benchmarks: Vec<BenchmarkResult> = stmt
+            .query_map(params![id], |row| {
+                let times_json: Option<String> = row.get(14)?;
+                let times_ns: Vec<u64> =
+                    times_json.and_then(|s| serde_json::from_str(&s).ok()).unwrap_or_default();
+
+                Ok(BenchmarkResult {
+                    benchmark: row.get(0)?,
+                    scenario: row.get(1)?,
+                    patch: row.get(2)?,
+                    phase: row.get(3)?,
+                    metric: row.get(4)?,
+                    timing: TimingStats {
+                        times_ns,
+                        mean_ns: row.get(5)?,
+                        stddev_ns: row.get(6)?,
+                        median_ns: row.get(7)?,
+                        min_ns: row.get(8)?,
+                        max_ns: row.get(9)?,
+                        mad_ns: row.get(10)?,
+                        runs: row.get(11)?,
+                        warmup: row.get(12)?,
+                    },
+                    success: row.get(13)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(RunResult { meta: RunMeta { timestamp_utc: timestamp, git_commit }, benchmarks })
+    }
+
+    fn list_runs(&self, limit: u32) -> Result<Vec<RunInfo>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, timestamp, git_commit FROM runs ORDER BY timestamp DESC LIMIT ?1",
+        )?;
+
+        let rows = stmt.query_map(params![limit], |row| {
+            Ok(RunInfo { id: row.get(0)?, timestamp: row.get(1)?, git_commit: row.get(2)? })
+        })?;
+
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    fn history(&self, display_name: &str, limit: u32) -> Result<Vec<HistoryEntry>> {
+        // Build display name from columns using SQLite CASE expression.
+        let mut stmt = self.conn.prepare(
+            "SELECT r.id, r.timestamp, r.git_commit, b.median_ns
+             FROM runs r
+             JOIN benchmark_results b ON r.id = b.run_id
+             WHERE CASE
+                 WHEN b.patch != '' THEN b.benchmark || '-patched-' || b.patch || '-' || b.phase \
+             || '-' || b.metric
+                 ELSE b.benchmark || '-' || b.scenario || '-' || b.phase || '-' || b.metric
+             END = ?1
+             ORDER BY r.timestamp DESC
+             LIMIT ?2",
+        )?;
+
+        let rows = stmt.query_map(params![display_name, limit], |row| {
+            Ok(HistoryEntry {
+                run_id: row.get(0)?,
+                timestamp: row.get(1)?,
+                git_commit: row.get(2)?,
+                median_ns: row.get(3)?,
+            })
+        })?;
+
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    fn list_benchmarks(&self) -> Result<Vec<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT DISTINCT benchmark, scenario, patch, phase, metric
+             FROM benchmark_results
+             ORDER BY benchmark, scenario, phase, metric",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let benchmark: String = row.get(0)?;
+            let scenario: String = row.get(1)?;
+            let patch: String = row.get(2)?;
+            let phase: String = row.get(3)?;
+            let metric: String = row.get(4)?;
+            let key = if patch.is_empty() {
+                format!("{}-{}-{}-{}", benchmark, scenario, phase, metric)
+            } else {
+                format!("{}-patched-{}-{}-{}", benchmark, patch, phase, metric)
+            };
+            Ok(key)
+        })?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    fn list_benchmarks_for_run(&self, run_id: &str) -> Result<Vec<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT benchmark, scenario, patch, phase, metric
+             FROM benchmark_results WHERE run_id = ?1
+             ORDER BY benchmark, scenario, phase, metric",
+        )?;
+        let rows = stmt.query_map(params![run_id], |row| {
+            let benchmark: String = row.get(0)?;
+            let scenario: String = row.get(1)?;
+            let patch: String = row.get(2)?;
+            let phase: String = row.get(3)?;
+            let metric: String = row.get(4)?;
+            let key = if patch.is_empty() {
+                format!("{}-{}-{}-{}", benchmark, scenario, phase, metric)
+            } else {
+                format!("{}-patched-{}-{}-{}", benchmark, patch, phase, metric)
+            };
+            Ok(key)
+        })?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    fn purge_run(&self, run_id: &str) -> Result<()> {
+        self.conn.execute("DELETE FROM benchmark_results WHERE run_id = ?1", params![run_id])?;
+        self.conn.execute("DELETE FROM runs WHERE id = ?1", params![run_id])?;
+        Ok(())
+    }
+
+    fn purge_failed_benchmarks(&self, run_id: &str) -> Result<usize> {
+        let deleted = self.conn.execute(
+            "DELETE FROM benchmark_results WHERE run_id = ?1 AND success = 0",
+            params![run_id],
+        )?;
+        Ok(deleted)
+    }
+}
+
+/// Information about a stored run.
+#[derive(Debug, Clone)]
+pub struct RunInfo {
+    pub id: String,
+    pub timestamp: String,
+    pub git_commit: Option<String>,
+}
+
+/// A single entry in the history of a benchmark.
+#[derive(Debug)]
+pub struct HistoryEntry {
+    pub run_id: String,
+    pub timestamp: String,
+    pub git_commit: Option<String>,
+    pub median_ns: u64,
+}
+
+#[cfg(test)]
+#[path = "database_test.rs"]
+mod tests;

--- a/crates/bin/cairo-metrics/src/database_test.rs
+++ b/crates/bin/cairo-metrics/src/database_test.rs
@@ -1,0 +1,205 @@
+use crate::database::{Database, SqliteDatabase};
+use crate::model::{BenchmarkResult, RunMeta, RunResult, TimingStats};
+
+fn make_result(commit: &str) -> RunResult {
+    RunResult {
+        meta: RunMeta {
+            timestamp_utc: "2025-01-01T00:00:00Z".into(),
+            git_commit: Some(commit.into()),
+        },
+        benchmarks: vec![BenchmarkResult {
+            benchmark: "test".into(),
+            scenario: "clean".into(),
+            patch: String::new(),
+            phase: "sierra".into(),
+            metric: "walltime".into(),
+            timing: TimingStats {
+                runs: 3,
+                warmup: 1,
+                times_ns: vec![1_000_000, 1_100_000, 900_000],
+                mean_ns: 1_000_000,
+                stddev_ns: 100_000,
+                median_ns: 1_000_000,
+                mad_ns: 100_000,
+                min_ns: 900_000,
+                max_ns: 1_100_000,
+            },
+            success: true,
+        }],
+    }
+}
+
+fn make_result_with_benchmarks(commit: &str, names: &[&str]) -> RunResult {
+    RunResult {
+        meta: RunMeta {
+            timestamp_utc: "2025-01-01T00:00:00Z".into(),
+            git_commit: Some(commit.into()),
+        },
+        benchmarks: names
+            .iter()
+            .map(|name| BenchmarkResult {
+                benchmark: (*name).into(),
+                scenario: "clean".into(),
+                patch: String::new(),
+                phase: "sierra".into(),
+                metric: "walltime".into(),
+                timing: TimingStats {
+                    runs: 3,
+                    warmup: 1,
+                    times_ns: vec![1_000_000],
+                    mean_ns: 1_000_000,
+                    stddev_ns: 100_000,
+                    median_ns: 1_000_000,
+                    mad_ns: 100_000,
+                    min_ns: 900_000,
+                    max_ns: 1_100_000,
+                },
+                success: true,
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn test_store_and_load() {
+    let db = SqliteDatabase::in_memory().unwrap();
+
+    let result = make_result("abc123");
+    db.store_run("baseline", &result).unwrap();
+
+    let loaded = db.load_run("baseline").unwrap();
+    assert_eq!(loaded.meta.git_commit, Some("abc123".into()));
+    assert_eq!(loaded.benchmarks.len(), 1);
+    assert_eq!(loaded.benchmarks[0].benchmark, "test");
+    assert_eq!(loaded.benchmarks[0].phase, "sierra");
+    assert_eq!(loaded.benchmarks[0].timing.mean_ns, 1_000_000);
+}
+
+#[test]
+fn test_list_runs() {
+    let db = SqliteDatabase::in_memory().unwrap();
+
+    db.store_run("run1", &make_result("aaa")).unwrap();
+    db.store_run("run2", &make_result("bbb")).unwrap();
+
+    let runs = db.list_runs(100).unwrap();
+    assert_eq!(runs.len(), 2);
+}
+
+#[test]
+fn test_load_nonexistent() {
+    let db = SqliteDatabase::in_memory().unwrap();
+
+    let err = db.load_run("nonexistent").unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn test_append_only_run_metadata() {
+    let db = SqliteDatabase::in_memory().unwrap();
+
+    db.store_run("same-id", &make_result("first")).unwrap();
+    db.store_run("same-id", &make_result("second")).unwrap();
+
+    let loaded = db.load_run("same-id").unwrap();
+    assert_eq!(loaded.meta.git_commit, Some("first".into()));
+}
+
+#[test]
+fn test_history() {
+    let db = SqliteDatabase::in_memory().unwrap();
+
+    db.store_run("run1", &make_result_with_benchmarks("aaa", &["a", "b"])).unwrap();
+    db.store_run("run2", &make_result_with_benchmarks("bbb", &["a", "c"])).unwrap();
+
+    let hist = db.history("a-clean-sierra-walltime", 10).unwrap();
+    assert_eq!(hist.len(), 2);
+
+    let hist_b = db.history("b-clean-sierra-walltime", 10).unwrap();
+    assert_eq!(hist_b.len(), 1);
+}
+
+#[test]
+fn test_list_benchmarks() {
+    let db = SqliteDatabase::in_memory().unwrap();
+
+    db.store_run("run1", &make_result_with_benchmarks("aaa", &["a", "b"])).unwrap();
+
+    let benchmarks = db.list_benchmarks().unwrap();
+    assert_eq!(benchmarks, vec!["a-clean-sierra-walltime", "b-clean-sierra-walltime"]);
+}
+
+#[test]
+fn test_purge_run() {
+    let db = SqliteDatabase::in_memory().unwrap();
+
+    db.store_run("run1", &make_result("aaa")).unwrap();
+    db.store_run("run2", &make_result("bbb")).unwrap();
+
+    db.purge_run("run1").unwrap();
+
+    assert!(db.load_run("run1").is_err());
+    assert!(db.load_run("run2").is_ok());
+    assert_eq!(db.list_runs(100).unwrap().len(), 1);
+}
+
+#[test]
+fn test_purge_failed_benchmarks() {
+    let db = SqliteDatabase::in_memory().unwrap();
+
+    let result = RunResult {
+        meta: RunMeta {
+            timestamp_utc: "2025-01-01T00:00:00Z".into(),
+            git_commit: Some("abc".into()),
+        },
+        benchmarks: vec![
+            BenchmarkResult {
+                benchmark: "pass".into(),
+                scenario: "clean".into(),
+                patch: String::new(),
+                phase: "sierra".into(),
+                metric: "walltime".into(),
+                timing: TimingStats {
+                    runs: 1,
+                    warmup: 0,
+                    times_ns: vec![1_000_000],
+                    mean_ns: 1_000_000,
+                    stddev_ns: 0,
+                    median_ns: 1_000_000,
+                    mad_ns: 0,
+                    min_ns: 1_000_000,
+                    max_ns: 1_000_000,
+                },
+                success: true,
+            },
+            BenchmarkResult {
+                benchmark: "fail".into(),
+                scenario: "clean".into(),
+                patch: String::new(),
+                phase: "sierra".into(),
+                metric: "walltime".into(),
+                timing: TimingStats {
+                    runs: 1,
+                    warmup: 0,
+                    times_ns: vec![1_000_000],
+                    mean_ns: 1_000_000,
+                    stddev_ns: 0,
+                    median_ns: 1_000_000,
+                    mad_ns: 0,
+                    min_ns: 1_000_000,
+                    max_ns: 1_000_000,
+                },
+                success: false,
+            },
+        ],
+    };
+
+    db.store_run("run1", &result).unwrap();
+    assert_eq!(db.list_benchmarks_for_run("run1").unwrap().len(), 2);
+
+    let deleted = db.purge_failed_benchmarks("run1").unwrap();
+    assert_eq!(deleted, 1);
+
+    let remaining = db.list_benchmarks_for_run("run1").unwrap();
+    assert_eq!(remaining, vec!["pass-clean-sierra-walltime"]);
+}

--- a/crates/bin/cairo-metrics/src/engine.rs
+++ b/crates/bin/cairo-metrics/src/engine.rs
@@ -1,0 +1,281 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use cairo_lang_compiler::{CompilerConfig, compile_cairo_project_at_path};
+use cairo_lang_lowering::utils::InliningStrategy;
+use time::OffsetDateTime;
+use tracing::info;
+
+use crate::config::{Benchmark, MetricsConfig};
+use crate::format::log_timing_stats;
+use crate::model::{BenchmarkResult, RunMeta, RunResult, TimingStats, format_display_name};
+use crate::runner::{TempDir, copy_dir};
+use crate::stats::compute_stats;
+use crate::{Engine, Metric, Phase, Scenario, hyperfine};
+
+/// Run all benchmarks and return the results.
+/// The `cached` set contains benchmark result names that are already stored.
+pub fn run_all(
+    config: MetricsConfig,
+    engine: Engine,
+    scenarios: &[Scenario],
+    phases: &[Phase],
+    metrics: &[Metric],
+    cached: &HashSet<String>,
+) -> Result<RunResult> {
+    let use_hyperfine = match engine {
+        Engine::Auto => {
+            let available = hyperfine::is_available();
+            if !available {
+                hyperfine::print_warning();
+            }
+            available
+        }
+        Engine::Builtin => false,
+        Engine::Hyperfine => {
+            anyhow::ensure!(
+                hyperfine::is_available(),
+                "hyperfine not found but --engine=hyperfine was specified"
+            );
+            true
+        }
+    };
+
+    let meta = RunMeta {
+        timestamp_utc: OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap(),
+        git_commit: Some(get_git_head()),
+    };
+
+    let mut benchmark_results = Vec::new();
+    let mut bench_count = 0;
+    let mut skipped_count = 0;
+    for bench in &config.benchmarks {
+        for &scenario in scenarios {
+            let is_incremental = scenario == Scenario::Incremental;
+
+            // TODO(gilad): Incremental compilation requires cairo compiler support.
+            // For now, skip incremental scenarios entirely.
+            if is_incremental {
+                info!(
+                    "Skipping {} for incremental (not yet supported by cairo-compile)",
+                    bench.name
+                );
+                continue;
+            }
+
+            for &phase in phases {
+                for &metric in metrics {
+                    let key = cache_key(&bench.name, scenario, phase, metric);
+                    if cached.contains(&key) {
+                        skipped_count += 1;
+                        continue;
+                    }
+                    bench_count += 1;
+                    if let Some(result) = run_single(
+                        &config,
+                        bench,
+                        scenario,
+                        phase,
+                        metric,
+                        use_hyperfine,
+                        bench_count,
+                    )? {
+                        benchmark_results.push(result);
+                    }
+                }
+            }
+        }
+    }
+
+    if skipped_count > 0 {
+        info!("Skipped {} cached results", skipped_count);
+    }
+    if benchmark_results.is_empty() && skipped_count > 0 {
+        info!("All results cached, nothing new to run");
+    }
+
+    Ok(RunResult { meta, benchmarks: benchmark_results })
+}
+
+/// Get the current git HEAD commit hash.
+pub fn get_git_head() -> String {
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| str::from_utf8(&o.stdout).unwrap().trim().to_string())
+        .unwrap()
+}
+
+/// Runs a single clean-build benchmark using the selected engine.
+/// Returns None if the benchmark should be skipped.
+fn run_single(
+    config: &MetricsConfig,
+    bench: &Benchmark,
+    scenario: Scenario,
+    phase: Phase,
+    metric: Metric,
+    use_hyperfine: bool,
+    bench_count: usize,
+) -> Result<Option<BenchmarkResult>> {
+    match metric {
+        Metric::Walltime => {
+            if use_hyperfine {
+                // Hyperfine doesn't support skip detection, so always returns Some.
+                hyperfine::Bench::new(config, bench, scenario, phase, metric)
+                    .run_clean(bench_count)
+                    .map(Some)
+            } else {
+                BuiltinBench::new(config, bench, scenario, phase, metric).run_clean(bench_count)
+            }
+        }
+    }
+}
+
+fn cache_key(bench_name: &str, scenario: Scenario, phase: Phase, metric: Metric) -> String {
+    format!("{}-{}-{}-{}", bench_name, scenario.as_str(), phase.as_str(), metric.as_str())
+}
+
+/// Builtin benchmark runner using temp directories.
+struct BuiltinBench {
+    runs: usize,
+    warmup: usize,
+    path: PathBuf,
+    /// Benchmark name (e.g., "corelib").
+    benchmark: String,
+    /// Build scenario (e.g., "clean").
+    scenario: String,
+    /// Compilation phase.
+    phase: Phase,
+    /// Metric type (e.g., "walltime").
+    metric: String,
+    /// Patch name for incremental builds (empty for clean).
+    patch: String,
+}
+
+impl BuiltinBench {
+    /// Creates a benchmark runner from config.
+    fn new(
+        config: &MetricsConfig,
+        bench: &Benchmark,
+        scenario: Scenario,
+        phase: Phase,
+        metric: Metric,
+    ) -> Self {
+        Self {
+            runs: config.defaults.runs,
+            warmup: config.defaults.warmup,
+            path: bench.path().to_path_buf(),
+            benchmark: bench.name.clone(),
+            scenario: scenario.as_str().to_string(),
+            phase,
+            metric: metric.as_str().to_string(),
+            patch: String::new(),
+        }
+    }
+
+    /// Runs a clean build benchmark.
+    /// Returns None if the benchmark should be skipped (e.g., Casm for library projects).
+    fn run_clean(&self, bench_count: usize) -> Result<Option<BenchmarkResult>> {
+        info!("Benchmark {}: {}", bench_count, self.display_name());
+
+        // Warm up OS/CPU caches to increase accuracy of timing.
+        for i in 0..self.warmup {
+            info!("  warmup {}/{}", i + 1, self.warmup);
+            match self.run_in_temp() {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    info!("  skipped: no contracts to compile");
+                    return Ok(None);
+                }
+                Err(e) => return Ok(Some(self.failed_result(&e))),
+            }
+        }
+
+        let mut times = Vec::with_capacity(self.runs);
+        for i in 0..self.runs {
+            info!("  run {}/{}", i + 1, self.runs);
+            match self.run_in_temp() {
+                Ok(Some(wall_time)) => times.push(wall_time.as_nanos().try_into().unwrap()),
+                Ok(None) => {
+                    info!("  skipped: no contracts to compile");
+                    return Ok(None);
+                }
+                Err(e) => return Ok(Some(self.failed_result(&e))),
+            }
+        }
+
+        self.compute_result(times).map(Some)
+    }
+
+    /// Returns the display name for logging.
+    fn display_name(&self) -> String {
+        format_display_name(
+            &self.benchmark,
+            &self.scenario,
+            &self.patch,
+            self.phase.as_str(),
+            &self.metric,
+        )
+    }
+
+    /// Copies source to temp dir and runs the compilation.
+    fn run_in_temp(&self) -> Result<Option<Duration>> {
+        // If this gets too slow, only do it for the first iteration and for subsequent iterations
+        // remove the target directory when running a clean build. For incremental
+        // mode, revert the patch after the first run then rebuild (incrementally).
+        let temp_dir_handle = TempDir::new(&self.benchmark)?;
+        copy_dir(&self.path, temp_dir_handle.path())?;
+
+        match self.phase {
+            Phase::Full => self.run_full(temp_dir_handle.path()).map(Some),
+        }
+    }
+
+    /// Runs full compilation: source to Sierra via library call.
+    fn run_full(&self, temp_path: &Path) -> Result<Duration> {
+        let start = Instant::now();
+        compile_cairo_project_at_path(
+            temp_path,
+            CompilerConfig::default(),
+            InliningStrategy::Default,
+        )?;
+        Ok(start.elapsed())
+    }
+
+    /// Computes statistics and returns the benchmark result.
+    fn compute_result(&self, times: Vec<u64>) -> Result<BenchmarkResult> {
+        let timing = compute_stats(&times, self.runs, self.warmup)?;
+        log_timing_stats(&timing);
+
+        Ok(BenchmarkResult {
+            benchmark: self.benchmark.clone(),
+            scenario: self.scenario.clone(),
+            patch: self.patch.clone(),
+            phase: self.phase.as_str().to_string(),
+            metric: self.metric.clone(),
+            timing,
+            success: true,
+        })
+    }
+
+    /// Logs the error and returns a failed benchmark result with empty timing stats.
+    fn failed_result(&self, error: &anyhow::Error) -> BenchmarkResult {
+        tracing::error!("  failed: {error}");
+        BenchmarkResult {
+            benchmark: self.benchmark.clone(),
+            scenario: self.scenario.clone(),
+            patch: self.patch.clone(),
+            phase: self.phase.as_str().to_string(),
+            metric: self.metric.clone(),
+            timing: TimingStats { runs: self.runs, warmup: self.warmup, ..Default::default() },
+            success: false,
+        }
+    }
+}

--- a/crates/bin/cairo-metrics/src/format.rs
+++ b/crates/bin/cairo-metrics/src/format.rs
@@ -1,0 +1,76 @@
+use tracing::info;
+
+use crate::compare::RunDiff;
+use crate::model::TimingStats;
+
+#[cfg(test)]
+#[path = "format_test.rs"]
+mod tests;
+
+/// Logs timing statistics in hyperfine-like format.
+pub fn log_timing_stats(timing: &TimingStats) {
+    info!(
+        "  Time (median ± σ):  {} ± {}",
+        format_duration(timing.median_ns),
+        format_duration(timing.stddev_ns)
+    );
+    info!(
+        "  Range (min … max):  {} … {}    [{} runs]",
+        format_duration(timing.min_ns),
+        format_duration(timing.max_ns),
+        timing.runs
+    );
+}
+
+/// Format a duration in nanoseconds to a human-readable string with appropriate units.
+pub fn format_duration(nanos: u64) -> String {
+    if nanos < 1_000 {
+        format!("{} ns", nanos)
+    } else if nanos < 1_000_000 {
+        format!("{:.1} \u{00b5}s", nanos as f64 / 1_000.0)
+    } else if nanos < 1_000_000_000 {
+        format!("{:.1} ms", nanos as f64 / 1_000_000.0)
+    } else {
+        format!("{:.2} s", nanos as f64 / 1_000_000_000.0)
+    }
+}
+
+/// Generate a plain text diff report (LLVM-style columns).
+pub fn text_diff(diff: &RunDiff) -> String {
+    let mut out = String::new();
+
+    // Find max name length for alignment.
+    let max_name = diff.entries.iter().map(|e| e.name.len()).max().unwrap_or(0).max(9);
+
+    // Header.
+    out.push_str(&format!(
+        "{:width$}  {:>12}  {:>12}  {:>8}\n",
+        "Benchmark",
+        "Baseline",
+        "Current",
+        "Diff",
+        width = max_name,
+    ));
+    out.push('\n');
+
+    for e in &diff.entries {
+        let emoji = if e.delta_pct > 0.0 {
+            "❌"
+        } else if e.delta_pct < 0.0 {
+            "✅"
+        } else {
+            "  "
+        };
+        out.push_str(&format!(
+            "{:width$}  {:>12}  {:>12}  {:>+7.1}% {}\n",
+            e.name,
+            format_duration(e.base_median),
+            format_duration(e.current_median),
+            e.delta_pct,
+            emoji,
+            width = max_name,
+        ));
+    }
+
+    out
+}

--- a/crates/bin/cairo-metrics/src/format_test.rs
+++ b/crates/bin/cairo-metrics/src/format_test.rs
@@ -1,0 +1,11 @@
+use crate::format::format_duration;
+
+#[test]
+fn test_format_duration() {
+    assert_eq!(format_duration(500), "500 ns");
+    assert_eq!(format_duration(1_500), "1.5 \u{00b5}s");
+    assert_eq!(format_duration(100_000), "100.0 \u{00b5}s");
+    assert_eq!(format_duration(1_000_000), "1.0 ms");
+    assert_eq!(format_duration(100_000_000), "100.0 ms");
+    assert_eq!(format_duration(1_500_000_000), "1.50 s");
+}

--- a/crates/bin/cairo-metrics/src/hyperfine.rs
+++ b/crates/bin/cairo-metrics/src/hyperfine.rs
@@ -1,0 +1,220 @@
+//! Hyperfine integration for benchmarking.
+//!
+//! This module is isolated to make it easy to remove if needed.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+use std::{env, fs};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use tracing::info;
+
+use crate::config::{Benchmark, MetricsConfig};
+use crate::format::log_timing_stats;
+use crate::model::{BenchmarkResult, TimingStats, format_display_name};
+use crate::runner::cairo_compile_path;
+use crate::stats::compute_mad;
+use crate::{Metric, Phase, Scenario};
+
+static AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+/// A hyperfine benchmark to execute.
+pub struct Bench {
+    runs: usize,
+    warmup: usize,
+    path: PathBuf,
+    temp_dir: PathBuf,
+    /// Benchmark name (e.g., "corelib").
+    benchmark: String,
+    /// Build scenario (e.g., "clean").
+    scenario: String,
+    /// Compilation phase.
+    phase: Phase,
+    /// Metric type (e.g., "walltime").
+    metric: String,
+    /// Patch name for incremental builds, empty string for clean builds.
+    patch: String,
+}
+
+impl Bench {
+    /// Creates a new benchmark from config.
+    pub fn new(
+        config: &MetricsConfig,
+        bench: &Benchmark,
+        scenario: Scenario,
+        phase: Phase,
+        metric: Metric,
+    ) -> Self {
+        let temp_dir = env::temp_dir().join(format!("cairo-metrics-{}", bench.name));
+        Self {
+            runs: config.defaults.runs,
+            warmup: config.defaults.warmup,
+            path: bench.path().to_path_buf(),
+            temp_dir,
+            benchmark: bench.name.clone(),
+            scenario: scenario.as_str().to_string(),
+            phase,
+            metric: metric.as_str().to_string(),
+            patch: String::new(),
+        }
+    }
+
+    /// Returns the display name for logging.
+    fn display_name(&self) -> String {
+        format_display_name(
+            &self.benchmark,
+            &self.scenario,
+            &self.patch,
+            self.phase.as_str(),
+            &self.metric,
+        )
+    }
+
+    /// Runs a clean build benchmark.
+    pub fn run_clean(&self, bench_count: usize) -> Result<BenchmarkResult> {
+        info!("Benchmark {}: {}", bench_count, self.display_name());
+
+        let hyperfine_config = self.build_clean_config();
+        self.run(&hyperfine_config)
+    }
+
+    fn run(&self, hyperfine_config: &Config) -> Result<BenchmarkResult> {
+        let result = run_benchmark(hyperfine_config)?;
+        let sec_to_ns = |s: f64| (s * 1_000_000_000.0).round() as u64;
+
+        let times_ns: Vec<u64> = result.times.into_iter().map(sec_to_ns).collect();
+        let median_ns = sec_to_ns(result.median);
+        let exit_code = result.exit_codes.into_iter().find(|&c| c != 0).unwrap_or(0);
+
+        let timing = TimingStats {
+            runs: hyperfine_config.runs,
+            warmup: hyperfine_config.warmup,
+            mean_ns: sec_to_ns(result.mean),
+            // stddev is None if only running a single benchmark, so we leave it as 0.
+            stddev_ns: sec_to_ns(result.stddev.unwrap_or(0.0)),
+            median_ns,
+            mad_ns: compute_mad(&times_ns, median_ns),
+            min_ns: sec_to_ns(result.min),
+            max_ns: sec_to_ns(result.max),
+            times_ns,
+        };
+        log_timing_stats(&timing);
+
+        Ok(BenchmarkResult {
+            benchmark: self.benchmark.clone(),
+            scenario: self.scenario.clone(),
+            patch: self.patch.clone(),
+            phase: self.phase.as_str().to_string(),
+            metric: self.metric.clone(),
+            timing,
+            success: exit_code == 0,
+        })
+    }
+
+    /// Returns the cairo-compile command string.
+    fn cairo_compile_cmd(&self) -> String {
+        format!("{} {}", cairo_compile_path().display(), self.temp_dir.display())
+    }
+
+    /// Returns the timed command for full compilation.
+    fn phase_command(&self) -> String {
+        match self.phase {
+            Phase::Full => self.cairo_compile_cmd(),
+        }
+    }
+
+    fn build_clean_config(&self) -> Config {
+        let temp = self.temp_dir.display();
+        let src = self.path.display();
+
+        // Copy source to temp directory.
+        let setup = format!("mkdir -p {0} && cp -r {1}/* {0}/", temp, src);
+        // Remove any previous output before each run.
+        let prepare = format!("rm -rf {0}/*.sierra", temp);
+        let command = self.phase_command();
+
+        Config { runs: self.runs, warmup: self.warmup, setup, prepare, command }
+    }
+}
+
+/// Check if hyperfine is installed and available.
+pub fn is_available() -> bool {
+    *AVAILABLE.get_or_init(|| {
+        Command::new("hyperfine")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+}
+
+/// Print a warning that hyperfine is not installed.
+pub fn print_warning() {
+    tracing::warn!("hyperfine not found, using builtin timing engine");
+    tracing::warn!("For more accurate benchmarks, install with: sudo apt install hyperfine");
+}
+
+struct Config {
+    runs: usize,
+    warmup: usize,
+    setup: String,
+    prepare: String,
+    command: String,
+}
+
+fn run_benchmark(config: &Config) -> Result<HyperfineResult> {
+    let output_path = env::temp_dir().join("cairo-metrics-hyperfine.json");
+
+    let mut command = Command::new("hyperfine");
+    command.arg("--warmup").arg(config.warmup.to_string());
+    command.arg("--runs").arg(config.runs.to_string());
+    command.arg("--export-json").arg(&output_path);
+    command.arg("--style").arg("none");
+
+    // Show command output only at DEBUG level or below.
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        command.arg("--output").arg("inherit");
+    } else {
+        command.arg("--output").arg("null");
+    }
+
+    command.arg("--setup").arg(&config.setup);
+    command.arg("--prepare").arg(&config.prepare);
+    command.arg(&config.command);
+
+    command.stdout(Stdio::inherit());
+    command.stderr(Stdio::inherit());
+
+    let status = command.spawn()?.wait()?;
+    anyhow::ensure!(status.success(), "hyperfine failed with status: {}", status);
+    let json_content = fs::read_to_string(&output_path)
+        .with_context(|| format!("failed to read hyperfine output: {}", output_path.display()))?;
+
+    let [result] = serde_json::from_str::<HyperfineOutput>(&json_content)
+        .with_context(|| "failed to parse hyperfine JSON")?
+        .results
+        .try_into()
+        .expect("Hyperfine returns results for multi-commands, but we always run one");
+    Ok(result)
+}
+
+#[derive(Debug, Deserialize)]
+struct HyperfineOutput {
+    results: Vec<HyperfineResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HyperfineResult {
+    mean: f64,
+    // Hyperfine returns null stddev when only running a single benchmark, we convert this to 0
+    // instead of messing with None values.
+    stddev: Option<f64>,
+    median: f64,
+    min: f64,
+    max: f64,
+    times: Vec<f64>,
+    exit_codes: Vec<i32>,
+}

--- a/crates/bin/cairo-metrics/src/main.rs
+++ b/crates/bin/cairo-metrics/src/main.rs
@@ -1,0 +1,382 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use cairo_lang_utils::logging::init_logging;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use tracing::info;
+
+use crate::compare::diff_runs;
+use crate::config::MetricsConfig;
+use crate::database::{Database, SqliteDatabase};
+use crate::engine::{get_git_head, run_all};
+use crate::format::text_diff;
+use crate::tui::run_tui;
+
+mod compare;
+mod config;
+mod database;
+mod engine;
+mod format;
+mod hyperfine;
+mod model;
+mod runner;
+mod stats;
+mod tui;
+
+fn main() -> Result<()> {
+    init_logging(tracing::Level::INFO);
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Run {
+            id,
+            benchmarks_dir,
+            db,
+            include,
+            exclude,
+            iterations,
+            warmup,
+            engine,
+            scenarios,
+            phases,
+            metrics,
+            purge,
+        } => {
+            let run_id = id.unwrap_or_else(get_git_head);
+            let database = SqliteDatabase::open(&db.db)?;
+
+            match purge {
+                Some(PurgeMode::Old) => {
+                    database.purge_run(&run_id)?;
+                    info!("Purged all results for '{}'", run_id);
+                }
+                Some(PurgeMode::Failed) => {
+                    let count = database.purge_failed_benchmarks(&run_id)?;
+                    info!("Purged {} failed benchmarks for '{}'", count, run_id);
+                }
+                None => {}
+            }
+
+            let cached = database.list_benchmarks_for_run(&run_id)?;
+            let cached: HashSet<String> = cached.into_iter().collect();
+
+            let mut cfg = MetricsConfig::discover(&benchmarks_dir).with_context(|| {
+                format!("failed to discover benchmarks in {}", benchmarks_dir.display())
+            })?;
+
+            if let Some(iterations) = iterations {
+                cfg.defaults.runs = iterations;
+            }
+            if let Some(warmup) = warmup {
+                cfg.defaults.warmup = warmup;
+            }
+            if !include.is_empty() {
+                cfg.benchmarks.retain(|bench| include.iter().any(|p| bench.name.contains(p)));
+            }
+            if !exclude.is_empty() {
+                cfg.benchmarks.retain(|bench| exclude.iter().all(|p| !bench.name.contains(p)));
+            }
+
+            if cfg.benchmarks.is_empty() {
+                info!("No benchmarks to run (filtered out by include/exclude)");
+                return Ok(());
+            }
+
+            let results = run_all(cfg, engine, &scenarios, &phases, &metrics, &cached)?;
+
+            database.store_run(&run_id, &results)?;
+            info!("Results stored with id '{}'", run_id);
+        }
+
+        Commands::Compare { baseline, current, phases, db } => match (baseline, current) {
+            (Some(baseline), Some(current)) => {
+                let mut base = load_result(&baseline, &db.db)?;
+                let mut cur = load_result(&current, &db.db)?;
+
+                if !phases.is_empty() {
+                    let phase_strs: Vec<&str> = phases.iter().map(Phase::as_str).collect();
+                    base.benchmarks.retain(|b| phase_strs.contains(&b.phase.as_str()));
+                    cur.benchmarks.retain(|b| phase_strs.contains(&b.phase.as_str()));
+                }
+
+                let diff = diff_runs(&base, &cur);
+                print!("{}", text_diff(&diff));
+            }
+            (None, None) => {
+                run_tui(&db.db)?;
+            }
+            _ => {
+                anyhow::bail!("Either provide both baseline and current, or neither (for TUI)");
+            }
+        },
+
+        Commands::List { limit, db } => {
+            let database = SqliteDatabase::open(&db.db)?;
+            let runs = database.list_runs(limit)?;
+
+            if runs.is_empty() {
+                println!("No stored runs.");
+            } else {
+                println!("{:<20} {:<28} Git Commit", "ID", "Timestamp");
+                println!("{}", "-".repeat(70));
+                for run in runs {
+                    println!(
+                        "{:<20} {:<28} {}",
+                        run.id,
+                        run.timestamp,
+                        run.git_commit.unwrap_or_else(|| "-".into())
+                    );
+                }
+            }
+        }
+
+        Commands::History { benchmark, limit, db } => {
+            let database = SqliteDatabase::open(&db.db)?;
+            let entries = database.history(&benchmark, limit)?;
+
+            if entries.is_empty() {
+                println!("No history for benchmark '{}'.", benchmark);
+                println!("\nAvailable benchmarks:");
+                for name in database.list_benchmarks()? {
+                    println!("  {}", name);
+                }
+            } else {
+                println!("History for: {}", benchmark);
+                println!();
+                println!("{:<20} {:<28} {:<12} Git Commit", "Run ID", "Timestamp", "Median");
+                println!("{}", "-".repeat(80));
+                for entry in entries {
+                    println!(
+                        "{:<20} {:<28} {:<12} {}",
+                        entry.run_id,
+                        entry.timestamp,
+                        format::format_duration(entry.median_ns),
+                        entry.git_commit.unwrap_or_else(|| "-".into())
+                    );
+                }
+            }
+        }
+
+        Commands::Purge { id, mode, db } => {
+            let database = SqliteDatabase::open(&db.db)?;
+            match mode {
+                PurgeMode::Old => {
+                    database.purge_run(&id)?;
+                    info!("Purged all results for '{}'", id);
+                }
+                PurgeMode::Failed => {
+                    let count = database.purge_failed_benchmarks(&id)?;
+                    info!("Purged {} failed benchmarks for '{}'", count, id);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn load_result(id: &str, db_path: &Path) -> Result<model::RunResult> {
+    let database = SqliteDatabase::open(db_path)?;
+    database.load_run(id).with_context(|| format!("failed to load run '{}' from database", id))
+}
+
+/// Timing engine to use for benchmarks.
+#[derive(Debug, Clone, Copy, ValueEnum, Default)]
+pub enum Engine {
+    /// Use hyperfine if available, otherwise fall back to builtin.
+    #[default]
+    Auto,
+    /// Always use the builtin timing engine.
+    Builtin,
+    /// Always use hyperfine (fails if not installed).
+    Hyperfine,
+}
+
+/// Purge mode for cached results.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum PurgeMode {
+    /// Delete entire run (all benchmarks for this run ID).
+    Old,
+    /// Delete only failed benchmarks (success = false) for this run ID.
+    Failed,
+}
+
+/// Build scenario for benchmarks.
+#[derive(Debug, Clone, Copy, ValueEnum, Default, PartialEq, Eq, Hash)]
+pub enum Scenario {
+    /// Clean build: delete target directory before each run.
+    #[default]
+    Clean,
+    /// Incremental build: keep target directory between runs.
+    Incremental,
+}
+
+impl Scenario {
+    /// Returns the scenario name as a string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Scenario::Clean => "clean",
+            Scenario::Incremental => "incremental",
+        }
+    }
+
+    /// Returns default scenarios (clean only; incremental requires cairo support).
+    pub fn defaults() -> Vec<Scenario> {
+        vec![Scenario::Clean]
+    }
+}
+
+/// Metric type to measure.
+#[derive(Debug, Clone, Copy, ValueEnum, Default, PartialEq, Eq, Hash)]
+pub enum Metric {
+    /// Wall-clock execution time.
+    #[default]
+    Walltime,
+}
+
+impl Metric {
+    /// Returns the metric name as a string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Metric::Walltime => "walltime",
+        }
+    }
+}
+
+/// Compilation phase to measure.
+#[derive(Debug, Clone, Copy, ValueEnum, Default, PartialEq, Eq, Hash)]
+pub enum Phase {
+    /// Full compilation pipeline: source to Sierra (cairo-compile).
+    #[default]
+    Full,
+}
+
+impl Phase {
+    /// Returns the phase name as a string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Phase::Full => "full",
+        }
+    }
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run benchmarks and store results.
+    Run {
+        /// Identifier for this run (stored in database).
+        id: Option<String>,
+
+        /// Directory containing benchmark subdirectories with benchmark.toml files.
+        #[arg(long, default_value = "crates/bin/cairo-metrics/benchmarks")]
+        benchmarks_dir: PathBuf,
+
+        #[command(flatten)]
+        db: DbOption,
+
+        /// Run only benchmarks whose name contains one of these substrings.
+        #[arg(long, value_delimiter = ',')]
+        include: Vec<String>,
+
+        /// Skip benchmarks whose name contains one of these substrings.
+        #[arg(long, value_delimiter = ',')]
+        exclude: Vec<String>,
+
+        /// Override default number of measured iterations for all benchmarks.
+        #[arg(long)]
+        iterations: Option<usize>,
+
+        /// Override default number of warmup runs for all benchmarks.
+        #[arg(long)]
+        warmup: Option<usize>,
+
+        /// Timing engine: auto (default), builtin, or hyperfine.
+        #[arg(long, value_enum, default_value_t = Engine::Auto)]
+        engine: Engine,
+
+        /// Build scenarios: clean (default) or incremental (not yet supported).
+        #[arg(long, value_enum, value_delimiter = ',', default_values_t = Scenario::defaults())]
+        scenarios: Vec<Scenario>,
+
+        /// Compilation phases to measure.
+        #[arg(long, value_enum, value_delimiter = ',', default_value = "full")]
+        phases: Vec<Phase>,
+
+        /// Metrics to measure.
+        #[arg(long, value_enum, value_delimiter = ',', default_value = "walltime")]
+        metrics: Vec<Metric>,
+
+        /// Purge cached results: 'old' deletes all, 'failed' deletes only failed benchmarks.
+        #[arg(long, value_enum)]
+        purge: Option<PurgeMode>,
+    },
+
+    /// Compare two benchmark runs. Without arguments, launches interactive TUI.
+    Compare {
+        /// Baseline run ID from database. Omit to use TUI selector.
+        baseline: Option<String>,
+
+        /// Current run ID from database. Omit to use TUI selector.
+        current: Option<String>,
+
+        /// Filter comparison to specific phases.
+        #[arg(long, value_enum, value_delimiter = ',')]
+        phases: Vec<Phase>,
+
+        #[command(flatten)]
+        db: DbOption,
+    },
+
+    /// List stored benchmark runs.
+    List {
+        /// Maximum number of runs to show.
+        #[arg(long, default_value = "100")]
+        limit: u32,
+
+        #[command(flatten)]
+        db: DbOption,
+    },
+
+    /// Show history for a specific benchmark.
+    History {
+        /// Benchmark name to show history for.
+        benchmark: String,
+
+        /// Maximum number of results to show.
+        #[arg(long, default_value = "100")]
+        limit: u32,
+
+        #[command(flatten)]
+        db: DbOption,
+    },
+
+    /// Delete a run from the database.
+    Purge {
+        /// Run ID to delete.
+        id: String,
+
+        /// Purge mode: 'old' deletes entire run, 'failed' deletes only failed benchmarks.
+        #[arg(long, value_enum, default_value_t = PurgeMode::Old)]
+        mode: PurgeMode,
+
+        #[command(flatten)]
+        db: DbOption,
+    },
+}
+
+/// Shared database path option.
+#[derive(Debug, Args)]
+struct DbOption {
+    /// Path to SQLite database for storing benchmark results.
+    /// Defaults to `results.db`, which is ignored by git.
+    #[arg(long, default_value = "results.db")]
+    db: PathBuf,
+}
+
+#[derive(Parser)]
+#[command(name = "cairo-metrics", version, about = "Benchmark harness for the Cairo compiler")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}

--- a/crates/bin/cairo-metrics/src/model.rs
+++ b/crates/bin/cairo-metrics/src/model.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+
+/// Format a display name from benchmark components.
+pub fn format_display_name(
+    benchmark: &str,
+    scenario: &str,
+    patch: &str,
+    phase: &str,
+    metric: &str,
+) -> String {
+    if patch.is_empty() {
+        format!("{}-{}-{}-{}", benchmark, scenario, phase, metric)
+    } else {
+        format!("{}-patched-{}-{}-{}", benchmark, patch, phase, metric)
+    }
+}
+
+/// Metadata about a benchmark run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunMeta {
+    pub timestamp_utc: String,
+    pub git_commit: Option<String>,
+}
+
+/// Top-level result of a benchmark run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunResult {
+    pub meta: RunMeta,
+    pub benchmarks: Vec<BenchmarkResult>,
+}
+
+/// Result of a single benchmark.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkResult {
+    /// Benchmark name (e.g., "corelib", "openzeppelin").
+    pub benchmark: String,
+    /// Build scenario (e.g., "clean", "incremental").
+    pub scenario: String,
+    /// Patch name for incremental builds, empty string for clean builds.
+    pub patch: String,
+    /// Compilation phase (e.g., "diagnostics", "sierra", "casm").
+    pub phase: String,
+    /// Metric type (e.g., "walltime").
+    pub metric: String,
+    /// Timing statistics.
+    pub timing: TimingStats,
+    /// Whether the benchmark completed successfully.
+    pub success: bool,
+}
+
+impl BenchmarkResult {
+    /// Returns a flat display name for this result (for compatibility and display).
+    pub fn display_name(&self) -> String {
+        format_display_name(&self.benchmark, &self.scenario, &self.patch, &self.phase, &self.metric)
+    }
+}
+
+/// Timing statistics for a benchmark (all durations in nanoseconds).
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct TimingStats {
+    /// Number of timed iterations (excluding warmup).
+    pub runs: usize,
+    /// Number of warmup iterations (not included in statistics).
+    // Default to 0, consider removing if not helpful, as this wastes time.
+    pub warmup: usize,
+    /// Raw timing data for all runs. Preserved for future analysis or re-computation.
+    pub times_ns: Vec<u64>,
+    /// Arithmetic mean. Sensitive to outliers; prefer median for comparisons.
+    pub mean_ns: u64,
+    /// Standard deviation. Pair with mean; for robust dispersion use MAD instead.
+    pub stddev_ns: u64,
+    /// Median (50th percentile). Primary metric for regression detection.
+    pub median_ns: u64,
+    /// Median absolute deviation. Measures benchmark stability; high values indicate noise.
+    pub mad_ns: u64,
+    /// Fastest observed run. Useful for spotting best-case performance.
+    pub min_ns: u64,
+    /// Slowest observed run. Large max/median ratio suggests system interference.
+    pub max_ns: u64,
+}

--- a/crates/bin/cairo-metrics/src/runner.rs
+++ b/crates/bin/cairo-metrics/src/runner.rs
@@ -1,0 +1,81 @@
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::{env, fs};
+
+use anyhow::{Context, Result};
+
+static CAIRO_COMPILE_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Returns the path to cairo-compile binary.
+/// First checks for sibling binary (same dir as cairo-metrics), then falls back to PATH.
+pub fn cairo_compile_path() -> &'static Path {
+    CAIRO_COMPILE_PATH.get_or_init(|| {
+        // Try sibling binary first (for local development).
+        if let Ok(exe) = env::current_exe()
+            && let Some(dir) = exe.parent()
+        {
+            let sibling = dir.join("cairo-compile");
+            if sibling.exists() {
+                tracing::debug!("Using sibling cairo-compile: {}", sibling.display());
+                return sibling;
+            }
+        }
+        // Fall back to PATH lookup.
+        tracing::debug!("Using cairo-compile from PATH");
+        PathBuf::from("cairo-compile")
+    })
+}
+
+/// Temporary directory with automatic cleanup.
+pub struct TempDir(PathBuf);
+
+impl TempDir {
+    /// Create a new temp directory for the given benchmark.
+    pub fn new(name: &str) -> Result<Self> {
+        let path = env::temp_dir().join(format!("cairo-metrics-{name}"));
+        if path.exists() {
+            fs::remove_dir_all(&path).with_context(|| {
+                format!("failed to clean existing temp dir: {}", path.display())
+            })?;
+        }
+        fs::create_dir_all(&path)
+            .with_context(|| format!("failed to create temp dir: {}", path.display()))?;
+        Ok(Self(path))
+    }
+
+    /// Returns the path to the temp directory.
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Deep copy a directory.
+pub fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir_all(dst).with_context(|| format!("failed to create dir: {}", dst.display()))?;
+
+    for entry in
+        fs::read_dir(src).with_context(|| format!("failed to read dir: {}", src.display()))?
+    {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if src_path.is_dir() {
+            // Optimization: Skip target directory.
+            if entry.file_name() == "target" {
+                continue;
+            }
+            copy_dir(&src_path, &dst_path)?;
+        } else {
+            fs::copy(&src_path, &dst_path)
+                .with_context(|| format!("failed to copy: {}", src_path.display()))?;
+        }
+    }
+    Ok(())
+}

--- a/crates/bin/cairo-metrics/src/stats.rs
+++ b/crates/bin/cairo-metrics/src/stats.rs
@@ -1,0 +1,79 @@
+//! Statistical functions for benchmark analysis.
+//!
+//! This module provides robust statistics for noisy CI environments:
+//!
+//! - **median**: Primary metric for comparing runs. Resistant to outliers from system noise.
+//! - **MAD**: Measures benchmark stability. High MAD/median ratio indicates unreliable results.
+//! - **mean/stddev**: Provided for completeness, but prefer median/MAD for regression detection.
+//! - **min/max**: Useful for spotting anomalies, not for comparisons.
+
+use anyhow::Result;
+
+use crate::model::TimingStats;
+
+#[cfg(test)]
+#[path = "stats_test.rs"]
+mod tests;
+
+/// Compute timing statistics from a slice of wall-clock times in nanoseconds.
+pub fn compute_stats(times: &[u64], runs: usize, warmup: usize) -> Result<TimingStats> {
+    let n = times.len();
+    if n == 0 {
+        return Ok(TimingStats { runs, warmup, ..Default::default() });
+    }
+
+    // Compute mean/stddev before sorting (doesn't need sorted data).
+    let times_f64: Vec<f64> = times.iter().map(|&x| x as f64).collect();
+    let mean_f64 = times_f64.iter().sum::<f64>() / n as f64;
+
+    let variance = if n > 1 {
+        times_f64.iter().map(|x| (x - mean_f64).powi(2)).sum::<f64>() / (n - 1) as f64
+    } else {
+        0.0
+    };
+    let stddev_f64 = variance.sqrt();
+
+    // Sort for median/min/max.
+    let mut sorted: Vec<u64> = times.to_vec();
+    sorted.sort();
+
+    let median = median_of_sorted(&sorted);
+    let mad = compute_mad(times, median);
+
+    Ok(TimingStats {
+        runs,
+        warmup,
+        times_ns: times.to_vec(),
+        mean_ns: mean_f64.round() as u64,
+        stddev_ns: stddev_f64.round() as u64,
+        median_ns: median,
+        mad_ns: mad,
+        min_ns: sorted[0],
+        max_ns: sorted[n - 1],
+    })
+}
+
+/// Computes MAD (median absolute deviation) from times and their median.
+///
+/// MAD measures dispersion around the median. Use MAD/median (relative MAD) to assess
+/// benchmark stability: values above 5% suggest high noise, making regression detection
+/// unreliable.
+pub fn compute_mad(times: &[u64], median: u64) -> u64 {
+    if times.len() < 3 {
+        return 0;
+    }
+    let mut abs_devs: Vec<u64> = times.iter().map(|&x| x.abs_diff(median)).collect();
+    abs_devs.sort();
+    median_of_sorted(&abs_devs)
+}
+
+/// Computes median of a sorted slice with proper rounding for even-length arrays.
+fn median_of_sorted(sorted: &[u64]) -> u64 {
+    let n = sorted.len();
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        // Round half up: (a + b + 1) / 2
+        (sorted[n / 2 - 1] + sorted[n / 2]).div_ceil(2)
+    }
+}

--- a/crates/bin/cairo-metrics/src/stats_test.rs
+++ b/crates/bin/cairo-metrics/src/stats_test.rs
@@ -1,0 +1,67 @@
+use crate::stats::{compute_mad, compute_stats};
+
+#[test]
+fn test_mean_simple() {
+    let stats = compute_stats(&[1, 2, 3], 3, 1).unwrap();
+    assert_eq!(stats.mean_ns, 2);
+}
+
+#[test]
+fn test_median_odd() {
+    let stats = compute_stats(&[3, 1, 2], 3, 1).unwrap();
+    assert_eq!(stats.median_ns, 2);
+}
+
+#[test]
+fn test_median_even() {
+    // [1, 2, 3, 4] -> median = (2 + 3) / 2 = 2.5, rounds to 3.
+    let stats = compute_stats(&[1, 2, 3, 4], 4, 1).unwrap();
+    assert_eq!(stats.median_ns, 3);
+}
+
+#[test]
+fn test_min_max() {
+    let stats = compute_stats(&[5, 1, 3], 3, 1).unwrap();
+    assert_eq!(stats.min_ns, 1);
+    assert_eq!(stats.max_ns, 5);
+}
+
+#[test]
+fn test_stddev() {
+    // [1, 2, 3] -> mean=2, variance=((1-2)^2 + (2-2)^2 + (3-2)^2) / 2 = 1, stddev=1.
+    let stats = compute_stats(&[1, 2, 3], 3, 1).unwrap();
+    assert_eq!(stats.stddev_ns, 1);
+}
+
+#[test]
+fn test_stddev_single_value() {
+    let stats = compute_stats(&[5], 1, 0).unwrap();
+    assert_eq!(stats.stddev_ns, 0);
+}
+
+#[test]
+fn test_mad_simple() {
+    // [1, 2, 3, 4, 5] -> median=3, deviations=[2, 1, 0, 1, 2], sorted=[0, 1, 1, 2, 2], MAD=1.
+    let stats = compute_stats(&[1, 2, 3, 4, 5], 5, 1).unwrap();
+    assert_eq!(stats.mad_ns, 1);
+}
+
+#[test]
+fn test_mad_too_few_samples() {
+    let stats = compute_stats(&[1, 2], 2, 0).unwrap();
+    assert_eq!(stats.mad_ns, 0);
+}
+
+#[test]
+fn test_empty_times() {
+    let stats = compute_stats(&[], 0, 0).unwrap();
+    assert_eq!(stats.mean_ns, 0);
+    assert_eq!(stats.median_ns, 0);
+    assert_eq!(stats.min_ns, 0);
+    assert_eq!(stats.max_ns, 0);
+}
+
+#[test]
+fn test_compute_mad_standalone() {
+    assert_eq!(compute_mad(&[1, 2, 3, 4, 5], 3), 1);
+}

--- a/crates/bin/cairo-metrics/src/tui.rs
+++ b/crates/bin/cairo-metrics/src/tui.rs
@@ -1,0 +1,225 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Row, Table};
+
+use crate::compare::{RunDiff, diff_runs};
+use crate::database::{Database, RunInfo, SqliteDatabase};
+use crate::format::format_duration;
+use crate::model::RunResult;
+
+/// Launch interactive TUI for comparing benchmark runs.
+pub fn run_tui(db_path: &Path) -> Result<()> {
+    let database = SqliteDatabase::open(db_path)?;
+    let runs = database.list_runs(1000)?;
+    drop(database);
+
+    anyhow::ensure!(
+        !runs.is_empty(),
+        "No runs in database. Run benchmarks first with: cairo-metrics run"
+    );
+    anyhow::ensure!(runs.len() >= 2, "Need at least 2 runs to compare. Found only {}.", runs.len());
+
+    enable_raw_mode()?;
+    let mut terminal = ratatui::init();
+    let mut app = App::new(runs, db_path.to_path_buf());
+
+    loop {
+        terminal.draw(|f| draw(&mut app, f))?;
+
+        if let Event::Key(key) = event::read()?
+            && app.handle_key(key.code)?
+        {
+            break;
+        }
+    }
+
+    disable_raw_mode()?;
+    ratatui::restore();
+    Ok(())
+}
+
+fn load_run(db_path: &Path, id: &str) -> Result<RunResult> {
+    let database = SqliteDatabase::open(db_path)?;
+    database.load_run(id)
+}
+
+fn draw(app: &mut App, frame: &mut Frame<'_>) {
+    match &app.screen {
+        Screen::SelectBaseline => draw_select(app, frame, "Select BASELINE run"),
+        Screen::SelectCurrent { baseline } => {
+            draw_select(app, frame, &format!("Select CURRENT run (baseline: {})", baseline.id))
+        }
+        Screen::Compare { baseline, current, diff } => draw_compare(frame, baseline, current, diff),
+    }
+}
+
+fn draw_select(app: &mut App, frame: &mut Frame<'_>, title: &str) {
+    let items: Vec<ListItem<'_>> = app
+        .runs
+        .iter()
+        .map(|r| {
+            let commit = r.git_commit.as_deref().unwrap_or("-");
+            let text = format!("{:<20} {} {}", r.id, &r.timestamp[..19], commit);
+            ListItem::new(text)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .highlight_style(Style::default().bg(Color::DarkGray).bold())
+        .highlight_symbol("> ");
+
+    frame.render_stateful_widget(list, frame.area(), &mut app.list_state);
+
+    let help = Paragraph::new("↑/↓: navigate | Enter: select | Backspace: back | q: quit")
+        .style(Style::default().fg(Color::DarkGray));
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(frame.area());
+    frame.render_widget(help, chunks[1]);
+}
+
+fn draw_compare(frame: &mut Frame<'_>, baseline: &RunInfo, current: &RunInfo, diff: &RunDiff) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0), Constraint::Length(1)])
+        .split(frame.area());
+
+    let header_text = format!("Comparing: {} (baseline) vs {} (current)", baseline.id, current.id);
+    let header = Paragraph::new(header_text).block(Block::default().borders(Borders::ALL));
+    frame.render_widget(header, chunks[0]);
+
+    let rows: Vec<Row<'_>> = diff
+        .entries
+        .iter()
+        .map(|e| {
+            let emoji = if e.delta_pct > 0.0 {
+                "❌"
+            } else if e.delta_pct < 0.0 {
+                "✅"
+            } else {
+                "  "
+            };
+            let style = if e.delta_pct > 0.0 {
+                Style::default().fg(Color::Red)
+            } else if e.delta_pct < 0.0 {
+                Style::default().fg(Color::Green)
+            } else {
+                Style::default()
+            };
+            Row::new(vec![
+                e.name.clone(),
+                format_duration(e.base_median),
+                format_duration(e.current_median),
+                format!("{:+.1}%", e.delta_pct),
+                emoji.to_string(),
+            ])
+            .style(style)
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(40),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+            Constraint::Percentage(15),
+        ],
+    )
+    .header(
+        Row::new(vec!["Benchmark", "Baseline", "Current", "Diff", ""])
+            .style(Style::default().bold()),
+    )
+    .block(Block::default().title("Results").borders(Borders::ALL));
+
+    frame.render_widget(table, chunks[1]);
+
+    let help = Paragraph::new("Backspace: back to selection | q: quit")
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(help, chunks[2]);
+}
+
+enum Screen {
+    SelectBaseline,
+    SelectCurrent { baseline: RunInfo },
+    Compare { baseline: RunInfo, current: RunInfo, diff: RunDiff },
+}
+
+struct App {
+    runs: Vec<RunInfo>,
+    list_state: ListState,
+    screen: Screen,
+    db_path: PathBuf,
+}
+
+impl App {
+    fn new(runs: Vec<RunInfo>, db_path: PathBuf) -> Self {
+        let mut list_state = ListState::default();
+        if !runs.is_empty() {
+            list_state.select(Some(0));
+        }
+        Self { runs, list_state, screen: Screen::SelectBaseline, db_path }
+    }
+
+    fn selected_run(&self) -> Option<&RunInfo> {
+        self.list_state.selected().and_then(|i| self.runs.get(i))
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> Result<bool> {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return Ok(true),
+            KeyCode::Down | KeyCode::Char('j') => {
+                if let Some(i) = self.list_state.selected()
+                    && i < self.runs.len().saturating_sub(1)
+                {
+                    self.list_state.select(Some(i + 1));
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if let Some(i) = self.list_state.selected()
+                    && i > 0
+                {
+                    self.list_state.select(Some(i - 1));
+                }
+            }
+            KeyCode::Enter => {
+                if let Some(run) = self.selected_run().cloned() {
+                    match &self.screen {
+                        Screen::SelectBaseline => {
+                            self.screen = Screen::SelectCurrent { baseline: run };
+                            self.list_state.select(Some(0));
+                        }
+                        Screen::SelectCurrent { baseline } => {
+                            let baseline_result = load_run(&self.db_path, &baseline.id)?;
+                            let current_result = load_run(&self.db_path, &run.id)?;
+                            let diff = diff_runs(&baseline_result, &current_result);
+                            self.screen =
+                                Screen::Compare { baseline: baseline.clone(), current: run, diff };
+                        }
+                        Screen::Compare { .. } => {}
+                    }
+                }
+            }
+            KeyCode::Backspace => match &self.screen {
+                Screen::SelectBaseline => {}
+                Screen::SelectCurrent { .. } => {
+                    self.screen = Screen::SelectBaseline;
+                    self.list_state.select(Some(0));
+                }
+                Screen::Compare { baseline, .. } => {
+                    self.screen = Screen::SelectCurrent { baseline: baseline.clone() };
+                    self.list_state.select(Some(0));
+                }
+            },
+            _ => {}
+        }
+        Ok(false)
+    }
+}

--- a/crates/bin/get-lowering/Cargo.toml
+++ b/crates/bin/get-lowering/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "2.15.0" }
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.15.0" }
 cairo-lang-debug = { path = "../../cairo-lang-debug", version = "2.15.0" }
 cairo-lang-defs = { path = "../../cairo-lang-defs", version = "2.15.0" }
 cairo-lang-executable-plugin = { path = "../../cairo-lang-executable-plugin", version = "=2.15.0" }


### PR DESCRIPTION
## Summary

- Introduce `cairo-metrics`: a small CLI that currently checks wall-clock regressions from main.
- Persist results in `repo_root/results.db` (git-ignored), currently SQLite keyed by run
    id (defaults to current git SHA). This enables caching and tracking results across time locally by
    checking out builds starting from this commit, and having the tool populate the db.
    The tool then allows comparisons based on the db results. Future work can easily extend this to
    a stateful DB machine (like RDS), since the DB is behind a trait.
- Add a GitHub Actions workflow that benchmarks baseline vs PR, reuses cached baseline results
    via artifacts (saves ci runtime for multiple PR runs over the same base branch), and posts a
    “Benchmark Comparison” PR comment, not blocking, the reviewer decided.
- Seed initial benchmark suites (corelib + OpenZeppelin): corelib uses local src, and openzepplin
    is bundeled as a vendored release (not a submodule for simplicity).
- Walltime engine is either home-brewed timed comparison of the compiler library,
    or via `hyperfine` which uses the binary. It uses hyperfine by
    default if available (need to install with `apt`) otherwise the builtin.
    This is useful locally, to debug the builtin engine itself
    (results are similar since hyperfine cancels out shell overhead), and since
    hyperfine outputs useful statistical anomaly messages.
    But if hyperfine is a pain to maintain it can be removed.


---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

Implemented a benchmarking harness for testing and tracking performance regressions

---

## What was the behavior or documentation before?

<!-- Optional but encouraged, especially for docs-only changes -->

---

## What is the behavior or documentation after?

<!-- Optional but encouraged -->

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

<!--
Anything else reviewers should know.
If this is a documentation PR, explain why this change is important for users.
-->

