### PR TITLE
refactor(semantic): Remove unnecessary clone in closure type inference

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference/conform.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/conform.rs
@@ -820,9 +820,8 @@ impl<'db> Inference<'db, '_> {
             TypeLongId::Closure(closure) => {
                 closure
                     .param_tys
-                    .clone()
-                    .into_iter()
-                    .any(|ty| self.internal_ty_contains_var(ty, var))
+                    .iter()
+                    .any(|ty| self.internal_ty_contains_var(*ty, var))
                     || self.internal_ty_contains_var(closure.ret_ty, var)
             }
         }


### PR DESCRIPTION
Remove redundant .clone() call when iterating over closure parameter types in internal_ty_contains_var.