### PR TITLE
Added more e2e testing for box work.

### DIFF
--- a/tests/e2e_test_data/libfuncs/box
+++ b/tests/e2e_test_data/libfuncs/box
@@ -729,6 +729,158 @@ test::foo@F1() -> (Tuple<Box<core::integer::u256>, Box<core::integer::u256>>);
 
 //! > ==========================================================================
 
+//! > box_struct_deconstruct libfunc recursive
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+mod a {
+    extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u256>, Box<u256>) nopanic;
+}
+
+mod b {
+    extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u128>, Box<u128>) nopanic;
+}
+
+fn foo(a: Box<(u256, u256)>) -> (Box<u128>, Box<u128>, Box<u128>, Box<u128>) {
+    let (b1, b2) = a::struct_boxed_deconstruct(a);
+    let (c1, c2) = b::struct_boxed_deconstruct(b1);
+    let (c3, c4) = b::struct_boxed_deconstruct(b2);
+    (c1, c2, c3, c4)
+}
+
+//! > casm
+[ap + 0] = [fp + -3], ap++;
+[ap + 0] = [fp + -3] + 1, ap++;
+[ap + 0] = [fp + -3] + 2, ap++;
+[ap + 0] = [fp + -3] + 3, ap++;
+ret;
+
+//! > sierra_code
+type Box<Tuple<core::integer::u256, core::integer::u256>> = Box<Tuple<core::integer::u256, core::integer::u256>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<u128> = Box<u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>> = Struct<ut@Tuple, Box<u128>, Box<u128>, Box<u128>, Box<u128>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<core::integer::u256, core::integer::u256> = Struct<ut@Tuple, core::integer::u256, core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<core::integer::u256> = Box<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<Tuple<core::integer::u256, core::integer::u256>> = struct_boxed_deconstruct<Tuple<core::integer::u256, core::integer::u256>>;
+libfunc struct_boxed_deconstruct<core::integer::u256> = struct_boxed_deconstruct<core::integer::u256>;
+libfunc struct_construct<Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>>> = struct_construct<Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>>>;
+libfunc store_temp<Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>>> = store_temp<Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>>>;
+
+F0:
+struct_boxed_deconstruct<Tuple<core::integer::u256, core::integer::u256>>([0]) -> ([1], [2]);
+struct_boxed_deconstruct<core::integer::u256>([1]) -> ([3], [4]);
+struct_boxed_deconstruct<core::integer::u256>([2]) -> ([5], [6]);
+struct_construct<Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>>>([3], [4], [5], [6]) -> ([7]);
+store_temp<Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>>>([7]) -> ([7]);
+return([7]);
+
+test::foo@F0([0]: Box<Tuple<core::integer::u256, core::integer::u256>>) -> (Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 400})
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc first same as param
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u128>, Box<u128>) nopanic;
+
+fn foo(a: Box<u256>) -> (u128, u128) {
+    let (a1, a2) = struct_boxed_deconstruct(a);
+    // Since `unbox` expects its argument by value (`deref`), we expect `a1` to be used directly,
+    // while `a2` to be stored prior to `unbox` call.
+    (a1.unbox(), a2.unbox())
+}
+
+//! > casm
+[ap + 0] = [fp + -3] + 1, ap++;
+[ap + 0] = [[fp + -3] + 0], ap++;
+[ap + 0] = [[ap + -2] + 0], ap++;
+ret;
+
+//! > sierra_code
+type Box<core::integer::u256> = Box<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u128, u128> = Struct<ut@Tuple, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::integer::u256 = Struct<ut@core::integer::u256, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<u128> = Box<u128> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<core::integer::u256> = struct_boxed_deconstruct<core::integer::u256>;
+libfunc unbox<u128> = unbox<u128>;
+libfunc store_temp<Box<u128>> = store_temp<Box<u128>>;
+libfunc struct_construct<Tuple<u128, u128>> = struct_construct<Tuple<u128, u128>>;
+libfunc store_temp<Tuple<u128, u128>> = store_temp<Tuple<u128, u128>>;
+
+F0:
+struct_boxed_deconstruct<core::integer::u256>([0]) -> ([1], [2]);
+unbox<u128>([1]) -> ([3]);
+store_temp<Box<u128>>([2]) -> ([2]);
+unbox<u128>([2]) -> ([4]);
+struct_construct<Tuple<u128, u128>>([3], [4]) -> ([5]);
+store_temp<Tuple<u128, u128>>([5]) -> ([5]);
+return([5]);
+
+test::foo@F0([0]: Box<core::integer::u256>) -> (Tuple<u128, u128>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 300})
+
+//! > ==========================================================================
+
+//! > box_struct_deconstruct libfunc first-non-zero-sized same as param
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<()>, Box<()>, Box<u128>) nopanic;
+
+fn foo(a: Box<((), (), u128)>) -> u128 {
+    let (_, _, b) = struct_boxed_deconstruct(a);
+    b.unbox()
+}
+
+//! > casm
+[ap + 0] = [[fp + -3] + 0], ap++;
+ret;
+
+//! > sierra_code
+type Box<Tuple<Unit, Unit, u128>> = Box<Tuple<Unit, Unit, u128>> [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type Tuple<Unit, Unit, u128> = Struct<ut@Tuple, Unit, Unit, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<u128> = Box<u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Unit> = Box<Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc struct_boxed_deconstruct<Tuple<Unit, Unit, u128>> = struct_boxed_deconstruct<Tuple<Unit, Unit, u128>>;
+libfunc drop<Box<Unit>> = drop<Box<Unit>>;
+libfunc unbox<u128> = unbox<u128>;
+libfunc store_temp<u128> = store_temp<u128>;
+
+F0:
+struct_boxed_deconstruct<Tuple<Unit, Unit, u128>>([0]) -> ([1], [2], [3]);
+drop<Box<Unit>>([1]) -> ();
+drop<Box<Unit>>([2]) -> ();
+unbox<u128>([3]) -> ([4]);
+store_temp<u128>([4]) -> ([4]);
+return([4]);
+
+test::foo@F0([0]: Box<Tuple<Unit, Unit, u128>>) -> (u128);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 100})
+
+//! > ==========================================================================
+
 //! > local_into_box with fp-based variable
 
 //! > test_runner_name
