### PR TITLE
performance(sierra-to-casm): For contracts, prevented re-calling of felt252 deserialization.

### DIFF
--- a/crates/bin/starknet-sierra-compile/src/main.rs
+++ b/crates/bin/starknet-sierra-compile/src/main.rs
@@ -69,9 +69,11 @@ fn main() -> anyhow::Result<()> {
         entry_points_by_type,
         abi: None,
     };
-    contract_class.validate_version_compatible(list_selector)?;
+    let extracted = contract_class.extract_sierra_program(false)?;
+    extracted.validate_version_compatible(list_selector)?;
     let casm_contract = CasmContractClass::from_contract_class(
         contract_class,
+        extracted,
         args.add_pythonic_hints,
         args.max_bytecode_size,
     )

--- a/crates/bin/starknet-sierra-extract-code/src/main.rs
+++ b/crates/bin/starknet-sierra-extract-code/src/main.rs
@@ -27,8 +27,9 @@ fn main() -> anyhow::Result<()> {
     )
     .with_context(|| "deserialization Failed.")?;
     let sierra_program = contract_class
-        .extract_sierra_program()
-        .with_context(|| "Failed parsing felt252s stream into Sierra program.")?;
+        .extract_sierra_program(true)
+        .with_context(|| "Failed parsing felt252s stream into Sierra program.")?
+        .program;
     match args.output {
         Some(path) => fs::write(path, sierra_program.to_string())
             .with_context(|| "Failed to write Sierra program.")?,

--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
@@ -13,9 +13,9 @@ use test_case::test_case;
 use crate::allowed_libfuncs::{
     BUILTIN_AUDITED_LIBFUNCS_LIST, ListSelector, lookup_allowed_libfuncs_list,
 };
-use crate::casm_contract_class::{BigUintAsHex, CasmContractClass, StarknetSierraCompilationError};
+use crate::casm_contract_class::{BigUintAsHex, CasmContractClass};
 use crate::contract_class::ContractClass;
-use crate::felt252_serde::sierra_from_felt252s;
+use crate::felt252_serde::{Felt252SerdeError, sierra_from_felt252s};
 use crate::test_utils::get_example_file_path;
 
 #[test_case("test_contract__test_contract")]
@@ -25,11 +25,9 @@ fn test_casm_contract_from_contract_class_failure(name: &str) {
         std::fs::File::open(get_example_file_path(&format!("{name}.contract_class.json"))).unwrap();
     let mut contract_class: ContractClass = serde_json::from_reader(BufReader::new(f)).unwrap();
     contract_class.sierra_program[17] = BigUintAsHex { value: Felt252::prime() };
-
-    let add_pythonic_hints = false;
     assert_eq!(
-        CasmContractClass::from_contract_class(contract_class, add_pythonic_hints, usize::MAX),
-        Err(StarknetSierraCompilationError::ValueOutOfRange)
+        contract_class.extract_sierra_program(false).err(),
+        Some(Felt252SerdeError::InvalidInputForDeserialization)
     );
 }
 
@@ -56,8 +54,10 @@ fn test_casm_contract_from_contract_class_from_contracts_crate(name: &str) {
         serde_json::from_reader(BufReader::new(std::fs::File::open(contract_path).unwrap()))
             .unwrap();
     let add_pythonic_hints = true;
+    let program = contract.extract_sierra_program(false).unwrap();
     let casm_contract =
-        CasmContractClass::from_contract_class(contract, add_pythonic_hints, usize::MAX).unwrap();
+        CasmContractClass::from_contract_class(contract, program, add_pythonic_hints, usize::MAX)
+            .unwrap();
     compare_contents_or_fix_with_path(
         &get_example_file_path(&format!("{name}.compiled_contract_class.json")),
         serde_json::to_string_pretty(&casm_contract).unwrap() + "\n",

--- a/crates/cairo-lang-starknet/src/compile.rs
+++ b/crates/cairo-lang-starknet/src/compile.rs
@@ -250,6 +250,8 @@ pub fn starknet_compile(
 ) -> Result<String> {
     let config = config.unwrap_or_default();
     let contract = compile_path(&crate_path, contract_path.as_deref(), config, inlining_strategy)?;
-    contract.validate_version_compatible(allowed_libfuncs_list.unwrap_or_default())?;
+    contract
+        .extract_sierra_program(false)?
+        .validate_version_compatible(allowed_libfuncs_list.unwrap_or_default())?;
     serde_json::to_string_pretty(&contract).with_context(|| "Serialization failed.")
 }

--- a/crates/cairo-lang-starknet/src/compile_test.rs
+++ b/crates/cairo-lang-starknet/src/compile_test.rs
@@ -31,18 +31,17 @@ fn test_compile_path_from_contracts_crate(example_contract_path: &str) {
     );
     let example_file_name = example_contract_path.replace("::", "__");
     let list_selector = ListSelector::ListName("all".to_string());
-    contract.validate_version_compatible(list_selector).unwrap();
+    let extracted = contract.extract_sierra_program(true).unwrap();
+    extracted.validate_version_compatible(list_selector).unwrap();
 
     compare_contents_or_fix_with_path(
         &get_example_file_path(format!("{example_file_name}.contract_class.json").as_str()),
         serde_json::to_string_pretty(&contract).unwrap() + "\n",
     );
 
-    let sierra_program = contract.extract_sierra_program().unwrap();
-
     // There is a separate file for the sierra code as it is hard to review inside the json.
     compare_contents_or_fix_with_path(
         &get_example_file_path(format!("{example_file_name}.sierra").as_str()),
-        sierra_program.to_string(),
+        extracted.program.to_string(),
     );
 }


### PR DESCRIPTION
## Summary

Refactored the Sierra program extraction process by introducing an `ExtractedSierraProgram` struct that encapsulates the Sierra program, Sierra version, and compiler version. This change improves code organization by:

1. Moving the validation of felt252 values (checking they're less than prime) to the extraction method
2. Separating program extraction from validation logic
3. Making the debug info population optional via a boolean parameter

The PR modifies several binaries and libraries to use this new approach, ensuring that validation happens on the extracted program rather than directly on the contract class.

Improves performance by  preventing deserialization of encoded sierra program from happening multiple times.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation mixed concerns between extracting the Sierra program and validating it. This refactoring creates a cleaner separation of responsibilities, making the code more maintainable and easier to understand. It also allows for more flexibility in how the Sierra program is processed after extraction.

---

## What was the behavior or documentation before?

Previously, the Sierra program extraction and validation were tightly coupled. The contract class had to be validated directly, and the extraction process always populated debug info when available.

---

## What is the behavior or documentation after?

Now, the extraction process returns an `ExtractedSierraProgram` struct containing the program and version information. Validation is performed on this extracted program rather than on the contract class directly. Additionally, debug info population is now optional via a boolean parameter.