### PR TITLE
refactor(cairo-lang-utils): remove unused Box import in no_std mode

### DIFF
--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -5,8 +5,6 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
 use core::fmt;
 
 /// Re-exporting the [`smol_str`] crate so that downstream projects can always use the same


### PR DESCRIPTION
Removes unused `alloc::boxed::Box` import that was conditionally included for `no_std` builds.