### PR TITLE
perf(graph-algos): optimize neighbor filtering in SCC with HashSet lookup

### DIFF
--- a/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
@@ -1,6 +1,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::hash::Hash;
+use hashbrown::HashSet;
 
 /// A trait for a node in a graph. Note that a GraphNode has to be able to provide its neighbors
 /// by itself, without additional information.
@@ -20,12 +21,12 @@ pub trait GraphNode: Sized + Clone {
     /// Helper function to get the neighbors of the node, given its SCC. Default-implemented and
     /// thus can be used in simple implementations of get_neighbors_in_scc.
     fn get_neighbors_in_given_scc(&self, scc: Vec<Self::NodeId>) -> Vec<Self> {
-        let mut neighbors_in_scc = Vec::new();
-        for neighbor in self.get_neighbors() {
-            if scc.contains(&neighbor.get_id()) {
-                neighbors_in_scc.push(neighbor);
-            }
-        }
-        neighbors_in_scc
+        let mut scc_set = HashSet::with_capacity(scc.len());
+        scc_set.extend(scc);
+
+        self.get_neighbors()
+            .into_iter()
+            .filter(|neighbor| scc_set.contains(&neighbor.get_id()))
+            .collect()
     }
 }


### PR DESCRIPTION
Optimize `get_neighbors_in_given_scc` by replacing O(n²) Vec scanning with O(n) HashSet lookup.