### PR TITLE
docs: add function example with return value to ABI documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/application-binary-interface.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/application-binary-interface.adoc
@@ -43,6 +43,20 @@ Function item:
 }
 ----
 
+Function item (with return value):
+[source,json]
+----
+{
+  "type": "function",
+  "name": "balance_of",
+  "inputs": [
+    { "name": "account", "type": "ContractAddress" }
+  ],
+  "outputs": [ { "type": "u256" } ],
+  "state_mutability": "view"
+}
+----
+
 Constructor item:
 [source,json]
 ----


### PR DESCRIPTION
## Summary

Adds a function example with return value to the ABI documentation. The existing example only showed a function with empty `outputs`, which doesn't demonstrate how to specify return values in ABI JSON.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The ABI documentation showed only one function example with empty `outputs: []`. While there is an example with non-empty `outputs` in the interface section, it's not immediately obvious. Many real-world functions return values, and developers need a clear example of how to specify return types in the `outputs` array.

---

## What was the behavior or documentation before?

The documentation had a function example with empty `outputs: []` (the `transfer` function). An example with non-empty `outputs` existed only nested inside an interface example, which is less discoverable.

---

## What is the behavior or documentation after?

The documentation now includes a dedicated function example (`balance_of`) that demonstrates how to specify return values in the `outputs` array, using a view function returning `u256`. This example is placed right after the basic function example.

---

## Related issue or discussion (if any)

<!-- None -->

---

## Additional context

The example uses `balance_of` returning `u256` as it's a familiar pattern from ERC20-like contracts and matches the existing interface example in the same file.