### PR TITLE
(test): Adding casm run and trace to e2e tests

### DIFF
--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -7,6 +7,7 @@ use cairo_lang_filesystem::flag::{Flag, FlagsGroup};
 use cairo_lang_filesystem::ids::FlagLongId;
 use cairo_lang_lowering::db::lowering_group_input;
 use cairo_lang_lowering::optimizations::config::{OptimizationConfig, Optimizations};
+use cairo_lang_runner::{Arg, RunResultValue, SierraCasmRunner};
 use cairo_lang_semantic::test_utils::setup_test_module;
 use cairo_lang_sierra::extensions::gas::{CostTokenMap, CostTokenType};
 use cairo_lang_sierra::ids::FunctionId;
@@ -24,6 +25,7 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::Itertools;
 use salsa::Setter;
+use starknet_types_core::felt::Felt as Felt252;
 
 /// Salsa databases configured to find the corelib, when reused by different tests should be able to
 /// use the cached queries that rely on the corelib's code, which vastly reduces the tests runtime.
@@ -106,6 +108,7 @@ cairo_lang_test_utils::test_file_test_with_runner!(
         u512: "u512",
         u64: "u64",
         u8: "u8",
+        casm_run_sanity: "casm_run_sanity",
     },
     SmallE2ETestRunner
 );
@@ -160,11 +163,29 @@ impl TestFileRunner for SmallE2ETestRunner {
         args: &OrderedHashMap<String, String>,
     ) -> TestRunnerResult {
         let future_sierra = args.get("future_sierra").is_some_and(|v| v == "true");
-        run_e2e_test(inputs, E2eTestParams { future_sierra, ..E2eTestParams::default() })
+        let skip_gas = args.get("skip_gas").is_some_and(|v| v == "true");
+
+        let test_data = match TestData::parse(args) {
+            Ok(td) => td,
+            Err(e) => {
+                return TestRunnerResult { outputs: OrderedHashMap::default(), error: Some(e) };
+            }
+        };
+
+        run_e2e_test(
+            inputs,
+            E2eTestParams {
+                future_sierra,
+                test_data,
+                add_withdraw_gas: !skip_gas,
+                ..E2eTestParams::default()
+            },
+        )
     }
 
     fn allowed_arg(&self, arg: &str) -> bool {
-        arg == "future_sierra"
+        ["future_sierra", "skip_gas", "test_data_function", "test_data_input", "test_data_output"]
+            .contains(&arg)
     }
 }
 
@@ -215,6 +236,41 @@ impl TestFileRunner for SmallE2ETestRunnerMetadataComputation {
     }
 }
 
+/// Represents test data for function execution: function_name(input)=output
+#[derive(Clone, Debug)]
+struct TestData {
+    function_name: String,
+    input: Vec<Felt252>,
+    expected_output: Vec<Felt252>,
+}
+
+impl TestData {
+    /// Parses test_data. Expects three args: test_data_function, test_data_input, test_data_output.
+    fn parse(args: &OrderedHashMap<String, String>) -> Result<Option<TestData>, String> {
+        let Some(function_name) = args.get("test_data_function").cloned() else {
+            return Ok(None);
+        };
+        let Some((input, output)) = args.get("test_data_input").zip(args.get("test_data_output"))
+        else {
+            return Err("Given test_data_function both test_data_input and test_data_output must \
+                        be present as well."
+                .to_string());
+        };
+
+        let input = Felt252::from_dec_str(input)
+            .map_err(|e| format!("Failed to parse input as a felt '{}': {}", input, e))?;
+        let expected_output = Felt252::from_dec_str(output).map_err(|e| {
+            format!("Failed to parse expected output as a felt '{}': {}", output, e)
+        })?;
+
+        Ok(Some(TestData {
+            function_name,
+            input: vec![input],
+            expected_output: vec![expected_output],
+        }))
+    }
+}
+
 /// Represents the parameters of `run_e2e_test`.
 struct E2eTestParams {
     /// Argument for `run_e2e_test` that controls whether to set the `add_withdraw_gas` flag
@@ -230,6 +286,9 @@ struct E2eTestParams {
 
     /// Argument for `run_e2e_test` that controls whether to enable the `future_sierra` flag.
     future_sierra: bool,
+
+    /// Test data for function execution validation.
+    test_data: Option<TestData>,
 }
 
 /// Implements default for `E2eTestParams`.
@@ -240,6 +299,7 @@ impl Default for E2eTestParams {
             metadata_computation: false,
             skip_optimization_passes: true,
             future_sierra: false,
+            test_data: None,
         }
     }
 }
