### PR TITLE
Avoid cloning closure param types in `internal_ty_contains_var`

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference/conform.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/conform.rs
@@ -818,11 +818,7 @@ impl<'db> Inference<'db, '_> {
                 self.internal_ty_contains_var(*type_id, var)
             }
             TypeLongId::Closure(closure) => {
-                closure
-                    .param_tys
-                    .clone()
-                    .into_iter()
-                    .any(|ty| self.internal_ty_contains_var(ty, var))
+                closure.param_tys.iter().any(|ty| self.internal_ty_contains_var(*ty, var))
                     || self.internal_ty_contains_var(closure.ret_ty, var)
             }
         }


### PR DESCRIPTION
## Summary

Replaced cloning of closure.param_tys with iteration over the existing collection to eliminate an unnecessary allocation and copies when checking for the presence of an InferenceVar

---

## Type of change

Please check **one**:

- [x] Performance improvement

---

## Why is this change needed?

the performance characteristics of the closure branch are improved.
