### PR TITLE
performance(sierra-to-casm): Removed `CellExpression` unrequired clone.

### DIFF
--- a/crates/cairo-lang-casm/src/builder.rs
+++ b/crates/cairo-lang-casm/src/builder.rs
@@ -2,7 +2,7 @@ use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::extract_matches;
 use cairo_lang_utils::small_ordered_map::{Entry, SmallOrderedMap};
 use num_bigint::BigInt;
-use num_traits::{One, Zero};
+use num_traits::{One, ToPrimitive, Zero};
 
 use crate::ap_change::ApplyApChange;
 use crate::cell_expression::{CellExpression, CellOperator};
@@ -44,18 +44,13 @@ pub struct State {
 }
 impl State {
     /// Returns the value, in relation to the initial ap value.
-    fn get_value(&self, var: Var) -> CellExpression {
-        self.vars[&var].clone()
+    fn get_unadjusted(&self, var: Var) -> &CellExpression {
+        &self.vars[&var]
     }
 
     /// Returns the value, in relation to the current ap value.
     pub fn get_adjusted(&self, var: Var) -> CellExpression {
-        self.get_value(var).unchecked_apply_known_ap_change(self.ap_change)
-    }
-
-    /// Returns the value, assuming it is a direct cell reference.
-    pub fn get_adjusted_as_cell_ref(&self, var: Var) -> CellRef {
-        extract_matches!(self.get_adjusted(var), CellExpression::Deref)
+        self.get_unadjusted(var).clone().unchecked_apply_known_ap_change(self.ap_change)
     }
 
     /// Validates that the state is valid, if it had enough AP change to support the requested
@@ -229,7 +224,7 @@ impl CasmBuilder {
 
     /// Returns an additional variable pointing to the same value.
     pub fn duplicate_var(&mut self, var: Var) -> Var {
-        self.add_var(self.get_value(var, false))
+        self.add_var(self.get_unadjusted(var).clone())
     }
 
     /// Adds a hint, generated from `inputs` which are cell refs or immediates and `outputs` which
@@ -247,25 +242,32 @@ impl CasmBuilder {
     ) {
         self.current_hints.push(
             f(
-                inputs.map(|v| match self.get_value(v, true) {
-                    CellExpression::Deref(cell) => ResOperand::Deref(cell),
-                    CellExpression::DoubleDeref(cell, offset) => {
-                        ResOperand::DoubleDeref(cell, offset)
+                inputs.map(|v| {
+                    match self.get_unadjusted(v) {
+                        CellExpression::Deref(cell) => ResOperand::Deref(*cell),
+                        CellExpression::DoubleDeref(cell, offset) => {
+                            ResOperand::DoubleDeref(*cell, *offset)
+                        }
+                        CellExpression::Immediate(imm) => imm.clone().into(),
+                        CellExpression::BinOp { op, a: other, b } => match op {
+                            CellOperator::Add => ResOperand::BinOp(BinOpOperand {
+                                op: Operation::Add,
+                                a: *other,
+                                b: b.clone(),
+                            }),
+                            CellOperator::Mul => ResOperand::BinOp(BinOpOperand {
+                                op: Operation::Mul,
+                                a: *other,
+                                b: b.clone(),
+                            }),
+                            CellOperator::Sub | CellOperator::Div => {
+                                panic!("hints to non ResOperand references are not supported.")
+                            }
+                        },
                     }
-                    CellExpression::Immediate(imm) => imm.into(),
-                    CellExpression::BinOp { op, a: other, b } => match op {
-                        CellOperator::Add => {
-                            ResOperand::BinOp(BinOpOperand { op: Operation::Add, a: other, b })
-                        }
-                        CellOperator::Mul => {
-                            ResOperand::BinOp(BinOpOperand { op: Operation::Mul, a: other, b })
-                        }
-                        CellOperator::Sub | CellOperator::Div => {
-                            panic!("hints to non ResOperand references are not supported.")
-                        }
-                    },
+                    .unchecked_apply_known_ap_change(self.main_state.ap_change)
                 }),
-                outputs.map(|v| self.as_cell_ref(v, true)),
+                outputs.map(|v| self.as_adjasted_cell_ref(v)),
             )
             .into(),
         );
@@ -274,28 +276,38 @@ impl CasmBuilder {
     /// Adds an assertion that `dst = res`.
     /// `dst` must be a cell reference.
     pub fn assert_vars_eq(&mut self, dst: Var, res: Var, kind: AssertEqKind) {
-        let a = self.as_cell_ref(dst, true);
-        let b = self.get_value(res, true);
+        let a = extract_matches!(self.get_unadjusted(dst), CellExpression::Deref);
+        let b = self.get_unadjusted(res);
         let (a, b) = match b {
-            CellExpression::Deref(cell) => (a, ResOperand::Deref(cell)),
-            CellExpression::DoubleDeref(cell, offset) => (a, ResOperand::DoubleDeref(cell, offset)),
-            CellExpression::Immediate(imm) => (a, imm.into()),
+            CellExpression::Deref(cell) => (a, ResOperand::Deref(*cell)),
+            CellExpression::DoubleDeref(cell, offset) => {
+                (a, ResOperand::DoubleDeref(*cell, *offset))
+            }
+            CellExpression::Immediate(imm) => (a, imm.clone().into()),
             CellExpression::BinOp { op, a: other, b } => match op {
-                CellOperator::Add => {
-                    (a, ResOperand::BinOp(BinOpOperand { op: Operation::Add, a: other, b }))
-                }
-                CellOperator::Mul => {
-                    (a, ResOperand::BinOp(BinOpOperand { op: Operation::Mul, a: other, b }))
-                }
-                CellOperator::Sub => {
-                    (other, ResOperand::BinOp(BinOpOperand { op: Operation::Add, a, b }))
-                }
-                CellOperator::Div => {
-                    (other, ResOperand::BinOp(BinOpOperand { op: Operation::Mul, a, b }))
-                }
+                CellOperator::Add => (
+                    a,
+                    ResOperand::BinOp(BinOpOperand { op: Operation::Add, a: *other, b: b.clone() }),
+                ),
+                CellOperator::Mul => (
+                    a,
+                    ResOperand::BinOp(BinOpOperand { op: Operation::Mul, a: *other, b: b.clone() }),
+                ),
+                CellOperator::Sub => (
+                    other,
+                    ResOperand::BinOp(BinOpOperand { op: Operation::Add, a: *a, b: b.clone() }),
+                ),
+                CellOperator::Div => (
+                    other,
+                    ResOperand::BinOp(BinOpOperand { op: Operation::Mul, a: *a, b: b.clone() }),
+                ),
             },
         };
-        let inner = AssertEqInstruction { a, b };
+        let ap_change = self.main_state.ap_change;
+        let inner = AssertEqInstruction {
+            a: a.unchecked_apply_known_ap_change(ap_change),
+            b: b.unchecked_apply_known_ap_change(ap_change),
+        };
         let instruction = self.next_instruction(
             match kind {
                 AssertEqKind::Felt252 => InstructionBody::AssertEq(inner),
@@ -320,18 +332,18 @@ impl CasmBuilder {
     /// `deref` (which includes trivial calculations as well) so it instead returns a variable
     /// pointing to that location.
     pub fn maybe_add_tempvar(&mut self, var: Var) -> Var {
-        self.add_var(CellExpression::Deref(match self.get_value(var, false) {
-            CellExpression::Deref(cell) => cell,
+        self.add_var(CellExpression::Deref(match self.get_unadjusted(var) {
+            CellExpression::Deref(cell) => *cell,
             CellExpression::BinOp {
                 op: CellOperator::Add | CellOperator::Sub,
                 a,
                 b: DerefOrImmediate::Immediate(imm),
-            } if imm.value.is_zero() => a,
+            } if imm.value.is_zero() => *a,
             CellExpression::BinOp {
                 op: CellOperator::Mul | CellOperator::Div,
                 a,
                 b: DerefOrImmediate::Immediate(imm),
-            } if imm.value.is_one() => a,
+            } if imm.value.is_one() => *a,
             _ => {
                 let temp = self.alloc_var(false);
                 self.assert_vars_eq(temp, var, AssertEqKind::Felt252);
@@ -342,7 +354,7 @@ impl CasmBuilder {
 
     /// Increments a buffer and allocates and returns a variable pointing to its previous value.
     pub fn get_ref_and_inc(&mut self, buffer: Var) -> Var {
-        let (cell, offset) = self.as_cell_ref_plus_const(buffer, 0, false);
+        let (cell, offset) = self.as_unadjusted_cell_ref_plus_const(buffer, 0);
         self.main_state.vars.insert(
             buffer,
             CellExpression::BinOp {
@@ -358,15 +370,7 @@ impl CasmBuilder {
     /// Useful for writing, reading and referencing values.
     /// `buffer` must be a cell reference, or a cell reference with a small added constant.
     fn buffer_get_and_inc(&mut self, buffer: Var) -> (CellRef, i16) {
-        let (base, offset) = match self.get_value(buffer, false) {
-            CellExpression::Deref(cell) => (cell, 0),
-            CellExpression::BinOp {
-                op: CellOperator::Add,
-                a,
-                b: DerefOrImmediate::Immediate(imm),
-            } => (a, imm.value.try_into().expect("Too many buffer writes.")),
-            _ => panic!("Not a valid buffer."),
-        };
+        let (base, offset) = self.as_unadjusted_cell_ref_plus_const(buffer, 0);
         self.main_state.vars.insert(
             buffer,
             CellExpression::BinOp {
@@ -397,19 +401,19 @@ impl CasmBuilder {
     /// Returns a variable that is the `op` of `lhs` and `rhs`.
     /// `lhs` must be a cell reference and `rhs` must be deref or immediate.
     pub fn bin_op(&mut self, op: CellOperator, lhs: Var, rhs: Var) -> Var {
-        let (a, b) = match self.get_value(lhs, false) {
+        let (a, b) = match self.get_unadjusted(lhs) {
             // Regular `bin_op` support.
-            CellExpression::Deref(cell) => (cell, self.as_deref_or_imm(rhs, false)),
+            CellExpression::Deref(cell) => (*cell, self.as_unadjasted_deref_or_imm(rhs)),
             // `add_with_const` + `imm` support.
             CellExpression::BinOp {
                 op: CellOperator::Add,
                 a,
                 b: DerefOrImmediate::Immediate(imm),
             } if op == CellOperator::Add => (
-                a,
+                *a,
                 DerefOrImmediate::Immediate(
-                    (imm.value
-                        + extract_matches!(self.get_value(rhs, false), CellExpression::Immediate))
+                    (&imm.value
+                        + extract_matches!(self.get_unadjusted(rhs), CellExpression::Immediate))
                     .into(),
                 ),
             ),
@@ -424,7 +428,7 @@ impl CasmBuilder {
     /// Returns a variable that is `[[var] + offset]`.
     /// `var` must be a cell reference, or a cell ref plus a small constant.
     pub fn double_deref(&mut self, var: Var, offset: i16) -> Var {
-        let (cell, full_offset) = self.as_cell_ref_plus_const(var, offset, false);
+        let (cell, full_offset) = self.as_unadjusted_cell_ref_plus_const(var, offset);
         self.add_var(CellExpression::DoubleDeref(cell, full_offset))
     }
 
@@ -446,7 +450,7 @@ impl CasmBuilder {
     /// Adds a statement to jump to `label` if `condition != 0`.
     /// `condition` must be a cell reference.
     pub fn jump_nz(&mut self, condition: Var, label: &'static str) {
-        let cell = self.as_cell_ref(condition, true);
+        let cell = self.as_adjasted_cell_ref(condition);
         self.push_labeled_instruction(
             label,
             InstructionBody::Jnz(JnzInstruction {
@@ -469,9 +473,9 @@ impl CasmBuilder {
     pub fn blake2s_compress(&mut self, state: Var, byte_count: Var, message: Var, finalize: bool) {
         let instruction = self.next_instruction(
             InstructionBody::Blake2sCompress(Blake2sCompressInstruction {
-                state: self.as_cell_ref(state, true),
-                byte_count: self.as_cell_ref(byte_count, true),
-                message: self.as_cell_ref(message, true),
+                state: self.as_adjasted_cell_ref(state),
+                byte_count: self.as_adjasted_cell_ref(byte_count),
+                message: self.as_adjasted_cell_ref(message),
                 finalize,
             }),
             true,
@@ -640,20 +644,26 @@ impl CasmBuilder {
     }
 
     /// Returns `var`s value, with fixed ap if `adjust_ap` is true.
-    pub fn get_value(&self, var: Var, adjust_ap: bool) -> CellExpression {
-        if adjust_ap { self.main_state.get_adjusted(var) } else { self.main_state.get_value(var) }
+    pub fn get_adjusted(&self, var: Var) -> CellExpression {
+        self.main_state.get_adjusted(var)
+    }
+
+    /// Returns `var`s value, with fixed ap if `adjust_ap` is true.
+    pub fn get_unadjusted(&self, var: Var) -> &CellExpression {
+        self.main_state.get_unadjusted(var)
     }
 
     /// Returns `var`s value as a cell reference, with fixed ap if `adjust_ap` is true.
-    fn as_cell_ref(&self, var: Var, adjust_ap: bool) -> CellRef {
-        extract_matches!(self.get_value(var, adjust_ap), CellExpression::Deref)
+    fn as_adjasted_cell_ref(&self, var: Var) -> CellRef {
+        extract_matches!(self.main_state.get_unadjusted(var), CellExpression::Deref)
+            .unchecked_apply_known_ap_change(self.main_state.ap_change)
     }
 
     /// Returns `var`s value as a cell reference or immediate, with fixed ap if `adjust_ap` is true.
-    fn as_deref_or_imm(&self, var: Var, adjust_ap: bool) -> DerefOrImmediate {
-        match self.get_value(var, adjust_ap) {
-            CellExpression::Deref(cell) => DerefOrImmediate::Deref(cell),
-            CellExpression::Immediate(imm) => DerefOrImmediate::Immediate(imm.into()),
+    fn as_unadjasted_deref_or_imm(&self, var: Var) -> DerefOrImmediate {
+        match self.get_unadjusted(var) {
+            CellExpression::Deref(cell) => DerefOrImmediate::Deref(*cell),
+            CellExpression::Immediate(imm) => DerefOrImmediate::Immediate(imm.clone().into()),
             CellExpression::DoubleDeref(_, _) | CellExpression::BinOp { .. } => {
                 panic!("wrong usage.")
             }
@@ -662,21 +672,23 @@ impl CasmBuilder {
 
     /// Returns `var`s value as a cell reference plus a small const offset, with fixed ap if
     /// `adjust_ap` is true.
-    fn as_cell_ref_plus_const(
+    fn as_unadjusted_cell_ref_plus_const(
         &self,
         var: Var,
         additional_offset: i16,
-        adjust_ap: bool,
     ) -> (CellRef, i16) {
-        match self.get_value(var, adjust_ap) {
-            CellExpression::Deref(cell) => (cell, additional_offset),
+        match self.main_state.get_unadjusted(var) {
+            CellExpression::Deref(cell) => (*cell, additional_offset),
             CellExpression::BinOp {
                 op: CellOperator::Add,
                 a,
                 b: DerefOrImmediate::Immediate(imm),
             } => (
-                a,
-                (imm.value + additional_offset).try_into().expect("Offset too large for deref."),
+                *a,
+                imm.value
+                    .to_i16()
+                    .and_then(|v| v.checked_add(additional_offset))
+                    .expect("Offset too large for deref."),
             ),
             _ => panic!("Not a valid ptr."),
         }

--- a/crates/cairo-lang-runnable-utils/src/builder.rs
+++ b/crates/cairo-lang-runnable-utils/src/builder.rs
@@ -416,7 +416,8 @@ impl EntryCodeHelper {
             if !self.config.testing {
                 // Add a local variable for the output builtin
                 casm_build_extend!(self.ctx, localvar local;);
-                self.local_exprs.insert(BuiltinName::output, self.ctx.get_value(local, false));
+                self.local_exprs
+                    .insert(BuiltinName::output, self.ctx.get_unadjusted(local).clone());
             }
 
             for (generic_ty, _ty_size) in param_types {
@@ -424,7 +425,7 @@ impl EntryCodeHelper {
                     && name != &BuiltinName::segment_arena
                 {
                     casm_build_extend!(self.ctx, localvar local;);
-                    self.local_exprs.insert(*name, self.ctx.get_value(local, false));
+                    self.local_exprs.insert(*name, self.ctx.get_unadjusted(local).clone());
                 }
             }
 
@@ -591,7 +592,7 @@ impl EntryCodeHelper {
                 );
 
                 let var = self.builtin_vars[name];
-                self.local_exprs.insert(*name, self.ctx.get_value(var, false));
+                self.local_exprs.insert(*name, self.ctx.get_unadjusted(var).clone());
                 var
             });
         }


### PR DESCRIPTION
## Summary

Refactored the `CasmBuilder` to improve handling of cell expressions by:
1. Splitting value retrieval into `get_unadjusted` and `get_adjusted` methods
2. Removing the `adjust_ap` boolean parameter in favor of explicit method names
3. Fixing potential overflow issues in offset calculations by using `to_i16()` and `checked_add`
4. Optimizing cell reference handling by applying AP changes more consistently

---

## Type of change

Please check **one**:

- [x] Performance improvement
- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The current implementation of `CasmBuilder` has inconsistent handling of AP adjustments and cell references. The boolean `adjust_ap` parameter creates confusion about when adjustments should be applied. Additionally, the offset calculations for cell references could potentially overflow without proper checking.

---

## What was the behavior or documentation before?

The code used a boolean parameter `adjust_ap` to determine whether to apply AP changes, leading to potential inconsistencies. Cell reference handling was also less efficient, with redundant cloning operations and unsafe offset calculations.

---

## What is the behavior or documentation after?

The code now has explicit methods for adjusted and unadjusted values, making the intent clearer. Offset calculations use proper checked arithmetic to prevent overflows, and AP changes are applied more consistently throughout the codebase.

---

## Additional context

This refactoring improves code maintainability by making the API more explicit about when AP adjustments are applied. It also reduces unnecessary cloning of cell expressions and adds proper bounds checking for offsets.