### PR TITLE
refactor(sierra): Removed unused param_idx parameter of AddConst.

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/store_variables/state.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/state.rs
@@ -15,18 +15,7 @@ pub struct DeferredVariableInfo {
     /// The type of the variable.
     pub ty: sierra::ids::ConcreteTypeId,
     /// The deferred type.
-    pub kind: DeferredVariableKind,
-}
-
-/// The type of a deferred variable.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DeferredVariableKind {
-    /// See [DeferredOutputKind::Const].
-    Const,
-    /// See [DeferredOutputKind::AddConst].
-    AddConst,
-    /// See [DeferredOutputKind::Generic].
-    Generic,
+    pub kind: DeferredOutputKind,
 }
 
 /// Represents the state of Sierra variable.
@@ -101,14 +90,7 @@ impl VariablesState {
 
         let var_state = match &output_info.ref_info {
             OutputVarReferenceInfo::Deferred(kind) => VarState::Deferred {
-                info: DeferredVariableInfo {
-                    ty: output_info.ty.clone(),
-                    kind: match kind {
-                        DeferredOutputKind::Const => DeferredVariableKind::Const,
-                        DeferredOutputKind::AddConst { .. } => DeferredVariableKind::AddConst,
-                        DeferredOutputKind::Generic => DeferredVariableKind::Generic,
-                    },
-                },
+                info: DeferredVariableInfo { ty: output_info.ty.clone(), kind: *kind },
             },
             OutputVarReferenceInfo::NewTempVar { idx } => {
                 add_to_known_stack = Some(idx.into_or_panic::<isize>());

--- a/crates/cairo-lang-sierra-generator/src/store_variables/test.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/test.rs
@@ -66,9 +66,7 @@ fn get_libfunc_signature(
             branch_signatures: vec![BranchSignature {
                 vars: vec![OutputVarInfo {
                     ty: felt252_ty.clone(),
-                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
-                        param_idx: 0,
-                    }),
+                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst),
                 }],
                 ap_change: SierraApChange::Known { new_vars_only: true },
             }],
@@ -93,9 +91,7 @@ fn get_libfunc_signature(
             branch_signatures: vec![BranchSignature {
                 vars: vec![OutputVarInfo {
                     ty: array_ty.clone(),
-                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
-                        param_idx: 0,
-                    }),
+                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst),
                 }],
                 ap_change: SierraApChange::Known { new_vars_only: true },
             }],

--- a/crates/cairo-lang-sierra/src/extensions/lib_func.rs
+++ b/crates/cairo-lang-sierra/src/extensions/lib_func.rs
@@ -378,12 +378,12 @@ pub enum OutputVarReferenceInfo {
 }
 
 /// The type of a deferred output.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum DeferredOutputKind {
     /// The output is a constant. For example, `7`.
     Const,
-    /// The output is the addition of a constant to one of the parameters. For example, `x + 3`.
-    AddConst { param_idx: usize },
+    /// The output is the addition of a constant to a deferred value. For example, `[ap - 5] + 4`.
+    AddConst,
     /// The output is not one of the above (e.g., `[ap] + [fp]`, `[ap + 1] * [fp - 3]`,
     /// `[ap] * 3`).
     Generic,
@@ -397,10 +397,10 @@ pub struct OutputVarInfo {
 }
 impl OutputVarInfo {
     /// Convenience function to get the common OutputVarInfo for builtins.
-    pub fn new_builtin(builtin: ConcreteTypeId, param_idx: usize) -> Self {
+    pub fn new_builtin(builtin: ConcreteTypeId) -> Self {
         Self {
             ty: builtin,
-            ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst { param_idx }),
+            ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst),
         }
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/array.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/array.rs
@@ -109,9 +109,7 @@ impl SignatureAndTypeGenericLibfunc for SpanFromTupleLibfuncWrapped {
                     context,
                     context.get_wrapped_concrete_type(ArrayType::id(), member_type)?,
                 )?,
-                ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
-                    param_idx: 0,
-                }),
+                ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst),
             }],
             SierraApChange::Known { new_vars_only: true },
         ))
