### PR TITLE
docs: update statements documentation index

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/statements.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/statements.adoc
@@ -13,9 +13,10 @@ The kinds of statements are:
 
 - xref:expression-statement.adoc[Expression statement].
 - xref:let-statement.adoc[Let statement].
+- xref:assignment-statement.adoc[Assignment statement].
 - xref:item-statement.adoc[Item statement].
 - Continue statement.
-- Return statement.
+- xref:return-expressions.adoc[Return statement].
 - Break statement.
 
 == Semicolons


### PR DESCRIPTION
## Summary

Added the missing `Assignment statement` to current statements list, and added a link to [return-expressions.adoc] for the `Return statement`.
 
---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The "Assignment statement" was completely missing from the index despite having its own documentation file, and the "Return statement" lacked a link to its detailed documentation, making navigation difficult for users.

---

## What was the behavior or documentation before?

The list omitted the assignment statement and presented the return statement as plain text without a link.

---

## What is the behavior or documentation after?

The list now includes the assignment statement and properly links the return statement to its expression documentation.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

<!--
Anything else reviewers should know.
If this is a documentation PR, explain why this change is important for users.
-->