### PR TITLE
Vastly removed the clones in sierra, bt not cloning type info.

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/specialization_context.rs
+++ b/crates/cairo-lang-sierra-generator/src/specialization_context.rs
@@ -16,8 +16,8 @@ impl TypeSpecializationContext for SierraSignatureSpecializationContext<'_> {
     fn try_get_type_info(
         &self,
         id: &cairo_lang_sierra::ids::ConcreteTypeId,
-    ) -> Option<cairo_lang_sierra::extensions::types::TypeInfo> {
-        self.0.get_type_info(id.clone()).cloned().to_option()
+    ) -> Option<&cairo_lang_sierra::extensions::types::TypeInfo> {
+        self.0.get_type_info(id.clone()).to_option()
     }
 }
 impl SignatureSpecializationContext for SierraSignatureSpecializationContext<'_> {

--- a/crates/cairo-lang-sierra/src/extensions/mod.rs
+++ b/crates/cairo-lang-sierra/src/extensions/mod.rs
@@ -61,15 +61,15 @@ fn args_as_single_user_func(args: &[GenericArg]) -> Result<&FunctionId, Speciali
 }
 
 /// Extracts the generic args of `ty`, additionally validates it is of generic type `T`.
-fn extract_type_generic_args<T: NamedType>(
-    context: &dyn TypeSpecializationContext,
+fn extract_type_generic_args<'a, T: NamedType>(
+    context: &'a dyn TypeSpecializationContext,
     ty: &ConcreteTypeId,
-) -> Result<Vec<GenericArg>, SpecializationError> {
-    let long_id = context.get_type_info(ty)?.long_id;
+) -> Result<&'a [GenericArg], SpecializationError> {
+    let long_id = &context.get_type_info(ty)?.long_id;
     if long_id.generic_id != T::ID {
         Err(SpecializationError::UnsupportedGenericArg)
     } else {
-        Ok(long_id.generic_args)
+        Ok(&long_id.generic_args)
     }
 }
 

--- a/crates/cairo-lang-sierra/src/extensions/modules/array.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/array.rs
@@ -31,13 +31,13 @@ impl GenericTypeArgGenericType for ArrayTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        TypeInfo { storable, droppable, zero_sized, .. }: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if storable && !zero_sized {
+        if wrapped_info.storable && !wrapped_info.zero_sized {
             Ok(TypeInfo {
                 long_id,
                 duplicatable: false,
-                droppable,
+                droppable: wrapped_info.droppable,
                 storable: true,
                 zero_sized: false,
             })

--- a/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
@@ -152,7 +152,7 @@ impl SignatureOnlyGenericLibfunc for BoundedIntMulLibfunc {
                 Range::from_type(context, inner_ty)
             })
         } else {
-            [lhs_info, rhs_info].map(|info| Range::from_type_info(&info))
+            [lhs_info, rhs_info].map(Range::from_type_info)
         };
         let (lhs_range, rhs_range) = (lhs_range?, rhs_range?);
         // The result is the minimum and maximum of the four possible extremes.
@@ -330,7 +330,7 @@ impl NamedLibfunc for BoundedIntConstrainLibfunc {
             let inner_ty = args_as_single_type(&ty_info.long_id.generic_args)?;
             Range::from_type(context, inner_ty)?
         } else {
-            Range::from_type_info(&ty_info)?
+            Range::from_type_info(ty_info)?
         };
         require(&range.lower < boundary && boundary < &range.upper)
             .ok_or(SpecializationError::UnsupportedGenericArg)?;
