### PR TITLE
docs: remove outdated WIP markers in expressions page

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/expressions.adoc
@@ -19,25 +19,25 @@ to detailed subpages where available.
   xref:parentheses.adoc[Parenthesized expressions].
 - **Operator expressions**.
   - Unary operators include logical not, bitwise not, negation, reference, address-of, and related
-    forms as defined by the syntax. See xref:operator-expressions.adoc[Operator expressions] (🚧)
+    forms as defined by the syntax. See xref:operator-expressions.adoc[Operator expressions]
     and xref:negation-operators.adoc[Negation operators].
   - Binary operators include arithmetic, comparison, logical and bitwise families. See
-    xref:operator-precedence.adoc[Operator precedence] and related operator pages (🚧).
-  - Error propagation uses the postfix `?` operator. See xref:error-propagation-operator.adoc[Error propagation] (🚧).
+    xref:operator-precedence.adoc[Operator precedence] and related operator pages.
+  - Error propagation uses the postfix `?` operator. See xref:error-propagation-operator.adoc[Error propagation].
 - **Function and method calls**. Invocation with positional or named arguments, including references.
   See xref:function-calls.adoc[Function calls] and xref:method-calls.adoc[Method calls].
 - **Member access and indexing**. Field selection with `.` and indexing with `[]` where supported.
   See xref:member-access-expressions.adoc[Member access expressions].
 - **Tuple and struct construction**. Tuple literals and struct constructor calls. See
-  xref:tuple-expressions.adoc[Tuple expressions] (🚧) and
-  xref:struct-expressions.adoc[Struct expressions] (🚧).
+  xref:tuple-expressions.adoc[Tuple expressions] and
+  xref:struct-expressions.adoc[Struct expressions].
 - **Array expressions**. Fixed-size array literals. See xref:array-expressions.adoc[Array expressions].
 - **Blocks**. Braced sequences of statements with an optional tail expression. See
   xref:block-expression.adoc[Block expression].
 - **Control flow expressions**. `if`/`match` and loop forms (`for`, `loop`, `while`) evaluate to
-  values. See xref:if-expressions.adoc[If expressions] (🚧),
-  xref:match-expressions.adoc[Match expressions] (🚧),
-  xref:for-loop-expressions.adoc[For loop expressions] (🚧).
+  values. See xref:if-expressions.adoc[If expressions],
+  xref:match-expressions.adoc[Match expressions],
+  xref:for-loop-expressions.adoc[For loop expressions].
 - **Closures**. Anonymous functions with parameter lists and an optional return type.
  
 == Evaluation order and typing


### PR DESCRIPTION
## Summary

Removes outdated `(🚧)` WIP markers from `expressions.adoc`, as the linked pages (`tuple-expressions`, `struct-expressions`, `match-expressions`, etc.) are now fully implemented.

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `expressions.adoc` page currently marks several reference pages as "under construction" `(🚧)`, which provides a misleading experience for users.

I have verified that all referenced files (e.g., `struct-expressions.adoc` with 200 lines, `if-expressions.adoc` with 249 lines) are fully populated and comprehensive. Removing these markers reflects the actual state of the documentation.

---

## What was the behavior or documentation before?

Documentation links were suffixed with `(🚧)`, implying incomplete or missing content.

---

## What is the behavior or documentation after?

Links are presented cleanly, accurately reflecting that the documentation is complete and ready for reference.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Verified file contents for correctness before removal.