### PR TITLE
performance(cairo-execute): Removed mimalloc dependency preventing `workspace-level feature unification`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,6 @@ dependencies = [
  "cairo-lang-sierra-generator",
  "cairo-vm",
  "clap",
- "mimalloc",
  "num-bigint",
  "salsa",
  "serde_json",

--- a/crates/bin/cairo-execute/Cargo.toml
+++ b/crates/bin/cairo-execute/Cargo.toml
@@ -18,11 +18,6 @@ cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.15.0" }
 cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "=2.15.0" }
 cairo-vm = { workspace = true, features = ["clap"] }
 clap.workspace = true
-mimalloc = { workspace = true, features = ["secure"], optional = true }
 num-bigint.workspace = true
 salsa.workspace = true
 serde_json.workspace = true
-
-[features]
-
-mimalloc = ["dep:mimalloc"]

--- a/crates/bin/cairo-execute/src/main.rs
+++ b/crates/bin/cairo-execute/src/main.rs
@@ -29,10 +29,6 @@ use clap::Parser;
 use num_bigint::BigInt;
 use salsa::Database;
 
-#[cfg(feature = "mimalloc")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 /// Compiles a Cairo project and runs a function marked `#[executable]`.
 /// Exits with 1 if the compilation or run fails, otherwise 0.
 #[derive(Parser, Debug)]


### PR DESCRIPTION
## Summary

Removed the `mimalloc` dependency and feature from the `cairo-execute` binary. This PR eliminates the optional memory allocator and its associated feature flag, removing it from both the Cargo.toml configuration and the global allocator declaration in the main.rs file.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `mimalloc` dependency was likely unnecessary for the `cairo-execute` binary and removing it simplifies the codebase. This change reduces dependencies and potential security concerns associated with using a custom memory allocator when the standard Rust allocator is sufficient for this use case.
When existed, it caused other crates in the workspace to use `secure` feature, which is much slower in the mimalloc usage.

---

## What was the behavior or documentation before?

Previously, `cairo-execute` had an optional `mimalloc` feature that, when enabled, would use the MiMalloc allocator instead of Rust's default allocator.

---

## What is the behavior or documentation after?

Now `cairo-execute` always uses Rust's default memory allocator, simplifying the codebase and dependency tree.

---

## Additional context

Memory allocators like `mimalloc` are typically used for performance optimization in specific scenarios. This change suggests that the standard Rust allocator provides adequate performance for this binary, making the custom allocator unnecessary.