### PR TITLE
refactor(lowering): eliminate redundant Vec clone in optimization strategy iteration

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -132,7 +132,8 @@ impl<'db> OptimizationStrategyId<'db> {
         function: ConcreteFunctionWithBodyId<'db>,
         lowered: &mut Lowered<'db>,
     ) -> Maybe<()> {
-        for phase in self.long(db).0.iter().cloned() {
+        let strategy = self.long(db);
+        for phase in strategy.0.iter().cloned() {
             phase.apply(db, function, lowered)?;
         }
 


### PR DESCRIPTION
Removes an unnecessary `Vec::clone()` allocation when iterating over optimization phases in `OptimizationStrategyId::apply_strategy`.