### PR TITLE
Refine felt252 const op reference info

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/felt252.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/felt252.rs
@@ -184,6 +184,11 @@ impl GenericLibfunc for Felt252BinaryOperationWithConstLibfunc {
                         return Err(SpecializationError::UnsupportedGenericArg);
                     }
                     OutputVarReferenceInfo::NewTempVar { idx: 0 }
+                } else if matches!(
+                    self.operator,
+                    Felt252BinaryOperator::Add | Felt252BinaryOperator::Sub
+                ) {
+                    OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst)
                 } else {
                     OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic)
                 };


### PR DESCRIPTION
Updates `felt252_add_const` and `felt252_sub_const` to use `Deferred(AddConst)` instead of `Generic`.
These operations guarantee a `Var + Const` result structure. Explicitly marking them as `AddConst` allows the compiler to track variable offsets more accurately, enabling potential constant folding and AP tracking optimizations that `Generic` obscures. 