### PR TITLE
(feat): Checking runner args in test to assert all are allowed

### DIFF
--- a/crates/cairo-lang-executable-plugin/src/test.rs
+++ b/crates/cairo-lang-executable-plugin/src/test.rs
@@ -28,6 +28,10 @@ pub static SHARED_DB: LazyLock<Mutex<RootDatabase>> = LazyLock::new(|| {
 struct ExpandExecutableTestRunner {}
 
 impl TestFileRunner for ExpandExecutableTestRunner {
+    fn allowed_arg(&self, arg: &str) -> bool {
+        arg == "expect_diagnostics"
+    }
+
     fn run(
         &mut self,
         inputs: &OrderedHashMap<String, String>,

--- a/crates/cairo-lang-executable/src/test.rs
+++ b/crates/cairo-lang-executable/src/test.rs
@@ -79,6 +79,10 @@ impl TestFileRunner for CompileExecutableTestRunner {
             error,
         }
     }
+
+    fn allowed_arg(&self, arg: &str) -> bool {
+        arg == "expect_diagnostics"
+    }
 }
 
 cairo_lang_test_utils::test_file_test_with_runner!(

--- a/crates/cairo-lang-lowering/src/lower/flow_control/graph_test.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/graph_test.rs
@@ -31,7 +31,8 @@ cairo_lang_test_utils::test_file_test!(
         if_: "if",
         match_: "match",
     },
-    test_create_graph
+    test_create_graph,
+    ["expect_diagnostics", "skip_lowering"]
 );
 
 fn test_create_graph(

--- a/crates/cairo-lang-lowering/src/test.rs
+++ b/crates/cairo-lang-lowering/src/test.rs
@@ -59,7 +59,8 @@ cairo_lang_test_utils::test_file_test!(
         while_: "while",
         for_: "for",
     },
-    test_function_lowering
+    test_function_lowering,
+    ["expect_diagnostics"]
 );
 
 fn test_function_lowering(

--- a/crates/cairo-lang-parser/src/parser_test.rs
+++ b/crates/cairo-lang-parser/src/parser_test.rs
@@ -131,7 +131,8 @@ cairo_lang_test_utils::test_file_test!(
         test2: "test2",
         test3: "test3",
     },
-    test_full_parser_tree
+    test_full_parser_tree,
+    ["expect_diagnostics"]
 );
 cairo_lang_test_utils::test_file_test!(
     colored_parsed_code,
@@ -139,7 +140,8 @@ cairo_lang_test_utils::test_file_test!(
     {
         colored: "colored",
     },
-    test_colored_parsed_code
+    test_colored_parsed_code,
+    ["expect_diagnostics"]
 );
 cairo_lang_test_utils::test_file_test!(
     diagnostics,
@@ -203,8 +205,9 @@ cairo_lang_test_utils::test_file_test!(
         use_: "use",
         type_alias: "type_alias",
         macro_declaration: "macro_declaration",
-},
-    test_partial_parser_tree
+    },
+    test_partial_parser_tree,
+    ["expect_diagnostics"]
 );
 cairo_lang_test_utils::test_file_test!(
     partial_parser_tree_with_trivia,
@@ -215,5 +218,6 @@ cairo_lang_test_utils::test_file_test!(
         path_compat: "path_compat",
         attribute_errors: "attribute_errors",
     },
-    test_partial_parser_tree_with_trivia
+    test_partial_parser_tree_with_trivia,
+    ["expect_diagnostics"]
 );

--- a/crates/cairo-lang-plugins/src/test.rs
+++ b/crates/cairo-lang-plugins/src/test.rs
@@ -38,7 +38,8 @@ cairo_lang_test_utils::test_file_test!(
         panicable: "panicable",
         external_attributes_validation: "external_attributes_validation",
     },
-    test_expand_plugin
+    test_expand_plugin,
+    ["expect_diagnostics"]
 );
 
 cairo_lang_test_utils::test_file_test!(
@@ -47,7 +48,8 @@ cairo_lang_test_utils::test_file_test!(
     {
         general: "general",
     },
-    test_general_plugin
+    test_general_plugin,
+    ["expect_diagnostics"]
 );
 
 #[salsa::db]

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -37,7 +37,8 @@ cairo_lang_test_utils::test_file_test!(
         plus_eq: "plus_eq",
         inline: "inline",
     },
-    test_expr_diagnostics
+    test_expr_diagnostics,
+    ["expect_diagnostics"]
 );
 
 #[cairo_lang_test_utils::test]

--- a/crates/cairo-lang-semantic/src/expr/test.rs
+++ b/crates/cairo-lang-semantic/src/expr/test.rs
@@ -24,7 +24,8 @@ cairo_lang_test_utils::test_file_test!(
     {
         inline_macros: "inline_macros",
     },
-    test_expand_expr
+    test_expand_expr,
+    ["expect_diagnostics"]
 );
 
 cairo_lang_test_utils::test_file_test!(
@@ -65,7 +66,8 @@ cairo_lang_test_utils::test_file_test!(
         while_: "while",
         impl_: "impl",
     },
-    test_function_diagnostics
+    test_function_diagnostics,
+    ["expect_diagnostics"]
 );
 
 cairo_lang_test_utils::test_file_test!(
@@ -94,7 +96,8 @@ cairo_lang_test_utils::test_file_test!(
         use_: "use",
         repr_ptr: "repr_ptr",
     },
-    test_expr_semantics
+    test_expr_semantics,
+    ["expect_diagnostics"]
 );
 
 /// Tests the syntactic expansion of a given expression. Can be use to test the expansion of inline

--- a/crates/cairo-lang-semantic/src/items/test.rs
+++ b/crates/cairo-lang-semantic/src/items/test.rs
@@ -21,5 +21,6 @@ cairo_lang_test_utils::test_file_test!(
         early_conform: "early_conform",
         type_mismatch_diagnostics: "type_mismatch_diagnostics",
     },
-    test_function_diagnostics
+    test_function_diagnostics,
+    ["expect_diagnostics"]
 );

