### PR TITLE
performance(sierra-to-casm): `check_types_match` accepts iterator - Avoids Vec allocation and ConcreteTypeId clones.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -543,12 +543,11 @@ pub fn compile(
                     .map_err(CompilationError::ProgramRegistryError)?;
                 check_basic_structure(statement_idx, invocation, libfunc)?;
 
-                let param_types: Vec<_> = libfunc
-                    .param_signatures()
-                    .iter()
-                    .map(|param_signature| param_signature.ty.clone())
-                    .collect();
-                check_types_match(&invoke_refs, &param_types).map_err(|error| {
+                check_types_match(
+                    &invoke_refs,
+                    libfunc.param_signatures().iter().map(|sig| &sig.ty),
+                )
+                .map_err(|error| {
                     Box::new(AnnotationError::ReferencesError { statement_idx, error }.into())
                 })?;
                 invoke_refs.iter().for_each(|r| r.validate(&program_info.type_sizes));

--- a/crates/cairo-lang-sierra-to-casm/src/references.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/references.rs
@@ -184,11 +184,11 @@ pub fn build_function_parameters_refs(
 }
 
 /// Checks that the list of references contains types matching the given types.
-pub fn check_types_match(
+pub fn check_types_match<'a>(
     refs: &[ReferenceValue],
-    types: &[ConcreteTypeId],
+    types: impl IntoIterator<Item = &'a ConcreteTypeId>,
 ) -> Result<(), ReferencesError> {
-    if itertools::equal(types.iter(), refs.iter().map(|r| &r.ty)) {
+    if itertools::equal(types, refs.iter().map(|r| &r.ty)) {
         Ok(())
     } else {
         Err(ReferencesError::InvalidReferenceTypeForArgument)


### PR DESCRIPTION
## Summary

Refactored the `check_types_match` function to accept an iterator instead of a slice of `ConcreteTypeId`, eliminating an unnecessary intermediate vector allocation. This change simplifies the code in the compiler module by allowing direct iteration over parameter signatures without collecting them into a temporary vector first.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation was creating an unnecessary temporary vector when checking type matches. By modifying the `check_types_match` function to accept an iterator instead of a slice, we can avoid this allocation and directly iterate over the parameter signatures, making the code more efficient.

---

## What was the behavior or documentation before?

Previously, the code was collecting parameter signatures into a temporary vector before passing them to the `check_types_match` function, which was an unnecessary allocation.

---

## What is the behavior or documentation after?

Now the `check_types_match` function accepts an iterator, allowing direct iteration over parameter signatures without the need for an intermediate collection step.