### PR TITLE
Made `ConcreteLibfunc::output_types` not uselessly create vectors.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -421,7 +421,7 @@ pub fn check_basic_structure(
     if invocation.args.len() != libfunc.param_signatures().len()
         || !itertools::equal(
             invocation.branches.iter().map(|branch| branch.results.len()),
-            libfunc.output_types().iter().map(|types| types.len()),
+            libfunc.output_types().map(|types| types.len()),
         )
         || match libfunc.fallthrough() {
             Some(expected_fallthrough) => {

--- a/crates/cairo-lang-sierra/src/extensions/lib_func.rs
+++ b/crates/cairo-lang-sierra/src/extensions/lib_func.rs
@@ -446,13 +446,13 @@ pub trait ConcreteLibfunc {
     fn fallthrough(&self) -> Option<usize>;
 
     /// Returns the output types returning from a library function per branch.
-    fn output_types(&self) -> Vec<Vec<ConcreteTypeId>> {
+    fn output_types(
+        &self,
+    ) -> impl Iterator<Item = impl ExactSizeIterator<Item = &ConcreteTypeId> + DoubleEndedIterator>
+    {
         self.branch_signatures()
             .iter()
-            .map(|branch_info| {
-                branch_info.vars.iter().map(|var_info| var_info.ty.clone()).collect()
-            })
-            .collect()
+            .map(|branch_info| branch_info.vars.iter().map(|var_info| &var_info.ty))
     }
 }
 


### PR DESCRIPTION
## Summary

Refactored `output_types()` in `ConcreteLibfunc` to return an iterator instead of a `Vec<Vec<ConcreteTypeId>>`. This change improves code efficiency by avoiding unnecessary allocations and cloning. Updated all call sites to use the new iterator-based API, leveraging `exactly_one()` from the `itertools` crate to make code more robust and expressive.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation of `output_types()` was creating unnecessary allocations by collecting iterators into vectors and cloning type IDs. By returning iterators directly, we avoid these allocations and improve performance. Additionally, using `exactly_one()` from itertools makes the code more robust by explicitly handling the case where we expect exactly one item.

---

## What was the behavior or documentation before?

`output_types()` returned a `Vec<Vec<ConcreteTypeId>>` which required allocating new vectors and cloning type IDs. Call sites had to index into these vectors and sometimes made assumptions about the structure without explicit checks.

---

## What is the behavior or documentation after?

`output_types()` now returns iterators over references to the original type IDs, avoiding allocations and clones. Call sites use `exactly_one()` to explicitly handle cases where exactly one item is expected, making the code more robust and the intent clearer.

---

## Additional context

This change is part of ongoing efforts to make the codebase more efficient by reducing unnecessary allocations and clones, especially in hot code paths.