### PR TITLE
Using `postcard` instead of unmaintained `bincode`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,7 +521,6 @@ dependencies = [
 name = "cairo-lang-defs"
 version = "2.15.0"
 dependencies = [
- "bincode",
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -523,6 +531,7 @@ dependencies = [
  "cairo-lang-utils",
  "indoc",
  "itertools 0.14.0",
+ "postcard",
  "pretty_assertions",
  "salsa",
  "serde",
@@ -681,7 +690,6 @@ name = "cairo-lang-lowering"
 version = "2.15.0"
 dependencies = [
  "assert_matches",
- "bincode",
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -700,6 +708,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "postcard",
  "pretty_assertions",
  "salsa",
  "serde",
@@ -839,7 +848,6 @@ dependencies = [
 name = "cairo-lang-semantic"
 version = "2.15.0"
 dependencies = [
- "bincode",
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -856,6 +864,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-traits",
+ "postcard",
  "pretty_assertions",
  "salsa",
  "serde",
@@ -1318,6 +1327,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1440,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1564,6 +1588,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -1948,6 +1984,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2024,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2915,6 +2974,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,6 +3720,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "sprs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ num-integer = "0.1.46"
 num-traits = { version = "0.2.19", default-features = false }
 parity-scale-codec = { version = "3.7.5", default-features = false, features = ["derive"] }
 path-clean = "1.0.1"
+postcard = { version = "1.1.3", features = ["alloc"] }
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.95"
 quote = "1.0.40"

--- a/crates/cairo-lang-defs/Cargo.toml
+++ b/crates/cairo-lang-defs/Cargo.toml
@@ -7,7 +7,6 @@ license-file.workspace = true
 description = "Handling of definitions of language items in Cairo."
 
 [dependencies]
-bincode.workspace = true
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.15.0" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.15.0" }
 cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.15.0" }
@@ -16,6 +15,7 @@ cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.15.
 cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.15.0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.15.0", features = ["tracing"] }
 itertools = { workspace = true, default-features = true }
+postcard.workspace = true
 salsa.workspace = true
 serde = { workspace = true, default-features = true }
 typetag.workspace = true

--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -98,14 +98,13 @@ pub fn load_cached_crate_modules<'db>(
 
     let content = &content[8..size + 8];
 
-    let ((metadata, module_data, defs_lookups), _): (DefCache<'_>, _) =
-        bincode::serde::borrow_decode_from_slice(content, bincode::config::standard())
-            .unwrap_or_else(|e| {
-                panic!(
-                    "failed to deserialize modules cache for crate `{}`: {e}",
-                    crate_id.long(db).name().long(db),
-                )
-            });
+    let (metadata, module_data, defs_lookups): DefCache<'_> = postcard::from_bytes(content)
+        .unwrap_or_else(|e| {
+            panic!(
+                "failed to deserialize modules cache for crate `{}`: {e}",
+                crate_id.long(db).name().long(db),
+            )
+        });
 
     validate_metadata(crate_id, &metadata, db);
 

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -8,7 +8,6 @@ description = "Cairo lowering phase."
 
 [dependencies]
 assert_matches.workspace = true
-bincode.workspace = true
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.15.0" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.15.0" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.15.0" }
@@ -24,6 +23,7 @@ log.workspace = true
 num-bigint = { workspace = true, default-features = true }
 num-integer = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
+postcard.workspace = true
 salsa.workspace = true
 serde = { workspace = true, default-features = true }
 starknet-types-core.workspace = true

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -10,7 +10,6 @@ description = "Cairo semantic model."
 testing = ["dep:cairo-lang-test-utils", "dep:toml"]
 
 [dependencies]
-bincode.workspace = true
 cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.15.0" }
 cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.15.0" }
 cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.15.0" }
@@ -28,6 +27,7 @@ indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
+postcard.workspace = true
 salsa.workspace = true
 serde.workspace = true
 sha3.workspace = true

--- a/crates/cairo-lang-semantic/src/cache/mod.rs
+++ b/crates/cairo-lang-semantic/src/cache/mod.rs
@@ -85,14 +85,13 @@ pub fn load_cached_crate_modules_semantic<'db>(
 
     let content = &content[semantic_start + 8..semantic_start + 8 + semantic_size];
 
-    let ((module_data, semantic_lookups), _): (SemanticCache<'_>, _) =
-        bincode::serde::borrow_decode_from_slice(content, bincode::config::standard())
-            .unwrap_or_else(|e| {
-                panic!(
-                    "failed to deserialize modules cache for crate `{}`: {e}",
-                    crate_id.long(db).name().long(db),
-                )
-            });
+    let (module_data, semantic_lookups): SemanticCache<'_> = postcard::from_bytes(content)
+        .unwrap_or_else(|e| {
+            panic!(
+                "failed to deserialize modules cache for crate `{}`: {e}",
+                crate_id.long(db).name().long(db),
+            )
+        });
 
     let mut ctx = SemanticCacheLoadingContext::new(db, semantic_lookups, def_loading_data);
     Some(ModuleSemanticDataCacheAndLoadingData {


### PR DESCRIPTION
## Summary

Replace `bincode` with `postcard` for serialization in the Cairo compiler cache system. This change affects the `cairo-lang-defs`, `cairo-lang-lowering`, and `cairo-lang-semantic` crates, updating their serialization/deserialization logic to use the more efficient `postcard` format.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `postcard` serialization format is more efficient than `bincode` for our use case, providing smaller binary sizes and potentially faster serialization/deserialization. This should improve compiler performance when reading from and writing to the cache.

---

## What was the behavior or documentation before?

The compiler used `bincode` for serialization of cache data, which worked but wasn't as efficient as it could be.

---

## What is the behavior or documentation after?

The compiler now uses `postcard` for serialization, which should result in smaller cache files and potentially faster cache operations.

---

## Additional context

This change required updating error handling to match the new serialization library's error types. The core functionality remains the same, but the underlying implementation is more efficient.