@@ -222,9 +220,7 @@ impl SignatureAndTypeGenericLibfunc for ArrayAppendLibfuncWrapped {
             ],
             vec![OutputVarInfo {
                 ty: arr_ty,
-                ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
-                    param_idx: 0,
-                }),
+                ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst),
             }],
             SierraApChange::Known { new_vars_only: true },
         ))
@@ -253,7 +249,7 @@ impl SignatureAndTypeGenericLibfunc for ArrayPopFrontLibfuncWrapped {
                         OutputVarInfo {
                             ty: arr_ty.clone(),
                             ref_info: OutputVarReferenceInfo::Deferred(
-                                DeferredOutputKind::AddConst { param_idx: 0 },
+                                DeferredOutputKind::AddConst,
                             ),
                         },
                         OutputVarInfo {
@@ -299,7 +295,7 @@ impl SignatureAndTypeGenericLibfunc for ArrayPopFrontConsumeLibfuncWrapped {
                         OutputVarInfo {
                             ty: arr_ty,
                             ref_info: OutputVarReferenceInfo::Deferred(
-                                DeferredOutputKind::AddConst { param_idx: 0 },
+                                DeferredOutputKind::AddConst,
                             ),
                         },
                         OutputVarInfo {
@@ -341,7 +337,7 @@ impl SignatureAndTypeGenericLibfunc for ArrayGetLibfuncWrapped {
             ParamSignature::new(snapshot_ty(context, arr_type)?),
             ParamSignature::new(index_type),
         ];
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type, 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type);
         let branch_signatures = vec![
             // First (success) branch returns rc, array and element; failure branch does not return
             // an element.
@@ -388,7 +384,7 @@ impl SignatureAndTypeGenericLibfunc for ArraySliceLibfuncWrapped {
             // Length
             ParamSignature::new(index_type),
         ];
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type, 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type);
         let branch_signatures = vec![
             // Success.
             BranchSignature {
@@ -435,7 +431,7 @@ impl SignatureAndTypeGenericLibfunc for ArraySnapshotPopFrontLibfuncWrapped {
                         OutputVarInfo {
                             ty: arr_snapshot_ty.clone(),
                             ref_info: OutputVarReferenceInfo::Deferred(
-                                DeferredOutputKind::AddConst { param_idx: 0 },
+                                DeferredOutputKind::AddConst,
                             ),
                         },
                         OutputVarInfo {
@@ -481,7 +477,7 @@ impl SignatureAndTypeGenericLibfunc for ArraySnapshotPopBackLibfuncWrapped {
                         OutputVarInfo {
                             ty: arr_snapshot_ty.clone(),
                             ref_info: OutputVarReferenceInfo::Deferred(
-                                DeferredOutputKind::AddConst { param_idx: 0 },
+                                DeferredOutputKind::AddConst,
                             ),
                         },
                         OutputVarInfo {
@@ -533,7 +529,7 @@ impl NamedLibfunc for ArraySnapshotMultiPopFrontLibfunc {
                 // Success.
                 BranchSignature {
                     vars: vec![
-                        OutputVarInfo::new_builtin(range_check_ty.clone(), 0),
+                        OutputVarInfo::new_builtin(range_check_ty.clone()),
                         OutputVarInfo {
                             ty: arr_snapshot_ty.clone(),
                             ref_info: OutputVarReferenceInfo::SimpleDerefs,
@@ -548,7 +544,7 @@ impl NamedLibfunc for ArraySnapshotMultiPopFrontLibfunc {
                 // Failure.
                 BranchSignature {
                     vars: vec![
-                        OutputVarInfo::new_builtin(range_check_ty, 0),
+                        OutputVarInfo::new_builtin(range_check_ty),
                         OutputVarInfo {
                             ty: arr_snapshot_ty,
                             ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 1 },
@@ -600,7 +596,7 @@ impl NamedLibfunc for ArraySnapshotMultiPopBackLibfunc {
                 // Success.
                 BranchSignature {
                     vars: vec![
-                        OutputVarInfo::new_builtin(range_check_ty.clone(), 0),
+                        OutputVarInfo::new_builtin(range_check_ty.clone()),
                         OutputVarInfo {
                             ty: arr_snapshot_ty.clone(),
                             ref_info: OutputVarReferenceInfo::SimpleDerefs,
@@ -615,7 +611,7 @@ impl NamedLibfunc for ArraySnapshotMultiPopBackLibfunc {
                 // Failure.
                 BranchSignature {
                     vars: vec![
-                        OutputVarInfo::new_builtin(range_check_ty, 0),
+                        OutputVarInfo::new_builtin(range_check_ty),
                         OutputVarInfo {
                             ty: arr_snapshot_ty,
                             ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 1 },

--- a/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
@@ -216,7 +216,7 @@ impl NamedLibfunc for BoundedIntDivRemLibfunc {
                 ParamSignature::new(nonzero_ty(context, rhs)?),
             ],
             vec![
-                OutputVarInfo::new_builtin(range_check_type, 0),
+                OutputVarInfo::new_builtin(range_check_type),
                 OutputVarInfo {
                     ty: bounded_int_ty(context, quotient_min, quotient_max)?,
                     ref_info: OutputVarReferenceInfo::SimpleDerefs,
@@ -344,7 +344,7 @@ impl NamedLibfunc for BoundedIntConstrainLibfunc {
             let res_ty = if is_nz { nonzero_ty(context, &inner_res_ty)? } else { inner_res_ty };
             Ok(BranchSignature {
                 vars: vec![
-                    OutputVarInfo::new_builtin(range_check_type.clone(), 0),
+                    OutputVarInfo::new_builtin(range_check_type.clone()),
                     OutputVarInfo {
                         ty: res_ty,
                         ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 1 },

--- a/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
@@ -89,9 +89,7 @@ impl SignatureAndTypeGenericLibfunc for LocalIntoBoxLibfuncWrapped {
             vec![ty.clone()],
             vec![OutputVarInfo {
                 ty: box_ty(context, ty)?,
-                ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
-                    param_idx: 0,
-                }),
+                ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst),
             }],
             SierraApChange::Known { new_vars_only: false },
         ))

--- a/crates/cairo-lang-sierra/src/extensions/modules/casts.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/casts.rs
@@ -124,7 +124,7 @@ impl NamedLibfunc for DowncastLibfunc {
         }
 
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         Ok(LibfuncSignature {
             param_signatures: vec![
                 ParamSignature::new(range_check_type).with_allow_add_const(),

--- a/crates/cairo-lang-sierra/src/extensions/modules/circuit.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/circuit.rs
@@ -521,9 +521,7 @@ impl SignatureAndTypeGenericLibfunc for InitCircuitDataLibFuncWrapped {
             vec![
                 OutputVarInfo {
                     ty: range_check96_type,
-                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
-                        param_idx: 0,
-                    }),
+                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst),
                 },
                 OutputVarInfo {
                     ty: circuit_input_accumulator_ty,
@@ -687,7 +685,7 @@ impl SignatureAndTypeGenericLibfunc for EvalCircuitLibFuncWrapped {
                 // Success.
                 BranchSignature {
                     vars: vec![
-                        OutputVarInfo::new_builtin(add_mod_builtin_ty.clone(), 0),
+                        OutputVarInfo::new_builtin(add_mod_builtin_ty.clone()),
                         OutputVarInfo {
                             ty: mul_mod_builtin_ty.clone(),
                             ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
@@ -706,7 +704,7 @@ impl SignatureAndTypeGenericLibfunc for EvalCircuitLibFuncWrapped {
                 // Failure (inverse of non-invertible).
                 BranchSignature {
                     vars: vec![
-                        OutputVarInfo::new_builtin(add_mod_builtin_ty, 0),
+                        OutputVarInfo::new_builtin(add_mod_builtin_ty),
                         OutputVarInfo {
                             ty: mul_mod_builtin_ty,
                             ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
@@ -775,7 +773,7 @@ impl NoGenericArgsGenericLibfunc for U96GuaranteeVerifyLibFunc {
                 ParamSignature::new(range_check96_type.clone()).with_allow_add_const(),
                 ParamSignature::new(guarantee_ty),
             ],
-            vec![OutputVarInfo::new_builtin(range_check96_type, 0)],
+            vec![OutputVarInfo::new_builtin(range_check96_type)],
             SierraApChange::Known { new_vars_only: true },
         ))
     }
@@ -862,8 +860,8 @@ impl NoGenericArgsGenericLibfunc for CircuitFailureGuaranteeVerifyLibFunc {
         Ok(LibfuncSignature::new_non_branch(
             vec![range_check96_type.clone(), mul_mod_builtin_ty.clone(), guarantee_ty, zero, one],
             vec![
-                OutputVarInfo::new_builtin(range_check96_type, 0),
-                OutputVarInfo::new_builtin(mul_mod_builtin_ty, 1),
+                OutputVarInfo::new_builtin(range_check96_type),
+                OutputVarInfo::new_builtin(mul_mod_builtin_ty),
                 OutputVarInfo {
                     ty: u384_less_than_guarantee_ty(context)?,
                     ref_info: OutputVarReferenceInfo::SimpleDerefs,

--- a/crates/cairo-lang-sierra/src/extensions/modules/ec.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/ec.rs
@@ -161,7 +161,7 @@ impl NoGenericArgsGenericLibfunc for EcPointFromXLibfunc {
         let nonzero_ecpoint_ty = nonzero_ty(context, &ecpoint_ty)?;
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
 
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         Ok(LibfuncSignature {
             param_signatures: vec![
                 ParamSignature::new(range_check_type).with_allow_add_const(),
@@ -407,7 +407,7 @@ impl NoGenericArgsGenericLibfunc for EcStateAddMulLibfunc {
                 ParamSignature::new(nonzero_ecpoint_ty),
             ],
             vec![
-                OutputVarInfo::new_builtin(ec_builtin_ty, 0),
+                OutputVarInfo::new_builtin(ec_builtin_ty),
                 OutputVarInfo {
                     ty: ec_state_ty,
                     ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),

--- a/crates/cairo-lang-sierra/src/extensions/modules/felt252_dict.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/felt252_dict.rs
@@ -125,7 +125,7 @@ impl SignatureOnlyGenericLibfunc for Felt252DictNewLibfunc {
         Ok(LibfuncSignature::new_non_branch_ex(
             vec![ParamSignature::new(segment_arena_ty.clone()).with_allow_add_const()],
             vec![
-                OutputVarInfo::new_builtin(segment_arena_ty, 0),
+                OutputVarInfo::new_builtin(segment_arena_ty),
                 OutputVarInfo {
                     ty: context.get_wrapped_concrete_type(Felt252DictType::id(), ty.clone())?,
                     ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
@@ -233,9 +233,7 @@ impl SignatureAndTypeGenericLibfunc for Felt252DictEntryGetLibfuncWrapped {
             vec![
                 OutputVarInfo {
                     ty: dict_entry_ty,
-                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
-                        param_idx: 0,
-                    }),
+                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst),
                 },
                 // Current value.
                 OutputVarInfo {

--- a/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
@@ -51,7 +51,7 @@ impl NoGenericArgsGenericLibfunc for WithdrawGasLibfunc {
     ) -> Result<LibfuncSignature, SpecializationError> {
         let gas_builtin_type = context.get_concrete_type(GasBuiltinType::id(), &[])?;
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         Ok(LibfuncSignature {
             param_signatures: vec![
                 ParamSignature::new(range_check_type).with_allow_add_const(),
@@ -316,7 +316,7 @@ impl NoGenericArgsGenericLibfunc for BuiltinCostWithdrawGasLibfunc {
         let gas_builtin_type = context.get_concrete_type(GasBuiltinType::id(), &[])?;
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
         let builtin_costs_type = context.get_concrete_type(BuiltinCostsType::id(), &[])?;
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         Ok(LibfuncSignature {
             param_signatures: vec![
                 ParamSignature::new(range_check_type).with_allow_add_const(),

--- a/crates/cairo-lang-sierra/src/extensions/modules/gas_reserve.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/gas_reserve.rs
@@ -48,7 +48,7 @@ impl NoGenericArgsGenericLibfunc for GasReserveCreateLibfunc {
         let u128_type = context.get_concrete_type(Uint128Type::id(), &[])?;
         let gas_reserve_type = context.get_concrete_type(GasReserveType::id(), &[])?;
 
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         Ok(LibfuncSignature {
             param_signatures: vec![
                 ParamSignature::new(range_check_type).with_allow_add_const(),

--- a/crates/cairo-lang-sierra/src/extensions/modules/int/signed.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/int/signed.rs
@@ -87,7 +87,7 @@ impl<TSintTraits: SintTraits> GenericLibfunc for SintOperationLibfunc<TSintTrait
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
 
         let ty_param = ParamSignature::new(ty.clone());
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         let wrapping_result_info = OutputVarInfo {
             ty: ty.clone(),
             ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
@@ -151,7 +151,7 @@ impl<TSintTraits: SintTraits> NoGenericArgsGenericLibfunc for SintDiffLibfunc<TS
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
 
         let signed_ty_param = ParamSignature::new(signed_ty);
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         let wrapping_result_ref_info = if TSintTraits::IS_SMALL {
             OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic)
         } else {

--- a/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned.rs
@@ -87,7 +87,7 @@ impl<TUintTraits: UintTraits> GenericLibfunc for UintOperationLibfunc<TUintTrait
             | (IntOperator::OverflowingAdd, true) => OutputVarReferenceInfo::NewTempVar { idx: 0 },
         };
 
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         let ty_param = ParamSignature::new(ty.clone());
         Ok(LibfuncSignature {
             param_signatures: vec![
@@ -151,7 +151,7 @@ impl<TUintTraits: UintTraits> NoGenericArgsGenericLibfunc for UintSquareRootLibf
                 ParamSignature::new(ty),
             ],
             vec![
-                OutputVarInfo::new_builtin(range_check_type, 0),
+                OutputVarInfo::new_builtin(range_check_type),
                 OutputVarInfo {
                     ty: sqrt_ty,
                     ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
@@ -183,7 +183,7 @@ impl<TUintTraits: UintTraits> NoGenericArgsGenericLibfunc for UintDivmodLibfunc<
                 ParamSignature::new(nonzero_ty(context, &ty)?),
             ],
             vec![
-                OutputVarInfo::new_builtin(range_check_type, 0),
+                OutputVarInfo::new_builtin(range_check_type),
                 OutputVarInfo {
                     ty: ty.clone(),
                     ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },
@@ -222,7 +222,7 @@ impl<TUintTraits: UintTraits> NoGenericArgsGenericLibfunc for UintBitwiseLibfunc
                 ty_param,
             ],
             vec![
-                OutputVarInfo::new_builtin(bitwise_ty, 0),
+                OutputVarInfo::new_builtin(bitwise_ty),
                 deferred_ty_output_info.clone(),
                 deferred_ty_output_info.clone(),
                 deferred_ty_output_info,

--- a/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned128.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned128.rs
@@ -130,7 +130,7 @@ impl NoGenericArgsGenericLibfunc for U128MulGuaranteeVerifyLibfunc {
                 ParamSignature::new(range_check_type.clone()).with_allow_add_const(),
                 ParamSignature::new(context.get_concrete_type(U128MulGuaranteeType::id(), &[])?),
             ],
-            vec![OutputVarInfo::new_builtin(range_check_type, 0)],
+            vec![OutputVarInfo::new_builtin(range_check_type)],
             SierraApChange::Known { new_vars_only: false },
         ))
     }
@@ -148,7 +148,7 @@ impl NoGenericArgsGenericLibfunc for Uint128sFromFelt252Libfunc {
         context: &dyn SignatureSpecializationContext,
     ) -> Result<LibfuncSignature, SpecializationError> {
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         Ok(LibfuncSignature {
             param_signatures: vec![
                 ParamSignature::new(range_check_type).with_allow_add_const(),
@@ -205,7 +205,7 @@ impl NoGenericArgsGenericLibfunc for U128ByteReverseLibfunc {
             ],
             vec![
                 // bitwise
-                OutputVarInfo::new_builtin(bitwise_ty, 0),
+                OutputVarInfo::new_builtin(bitwise_ty),
                 // result
                 OutputVarInfo {
                     ty: u128_ty,

--- a/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned256.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned256.rs
@@ -74,7 +74,7 @@ impl NoGenericArgsGenericLibfunc for Uint256DivmodLibfunc {
                 ParamSignature::new(nonzero_ty(context, &u256_type)?),
             ],
             vec![
-                OutputVarInfo::new_builtin(range_check_type, 0),
+                OutputVarInfo::new_builtin(range_check_type),
                 simple_deref_u256_output_info.clone(),
                 simple_deref_u256_output_info,
                 OutputVarInfo {
@@ -104,7 +104,7 @@ impl NoGenericArgsGenericLibfunc for Uint256SquareRootLibfunc {
                 ParamSignature::new(get_u256_type(context)?),
             ],
             vec![
-                OutputVarInfo::new_builtin(range_check_type, 0),
+                OutputVarInfo::new_builtin(range_check_type),
                 OutputVarInfo {
                     ty: context.get_concrete_type(Uint128Type::id(), &[])?,
                     ref_info: OutputVarReferenceInfo::SimpleDerefs,
@@ -131,7 +131,7 @@ impl NoGenericArgsGenericLibfunc for Uint256InvModNLibfunc {
         let u256_ty = get_u256_type(context)?;
         let nz_ty = nonzero_ty(context, &u256_ty)?;
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
-        let rc_output = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output = OutputVarInfo::new_builtin(range_check_type.clone());
         let guarantee_output = OutputVarInfo {
             ty: context.get_concrete_type(U128MulGuaranteeType::id(), &[])?,
             ref_info: OutputVarReferenceInfo::SimpleDerefs,

--- a/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned512.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/int/unsigned512.rs
@@ -42,7 +42,7 @@ impl NoGenericArgsGenericLibfunc for Uint512DivmodU256Libfunc {
                 ParamSignature::new(nonzero_ty(context, &u256_ty)?),
             ],
             vec![
-                OutputVarInfo::new_builtin(range_check_type, 0),
+                OutputVarInfo::new_builtin(range_check_type),
                 OutputVarInfo { ty: u512_ty, ref_info: OutputVarReferenceInfo::SimpleDerefs },
                 OutputVarInfo { ty: u256_ty, ref_info: OutputVarReferenceInfo::SimpleDerefs },
                 guarantee_output_info.clone(),

--- a/crates/cairo-lang-sierra/src/extensions/modules/pedersen.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/pedersen.rs
@@ -48,7 +48,7 @@ impl NoGenericArgsGenericLibfunc for PedersenHashLibfunc {
                 felt252_param,
             ],
             vec![
-                OutputVarInfo::new_builtin(pedersen_ty, 0),
+                OutputVarInfo::new_builtin(pedersen_ty),
                 OutputVarInfo {
                     ty: felt252_ty,
                     ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),

--- a/crates/cairo-lang-sierra/src/extensions/modules/poseidon.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/poseidon.rs
@@ -53,7 +53,7 @@ impl NoGenericArgsGenericLibfunc for HadesPermutationLibfunc {
                 felt252_param,
             ],
             vec![
-                OutputVarInfo::new_builtin(poseidon_ty, 0),
+                OutputVarInfo::new_builtin(poseidon_ty),
                 deferred_felt252_output_info.clone(),
                 deferred_felt252_output_info.clone(),
                 deferred_felt252_output_info,

--- a/crates/cairo-lang-sierra/src/extensions/modules/qm31.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/qm31.rs
@@ -273,7 +273,7 @@ impl NoGenericArgsGenericLibfunc for QM31UnpackLibfunc {
                 ParamSignature::new(context.get_concrete_type(QM31Type::id(), &[])?),
             ],
             vec![
-                OutputVarInfo::new_builtin(range_check_ty, 0),
+                OutputVarInfo::new_builtin(range_check_ty),
                 output_var_info.clone(),
                 output_var_info.clone(),
                 output_var_info.clone(),

--- a/crates/cairo-lang-sierra/src/extensions/modules/range.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/range.rs
@@ -109,7 +109,7 @@ impl SignatureOnlyGenericLibfunc for IntRangeTryNewLibfunc {
                 // Success.
                 BranchSignature {
                     vars: vec![
-                        OutputVarInfo::new_builtin(range_check_type.clone(), 0),
+                        OutputVarInfo::new_builtin(range_check_type.clone()),
                         OutputVarInfo {
                             ty: range_ty.clone(),
                             ref_info: OutputVarReferenceInfo::SimpleDerefs,
@@ -120,7 +120,7 @@ impl SignatureOnlyGenericLibfunc for IntRangeTryNewLibfunc {
                 // Failure.
                 BranchSignature {
                     vars: vec![
-                        OutputVarInfo::new_builtin(range_check_type, 0),
+                        OutputVarInfo::new_builtin(range_check_type),
                         OutputVarInfo {
                             ty: range_ty,
                             ref_info: OutputVarReferenceInfo::SimpleDerefs,
@@ -163,7 +163,7 @@ impl SignatureOnlyGenericLibfunc for IntRangePopFrontLibfunc {
                         OutputVarInfo {
                             ty: range_ty,
                             ref_info: OutputVarReferenceInfo::Deferred(
-                                DeferredOutputKind::AddConst { param_idx: 0 },
+                                DeferredOutputKind::AddConst,
                             ),
                         },
                         OutputVarInfo {

--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/storage.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/storage.rs
@@ -138,7 +138,7 @@ impl NoGenericArgsGenericLibfunc for StorageBaseAddressFromFelt252Libfunc {
                 ParamSignature::new(context.get_concrete_type(Felt252Type::id(), &[])?),
             ],
             vec![
-                OutputVarInfo::new_builtin(range_check_ty, 0),
+                OutputVarInfo::new_builtin(range_check_ty),
                 OutputVarInfo {
                     ty: context.get_concrete_type(StorageBaseAddressType::id(), &[])?,
                     ref_info: OutputVarReferenceInfo::NewTempVar { idx: 0 },

--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/syscalls.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/syscalls.rs
@@ -62,7 +62,7 @@ impl<T: SyscallGenericLibfunc> NoGenericArgsGenericLibfunc for T {
             ty: gas_builtin_ty.clone(),
             ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
         };
-        let system_output_info = OutputVarInfo::new_builtin(system_ty.clone(), 1);
+        let system_output_info = OutputVarInfo::new_builtin(system_ty.clone());
         Ok(LibfuncSignature {
             param_signatures: chain!(
                 [

--- a/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
@@ -330,9 +330,7 @@ impl StructBoxedDeconstructLibfunc {
                 .into_iter()
                 .map(|member_ty| {
                     let ref_info = if is_shifted {
-                        OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst {
-                            param_idx: 0,
-                        })
+                        OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst)
                     } else {
                         is_shifted = !context.get_type_info(&member_ty)?.zero_sized;
                         OutputVarReferenceInfo::SameAsParam { param_idx: 0 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/try_from_felt252.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/try_from_felt252.rs
@@ -33,7 +33,7 @@ impl<TTryFromFelt252: TryFromFelt252> NoGenericArgsGenericLibfunc
         context: &dyn SignatureSpecializationContext,
     ) -> Result<LibfuncSignature, SpecializationError> {
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
-        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone(), 0);
+        let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
         Ok(LibfuncSignature {
             param_signatures: vec![
                 ParamSignature::new(range_check_type).with_allow_add_const(),


### PR DESCRIPTION
## Summary

Refactored the `DeferredVariableKind` enum by replacing it with the existing `DeferredOutputKind` from the Sierra library. This simplifies the codebase by eliminating duplicate enum definitions and standardizing on a single representation for deferred output types.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The codebase had two separate enums (`DeferredVariableKind` and `DeferredOutputKind`) representing the same concept. This duplication required mapping between the two types and maintaining parallel implementations. By using the existing `DeferredOutputKind` enum directly, we eliminate this redundancy and simplify the code.

Additionally, the `AddConst` variant in `DeferredOutputKind` previously contained a `param_idx` field that wasn't actually being used in a meaningful way, so it was removed to further simplify the implementation.

---

## What was the behavior or documentation before?

Before this change, the code maintained two parallel enum types:
1. `DeferredVariableKind` in the store_variables module
2. `DeferredOutputKind` in the sierra library

The code had to map between these types, and the `AddConst` variant in `DeferredOutputKind` contained an unused `param_idx` field.

---

## What is the behavior or documentation after?

After this change:
- `DeferredVariableKind` has been removed entirely
- All code now uses `DeferredOutputKind` directly
- The `param_idx` field has been removed from the `AddConst` variant in `DeferredOutputKind`
- The code is simpler and more maintainable with fewer type conversions

---

## Additional context

This refactoring doesn't change any functionality but makes the code more consistent and easier to maintain by eliminating duplicate type definitions and unnecessary fields.