--- a/crates/cairo-lang-semantic/src/path_test.rs
+++ b/crates/cairo-lang-semantic/src/path_test.rs
@@ -10,7 +10,8 @@ cairo_lang_test_utils::test_file_test!(
     {
         tests: "tests",
     },
-    test_path_diagnostics
+    test_path_diagnostics,
+    ["expect_diagnostics"]
 );
 
 pub fn test_path_diagnostics(

--- a/crates/cairo-lang-sierra-generator/src/function_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test.rs
@@ -15,5 +15,6 @@ cairo_lang_test_utils::test_file_test!(
         generics: "generics",
 
     },
-    test_function_generator
+    test_function_generator,
+    ["future_sierra"]
 );

--- a/crates/cairo-lang-starknet/src/abi_test.rs
+++ b/crates/cairo-lang-starknet/src/abi_test.rs
@@ -49,7 +49,8 @@ cairo_lang_test_utils::test_file_test!(
   {
       abi_failures: "abi_failures",
   },
-  test_abi_failure
+  test_abi_failure,
+  ["expect_diagnostics"]
 );
 
 /// Helper function for testing multiple Storage path accesses to the same place.
@@ -76,5 +77,6 @@ cairo_lang_test_utils::test_file_test!(
       storage_node: "storage_node",
       storage_path_check: "storage_path_check",
   },
-  test_plugin_diagnostics
+  test_plugin_diagnostics,
+  ["expect_diagnostics"]
 );

--- a/crates/cairo-lang-starknet/src/plugin/test.rs
+++ b/crates/cairo-lang-starknet/src/plugin/test.rs
@@ -71,6 +71,10 @@ impl TestFileRunner for ExpandContractTestRunner {
             error,
         }
     }
+
+    fn allowed_arg(&self, arg: &str) -> bool {
+        arg == "expect_diagnostics"
+    }
 }
 
 cairo_lang_test_utils::test_file_test_with_runner!(
@@ -117,7 +121,7 @@ impl TestFileRunner for ExpandContractFromCrateTestRunner {
     fn run(
         &mut self,
         inputs: &OrderedHashMap<String, String>,
-        _args: &OrderedHashMap<String, String>,
+        args: &OrderedHashMap<String, String>,
     ) -> TestRunnerResult {
         let db = SHARED_DB_WITH_CONTRACTS.lock().unwrap().snapshot();
         let contract_file_id =
@@ -130,7 +134,7 @@ impl TestFileRunner for ExpandContractFromCrateTestRunner {
             .collect::<Vec<_>>()
             .join("\n");
         let joined_diagnostics = diagnostic_items.join("\n");
-        let error = verify_diagnostics_expectation(_args, &joined_diagnostics);
+        let error = verify_diagnostics_expectation(args, &joined_diagnostics);
         TestRunnerResult {
             outputs: OrderedHashMap::from([
                 ("generated_cairo_code".into(), result),
@@ -138,6 +142,10 @@ impl TestFileRunner for ExpandContractFromCrateTestRunner {
             ]),
             error,
         }
+    }
+
+    fn allowed_arg(&self, arg: &str) -> bool {
+        arg == "expect_diagnostics"
     }
 }
 

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -162,6 +162,10 @@ impl TestFileRunner for SmallE2ETestRunner {
         let future_sierra = args.get("future_sierra").is_some_and(|v| v == "true");
         run_e2e_test(inputs, E2eTestParams { future_sierra, ..E2eTestParams::default() })
     }
+
+    fn allowed_arg(&self, arg: &str) -> bool {
+        arg == "future_sierra"
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary

Added support for test file arguments validation by implementing an `allowed_arg` method in the `TestFileRunner` trait. This method allows test runners to specify which arguments they accept, preventing unintended argument usage. The implementation includes:

1. A default `allowed_arg` method that returns false for all arguments
2. A `verify_and_run` method that checks arguments before running tests
3. Updates to various test files to explicitly allow specific arguments like "expect_diagnostics" and "future_sierra"

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, test runners would silently ignore unrecognized arguments, which could lead to tests not behaving as expected when arguments were misspelled or used incorrectly. This change ensures that test runners explicitly declare which arguments they support, preventing silent failures when invalid arguments are provided.

---

## What was the behavior or documentation before?

Test runners would accept any arguments passed to them without validation, potentially ignoring important test configuration due to typos or incorrect usage.

---

## What is the behavior or documentation after?

Test runners now validate arguments before execution and will fail with a clear error message if an unsupported argument is provided. Each test runner explicitly declares which arguments it supports through the `allowed_arg` method.

---

## Additional context

This change improves test reliability by ensuring that test configuration arguments are properly validated before tests are run, preventing silent failures due to argument misuse.