### PR TITLE
refactor(semantic): Refactored formatting of generic args.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/fmt.rs
+++ b/crates/cairo-lang-semantic/src/expr/fmt.rs
@@ -42,26 +42,3 @@ impl<'db> DebugWithDb<'db> for StatementId {
         statement.fmt(f, db)
     }
 }
-
-/// A wrapper around std::fmt::Formatter that counts the number of characters written so far.
-pub struct CountingWriter<'a, 'b> {
-    inner: &'a mut std::fmt::Formatter<'b>,
-    count: usize,
-}
-
-impl<'a, 'b> CountingWriter<'a, 'b> {
-    pub fn new(inner: &'a mut std::fmt::Formatter<'b>) -> Self {
-        Self { inner, count: 0 }
-    }
-
-    pub fn count(&self) -> usize {
-        self.count
-    }
-}
-
-impl<'a, 'b> std::fmt::Write for CountingWriter<'a, 'b> {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.count += s.len();
-        self.inner.write_str(s)
-    }
-}

--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -1,4 +1,3 @@
-use std::fmt::Write;
 use std::sync::Arc;
 
 use cairo_lang_debug::DebugWithDb;
@@ -22,14 +21,13 @@ use syntax::attribute::consts::MUST_USE_ATTR;
 use syntax::node::TypedStablePtr;
 
 use super::attribute::SemanticQueryAttrs;
-use super::generics::{fmt_generic_args, generic_params_to_args};
+use super::generics::{displayable_concrete, generic_params_to_args};
 use super::imp::{ImplId, ImplLongId};
 use super::modifiers;
 use super::trt::ConcreteTraitGenericFunctionId;
 use crate::corelib::{CorelibSemantic, fn_traits, unit_ty};
 use crate::diagnostic::{SemanticDiagnosticKind, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::compute::Environment;
-use crate::expr::fmt::CountingWriter;
 use crate::items::extern_function::ExternFunctionSemantic;
 use crate::items::free_function::FreeFunctionSemantic;
 use crate::items::imp::ImplSemantic;
@@ -617,9 +615,11 @@ impl<'db> DebugWithDb<'db> for ConcreteFunctionWithBody<'db> {
     type Db = dyn Database;
 
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db dyn Database) -> std::fmt::Result {
-        let f = &mut CountingWriter::new(f);
-        write!(f, "{}", self.generic_function.full_path(db))?;
-        fmt_generic_args(&self.generic_args, f, db)
+        write!(
+            f,
+            "{}",
+            displayable_concrete(db, &self.generic_function.full_path(db), &self.generic_args)
+        )
     }
 }
 
@@ -707,9 +707,11 @@ impl<'db> DebugWithDb<'db> for ConcreteFunction<'db> {
     type Db = dyn Database;
 
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db dyn Database) -> std::fmt::Result {
-        let f = &mut CountingWriter::new(f);
-        write!(f, "{}", self.generic_function.format(db))?;
-        fmt_generic_args(&self.generic_args, f, db)
+        write!(
+            f,
+            "{}",
+            displayable_concrete(db, &self.generic_function.format(db), &self.generic_args)
+        )
     }
 }
 

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeSet;
-use std::fmt::Write;
 use std::hash::Hash;
 use std::sync::Arc;
 use std::{mem, panic, vec};