@@ -425,7 +425,7 @@ impl BoundedIntTrimConcreteLibfunc {
     ) -> Result<Self, SpecializationError> {
         let ty = args_as_single_type(args)?;
         let ty_info = context.get_type_info(ty)?;
-        let range = Range::from_type_info(&ty_info)?;
+        let range = Range::from_type_info(ty_info)?;
         let (res_ty, trimmed_value) = if IS_MAX {
             (
                 bounded_int_ty(context, range.lower.clone(), range.upper.clone() - 2)?,

--- a/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
@@ -23,10 +23,16 @@ impl GenericTypeArgGenericType for BoxTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        TypeInfo { storable, droppable, duplicatable, .. }: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if storable {
-            Ok(TypeInfo { long_id, zero_sized: false, storable, droppable, duplicatable })
+        if wrapped_info.storable {
+            Ok(TypeInfo {
+                long_id,
+                zero_sized: false,
+                storable: true,
+                droppable: wrapped_info.droppable,
+                duplicatable: wrapped_info.duplicatable,
+            })
         } else {
             Err(SpecializationError::UnsupportedGenericArg)
         }

--- a/crates/cairo-lang-sierra/src/extensions/modules/coupon.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/coupon.rs
@@ -106,7 +106,7 @@ impl NamedLibfunc for CouponBuyLibfunc {
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
         let coupon_ty = args_as_single_type(args)?;
-        let long_id = context.get_type_info(coupon_ty)?.long_id;
+        let long_id = &context.get_type_info(coupon_ty)?.long_id;
         if long_id.generic_id != CouponType::id() {
             return Err(SpecializationError::UnsupportedGenericArg);
         }
@@ -151,7 +151,7 @@ impl NamedLibfunc for CouponRefundLibfunc {
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
         let coupon_ty = args_as_single_type(args)?;
-        let long_id = context.get_type_info(coupon_ty)?.long_id;
+        let long_id = &context.get_type_info(coupon_ty)?.long_id;
         if long_id.generic_id != CouponType::id() {
             return Err(SpecializationError::UnsupportedGenericArg);
         }

--- a/crates/cairo-lang-sierra/src/extensions/modules/non_zero.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/non_zero.rs
@@ -22,10 +22,16 @@ impl GenericTypeArgGenericType for NonZeroTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        TypeInfo { zero_sized, storable, droppable, duplicatable, .. }: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if storable {
-            Ok(TypeInfo { long_id, zero_sized, storable, droppable, duplicatable })
+        if wrapped_info.storable {
+            Ok(TypeInfo {
+                long_id,
+                zero_sized: wrapped_info.zero_sized,
+                storable: true,
+                droppable: wrapped_info.droppable,
+                duplicatable: wrapped_info.duplicatable,
+            })
         } else {
             Err(SpecializationError::UnsupportedGenericArg)
         }

--- a/crates/cairo-lang-sierra/src/extensions/modules/nullable.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/nullable.rs
@@ -31,10 +31,16 @@ impl GenericTypeArgGenericType for NullableTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        TypeInfo { storable, droppable, duplicatable, .. }: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if storable {
-            Ok(TypeInfo { long_id, zero_sized: false, storable: true, droppable, duplicatable })
+        if wrapped_info.storable {
+            Ok(TypeInfo {
+                long_id,
+                zero_sized: false,
+                storable: true,
+                droppable: wrapped_info.droppable,
+                duplicatable: wrapped_info.duplicatable,
+            })
         } else {
             Err(SpecializationError::UnsupportedGenericArg)
         }

--- a/crates/cairo-lang-sierra/src/extensions/modules/range.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/range.rs
@@ -49,9 +49,9 @@ impl GenericTypeArgGenericType for IntRangeTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        check_inner_type(&wrapped_info)?;
+        check_inner_type(wrapped_info)?;
 
         // The following assert is a sanity check. It should follow from the fact that
         // `check_inner_type` passed.

--- a/crates/cairo-lang-sierra/src/extensions/modules/snapshot.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/snapshot.rs
@@ -22,14 +22,14 @@ impl GenericTypeArgGenericType for SnapshotTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        TypeInfo { zero_sized, storable, duplicatable, .. }: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
         // Duplicatable types are their own snapshot - as the snapshot itself is useless if we can
         // dup the value already.
-        if storable && !duplicatable {
+        if wrapped_info.storable && !wrapped_info.duplicatable {
             Ok(TypeInfo {
                 long_id,
-                zero_sized,
+                zero_sized: wrapped_info.zero_sized,
                 storable: true,
                 droppable: true,
                 duplicatable: true,

--- a/crates/cairo-lang-sierra/src/extensions/modules/span.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/span.rs
@@ -15,10 +15,16 @@ impl GenericTypeArgGenericType for SpanTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        TypeInfo { storable, duplicatable, droppable, zero_sized, .. }: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if storable && !zero_sized {
-            Ok(TypeInfo { long_id, duplicatable, droppable, storable: true, zero_sized: false })
+        if wrapped_info.storable && !wrapped_info.zero_sized {
+            Ok(TypeInfo {
+                long_id,
+                duplicatable: wrapped_info.duplicatable,
+                droppable: wrapped_info.droppable,
+                storable: true,
+                zero_sized: false,
+            })
         } else {
             Err(SpecializationError::UnsupportedGenericArg)
         }

--- a/crates/cairo-lang-sierra/src/extensions/modules/squashed_felt252_dict.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/squashed_felt252_dict.rs
@@ -30,17 +30,17 @@ impl GenericTypeArgGenericType for SquashedFelt252DictTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        TypeInfo { zero_sized, storable, droppable, .. }: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
         // Note: SquashedFelt252Dict is defined as non-duplicatable even if the inner type is
         // duplicatable to allow libfunc that adds entries to it (treat it similarly to an array).
         // TODO(Gil): the implementation support values of size 1. Remove when other sizes are
         // supported.
-        if storable && !zero_sized {
+        if wrapped_info.storable && !wrapped_info.zero_sized {
             Ok(TypeInfo {
                 long_id,
                 storable: true,
-                droppable,
+                droppable: wrapped_info.droppable,
                 duplicatable: false,
                 zero_sized: false,
             })

--- a/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
@@ -63,7 +63,7 @@ impl StructConcreteType {
         let mut duplicatable = true;
         let mut droppable = true;
         let mut storable = true;
-        let mut members: Vec<ConcreteTypeId> = Vec::new();
+        let mut members: Vec<ConcreteTypeId> = Vec::with_capacity(args_iter.len());
         let mut zero_sized = true;
         for arg in args_iter {
             let ty = try_extract_matches!(arg, GenericArg::Type)
@@ -114,8 +114,7 @@ impl StructConcreteType {
         context: &dyn SignatureSpecializationContext,
         ty: &ConcreteTypeId,
     ) -> Result<Self, SpecializationError> {
-        let long_id = context.get_type_info(ty)?.long_id;
-        Self::try_from_long_id(context, &long_id)
+        Self::try_from_long_id(context, &context.get_type_info(ty)?.long_id)
     }
 }
 impl ConcreteType for StructConcreteType {
@@ -296,7 +295,7 @@ impl StructBoxedDeconstructLibfunc {
         ty: &ConcreteTypeId,
     ) -> Result<(Vec<ConcreteTypeId>, bool), SpecializationError> {
         let type_info = context.get_type_info(ty)?;
-        let (inner_ty, is_snapshot) = peel_snapshot(ty, &type_info)?;
+        let (inner_ty, is_snapshot) = peel_snapshot(ty, type_info)?;
         let struct_type = StructConcreteType::try_from_concrete_type(context, inner_ty)?;
         Ok((struct_type.members, is_snapshot))
     }

--- a/crates/cairo-lang-sierra/src/extensions/modules/uninitialized.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/uninitialized.rs
@@ -15,15 +15,15 @@ impl GenericTypeArgGenericType for UninitializedTypeWrapped {
         &self,
         _context: &dyn TypeSpecializationContext,
         long_id: crate::program::ConcreteTypeLongId,
-        TypeInfo { storable, zero_sized, .. }: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError> {
-        if storable {
+        if wrapped_info.storable {
             Ok(TypeInfo {
                 long_id,
                 storable: false,
                 droppable: true,
                 duplicatable: false,
-                zero_sized,
+                zero_sized: wrapped_info.zero_sized,
             })
         } else {
             Err(SpecializationError::UnsupportedGenericArg)

--- a/crates/cairo-lang-sierra/src/extensions/modules/utils.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/utils.rs
@@ -93,7 +93,7 @@ impl Range {
         context: &dyn SignatureSpecializationContext,
         ty: &ConcreteTypeId,
     ) -> Result<Self, SpecializationError> {
-        Self::from_type_info(&context.get_type_info(ty)?)
+        Self::from_type_info(context.get_type_info(ty)?)
     }
     /// Returns true if this range is smaller than the RangeCheck range.
     pub fn is_small_range(&self) -> bool {

--- a/crates/cairo-lang-sierra/src/extensions/test.rs
+++ b/crates/cairo-lang-sierra/src/extensions/test.rs
@@ -1,4 +1,5 @@
 use bimap::BiMap;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use num_bigint::BigInt;
 use test_case::test_case;
 
@@ -29,75 +30,106 @@ fn value_arg(v: i64) -> GenericArg {
 
 struct MockSpecializationContext {
     mapping: BiMap<ConcreteTypeId, ConcreteTypeLongId>,
+    type_infos: UnorderedHashMap<ConcreteTypeId, TypeInfo>,
 }
 impl MockSpecializationContext {
     pub fn new() -> Self {
-        Self { mapping: build_bijective_mapping() }
+        let mapping = build_bijective_mapping();
+        let mut type_infos = UnorderedHashMap::<ConcreteTypeId, TypeInfo>::default();
+        for name in [
+            "T",
+            "felt252",
+            "u128",
+            "bytes31",
+            "Option",
+            "NonZeroFelt252",
+            "Tuple<>",
+            "U128AndFelt252",
+            "StorageAddress",
+            "ContractAddress",
+            "BoundedInt0_3",
+            "BoundedInt0_-1",
+            "BoundedInt0_10",
+            "BoundedInt0_0",
+            "BoundedInt2_3",
+        ] {
+            let key = name.into();
+            let long_id = mapping.get_by_left(&key).unwrap().clone();
+            type_infos.insert(
+                key,
+                TypeInfo {
+                    long_id,
+                    storable: true,
+                    droppable: true,
+                    duplicatable: true,
+                    zero_sized: false,
+                },
+            );
+        }
+        for name in ["ArrayFelt252", "ArrayU128"] {
+            let key = name.into();
+            let long_id = mapping.get_by_left(&key).unwrap().clone();
+            type_infos.insert(
+                key,
+                TypeInfo {
+                    long_id,
+                    storable: true,
+                    droppable: true,
+                    duplicatable: false,
+                    zero_sized: false,
+                },
+            );
+        }
+        {
+            let name = "UninitializedFelt252";
+            let key = name.into();
+            let long_id = mapping.get_by_left(&key).unwrap().clone();
+            type_infos.insert(
+                key,
+                TypeInfo {
+                    long_id,
+                    storable: false,
+                    droppable: true,
+                    duplicatable: false,
+                    zero_sized: true,
+                },
+            );
+        }
+        for name in ["GasBuiltin", "System", "RangeCheck", "NonDupEnum", "NonDupStruct"] {
+            let key = name.into();
+            let long_id = mapping.get_by_left(&key).unwrap().clone();
+            type_infos.insert(
+                key,
+                TypeInfo {
+                    long_id,
+                    storable: true,
+                    droppable: false,
+                    duplicatable: false,
+                    zero_sized: false,
+                },
+            );
+        }
+        for name in ["SnapshotRangeCheck", "SnapshotArrayU128"] {
+            let key = name.into();
+            let long_id = mapping.get_by_left(&key).unwrap().clone();
+            type_infos.insert(
+                key,
+                TypeInfo {
+                    long_id,
+                    storable: true,
+                    droppable: true,
+                    duplicatable: true,
+                    zero_sized: false,
+                },
+            );
+        }
+        Self { mapping, type_infos }
     }
 }
 
 impl TypeSpecializationContext for MockSpecializationContext {
-    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo> {
-        if id == &"T".into()
-            || id == &"felt252".into()
-            || id == &"u128".into()
-            || id == &"bytes31".into()
-            || id == &"Option".into()
-            || id == &"NonZeroFelt252".into()
-            || id == &"NonZeroInt".into()
-            || id == &"Tuple<>".into()
-            || id == &"U128AndFelt252".into()
-            || id == &"StorageAddress".into()
-            || id == &"ContractAddress".into()
-            || id.debug_name.clone().unwrap().contains("BoundedInt")
-        {
-            Some(TypeInfo {
-                long_id: self.mapping.get_by_left(id)?.clone(),
-                storable: true,
-                droppable: true,
-                duplicatable: true,
-                zero_sized: false,
-            })
-        } else if id == &"ArrayFelt252".into() || id == &"ArrayU128".into() {
-            Some(TypeInfo {
-                long_id: self.mapping.get_by_left(id)?.clone(),
-                storable: true,
-                droppable: true,
-                duplicatable: false,
-                zero_sized: false,
-            })
-        } else if id == &"UninitializedFelt252".into() || id == &"UninitializedU128".into() {
-            Some(TypeInfo {
-                long_id: self.mapping.get_by_left(id)?.clone(),
-                storable: false,
-                droppable: true,
-                duplicatable: false,
-                zero_sized: true,
-            })
-        } else if id == &"GasBuiltin".into()
-            || id == &"System".into()
-            || id == &"RangeCheck".into()
-            || id == &"NonDupEnum".into()
-            || id == &"NonDupStruct".into()
-        {
-            Some(TypeInfo {
-                long_id: self.mapping.get_by_left(id)?.clone(),
-                storable: true,
-                droppable: false,
-                duplicatable: false,
-                zero_sized: false,
-            })
-        } else if id == &"SnapshotRangeCheck".into() || id == &"SnapshotArrayU128".into() {
-            Some(TypeInfo {
-                long_id: self.mapping.get_by_left(id)?.clone(),
-                storable: true,
-                droppable: true,
-                duplicatable: true,
-                zero_sized: false,
-            })
-        } else {
-            None
-        }
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<&TypeInfo> {
+        self.type_infos.get(id)
     }
 }
 impl SignatureSpecializationContext for MockSpecializationContext {

--- a/crates/cairo-lang-sierra/src/extensions/type_specialization_context.rs
+++ b/crates/cairo-lang-sierra/src/extensions/type_specialization_context.rs
@@ -5,10 +5,13 @@ use crate::ids::ConcreteTypeId;
 /// Trait for the specialization of types.
 pub trait TypeSpecializationContext {
     /// Returns the type information for the type with the given id.
-    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo>;
+    fn try_get_type_info<'a>(&'a self, id: &ConcreteTypeId) -> Option<&'a TypeInfo>;
 
     /// Wraps [Self::try_get_type_info] with a result object.
-    fn get_type_info(&self, id: &ConcreteTypeId) -> Result<TypeInfo, SpecializationError> {
+    fn get_type_info<'a>(
+        &'a self,
+        id: &ConcreteTypeId,
+    ) -> Result<&'a TypeInfo, SpecializationError> {
         self.try_get_type_info(id).ok_or(SpecializationError::MissingTypeInfo(id.clone()))
     }
 }

--- a/crates/cairo-lang-sierra/src/extensions/types.rs
+++ b/crates/cairo-lang-sierra/src/extensions/types.rs
@@ -122,7 +122,7 @@ pub trait GenericTypeArgGenericType: Default {
         &self,
         context: &dyn TypeSpecializationContext,
         long_id: ConcreteTypeLongId,
-        wrapped_info: TypeInfo,
+        wrapped_info: &TypeInfo,
     ) -> Result<TypeInfo, SpecializationError>;
 }
 

--- a/crates/cairo-lang-sierra/src/program_registry.rs
+++ b/crates/cairo-lang-sierra/src/program_registry.rs
@@ -266,11 +266,8 @@ struct TypeSpecializationContextForRegistry<'a, TType: GenericType> {
 impl<TType: GenericType> TypeSpecializationContext
     for TypeSpecializationContextForRegistry<'_, TType>
 {
-    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo> {
-        self.declared_type_info
-            .get(id)
-            .or_else(|| self.concrete_types.get(id).map(|ty| ty.info()))
-            .cloned()
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<&TypeInfo> {
+        self.declared_type_info.get(id).or_else(|| self.concrete_types.get(id).map(|ty| ty.info()))
     }
 }
 
@@ -349,8 +346,8 @@ pub struct SpecializationContextForRegistry<'a, TType: GenericType> {
     pub concrete_types: &'a TypeMap<TType::Concrete>,
 }
 impl<TType: GenericType> TypeSpecializationContext for SpecializationContextForRegistry<'_, TType> {
-    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<TypeInfo> {
-        self.concrete_types.get(id).map(|ty| ty.info().clone())
+    fn try_get_type_info(&self, id: &ConcreteTypeId) -> Option<&TypeInfo> {
+        self.concrete_types.get(id).map(|ty| ty.info())
     }
 }
 impl<TType: GenericType> SignatureSpecializationContext


### PR DESCRIPTION
## Summary

Optimize memory usage by changing `TypeSpecializationContext::try_get_type_info` to return a reference to `TypeInfo` instead of cloning it. This change propagates throughout the codebase, updating all implementations and callers to work with references rather than owned values.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The current implementation of `try_get_type_info` returns a cloned `TypeInfo` object, which creates unnecessary copies of data structures. By changing the method to return a reference instead, we avoid these allocations and copies, improving performance especially in code paths that frequently access type information.

---

## What was the behavior or documentation before?

Previously, `try_get_type_info` returned an owned `TypeInfo` object, requiring a clone operation each time type information was accessed. This was inefficient, especially in hot code paths that frequently query type information.

---

## What is the behavior or documentation after?

Now `try_get_type_info` returns a reference (`&TypeInfo`), avoiding unnecessary cloning. All callers have been updated to work with references rather than owned values, and generic type implementations now take `&TypeInfo` parameters instead of owned values.

---

## Additional context

This change is part of ongoing performance optimizations in the Sierra compiler. It reduces memory allocations and copying, which should improve compilation speed, especially for large programs with many type references.