### PR TITLE
Standardize corelib references to use links

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/bitwise-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/bitwise-operators.adoc
@@ -151,4 +151,4 @@ fn main() {
 == References (source)
 
 - Operator precedence: link:{cairo-repo}/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs] (lines 9, 23-25)
-- Traits: `corelib/src/traits.cairo` (`BitAnd`, `BitOr`, `BitXor`, `BitNot`)
+- link:{cairo-repo}/corelib/src/traits.cairo[Traits] (`BitAnd`, `BitOr`, `BitXor`, `BitNot`)

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/box-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/box-type.adoc
@@ -1,3 +1,5 @@
+:cairo-repo: https://github.com/starkware-libs/cairo/blob/main
+
 = Box type
 
 `Box<T>` is a pointer type that provides an indirection layer for values.
@@ -113,4 +115,4 @@ but not for implicit type conversion when passing arguments to functions.
 == See also
 
 * xref:../../language_semantics/pages/linear-types.adoc[Linear types system] — Move semantics and Copy/Drop
-* Implementation: `corelib/src/box.cairo`
+* link:{cairo-repo}/corelib/src/box.cairo[Implementation]

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/error-propagation-operator.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/error-propagation-operator.adoc
@@ -104,4 +104,4 @@ fn process_empty() -> Option<u8> {
 - Syntax tree: link:{cairo-repo}/crates/cairo-lang-syntax-codegen/src/cairo_spec.rs[crates/cairo-lang-syntax-codegen/src/cairo_spec.rs] (`ExprErrorPropagate`)
 - Operator precedence: link:{cairo-repo}/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs] (line 18)
 - Lexer token: link:{cairo-repo}/crates/cairo-lang-parser/src/lexer.rs[crates/cairo-lang-parser/src/lexer.rs] (`TerminalQuestionMark`)
-- Error types: `corelib/src/result.cairo` (`Result`), `corelib/src/option.cairo` (`Option`)
+- Error types: link:{cairo-repo}/corelib/src/result.cairo[Result], link:{cairo-repo}/corelib/src/option.cairo[Option]

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/error-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/error-type.adoc
@@ -1,3 +1,5 @@
+:cairo-repo: https://github.com/starkware-libs/cairo/blob/main
+
 = Error types
 
 Error handling in _Cairo_ is built around a small set of core types.
@@ -94,8 +96,8 @@ The core library defines:
 These are mostly used by low-level infrastructure and tooling. In
 application-level code, panics are typically triggered indirectly via:
 
-- `panic` / `panic_with_*` functions from `corelib/src/panics.cairo`
-  and `corelib/src/lib.cairo`.
+- `panic` / `panic_with_*` functions from link:{cairo-repo}/corelib/src/panics.cairo[corelib/src/panics.cairo]
+  and link:{cairo-repo}/corelib/src/lib.cairo[corelib/src/lib.cairo].
 - Methods like `unwrap` / `expect` on `Result` and `Option`, which
   convert a recoverable error into a panic when the error occurs.
 
@@ -137,13 +139,13 @@ type. See the dedicated page for detailed semantics and examples.
 
 Error type and methods:
 
-- `corelib/src/result.cairo` (`Result<T, E>`)
-- `corelib/src/option.cairo` (`Option<T>` helpers)
+- link:{cairo-repo}/corelib/src/result.cairo[corelib/src/result.cairo] (`Result<T, E>`)
+- link:{cairo-repo}/corelib/src/option.cairo[corelib/src/option.cairo] (`Option<T>` helpers)
 
 Panic infrastructure:
 
-- `corelib/src/panics.cairo` (`Panic`, `PanicResult<T>`, `panic`)
-- `corelib/src/lib.cairo` (`panic_with_felt252`, `assert`, etc.)
+- link:{cairo-repo}/corelib/src/panics.cairo[corelib/src/panics.cairo] (`Panic`, `PanicResult<T>`, `panic`)
+- link:{cairo-repo}/corelib/src/lib.cairo[corelib/src/lib.cairo] (`panic_with_felt252`, `assert`, etc.)
 
 Language features:
 


### PR DESCRIPTION
 Converts bare text corelib paths to clickable links, matching the style used in `arithmetic-and-logical-operators.adoc` and other doc files.

  **Current inconsistency:**
  - `bitwise-operators.adoc` uses `Traits: \`corelib/src/traits.cairo\`` (plain text)
  - `arithmetic-and-logical-operators.adoc` uses `link:{cairo-repo}/corelib/src/traits.cairo[Traits]` (clickable link)

  **Changes:**
  - Add `:cairo-repo:` variable to `box-type.adoc` and `error-type.adoc`
  - Convert 10+ corelib path references to `link:{cairo-repo}/...` format across 4 files

  Makes all corelib references clickable and maintainable through the shared variable.