### PR TITLE
Optimize storage struct generation for non-backwards-compatible editions

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/storage.rs
+++ b/crates/cairo-lang-starknet/src/plugin/storage.rs
@@ -32,7 +32,7 @@ pub fn handle_storage_struct<'db, 'a>(
 
     let mut substorage_members_struct_code = vec![];
     let mut substorage_members_init_code = vec![];
-    let mut storage_struct_members = if is_backwards_compatible { Some(Vec::new()) } else { None };
+    let mut storage_struct_members = is_backwards_compatible.then_some(Vec::new);
     let configs = struct_members_storage_configs(db, &struct_ast, diagnostics);
     for (member, config) in zip_eq(struct_ast.members(db).elements(db), &configs) {
         if config.kind == StorageMemberKind::SubStorage {


### PR DESCRIPTION
## Summary

Avoid building storage_struct_members and calling get_simple_member_code when backwards_compatible_storage is false, since the generated Storage struct is not emitted in these editions.

---

## Type of change

Please check **one**:


- [x] Performance improvement

---

## Why is this change needed?

This removes unnecessary work and allocations in the Starknet storage plugin without changing the generated Cairo code.

---

