### PR TITLE
performance(sierra-to-casm): Using builder with capacity for instructions and relocations.

### DIFF
--- a/crates/cairo-lang-casm/src/builder.rs
+++ b/crates/cairo-lang-casm/src/builder.rs
@@ -748,18 +748,28 @@ fn relocate_instruction(instruction: &mut Instruction, updated: i32) {
     }
 }
 
-impl Default for CasmBuilder {
-    fn default() -> Self {
+impl CasmBuilder {
+    /// Creates a new `CasmBuilder` with pre-allocated capacity for instructions and relocations.
+    ///
+    /// Use this when you know the approximate number of instructions and relocations
+    /// to avoid repeated allocations during building.
+    pub fn with_capacity(instructions: usize, relocations: usize) -> Self {
         Self {
             label_info: Default::default(),
             main_state: Default::default(),
-            instructions: Default::default(),
-            relocations: Default::default(),
+            instructions: Vec::with_capacity(instructions),
+            relocations: Vec::with_capacity(relocations),
             current_hints: Default::default(),
             var_count: Default::default(),
             reachable: true,
             next_instruction_offset: 0,
         }
+    }
+}
+
+impl Default for CasmBuilder {
+    fn default() -> Self {
+        Self::with_capacity(1, 0)
     }
 }
 

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/array.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/array.rs
@@ -46,7 +46,7 @@ fn build_array_new(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     builder.try_get_refs::<0>()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     casm_build_extend! {casm_builder,
         tempvar arr_start;
         hint AllocSegment into {dst: arr_start};
@@ -67,9 +67,7 @@ fn build_span_from_tuple(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [start_ptr] = builder.try_get_single_cells()?;
     let full_struct_size = builder.program_info.type_sizes[ty];
-
-    let mut casm_builder = CasmBuilder::default();
-
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     add_input_variables! {casm_builder,
         deref start_ptr;
     };
@@ -95,7 +93,7 @@ fn build_tuple_from_span(
     let [arr_start, arr_end] = builder.try_get_refs::<1>()?[0].try_unpack()?;
     let full_struct_size = builder.program_info.type_sizes[ty];
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(3, 1);
 
     add_input_variables! {casm_builder,
         deref arr_start;
@@ -121,8 +119,7 @@ fn build_array_append(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [expr_arr, elem] = builder.try_get_refs()?;
     let [arr_start, arr_end] = expr_arr.try_unpack()?;
-
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(elem.cells.len(), 0);
     add_input_variables! {casm_builder,
         buffer(0) arr_start;
         buffer(elem.cells.len() as i16) arr_end;
@@ -147,7 +144,7 @@ fn build_pop_front(
     let [arr_start, arr_end] = builder.try_get_refs::<1>()?[0].try_unpack()?;
     let element_size = builder.program_info.type_sizes[elem_ty];
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(3, 2);
     add_input_variables! {casm_builder,
         deref arr_start;
         deref arr_end;
@@ -182,7 +179,7 @@ fn build_pop_back(
     let [arr_start, arr_end] = builder.try_get_refs::<1>()?[0].try_unpack()?;
     let element_size = builder.program_info.type_sizes[elem_ty];
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(3, 2);
     add_input_variables! {casm_builder,
         deref arr_start;
         deref arr_end;
@@ -217,10 +214,8 @@ fn build_array_get(
     let range_check = expr_range_check.try_unpack_single()?;
     let [arr_start, arr_end] = expr_arr.try_unpack()?;
     let index = expr_index.try_unpack_single()?;
-
     let element_size = builder.program_info.type_sizes[elem_ty];
-
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(10, 2);
     add_input_variables! {casm_builder,
         deref_or_immediate index;
         deref arr_start;
@@ -289,7 +284,7 @@ fn build_array_slice(
 
     let element_size = builder.program_info.type_sizes[elem_ty];
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(11, 2);
     add_input_variables! {casm_builder,
         deref slice_start;
         deref_or_immediate slice_length;
@@ -356,7 +351,7 @@ fn build_array_len(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [arr_start, arr_end] = builder.try_get_refs::<1>()?[0].try_unpack()?;
     let element_size = builder.program_info.type_sizes[elem_ty];
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(if element_size == 1 { 0 } else { 1 }, 0);
     add_input_variables! {casm_builder,
         deref arr_start;
         deref arr_end;
@@ -390,8 +385,7 @@ fn build_multi_pop_front(
     let range_check = expr_range_check.try_unpack_single()?;
     let [arr_start, arr_end] = expr_arr.try_unpack()?;
     let popped_size = builder.program_info.type_sizes[&libfunc.popped_ty];
-
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(8, 2);
     add_input_variables! {casm_builder,
         buffer(1) range_check;
         deref arr_start;
@@ -441,8 +435,7 @@ fn build_multi_pop_back(
     let range_check = expr_range_check.try_unpack_single()?;
     let [arr_start, arr_end] = expr_arr.try_unpack()?;
     let popped_size = builder.program_info.type_sizes[&libfunc.popped_ty];
-
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(8, 2);
     add_input_variables! {casm_builder,
         buffer(1) range_check;
         deref arr_start;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/bitwise.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/bitwise.rs
@@ -21,7 +21,7 @@ fn build_bitwise(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [bitwise, x, y] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(2, 0);
     add_input_variables! {casm_builder,
         deref x;
         deref y;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/blake.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/blake.rs
@@ -24,7 +24,7 @@ fn build_compress(
     finalize: bool,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [state, byte_count, message] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder,
         deref state;
         deref byte_count;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/boolean.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/boolean.rs
@@ -24,7 +24,7 @@ fn build_bool_and(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a, b] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     add_input_variables! {casm_builder,
         deref a;
         deref b;
@@ -42,7 +42,7 @@ fn build_bool_not(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder, deref a; };
     casm_build_extend! {casm_builder,
         const one_imm = 1;
@@ -62,7 +62,7 @@ fn build_bool_xor(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a, b] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder,
         deref a;
         deref b;
@@ -86,7 +86,7 @@ fn build_bool_or(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a, b] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(2, 0);
     add_input_variables! {casm_builder,
         deref a;
         deref b;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/boxing.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/boxing.rs
@@ -30,7 +30,7 @@ fn build_into_box(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [operand] = builder.try_get_refs()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(std::cmp::max(1, operand.cells.len()), 0);
     let addr = if operand.cells.is_empty() {
         // In cases of a zero-sized variable, we just simulate a non-zero address.
         casm_build_extend!(casm_builder,

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/casts.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/casts.rs
@@ -35,7 +35,7 @@ pub fn build_downcast(
         return build_felt252_range_reduction(builder, &libfunc.to_range, true);
     }
     let [range_check, value] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(12, 4);
     add_input_variables!(casm_builder,
         buffer(1) range_check;
         deref value;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/circuit.rs
@@ -64,7 +64,7 @@ fn build_init_circuit_data(
     let n_inputs = circ_info.n_inputs;
     let rc96_usage = circ_info.rc96_usage();
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
 
     add_input_variables! {casm_builder,
         buffer(1) rc96;
@@ -102,7 +102,7 @@ fn build_add_input(
     let [expr_handle, elem] = builder.try_get_refs()?;
     let [start, end] = expr_handle.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(elem.cells.len() + 3, 1);
     add_input_variables! {casm_builder,
         buffer(elem.cells.len() as i16) start;
         deref end;
@@ -191,7 +191,7 @@ fn build_circuit_eval(
 
     let zero = expr_zero.try_unpack_single()?;
     let one = expr_one.try_unpack_single()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(22, 1);
 
     let instance_size = MOD_BUILTIN_INSTANCE_SIZE.into_or_panic();
     add_input_variables! {casm_builder,
@@ -312,7 +312,7 @@ fn build_try_into_circuit_modulus(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [l0, l1, l2, l3] = builder.try_get_refs::<1>()?[0].try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(8, 7);
     add_input_variables!(casm_builder, deref l0; deref l1; deref l2; deref l3;);
     casm_build_extend! {casm_builder,
         const one = 1;
@@ -351,7 +351,7 @@ fn build_failure_guarantee_verify(
     let zero = expr_zero.try_unpack_single()?;
     let one = expr_one.try_unpack_single()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(33, 4);
     let rc_usage = (2 + VALUE_SIZE).into_or_panic();
 
     let instance_size = MOD_BUILTIN_INSTANCE_SIZE.into_or_panic();
@@ -473,7 +473,7 @@ fn build_get_output(
     let [expr_outputs] = builder.try_get_refs()?;
     let [values_ptr, modulus0, modulus1, modulus2, modulus3] = expr_outputs.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(5, 0);
 
     let CircuitInfo { values, .. } =
         builder.program_info.circuits_info.circuits.get(circuit_ty).unwrap();
@@ -524,7 +524,7 @@ fn build_u96_guarantee_verify(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [rc96, guarantee] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder,
         buffer(0) rc96;
         deref guarantee;
@@ -555,7 +555,7 @@ fn build_u96_limbs_less_than_guarantee_verify(
     let [expr_guarantee] = builder.try_get_refs()?;
     let guarantee = &expr_guarantee.cells;
     assert_eq!(guarantee.len(), limb_count * 2);
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(2, 1);
     let lhs_high_limb_idx = limb_count - 1;
     let rhs_high_limb_idx = 2 * limb_count - 1;
     let lhs_high_limb = casm_builder.add_var(guarantee[lhs_high_limb_idx].clone());
@@ -585,7 +585,7 @@ fn build_u96_single_limb_less_than_guarantee_verify(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [expr_guarantee] = builder.try_get_refs()?;
     let [lhs, rhs] = expr_guarantee.try_unpack()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     add_input_variables! {casm_builder,
         deref lhs;
         deref rhs;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/debug.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/debug.rs
@@ -20,7 +20,7 @@ fn build_print(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [arr_start, arr_end] = builder.try_get_refs::<1>()?[0].try_unpack()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder,
         buffer(0) arr_start;
         buffer(0) arr_end;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs
@@ -107,7 +107,7 @@ fn add_ec_points_inner(
 fn build_ec_zero(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
 
     casm_build_extend!(casm_builder,
         const zero = 0;
@@ -126,7 +126,7 @@ fn build_ec_point_try_new_nz(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [x, y] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(7, 1);
     add_input_variables! {casm_builder,
         deref x;
         deref y;
@@ -160,7 +160,7 @@ fn build_ec_point_from_x_nz(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [range_check, x] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(16, 3);
     add_input_variables! {casm_builder,
         buffer(2) range_check;
         deref x;
@@ -242,7 +242,7 @@ fn build_ec_point_unwrap(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [x, y] = builder.try_get_refs::<1>()?[0].try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     add_input_variables! {casm_builder,
         deref x;
         deref y;
@@ -261,7 +261,7 @@ fn build_ec_point_is_zero(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [x, y] = builder.try_get_refs::<1>()?[0].try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 1);
     add_input_variables!(casm_builder, deref x; deref y; );
     casm_build_extend! {casm_builder,
         // To check whether `(x, y) = (0, 0)` (the zero point), it is enough to check
@@ -283,7 +283,7 @@ fn build_ec_neg(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [x, y] = builder.try_get_refs::<1>()?[0].try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     add_input_variables! {casm_builder,
         deref x;
         deref y;
@@ -304,7 +304,7 @@ fn build_ec_neg(
 fn build_ec_state_init(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(7, 0);
 
     // Sample a random point on the curve.
     casm_build_extend! {casm_builder,
@@ -346,7 +346,7 @@ fn build_ec_state_add(
     let [sx, sy, random_ptr] = expr_state.try_unpack()?;
     let [px, py] = expr_point.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(11, 1);
     add_input_variables! {casm_builder,
         deref px;
         deref py;
@@ -384,7 +384,7 @@ fn build_ec_state_finalize(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [x, y, random_ptr] = builder.try_get_refs::<1>()?[0].try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(14, 2);
     add_input_variables! {casm_builder,
         deref x;
         deref y;
@@ -436,7 +436,7 @@ fn build_ec_state_add_mul(
     let [m] = expr_m.try_unpack()?;
     let [px, py] = expr_point.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(5, 0);
     add_input_variables! {casm_builder,
         buffer(6) ec_builtin;
         deref sx;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -123,7 +123,7 @@ fn build_enum_from_bounded_int(
     }
 
     let [value] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder,
         deref value;
     };

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/felt252.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/felt252.rs
@@ -42,7 +42,8 @@ pub fn build_felt252_op_with_var(
     op: Felt252BinaryOperator,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a, b] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder =
+        CasmBuilder::with_capacity(if matches!(op, Felt252BinaryOperator::Div) { 1 } else { 0 }, 0);
     add_input_variables! {casm_builder,
         deref a;
         deref_or_immediate b;
@@ -62,7 +63,8 @@ fn build_felt252_op_with_const(
     c: BigInt,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder =
+        CasmBuilder::with_capacity(if matches!(op, Felt252BinaryOperator::Div) { 1 } else { 0 }, 0);
     add_input_variables! {casm_builder, deref a; };
     let c = casm_builder.add_var(CellExpression::Immediate(c));
     let (res_var, extra_costs) = bin_op_helper(&mut casm_builder, a, c, op);

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/felt252_dict.rs
@@ -31,7 +31,7 @@ fn build_felt252_dict_new(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [segment_arena_ptr] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(9, 0);
     add_input_variables! {casm_builder, buffer(2) segment_arena_ptr; };
     casm_build_extend! {casm_builder,
         hint AllocFelt252Dict {segment_arena_ptr: segment_arena_ptr};
@@ -72,7 +72,7 @@ fn build_felt252_dict_squash(
     let mut unique_key_steps: i32 = 0;
     let mut repeated_access_steps: i32 = 0;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(135, 18);
     add_input_variables! {casm_builder,
         buffer(2) segment_arena_ptr;
         buffer(0) range_check_ptr;
@@ -728,7 +728,7 @@ fn build_felt252_dict_entry_get(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [dict_ptr, key] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder, buffer(2) dict_ptr; deref key; };
     casm_build_extend! {casm_builder,
         hint Felt252DictEntryInit { dict_ptr, key };
@@ -752,7 +752,7 @@ fn build_felt252_dict_entry_finalize(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [dict_entry, new_value] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder, buffer(0) dict_entry; deref new_value; };
     casm_build_extend! {casm_builder,
         hint Felt252DictEntryUpdate { dict_ptr: dict_entry, value: new_value };

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs
@@ -36,7 +36,7 @@ fn build_withdraw_gas(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [range_check, gas_counter] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(16, 2);
     add_input_variables! {casm_builder,
         buffer(1) range_check;
         deref gas_counter;
@@ -118,7 +118,7 @@ fn build_redeposit_gas(
             .into_iter(),
         ));
     }
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(16, 0);
     add_input_variables! {casm_builder,
         deref gas_counter;
     };
@@ -145,7 +145,7 @@ fn build_get_unspent_gas(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [gas_counter] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(16, 0);
     add_input_variables! {casm_builder,
         deref gas_counter;
     };
@@ -188,7 +188,7 @@ fn build_builtin_withdraw_gas(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [range_check, gas_counter, builtin_cost] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(16, 2);
     add_input_variables! {casm_builder,
         buffer(1) range_check;
         deref gas_counter;
@@ -310,7 +310,7 @@ impl CompiledInvocationBuilder<'_> {
 fn build_get_builtin_costs(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     let (pre_instructions, cost_builtin_ptr) = add_cost_builtin_ptr_fetch_code(&mut casm_builder);
     Ok(builder.build_from_casm_builder_ex(
         casm_builder,

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/gas_reserve.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/gas_reserve.rs
@@ -33,7 +33,7 @@ fn build_gas_reserve_utilize(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [gas_counter, reserve] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     add_input_variables! {casm_builder,
         deref gas_counter;
         deref reserve;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs
@@ -59,7 +59,7 @@ pub fn build_div_rem(
 
     let alg = BoundedIntDivRemAlgorithm::try_new(lhs, rhs).unwrap();
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(12, 2);
     let rc_slack = match &alg {
         BoundedIntDivRemAlgorithm::KnownSmallRhs => 2,
         BoundedIntDivRemAlgorithm::KnownSmallQuotient { .. }
@@ -185,7 +185,7 @@ fn build_constrain(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [range_check, value] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(6, 2);
     add_input_variables! {casm_builder,
         buffer(1) range_check;
         deref value;
@@ -232,7 +232,7 @@ fn build_trim(
     trimmed_value: &BigInt,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [value] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(2, 1);
     add_input_variables!(casm_builder, deref value; );
     casm_build_extend! {casm_builder,
         const trimmed_value = trimmed_value.clone();

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/mod.rs
@@ -42,7 +42,7 @@ pub fn build_small_wide_mul(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a, b] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     add_input_variables! {casm_builder,
         deref a;
         deref_or_immediate b;
@@ -89,7 +89,7 @@ impl<'a> SmallDiffHelper<'a> {
         limit: BigInt,
     ) -> Result<Self, InvocationError> {
         let [range_check, a, b] = builder.try_get_single_cells()?;
-        let mut casm_builder = CasmBuilder::default();
+        let mut casm_builder = CasmBuilder::with_capacity(6, 2);
         add_input_variables! {casm_builder,
             buffer(0) range_check;
             deref a;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/signed.rs
@@ -47,7 +47,7 @@ pub fn build_sint_overflowing_operation(
     else {
         panic!("malformed invocation");
     };
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(16, 4);
     add_input_variables! {casm_builder,
         buffer(1) range_check;
         deref lhs;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned.rs
@@ -22,7 +22,7 @@ fn build_small_uint_overflowing_add(
 ) -> Result<CompiledInvocation, InvocationError> {
     let failure_handle_statement_id = get_non_fallthrough_statement_id(&builder);
     let [range_check, a, b] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(8, 2);
     add_input_variables! {casm_builder,
         buffer(0) range_check;
         deref a;
@@ -74,7 +74,7 @@ pub fn build_sqrt(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [range_check, value] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(9, 0);
     add_input_variables! {casm_builder,
         buffer(3) range_check;
         deref value;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned128.rs
@@ -47,7 +47,7 @@ fn build_u128_overflowing_add(
 ) -> Result<CompiledInvocation, InvocationError> {
     let failure_handle_statement_id = get_non_fallthrough_statement_id(&builder);
     let [range_check, a, b] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(6, 2);
     add_input_variables! {casm_builder,
         buffer(0) range_check;
         deref a;
@@ -90,7 +90,7 @@ fn build_u128_guarantee_mul(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a, b] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder,
         deref a;
         deref b;
@@ -119,7 +119,7 @@ fn build_u128_mul_guarantee_verify(
     let [range_check] = range_check_ref.try_unpack()?;
     let [a, b, res_high, res_low] = guarantee.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(23, 0);
     add_input_variables! {casm_builder,
         buffer(8) range_check;
         deref a;
@@ -243,7 +243,7 @@ fn build_u128_from_felt252(
     // Represent the maximal possible value (PRIME - 1) as 2**128 * max_x + max_y.
     let max_x: i128 = 10633823966279327296825105735305134080;
     let max_y: i128 = 0;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(14, 4);
     add_input_variables! {casm_builder,
         buffer(3) range_check;
         deref value;
@@ -314,7 +314,7 @@ pub fn build_u128_byte_reverse(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [bitwise, input] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(24, 0);
     add_input_variables! {casm_builder,
         deref input;
         buffer(20) bitwise;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned256.rs
@@ -28,7 +28,7 @@ fn build_u256_is_zero(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [x, y] = builder.try_get_refs::<1>()?[0].try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(2, 2);
     add_input_variables!(casm_builder, deref x; deref y; );
     casm_build_extend! {casm_builder,
         jump Target if x != 0;
@@ -52,7 +52,7 @@ fn build_u256_divmod(
     let [dividend0, dividend1] = dividend.try_unpack()?;
     let [divisor0, divisor1] = divisor.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(37, 8);
     add_input_variables! {casm_builder,
         buffer(5) range_check;
         deref dividend0;
@@ -193,7 +193,7 @@ fn build_u256_sqrt(
     let [range_check] = range_check.try_unpack()?;
     let [value_low, value_high] = value.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(32, 2);
     add_input_variables! {casm_builder,
         buffer(6) range_check;
         deref value_low;
@@ -333,7 +333,7 @@ fn build_u256_inv_mod_n(
     let [b0, b1] = b.try_unpack()?;
     let [n0, n1] = n.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(73, 13);
     add_input_variables! {casm_builder,
         buffer(6) range_check;
         deref b0;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned512.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/unsigned512.rs
@@ -28,7 +28,7 @@ fn build_u512_safe_divmod_by_u256(
     let [dividend0, dividend1, dividend2, dividend3] = dividend.try_unpack()?;
     let [divisor0, divisor1] = divisor.try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(57, 8);
     add_input_variables! {casm_builder,
         buffer(9) range_check;
         deref dividend0;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/misc.rs
@@ -61,7 +61,7 @@ pub fn build_is_zero(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [value] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 1);
     add_input_variables!(casm_builder, deref value; );
     casm_build_extend! {casm_builder,
         jump Target if value != 0;
@@ -82,7 +82,7 @@ pub fn build_jump(
         [BranchInfo { target: BranchTarget::Statement(statement_id), .. }] => statement_id,
         _ => panic!("malformed invocation"),
     };
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 1);
     casm_build_extend! {casm_builder,
         jump Target;
     };
@@ -123,7 +123,7 @@ pub fn build_branch_align(
 pub fn build_cell_eq(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(3, 2);
     let [a, b] = builder.try_get_single_cells()?;
 
     add_input_variables! {casm_builder,
@@ -269,7 +269,7 @@ pub fn build_unsigned_try_from_felt252(
 ) -> Result<CompiledInvocation, InvocationError> {
     let val_bound: BigInt = BigInt::from(1) << num_bits;
     let [range_check, value] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(15, 2);
     add_input_variables! {casm_builder,
         buffer(2) range_check;
         deref value;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/pedersen.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/pedersen.rs
@@ -25,7 +25,7 @@ fn build_pedersen_hash(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [pedersen, x, y] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(2, 0);
     add_input_variables! {casm_builder,
         deref x;
         deref y;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/poseidon.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/poseidon.rs
@@ -21,7 +21,7 @@ fn build_poseidon_permutation(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [poseidon, s0, s1, s2] = builder.try_get_single_cells()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(3, 0);
     add_input_variables! {casm_builder,
         deref s0;
         deref s1;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/qm31.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/qm31.rs
@@ -35,7 +35,7 @@ pub fn build_qm31_op(
     op: QM31BinaryOperator,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [a, b] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     add_input_variables! {casm_builder,
         deref a;
         deref_or_immediate b;
@@ -82,7 +82,7 @@ fn build_qm31_pack(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [w0, w1, w2, w3] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(6, 0);
     add_input_variables! {casm_builder,
         deref w0;
         deref w1;
@@ -111,7 +111,7 @@ fn build_qm31_unpack(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [range_check, w3_w2_w1_w0] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(15, 0);
     add_input_variables! {casm_builder,
         buffer(5) range_check;
         deref w3_w2_w1_w0;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/range.rs
@@ -29,7 +29,7 @@ fn build_try_new(
     let start = expr_start.try_unpack_single()?;
     let end = expr_end.try_unpack_single()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(6, 2);
     add_input_variables! {casm_builder,
         deref start;
         deref end;
@@ -77,7 +77,7 @@ fn build_pop_front(
 ) -> Result<CompiledInvocation, InvocationError> {
     let [start, end] = builder.try_get_refs::<1>()?[0].try_unpack()?;
 
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(2, 1);
     add_input_variables! {casm_builder,
         deref start;
         deref end;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/range_reduction.rs
@@ -41,7 +41,7 @@ pub fn build_felt252_range_reduction(
     );
 
     let [range_check, value] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(15, 2);
     add_input_variables! {casm_builder,
         buffer(0) range_check;
         deref value;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs
@@ -110,7 +110,8 @@ pub fn build_syscalls<const INPUT_COUNT: usize, const OUTPUT_COUNT: usize>(
     }
     let [gas_builtin] = builder.refs[0].expression.try_unpack()?;
     let [system] = builder.refs[1].expression.try_unpack()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder =
+        CasmBuilder::with_capacity((5 + input_sizes.iter().sum::<i16>()) as usize, 1);
     // +2 for Gas and Selector cells.
     let total_input_size = input_sizes.iter().sum::<i16>() + 2;
     let success_output_size = output_sizes.iter().sum::<i16>();

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/storage.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/storage.rs
@@ -13,7 +13,7 @@ pub fn build_storage_address_from_base_and_offset(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
     let [base, offset] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(0, 0);
     add_input_variables! {casm_builder,
         deref base;
         deref_or_immediate offset;
@@ -32,7 +32,7 @@ pub fn build_storage_base_address_from_felt252(
 ) -> Result<CompiledInvocation, InvocationError> {
     let addr_bound: BigInt = (BigInt::from(1) << 251) - 256;
     let [range_check, addr] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(19, 3);
     add_input_variables! {casm_builder,
         buffer(2) range_check;
         deref addr;

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/testing.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/testing.rs
@@ -16,7 +16,7 @@ pub fn build(
 ) -> Result<CompiledInvocation, InvocationError> {
     match libfunc {
         TestingConcreteLibfunc::Cheatcode(c) => {
-            let mut casm_builder = CasmBuilder::default();
+            let mut casm_builder = CasmBuilder::with_capacity(1, 0);
             let [input] = builder.try_get_refs()?;
             let [input_start, input_end] = input.try_unpack()?;
 

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/trace.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/trace.rs
@@ -11,7 +11,7 @@ pub fn build(
     libfunc: &<TraceLibfunc as GenericLibfunc>::Concrete,
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     casm_build_extend! {casm_builder,
         const flag = libfunc.c.clone();
         hint ExternalHint::AddTrace { flag };

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/unsafe_panic.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/unsafe_panic.rs
@@ -7,7 +7,7 @@ use crate::invocations::CostValidationInfo;
 pub fn build(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
-    let mut casm_builder = CasmBuilder::default();
+    let mut casm_builder = CasmBuilder::with_capacity(1, 0);
     casm_build_extend! {casm_builder,
         fail;
     }


### PR DESCRIPTION
## Summary

Added a `with_capacity` constructor to `CasmBuilder` to pre-allocate memory for instructions and relocations, and updated all invocation implementations to use this constructor with appropriate capacity estimates. This optimization reduces memory allocations during the Sierra to CASM compilation process.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `CasmBuilder` was previously using `Default::default()` for all vector allocations, which resulted in many small allocations and reallocations as instructions were added. By pre-allocating vectors with appropriate capacities based on the expected number of instructions and relocations for each invocation type, we can reduce memory allocations and improve compilation performance.

---

## What was the behavior or documentation before?

Previously, all invocations created a `CasmBuilder` using `Default::default()`, which initialized empty vectors for instructions and relocations. These vectors would need to reallocate memory as elements were added, causing performance overhead.

---

## What is the behavior or documentation after?

Now, `CasmBuilder` has a new `with_capacity` constructor that pre-allocates memory for instructions and relocations. All invocation implementations have been updated to use this constructor with appropriate capacity estimates based on their expected usage patterns. The `Default` implementation now uses `with_capacity(1, 0)` as a minimal allocation.

---

## Additional context

This change is purely a performance optimization that doesn't affect functionality. It reduces memory allocations during the Sierra to CASM compilation process, which should improve compilation speed, especially for larger programs.