### PR TITLE
(refactor): Build jump and jump table to support prepended instructions.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -1,5 +1,6 @@
 use cairo_lang_casm::builder::CasmBuilder;
 use cairo_lang_casm::cell_expression::CellExpression;
+use cairo_lang_casm::instructions::Instruction;
 use cairo_lang_casm::operand::CellRef;
 use cairo_lang_casm::{casm, casm_build_extend, casm_extend};
 use cairo_lang_sierra::extensions::ConcreteLibfunc;
@@ -230,8 +231,20 @@ fn build_enum_match_short(
         Item = impl ExactSizeIterator<Item = ReferenceExpression>,
     >,
 ) -> Result<CompiledInvocation, InvocationError> {
-    let mut instructions = Vec::new();
+    build_enum_match_short_ex(builder, variant_selector, output_expressions, Vec::with_capacity(1))
+}
+
+/// Extended version of `build_enum_match_short` that allows prepending instructions.
+fn build_enum_match_short_ex(
+    builder: CompiledInvocationBuilder<'_>,
+    variant_selector: CellRef,
+    output_expressions: impl ExactSizeIterator<
+        Item = impl ExactSizeIterator<Item = ReferenceExpression>,
+    >,
+    mut instructions: Vec<Instruction>,
+) -> Result<CompiledInvocation, InvocationError> {
     let mut relocations = Vec::new();
+    let base_instruction_count = instructions.len();
 
     // First branch is fallthrough. If there is only one branch, this `match` statement is
     // translated to nothing in Casm.
@@ -245,7 +258,7 @@ fn build_enum_match_short(
 
         instructions.extend(casm! { jmp rel 0 if variant_selector != 0; }.instructions);
         relocations.push(RelocationEntry {
-            instruction_idx: 0,
+            instruction_idx: base_instruction_count,
             relocation: Relocation::RelativeStatementId(statement_id),
         });
     }
@@ -285,10 +298,30 @@ fn build_enum_match_long(
         Item = impl ExactSizeIterator<Item = ReferenceExpression>,
     >,
 ) -> Result<CompiledInvocation, InvocationError> {
+    let expected_instruction_count = builder.invocation.branches.len() + 1;
+    build_enum_match_long_ex(
+        builder,
+        variant_selector,
+        output_expressions,
+        Vec::with_capacity(expected_instruction_count),
+    )
+}
+
+/// Extended version of `build_enum_match_long` that allows prepending instructions.
+fn build_enum_match_long_ex(
+    builder: CompiledInvocationBuilder<'_>,
+    variant_selector: CellRef,
+    output_expressions: impl ExactSizeIterator<
+        Item = impl ExactSizeIterator<Item = ReferenceExpression>,
+    >,
+    mut instructions: Vec<Instruction>,
+) -> Result<CompiledInvocation, InvocationError> {
     let target_statement_ids = builder.invocation.branches[1..].iter().map(|b| match b {
         BranchInfo { target: BranchTarget::Statement(stmnt_id), .. } => *stmnt_id,
         _ => panic!("malformed invocation"),
     });
+
+    let base_instruction_count = instructions.len();
 
     // The first instruction is the jmp to the relevant index in the jmp table.
     let mut ctx = casm! { jmp rel variant_selector; };
@@ -300,12 +333,13 @@ fn build_enum_match_long(
         // Add the jump instruction to the relevant target.
         casm_extend!(ctx, jmp rel 0;);
         relocations.push(RelocationEntry {
-            instruction_idx: i + 1,
+            instruction_idx: base_instruction_count + i + 1,
             relocation: Relocation::RelativeStatementId(stmnt_id),
         });
     }
 
-    Ok(builder.build(ctx.instructions, relocations, output_expressions))
+    instructions.extend(ctx.instructions);
+    Ok(builder.build(instructions, relocations, output_expressions))
 }
 
 /// A struct representing an actual enum value in the Sierra program.


### PR DESCRIPTION
## Summary

Added extended versions of `build_enum_match_short` and `build_enum_match_long` functions that allow prepending instructions. The new functions `build_enum_match_short_ex` and `build_enum_match_long_ex` take an additional parameter for initial instructions and properly handle relocation offsets. The original functions were refactored to call these extended versions with empty instruction vectors.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This change enables more flexibility when generating code for enum matching operations by allowing custom instructions to be prepended before the standard matching logic. This is particularly useful for complex enum operations that require setup code before the actual matching logic.

---

## What was the behavior or documentation before?

Previously, the enum matching functions could only generate a fixed set of instructions without the ability to prepend custom setup instructions.

---

## What is the behavior or documentation after?

Now, there are extended versions of the enum matching functions that accept an additional parameter for initial instructions. The original functions remain unchanged in behavior but internally call the new extended versions.

---

## Additional context

The implementation carefully handles relocation offsets to ensure that jump targets remain correct when instructions are prepended. This change maintains backward compatibility while providing more flexibility for code generation.