@@ -50,7 +49,7 @@ use super::functions::{
     forbid_inline_always_with_impl_generic_param,
 };
 use super::generics::{
-    GenericArgumentHead, GenericParamImpl, GenericParamsData, fmt_generic_args,
+    GenericArgumentHead, GenericParamImpl, GenericParamsData, displayable_concrete,
     generic_params_to_args, semantic_generic_params,
 };
 use super::impl_alias::{
@@ -72,7 +71,6 @@ use crate::db::get_resolver_data_options;
 use crate::diagnostic::SemanticDiagnosticKind::{self, *};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::compute::{ComputationContext, ContextFunction, Environment, compute_root_expr};
-use crate::expr::fmt::CountingWriter;
 use crate::expr::inference::canonic::ResultNoErrEx;
 use crate::expr::inference::conform::InferenceConform;
 use crate::expr::inference::infers::InferenceEmbeddings;
@@ -120,9 +118,11 @@ impl<'db> DebugWithDb<'db> for ConcreteImplLongId<'db> {
     type Db = dyn Database;
 
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db dyn Database) -> std::fmt::Result {
-        let mut f = CountingWriter::new(f);
-        write!(f, "{}", self.impl_def_id.full_path(db))?;
-        fmt_generic_args(&self.generic_args, &mut f, db)
+        write!(
+            f,
+            "{}",
+            displayable_concrete(db, &self.impl_def_id.full_path(db), &self.generic_args)
+        )
     }
 }
 impl<'db> ConcreteImplId<'db> {

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -1,4 +1,3 @@
-use std::fmt::Write;
 use std::sync::Arc;
 
 use cairo_lang_debug::DebugWithDb;
@@ -30,7 +29,7 @@ use super::functions::{
     InlineConfiguration,
 };
 use super::generics::{
-    GenericParamsData, fmt_generic_args, generic_params_to_args, semantic_generic_params,
+    GenericParamsData, displayable_concrete, generic_params_to_args, semantic_generic_params,
     semantic_generic_params_ex,
 };
 use super::imp::{GenericsHeadFilter, ImplLongId, TraitFilter};
@@ -38,7 +37,6 @@ use crate::db::get_resolver_data_options;
 use crate::diagnostic::SemanticDiagnosticKind::{self, *};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::compute::{ComputationContext, ContextFunction, Environment, compute_root_expr};
-use crate::expr::fmt::CountingWriter;
 use crate::expr::inference::InferenceId;
 use crate::expr::inference::canonic::ResultNoErrEx;
 use crate::items::feature_kind::HasFeatureKind;
@@ -63,9 +61,7 @@ impl<'db> DebugWithDb<'db> for ConcreteTraitLongId<'db> {
     type Db = dyn Database;
 
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db dyn Database) -> std::fmt::Result {
-        let mut f = CountingWriter::new(f);
-        write!(f, "{}", self.trait_id.full_path(db))?;
-        fmt_generic_args(&self.generic_args, &mut f, db)
+        write!(f, "{}", displayable_concrete(db, &self.trait_id.full_path(db), &self.generic_args))
     }
 }
 

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
@@ -29,7 +27,6 @@ use crate::corelib::{
 use crate::diagnostic::SemanticDiagnosticKind::*;
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::compute::{ComputationContext, compute_expr_semantic};
-use crate::expr::fmt::CountingWriter;
 use crate::expr::inference::canonic::{CanonicalTrait, ResultNoErrEx};
 use crate::expr::inference::solver::{SemanticSolver, SolutionSet, enrich_lookup_context};
 use crate::expr::inference::{InferenceData, InferenceError, InferenceId, TypeVar};
@@ -37,7 +34,7 @@ use crate::items::attribute::SemanticQueryAttrs;
 use crate::items::constant::{ConstValue, ConstValueId, resolve_const_expr_and_evaluate};
 use crate::items::enm::{EnumSemantic, SemanticEnumEx};
 use crate::items::extern_type::ExternTypeSemantic;
-use crate::items::generics::{GenericParamSemantic, fmt_generic_args};
+use crate::items::generics::{GenericParamSemantic, displayable_concrete};
 use crate::items::imp::{ImplId, ImplLookupContext, ImplLookupContextId, ImplSemantic};
 use crate::items::structure::StructSemantic;
 use crate::resolve::{ResolutionContext, ResolvedConcreteItem, ResolvedGenericItem, Resolver};
@@ -378,9 +375,11 @@ impl<'db> DebugWithDb<'db> for ConcreteTypeId<'db> {
     type Db = dyn Database;
 
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db dyn Database) -> std::fmt::Result {
-        let f = &mut CountingWriter::new(f);
-        write!(f, "{}", self.generic_type(db).format(db))?;
-        fmt_generic_args(&self.generic_args(db), f, db)
+        write!(
+            f,
+            "{}",
+            displayable_concrete(db, &self.generic_type(db).format(db), &self.generic_args(db))
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Refactored the generic arguments formatting code by moving the `CountingWriter` from `expr/fmt.rs` to `items/generics.rs` and introducing a new `displayable_concrete` function. This function returns a displayable structure for concrete ID formatting that limits the number of characters written during the process. Updated all call sites to use this new approach, which simplifies the code and improves maintainability.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous approach to formatting generic arguments was scattered across multiple files, with duplicated code patterns. This refactoring centralizes the formatting logic into a single function that returns a displayable structure, making the code more maintainable and consistent.

---

## What was the behavior or documentation before?

Previously, each file that needed to format generic arguments had to create a `CountingWriter` instance and call `fmt_generic_args`. This led to repetitive code patterns across multiple files.

---

## What is the behavior or documentation after?

Now, all code that needs to format generic arguments can use the new `displayable_concrete` function, which returns a displayable structure that handles the formatting internally. This simplifies the calling code and centralizes the formatting logic.

---

## Additional context

This refactoring doesn't change the actual formatting output, but makes the code more maintainable by centralizing the formatting logic and reducing duplication.