### PR TITLE
refactor(tools): lazily clone optimization phases in get-lowering

### DIFF
--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -145,7 +145,7 @@ impl<'a> fmt::Display for PhasesDisplay<'a> {
             (db.baseline_optimization_strategy(), post_base_opts),
             (db.final_optimization_strategy(), final_state),
         ] {
-            for phase in strategy.long(db).0.clone() {
+            for phase in strategy.long(db).0.iter().cloned() {
                 let name = format!("{phase:?}").to_case(convert_case::Case::Snake);
                 phase.apply(db, function_id, &mut curr_state).unwrap();
                 add_stage_state(&name, &curr_state);


### PR DESCRIPTION
## Summary

Replaces `.clone()` with `.iter().cloned()` when iterating over optimization phases in the `get-lowering` debugging tool. This optimizes memory usage by avoiding the allocation of an intermediate `Vec`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The original code cloned the entire `Vec<OptimizationPhase>` just to iterate over it. This resulted in an unnecessary heap allocation and a full copy of the vector's contents before iteration began.

Using `.iter().cloned()` achieves the same logical result (producing owned `OptimizationPhase` items for the loop) but does so lazily:
- No intermediate `Vec` is allocated.
- Items are cloned one by one as needed.

This aligns with Rust best practices and follows the same optimization pattern recently applied to the core compiler crate.

---

## What was the behavior or documentation before?
