### PR TITLE
refactor: remove redundant PartialEq bound from GraphNode::NodeId

### DIFF
--- a/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
@@ -6,7 +6,7 @@ use core::hash::Hash;
 /// by itself, without additional information.
 pub trait GraphNode: Sized + Clone {
     /// The type used to identify the nodes in the graph.
-    type NodeId: PartialEq + Eq + Hash + Clone;
+    type NodeId: Eq + Hash + Clone;
 
     /// Returns a list of the node's neighbors.
     /// Must be stable for the SCC result to be stable. i.e. if the output for a node here doesn't


### PR DESCRIPTION
Remove redundant `PartialEq` trait bound from `GraphNode::NodeId` associated type.