### PR TITLE
Made handling sierra failure easier in e2e testing.

### DIFF
--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -293,8 +293,8 @@ fn run_e2e_test(
         compiler::SierraToCasmConfig { gas_usage_check: true, max_bytecode_size: usize::MAX };
     // Compile to casm.
     let casm = compiler::compile(&sierra_program, &program_info, &metadata_with_linear, config)
-        .unwrap()
-        .to_string();
+        .map(|x| x.to_string())
+        .unwrap_or_else(|e| format!("failing with: `{e}`."));
 
     let mut res: OrderedHashMap<String, String> =
         OrderedHashMap::from([("casm".into(), casm), ("sierra_code".into(), sierra_program_str)]);


### PR DESCRIPTION
## Summary

Improve error handling in the e2e test by formatting compilation errors instead of unwrapping them directly. When compilation fails, the test now captures the error message in the output rather than panicking.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The e2e test was previously unwrapping the compilation result directly, which would cause the test to panic if compilation failed. This made it difficult to debug compilation issues since the test would terminate without providing useful error information.

---

## What was the behavior or documentation before?

When compilation failed, the test would panic with a generic unwrap error message, not providing any context about the actual compilation error.

---

## What is the behavior or documentation after?

Now when compilation fails, the test captures the error message and includes it in the output with the format "failing with: `{error}`". This allows for better debugging and visibility into compilation failures.

---

## Additional context

This change makes the e2e tests more robust by handling compilation errors gracefully instead of panicking, which improves the developer experience when debugging compilation issues.