### PR TITLE
More propely building `format` and `full_path`.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -66,7 +66,7 @@ impl<'db> ImplGenericFunctionId<'db> {
         }
     }
     pub fn format(&self, db: &dyn Database) -> String {
-        format!("{}::{}", self.impl_id.name(db), self.function.name(db).long(db))
+        format!("{}::{}", self.impl_id.format(db), self.function.name(db).long(db))
     }
 }
 impl<'db> DebugWithDb<'db> for ImplGenericFunctionId<'db> {
@@ -116,9 +116,7 @@ impl<'db> GenericFunctionId<'db> {
         match self {
             GenericFunctionId::Free(id) => id.full_path(db),
             GenericFunctionId::Extern(id) => id.full_path(db),
-            GenericFunctionId::Impl(id) => {
-                format!("{:?}::{}", id.impl_id.debug(db), id.function.name(db).long(db))
-            }
+            GenericFunctionId::Impl(id) => id.format(db),
         }
     }
     pub fn generic_signature(&self, db: &'db dyn Database) -> Maybe<&'db Signature<'db>> {

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -214,22 +214,7 @@ impl<'db> ImplLongId<'db> {
         }
     }
     pub fn format(&self, db: &dyn Database) -> String {
-        match self {
-            ImplLongId::Concrete(concrete_impl) => {
-                format!("{:?}", concrete_impl.debug(db))
-            }
-            ImplLongId::GenericParameter(generic_param_impl) => {
-                generic_param_impl.format(db).to_string(db)
-            }
-            ImplLongId::ImplVar(var) => format!("{var:?}"),
-            ImplLongId::ImplImpl(impl_impl) => format!("{:?}", impl_impl.debug(db)),
-            ImplLongId::SelfImpl(concrete_trait_id) => {
-                format!("{:?}", concrete_trait_id.debug(db))
-            }
-            ImplLongId::GeneratedImpl(generated_impl) => {
-                format!("{:?}", generated_impl.debug(db))
-            }
-        }
+        format!("{:?}", self.debug(db))
     }
 
     /// Returns true if the `impl` does not depend on impl or type variables.
@@ -279,7 +264,7 @@ impl<'db> DebugWithDb<'db> for ImplLongId<'db> {
             ImplLongId::Concrete(concrete_impl_id) => {
                 write!(f, "{:?}", concrete_impl_id.debug(db))
             }
-            ImplLongId::GenericParameter(param) => write!(f, "{}", param.debug_name(db).long(db)),
+            ImplLongId::GenericParameter(param) => write!(f, "{}", param.format(db).long(db)),
             ImplLongId::ImplVar(var) => write!(f, "?{}", var.long(db).id.0),
             ImplLongId::ImplImpl(impl_impl) => write!(f, "{:?}", impl_impl.debug(db)),
             ImplLongId::SelfImpl(trait_impl) => write!(f, "{:?}", trait_impl.debug(db)),

--- a/crates/cairo-lang-semantic/src/items/tests/trait_type
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_type
@@ -2408,7 +2408,7 @@ trait TraitWithInferredParams<T, +OtherTrait<T>> {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::OtherTrait::<_::ty>.
+error[E2311]: Trait has no implementation in context: test::OtherTrait::<+MyTrait::ty>.
  --> lib.cairo:19:6
     +TraitWithInferredParams<MyTrait::ty>,
      ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Fixed the formatting of impl IDs in error messages by updating the `format` method in `ImplLongId` to use `debug` and correcting the implementation of `ImplGenericFunctionId::format` to use the formatted impl ID instead of just the name. This ensures more accurate and consistent error messages, particularly for trait implementations.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Error messages for trait implementations were displaying incomplete information. Specifically, in the case of generic parameter impls, the error message was showing a placeholder (`_::ty`) instead of the actual trait type (`+MyTrait::ty`), making it harder to understand the context of the error.

---

## What was the behavior or documentation before?

Error messages for missing trait implementations would show incomplete type information. For example:
```
error[E2311]: Trait has no implementation in context: test::OtherTrait::<_::ty>.
```

---

## What is the behavior or documentation after?

Error messages now show the complete type information, making it clearer what implementation is missing:
```
error[E2311]: Trait has no implementation in context: test::OtherTrait::<+MyTrait::ty>.
```

---

## Additional context

This change improves the developer experience by providing more accurate error messages when working with traits and implementations, making it easier to diagnose and fix issues related to missing trait implementations.