### PR TITLE
perf: avoid extra Vec allocation in split_structs

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/split_structs.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/split_structs.rs
@@ -168,11 +168,9 @@ fn rebuild_blocks(lowered: &mut Lowered<'_>, split: SplitMapping) {
                     if let Some(output_split) =
                         split.get(&ctx.var_remapper.map_var_id(stmt.input.var_id))
                     {
-                        for (output, new_var) in
-                            zip_eq(stmt.outputs.iter(), output_split.vars.iter().cloned())
-                        {
+                        for (output, new_var) in zip_eq(&stmt.outputs, &output_split.vars) {
                             assert!(
-                                ctx.var_remapper.renamed_vars.insert(*output, new_var).is_none()
+                                ctx.var_remapper.renamed_vars.insert(*output, new_var.clone()).is_none()
                             )
                         }
                     } else {


### PR DESCRIPTION
## Summary

Replace output_split.vars.to_vec() in the StructDestructure handling with output_split.vars.iter().cloned() so we no longer allocate a temporary Vec just to iterate over it.

---

## Type of change


- [x] Performance improvement


---

## Why is this change needed?

Avoid per-statement heap allocation in a hot optimization pass.