### PR TITLE
perf: optimize HeapSize for num_bigint big integers

### DIFF
--- a/crates/cairo-lang-utils/src/heap_size.rs
+++ b/crates/cairo-lang-utils/src/heap_size.rs
@@ -202,14 +202,15 @@ impl HeapSize for smol_str::SmolStr {
 // For num-bigint
 impl HeapSize for num_bigint::BigUint {
     fn heap_size(&self) -> usize {
-        // BigUint has internal Vec<u8>
-        self.to_bytes_le().capacity()
+        // Approximate the number of bytes required to store the magnitude.
+        let bits = self.bits() as usize;
+        bits.div_ceil(8)
     }
 }
 
 impl HeapSize for num_bigint::BigInt {
     fn heap_size(&self) -> usize {
-        self.to_bytes_le().1.capacity()
+        self.magnitude().heap_size()
     }
 }
 


### PR DESCRIPTION
## Summary

BigUint::heap_size uses bits() to approximate the number of bytes required for the magnitude, and BigInt::heap_size delegates to magnitude().heap_size(), avoiding allocations while still tracking the heap-owned magnitude.

---

## Type of change

Please check **one**:


- [x] Performance improvement


---

## Why is this change needed?

HeapSize for BigUint and BigInt called to_bytes_le(), allocating a temporary Vec and copying all digits on every call, effectively measuring the capacity of that temporary buffer instead of the in-place magnitude. This made heap_size() O(n) with extra allocations for large big integers.


