### PR TITLE
Clean up unused pedersen/poseidon imports in corelib lib

### DIFF
--- a/corelib/src/lib.cairo
+++ b/corelib/src/lib.cairo
@@ -385,12 +385,8 @@ pub mod qm31;
 pub mod serde;
 
 pub mod sha256;
-#[allow(unused_imports)]
-use pedersen::Pedersen;
 
 pub mod poseidon;
-#[allow(unused_imports)]
-use poseidon::Poseidon;
 
 pub mod debug;
 


### PR DESCRIPTION
Summary: Drop no-op use pedersen::Pedersen and use poseidon::Poseidon re-exports from corelib/src/lib.cairo to remove dead code and reduce redundant imports.
Rationale: The modules remain exposed; the unused imports added no behavior and triggered lint noise.