### PR TITLE
Removed extra `Path::new` when reusing the same path.

### DIFF
--- a/crates/cairo-lang-executable/src/compile.rs
+++ b/crates/cairo-lang-executable/src/compile.rs
@@ -109,9 +109,7 @@ pub fn compile_executable<'db>(
     diagnostics_reporter: DiagnosticsReporter<'_>,
     config: ExecutableConfig,
 ) -> Result<CompileExecutableResult<'db>> {
-    // let mut db = prepare_db(&config)?;
-
-    let main_crate_inputs = setup_project(db, Path::new(&path))?;
+    let main_crate_inputs = setup_project(db, path)?;
     let diagnostics_reporter = diagnostics_reporter.with_crates(&main_crate_inputs);
     let main_crate_ids = CrateInput::into_crate_ids(db, main_crate_inputs);
 

--- a/crates/cairo-lang-starknet/src/compile.rs
+++ b/crates/cairo-lang-starknet/src/compile.rs
@@ -53,7 +53,7 @@ pub fn compile_path(
         .with_default_plugin_suite(starknet_plugin_suite())
         .build()?;
 
-    let main_crate_inputs = setup_project(&mut db, Path::new(&path))?;
+    let main_crate_inputs = setup_project(&mut db, path)?;
     compiler_config.diagnostics_reporter =
         compiler_config.diagnostics_reporter.with_crates(&main_crate_inputs);
     let main_crate_ids = CrateInput::into_crate_ids(&db, main_crate_inputs);

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -238,7 +238,7 @@ impl<'db> TestCompiler<'db> {
             b.build()?
         };
 
-        let main_crate_inputs = setup_project(&mut db, Path::new(&path))?;
+        let main_crate_inputs = setup_project(&mut db, path)?;
 
         Ok(Self {
             db: db.snapshot(),


### PR DESCRIPTION
## Summary

Simplified the `setup_project` function calls by removing unnecessary `Path::new` conversions in three files: `compile.rs` in the `cairo-lang-executable` crate, `compile.rs` in the `cairo-lang-starknet` crate, and `lib.rs` in the `cairo-lang-test-runner` crate.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The code was unnecessarily converting path parameters to `Path` objects when the `setup_project` function already accepts the appropriate path type. This redundant conversion made the code less clean and could potentially cause confusion.

---

## What was the behavior or documentation before?

Previously, the code was using `Path::new(&path)` when calling `setup_project`, even though the path parameter was already of a compatible type.

---

## What is the behavior or documentation after?

The code now directly passes the path parameter to `setup_project` without the unnecessary `Path::new` conversion, making the code cleaner and more straightforward.

---

## Additional context

This is a small cleanup that improves code consistency and removes redundant type conversions. The functional behavior remains unchanged.