@@ -986,3 +1138,49 @@ store_temp<Box<test::LargeStruct>>([3]) -> ([3]);
 return([3]);
 
 test::foo@F0([0]: test::LargeStruct) -> (Box<test::LargeStruct>);
+
+//! > ==========================================================================
+
+//! > local_into_box and box_struct_deconstruct libfuncs - no intermediate stores.
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+extern fn local_into_box<T>(value: T) -> Box<T> nopanic;
+extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u128>, Box<u128>, Box<u128>) nopanic;
+
+fn foo(a: (u128, u128, u128)) -> Box<u128> {
+    let boxed = local_into_box(a);
+    let (_, _, c) = struct_boxed_deconstruct(boxed);
+    c
+}
+
+//! > casm
+call rel 5;
+[ap + 0] = [ap + -2] + -3, ap++;
+ret;
+
+//! > sierra_code
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u128, u128, u128> = Struct<ut@Tuple, u128, u128, u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<u128> = Box<u128> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Tuple<u128, u128, u128>> = Box<Tuple<u128, u128, u128>> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc local_into_box<Tuple<u128, u128, u128>> = local_into_box<Tuple<u128, u128, u128>>;
+libfunc struct_boxed_deconstruct<Tuple<u128, u128, u128>> = struct_boxed_deconstruct<Tuple<u128, u128, u128>>;
+libfunc drop<Box<u128>> = drop<Box<u128>>;
+libfunc store_temp<Box<u128>> = store_temp<Box<u128>>;
+
+F0:
+local_into_box<Tuple<u128, u128, u128>>([0]) -> ([1]);
+struct_boxed_deconstruct<Tuple<u128, u128, u128>>([1]) -> ([2], [3], [4]);
+drop<Box<u128>>([2]) -> ();
+drop<Box<u128>>([3]) -> ();
+store_temp<Box<u128>>([4]) -> ([4]);
+return([4]);
+
+test::foo@F0([0]: Tuple<u128, u128, u128>) -> (Box<u128>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 300})


### PR DESCRIPTION
## Summary

Added several tests for `box_struct_deconstruct` libfunc demonstrating its functionality in different scenarios:
- Recursive deconstruction of boxed structs
- Deconstruction where the first element is the same as the parameter
- Handling of non-zero-sized elements
- Integration with `local_into_box` without intermediate stores

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`box_struct_deconstruct` libfunc allows for efficient deconstruction of boxed structs into their component parts. This PR enhances its tests.
