### PR TITLE
Remove redundant PartialEq bound in inference helper

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference/conform.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/conform.rs
@@ -725,7 +725,7 @@ impl<'db> Inference<'db, '_> {
     /// Helper function for getting an impl vars item ids.
     /// These ids are likely to be variables, but may have more specific information due to
     /// rewriting.
-    fn rewritten_impl_item<K: Hash + PartialEq + Eq, V: Copy>(
+    fn rewritten_impl_item<K: Hash + Eq, V: Copy>(
         &mut self,
         id: ImplVarId<'db>,
         key: K,


### PR DESCRIPTION
Drop the superfluous PartialEq bound from rewritten_impl_item, keeping only Hash + Eq as required by OrderedHashMap, no behavioral change; simplifies generics and avoids redundant constraints