### PR TITLE
performance(strategy): Remove the need for clone on `Strategy`.

### DIFF
--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -145,7 +145,7 @@ impl<'a> fmt::Display for PhasesDisplay<'a> {
             (db.baseline_optimization_strategy(), post_base_opts),
             (db.final_optimization_strategy(), final_state),
         ] {
-            for phase in strategy.long(db).0.clone() {
+            for phase in &strategy.long(db).0 {
                 let name = format!("{phase:?}").to_case(convert_case::Case::Snake);
                 phase.apply(db, function_id, &mut curr_state).unwrap();
                 add_stage_state(&name, &curr_state);

--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -67,7 +67,7 @@ impl<'db> OptimizationPhase<'db> {
     ///
     /// Assumes `lowered` is a lowering of `function`.
     pub fn apply(
-        self,
+        &self,
         db: &'db dyn Database,
         function: ConcreteFunctionWithBodyId<'db>,
         lowered: &mut Lowered<'db>,
@@ -76,7 +76,7 @@ impl<'db> OptimizationPhase<'db> {
 
         match self {
             OptimizationPhase::ApplyInlining { enable_const_folding } => {
-                apply_inlining(db, function, lowered, enable_const_folding)?
+                apply_inlining(db, function, lowered, *enable_const_folding)?
             }
             OptimizationPhase::BranchInversion => branch_inversion(db, lowered),
             OptimizationPhase::CancelOps => cancel_ops(lowered),
@@ -102,7 +102,7 @@ impl<'db> OptimizationPhase<'db> {
                 )
             }),
             OptimizationPhase::SubStrategy { strategy, iterations } => {
-                for _ in 1..iterations {
+                for _ in 1..*iterations {
                     let before = lowered.clone();
                     strategy.apply_strategy(db, function, lowered)?;
                     if *lowered == before {
@@ -132,7 +132,7 @@ impl<'db> OptimizationStrategyId<'db> {
         function: ConcreteFunctionWithBodyId<'db>,
         lowered: &mut Lowered<'db>,
     ) -> Maybe<()> {
-        for phase in self.long(db).0.iter().cloned() {
+        for phase in &self.long(db).0 {
             phase.apply(db, function, lowered)?;
         }
 


### PR DESCRIPTION
## Summary

Optimized the lowering phase by changing `OptimizationPhase::apply` to take a reference instead of consuming the phase object. This change eliminates unnecessary cloning in multiple places:

1. Changed `phase.apply()` to take `&self` instead of `self`
2. Updated callers to pass references to strategy phases instead of cloning collections

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The current implementation unnecessarily clones optimization phases and strategies when applying them. By changing the `apply` method to take a reference instead of consuming the object, we can avoid these clones and improve performance.
