### PR TITLE
Refactor executable_plugin_suite to avoid unnecessary mem::take

### DIFF
--- a/crates/cairo-lang-executable-plugin/src/lib.rs
+++ b/crates/cairo-lang-executable-plugin/src/lib.rs
@@ -24,11 +24,9 @@ pub const EXECUTABLE_PREFIX: &str = "__executable_wrapper__";
 
 /// Returns a plugin suite with the `ExecutablePlugin` and `RawExecutableAnalyzer`.
 pub fn executable_plugin_suite() -> PluginSuite {
-    std::mem::take(
-        PluginSuite::default()
-            .add_plugin::<ExecutablePlugin>()
-            .add_analyzer_plugin::<RawExecutableAnalyzer>(),
-    )
+    let mut suite = PluginSuite::default();
+    suite.add_plugin::<ExecutablePlugin>().add_analyzer_plugin::<RawExecutableAnalyzer>();
+    suite
 }
 
 const IMPLICIT_PRECEDENCE: &[&str] = &[


### PR DESCRIPTION
## Summary

Use a local mutable PluginSuite instead of calling std::mem::take on a temporary.

---

## Type of change

Please check **one**:


- [ ] Performance improvement


---

## Why is this change needed?

This keeps the construction pattern consistent with other plugin suite helpers, simplifies the code and avoids an extra Default initialization without changing behavior.