### PR TITLE
docs: add usage examples to type aliases documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/type-aliases.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/type-aliases.adoc
@@ -49,6 +49,44 @@ type BoxIntAlias = Box<i32>;
 type TupleAlias = (felt252, u128);
 ----
 
+== Usage
+
+Type aliases can be used anywhere the original type can be used:
+in variable declarations, function parameters, and return types.
+
+=== In function parameters and return types
+
+Type aliases can be used as parameter types and return types:
+
+[source,cairo]
+----
+fn process_struct(s: RenamedStruct) -> felt252 {
+    s.a
+}
+
+fn process_enum(e: RenamedEnum) -> felt252 {
+    match e {
+        MyEnum::f(v) => v,
+    }
+}
+
+fn process_tuple(t: TupleAlias) -> felt252 {
+    let (value, _) = t;
+    value
+}
+----
+
+=== In variable declarations
+
+Type aliases can be used when declaring variables:
+
+[source,cairo]
+----
+let x: IntAlias = 42;
+let boxed: BoxIntAlias = BoxTrait::new(10);
+let pair: TupleAlias = (5, 100);
+----
+
 == Generic type aliases
 
 Type aliases can themselves be generic.
@@ -59,6 +97,11 @@ while leaving others as parameters of the alias.
 ----
 type BoxOption<T> = Box<Option<T>>;
 type RenamedTuple<T> = (felt252, T);
+
+fn use_generic_alias(t: RenamedTuple<u128>) -> u128 {
+    let (_, value) = t;
+    value
+}
 ----
 
 == Chaining type aliases
@@ -71,6 +114,10 @@ underlying concrete type.
 ----
 type A<P4> = B<felt252, P4, u128>;
 type B<P1, P2, P3> = (P1, P3, P2);
+
+fn use_chained_alias(value: A<bool>) -> (felt252, u128, bool) {
+    value
+}
 ----
 
 == Errors and limitations


### PR DESCRIPTION
## Summary

Adds a "Usage" section to type aliases documentation with examples showing how to use type aliases in function parameters, return types, and variable declarations. Also adds usage examples to generic and chaining sections.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The documentation showed only type alias definitions without usage examples, unlike similar pages (structs.adoc, enums.adoc) which include usage sections. This makes it unclear how to actually use type aliases in code.

---

## What was the behavior or documentation before?

The "Basic examples" section showed only type alias definitions. No examples demonstrated usage in functions, variables, or with generic parameters.

---

## What is the behavior or documentation after?

Added a "Usage" section with examples for function parameters/return types and variable declarations. Also added usage examples to the generic and chaining sections. Structure now matches structs.adoc and enums.adoc.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

Examples are based on test cases from `crates/cairo-lang-semantic/src/items/tests/type_alias` to ensure they reflect real usage patterns.