### PR TITLE
refactor: remove redundant Sized bound from GraphNode trait

### DIFF
--- a/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/graph_node.rs
@@ -4,7 +4,7 @@ use core::hash::Hash;
 
 /// A trait for a node in a graph. Note that a GraphNode has to be able to provide its neighbors
 /// by itself, without additional information.
-pub trait GraphNode: Sized + Clone {
+pub trait GraphNode: Clone {
     /// The type used to identify the nodes in the graph.
     type NodeId: Eq + Hash + Clone;
 


### PR DESCRIPTION
Remove redundant `Sized` trait bound from `GraphNode` trait