### PR TITLE
docs: fix panic_with terminology from macro to attribute

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
@@ -38,10 +38,10 @@ If a trait function is not marked with `nopanic`, all implementations of that tr
 with `nopanic` or not.
 An example for such a function is `Add` trait `add` function, which is _nopanic_ for `felt252` addition, but isn't so for integer addition.
 
-== `panic_with` macro
+== `panic_with` attribute
 
-A function returning an `Option` or `Result` may be marked with the `panic_with` macro.
-This macro takes two arguments: the data that is passed as the panic reason as well as the
+A function returning an `Option` or `Result` may be marked with the `panic_with` attribute.
+This attribute takes two arguments: the data that is passed as the panic reason as well as the
 name for a wrapping function.
 If the function returns `None` or `Err`, _panic_ function will be called with the given data.
 


### PR DESCRIPTION
## Summary

Fix terminology in panic documentation: replace "macro" with "attribute" for `panic_with` to match the actual implementation. The `panic_with` is processed as an attribute via `MacroPlugin`, not as an inline macro expression.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The documentation incorrectly refers to `panic_with` as a "macro" when it is technically an attribute. This creates confusion because:

1. The implementation uses `#[panic_with(...)]` syntax, which is attribute syntax
2. The code processes it via `MacroPlugin.declared_attributes()` and `query_attr()`, treating it as an attribute
3. Comments in the source code (`panicable.rs`) consistently refer to it as an "attribute"
4. This mismatch between documentation and implementation can mislead developers trying to understand how the feature works

While Cairo's documentation sometimes uses "macro" for code-generating attributes (like `derive`), using the technically accurate term "attribute" here aligns with the implementation and reduces confusion.

---

## What was the behavior or documentation before?

The documentation stated:
- Section heading: `== `panic_with` macro`
- Description: "A function returning an `Option` or `Result` may be marked with the `panic_with` macro."
- "This macro takes two arguments..."

---

## What is the behavior or documentation after?

The documentation now states:
- Section heading: `== `panic_with` attribute`
- Description: "A function returning an `Option` or `Result` may be marked with the `panic_with` attribute."
- "This attribute takes two arguments..."

The functionality remains unchanged; only the terminology is corrected to match the implementation.

---

## Related issue or discussion (if any)

<!--
No related issue. This is a documentation accuracy fix identified during code review.
-->

---

## Additional context

This change improves technical accuracy. The `panic_with` feature is implemented as an attribute processed by the `PanicablePlugin` which implements `MacroPlugin` trait. While `MacroPlugin` can handle both attributes and macros, in this case it specifically processes `panic_with` as an attribute (via `declared_attributes()` and `query_attr()`), not as an inline macro expression.

The fix ensures documentation terminology matches the codebase, making it easier for developers to understand the feature's implementation and find relevant code when needed.