### PR TITLE
refactor: deduplicate downcast specialization logic

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/casts.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/casts.rs
@@ -87,15 +87,12 @@ impl SignatureBasedConcreteLibfunc for DowncastConcreteLibfunc {
 /// destination type. For example, from u64 to u8.
 #[derive(Default)]
 pub struct DowncastLibfunc {}
-impl NamedLibfunc for DowncastLibfunc {
-    type Concrete = DowncastConcreteLibfunc;
-    const STR_ID: &'static str = "downcast";
-
-    fn specialize_signature(
+impl DowncastLibfunc {
+    fn specialize_concrete_lib_func(
         &self,
         context: &dyn SignatureSpecializationContext,
         args: &[GenericArg],
-    ) -> Result<LibfuncSignature, SpecializationError> {
+    ) -> Result<DowncastConcreteLibfunc, SpecializationError> {
         let (from_ty, to_ty) = args_as_two_types(args)?;
         let to_range = Range::from_type(context, to_ty)?;
         let from_range = Range::from_type(context, from_ty)?;
@@ -125,7 +122,7 @@ impl NamedLibfunc for DowncastLibfunc {
 
         let range_check_type = context.get_concrete_type(RangeCheckType::id(), &[])?;
         let rc_output_info = OutputVarInfo::new_builtin(range_check_type.clone());
-        Ok(LibfuncSignature {
+        let signature = LibfuncSignature {
             param_signatures: vec![
                 ParamSignature::new(range_check_type).with_allow_add_const(),
                 ParamSignature::new(from_ty.clone()),
@@ -149,7 +146,27 @@ impl NamedLibfunc for DowncastLibfunc {
                 },
             ],
             fallthrough: Some(0),
+        };
+
+        Ok(DowncastConcreteLibfunc {
+            signature,
+            from_range,
+            from_ty: from_ty.clone(),
+            to_range,
+            to_ty: to_ty.clone(),
         })
+    }
+}
+impl NamedLibfunc for DowncastLibfunc {
+    type Concrete = DowncastConcreteLibfunc;
+    const STR_ID: &'static str = "downcast";
+
+    fn specialize_signature(
+        &self,
+        context: &dyn SignatureSpecializationContext,
+        args: &[GenericArg],
+    ) -> Result<LibfuncSignature, SpecializationError> {
+        Ok(self.specialize_concrete_lib_func(context, args)?.signature)
     }
 
     fn specialize(
@@ -157,18 +174,6 @@ impl NamedLibfunc for DowncastLibfunc {
         context: &dyn SpecializationContext,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        let (from_ty, to_ty) = args_as_two_types(args)?;
-        let from_range = Range::from_type(context, from_ty)?;
-        // Shrinking the range of the destination type by the range of the source type.
-        let to_range: Range = Range::from_type(context, to_ty)?
-            .intersection(&from_range)
-            .ok_or(SpecializationError::UnsupportedGenericArg)?;
-        Ok(DowncastConcreteLibfunc {
-            signature: self.specialize_signature(context, args)?,
-            from_range,
-            from_ty: from_ty.clone(),
-            to_range,
-            to_ty: to_ty.clone(),
-        })
+        self.specialize_concrete_lib_func(context, args)
     }
 }


### PR DESCRIPTION
## Summary

This refactor introduces a shared helper specialize_concrete_lib_func on DowncastLibfunc that computes the ranges, validates them, builds the LibfuncSignature, and returns a fully initialized DowncastConcreteLibfunc. Both specialize_signature and specialize now delegate to this helper, so the range computations and checks are done exactly once while keeping the public behavior and signature of the downcast libfunc unchanged.

---

## Type of change

Please check **one**:


- [x] Performance improvement


---

## Why is this change needed?

Previously, DowncastLibfunc::specialize_signature and DowncastLibfunc::specialize each recomputed the same from_range / to_range via Range::from_type and intersection, and specialize also called specialize_signature again. This meant duplicated work on type info and BigInt operations without any semantic benefit, and it diverged from the cleaner pattern already used in other libfuncs.

---