### PR TITLE
refactor(sierra-to-casm): Using existing `beta` for ec calc.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/ec.rs
@@ -1,10 +1,7 @@
-use std::str::FromStr;
-
 use cairo_lang_casm::builder::{CasmBuilder, Var};
 use cairo_lang_casm::casm_build_extend;
-use cairo_lang_sierra::extensions::ec::EcConcreteLibfunc;
+use cairo_lang_sierra::extensions::ec::{EcConcreteLibfunc, EcPointType};
 use cairo_lang_sierra::extensions::gas::CostTokenType;
-use num_bigint::BigInt;
 use starknet_types_core::felt::{Felt as Felt252, NonZeroFelt};
 
 use super::{CompiledInvocation, CompiledInvocationBuilder, InvocationError};
@@ -12,12 +9,6 @@ use crate::invocations::misc::validate_under_limit;
 use crate::invocations::{
     BuiltinInfo, CostValidationInfo, add_input_variables, get_non_fallthrough_statement_id,
 };
-
-/// Returns the Beta value of the Starkware elliptic curve.
-fn get_beta() -> BigInt {
-    BigInt::from_str("3141592653589793238462643383279502884197169399375105820974944592307816406665")
-        .unwrap()
-}
 
 /// Builds instructions for Sierra EC operations.
 pub fn build(
@@ -67,7 +58,7 @@ fn compute_rhs(
     computed_rhs: Var,
 ) {
     casm_build_extend! {casm_builder,
-        const beta = (get_beta());
+        const beta = EcPointType::BETA.to_bigint();
         assert x2 = x * x;
         assert x3 = x2 * x;
         assert alpha_x_plus_beta = x + beta; // Here we use the fact that Alpha is 1.

--- a/crates/cairo-lang-sierra/src/extensions/modules/ec.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/ec.rs
@@ -30,7 +30,7 @@ impl NoGenericArgsGenericType for EcOpType {
 pub struct EcPointType {}
 impl EcPointType {
     /// The beta parameter of the curve.
-    const BETA: Felt252 = Felt252::from_hex_unchecked(
+    pub const BETA: Felt252 = Felt252::from_hex_unchecked(
         "0x6f21413efbe40de150e596d72f7a8c5609ad26c15c915c1f4cdfcb99cee9e89",
     );
     /// Returns the left hand side of the curve equation.


### PR DESCRIPTION
## Summary

Refactored EC operations to use the public `BETA` constant from `EcPointType` instead of recreating the value locally. This change removes the need for `std::str::FromStr` and `num_bigint::BigInt` imports in the EC invocations module, and makes the code more maintainable by using a single source of truth for the curve parameter.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The code was previously defining the Beta value of the Starkware elliptic curve in two places - once as a constant in `EcPointType` and again as a local function in the invocations module. This duplication could lead to inconsistencies if one value was updated but not the other. By using the existing constant, we ensure consistency and reduce code duplication.

---

## What was the behavior or documentation before?

The `get_beta()` function in the invocations module was recreating a value that was already defined as a constant in `EcPointType`, but was not publicly accessible.

---

## What is the behavior or documentation after?

The `BETA` constant in `EcPointType` is now public and directly used in the invocations module, eliminating the need for the redundant `get_beta()` function.

---

## Additional context

This change also removes unnecessary imports, making the code cleaner and more maintainable.