### PR TITLE
docs: add impl aliases to items

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/items.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/items.adoc
@@ -24,6 +24,8 @@ Cairo supports the following types of items:
 === Trait and implementation items
 
 * xref:traits.adoc[Traits] — Define shared behavior and implement it using `trait` and `impl`
+* xref:impl-aliases.adoc[Impl aliases] — Create alternate names for existing implementations
+
 
 === Value items
 


### PR DESCRIPTION
## Summary

Added the missing [impl-aliases.adoc] entry to the [items.adoc] index page to ensure documentation completeness.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The [impl-aliases.adoc] index. This made the feature harder to discover and the documentation structure inconsistent with other items like Type aliases.

---

## What was the behavior or documentation before?

The "Trait and implementation items" section in [items.adoc] only listed Traits.

---

## What is the behavior or documentation after?

The "Trait and implementation items" section now properly lists both Traits and Impl aliases.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

<!--
Anything else reviewers should know.
If this is a documentation PR, explain why this change is important for users.
-->