### PR TITLE
refactor(utils): relax trait bounds from Eq to PartialEq in MergeCollection

### DIFF
--- a/crates/cairo-lang-utils/src/collection_arithmetics.rs
+++ b/crates/cairo-lang-utils/src/collection_arithmetics.rs
@@ -74,7 +74,8 @@ impl<Key, Value: Sub<Output = Value>, T: MergeCollection<Key, Value>> SubCollect
     }
 }
 
-impl<Key: Hash + Eq, Value: HasZero + Clone + Eq, BH: BuildHasher> MergeCollection<Key, Value>
+impl<Key: Hash + Eq, Value: HasZero + Clone + PartialEq, BH: BuildHasher>
+    MergeCollection<Key, Value>
     for OrderedHashMap<Key, Value, BH>
 {
     fn merge_collection(


### PR DESCRIPTION
Relaxes trait bound from `Eq` to `PartialEq` for the `Value` type parameter in `MergeCollection` implementations for `OrderedHashMap` and `SmallOrderedMap`.