### PR TITLE
performance(sierra): Vastly removing the number of clones for building a program.

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/specialization_context.rs
+++ b/crates/cairo-lang-sierra-generator/src/specialization_context.rs
@@ -15,9 +15,9 @@ pub struct SierraSignatureSpecializationContext<'a>(pub &'a dyn Database);
 impl TypeSpecializationContext for SierraSignatureSpecializationContext<'_> {
     fn try_get_type_info(
         &self,
-        id: cairo_lang_sierra::ids::ConcreteTypeId,
+        id: &cairo_lang_sierra::ids::ConcreteTypeId,
     ) -> Option<cairo_lang_sierra::extensions::types::TypeInfo> {
-        self.0.get_type_info(id).cloned().to_option()
+        self.0.get_type_info(id.clone()).cloned().to_option()
     }
 }
 impl SignatureSpecializationContext for SierraSignatureSpecializationContext<'_> {

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/test_utils.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/test_utils.rs
@@ -103,9 +103,10 @@ macro_rules! ref_expr {
 /// libfuncs without salsa db or program registry.
 struct MockSpecializationContext {}
 impl TypeSpecializationContext for MockSpecializationContext {
-    fn try_get_type_info(&self, id: ConcreteTypeId) -> Option<TypeInfo> {
-        let long_id =
-            cairo_lang_sierra::ConcreteTypeLongIdParser::new().parse(&id.debug_name?).unwrap();
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo> {
+        let long_id = cairo_lang_sierra::ConcreteTypeLongIdParser::new()
+            .parse(id.debug_name.as_ref()?)
+            .unwrap();
         Some(
             CoreType::specialize_by_id(self, &long_id.generic_id, &long_id.generic_args)
                 .ok()?

--- a/crates/cairo-lang-sierra/src/extensions/lib_func.rs
+++ b/crates/cairo-lang-sierra/src/extensions/lib_func.rs
@@ -253,7 +253,7 @@ impl<T: SignatureAndTypeGenericLibfunc> NamedLibfunc for WrapSignatureAndTypeGen
         context: &dyn SignatureSpecializationContext,
         args: &[GenericArg],
     ) -> Result<LibfuncSignature, SpecializationError> {
-        self.0.specialize_signature(context, args_as_single_type(args)?)
+        self.0.specialize_signature(context, args_as_single_type(args)?.clone())
     }
 
     fn specialize(
@@ -264,7 +264,7 @@ impl<T: SignatureAndTypeGenericLibfunc> NamedLibfunc for WrapSignatureAndTypeGen
         let ty = args_as_single_type(args)?;
         Ok(SignatureAndTypeConcreteLibfunc {
             ty: ty.clone(),
-            signature: self.0.specialize_signature(context, ty)?,
+            signature: self.0.specialize_signature(context, ty.clone())?,
         })
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/mod.rs
+++ b/crates/cairo-lang-sierra/src/extensions/mod.rs
@@ -23,18 +23,18 @@ use crate::ids::{ConcreteTypeId, FunctionId};
 use crate::program::GenericArg;
 
 /// Helper for extracting the value from the template arguments.
-fn args_as_single_value(args: &[GenericArg]) -> Result<BigInt, SpecializationError> {
+fn args_as_single_value(args: &[GenericArg]) -> Result<&BigInt, SpecializationError> {
     match args {
-        [GenericArg::Value(c)] => Ok(c.clone()),
+        [GenericArg::Value(c)] => Ok(c),
         [_] => Err(SpecializationError::UnsupportedGenericArg),
         _ => Err(SpecializationError::WrongNumberOfGenericArgs),
     }
 }
 
 /// Helper for extracting the type from the template arguments.
-pub fn args_as_single_type(args: &[GenericArg]) -> Result<ConcreteTypeId, SpecializationError> {
+pub fn args_as_single_type(args: &[GenericArg]) -> Result<&ConcreteTypeId, SpecializationError> {
     match args {
-        [GenericArg::Type(ty)] => Ok(ty.clone()),
+        [GenericArg::Type(ty)] => Ok(ty),
         [_] => Err(SpecializationError::UnsupportedGenericArg),
         _ => Err(SpecializationError::WrongNumberOfGenericArgs),
     }
@@ -43,18 +43,18 @@ pub fn args_as_single_type(args: &[GenericArg]) -> Result<ConcreteTypeId, Specia
 /// Helper for extracting two types from the template arguments.
 fn args_as_two_types(
     args: &[GenericArg],
-) -> Result<(ConcreteTypeId, ConcreteTypeId), SpecializationError> {
+) -> Result<(&ConcreteTypeId, &ConcreteTypeId), SpecializationError> {
     match args {
-        [GenericArg::Type(ty0), GenericArg::Type(ty1)] => Ok((ty0.clone(), ty1.clone())),
+        [GenericArg::Type(ty0), GenericArg::Type(ty1)] => Ok((ty0, ty1)),
         [_, _] => Err(SpecializationError::UnsupportedGenericArg),
         _ => Err(SpecializationError::WrongNumberOfGenericArgs),
     }
 }
 
 /// Helper for extracting the type from the template arguments.
-fn args_as_single_user_func(args: &[GenericArg]) -> Result<FunctionId, SpecializationError> {
+fn args_as_single_user_func(args: &[GenericArg]) -> Result<&FunctionId, SpecializationError> {
     match args {
-        [GenericArg::UserFunc(function_id)] => Ok(function_id.clone()),
+        [GenericArg::UserFunc(function_id)] => Ok(function_id),
         [_] => Err(SpecializationError::UnsupportedGenericArg),
         _ => Err(SpecializationError::WrongNumberOfGenericArgs),
     }
@@ -65,7 +65,7 @@ fn extract_type_generic_args<T: NamedType>(
     context: &dyn TypeSpecializationContext,
     ty: &ConcreteTypeId,
 ) -> Result<Vec<GenericArg>, SpecializationError> {
-    let long_id = context.get_type_info(ty.clone())?.long_id;
+    let long_id = context.get_type_info(ty)?.long_id;
     if long_id.generic_id != T::ID {
         Err(SpecializationError::UnsupportedGenericArg)
     } else {

--- a/crates/cairo-lang-sierra/src/extensions/modules/array.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/array.rs
@@ -81,7 +81,7 @@ impl SignatureOnlyGenericLibfunc for ArrayNewLibfunc {
         Ok(LibfuncSignature::new_non_branch(
             vec![],
             vec![OutputVarInfo {
-                ty: context.get_wrapped_concrete_type(ArrayType::id(), ty)?,
+                ty: context.get_wrapped_concrete_type(ArrayType::id(), ty.clone())?,
                 ref_info: OutputVarReferenceInfo::SimpleDerefs,
             }],
             SierraApChange::Known { new_vars_only: false },
@@ -520,7 +520,7 @@ impl NamedLibfunc for ArraySnapshotMultiPopFrontLibfunc {
         args: &[GenericArg],
     ) -> Result<LibfuncSignature, SpecializationError> {
         let popped_ty = args_as_single_type(args)?;
-        let ty = validate_tuple_and_fetch_ty(context, &popped_ty)?;
+        let ty = validate_tuple_and_fetch_ty(context, popped_ty)?;
         let arr_ty = context.get_wrapped_concrete_type(ArrayType::id(), ty)?;
         let arr_snapshot_ty = snapshot_ty(context, arr_ty)?;
         let range_check_ty = context.get_concrete_type(RangeCheckType::id(), &[])?;
@@ -539,7 +539,7 @@ impl NamedLibfunc for ArraySnapshotMultiPopFrontLibfunc {
                             ref_info: OutputVarReferenceInfo::SimpleDerefs,
                         },
                         OutputVarInfo {
-                            ty: snapshot_ty(context, box_ty(context, popped_ty)?)?,
+                            ty: snapshot_ty(context, box_ty(context, popped_ty.clone())?)?,
                             ref_info: OutputVarReferenceInfo::PartialParam { param_idx: 1 },
                         },
                     ],
@@ -566,9 +566,8 @@ impl NamedLibfunc for ArraySnapshotMultiPopFrontLibfunc {
         context: &dyn SpecializationContext,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        let popped_ty = args_as_single_type(args)?;
         Ok(ConcreteMultiPopLibfunc {
-            popped_ty,
+            popped_ty: args_as_single_type(args)?.clone(),
             signature: self.specialize_signature(context, args)?,
         })
     }
@@ -588,7 +587,7 @@ impl NamedLibfunc for ArraySnapshotMultiPopBackLibfunc {
         args: &[GenericArg],
     ) -> Result<LibfuncSignature, SpecializationError> {
         let popped_ty = args_as_single_type(args)?;
-        let ty = validate_tuple_and_fetch_ty(context, &popped_ty)?;
+        let ty = validate_tuple_and_fetch_ty(context, popped_ty)?;
         let arr_ty = context.get_wrapped_concrete_type(ArrayType::id(), ty)?;
         let arr_snapshot_ty = snapshot_ty(context, arr_ty)?;
         let range_check_ty = context.get_concrete_type(RangeCheckType::id(), &[])?;
@@ -607,7 +606,7 @@ impl NamedLibfunc for ArraySnapshotMultiPopBackLibfunc {
                             ref_info: OutputVarReferenceInfo::SimpleDerefs,
                         },
                         OutputVarInfo {
-                            ty: snapshot_ty(context, box_ty(context, popped_ty)?)?,
+                            ty: snapshot_ty(context, box_ty(context, popped_ty.clone())?)?,
                             ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
                         },
                     ],
@@ -634,9 +633,8 @@ impl NamedLibfunc for ArraySnapshotMultiPopBackLibfunc {
         context: &dyn SpecializationContext,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        let popped_ty = args_as_single_type(args)?;
         Ok(ConcreteMultiPopLibfunc {
-            popped_ty,
+            popped_ty: args_as_single_type(args)?.clone(),
             signature: self.specialize_signature(context, args)?,
         })
     }

--- a/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
@@ -114,7 +114,7 @@ impl SignatureAndTypeGenericLibfunc for UnboxLibfuncWrapped {
             vec![box_ty(context, ty.clone())?],
             vec![OutputVarInfo {
                 ty: ty.clone(),
-                ref_info: if context.get_type_info(ty)?.zero_sized {
+                ref_info: if context.get_type_info(&ty)?.zero_sized {
                     OutputVarReferenceInfo::ZeroSized
                 } else {
                     OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic)

--- a/crates/cairo-lang-sierra/src/extensions/modules/const_type.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/const_type.rs
@@ -74,7 +74,7 @@ fn validate_const_data(
     inner_ty: &ConcreteTypeId,
     inner_data: &[GenericArg],
 ) -> Result<(), SpecializationError> {
-    let inner_type_info = context.get_type_info(inner_ty.clone())?;
+    let inner_type_info = context.get_type_info(inner_ty)?;
     let inner_generic_id = &inner_type_info.long_id.generic_id;
     if *inner_generic_id == StructType::ID {
         return validate_const_struct_data(context, &inner_type_info, inner_data);
@@ -173,8 +173,8 @@ fn validate_const_nz_data(
     let wrapped_ty_from_nz = args_as_single_type(&inner_type_info.long_id.generic_args)?;
     let inner_const_type_id = args_as_single_type(inner_data)?;
     let (wrapped_ty_from_const, inner_const_data) =
-        extract_const_info(context, &inner_const_type_id)?;
-    if wrapped_ty_from_const != wrapped_ty_from_nz {
+        extract_const_info(context, inner_const_type_id)?;
+    if &wrapped_ty_from_const != wrapped_ty_from_nz {
         return Err(SpecializationError::UnsupportedGenericArg);
     }
     let ty_info = context.get_type_info(wrapped_ty_from_nz)?;
@@ -373,9 +373,9 @@ impl ConstAsImmediateLibfunc {
         args: &[GenericArg],
     ) -> Result<ConstAsImmediateConcreteLibfunc, SpecializationError> {
         let const_type = args_as_single_type(args)?;
-        let (ty, _) = extract_const_info(context, &const_type)?;
+        let (ty, _) = extract_const_info(context, const_type)?;
         Ok(ConstAsImmediateConcreteLibfunc {
-            const_type,
+            const_type: const_type.clone(),
             signature: LibfuncSignature::new_non_branch(
                 vec![],
                 vec![OutputVarInfo {

--- a/crates/cairo-lang-sierra/src/extensions/modules/consts.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/consts.rs
@@ -51,11 +51,11 @@ impl<T: ConstGenLibfunc> NamedLibfunc for WrapConstGenLibfunc<T> {
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
         let c = args_as_single_value(args)?;
-        if c.is_negative() || c > (<T as ConstGenLibfunc>::bound()) {
+        if c.is_negative() || *c > (<T as ConstGenLibfunc>::bound()) {
             return Err(SpecializationError::UnsupportedGenericArg);
         }
         Ok(SignatureAndConstConcreteLibfunc {
-            c,
+            c: c.clone(),
             signature: <Self as NamedLibfunc>::specialize_signature(self, context, args)?,
         })
     }

--- a/crates/cairo-lang-sierra/src/extensions/modules/coupon.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/coupon.rs
@@ -38,7 +38,7 @@ impl NamedType for CouponType {
                 storable: true,
                 zero_sized: true,
             },
-            function_id,
+            function_id: function_id.clone(),
         })
     }
 }
@@ -86,13 +86,16 @@ impl NamedLibfunc for CouponBuyLibfunc {
         args: &[GenericArg],
     ) -> Result<LibfuncSignature, SpecializationError> {
         let coupon_ty = args_as_single_type(args)?;
-        if context.get_type_info(coupon_ty.clone())?.long_id.generic_id != CouponType::id() {
+        if context.get_type_info(coupon_ty)?.long_id.generic_id != CouponType::id() {
             return Err(SpecializationError::UnsupportedGenericArg);
         }
 
         Ok(LibfuncSignature::new_non_branch(
             vec![],
-            vec![OutputVarInfo { ty: coupon_ty, ref_info: OutputVarReferenceInfo::ZeroSized }],
+            vec![OutputVarInfo {
+                ty: coupon_ty.clone(),
+                ref_info: OutputVarReferenceInfo::ZeroSized,
+            }],
             SierraApChange::Known { new_vars_only: true },
         ))
     }
@@ -111,7 +114,7 @@ impl NamedLibfunc for CouponBuyLibfunc {
         let function_id = args_as_single_user_func(&long_id.generic_args)?;
 
         Ok(SignatureAndFunctionConcreteLibfunc {
-            function: context.get_function(&function_id)?,
+            function: context.get_function(function_id)?,
             signature: self.specialize_signature(context, args)?,
         })
     }
@@ -131,12 +134,12 @@ impl NamedLibfunc for CouponRefundLibfunc {
         args: &[GenericArg],
     ) -> Result<LibfuncSignature, SpecializationError> {
         let coupon_ty = args_as_single_type(args)?;
-        if context.get_type_info(coupon_ty.clone())?.long_id.generic_id != CouponType::id() {
+        if context.get_type_info(coupon_ty)?.long_id.generic_id != CouponType::id() {
             return Err(SpecializationError::UnsupportedGenericArg);
         }
 
         Ok(LibfuncSignature::new_non_branch(
-            vec![coupon_ty],
+            vec![coupon_ty.clone()],
             vec![],
             SierraApChange::Known { new_vars_only: true },
         ))
@@ -156,7 +159,7 @@ impl NamedLibfunc for CouponRefundLibfunc {
         let function_id = args_as_single_user_func(&long_id.generic_args)?;
 
         Ok(SignatureAndFunctionConcreteLibfunc {
-            function: context.get_function(&function_id)?,
+            function: context.get_function(function_id)?,
             signature: self.specialize_signature(context, args)?,
         })
     }

--- a/crates/cairo-lang-sierra/src/extensions/modules/drop.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/drop.rs
@@ -17,11 +17,11 @@ impl SignatureOnlyGenericLibfunc for DropLibfunc {
         generic_args: &[GenericArg],
     ) -> Result<LibfuncSignature, SpecializationError> {
         let ty = args_as_single_type(generic_args)?;
-        let info = context.get_type_info(ty.clone())?;
+        let info = context.get_type_info(ty)?;
         if info.droppable {
             Ok(LibfuncSignature::new_non_branch_ex(
                 vec![ParamSignature {
-                    ty,
+                    ty: ty.clone(),
                     allow_deferred: true,
                     allow_add_const: true,
                     allow_const: true,

--- a/crates/cairo-lang-sierra/src/extensions/modules/duplicate.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/duplicate.rs
@@ -17,7 +17,7 @@ impl SignatureOnlyGenericLibfunc for DupLibfunc {
         generic_args: &[GenericArg],
     ) -> Result<LibfuncSignature, SpecializationError> {
         let ty = args_as_single_type(generic_args)?;
-        let info = context.get_type_info(ty.clone())?;
+        let info = context.get_type_info(ty)?;
         if !info.duplicatable {
             return Err(SpecializationError::UnsupportedGenericArg);
         }
@@ -27,7 +27,7 @@ impl SignatureOnlyGenericLibfunc for DupLibfunc {
             ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 0 },
         };
         Ok(LibfuncSignature::new_non_branch_ex(
-            vec![ParamSignature::new(ty).with_allow_const()],
+            vec![ParamSignature::new(ty.clone()).with_allow_const()],
             vec![output_info.clone(), output_info],
             SierraApChange::Known { new_vars_only: true },
         ))

--- a/crates/cairo-lang-sierra/src/extensions/modules/felt252_dict.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/felt252_dict.rs
@@ -80,7 +80,7 @@ fn specialize_with_dict_value_param(
                     let GenericArg::Type(ty) = arg else {
                         return false;
                     };
-                    let Ok(info) = context.get_type_info(ty) else {
+                    let Ok(info) = context.get_type_info(&ty) else {
                         return false;
                     };
                     info.zero_sized
@@ -127,7 +127,7 @@ impl SignatureOnlyGenericLibfunc for Felt252DictNewLibfunc {
             vec![
                 OutputVarInfo::new_builtin(segment_arena_ty, 0),
                 OutputVarInfo {
-                    ty: context.get_wrapped_concrete_type(Felt252DictType::id(), ty)?,
+                    ty: context.get_wrapped_concrete_type(Felt252DictType::id(), ty.clone())?,
                     ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
                 },
             ],
@@ -151,7 +151,7 @@ impl SignatureOnlyGenericLibfunc for Felt252DictSquashLibfunc {
         let dict_ty =
             context.get_wrapped_concrete_type(Felt252DictType::id(), generic_ty.clone())?;
         let squashed_dict_ty =
-            context.get_wrapped_concrete_type(SquashedFelt252DictType::id(), generic_ty)?;
+            context.get_wrapped_concrete_type(SquashedFelt252DictType::id(), generic_ty.clone())?;
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
         let gas_builtin_type = context.get_concrete_type(GasBuiltinType::id(), &[])?;
         let segment_arena_ty = context.get_concrete_type(SegmentArenaType::id(), &[])?;

--- a/crates/cairo-lang-sierra/src/extensions/modules/mem.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/mem.rs
@@ -34,7 +34,7 @@ impl SignatureAndTypeGenericLibfunc for StoreTempLibfuncWrapped {
         context: &dyn SignatureSpecializationContext,
         ty: ConcreteTypeId,
     ) -> Result<LibfuncSignature, SpecializationError> {
-        let type_info = context.get_type_info(ty.clone())?;
+        let type_info = context.get_type_info(&ty)?;
         if !type_info.storable {
             return Err(SpecializationError::UnsupportedGenericArg);
         }
@@ -72,7 +72,7 @@ impl SignatureAndTypeGenericLibfunc for StoreLocalLibfuncWrapped {
     ) -> Result<LibfuncSignature, SpecializationError> {
         let uninitialized_type =
             context.get_wrapped_concrete_type(UninitializedType::id(), ty.clone())?;
-        let type_info = context.get_type_info(ty.clone())?;
+        let type_info = context.get_type_info(&ty)?;
         if !type_info.storable {
             return Err(SpecializationError::UnsupportedGenericArg);
         }
@@ -129,7 +129,7 @@ impl SignatureAndTypeGenericLibfunc for AllocLocalLibfuncWrapped {
         context: &dyn SignatureSpecializationContext,
         ty: ConcreteTypeId,
     ) -> Result<LibfuncSignature, SpecializationError> {
-        let type_info = context.get_type_info(ty.clone())?;
+        let type_info = context.get_type_info(&ty)?;
         Ok(LibfuncSignature::new_non_branch(
             vec![],
             vec![OutputVarInfo {
@@ -158,6 +158,6 @@ impl SignatureOnlyGenericLibfunc for RenameLibfunc {
         args: &[GenericArg],
     ) -> Result<LibfuncSignature, SpecializationError> {
         let ty = args_as_single_type(args)?;
-        Ok(reinterpret_cast_signature(ty.clone(), ty))
+        Ok(reinterpret_cast_signature(ty.clone(), ty.clone()))
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/non_zero.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/non_zero.rs
@@ -54,9 +54,9 @@ impl SignatureOnlyGenericLibfunc for UnwrapNonZeroLibfunc {
     ) -> Result<LibfuncSignature, SpecializationError> {
         let ty = args_as_single_type(args)?;
         Ok(LibfuncSignature::new_non_branch(
-            vec![nonzero_ty(context, &ty)?],
+            vec![nonzero_ty(context, ty)?],
             vec![OutputVarInfo {
-                ty,
+                ty: ty.clone(),
                 ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 0 },
             }],
             SierraApChange::Known { new_vars_only: true },

--- a/crates/cairo-lang-sierra/src/extensions/modules/nullable.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/nullable.rs
@@ -84,7 +84,7 @@ impl SignatureOnlyGenericLibfunc for NullLibfunc {
         Ok(LibfuncSignature::new_non_branch(
             vec![],
             vec![OutputVarInfo {
-                ty: nullable_ty(context, ty)?,
+                ty: nullable_ty(context, ty.clone())?,
                 ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
             }],
             SierraApChange::Known { new_vars_only: true },

--- a/crates/cairo-lang-sierra/src/extensions/modules/range.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/range.rs
@@ -95,7 +95,7 @@ impl SignatureOnlyGenericLibfunc for IntRangeTryNewLibfunc {
         let range_ty = context.get_wrapped_concrete_type(IntRangeType::id(), ty.clone())?;
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
 
-        if !Range::from_type(context, ty.clone())?.is_small_range() {
+        if !Range::from_type(context, ty)?.is_small_range() {
             return Err(SpecializationError::UnsupportedGenericArg);
         }
 
@@ -103,7 +103,7 @@ impl SignatureOnlyGenericLibfunc for IntRangeTryNewLibfunc {
             param_signatures: vec![
                 ParamSignature::new(range_check_type.clone()).with_allow_add_const(),
                 ParamSignature::new(ty.clone()),
-                ParamSignature::new(ty),
+                ParamSignature::new(ty.clone()),
             ],
             branch_signatures: vec![
                 // Success.
@@ -167,7 +167,7 @@ impl SignatureOnlyGenericLibfunc for IntRangePopFrontLibfunc {
                             ),
                         },
                         OutputVarInfo {
-                            ty,
+                            ty: ty.clone(),
                             ref_info: OutputVarReferenceInfo::PartialParam { param_idx: 0 },
                         },
                     ],

--- a/crates/cairo-lang-sierra/src/extensions/modules/snapshot.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/snapshot.rs
@@ -47,7 +47,7 @@ pub fn snapshot_ty(
     context: &dyn SignatureSpecializationContext,
     ty: ConcreteTypeId,
 ) -> Result<ConcreteTypeId, SpecializationError> {
-    if context.get_type_info(ty.clone())?.duplicatable {
+    if context.get_type_info(&ty)?.duplicatable {
         Ok(ty)
     } else {
         context.get_wrapped_concrete_type(SnapshotType::id(), ty)
@@ -79,7 +79,7 @@ impl SignatureOnlyGenericLibfunc for SnapshotTakeLibfunc {
                     ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 0 },
                 },
                 OutputVarInfo {
-                    ty: snapshot_ty(context, ty)?,
+                    ty: snapshot_ty(context, ty.clone())?,
                     ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 0 },
                 },
             ],

--- a/crates/cairo-lang-sierra/src/extensions/modules/trace.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/trace.rs
@@ -32,6 +32,6 @@ impl NamedLibfunc for TraceLibfunc {
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
         let flag = args_as_single_value(args)?;
-        Ok(Self::Concrete { signature: self.specialize_signature(context, args)?, c: flag })
+        Ok(Self::Concrete { signature: self.specialize_signature(context, args)?, c: flag.clone() })
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/utils.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/utils.rs
@@ -87,7 +87,7 @@ impl Range {
     /// Returns the Range bounds from the given type.
     pub fn from_type(
         context: &dyn SignatureSpecializationContext,
-        ty: ConcreteTypeId,
+        ty: &ConcreteTypeId,
     ) -> Result<Self, SpecializationError> {
         Self::from_type_info(&context.get_type_info(ty)?)
     }

--- a/crates/cairo-lang-sierra/src/extensions/test.rs
+++ b/crates/cairo-lang-sierra/src/extensions/test.rs
@@ -37,59 +37,59 @@ impl MockSpecializationContext {
 }
 
 impl TypeSpecializationContext for MockSpecializationContext {
-    fn try_get_type_info(&self, id: ConcreteTypeId) -> Option<TypeInfo> {
-        if id == "T".into()
-            || id == "felt252".into()
-            || id == "u128".into()
-            || id == "bytes31".into()
-            || id == "Option".into()
-            || id == "NonZeroFelt252".into()
-            || id == "NonZeroInt".into()
-            || id == "Tuple<>".into()
-            || id == "U128AndFelt252".into()
-            || id == "StorageAddress".into()
-            || id == "ContractAddress".into()
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo> {
+        if id == &"T".into()
+            || id == &"felt252".into()
+            || id == &"u128".into()
+            || id == &"bytes31".into()
+            || id == &"Option".into()
+            || id == &"NonZeroFelt252".into()
+            || id == &"NonZeroInt".into()
+            || id == &"Tuple<>".into()
+            || id == &"U128AndFelt252".into()
+            || id == &"StorageAddress".into()
+            || id == &"ContractAddress".into()
             || id.debug_name.clone().unwrap().contains("BoundedInt")
         {
             Some(TypeInfo {
-                long_id: self.mapping.get_by_left(&id)?.clone(),
+                long_id: self.mapping.get_by_left(id)?.clone(),
                 storable: true,
                 droppable: true,
                 duplicatable: true,
                 zero_sized: false,
             })
-        } else if id == "ArrayFelt252".into() || id == "ArrayU128".into() {
+        } else if id == &"ArrayFelt252".into() || id == &"ArrayU128".into() {
             Some(TypeInfo {
-                long_id: self.mapping.get_by_left(&id)?.clone(),
+                long_id: self.mapping.get_by_left(id)?.clone(),
                 storable: true,
                 droppable: true,
                 duplicatable: false,
                 zero_sized: false,
             })
-        } else if id == "UninitializedFelt252".into() || id == "UninitializedU128".into() {
+        } else if id == &"UninitializedFelt252".into() || id == &"UninitializedU128".into() {
             Some(TypeInfo {
-                long_id: self.mapping.get_by_left(&id)?.clone(),
+                long_id: self.mapping.get_by_left(id)?.clone(),
                 storable: false,
                 droppable: true,
                 duplicatable: false,
                 zero_sized: true,
             })
-        } else if id == "GasBuiltin".into()
-            || id == "System".into()
-            || id == "RangeCheck".into()
-            || id == "NonDupEnum".into()
-            || id == "NonDupStruct".into()
+        } else if id == &"GasBuiltin".into()
+            || id == &"System".into()
+            || id == &"RangeCheck".into()
+            || id == &"NonDupEnum".into()
+            || id == &"NonDupStruct".into()
         {
             Some(TypeInfo {
-                long_id: self.mapping.get_by_left(&id)?.clone(),
+                long_id: self.mapping.get_by_left(id)?.clone(),
                 storable: true,
                 droppable: false,
                 duplicatable: false,
                 zero_sized: false,
             })
-        } else if id == "SnapshotRangeCheck".into() || id == "SnapshotArrayU128".into() {
+        } else if id == &"SnapshotRangeCheck".into() || id == &"SnapshotArrayU128".into() {
             Some(TypeInfo {
-                long_id: self.mapping.get_by_left(&id)?.clone(),
+                long_id: self.mapping.get_by_left(id)?.clone(),
                 storable: true,
                 droppable: true,
                 duplicatable: true,

--- a/crates/cairo-lang-sierra/src/extensions/type_specialization_context.rs
+++ b/crates/cairo-lang-sierra/src/extensions/type_specialization_context.rs
@@ -5,10 +5,10 @@ use crate::ids::ConcreteTypeId;
 /// Trait for the specialization of types.
 pub trait TypeSpecializationContext {
     /// Returns the type information for the type with the given id.
-    fn try_get_type_info(&self, id: ConcreteTypeId) -> Option<TypeInfo>;
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo>;
 
     /// Wraps [Self::try_get_type_info] with a result object.
-    fn get_type_info(&self, id: ConcreteTypeId) -> Result<TypeInfo, SpecializationError> {
-        self.try_get_type_info(id.clone()).ok_or(SpecializationError::MissingTypeInfo(id))
+    fn get_type_info(&self, id: &ConcreteTypeId) -> Result<TypeInfo, SpecializationError> {
+        self.try_get_type_info(id).ok_or(SpecializationError::MissingTypeInfo(id.clone()))
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/types.rs
+++ b/crates/cairo-lang-sierra/src/extensions/types.rs
@@ -140,8 +140,11 @@ impl<T: GenericTypeArgGenericType> NamedType for GenericTypeArgGenericTypeWrappe
     ) -> Result<Self::Concrete, SpecializationError> {
         let ty = args_as_single_type(args)?;
         let long_id = Self::concrete_type_long_id(args);
-        let wrapped_info = context.get_type_info(ty.clone())?;
-        Ok(Self::Concrete { info: self.0.calc_info(context, long_id, wrapped_info)?, ty })
+        let wrapped_info = context.get_type_info(ty)?;
+        Ok(Self::Concrete {
+            info: self.0.calc_info(context, long_id, wrapped_info)?,
+            ty: ty.clone(),
+        })
     }
 }
 

--- a/crates/cairo-lang-sierra/src/program_registry.rs
+++ b/crates/cairo-lang-sierra/src/program_registry.rs
@@ -266,10 +266,10 @@ struct TypeSpecializationContextForRegistry<'a, TType: GenericType> {
 impl<TType: GenericType> TypeSpecializationContext
     for TypeSpecializationContextForRegistry<'_, TType>
 {
-    fn try_get_type_info(&self, id: ConcreteTypeId) -> Option<TypeInfo> {
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo> {
         self.declared_type_info
-            .get(&id)
-            .or_else(|| self.concrete_types.get(&id).map(|ty| ty.info()))
+            .get(id)
+            .or_else(|| self.concrete_types.get(id).map(|ty| ty.info()))
             .cloned()
     }
 }
@@ -349,8 +349,8 @@ pub struct SpecializationContextForRegistry<'a, TType: GenericType> {
     pub concrete_types: &'a TypeMap<TType::Concrete>,
 }
 impl<TType: GenericType> TypeSpecializationContext for SpecializationContextForRegistry<'_, TType> {
-    fn try_get_type_info(&self, id: ConcreteTypeId) -> Option<TypeInfo> {
-        self.concrete_types.get(&id).map(|ty| ty.info().clone())
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo> {
+        self.concrete_types.get(id).map(|ty| ty.info().clone())
     }
 }
 impl<TType: GenericType> SignatureSpecializationContext

--- a/crates/cairo-lang-sierra/src/simulation/test.rs
+++ b/crates/cairo-lang-sierra/src/simulation/test.rs
@@ -49,26 +49,26 @@ impl SpecializationContext for MockSpecializationContext {
     }
 }
 impl TypeSpecializationContext for MockSpecializationContext {
-    fn try_get_type_info(&self, id: ConcreteTypeId) -> Option<TypeInfo> {
-        if id == "u128".into() || id == "u64".into() || id == "NonZeroInt".into() {
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo> {
+        if id == &"u128".into() || id == &"u64".into() || id == &"NonZeroInt".into() {
             Some(TypeInfo {
-                long_id: self.mapping.get_by_left(&id)?.clone(),
+                long_id: self.mapping.get_by_left(id)?.clone(),
                 storable: true,
                 droppable: true,
                 duplicatable: true,
                 zero_sized: false,
             })
-        } else if id == "UninitializedInt".into() {
+        } else if id == &"UninitializedInt".into() {
             Some(TypeInfo {
-                long_id: self.mapping.get_by_left(&id)?.clone(),
+                long_id: self.mapping.get_by_left(id)?.clone(),
                 storable: false,
                 droppable: true,
                 duplicatable: false,
                 zero_sized: true,
             })
-        } else if id == "ArrayU128".into() {
+        } else if id == &"ArrayU128".into() {
             Some(TypeInfo {
-                long_id: self.mapping.get_by_left(&id)?.clone(),
+                long_id: self.mapping.get_by_left(id)?.clone(),
                 storable: true,
                 droppable: true,
                 duplicatable: false,


### PR DESCRIPTION
## Summary

This PR changes the `TypeSpecializationContext::try_get_type_info` method to take a reference to `ConcreteTypeId` instead of taking it by value. This reduces unnecessary cloning throughout the codebase.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `try_get_type_info` method was taking `ConcreteTypeId` by value, which led to unnecessary cloning throughout the codebase. By changing the method to take a reference instead, we can avoid these clones and improve performance.

---

## What was the behavior or documentation before?

The `try_get_type_info` method took `ConcreteTypeId` by value, requiring callers to clone the ID when they needed to use it after the call. This pattern was repeated throughout the codebase.

---

## What is the behavior or documentation after?

The method now takes a reference to `ConcreteTypeId`, which eliminates the need for many clones throughout the codebase. This should improve performance by reducing unnecessary memory allocations.

---

## Additional context

This change is part of ongoing efforts to optimize the compiler by reducing unnecessary cloning and memory allocations. The PR updates all call sites to pass references instead of values, and adjusts related code to maintain the same behavior.