### PR TITLE
fix: remove dead introduction tracking in for-usage analysis

### DIFF
--- a/crates/cairo-lang-semantic/src/usage/mod.rs
+++ b/crates/cairo-lang-semantic/src/usage/mod.rs
@@ -3,7 +3,6 @@
 
 use cairo_lang_defs::ids::MemberId;
 use cairo_lang_proc_macros::DebugWithDb;
-use cairo_lang_utils::extract_matches;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 
@@ -316,9 +315,6 @@ impl<'db> Usages<'db> {
                 ty: _,
             }) => {
                 self.handle_expr(arenas, *expr_id, current);
-                current
-                    .introductions
-                    .insert(extract_matches!(into_iter_member_path, ExprVarMemberPath::Var).var);
                 let mut usage: Usage<'_> = Default::default();
                 usage.usage.insert(into_iter_member_path.into(), into_iter_member_path.clone());
                 usage.changes.insert(into_iter_member_path.into(), into_iter_member_path.clone());


### PR DESCRIPTION
## Summary

The for-expression usage analysis was writing the iterator variable into the outer Usage.introductions set, but that field is never read for the outer accumulator and finalize_as_scope is not called on it. All scoping and pruning for the for body is already handled by the local Usage instance.

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Removing this write eliminates dead code and potential confusion without changing the behavior of lowering or usage consumers.

