### PR TITLE
performance(sierra-gas): Made vec be allocated with capacity.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/compute_costs.rs
+++ b/crates/cairo-lang-sierra-gas/src/compute_costs.rs
@@ -124,7 +124,7 @@ pub fn compute_costs<
 ) -> Result<GasInfo, CostError> {
     let mut context = CostContext {
         program,
-        branch_costs: Default::default(),
+        branch_costs: Vec::with_capacity(program.statements.len()),
         enforced_wallet_values,
         costs: Default::default(),
         target_values: Default::default(),


### PR DESCRIPTION
## Summary

Optimize memory allocation in the `compute_costs` function by pre-allocating capacity for the `branch_costs` vector based on the program's statement count, rather than using the default capacity.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This change improves performance by reducing memory reallocations during the cost computation process. By pre-allocating the `branch_costs` vector with the exact capacity needed (based on the program's statement count), we avoid multiple costly reallocations that would occur as the vector grows.

---

## What was the behavior or documentation before?

Previously, `branch_costs` was initialized with `Default::default()`, which creates a vector with zero initial capacity. This meant the vector would need to reallocate memory multiple times as elements were added during processing.

---

## What is the behavior or documentation after?

Now `branch_costs` is initialized with a capacity equal to the number of statements in the program, ensuring that all elements can be added without triggering any reallocations.

---

## Additional context

This is a small but meaningful optimization for the gas cost computation process, which can be performance-sensitive when dealing with large programs.