### PR TITLE
performance(sierra-to-casm): Made `ApplyApChange` inplace.

### DIFF
--- a/crates/cairo-lang-casm/src/ap_change_test.rs
+++ b/crates/cairo-lang-casm/src/ap_change_test.rs
@@ -19,13 +19,13 @@ fn test_res_operand_ap_change() {
     });
 
     assert_eq!(
-        operand.clone().apply_ap_change(ApChange::Known(5)).unwrap().to_string(),
+        apply_ap_change(operand.clone(), ApChange::Known(5)).unwrap().to_string(),
         "[fp + -3] * [ap + -2]"
     );
 
-    assert_eq!(operand.apply_ap_change(ApChange::Unknown), Err(ApChangeError::UnknownApChange));
+    assert_eq!(apply_ap_change(operand, ApChange::Unknown), Err(ApChangeError::UnknownApChange));
 
-    assert_eq!(fp_based_operand.apply_ap_change(ApChange::Unknown).unwrap(), fp_based_operand);
+    assert_eq!(apply_ap_change(fp_based_operand, ApChange::Unknown).unwrap(), fp_based_operand);
 }
 
 #[test]
@@ -33,7 +33,13 @@ fn test_overflow() {
     let ap_based_operand = CellRef { register: Register::AP, offset: i16::MIN };
 
     assert_eq!(
-        ap_based_operand.apply_ap_change(ApChange::Known(1)),
+        apply_ap_change(ap_based_operand, ApChange::Known(1)),
         Err(ApChangeError::OffsetOverflow)
     );
+}
+
+/// Helper function to apply an AP change to a value.
+fn apply_ap_change<T: ApplyApChange>(mut t: T, ap_change: ApChange) -> Result<T, ApChangeError> {
+    t.apply_ap_change(ap_change)?;
+    Ok(t)
 }

--- a/crates/cairo-lang-casm/src/cell_expression.rs
+++ b/crates/cairo-lang-casm/src/cell_expression.rs
@@ -116,21 +116,15 @@ impl CellExpression {
 }
 
 impl ApplyApChange for CellExpression {
-    fn apply_known_ap_change(self, ap_change: usize) -> Option<Self> {
-        Some(match self {
-            CellExpression::Deref(operand) => {
-                CellExpression::Deref(operand.apply_known_ap_change(ap_change)?)
+    fn apply_known_ap_change(&mut self, ap_change: usize) -> bool {
+        match self {
+            CellExpression::Deref(operand) => operand.apply_known_ap_change(ap_change),
+            CellExpression::DoubleDeref(operand, _) => operand.apply_known_ap_change(ap_change),
+            CellExpression::BinOp { op: _, a, b } => {
+                a.apply_known_ap_change(ap_change) && b.apply_known_ap_change(ap_change)
             }
-            CellExpression::DoubleDeref(operand, offset) => {
-                CellExpression::DoubleDeref(operand.apply_known_ap_change(ap_change)?, offset)
-            }
-            CellExpression::BinOp { op, a, b } => CellExpression::BinOp {
-                op,
-                a: a.apply_known_ap_change(ap_change)?,
-                b: b.apply_known_ap_change(ap_change)?,
-            },
-            expr @ CellExpression::Immediate(_) => expr,
-        })
+            CellExpression::Immediate(_) => true,
+        }
     }
 
     fn can_apply_unknown(&self) -> bool {

--- a/crates/cairo-lang-sierra-to-casm/src/annotations.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/annotations.rs
@@ -321,16 +321,15 @@ impl ProgramAnnotations {
             if branch_changes.clear_old_stack {
                 ref_value.stack_idx = None;
             }
-            ref_value.expression =
-                std::mem::replace(&mut ref_value.expression, ReferenceExpression::zero_sized())
-                    .apply_ap_change(branch_changes.ap_change)
-                    .map_err(|error| AnnotationError::ApChangeError {
-                        var_id: var_id.clone(),
-                        source_statement_idx,
-                        destination_statement_idx,
-                        introduction_point: ref_value.introduction_point.clone(),
-                        error,
-                    })?;
+            ref_value.expression.apply_ap_change(branch_changes.ap_change).map_err(|error| {
+                AnnotationError::ApChangeError {
+                    var_id: var_id.clone(),
+                    source_statement_idx,
+                    destination_statement_idx,
+                    introduction_point: ref_value.introduction_point.clone(),
+                    error,
+                }
+            })?;
         }
         let mut refs = put_results(
             annotations.refs,

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/mem.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/mem.rs
@@ -57,8 +57,8 @@ fn get_store_instructions<DstCells: Iterator<Item = CellRef>>(
     }
     let mut ctx = casm!();
     let mut ap_change = 0;
-    for (dst, cell_expr_orig) in zip_eq(dst_cells, &src_expr.cells) {
-        let cell_expr = cell_expr_orig.clone().apply_known_ap_change(ap_change as usize).unwrap();
+    for (dst, mut cell_expr) in zip_eq(dst_cells, src_expr.cells.iter().cloned()) {
+        assert!(cell_expr.apply_known_ap_change(ap_change));
         match cell_expr {
             CellExpression::Deref(operand) => add_instruction!(ctx, dst = operand),
             CellExpression::DoubleDeref(operand, offset) => {

--- a/crates/cairo-lang-sierra-to-casm/src/references.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/references.rs
@@ -126,14 +126,8 @@ impl ReferenceExpression {
 }
 
 impl ApplyApChange for ReferenceExpression {
-    fn apply_known_ap_change(self, ap_change: usize) -> Option<Self> {
-        Some(ReferenceExpression {
-            cells: self
-                .cells
-                .into_iter()
-                .map(|cell_expr| cell_expr.apply_known_ap_change(ap_change))
-                .collect::<Option<Vec<_>>>()?,
-        })
+    fn apply_known_ap_change(&mut self, ap_change: usize) -> bool {
+        self.cells.iter_mut().all(|cell| cell.apply_known_ap_change(ap_change))
     }
 
     fn can_apply_unknown(&self) -> bool {


### PR DESCRIPTION
## Summary

Refactored the `ApplyApChange` trait to modify values in-place rather than returning new values. This changes the signature from `fn apply_known_ap_change(self, ap_change: usize) -> Option<Self>` to `fn apply_known_ap_change(&mut self, ap_change: usize) -> bool`, which simplifies error handling and avoids unnecessary cloning. The implementation also improves the handling of AP change overflow by using `num_traits::ToPrimitive` for safer conversions.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation of `ApplyApChange` required cloning and recreating objects when applying AP changes. By modifying values in-place, we can avoid unnecessary allocations and improve performance, especially in code paths that apply AP changes frequently.

---

## What was the behavior or documentation before?

Previously, `apply_known_ap_change` consumed `self` and returned a new instance wrapped in an `Option`, requiring callers to handle the `None` case separately and often leading to unnecessary cloning of data structures.

---

## What is the behavior or documentation after?

Now `apply_known_ap_change` takes `&mut self` and returns a boolean indicating success, which is more efficient and follows a more conventional error-handling pattern. The implementation also uses `num_traits::ToPrimitive` for safer numeric conversions.

---

## Additional context

This change affects multiple implementations of the `ApplyApChange` trait across the codebase, including `ResOperand`, `CellRef`, `DerefOrImmediate`, `BinOpOperand`, `CellExpression`, and `ReferenceExpression`. Tests have been updated to use a helper function that maintains the previous API for testing purposes.