### PR TITLE
performance(orizi): Made allocations for state edits more efficient.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/annotations.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/annotations.rs
@@ -281,7 +281,7 @@ impl ProgramAnnotations {
     pub fn get_annotations_after_take_args<'a>(
         &mut self,
         statement_idx: StatementIdx,
-        ref_ids: impl Iterator<Item = &'a VarId>,
+        ref_ids: impl ExactSizeIterator<Item = &'a VarId>,
     ) -> Result<(StatementAnnotations, Vec<ReferenceValue>), AnnotationError> {
         let mut entry = self.per_statement_annotations[statement_idx.0]
             .take()

--- a/crates/cairo-lang-sierra/src/edit_state.rs
+++ b/crates/cairo-lang-sierra/src/edit_state.rs
@@ -26,9 +26,9 @@ impl EditStateError {
 /// Given a map with var ids as keys, extracts out the given ids, failing if some id is missing.
 pub fn take_args<'a, V: 'a>(
     mut state: OrderedHashMap<VarId, V>,
-    ids: impl Iterator<Item = &'a VarId>,
+    ids: impl ExactSizeIterator<Item = &'a VarId>,
 ) -> Result<(OrderedHashMap<VarId, V>, Vec<V>), EditStateError> {
-    let mut vals = vec![];
+    let mut vals = Vec::with_capacity(ids.len());
     for id in ids {
         match state.swap_remove(id) {
             None => {
@@ -45,8 +45,9 @@ pub fn take_args<'a, V: 'a>(
 /// Adds the given pairs to map with var ids as keys, failing if some variable is overridden.
 pub fn put_results<'a, V>(
     mut state: OrderedHashMap<VarId, V>,
-    results: impl Iterator<Item = (&'a VarId, V)>,
+    results: impl ExactSizeIterator<Item = (&'a VarId, V)>,
 ) -> Result<OrderedHashMap<VarId, V>, EditStateError> {
+    state.reserve(results.len());
     for (id, v) in results {
         if state.insert(id.clone(), v).is_some() {
             return Err(EditStateError::VariableOverride(id.clone()));


### PR DESCRIPTION
## Summary

Optimized the `take_args` and `put_results` functions by requiring `ExactSizeIterator` instead of just `Iterator`, allowing for pre-allocation of vectors and reserving capacity in hash maps. This change improves performance by reducing memory reallocations during Sierra to CASM compilation.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The current implementation of `take_args` and `put_results` functions doesn't pre-allocate memory for the collections they build, which can lead to multiple reallocations as elements are added. By requiring `ExactSizeIterator`, we can know the size upfront and allocate the right amount of memory once, improving performance.

---

## What was the behavior or documentation before?

Previously, the functions accepted any `Iterator` and allocated collections with default capacity, causing potential reallocations as elements were added.

---

## What is the behavior or documentation after?

Now the functions require `ExactSizeIterator` and use the iterator's length to pre-allocate collections with the exact required capacity, avoiding reallocations.

---

## Additional context

This change is particularly beneficial for the Sierra to CASM compilation process, which involves many operations on collections of variable references. The performance improvement will be more noticeable for larger programs with many variables.