### PR TITLE
Optimize OrderedHashMap serde helper to avoid extra allocation

### DIFF
--- a/crates/cairo-lang-utils/src/ordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_map.rs
@@ -147,7 +147,7 @@ mod impl_serde {
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
 
-    use itertools::Itertools;
+    use serde::ser::SerializeSeq;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     use super::*;
@@ -180,7 +180,11 @@ mod impl_serde {
         K: Serialize + Deserialize<'de> + Hash + Eq,
         V: Serialize + Deserialize<'de>,
     {
-        v.iter().collect_vec().serialize(serializer)
+        let mut seq = serializer.serialize_seq(Some(v.len()))?;
+        for (key, value) in v.iter() {
+            seq.serialize_element(&(key, value))?;
+        }
+        seq.end()
     }
 
     pub fn deserialize_ordered_hashmap_vec<'de, K, V, BH: BuildHasher + Default, D>(


### PR DESCRIPTION
## Summary

Previously, serialize_ordered_hashmap_vec always collected the map entries into a Vec before delegating to serde, which caused unnecessary allocation and work for large maps.

---

## Type of change

- [x] Performance improvement

---

## Why is this change needed?

This change serializes the OrderedHashMap directly via Serializer::serialize_seq, iterating over (key, value) pairs without building an intermediate Vec, while preserving the existing serialization format.