@@ -325,7 +385,63 @@ fn run_e2e_test(
         res.insert("function_costs".into(), function_costs_str);
     }
 
+    // Handle test_data if specified.
+    // This runs AFTER sierra/casm generation, so compilation outputs are always verified first.
+    if let Some(test_data) = params.test_data {
+        if let Err(e) =
+            run_and_validate_test_data(sierra_program, test_data, params.add_withdraw_gas)
+        {
+            return TestRunnerResult { outputs: res, error: Some(e) };
+        }
+    }
+
     TestRunnerResult::success(res)
+}
+
+/// Runs the specified function and validates its output against expected values.
+fn run_and_validate_test_data(
+    sierra_program: Program,
+    test_data: TestData,
+    withdraw_gas: bool,
+) -> Result<(), String> {
+    let runner = SierraCasmRunner::new(
+        sierra_program,
+        withdraw_gas.then(Default::default),
+        Default::default(),
+        None,
+    )
+    .expect("Failed setting up runner for test_data.");
+
+    let func = runner
+        .find_function(&test_data.function_name)
+        .map_err(|e| format!("Function '{}' not found: {}", test_data.function_name, e))?;
+
+    let result = runner
+        .run_function_with_starknet_context(
+            func,
+            test_data.input.into_iter().map(Arg::Value).collect_vec(),
+            withdraw_gas.then_some(usize::MAX),
+            Default::default(),
+        )
+        .map_err(|e| format!("Failed running function '{}': {}", test_data.function_name, e))?;
+
+    match &result.value {
+        RunResultValue::Success(values) => {
+            if values != &test_data.expected_output {
+                return Err(format!(
+                    "Function '{}' output mismatch: expected {}, got {}",
+                    test_data.function_name,
+                    test_data.expected_output.iter().map(|f| f.to_string()).join(", "),
+                    values.iter().map(|f| f.to_string()).join(", ")
+                ));
+            }
+            Ok(())
+        }
+        RunResultValue::Panic(panic_data) => Err(format!(
+            "Function '{}' panicked with data: {panic_data:?}",
+            test_data.function_name
+        )),
+    }
 }
 
 /// Parses the `enforced_costs` test argument. It should consist of lines of the form

