### PR TITLE
Explicitly implementing execute-result file writing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,18 +298,8 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
- "bincode_derive",
  "serde",
  "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -431,7 +421,6 @@ name = "cairo-execute"
 version = "2.15.0"
 dependencies = [
  "anyhow",
- "bincode",
  "cairo-lang-compiler",
  "cairo-lang-debug",
  "cairo-lang-executable",
@@ -4470,12 +4459,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ ark-secp256r1 = "0.5.0"
 ark-std = "0.5.0"
 assert_matches = "1.5"
 bimap = "0.6.3"
-bincode = { version = "2", features = ["serde"] }
 cairo-lang-primitive-token = "1"
 cairo-vm = { version = "3.0.0", features = ["mod_builtin"] }
 clap = { version = "4.5.42", features = ["derive"] }

--- a/crates/bin/cairo-execute/Cargo.toml
+++ b/crates/bin/cairo-execute/Cargo.toml
@@ -8,7 +8,6 @@ description = "Executable for creating executables and running them for the Cair
 
 [dependencies]
 anyhow.workspace = true
-bincode.workspace = true
 cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.15.0" }
 cairo-lang-debug = { path = "../../cairo-lang-debug", version = "=2.15.0" }
 cairo-lang-executable = { path = "../../cairo-lang-executable", version = "=2.15.0" }


### PR DESCRIPTION
## Summary

Replaced `bincode` serialization with custom encoding for trace and memory files in `cairo-execute`. This PR removes the `bincode` dependency and implements direct binary encoding for relocated trace entries and memory cells.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [X] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `bincode` dependency was unnecessary for the simple serialization needs of trace and memory files. By implementing direct binary encoding, we reduce dependencies.

---

## What was the behavior or documentation before?

Previously, the code used `bincode` to serialize trace entries and memory cells to files, requiring additional dependencies (`bincode`, `bincode_derive`, and `virtue`).

---

## What is the behavior or documentation after?

Now, trace entries and memory cells are directly encoded as binary data without using a serialization library. The implementation writes the data in the same format but with custom encoding functions that write the raw bytes directly to the output files.

---

## Additional context

This change simplifies the codebase by removing unnecessary dependencies while maintaining the same functionality. The custom encoding functions are straightforward and match the previous binary format.