### PR TITLE
Refactor hints.adoc to use cairo-repo variable

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/hints.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/hints.adoc
@@ -1,3 +1,5 @@
+:cairo-repo: https://github.com/starkware-libs/cairo/blob/main
+
 = Hints
 
 Hints are implementation-side directives emitted by the compiler and executed by the Cairo
@@ -82,7 +84,7 @@ read/write and assert helpers). New code should not emit them.
 
 == References
 
-- link:https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-casm/src/hints/mod.rs[source of hint enums and their pythonic
+- link:{cairo-repo}/crates/cairo-lang-casm/src/hints/mod.rs[source of hint enums and their pythonic
   renderings].
-- link:https://github.com/starkware-libs/cairo/tree/main/crates/cairo-lang-runner[Cairo program runner]. Hint handling lives under
-  link:https://github.com/starkware-libs/cairo/tree/main/crates/cairo-lang-runner/src/casm_run[crates/cairo-lang-runner/src/casm_run].
+- link:{cairo-repo}/crates/cairo-lang-runner[Cairo program runner]. Hint handling lives under
+  link:{cairo-repo}/crates/cairo-lang-runner/src/casm_run[crates/cairo-lang-runner/src/casm_run].


### PR DESCRIPTION
Currently this file hardcodes 3 GitHub URLs while other doc files use the `{cairo-repo}` variable. This change adds the variable definition and replaces hardcoded links, making future URL changes require only one-line updates.

  **Changes:**
  - Add `:cairo-repo:` variable at file start
  - Replace 3 hardcoded `https://github.com/starkware-libs/cairo/...` links with `{cairo-repo}/...`