--- a/tests/e2e_test_data/libfuncs/casm_run_sanity
+++ b/tests/e2e_test_data/libfuncs/casm_run_sanity
@@ -1,0 +1,435 @@
+//! > simple addition - basic arithmetic
+
+//! > test_runner_name
+SmallE2ETestRunner(test_data_function: add_three, test_data_input: 5, test_data_output: 8)
+
+//! > cairo_code
+fn add_three(x: felt252) -> felt252 {
+    x + 3
+}
+
+//! > casm
+[ap + 0] = [fp + -3] + 3, ap++;
+ret;
+
+//! > function_costs
+test::add_three: SmallOrderedMap({Const: 100})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 3> = Const<felt252, 3> [storable: false, drop: false, dup: false, zero_sized: false];
+
+libfunc const_as_immediate<Const<felt252, 3>> = const_as_immediate<Const<felt252, 3>>;
+libfunc felt252_add = felt252_add;
+libfunc store_temp<felt252> = store_temp<felt252>;
+
+F0:
+const_as_immediate<Const<felt252, 3>>() -> ([1]);
+felt252_add([0], [1]) -> ([2]);
+store_temp<felt252>([2]) -> ([2]);
+return([2]);
+
+test::add_three@F0([0]: felt252) -> (felt252);
+
+//! > ==========================================================================
+
+//! > box creation and unbox - simple box operations
+
+//! > test_runner_name
+SmallE2ETestRunner(test_data_function: box_double, test_data_input: 7, test_data_output: 14)
+
+//! > cairo_code
+fn box_double(x: felt252) -> felt252 {
+    let boxed = BoxTrait::new(x);
+    let val = boxed.unbox();
+    val + val
+}
+
+//! > casm
+%{
+if '__boxed_segment' not in globals():
+    __boxed_segment = segments.add()
+memory[ap + 0] = __boxed_segment
+__boxed_segment += 1
+%}
+[fp + -3] = [[ap + 0] + 0], ap++;
+[ap + 0] = [[ap + -1] + 0], ap++;
+[ap + 0] = [ap + -1] + [ap + -1], ap++;
+ret;
+
+//! > function_costs
+test::box_double: SmallOrderedMap({Const: 300})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc into_box<felt252> = into_box<felt252>;
+libfunc unbox<felt252> = unbox<felt252>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc dup<felt252> = dup<felt252>;
+libfunc felt252_add = felt252_add;
+
+F0:
+into_box<felt252>([0]) -> ([1]);
+unbox<felt252>([1]) -> ([2]);
+store_temp<felt252>([2]) -> ([2]);
+dup<felt252>([2]) -> ([2], [3]);
+felt252_add([3], [2]) -> ([4]);
+store_temp<felt252>([4]) -> ([4]);
+return([4]);
+
+test::box_double@F0([0]: felt252) -> (felt252);
+
+//! > ==========================================================================
+
+//! > match control flow - returns different values based on input
+
+//! > test_runner_name
+SmallE2ETestRunner(test_data_function: match_val, test_data_input: 2, test_data_output: 20)
+
+//! > cairo_code
+fn match_val(x: felt252) -> felt252 {
+    if x == 0 {
+        0
+    } else if x == 1 {
+        10
+    } else {
+        20
+    }
+}
+
+//! > casm
+[fp + -3] = [ap + 0] + 0, ap++;
+jmp rel 7 if [ap + -1] != 0;
+ap += 1;
+[ap + 0] = 0, ap++;
+ret;
+[fp + -3] = [ap + 0] + 1, ap++;
+jmp rel 5 if [ap + -1] != 0;
+[ap + 0] = 10, ap++;
+ret;
+[ap + 0] = 20, ap++;
+ret;
+
+//! > function_costs
+test::match_val: SmallOrderedMap({Const: 500})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 20> = Const<felt252, 20> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 10> = Const<felt252, 10> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 1> = Const<felt252, 1> [storable: false, drop: false, dup: false, zero_sized: false];
+type NonZero<felt252> = NonZero<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 0> = Const<felt252, 0> [storable: false, drop: false, dup: false, zero_sized: false];
+
+libfunc const_as_immediate<Const<felt252, 0>> = const_as_immediate<Const<felt252, 0>>;
+libfunc dup<felt252> = dup<felt252>;
+libfunc felt252_sub = felt252_sub;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc felt252_is_zero = felt252_is_zero;
+libfunc branch_align = branch_align;
+libfunc drop<felt252> = drop<felt252>;
+libfunc drop<NonZero<felt252>> = drop<NonZero<felt252>>;
+libfunc const_as_immediate<Const<felt252, 1>> = const_as_immediate<Const<felt252, 1>>;
+libfunc const_as_immediate<Const<felt252, 10>> = const_as_immediate<Const<felt252, 10>>;
+libfunc const_as_immediate<Const<felt252, 20>> = const_as_immediate<Const<felt252, 20>>;
+
+F0:
+const_as_immediate<Const<felt252, 0>>() -> ([1]);
+dup<felt252>([0]) -> ([0], [2]);
+dup<felt252>([1]) -> ([1], [3]);
+felt252_sub([2], [3]) -> ([4]);
+store_temp<felt252>([4]) -> ([4]);
+felt252_is_zero([4]) { fallthrough() F0_B0([5]) };
+branch_align() -> ();
+drop<felt252>([0]) -> ();
+store_temp<felt252>([1]) -> ([1]);
+return([1]);
+F0_B0:
+branch_align() -> ();
+drop<NonZero<felt252>>([5]) -> ();
+drop<felt252>([1]) -> ();
+const_as_immediate<Const<felt252, 1>>() -> ([6]);
+felt252_sub([0], [6]) -> ([7]);
+store_temp<felt252>([7]) -> ([7]);
+felt252_is_zero([7]) { fallthrough() F0_B1([8]) };
+branch_align() -> ();
+const_as_immediate<Const<felt252, 10>>() -> ([9]);
+store_temp<felt252>([9]) -> ([9]);
+return([9]);
+F0_B1:
+branch_align() -> ();
+drop<NonZero<felt252>>([8]) -> ();
+const_as_immediate<Const<felt252, 20>>() -> ([10]);
+store_temp<felt252>([10]) -> ([10]);
+return([10]);
+
+test::match_val@F0([0]: felt252) -> (felt252);
+
+//! > ==========================================================================
+
+//! > fibonacci with loop - fib(n) using while loop (without gas tracking)
+
+//! > test_runner_name
+SmallE2ETestRunner(skip_gas: false, test_data_function: fib, test_data_input: 3, test_data_output: 2)
+
+//! > cairo_code
+fn fib(n: felt252) -> felt252 {
+    let mut a: felt252 = 0;
+    let mut b: felt252 = 1;
+    let mut i: felt252 = 0;
+    while i != n {
+        let temp = b;
+        b = a + b;
+        a = temp;
+        i = i + 1;
+    }
+    a
+}
+
+//! > casm
+[ap + 0] = [fp + -5], ap++;
+[ap + 0] = [fp + -4], ap++;
+[ap + 0] = 1, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -3], ap++;
+call rel 19;
+jmp rel 10 if [ap + -4] != 0;
+[ap + 0] = [ap + -6], ap++;
+[ap + 0] = [ap + -6], ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = [ap + -6], ap++;
+ret;
+[ap + 0] = [ap + -6], ap++;
+[ap + 0] = [ap + -6], ap++;
+[ap + 0] = 1, ap++;
+[ap + 0] = [ap + -5], ap++;
+[ap + 0] = [ap + -5], ap++;
+ret;
+%{ memory[ap + 0] = 1570 <= memory[fp + -7] %}
+jmp rel 7 if [ap + 0] != 0, ap++;
+[ap + 0] = [fp + -7] + 340282366920938463463374607431768209886, ap++;
+[ap + -1] = [[fp + -8] + 0];
+jmp rel 37;
+[fp + -7] = [ap + 0] + 1570, ap++;
+[ap + -1] = [[fp + -8] + 0];
+[fp + -4] = [ap + 0] + [fp + -3], ap++;
+jmp rel 16 if [ap + -1] != 0;
+[ap + 0] = 1, ap++;
+[ap + 0] = 1, ap++;
+[ap + 0] = [fp + -8] + 1, ap++;
+[ap + 0] = [ap + -5] + 2170, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = [fp + -6], ap++;
+[ap + 0] = [fp + -5], ap++;
+[ap + 0] = [fp + -4], ap++;
+ret;
+[ap + 0] = 0, ap++;
+[ap + 0] = 1, ap++;
+[ap + 0] = [fp + -8] + 1, ap++;
+[ap + 0] = [ap + -5], ap++;
+[ap + 0] = [fp + -5] + [fp + -6], ap++;
+[ap + 0] = [fp + -6], ap++;
+[ap + 0] = [fp + -4] + 1, ap++;
+[ap + 0] = [fp + -3], ap++;
+call rel -39;
+ret;
+call rel 12;
+[ap + 0] = [fp + -8] + 1, ap++;
+[ap + 0] = [fp + -7], ap++;
+[ap + 0] = 1, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = [ap + -6], ap++;
+[ap + 0] = [ap + -6], ap++;
+ret;
+[ap + 0] = 375233589013918064796019, ap++;
+call rel 3;
+ret;
+%{ memory[ap + 0] = segments.add() %}
+ap += 1;
+[fp + -3] = [[ap + -1] + 0];
+[ap + 0] = [ap + -1], ap++;
+[ap + 0] = [ap + -2] + 1, ap++;
+ret;
+
+//! > function_costs
+test::fib: SmallOrderedMap({Const: 3370})
+test::fib[116-219]: SmallOrderedMap({Const: 1970})
+core::panic_with_const_felt252::<375233589013918064796019>: SmallOrderedMap({Const: 700})
+core::panic_with_felt252: SmallOrderedMap({Const: 400})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type core::panics::Panic = Struct<ut@core::panics::Panic> [storable: true, drop: true, dup: true, zero_sized: true];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Const<felt252, 375233589013918064796019> = Const<felt252, 375233589013918064796019> [storable: false, drop: false, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type NonZero<felt252> = NonZero<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<felt252> = Struct<ut@Tuple, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<core::panics::Panic, Array<felt252>> = Struct<ut@Tuple, core::panics::Panic, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type core::panics::PanicResult::<(core::felt252,)> = Enum<ut@core::panics::PanicResult::<(core::felt252,)>, Tuple<felt252>, Tuple<core::panics::Panic, Array<felt252>>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Tuple<felt252, felt252, felt252, Unit> = Struct<ut@Tuple, felt252, felt252, felt252, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())> = Enum<ut@core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>, Tuple<felt252, felt252, felt252, Unit>, Tuple<core::panics::Panic, Array<felt252>>> [storable: true, drop: true, dup: false, zero_sized: false];
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 1> = Const<felt252, 1> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 0> = Const<felt252, 0> [storable: false, drop: false, dup: false, zero_sized: false];
+
+libfunc disable_ap_tracking = disable_ap_tracking;
+libfunc const_as_immediate<Const<felt252, 0>> = const_as_immediate<Const<felt252, 0>>;
+libfunc const_as_immediate<Const<felt252, 1>> = const_as_immediate<Const<felt252, 1>>;
+libfunc snapshot_take<felt252> = snapshot_take<felt252>;
+libfunc drop<felt252> = drop<felt252>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc dup<felt252> = dup<felt252>;
+libfunc function_call<user@test::fib[116-219]> = function_call<user@test::fib[116-219]>;
+libfunc enum_match<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>> = enum_match<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>>;
+libfunc branch_align = branch_align;
+libfunc redeposit_gas = redeposit_gas;
+libfunc struct_deconstruct<Tuple<felt252, felt252, felt252, Unit>> = struct_deconstruct<Tuple<felt252, felt252, felt252, Unit>>;
+libfunc drop<Unit> = drop<Unit>;
+libfunc struct_construct<Tuple<felt252>> = struct_construct<Tuple<felt252>>;
+libfunc enum_init<core::panics::PanicResult::<(core::felt252,)>, 0> = enum_init<core::panics::PanicResult::<(core::felt252,)>, 0>;
+libfunc store_temp<core::panics::PanicResult::<(core::felt252,)>> = store_temp<core::panics::PanicResult::<(core::felt252,)>>;
+libfunc enum_init<core::panics::PanicResult::<(core::felt252,)>, 1> = enum_init<core::panics::PanicResult::<(core::felt252,)>, 1>;
+libfunc withdraw_gas = withdraw_gas;
+libfunc rename<felt252> = rename<felt252>;
+libfunc felt252_sub = felt252_sub;
+libfunc felt252_is_zero = felt252_is_zero;
+libfunc struct_construct<Unit> = struct_construct<Unit>;
+libfunc dup<Unit> = dup<Unit>;
+libfunc enum_init<core::bool, 1> = enum_init<core::bool, 1>;
+libfunc store_temp<core::bool> = store_temp<core::bool>;
+libfunc bool_not_impl = bool_not_impl;
+libfunc drop<core::bool> = drop<core::bool>;
+libfunc struct_construct<Tuple<felt252, felt252, felt252, Unit>> = struct_construct<Tuple<felt252, felt252, felt252, Unit>>;
+libfunc enum_init<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>, 0> = enum_init<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>, 0>;
+libfunc store_temp<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>> = store_temp<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>>;
+libfunc drop<NonZero<felt252>> = drop<NonZero<felt252>>;
+libfunc enum_init<core::bool, 0> = enum_init<core::bool, 0>;
+libfunc felt252_add = felt252_add;
+libfunc function_call<user@core::panic_with_const_felt252::<375233589013918064796019>> = function_call<user@core::panic_with_const_felt252::<375233589013918064796019>>;
+libfunc enum_init<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>, 1> = enum_init<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>, 1>;
+libfunc const_as_immediate<Const<felt252, 375233589013918064796019>> = const_as_immediate<Const<felt252, 375233589013918064796019>>;
+libfunc function_call<user@core::panic_with_felt252> = function_call<user@core::panic_with_felt252>;
+libfunc array_new<felt252> = array_new<felt252>;
+libfunc array_append<felt252> = array_append<felt252>;
+libfunc struct_construct<core::panics::Panic> = struct_construct<core::panics::Panic>;
+libfunc struct_construct<Tuple<core::panics::Panic, Array<felt252>>> = struct_construct<Tuple<core::panics::Panic, Array<felt252>>>;
+libfunc store_temp<Tuple<core::panics::Panic, Array<felt252>>> = store_temp<Tuple<core::panics::Panic, Array<felt252>>>;
+
+F0:
+disable_ap_tracking() -> ();
+const_as_immediate<Const<felt252, 0>>() -> ([3]);
+const_as_immediate<Const<felt252, 1>>() -> ([4]);
+snapshot_take<felt252>([2]) -> ([5], [6]);
+drop<felt252>([5]) -> ();
+store_temp<RangeCheck>([0]) -> ([0]);
+store_temp<GasBuiltin>([1]) -> ([1]);
+store_temp<felt252>([4]) -> ([4]);
+dup<felt252>([3]) -> ([3], [7]);
+store_temp<felt252>([7]) -> ([7]);
+store_temp<felt252>([3]) -> ([3]);
+store_temp<felt252>([6]) -> ([6]);
+function_call<user@test::fib[116-219]>([0], [1], [4], [7], [3], [6]) -> ([8], [9], [10]);
+enum_match<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>>([10]) { fallthrough([11]) F0_B0([12]) };
+branch_align() -> ();
+redeposit_gas([9]) -> ([13]);
+struct_deconstruct<Tuple<felt252, felt252, felt252, Unit>>([11]) -> ([14], [15], [16], [17]);
+drop<felt252>([14]) -> ();
+drop<felt252>([16]) -> ();
+drop<Unit>([17]) -> ();
+struct_construct<Tuple<felt252>>([15]) -> ([18]);
+enum_init<core::panics::PanicResult::<(core::felt252,)>, 0>([18]) -> ([19]);
+store_temp<RangeCheck>([8]) -> ([8]);
+store_temp<GasBuiltin>([13]) -> ([13]);
+store_temp<core::panics::PanicResult::<(core::felt252,)>>([19]) -> ([19]);
+return([8], [13], [19]);
+F0_B0:
+branch_align() -> ();
+enum_init<core::panics::PanicResult::<(core::felt252,)>, 1>([12]) -> ([20]);
+store_temp<RangeCheck>([8]) -> ([8]);
+store_temp<GasBuiltin>([9]) -> ([9]);
+store_temp<core::panics::PanicResult::<(core::felt252,)>>([20]) -> ([20]);
+return([8], [9], [20]);
+F1:
+disable_ap_tracking() -> ();
+withdraw_gas([0], [1]) { fallthrough([6], [7]) F1_B1([8], [9]) };
+branch_align() -> ();
+dup<felt252>([5]) -> ([5], [10]);
+rename<felt252>([10]) -> ([11]);
+dup<felt252>([4]) -> ([4], [12]);
+felt252_sub([12], [11]) -> ([13]);
+store_temp<felt252>([13]) -> ([13]);
+felt252_is_zero([13]) { fallthrough() F1_B0([14]) };
+branch_align() -> ();
+drop<felt252>([5]) -> ();
+redeposit_gas([7]) -> ([15]);
+struct_construct<Unit>() -> ([16]);
+dup<Unit>([16]) -> ([16], [17]);
+enum_init<core::bool, 1>([17]) -> ([18]);
+store_temp<core::bool>([18]) -> ([18]);
+bool_not_impl([18]) -> ([19]);
+drop<core::bool>([19]) -> ();
+struct_construct<Tuple<felt252, felt252, felt252, Unit>>([2], [3], [4], [16]) -> ([20]);
+enum_init<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>, 0>([20]) -> ([21]);
+store_temp<RangeCheck>([6]) -> ([6]);
+store_temp<GasBuiltin>([15]) -> ([15]);
+store_temp<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>>([21]) -> ([21]);
+return([6], [15], [21]);
+F1_B0:
+branch_align() -> ();
+drop<NonZero<felt252>>([14]) -> ();
+redeposit_gas([7]) -> ([22]);
+struct_construct<Unit>() -> ([23]);
+enum_init<core::bool, 0>([23]) -> ([24]);
+store_temp<core::bool>([24]) -> ([24]);
+bool_not_impl([24]) -> ([25]);
+drop<core::bool>([25]) -> ();
+dup<felt252>([2]) -> ([2], [26]);
+felt252_add([3], [26]) -> ([27]);
+const_as_immediate<Const<felt252, 1>>() -> ([28]);
+felt252_add([4], [28]) -> ([29]);
+store_temp<RangeCheck>([6]) -> ([6]);
+store_temp<GasBuiltin>([22]) -> ([22]);
+store_temp<felt252>([27]) -> ([27]);
+store_temp<felt252>([2]) -> ([2]);
+store_temp<felt252>([29]) -> ([29]);
+store_temp<felt252>([5]) -> ([5]);
+function_call<user@test::fib[116-219]>([6], [22], [27], [2], [29], [5]) -> ([30], [31], [32]);
+return([30], [31], [32]);
+F1_B1:
+branch_align() -> ();
+drop<felt252>([5]) -> ();
+drop<felt252>([3]) -> ();
+drop<felt252>([2]) -> ();
+drop<felt252>([4]) -> ();
+function_call<user@core::panic_with_const_felt252::<375233589013918064796019>>() -> ([33]);
+enum_init<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>, 1>([33]) -> ([34]);
+store_temp<RangeCheck>([8]) -> ([8]);
+store_temp<GasBuiltin>([9]) -> ([9]);
+store_temp<core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>>([34]) -> ([34]);
+return([8], [9], [34]);
+F2:
+const_as_immediate<Const<felt252, 375233589013918064796019>>() -> ([0]);
+store_temp<felt252>([0]) -> ([0]);
+function_call<user@core::panic_with_felt252>([0]) -> ([1]);
+return([1]);
+F3:
+array_new<felt252>() -> ([1]);
+array_append<felt252>([1], [0]) -> ([2]);
+struct_construct<core::panics::Panic>() -> ([3]);
+struct_construct<Tuple<core::panics::Panic, Array<felt252>>>([3], [2]) -> ([4]);
+store_temp<Tuple<core::panics::Panic, Array<felt252>>>([4]) -> ([4]);
+return([4]);
+
+test::fib@F0([0]: RangeCheck, [1]: GasBuiltin, [2]: felt252) -> (RangeCheck, GasBuiltin, core::panics::PanicResult::<(core::felt252,)>);
+test::fib[116-219]@F1([0]: RangeCheck, [1]: GasBuiltin, [2]: felt252, [3]: felt252, [4]: felt252, [5]: felt252) -> (RangeCheck, GasBuiltin, core::panics::PanicResult::<(core::felt252, core::felt252, core::felt252, ())>);
+core::panic_with_const_felt252::<375233589013918064796019>@F2() -> (Tuple<core::panics::Panic, Array<felt252>>);
+core::panic_with_felt252@F3([0]: felt252) -> (Tuple<core::panics::Panic, Array<felt252>>);


