### PR TITLE
refactor(lowering): remove unnecessary trait bounds from Demand::Default impl

### DIFF
--- a/crates/cairo-lang-lowering/src/borrow_check/demand.rs
+++ b/crates/cairo-lang-lowering/src/borrow_check/demand.rs
@@ -30,11 +30,11 @@ impl<Var> DemandReporter<Var> for EmptyDemandReporter {
 /// Demanded variables from a certain point in the flow until the end of the function.
 /// Needs to be updated in backwards order.
 #[derive(Clone)]
-pub struct Demand<Var: std::hash::Hash + Eq + Copy, UsePosition, Aux: Clone + Default = ()> {
+pub struct Demand<Var, UsePosition, Aux = ()> {
     pub vars: OrderedHashMap<Var, UsePosition>,
     pub aux: Aux,
 }
-impl<Var: std::hash::Hash + Eq + Copy, UsePosition, Aux: Clone + Default> Default
+impl<Var: std::hash::Hash + Eq, UsePosition, Aux: Default> Default
     for Demand<Var, UsePosition, Aux>
 {
     fn default() -> Self {


### PR DESCRIPTION
Removed unnecessary trait bounds from the `Default` implementation for `Demand<Var, UsePosition, Aux>`: removed `Copy` bound from `Var`, removed `Clone` bound from `Aux`