### PR TITLE
docs: add tuple return and L1 handler examples to ABI docs

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/application-binary-interface.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/application-binary-interface.adoc
@@ -55,6 +55,22 @@ Function item (with return value):
   "outputs": [ { "type": "u256" } ],
   "state_mutability": "view"
 }
+
+Function item (tuple return):
+[source,json]
+----
+{
+  "type": "function",
+  "name": "div_mod",
+  "inputs": [
+    { "name": "a", "type": "u8" },
+    { "name": "b", "type": "u8" }
+  ],
+  "outputs": [
+    { "type": "(u8, u8)" }
+  ],
+  "state_mutability": "view"
+}
 ----
 
 Constructor item:
@@ -76,6 +92,22 @@ L1 handler item:
   "type": "l1_handler",
   "name": "handle_deposit",
   "inputs": [ { "name": "from_address", "type": "felt252" } ],
+  "outputs": [],
+  "state_mutability": "external"
+}
+----
+
+L1 handler item (with payload):
+[source,json]
+----
+{
+  "type": "l1_handler",
+  "name": "handle_token_deposit",
+  "inputs": [
+    { "name": "from_address", "type": "felt252" },
+    { "name": "amount",       "type": "u256" },
+    { "name": "recipient",    "type": "ContractAddress" }
+  ],
   "outputs": [],
   "state_mutability": "external"
 }


### PR DESCRIPTION
## Summary

Adds examples for function items with tuple returns and L1 handler items with payloads to [application-binary-interface.adoc], clarifying their JSON representation.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

An example was missing for non-obvious ABI patterns like tuple returns (which are represented as a single output with a tuple type string) and L1 handlers with message payloads. This clarifies how developers should interpret these common cases in the ABI JSON.

---

## What was the behavior or documentation before?

The documentation only showed basic function and L1 handler examples, leaving users to potentially guess the representation of tuple returns (e.g. assuming they might be flattened) or L1 payloads.

---

## What is the behavior or documentation after?

The documentation now explicitly shows how tuple returns are formatted as a single output type string (e.g. `"(u8, u8)"`) and how L1 handler payloads appear as standard input parameters alongside the sender address.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

This follows the detailed example pattern established in recent documentation updates (e.g. adding return value examples), making the reference manual more self-contained.