### PR TITLE
Improve sierra debug info serde.

### DIFF
--- a/crates/cairo-lang-sierra/src/debug_info.rs
+++ b/crates/cairo-lang-sierra/src/debug_info.rs
@@ -1,7 +1,9 @@
 use std::hash::Hash;
+use std::marker::PhantomData;
 
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use itertools::Itertools;
+use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
@@ -202,15 +204,41 @@ fn serialize_map<Id: IdAsHashKey, S: serde::Serializer>(
     m: &OrderedHashMap<Id, SmolStr>,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    let v: Vec<_> = m.iter().map(|(id, name)| (id.get(), name)).sorted().collect();
-    v.serialize(serializer)
+    serializer.collect_seq(m.iter().map(|(id, name)| (id.get(), name)).sorted())
 }
 
 fn deserialize_map<'de, Id: IdAsHashKey, D: serde::Deserializer<'de>>(
     deserializer: D,
 ) -> Result<OrderedHashMap<Id, SmolStr>, D::Error> {
-    Ok(Vec::<(u64, SmolStr)>::deserialize(deserializer)?
-        .into_iter()
-        .map(|(id, name)| (Id::new(id), name))
-        .collect())
+    struct OrderedHashMapVisitor<Id> {
+        marker: PhantomData<Id>,
+    }
+
+    impl<'de, Id> Visitor<'de> for OrderedHashMapVisitor<Id>
+    where
+        Id: IdAsHashKey,
+    {
+        type Value = OrderedHashMap<Id, SmolStr>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            formatter.write_str("a sequence of pairs")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut values = OrderedHashMap::default();
+            if let Some(size) = seq.size_hint() {
+                values.reserve_exact(size);
+            }
+
+            while let Some((k, v)) = seq.next_element()? {
+                values.insert(Id::new(k), v);
+            }
+
+            Ok(values)
+        }
+    }
+    deserializer.deserialize_seq(OrderedHashMapVisitor { marker: PhantomData })
 }


### PR DESCRIPTION
## Summary

Refactored the serialization and deserialization of `OrderedHashMap` in the debug info module to use a more efficient approach. Instead of collecting items into a temporary vector, the implementation now directly serializes elements into a sequence. For deserialization, introduced a custom `Visitor` implementation that properly handles sequence access and constructs the map directly.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] Performance improvement
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation of serialization and deserialization for `OrderedHashMap` was inefficient as it created intermediate collections. This change improves performance by eliminating the need for temporary vectors during serialization and deserialization processes.

---

## What was the behavior or documentation before?

Previously, the code would collect all map entries into a temporary vector during serialization, and similarly deserialize into a vector before converting back to an `OrderedHashMap`.

---

## What is the behavior or documentation after?

Now the implementation directly serializes map entries into a sequence without the intermediate collection. For deserialization, a custom `Visitor` implementation properly handles sequence access and constructs the map directly with appropriate size hints when available.

---

## Additional context

This change follows serialization best practices by using the visitor pattern for deserialization and direct sequence serialization, which should be more memory efficient for large maps.