### PR TITLE
fix: SHA-256 syscall doc comments in Starknet module

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/syscalls.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/syscalls.rs
@@ -198,7 +198,7 @@ impl SyscallGenericLibfunc for Sha256ProcessBlockLibfunc {
     }
 }
 
-/// Libfunc for converting a ContractAddress into a felt252.
+/// Libfunc for initializing a Sha256StateHandle from its inner state representation.
 #[derive(Default)]
 pub struct Sha256StateHandleInitLibfunc {}
 impl NoGenericArgsGenericLibfunc for Sha256StateHandleInitLibfunc {
@@ -221,7 +221,7 @@ impl NoGenericArgsGenericLibfunc for Sha256StateHandleInitLibfunc {
     }
 }
 
-/// Libfunc for converting a ContractAddress into a felt252.
+/// Libfunc for extracting the inner state representation from a Sha256StateHandle.
 #[derive(Default)]
 pub struct Sha256StateHandleDigestLibfunc {}
 impl NoGenericArgsGenericLibfunc for Sha256StateHandleDigestLibfunc {


### PR DESCRIPTION
## Summary

Updated the documentation for Sha256StateHandleInitLibfunc and Sha256StateHandleDigestLibfunc to accurately describe initializing a Sha256StateHandle from its inner Box<[u32; 8]> representation and extracting that inner state.

---

## Type of change

Please check **one**:


- [x] Documentation change with concrete technical impact

---

## Why is this change needed?

This makes the intent of these libfuncs clear and reduces the risk of misuse or confusion when maintaining the Starknet syscalls.

---

## What was the behavior or documentation before?

The SHA-256 syscall libfuncs in the Starknet module had incorrect doc comments that described ContractAddress-to-felt252 conversion, likely copied from another libfunc in interoperability.rs.



