### PR TITLE
docs: add missing statement types to statements.adoc

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/statements.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/statements.adoc
@@ -13,7 +13,7 @@ The kinds of statements are:
 
 - xref:expression-statement.adoc[Expression statement].
 - xref:let-statement.adoc[Let statement].
-- xref:item-statement.adoc[Item statement 🚧].
+- xref:item-statement.adoc[Item statement].
 - Continue statement.
 - Return statement.
 - Break statement.


### PR DESCRIPTION
## Summary

Adds missing Item statement and Continue statement to the statement types list in `statements.adoc` to match the formal grammar.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The documentation listed 4 statement types while the formal grammar defines 6, which can mislead readers.

---

## What was the behavior or documentation before?

The list included only: Expression statement, Let statement, Return statement, Break statement.

---

## What is the behavior or documentation after?

The list now includes all six types: Expression statement, Let statement, Item statement 🚧, Continue statement, Return statement, Break statement.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

Item statement is marked with 🚧 for consistency with navigation. Continue statement has no dedicated page (like Return/Break).