### PR DESCRIPTION
## Summary

Added support for capturing and returning VM execution traces in the Cairo runner. This enables checking real run output, debugging and analysis of Cairo program execution by providing access to the program counter, allocation pointer, and frame pointer at each step, as well as the final memory state.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

This PR adds the ability to capture and return VM execution traces, which is essential for debugging and analyzing Cairo program execution. The trace provides visibility into the program counter, allocation pointer, and frame pointer at each execution step, along with the final memory state. This is particularly useful for developers who need to understand the low-level execution details of their Cairo programs.

---

## What was the behavior or documentation before?

Previously, the runner would execute Cairo programs but did not provide a way to access the execution trace or memory state after execution. This made debugging complex programs difficult as developers couldn't inspect the execution flow.

---

## What is the behavior or documentation after?

The runner now has the ability to optionally capture and return the execution trace and memory state. This is implemented through:

1. Added `trace` field to `RunResult` and `RunResultStarknet` structs
2. Added `run_function_with_starknet_context_with_trace` method with a `return_trace` parameter
3. Updated existing methods to support trace capture
4. Added test infrastructure to demonstrate and validate trace capture functionality

The e2e test runner now supports a `trace: true` option and can display the execution trace in a readable table format.

---

## Additional context

The implementation includes comprehensive test cases that demonstrate the trace functionality with different Cairo programs, from simple arithmetic to more complex control flow and loops. This provides examples for users on how to use and interpret the trace data.