### PR TITLE
performance(starknet-classes): Made decompress word extraction less costly.

### DIFF
--- a/crates/cairo-lang-starknet-classes/src/felt252_vec_compression.rs
+++ b/crates/cairo-lang-starknet-classes/src/felt252_vec_compression.rs
@@ -40,16 +40,24 @@ pub fn decompress(packed_values: &[BigUintAsHex]) -> Option<Vec<&BigUint>> {
     let (packed_values, mut remaining_unpacked_size) = pop_usize(packed_values)?;
     let padded_code_size = code_size.checked_add(padding_size)?;
     let words_per_felt = words_per_felt(padded_code_size);
-    let padded_code_size = BigUint::from(padded_code_size);
     require(remaining_unpacked_size <= packed_values.len() * words_per_felt)?;
     let mut result = Vec::with_capacity(remaining_unpacked_size);
     for packed_value in packed_values {
         let curr_words = std::cmp::min(words_per_felt, remaining_unpacked_size);
-        let mut v = packed_value.value.clone();
+        let mut iter = packed_value.value.iter_u64_digits();
+        // Since all values are felt252s, we can assume 4 `u64` limbs are enough.
+        let mut v: [u64; 4] = std::array::from_fn(|_| iter.next().unwrap_or_default());
+        assert_eq!(iter.next(), None, "Unexpected extra limbs.");
         for _ in 0..curr_words {
-            let (remaining, code_word) = v.div_mod_floor(&padded_code_size);
-            result.push(&code.get(code_word.to_usize()?)?.value);
-            v = remaining;
+            // No allocation 4 limbs long division implementation.
+            let divisor = padded_code_size as u128;
+            let mut rem: usize = 0;
+            for limb in v.iter_mut().rev() {
+                let (q, r) = (*limb as u128 | ((rem as u128) << 64)).div_rem(&divisor);
+                *limb = q as u64;
+                rem = r as usize;
+            }
+            result.push(&code.get(rem)?.value);
         }
         remaining_unpacked_size -= curr_words;
     }


### PR DESCRIPTION
## Summary

Optimized the `decompress` function in the Starknet classes crate by replacing BigUint division with a more efficient no-allocation implementation using fixed-size arrays and u64/u128 operations. This change improves performance by avoiding heap allocations during the decompression process.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation of the `decompress` function used BigUint division operations which require heap allocations. This is inefficient for this particular use case since we're working with felt252 values that can be represented with a fixed number of u64 limbs.

---

## What was the behavior or documentation before?

The code used BigUint division and modulo operations which allocate memory on the heap for intermediate results during decompression.

---

## What is the behavior or documentation after?

The new implementation uses a fixed-size array of u64 values and performs division using u128 operations without any heap allocations, making the decompression process more efficient.

---

## Additional context

Since all values are felt252s, we can safely assume that 4 u64 limbs are sufficient for the representation, allowing us to use a more efficient division algorithm with fixed-size arrays.