### PR TITLE
refactor(sierra-to-casm): Made edit_state based on `&mut self`.

### DIFF
--- a/crates/cairo-lang-sierra/src/edit_state_test.rs
+++ b/crates/cairo-lang-sierra/src/edit_state_test.rs
@@ -1,33 +1,48 @@
 use cairo_lang_test_utils::test;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 
-use crate::edit_state::{EditStateError, put_results, take_args};
+use crate::edit_state::{EditState, EditStateError};
 use crate::ids::VarId;
-
-pub type State = OrderedHashMap<VarId, i64>;
 
 #[test]
 fn empty() {
-    assert_eq!(take_args(State::default(), vec![].into_iter()), Ok((State::default(), vec![])));
-    assert_eq!(put_results(State::default(), vec![].into_iter()), Ok(State::default()));
+    assert_eq!(take_args([], vec![]), Ok((State::default(), vec![])));
+    assert_eq!(put_results([], vec![]), Ok(State::default()));
 }
 
 #[test]
 fn basic_mapping() {
+    assert_eq!(take_args([("arg".into(), 0)], vec!["arg".into()]), Ok((State::default(), vec![0])));
+    assert_eq!(put_results([], vec![("res".into(), 1)]), Ok(State::from([("res".into(), 1)])));
     assert_eq!(
-        take_args(State::from([("arg".into(), 0)]), vec![&"arg".into()].into_iter(),),
-        Ok((State::default(), vec![0]))
-    );
-    assert_eq!(
-        put_results(State::default(), vec![(&"res".into(), 1)].into_iter(),),
-        Ok(State::from([("res".into(), 1)]))
-    );
-    assert_eq!(
-        take_args(State::default(), vec![&"arg".into()].into_iter(),),
+        take_args([], vec!["arg".into()]),
         Err(EditStateError::MissingReference("arg".into()))
     );
     assert_eq!(
-        put_results(State::from([("res".into(), 1)]), vec![(&"res".into(), 1)].into_iter(),),
+        put_results([("res".into(), 1)], vec![("res".into(), 1)]),
         Err(EditStateError::VariableOverride("res".into()))
     );
+}
+
+/// The type for the state in the testing.
+pub type State = OrderedHashMap<VarId, i64>;
+
+/// Test helper wrapper for `VarManagement::take_vars`.
+fn take_args(
+    state: impl Into<State>,
+    ids: Vec<VarId>,
+) -> Result<(State, Vec<i64>), EditStateError> {
+    let mut state: State = state.into();
+    let taken = state.take_vars(ids.iter())?;
+    Ok((state, taken))
+}
+
+/// Test helper wrapper for `VarManagement::put_vars`.
+fn put_results(
+    state: impl Into<State>,
+    results: Vec<(VarId, i64)>,
+) -> Result<State, EditStateError> {
+    let mut state: State = state.into();
+    state.put_vars(results.iter().map(|(k, v)| (k, *v)))?;
+    Ok(state)
 }


### PR DESCRIPTION
## Summary

Refactored variable state management in Sierra by introducing an `EditState` trait to replace the standalone `take_args` and `put_results` functions. This change improves code organization by moving the state manipulation logic into a trait implementation for `OrderedHashMap<VarId, V>`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous approach used standalone functions to manipulate variable state, which required returning a new state object each time. This led to more verbose code with multiple variable reassignments. The new trait-based approach allows for more idiomatic in-place modifications, making the code cleaner and easier to maintain.

---

## What was the behavior or documentation before?

Previously, state manipulation required calling standalone functions `take_args` and `put_results` that would return a new state object, requiring explicit reassignment:

```rust
let (statement_refs, taken_refs) = take_args(entry.refs, ref_ids)?;
entry.refs = statement_refs;
```

---

## What is the behavior or documentation after?

Now, state manipulation is done through the `EditState` trait methods that modify the state in-place:

```rust
let taken_refs = entry.refs.take_vars(ref_ids)?;
```

This eliminates the need for explicit reassignment and makes the code more concise.

---

## Additional context

This change maintains the same functionality while improving code organization. The implementation updates all relevant code in the Sierra codebase to use the new trait methods, including tests that verify the behavior remains consistent.