### PR TITLE
performance(utils): By hand implementation of small-ordered-map.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,6 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "vector-map",
 ]
 
 [[package]]
@@ -4587,15 +4586,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vector-map"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b34e878e32c750bb4253be124adb9da1dc93ca5d98c210787badf1e1ccdca7"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ opt-level = 3
 opt-level = 3
 [profile.ci-dev.package."tokio"]
 opt-level = 3
-[profile.ci-dev.package."vector-map"]
-opt-level = 3
 [profile.ci-dev.package."mimalloc"]
 opt-level = 3
 [profile.ci-dev.package."libmimalloc-sys"]
@@ -160,7 +158,6 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "time"] }
 typetag = "0.2"
 unescaper = "0.1.6"
-vector-map = { version = "1.0.2", features = ["serde_impl"] }
 xshell = "0.2.7"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 

--- a/crates/cairo-lang-sierra-gas/src/test_data/fib_jumps
+++ b/crates/cairo-lang-sierra-gas/src/test_data/fib_jumps
@@ -7,15 +7,15 @@ fib_jumps
 test_solve_gas
 
 //! > gas_solution
-#2: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0})
-#4: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1070})
-#9: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0})
-#19: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0})
-#22: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 470})
-#26: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0})
-#28: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1070})
-#29: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0})
-#40: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0})
-#45: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0})
+#2: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0)])
+#4: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1070)])
+#9: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0)])
+#19: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0)])
+#22: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 470)])
+#26: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0)])
+#28: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1070)])
+#29: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0)])
+#40: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0)])
+#45: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0)])
 
-Fibonacci: SmallOrderedMap({Const: 1470})
+Fibonacci: SmallOrderedMap([(Const, 1470)])

--- a/crates/cairo-lang-utils/Cargo.toml
+++ b/crates/cairo-lang-utils/Cargo.toml
@@ -22,7 +22,6 @@ serde = { workspace = true, features = ["alloc"], optional = true }
 tracing = { workspace = true, optional = true }
 tracing-log = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
-vector-map = { workspace = true, optional = true }
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
@@ -35,14 +34,6 @@ default = ["std", "tracing"]
 parity-scale-codec = ["dep:parity-scale-codec"]
 schemars = ["dep:schemars", "serde", "std"]
 serde = ["dep:serde", "indexmap/serde", "num-bigint/serde", "smol_str/serde"]
-std = [
-  "indexmap/std",
-  "num-bigint/std",
-  "num-traits/std",
-  "salsa",
-  "serde?/std",
-  "smol_str/std",
-  "vector-map",
-]
+std = ["indexmap/std", "num-bigint/std", "num-traits/std", "salsa", "serde?/std", "smol_str/std"]
 testing = []
 tracing = ["dep:tracing", "dep:tracing-log", "dep:tracing-subscriber", "std"]

--- a/crates/cairo-lang-utils/src/small_ordered_map.rs
+++ b/crates/cairo-lang-utils/src/small_ordered_map.rs
@@ -1,6 +1,10 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// A mapping optimized for very small maps.
 ///
-/// Wraps the `vector_map::VecMap` structure.
+/// Uses a single `Vec<(Key, Value)>` for better cache locality compared to
+/// separate key/value vectors.
 #[derive(Clone, Debug)]
 #[cfg_attr(
     feature = "serde",
@@ -11,57 +15,220 @@
         deserialize = "Key: serde::Deserialize<'de> + Eq, Value: serde::Deserialize<'de>",
     ))
 )]
-pub struct SmallOrderedMap<Key, Value>(vector_map::VecMap<Key, Value>);
+pub struct SmallOrderedMap<Key, Value>(Vec<(Key, Value)>);
+
 impl<Key: Eq, Value> SmallOrderedMap<Key, Value> {
     /// Creates a new empty map.
     pub fn new() -> Self {
-        Self(vector_map::VecMap::new())
+        Self(Vec::new())
     }
+
     /// Creates a new map with the given capacity.
     pub fn with_capacity(capacity: usize) -> Self {
-        Self(vector_map::VecMap::with_capacity(capacity))
+        Self(Vec::with_capacity(capacity))
+    }
+
+    /// Returns the number of elements in the map.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the map contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Clears the map, removing all key-value pairs.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    #[inline]
+    pub fn get<Q>(&self, key: &Q) -> Option<&Value>
+    where
+        Key: PartialEq<Q>,
+    {
+        self.0.iter().find_map(|(k, v)| (k == key).then_some(v))
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    #[inline]
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut Value>
+    where
+        Key: PartialEq<Q>,
+    {
+        self.0.iter_mut().find_map(|(k, v)| (k == key).then_some(v))
+    }
+
+    /// Returns `true` if the map contains the key.
+    #[inline]
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        Key: PartialEq<Q>,
+    {
+        self.0.iter().any(|(k, _)| k == key)
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map already had the key present, the value is updated, and the old
+    /// value is returned.
+    pub fn insert(&mut self, key: Key, value: Value) -> Option<Value> {
+        if let Some(v) = self.get_mut(&key) {
+            Some(core::mem::replace(v, value))
+        } else {
+            self.0.push((key, value));
+            None
+        }
+    }
+
+    /// Gets the given key's corresponding entry in the map for in-place manipulation.
+    #[inline]
+    pub fn entry(&mut self, key: Key) -> Entry<'_, Key, Value> {
+        match self.0.iter().position(|(k, _)| k == &key) {
+            Some(index) => Entry::Occupied(OccupiedEntry { map: &mut self.0, index }),
+            None => Entry::Vacant(VacantEntry { map: &mut self.0, key }),
+        }
+    }
+
+    /// An iterator visiting all keys in insertion order.
+    #[inline]
+    pub fn keys(&self) -> impl Iterator<Item = &Key> {
+        self.0.iter().map(|(k, _)| k)
+    }
+
+    /// An iterator visiting all values in insertion order.
+    #[inline]
+    pub fn values(&self) -> impl Iterator<Item = &Value> {
+        self.0.iter().map(|(_, v)| v)
+    }
+
+    /// An iterator visiting all key-value pairs in insertion order.
+    #[inline]
+    pub fn iter(&self) -> Iter<'_, Key, Value> {
+        Iter(self.0.iter())
+    }
+
+    /// An iterator visiting all key-value pairs in insertion order, with mutable
+    /// references to the values.
+    #[inline]
+    pub fn iter_mut(&mut self) -> IterMut<'_, Key, Value> {
+        IterMut(self.0.iter_mut())
+    }
+
+    /// Reserves capacity for at least `additional` more elements.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+
+    /// Reserves the minimum capacity for exactly `additional` more elements.
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.0.reserve_exact(additional);
+    }
+
+    /// Removes a key from the map, returning the value if the key was present.
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<Value>
+    where
+        Key: PartialEq<Q>,
+    {
+        if let Some(index) = self.0.iter().position(|(k, _)| k == key) {
+            Some(self.0.swap_remove(index).1)
+        } else {
+            None
+        }
+    }
+
+    /// Retains only the elements specified by the predicate.
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&Key, &mut Value) -> bool,
+    {
+        self.0.retain_mut(|(k, v)| f(k, v));
     }
 }
+
+impl<Key: Eq + PartialEq<Q>, Value, Q> core::ops::Index<&Q> for SmallOrderedMap<Key, Value> {
+    type Output = Value;
+
+    fn index(&self, key: &Q) -> &Self::Output {
+        self.get(key).expect("key not found")
+    }
+}
+
+impl<Key: Eq + PartialEq<Q>, Value, Q> core::ops::IndexMut<&Q> for SmallOrderedMap<Key, Value> {
+    fn index_mut(&mut self, key: &Q) -> &mut Self::Output {
+        self.get_mut(key).expect("key not found")
+    }
+}
+
 impl<Key: Eq, Value: Eq> SmallOrderedMap<Key, Value> {
-    /// Checks if the two maps have the same keys and values.
+    /// Checks if the two maps have the same keys and values (order independent).
     pub fn eq_unordered(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        self.iter().all(|(k, v)| other.get(k) == Some(v))
+    }
+}
+
+impl<Key: Eq, Value: Eq> PartialEq for SmallOrderedMap<Key, Value> {
+    fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
-impl<Key: Eq, Value: Eq> PartialEq for SmallOrderedMap<Key, Value> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.iter().eq(other.0.iter())
-    }
-}
+
 impl<Key: Eq, Value: Eq> Eq for SmallOrderedMap<Key, Value> {}
+
 impl<Key: Eq, Value> Default for SmallOrderedMap<Key, Value> {
     fn default() -> Self {
         Self::new()
     }
 }
+
 impl<Key: Eq, Value> FromIterator<(Key, Value)> for SmallOrderedMap<Key, Value> {
     fn from_iter<T: IntoIterator<Item = (Key, Value)>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        let mut map = Self::with_capacity(lower);
+        for (k, v) in iter {
+            map.insert(k, v);
+        }
+        map
     }
 }
+
 impl<Key, Value> IntoIterator for SmallOrderedMap<Key, Value> {
     type Item = (Key, Value);
-    type IntoIter = vector_map::IntoIter<Key, Value>;
+    type IntoIter = <Vec<(Key, Value)> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
-impl<Key, Value> core::ops::Deref for SmallOrderedMap<Key, Value> {
-    type Target = vector_map::VecMap<Key, Value>;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl<'a, Key, Value> IntoIterator for &'a SmallOrderedMap<Key, Value> {
+    type Item = (&'a Key, &'a Value);
+    type IntoIter = core::iter::Map<
+        core::slice::Iter<'a, (Key, Value)>,
+        fn(&'a (Key, Value)) -> (&'a Key, &'a Value),
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter().map(|(k, v)| (k, v))
     }
 }
-impl<Key, Value> core::ops::DerefMut for SmallOrderedMap<Key, Value> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+
+impl<Key: Eq, Value> Extend<(Key, Value)> for SmallOrderedMap<Key, Value> {
+    fn extend<T: IntoIterator<Item = (Key, Value)>>(&mut self, iter: T) {
+        for (k, v) in iter {
+            self.insert(k, v);
+        }
     }
 }
 
@@ -99,5 +266,112 @@ unsafe impl<Key: salsa::Update + Eq, Value: salsa::Update> salsa::Update
         changed
     }
 }
+
 /// Entry for an existing key-value pair or a vacant location to insert one.
-pub type Entry<'a, Key, Value> = vector_map::Entry<'a, Key, Value>;
+pub enum Entry<'a, Key, Value> {
+    /// An occupied entry.
+    Occupied(OccupiedEntry<'a, Key, Value>),
+    /// A vacant entry.
+    Vacant(VacantEntry<'a, Key, Value>),
+}
+
+impl<'a, Key: Eq, Value> Entry<'a, Key, Value> {
+    /// Ensures a value is in the entry by inserting the default if empty,
+    /// and returns a mutable reference to the value in the entry.
+    pub fn or_insert(self, default: Value) -> &'a mut Value {
+        match self {
+            Entry::Occupied(e) => e.into_mut(),
+            Entry::Vacant(e) => e.insert(default),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting the result of the default
+    /// function if empty, and returns a mutable reference to the value in the entry.
+    pub fn or_insert_with<F: FnOnce() -> Value>(self, default: F) -> &'a mut Value {
+        match self {
+            Entry::Occupied(e) => e.into_mut(),
+            Entry::Vacant(e) => e.insert(default()),
+        }
+    }
+}
+
+/// An occupied entry in a `SmallOrderedMap`.
+pub struct OccupiedEntry<'a, Key, Value> {
+    map: &'a mut Vec<(Key, Value)>,
+    index: usize,
+}
+
+impl<'a, Key, Value> OccupiedEntry<'a, Key, Value> {
+    /// Gets a reference to the value in the entry.
+    pub fn get(&self) -> &Value {
+        &self.map[self.index].1
+    }
+
+    /// Gets a mutable reference to the value in the entry.
+    pub fn get_mut(&mut self) -> &mut Value {
+        &mut self.map[self.index].1
+    }
+
+    /// Converts the entry into a mutable reference to the value.
+    pub fn into_mut(self) -> &'a mut Value {
+        &mut self.map[self.index].1
+    }
+
+    /// Sets the value of the entry, and returns the entry's old value.
+    pub fn insert(&mut self, value: Value) -> Value {
+        core::mem::replace(&mut self.map[self.index].1, value)
+    }
+
+    /// Removes the entry from the map and returns the value.
+    pub fn remove(self) -> Value {
+        self.map.swap_remove(self.index).1
+    }
+}
+
+/// A vacant entry in a `SmallOrderedMap`.
+pub struct VacantEntry<'a, Key, Value> {
+    map: &'a mut Vec<(Key, Value)>,
+    key: Key,
+}
+
+impl<'a, Key, Value> VacantEntry<'a, Key, Value> {
+    /// Sets the value of the entry and returns a mutable reference to it.
+    pub fn insert(self, value: Value) -> &'a mut Value {
+        self.map.push((self.key, value));
+        &mut self.map.last_mut().unwrap().1
+    }
+}
+
+/// An iterator over the entries of a `SmallOrderedMap`.
+pub struct Iter<'a, Key, Value>(core::slice::Iter<'a, (Key, Value)>);
+
+impl<'a, Key, Value> Iterator for Iter<'a, Key, Value> {
+    type Item = (&'a Key, &'a Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(k, v)| (k, v))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<Key, Value> ExactSizeIterator for Iter<'_, Key, Value> {}
+
+/// A mutable iterator over the entries of a `SmallOrderedMap`.
+pub struct IterMut<'a, Key, Value>(core::slice::IterMut<'a, (Key, Value)>);
+
+impl<'a, Key, Value> Iterator for IterMut<'a, Key, Value> {
+    type Item = (&'a Key, &'a mut Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(k, v)| (&*k, v))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<Key, Value> ExactSizeIterator for IterMut<'_, Key, Value> {}

--- a/tests/e2e_test_data/cmp
+++ b/tests/e2e_test_data/cmp
@@ -25,7 +25,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -91,7 +91,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -157,7 +157,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -223,7 +223,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/array
+++ b/tests/e2e_test_data/libfuncs/array
@@ -16,7 +16,7 @@ ap += 1;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -51,7 +51,7 @@ fn foo(ref arr: Array<felt252>, value: felt252) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -88,7 +88,7 @@ fn foo(ref arr: Array<felt252>, value1: felt252, value2: felt252) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -133,7 +133,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 700})
+test::foo: SmallOrderedMap([(Const, 700)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -195,7 +195,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 700})
+test::foo: SmallOrderedMap([(Const, 700)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -257,7 +257,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 700})
+test::foo: SmallOrderedMap([(Const, 700)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -320,7 +320,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 700})
+test::foo: SmallOrderedMap([(Const, 700)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -388,7 +388,7 @@ ap += 1;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 980})
+test::foo: SmallOrderedMap([(Const, 980)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -459,7 +459,7 @@ ap += 1;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1080})
+test::foo: SmallOrderedMap([(Const, 1080)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -531,7 +531,7 @@ ap += 1;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1080})
+test::foo: SmallOrderedMap([(Const, 1080)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -606,7 +606,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1170})
+test::foo: SmallOrderedMap([(Const, 1170)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -679,7 +679,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1270})
+test::foo: SmallOrderedMap([(Const, 1270)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -755,7 +755,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1270})
+test::foo: SmallOrderedMap([(Const, 1270)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -811,7 +811,7 @@ fn foo(ref arr: Array<felt252>) -> usize {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -853,7 +853,7 @@ fn foo(ref arr: Array<u256>) -> usize {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type Array<core::integer::u256> = Array<core::integer::u256> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -896,7 +896,7 @@ fn foo(x1: Box<@(felt252, felt252, felt252)>) -> @Array<felt252> {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type Box<Tuple<felt252, felt252, felt252>> = Box<Tuple<felt252, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -941,7 +941,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -1010,7 +1010,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1070})
+test::foo: SmallOrderedMap([(Const, 1070)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -1086,7 +1086,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1070})
+test::foo: SmallOrderedMap([(Const, 1070)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/bitwise
+++ b/tests/e2e_test_data/libfuncs/bitwise
@@ -20,7 +20,7 @@ fn foo(a: u8, b: u8) -> (u8, u8, u8) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Bitwise: 1, Const: 600})
+test::foo: SmallOrderedMap([(Bitwise, 1), (Const, 600)])
 
 //! > sierra_code
 type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
@@ -65,7 +65,7 @@ fn foo(a: u16, b: u16) -> (u16, u16, u16) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Bitwise: 1, Const: 600})
+test::foo: SmallOrderedMap([(Bitwise, 1), (Const, 600)])
 
 //! > sierra_code
 type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
@@ -110,7 +110,7 @@ fn foo(a: u32, b: u32) -> (u32, u32, u32) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Bitwise: 1, Const: 600})
+test::foo: SmallOrderedMap([(Bitwise, 1), (Const, 600)])
 
 //! > sierra_code
 type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
@@ -155,7 +155,7 @@ fn foo(a: u64, b: u64) -> (u64, u64, u64) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Bitwise: 1, Const: 600})
+test::foo: SmallOrderedMap([(Bitwise, 1), (Const, 600)])
 
 //! > sierra_code
 type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
@@ -200,7 +200,7 @@ fn foo(a: u128, b: u128) -> (u128, u128, u128) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Bitwise: 1, Const: 600})
+test::foo: SmallOrderedMap([(Bitwise, 1), (Const, 600)])
 
 //! > sierra_code
 type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/blake
+++ b/tests/e2e_test_data/libfuncs/blake
@@ -23,7 +23,7 @@ blake2s[state=[fp + -5], message=[fp + -3], byte_count=[fp + -4], finalize=false
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Blake: 1, Const: 100})
+test::foo: SmallOrderedMap([(Blake, 1), (Const, 100)])
 
 //! > sierra_code
 type Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> = Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -67,7 +67,7 @@ blake2s[state=[fp + -5], message=[fp + -3], byte_count=[fp + -4], finalize=true]
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Blake: 1, Const: 100})
+test::foo: SmallOrderedMap([(Blake, 1), (Const, 100)])
 
 //! > sierra_code
 type Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> = Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/bool
+++ b/tests/e2e_test_data/libfuncs/bool
@@ -16,7 +16,7 @@ fn foo(mut a: bool, b: bool) -> bool {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -53,7 +53,7 @@ fn foo(a: bool, b: bool) -> bool {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -88,7 +88,7 @@ fn foo(a: bool, b: bool) -> bool {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -125,7 +125,7 @@ fn foo(a: bool) -> bool {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -161,7 +161,7 @@ fn foo(a: bool) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];

--- a/tests/e2e_test_data/libfuncs/bounded_int
+++ b/tests/e2e_test_data/libfuncs/bounded_int
@@ -20,7 +20,7 @@ fn foo(a: i8, b: i8) -> AddType {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -60,7 +60,7 @@ fn foo(a: i8, b: i8) -> SubType {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -100,7 +100,7 @@ fn foo(a: i8, b: i8) -> MulType {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -140,7 +140,7 @@ fn foo(a: NonZero<i8>, b: NonZero<i8>) -> MulType {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -182,7 +182,7 @@ fn foo(a: i8) -> AddType {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -235,7 +235,7 @@ fn foo(a: BoundedInt<128, 255>, b: NonZero<BoundedInt<3, 8>>) -> DivRemType {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1210})
+test::foo: SmallOrderedMap([(Const, 1210)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -303,7 +303,7 @@ jmp rel 4;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1680})
+test::foo: SmallOrderedMap([(Const, 1680)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -367,7 +367,7 @@ fn foo(
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1480})
+test::foo: SmallOrderedMap([(Const, 1480)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -429,7 +429,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -498,7 +498,7 @@ ap += 1;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 780})
+test::foo: SmallOrderedMap([(Const, 780)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -571,7 +571,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -640,7 +640,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -700,7 +700,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -758,7 +758,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type BoundedInt<0, 680564733841876926926749214863536422911> = BoundedInt<0, 680564733841876926926749214863536422911> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -810,7 +810,7 @@ fn foo(
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type BoundedInt<1, 680564733841876926926749214863536422911> = BoundedInt<1, 680564733841876926926749214863536422911> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -848,7 +848,7 @@ fn foo(
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type BoundedInt<-680564733841876926926749214863536422911, -1> = BoundedInt<-680564733841876926926749214863536422911, -1> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -918,7 +918,7 @@ return([4]);
 test::foo@F0([0]: u8) -> (core::internal::OptionRev::<test::BoundedInt::<1, 255>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -974,7 +974,7 @@ return([4]);
 test::foo@F0([0]: BoundedInt<-255, 0>) -> (core::internal::OptionRev::<test::BoundedInt::<-255, -1>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -1031,7 +1031,7 @@ return([4]);
 test::foo@F0([0]: i8) -> (core::internal::OptionRev::<test::BoundedInt::<-127, 127>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > ==========================================================================
 
@@ -1088,4 +1088,4 @@ return([4]);
 test::foo@F0([0]: u8) -> (core::internal::OptionRev::<test::BoundedInt::<0, 254>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])

--- a/tests/e2e_test_data/libfuncs/box
+++ b/tests/e2e_test_data/libfuncs/box
@@ -19,7 +19,7 @@ __boxed_segment += 1
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -50,7 +50,7 @@ fn foo(x: Box<felt252>) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -90,7 +90,7 @@ __boxed_segment += 2
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -123,7 +123,7 @@ fn foo(x: Box<u256>) -> u256 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type Box<core::integer::u256> = Box<core::integer::u256> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -157,7 +157,7 @@ fn foo(e: ()) -> Box<()> {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -187,7 +187,7 @@ fn foo(x: Box<()>) -> () {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({})
+test::foo: SmallOrderedMap([])
 
 //! > sierra_code
 type Box<Unit> = Box<Unit> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -219,7 +219,7 @@ fn foo(e: Empty) -> Box<Empty> {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type test::Empty = Struct<ut@test::Empty> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -250,7 +250,7 @@ fn foo(x: Box<Empty>) -> Empty {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({})
+test::foo: SmallOrderedMap([])
 
 //! > sierra_code
 type Box<test::Empty> = Box<test::Empty> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -281,7 +281,7 @@ fn foo(value: @Box::<Array<felt252>>) -> Box<@Array<felt252>> {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Box<Array<felt252>> = Box<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -346,7 +346,7 @@ return([3]);
 test::foo@F0([0]: Box<test::A>) -> (Tuple<Box<core::integer::u256>, Box<core::integer::u256>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > ==========================================================================
 
@@ -391,7 +391,7 @@ return([2]);
 test::foo@F0([0]: Box<test::Single>) -> (Tuple<Box<Array<felt252>>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > ==========================================================================
 
@@ -448,7 +448,7 @@ return([5]);
 test::foo@F0([0]: Box<test::Many>) -> (Tuple<Box<core::integer::u256>, Box<felt252>, Box<Array<felt252>>, Box<core::integer::u256>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > ==========================================================================
 
@@ -482,7 +482,7 @@ return();
 test::foo@F0([0]: Box<test::Empty>) -> ();
 
 //! > function_costs
-test::foo: SmallOrderedMap({})
+test::foo: SmallOrderedMap([])
 
 //! > ==========================================================================
 
@@ -529,7 +529,7 @@ return([3]);
 test::foo@F0([0]: Box<test::A>) -> (Tuple<Box<core::integer::u256>, Box<core::integer::u256>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > ==========================================================================
 
@@ -554,7 +554,7 @@ struct Single {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Box<Snapshot<test::Single>> = Box<Snapshot<test::Single>> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -609,7 +609,7 @@ struct Many {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type Box<Snapshot<test::Many>> = Box<Snapshot<test::Many>> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -684,8 +684,8 @@ call rel -13;
 ret;
 
 //! > function_costs
-test::helper: SmallOrderedMap({Const: 800})
-test::foo: SmallOrderedMap({Const: 1200})
+test::helper: SmallOrderedMap([(Const, 800)])
+test::foo: SmallOrderedMap([(Const, 1200)])
 
 //! > sierra_code
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -782,7 +782,7 @@ return([7]);
 test::foo@F0([0]: Box<Tuple<core::integer::u256, core::integer::u256>>) -> (Tuple<Box<u128>, Box<u128>, Box<u128>, Box<u128>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > ==========================================================================
 
@@ -832,7 +832,7 @@ return([5]);
 test::foo@F0([0]: Box<core::integer::u256>) -> (Tuple<u128, u128>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -877,7 +877,7 @@ return([4]);
 test::foo@F0([0]: Box<Tuple<Unit, Unit, u128>>) -> (u128);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > ==========================================================================
 
@@ -898,7 +898,7 @@ call rel 5;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -933,7 +933,7 @@ call rel 4;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -985,7 +985,7 @@ return([1]);
 test::foo@F0() -> (Box<Unit>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -1006,7 +1006,7 @@ call rel 5;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -1055,8 +1055,8 @@ call rel 4;
 ret;
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 100})
-test::foo: SmallOrderedMap({Const: 800})
+test::bar: SmallOrderedMap([(Const, 100)])
+test::foo: SmallOrderedMap([(Const, 800)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -1118,7 +1118,7 @@ call rel 5;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -1183,4 +1183,4 @@ return([4]);
 test::foo@F0([0]: Tuple<u128, u128, u128>) -> (Box<u128>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])

--- a/tests/e2e_test_data/libfuncs/builtin_costs
+++ b/tests/e2e_test_data/libfuncs/builtin_costs
@@ -20,7 +20,7 @@ call rel 6;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 700})
+test::foo: SmallOrderedMap([(Const, 700)])
 
 //! > sierra_code
 type BuiltinCosts = BuiltinCosts [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/bytes31
+++ b/tests/e2e_test_data/libfuncs/bytes31
@@ -13,7 +13,7 @@ fn foo() -> bytes31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type bytes31 = bytes31 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -82,7 +82,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1410})
+test::foo: SmallOrderedMap([(Const, 1410)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -133,7 +133,7 @@ fn foo(value: bytes31) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type bytes31 = bytes31 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -166,7 +166,7 @@ fn foo(value: u8) -> bytes31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/casm_run_sanity
+++ b/tests/e2e_test_data/libfuncs/casm_run_sanity
@@ -13,7 +13,7 @@ fn add_three(x: felt252) -> felt252 {
 ret;
 
 //! > function_costs
-test::add_three: SmallOrderedMap({Const: 100})
+test::add_three: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -58,7 +58,7 @@ __boxed_segment += 1
 ret;
 
 //! > function_costs
-test::box_double: SmallOrderedMap({Const: 300})
+test::box_double: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -113,7 +113,7 @@ ret;
 ret;
 
 //! > function_costs
-test::match_val: SmallOrderedMap({Const: 500})
+test::match_val: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -256,10 +256,10 @@ ap += 1;
 ret;
 
 //! > function_costs
-test::fib: SmallOrderedMap({Const: 3370})
-test::fib[116-219]: SmallOrderedMap({Const: 1970})
-core::panic_with_const_felt252::<375233589013918064796019>: SmallOrderedMap({Const: 700})
-core::panic_with_felt252: SmallOrderedMap({Const: 400})
+test::fib: SmallOrderedMap([(Const, 3370)])
+test::fib[116-219]: SmallOrderedMap([(Const, 1970)])
+core::panic_with_const_felt252::<375233589013918064796019>: SmallOrderedMap([(Const, 700)])
+core::panic_with_felt252: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/casts
+++ b/tests/e2e_test_data/libfuncs/casts
@@ -13,7 +13,7 @@ fn foo(a: u16) -> u64 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -46,7 +46,7 @@ fn foo(a: u64) -> u64 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -91,7 +91,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -155,7 +155,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -211,7 +211,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -267,7 +267,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -338,7 +338,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 950})
+test::foo: SmallOrderedMap([(Const, 950)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -402,7 +402,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -473,7 +473,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 940})
+test::foo: SmallOrderedMap([(Const, 940)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -537,7 +537,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -601,7 +601,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -665,7 +665,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -738,7 +738,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 940})
+test::foo: SmallOrderedMap([(Const, 940)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -811,7 +811,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 950})
+test::foo: SmallOrderedMap([(Const, 950)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -884,7 +884,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 940})
+test::foo: SmallOrderedMap([(Const, 940)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -956,7 +956,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 940})
+test::foo: SmallOrderedMap([(Const, 940)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -1061,7 +1061,7 @@ return([4], [7]);
 test::foo@F0([0]: RangeCheck, [1]: BoundedInt<100, 200>) -> (RangeCheck, core::option::Option::<test::BoundedInt::<120, 180>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 940})
+test::foo: SmallOrderedMap([(Const, 940)])
 
 //! > ==========================================================================
 
@@ -1136,4 +1136,4 @@ return([4], [7]);
 test::foo@F0([0]: RangeCheck, [1]: BoundedInt<340282366920938463463374607431768211556, 340282366920938463463374607431768211656>) -> (RangeCheck, core::option::Option::<test::BoundedInt::<340282366920938463463374607431768211576, 340282366920938463463374607431768211636>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 940})
+test::foo: SmallOrderedMap([(Const, 940)])

--- a/tests/e2e_test_data/libfuncs/circuit
+++ b/tests/e2e_test_data/libfuncs/circuit
@@ -18,7 +18,7 @@ fn foo() -> CircuitInputAccumulator<MyCircuit> {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 2092})
+test::foo: SmallOrderedMap([(Const, 2092)])
 
 //! > sierra_code
 type RangeCheck96 = RangeCheck96 [storable: true, drop: false, dup: false, zero_sized: false];
@@ -66,7 +66,7 @@ fn foo() -> (CircuitInputAccumulator<MyCircuit>, CircuitInputAccumulator<MyCircu
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 4084})
+test::foo: SmallOrderedMap([(Const, 4084)])
 
 //! > sierra_code
 type RangeCheck96 = RangeCheck96 [storable: true, drop: false, dup: false, zero_sized: false];
@@ -165,7 +165,7 @@ return([5]);
 test::foo@F0([0]: CircuitInputAccumulator<Circuit<(core::circuit::AddModGate::<core::circuit::CircuitInput::<0>, core::circuit::CircuitInput::<1>>, core::circuit::CircuitInput::<2>)>>, [1]: Tuple<U96Guarantee, U96Guarantee, U96Guarantee, U96Guarantee>) -> (core::circuit::AddInputResult::<core::circuit::Circuit::<(core::circuit::AddModGate::<core::circuit::CircuitInput::<0>, core::circuit::CircuitInput::<1>>, core::circuit::CircuitInput::<2>)>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1000})
+test::foo: SmallOrderedMap([(Const, 1000)])
 
 //! > ==========================================================================
 
@@ -245,7 +245,7 @@ return([0]);
 test::foo@F0() -> (CircuitDescriptor<Circuit<(core::circuit::AddModGate::<core::circuit::CircuitInput::<0>, core::circuit::CircuitInput::<1>>, core::circuit::InverseGate::<core::circuit::CircuitInput::<2>>, core::circuit::MulModGate::<core::circuit::CircuitInput::<1>, core::circuit::CircuitInput::<2>>, core::circuit::SubModGate::<core::circuit::CircuitInput::<2>, core::circuit::CircuitInput::<0>>)>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 600})
+test::foo: SmallOrderedMap([(Const, 600)])
 
 //! > ==========================================================================
 
@@ -313,7 +313,7 @@ return([4]);
 test::foo@F0([0]: Tuple<BoundedInt<0, 79228162514264337593543950335>, BoundedInt<0, 79228162514264337593543950335>, BoundedInt<0, 79228162514264337593543950335>, BoundedInt<0, 79228162514264337593543950335>>) -> (core::option::Option::<core::circuit::CircuitModulus>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1200})
+test::foo: SmallOrderedMap([(Const, 1200)])
 
 //! > ==========================================================================
 
@@ -465,7 +465,7 @@ return([10], [11], [16]);
 test::foo@F0([0]: AddMod, [1]: MulMod, [2]: CircuitDescriptor<Circuit<(core::circuit::AddModGate::<core::circuit::CircuitInput::<0>, core::circuit::CircuitInput::<1>>, core::circuit::CircuitInput::<2>)>>, [3]: CircuitData<Circuit<(core::circuit::AddModGate::<core::circuit::CircuitInput::<0>, core::circuit::CircuitInput::<1>>, core::circuit::CircuitInput::<2>)>>, [4]: CircuitModulus) -> (AddMod, MulMod, core::result::Result::<core::circuit::CircuitOutputs::<core::circuit::Circuit::<(core::circuit::AddModGate::<core::circuit::CircuitInput::<0>, core::circuit::CircuitInput::<1>>, core::circuit::CircuitInput::<2>)>>, (core::circuit::CircuitPartialOutputs::<core::circuit::Circuit::<(core::circuit::AddModGate::<core::circuit::CircuitInput::<0>, core::circuit::CircuitInput::<1>>, core::circuit::CircuitInput::<2>)>>, core::circuit::CircuitFailureGuarantee)>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({AddMod: 1, MulMod: 3, Const: 4100})
+test::foo: SmallOrderedMap([(AddMod, 1), (MulMod, 3), (Const, 4100)])
 
 //! > ==========================================================================
 
@@ -608,7 +608,7 @@ return([10], [11], [16]);
 test::foo@F0([0]: AddMod, [1]: MulMod, [2]: CircuitDescriptor<Circuit<(core::circuit::InverseGate::<core::circuit::CircuitInput::<0>>,)>>, [3]: CircuitData<Circuit<(core::circuit::InverseGate::<core::circuit::CircuitInput::<0>>,)>>, [4]: CircuitModulus) -> (AddMod, MulMod, core::result::Result::<core::circuit::CircuitOutputs::<core::circuit::Circuit::<(core::circuit::InverseGate::<core::circuit::CircuitInput::<0>>,)>>, (core::circuit::CircuitPartialOutputs::<core::circuit::Circuit::<(core::circuit::InverseGate::<core::circuit::CircuitInput::<0>>,)>>, core::circuit::CircuitFailureGuarantee)>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({MulMod: 2, Const: 3400})
+test::foo: SmallOrderedMap([(MulMod, 2), (Const, 3400)])
 
 //! > ==========================================================================
 
@@ -706,7 +706,7 @@ return([6], [5], [7]);
 test::foo@F0([0]: MulMod, [1]: RangeCheck96, [2]: CircuitFailureGuarantee) -> (MulMod, RangeCheck96, U96LimbsLtGuarantee<4>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 4736})
+test::foo: SmallOrderedMap([(Const, 4736)])
 
 //! > ==========================================================================
 
@@ -774,7 +774,7 @@ return([3]);
 test::foo@F0([0]: CircuitOutputs<Circuit<(core::circuit::AddModGate::<core::circuit::CircuitInput::<0>, core::circuit::CircuitInput::<1>>, core::circuit::CircuitInput::<2>)>>) -> (Tuple<core::circuit::u384, U96LimbsLtGuarantee<4>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1700})
+test::foo: SmallOrderedMap([(Const, 1700)])
 
 //! > ==========================================================================
 
@@ -810,7 +810,7 @@ return([1]);
 test::foo@F0([0]: u8) -> (U96Guarantee);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > ==========================================================================
 
@@ -847,7 +847,7 @@ return([2]);
 test::foo@F0([0]: RangeCheck96, [1]: U96Guarantee) -> (RangeCheck96);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 256})
+test::foo: SmallOrderedMap([(Const, 256)])
 
 //! > ==========================================================================
 
@@ -912,7 +912,7 @@ return([4]);
 test::foo@F0([0]: U96LimbsLtGuarantee<4>) -> (core::circuit::NextU96LessThanGuarantee::<3>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 900})
+test::foo: SmallOrderedMap([(Const, 900)])
 
 //! > ==========================================================================
 
@@ -947,7 +947,7 @@ return([1]);
 test::foo@F0([0]: U96LimbsLtGuarantee<1>) -> (U96Guarantee);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > ==========================================================================
 
@@ -1026,4 +1026,4 @@ return([10]);
 test::foo@F0([0]: RangeCheck96, [1]: U96LimbsLtGuarantee<4>) -> (RangeCheck96);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1056})
+test::foo: SmallOrderedMap([(Const, 1056)])

--- a/tests/e2e_test_data/libfuncs/consts
+++ b/tests/e2e_test_data/libfuncs/consts
@@ -23,8 +23,8 @@ ret;
 dw 100;
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 100})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 100)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -73,8 +73,8 @@ ret;
 dw 100;
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 100})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 100)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -123,8 +123,8 @@ ret;
 dw -1000;
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 100})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 100)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -188,10 +188,10 @@ dw 16;
 dw 32;
 
 //! > function_costs
-test::bar1: SmallOrderedMap({Const: 200})
-test::bar2: SmallOrderedMap({Const: 200})
-test::foo1: SmallOrderedMap({Const: 300})
-test::foo2: SmallOrderedMap({Const: 300})
+test::bar1: SmallOrderedMap([(Const, 200)])
+test::bar2: SmallOrderedMap([(Const, 200)])
+test::foo1: SmallOrderedMap([(Const, 300)])
+test::foo2: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -250,8 +250,8 @@ ret;
 dw 0;
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 100})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 100)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
@@ -314,8 +314,8 @@ dw 16;
 dw 32;
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 300})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 300)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -381,8 +381,8 @@ dw 0;
 dw 1337;
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 300})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 300)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -466,8 +466,8 @@ dw 0;
 dw 0;
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 1000})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 1000)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -523,7 +523,7 @@ ret;
 dw 100;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 800})
+test::foo: SmallOrderedMap([(Const, 800)])
 
 //! > sierra_code
 type BuiltinCosts = BuiltinCosts [storable: true, drop: true, dup: true, zero_sized: false];
@@ -598,7 +598,7 @@ ret;
 dw 300;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 2400})
+test::foo: SmallOrderedMap([(Const, 2400)])
 
 //! > sierra_code
 type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -679,7 +679,7 @@ return([1]);
 test::foo@F0() -> (Snapshot<Array<felt252>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > ==========================================================================
 
@@ -749,7 +749,7 @@ return([1]);
 test::foo@F0() -> (Snapshot<Array<Tuple<felt252, felt252, felt252, felt252>>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > ==========================================================================
 
@@ -800,8 +800,8 @@ test::bar@F0() -> (NonZero<felt252>);
 test::foo@F1() -> (Box<NonZero<felt252>>);
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 100})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 100)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -852,8 +852,8 @@ test::bar@F0() -> (NonZero<u8>);
 test::foo@F1() -> (Box<NonZero<u8>>);
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 100})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 100)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -909,8 +909,8 @@ test::bar@F0() -> (NonZero<core::integer::u256>);
 test::foo@F1() -> (Box<NonZero<core::integer::u256>>);
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 200})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 200)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -966,8 +966,8 @@ test::bar@F0() -> (NonZero<core::integer::u256>);
 test::foo@F1() -> (Box<NonZero<core::integer::u256>>);
 
 //! > function_costs
-test::bar: SmallOrderedMap({Const: 200})
-test::foo: SmallOrderedMap({Const: 300})
+test::bar: SmallOrderedMap([(Const, 200)])
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -1035,7 +1035,7 @@ return([0]);
 test::foo@F0() -> (Box<NonZero<core::integer::u512>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -1085,7 +1085,7 @@ return([0]);
 test::foo@F0() -> (Box<EcPoint>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -1128,7 +1128,7 @@ return([0]);
 test::foo@F0() -> (Box<EcPoint>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -1186,4 +1186,4 @@ return([0]);
 test::foo@F0() -> (Box<NonZero<EcPoint>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])

--- a/tests/e2e_test_data/libfuncs/coupon
+++ b/tests/e2e_test_data/libfuncs/coupon
@@ -22,8 +22,8 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
-test::bar::<core::integer::u8, core::integer::u8Drop>: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 300)])
+test::bar::<core::integer::u8, core::integer::u8Drop>: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -93,9 +93,9 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 700})
-test::buy_coupons: SmallOrderedMap({Const: 200})
-test::bar::<core::integer::u8, core::integer::u8Drop>: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 700)])
+test::buy_coupons: SmallOrderedMap([(Const, 200)])
+test::bar::<core::integer::u8, core::integer::u8Drop>: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Coupon<user@test::bar::<core::integer::u8, core::integer::u8Drop>> = Coupon<user@test::bar::<core::integer::u8, core::integer::u8Drop>> [storable: true, drop: true, dup: false, zero_sized: true];
@@ -171,8 +171,8 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
-test::bar::<core::integer::u8, core::integer::u8Drop>: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 300)])
+test::bar::<core::integer::u8, core::integer::u8Drop>: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Coupon<user@test::bar::<core::integer::u8, core::integer::u8Drop>> = Coupon<user@test::bar::<core::integer::u8, core::integer::u8Drop>> [storable: true, drop: true, dup: false, zero_sized: true];
@@ -251,7 +251,7 @@ ret;
 ret;
 
 //! > function_costs
-test::destruct: SmallOrderedMap({Bitwise: 1, Const: 1200})
+test::destruct: SmallOrderedMap([(Bitwise, 1), (Const, 1200)])
 
 //! > sierra_code
 type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -410,11 +410,11 @@ ap += 1;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 4640})
-test::recursive_buy::<core::integer::u8>: SmallOrderedMap({Const: 1870})
-test::recursive_refund::<core::integer::u8>: SmallOrderedMap({Const: 1870})
-core::panic_with_const_felt252::<375233589013918064796019>: SmallOrderedMap({Const: 700})
-core::panic_with_felt252: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 4640)])
+test::recursive_buy::<core::integer::u8>: SmallOrderedMap([(Const, 1870)])
+test::recursive_refund::<core::integer::u8>: SmallOrderedMap([(Const, 1870)])
+core::panic_with_const_felt252::<375233589013918064796019>: SmallOrderedMap([(Const, 700)])
+core::panic_with_felt252: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/ec
+++ b/tests/e2e_test_data/libfuncs/ec
@@ -16,7 +16,7 @@ fn foo() -> EcPoint {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
@@ -63,7 +63,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1000})
+test::foo: SmallOrderedMap([(Const, 1000)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -157,7 +157,7 @@ ap += 4;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 2010})
+test::foo: SmallOrderedMap([(Const, 2010)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -212,7 +212,7 @@ fn foo(p: ec::NonZeroEcPoint) -> (felt252, felt252) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
@@ -261,7 +261,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
@@ -311,7 +311,7 @@ fn foo(a: ec::EcPoint) -> ec::EcPoint {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
@@ -346,7 +346,7 @@ fn foo(a: ec::NonZeroEcPoint) -> ec::NonZeroEcPoint {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type EcPoint = EcPoint [storable: true, drop: true, dup: true, zero_sized: false];
@@ -398,7 +398,7 @@ __boxed_segment += 2
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 700})
+test::foo: SmallOrderedMap([(Const, 700)])
 
 //! > sierra_code
 type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false];
@@ -443,7 +443,7 @@ jmp rel 4 if [ap + -1] != 0;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1300})
+test::foo: SmallOrderedMap([(Const, 1300)])
 
 //! > sierra_code
 type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false];
@@ -500,7 +500,7 @@ ap += 8;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1500})
+test::foo: SmallOrderedMap([(Const, 1500)])
 
 //! > sierra_code
 type EcState = EcState [storable: true, drop: true, dup: true, zero_sized: false];
@@ -558,7 +558,7 @@ fn foo(ref s: ec::EcState, m: felt252, p: ec::NonZeroEcPoint) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({EcOp: 1, Const: 900})
+test::foo: SmallOrderedMap([(EcOp, 1), (Const, 900)])
 
 //! > sierra_code
 type EcOp = EcOp [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/enum
+++ b/tests/e2e_test_data/libfuncs/enum
@@ -18,7 +18,7 @@ fn foo() -> SingleVariant {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -60,7 +60,7 @@ fn foo(e: SingleVariant) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -106,7 +106,7 @@ fn foo() -> Option {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -154,7 +154,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -211,7 +211,7 @@ fn foo() -> Color {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -254,7 +254,7 @@ fn foo() -> Color {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -307,7 +307,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -382,7 +382,7 @@ fn foo(index: BoundedInt<0, 4>) -> IndexEnum5 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type BoundedInt<0, 4> = BoundedInt<0, 4> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -431,7 +431,7 @@ fn foo(index: BoundedInt<0, 1>) -> IndexEnum2 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type BoundedInt<0, 1> = BoundedInt<0, 1> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -479,7 +479,7 @@ fn foo(index: BoundedInt<0, 0>) -> IndexEnum1 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type BoundedInt<0, 0> = BoundedInt<0, 0> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -524,7 +524,7 @@ fn foo(e: Box<Single>) -> BoxedSingle {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type Box<test::Single> = Box<test::Single> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -577,7 +577,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type Box<core::option::Option::<core::felt252>> = Box<core::option::Option::<core::felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -650,7 +650,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type Box<test::Color> = Box<test::Color> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -720,7 +720,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type Box<test::Data> = Box<test::Data> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -793,7 +793,7 @@ __boxed_segment += 2
 ret;
 
 //! > function_costs
-test::add_123: SmallOrderedMap({Const: 700})
+test::add_123: SmallOrderedMap([(Const, 700)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -874,7 +874,7 @@ ap += 2;
 ret;
 
 //! > function_costs
-test::add_123: SmallOrderedMap({Const: 900})
+test::add_123: SmallOrderedMap([(Const, 900)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -980,7 +980,7 @@ ret;
 ret;
 
 //! > function_costs
-test::test_blue: SmallOrderedMap({Const: 1100})
+test::test_blue: SmallOrderedMap([(Const, 1100)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -1087,7 +1087,7 @@ ap += 1;
 ret;
 
 //! > function_costs
-test::test_small: SmallOrderedMap({Const: 1210})
+test::test_small: SmallOrderedMap([(Const, 1210)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -1188,7 +1188,7 @@ ret;
 ret;
 
 //! > function_costs
-test::test_large: SmallOrderedMap({Const: 1600})
+test::test_large: SmallOrderedMap([(Const, 1600)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -1295,4 +1295,4 @@ return([2]);
 test::foo@F0([0]: Box<Snapshot<test::SingleArray>>) -> (test::BoxedSingleArray);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])

--- a/tests/e2e_test_data/libfuncs/enum_snapshot
+++ b/tests/e2e_test_data/libfuncs/enum_snapshot
@@ -19,7 +19,7 @@ fn foo(e: @SingleVariant) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -66,7 +66,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -133,7 +133,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -206,7 +206,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];

--- a/tests/e2e_test_data/libfuncs/felt252
+++ b/tests/e2e_test_data/libfuncs/felt252
@@ -15,7 +15,7 @@ fn foo(a: felt252, b: NonZero<felt252>) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1000})
+test::foo: SmallOrderedMap([(Const, 1000)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -54,7 +54,7 @@ fn foo(a: felt252, b: felt252) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/felt252_dict
+++ b/tests/e2e_test_data/libfuncs/felt252_dict
@@ -51,7 +51,7 @@ memory[memory[memory[fp + -3] - 3] + index * 3] = segment_start
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1900})
+test::foo: SmallOrderedMap([(Const, 1900)])
 
 //! > sierra_code
 type SegmentArena = SegmentArena [storable: true, drop: false, dup: false, zero_sized: false];
@@ -100,7 +100,7 @@ dict_tracker.data[memory[memory[fp + -5] + 3 - 3]] = memory[fp + -3]
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 5320})
+test::foo: SmallOrderedMap([(Const, 5320)])
 
 //! > sierra_code
 type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
@@ -153,7 +153,7 @@ dict_tracker.data[memory[memory[fp + -4] + 3 - 3]] = memory[ap + -1]
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 5520})
+test::foo: SmallOrderedMap([(Const, 5520)])
 
 //! > sierra_code
 type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
@@ -245,7 +245,7 @@ dict_tracker.data[memory[memory[fp + -4] + 12 - 3]] = memory[ap + -1]
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 21180})
+test::foo: SmallOrderedMap([(Const, 21180)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -502,7 +502,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 6410})
+test::foo: SmallOrderedMap([(Const, 6410)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -556,7 +556,7 @@ memory[memory[fp + -4] + 1] = dict_tracker.data[memory[fp + -3]]
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 5320})
+test::foo: SmallOrderedMap([(Const, 5320)])
 
 //! > sierra_code
 type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
@@ -600,7 +600,7 @@ dict_tracker.data[memory[memory[fp + -4] - 3]] = memory[fp + -3]
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type Felt252DictEntry<felt252> = Felt252DictEntry<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
@@ -666,7 +666,7 @@ dict_tracker.data[memory[memory[fp + -7] + 6 - 3]] = memory[fp + -3]
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 10740})
+test::foo: SmallOrderedMap([(Const, 10740)])
 
 //! > sierra_code
 type Felt252Dict<felt252> = Felt252Dict<felt252> [storable: true, drop: false, dup: false, zero_sized: false];
@@ -728,7 +728,7 @@ return([1]);
 test::test_squashed_dict_entries@F0([0]: SquashedFelt252Dict<felt252>) -> (Array<Tuple<felt252, felt252, felt252>>);
 
 //! > function_costs
-test::test_squashed_dict_entries: SmallOrderedMap({Const: 200})
+test::test_squashed_dict_entries: SmallOrderedMap([(Const, 200)])
 
 //! > ==========================================================================
 
@@ -776,4 +776,4 @@ return([2]);
 test::test_squashed_dict_entries@F0([0]: SquashedFelt252Dict<Nullable<core::integer::u256>>) -> (core::option::Option::<core::array::Array::<(core::felt252, core::nullable::Nullable::<core::integer::u256>, core::nullable::Nullable::<core::integer::u256>)>>);
 
 //! > function_costs
-test::test_squashed_dict_entries: SmallOrderedMap({Const: 300})
+test::test_squashed_dict_entries: SmallOrderedMap([(Const, 300)])

--- a/tests/e2e_test_data/libfuncs/felt252_downcast
+++ b/tests/e2e_test_data/libfuncs/felt252_downcast
@@ -45,7 +45,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -128,7 +128,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -214,7 +214,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -333,7 +333,7 @@ return([4], [7]);
 test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<test::BoundedInt::<-10633823966279327296825105735305134080, -1>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1410})
+test::foo: SmallOrderedMap([(Const, 1410)])
 
 //! > ==========================================================================
 
@@ -425,7 +425,7 @@ return([4], [7]);
 test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option::<test::BoundedInt::<329648542954659136166549501696463077377, 340282366920938463463374607431768211456>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > ==========================================================================
 
@@ -513,4 +513,4 @@ return([4], [7]);
 test::foo@F0([0]: RangeCheck, [1]: BoundedInt<-3618502788666131213697322783095070105623107215331596699973092056135872020480, 0>) -> (RangeCheck, core::option::Option::<test::BoundedInt::<0, 10>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])

--- a/tests/e2e_test_data/libfuncs/fixed_size_array
+++ b/tests/e2e_test_data/libfuncs/fixed_size_array
@@ -23,8 +23,8 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
-test::bar: SmallOrderedMap({})
+test::foo: SmallOrderedMap([(Const, 500)])
+test::bar: SmallOrderedMap([])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/gas
+++ b/tests/e2e_test_data/libfuncs/gas
@@ -33,8 +33,8 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 900})
-test::bar: SmallOrderedMap({})
+test::foo: SmallOrderedMap([(Const, 900)])
+test::bar: SmallOrderedMap([])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -129,7 +129,7 @@ call rel 16;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Bitwise: 2, Pedersen: 1, Const: 1830})
+test::foo: SmallOrderedMap([(Bitwise, 2), (Pedersen, 1), (Const, 1830)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -238,7 +238,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 770})
+test::foo: SmallOrderedMap([(Const, 770)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -319,7 +319,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1570})
+test::foo: SmallOrderedMap([(Const, 1570)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -432,7 +432,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1970})
+test::foo: SmallOrderedMap([(Const, 1970)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -546,7 +546,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type BuiltinCosts = BuiltinCosts [storable: true, drop: true, dup: true, zero_sized: false];
@@ -632,7 +632,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1170})
+test::foo: SmallOrderedMap([(Const, 1170)])
 
 //! > sierra_code
 type BuiltinCosts = BuiltinCosts [storable: true, drop: true, dup: true, zero_sized: false];
@@ -735,7 +735,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1170})
+test::foo: SmallOrderedMap([(Const, 1170)])
 
 //! > sierra_code
 type BuiltinCosts = BuiltinCosts [storable: true, drop: true, dup: true, zero_sized: false];
@@ -849,7 +849,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1470})
+test::foo: SmallOrderedMap([(Const, 1470)])
 
 //! > sierra_code
 type BuiltinCosts = BuiltinCosts [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/gas_reserve
+++ b/tests/e2e_test_data/libfuncs/gas_reserve
@@ -30,7 +30,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1070})
+test::foo: SmallOrderedMap([(Const, 1070)])
 
 //! > sierra_code
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -93,7 +93,7 @@ fn foo(reserve: gas::GasReserve) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/i128
+++ b/tests/e2e_test_data/libfuncs/i128
@@ -13,7 +13,7 @@ fn foo(v: i128) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -74,7 +74,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -130,7 +130,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -183,7 +183,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type i128 = i128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -262,7 +262,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 970})
+test::foo: SmallOrderedMap([(Const, 970)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -340,7 +340,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 970})
+test::foo: SmallOrderedMap([(Const, 970)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -408,7 +408,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/i16
+++ b/tests/e2e_test_data/libfuncs/i16
@@ -13,7 +13,7 @@ fn foo(v: i16) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -76,7 +76,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -132,7 +132,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -185,7 +185,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -265,7 +265,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1040})
+test::foo: SmallOrderedMap([(Const, 1040)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -344,7 +344,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1040})
+test::foo: SmallOrderedMap([(Const, 1040)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -412,7 +412,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -461,7 +461,7 @@ fn foo(a: i16, b: i16) -> i32 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i16 = i16 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/i32
+++ b/tests/e2e_test_data/libfuncs/i32
@@ -13,7 +13,7 @@ fn foo(v: i32) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -76,7 +76,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -132,7 +132,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -185,7 +185,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -265,7 +265,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1040})
+test::foo: SmallOrderedMap([(Const, 1040)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -344,7 +344,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1040})
+test::foo: SmallOrderedMap([(Const, 1040)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -412,7 +412,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -461,7 +461,7 @@ fn foo(a: i32, b: i32) -> i64 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i32 = i32 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/i64
+++ b/tests/e2e_test_data/libfuncs/i64
@@ -13,7 +13,7 @@ fn foo(v: i64) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -76,7 +76,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -132,7 +132,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -185,7 +185,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -265,7 +265,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1040})
+test::foo: SmallOrderedMap([(Const, 1040)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -344,7 +344,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1040})
+test::foo: SmallOrderedMap([(Const, 1040)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -412,7 +412,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -461,7 +461,7 @@ fn foo(a: i64, b: i64) -> i128 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i64 = i64 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/i8
+++ b/tests/e2e_test_data/libfuncs/i8
@@ -13,7 +13,7 @@ fn foo(v: i8) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -76,7 +76,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -132,7 +132,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -185,7 +185,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -265,7 +265,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1040})
+test::foo: SmallOrderedMap([(Const, 1040)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -344,7 +344,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1040})
+test::foo: SmallOrderedMap([(Const, 1040)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -412,7 +412,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -461,7 +461,7 @@ fn foo(a: i8, b: i8) -> i16 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type i8 = i8 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/nullable
+++ b/tests/e2e_test_data/libfuncs/nullable
@@ -13,7 +13,7 @@ fn foo() -> Nullable<felt252> {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Nullable<felt252> = Nullable<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -46,7 +46,7 @@ fn foo(x: Box<felt252>) -> Nullable<felt252> {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -86,7 +86,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type Nullable<felt252> = Nullable<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -128,7 +128,7 @@ fn foo(value: @Nullable::<Array<felt252>>) -> Nullable<@Array<felt252>> {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type Nullable<Array<felt252>> = Nullable<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -171,7 +171,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type Nullable<Array<felt252>> = Nullable<Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -232,7 +232,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -288,7 +288,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > sierra_code
 type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];

--- a/tests/e2e_test_data/libfuncs/poseidon
+++ b/tests/e2e_test_data/libfuncs/poseidon
@@ -19,7 +19,7 @@ fn foo(s0: felt252, s1: felt252, s2: felt252) -> (felt252, felt252, felt252) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Poseidon: 1, Const: 700})
+test::foo: SmallOrderedMap([(Poseidon, 1), (Const, 700)])
 
 //! > sierra_code
 type Poseidon = Poseidon [storable: true, drop: false, dup: false, zero_sized: false];
@@ -76,7 +76,7 @@ fn foo(s0: felt252, s1: felt252, s2: felt252) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Poseidon: 2, Const: 1800})
+test::foo: SmallOrderedMap([(Poseidon, 2), (Const, 1800)])
 
 //! > sierra_code
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/qm31
+++ b/tests/e2e_test_data/libfuncs/qm31
@@ -15,7 +15,7 @@ fn foo(a: qm31, b: qm31) -> qm31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type qm31 = qm31 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -47,7 +47,7 @@ fn foo(a: qm31, b: qm31) -> qm31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type qm31 = qm31 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -79,7 +79,7 @@ fn foo(a: qm31, b: qm31) -> qm31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type qm31 = qm31 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -112,7 +112,7 @@ fn foo(a: qm31, b: NonZero<qm31>) -> qm31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type qm31 = qm31 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -157,7 +157,7 @@ return([0]);
 test::foo@F0() -> (qm31);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > ==========================================================================
 
@@ -213,7 +213,7 @@ return([4]);
 test::foo@F0([0]: qm31) -> (core::internal::OptionRev::<core::zeroable::NonZero::<core::qm31::qm31>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 300})
+test::foo: SmallOrderedMap([(Const, 300)])
 
 //! > ==========================================================================
 
@@ -254,7 +254,7 @@ return([4]);
 test::foo@F0([0]: BoundedInt<0, 2147483646>, [1]: BoundedInt<0, 2147483646>, [2]: BoundedInt<0, 2147483646>, [3]: BoundedInt<0, 2147483646>) -> (qm31);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 700})
+test::foo: SmallOrderedMap([(Const, 700)])
 
 //! > ==========================================================================
 
@@ -317,7 +317,7 @@ return([2], [7]);
 test::foo@F0([0]: RangeCheck, [1]: qm31) -> (RangeCheck, Tuple<BoundedInt<0, 2147483646>, BoundedInt<0, 2147483646>, BoundedInt<0, 2147483646>, BoundedInt<0, 2147483646>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 2350})
+test::foo: SmallOrderedMap([(Const, 2350)])
 
 //! > ==========================================================================
 
@@ -352,7 +352,7 @@ return([1]);
 test::foo@F0([0]: BoundedInt<0, 2147483646>) -> (qm31);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > ==========================================================================
 
@@ -373,7 +373,7 @@ fn foo(a: m31, b: m31) -> m31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type BoundedInt<0, 2147483646> = BoundedInt<0, 2147483646> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -405,7 +405,7 @@ fn foo(a: m31, b: m31) -> m31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type BoundedInt<0, 2147483646> = BoundedInt<0, 2147483646> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -437,7 +437,7 @@ fn foo(a: m31, b: m31) -> m31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type BoundedInt<0, 2147483646> = BoundedInt<0, 2147483646> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -469,7 +469,7 @@ fn foo(a: m31, b: NonZero<m31>) -> m31 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type BoundedInt<0, 2147483646> = BoundedInt<0, 2147483646> [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/range
+++ b/tests/e2e_test_data/libfuncs/range
@@ -26,7 +26,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 600})
+test::foo: SmallOrderedMap([(Const, 600)])
 
 //! > sierra_code
 type IntRange<i16> = IntRange<i16> [storable: true, drop: true, dup: true, zero_sized: false];
@@ -94,7 +94,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 970})
+test::foo: SmallOrderedMap([(Const, 970)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -356,7 +356,7 @@ core::panic_with_const_felt252::<375233589013918064796019>@F2() -> (Tuple<core::
 core::panic_with_felt252@F3([0]: felt252) -> (Tuple<core::panics::Panic, Array<felt252>>);
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 3840})
-test::foo[11-37]: SmallOrderedMap({Const: 1870})
-core::panic_with_const_felt252::<375233589013918064796019>: SmallOrderedMap({Const: 700})
-core::panic_with_felt252: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 3840)])
+test::foo[11-37]: SmallOrderedMap([(Const, 1870)])
+core::panic_with_const_felt252::<375233589013918064796019>: SmallOrderedMap([(Const, 700)])
+core::panic_with_felt252: SmallOrderedMap([(Const, 400)])

--- a/tests/e2e_test_data/libfuncs/snapshot
+++ b/tests/e2e_test_data/libfuncs/snapshot
@@ -23,8 +23,8 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 600})
-test::bar: SmallOrderedMap({})
+test::foo: SmallOrderedMap([(Const, 600)])
+test::bar: SmallOrderedMap([])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -89,8 +89,8 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1300})
-test::bar: SmallOrderedMap({})
+test::foo: SmallOrderedMap([(Const, 1300)])
+test::bar: SmallOrderedMap([])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -177,9 +177,9 @@ call rel -14;
 ret;
 
 //! > function_costs
-test::bar0: SmallOrderedMap({})
-test::bar1: SmallOrderedMap({})
-test::foo: SmallOrderedMap({Const: 810})
+test::bar0: SmallOrderedMap([])
+test::bar1: SmallOrderedMap([])
+test::foo: SmallOrderedMap([(Const, 810)])
 
 //! > sierra_code
 type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/starknet/class_hash
+++ b/tests/e2e_test_data/libfuncs/starknet/class_hash
@@ -52,7 +52,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1410})
+test::foo: SmallOrderedMap([(Const, 1410)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -105,7 +105,7 @@ fn foo(address: starknet::ClassHash) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type ClassHash = ClassHash [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/starknet/contract_address
+++ b/tests/e2e_test_data/libfuncs/starknet/contract_address
@@ -52,7 +52,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1410})
+test::foo: SmallOrderedMap([(Const, 1410)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -105,7 +105,7 @@ fn foo(address: starknet::ContractAddress) -> felt252 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type ContractAddress = ContractAddress [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/starknet/secp256k1
+++ b/tests/e2e_test_data/libfuncs/starknet/secp256k1
@@ -35,7 +35,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11300})
+test::foo: SmallOrderedMap([(Const, 11300)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -116,7 +116,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11400})
+test::foo: SmallOrderedMap([(Const, 11400)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -199,7 +199,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11400})
+test::foo: SmallOrderedMap([(Const, 11400)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -284,7 +284,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11500})
+test::foo: SmallOrderedMap([(Const, 11500)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -369,7 +369,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11400})
+test::foo: SmallOrderedMap([(Const, 11400)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/starknet/secp256r1
+++ b/tests/e2e_test_data/libfuncs/starknet/secp256r1
@@ -35,7 +35,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11300})
+test::foo: SmallOrderedMap([(Const, 11300)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -116,7 +116,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11400})
+test::foo: SmallOrderedMap([(Const, 11400)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -199,7 +199,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11400})
+test::foo: SmallOrderedMap([(Const, 11400)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -284,7 +284,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11500})
+test::foo: SmallOrderedMap([(Const, 11500)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -369,7 +369,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11400})
+test::foo: SmallOrderedMap([(Const, 11400)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/starknet/storage_address
+++ b/tests/e2e_test_data/libfuncs/starknet/storage_address
@@ -50,7 +50,7 @@ jmp rel 4 if [ap + -3] != 0;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1410})
+test::foo: SmallOrderedMap([(Const, 1410)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -88,7 +88,7 @@ fn foo(base: starknet::StorageBaseAddress, offset: u8) -> starknet::StorageAddre
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type StorageBaseAddress = StorageBaseAddress [storable: true, drop: true, dup: true, zero_sized: false];
@@ -161,7 +161,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1410})
+test::foo: SmallOrderedMap([(Const, 1410)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/starknet/syscalls
+++ b/tests/e2e_test_data/libfuncs/starknet/syscalls
@@ -37,7 +37,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11500})
+test::foo: SmallOrderedMap([(Const, 11500)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -120,7 +120,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11200})
+test::foo: SmallOrderedMap([(Const, 11200)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -198,7 +198,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11100})
+test::foo: SmallOrderedMap([(Const, 11100)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -286,7 +286,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11100})
+test::foo: SmallOrderedMap([(Const, 11100)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -379,7 +379,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11100})
+test::foo: SmallOrderedMap([(Const, 11100)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -478,7 +478,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11500})
+test::foo: SmallOrderedMap([(Const, 11500)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -560,7 +560,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11300})
+test::foo: SmallOrderedMap([(Const, 11300)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -644,7 +644,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11400})
+test::foo: SmallOrderedMap([(Const, 11400)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -740,7 +740,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11700})
+test::foo: SmallOrderedMap([(Const, 11700)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -828,7 +828,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11300})
+test::foo: SmallOrderedMap([(Const, 11300)])
 
 //! > sierra_code
 type Array<u64> = Array<u64> [storable: true, drop: true, dup: false, zero_sized: false];
@@ -923,7 +923,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11500})
+test::foo: SmallOrderedMap([(Const, 11500)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -1008,7 +1008,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11400})
+test::foo: SmallOrderedMap([(Const, 11400)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -1093,7 +1093,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11200})
+test::foo: SmallOrderedMap([(Const, 11200)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
@@ -1185,7 +1185,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 11700})
+test::foo: SmallOrderedMap([(Const, 11700)])
 
 //! > sierra_code
 type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/u128
+++ b/tests/e2e_test_data/libfuncs/u128
@@ -28,7 +28,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -90,7 +90,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -168,7 +168,7 @@ ap += 2;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 3330})
+test::foo: SmallOrderedMap([(Const, 3330)])
 
 //! > sierra_code
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -225,7 +225,7 @@ jmp rel 4;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1680})
+test::foo: SmallOrderedMap([(Const, 1680)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -289,7 +289,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1710})
+test::foo: SmallOrderedMap([(Const, 1710)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -345,7 +345,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -398,7 +398,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -468,7 +468,7 @@ memory[ap + 5] = math.isqrt(memory[fp + -3])
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1380})
+test::foo: SmallOrderedMap([(Const, 1380)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -531,7 +531,7 @@ fn foo(input: u128) -> u128 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Bitwise: 4, Const: 2600})
+test::foo: SmallOrderedMap([(Bitwise, 4), (Const, 2600)])
 
 //! > sierra_code
 type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/u16
+++ b/tests/e2e_test_data/libfuncs/u16
@@ -29,7 +29,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -91,7 +91,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -143,7 +143,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -196,7 +196,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -280,7 +280,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -338,7 +338,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -392,7 +392,7 @@ fn foo(a: u16, b: NonZero<u16>) -> (u16, u16) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1210})
+test::foo: SmallOrderedMap([(Const, 1210)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -446,7 +446,7 @@ memory[ap + 5] = math.isqrt(memory[fp + -3])
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1380})
+test::foo: SmallOrderedMap([(Const, 1380)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -483,7 +483,7 @@ fn foo(a: u16, b: u16) -> u32 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type u16 = u16 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/u256
+++ b/tests/e2e_test_data/libfuncs/u256
@@ -94,7 +94,7 @@ jmp rel 4;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 6450})
+test::foo: SmallOrderedMap([(Const, 6450)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -149,7 +149,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -245,7 +245,7 @@ jmp rel 5;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 3690})
+test::foo: SmallOrderedMap([(Const, 3690)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -674,7 +674,7 @@ ap += 122;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 28470})
+test::foo: SmallOrderedMap([(Const, 28470)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/u32
+++ b/tests/e2e_test_data/libfuncs/u32
@@ -29,7 +29,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -91,7 +91,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -143,7 +143,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -196,7 +196,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -280,7 +280,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -338,7 +338,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -392,7 +392,7 @@ fn foo(a: u32, b: NonZero<u32>) -> (u32, u32) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1210})
+test::foo: SmallOrderedMap([(Const, 1210)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -446,7 +446,7 @@ memory[ap + 5] = math.isqrt(memory[fp + -3])
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1380})
+test::foo: SmallOrderedMap([(Const, 1380)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -483,7 +483,7 @@ fn foo(a: u32, b: u32) -> u64 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/u512
+++ b/tests/e2e_test_data/libfuncs/u512
@@ -225,7 +225,7 @@ jmp rel 4;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 20890})
+test::foo: SmallOrderedMap([(Const, 20890)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/u64
+++ b/tests/e2e_test_data/libfuncs/u64
@@ -29,7 +29,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -91,7 +91,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -143,7 +143,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -196,7 +196,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -280,7 +280,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -338,7 +338,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -392,7 +392,7 @@ fn foo(a: u64, b: NonZero<u64>) -> (u64, u64) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1210})
+test::foo: SmallOrderedMap([(Const, 1210)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -446,7 +446,7 @@ memory[ap + 5] = math.isqrt(memory[fp + -3])
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1380})
+test::foo: SmallOrderedMap([(Const, 1380)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -483,7 +483,7 @@ fn foo(a: u64, b: u64) -> u128 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type u64 = u64 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/libfuncs/u8
+++ b/tests/e2e_test_data/libfuncs/u8
@@ -29,7 +29,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -91,7 +91,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 870})
+test::foo: SmallOrderedMap([(Const, 870)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -143,7 +143,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 400})
+test::foo: SmallOrderedMap([(Const, 400)])
 
 //! > sierra_code
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -196,7 +196,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 500})
+test::foo: SmallOrderedMap([(Const, 500)])
 
 //! > sierra_code
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -280,7 +280,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1510})
+test::foo: SmallOrderedMap([(Const, 1510)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -338,7 +338,7 @@ ret;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap([(Const, 200)])
 
 //! > sierra_code
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -392,7 +392,7 @@ fn foo(a: u8, b: NonZero<u8>) -> (u8, u8) {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1210})
+test::foo: SmallOrderedMap([(Const, 1210)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -446,7 +446,7 @@ memory[ap + 5] = math.isqrt(memory[fp + -3])
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 1380})
+test::foo: SmallOrderedMap([(Const, 1380)])
 
 //! > sierra_code
 type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
@@ -482,7 +482,7 @@ fn foo(a: u8, b: u8) -> u16 {
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 100})
+test::foo: SmallOrderedMap([(Const, 100)])
 
 //! > sierra_code
 type u8 = u8 [storable: true, drop: true, dup: true, zero_sized: false];

--- a/tests/e2e_test_data/metadata_computation
+++ b/tests/e2e_test_data/metadata_computation
@@ -30,30 +30,30 @@ fn two() -> u32 {
 }
 
 //! > gas_solution_lp
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 250, Step: 2, Hole: 0, RangeCheck: 1})
-#10: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 5, RangeCheck: 0})
-#20: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 4, RangeCheck: 0})
-#36: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 260, Step: 3, Hole: 0, RangeCheck: 0})
-#43: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 90, Step: 1, Hole: 0, RangeCheck: 0})
-#47: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 1, RangeCheck: 0})
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 250), (Step, 2), (Hole, 0), (RangeCheck, 1)])
+#10: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 5), (RangeCheck, 0)])
+#20: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 4), (RangeCheck, 0)])
+#36: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 260), (Step, 3), (Hole, 0), (RangeCheck, 0)])
+#43: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 90), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#47: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 1), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 1570, Step: 15, Hole: 6, RangeCheck: 1})
-test::holes: SmallOrderedMap({Const: 600, Step: 6, Hole: 4, RangeCheck: 0})
-test::use_rc: SmallOrderedMap({Const: 1070, Step: 10, Hole: 1, RangeCheck: 1})
-test::two: SmallOrderedMap({Const: 100, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 1570), (Step, 15), (Hole, 6), (RangeCheck, 1)])
+test::holes: SmallOrderedMap([(Const, 600), (Step, 6), (Hole, 4), (RangeCheck, 0)])
+test::use_rc: SmallOrderedMap([(Const, 1070), (Step, 10), (Hole, 1), (RangeCheck, 1)])
+test::two: SmallOrderedMap([(Const, 100), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 250, Step: 2, Hole: 0, RangeCheck: 1})
-#10: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 5, RangeCheck: 0})
-#20: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 4, RangeCheck: 0})
-#36: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 260, Step: 3, Hole: 0, RangeCheck: 0})
-#43: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 90, Step: 1, Hole: 0, RangeCheck: 0})
-#47: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 1, RangeCheck: 0})
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 250), (Step, 2), (Hole, 0), (RangeCheck, 1)])
+#10: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 5), (RangeCheck, 0)])
+#20: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 4), (RangeCheck, 0)])
+#36: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 260), (Step, 3), (Hole, 0), (RangeCheck, 0)])
+#43: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 90), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#47: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 1), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 1570, Step: 15, Hole: 6, RangeCheck: 1})
-test::holes: SmallOrderedMap({Const: 600, Step: 6, Hole: 4, RangeCheck: 0})
-test::use_rc: SmallOrderedMap({Const: 1070, Step: 10, Hole: 1, RangeCheck: 1})
-test::two: SmallOrderedMap({Const: 100, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 1570), (Step, 15), (Hole, 6), (RangeCheck, 1)])
+test::holes: SmallOrderedMap([(Const, 600), (Step, 6), (Hole, 4), (RangeCheck, 0)])
+test::use_rc: SmallOrderedMap([(Const, 1070), (Step, 10), (Hole, 1), (RangeCheck, 1)])
+test::two: SmallOrderedMap([(Const, 100), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 #5: 2
@@ -255,28 +255,28 @@ fn bar() {
 test::bar 10000
 
 //! > gas_solution_lp
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9880, Step: 0, Hole: 0, RangeCheck: 0})
-#11: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9780, Step: 0, Hole: 0, RangeCheck: 0})
-#16: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#18: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 100, Step: 1, Hole: 0, RangeCheck: 0})
-#23: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 1, Hole: 2, RangeCheck: 0})
-#30: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 1, Hole: 4, RangeCheck: 0})
-#38: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9900, Step: 0, Hole: 0, RangeCheck: 0})
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9880), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#11: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9780), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#16: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#18: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 100), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#23: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 1), (Hole, 2), (RangeCheck, 0)])
+#30: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 1), (Hole, 4), (RangeCheck, 0)])
+#38: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 30900, Step: 13, Hole: 4, RangeCheck: 0})
-test::bar: SmallOrderedMap({Const: 10000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 30900), (Step, 13), (Hole, 4), (RangeCheck, 0)])
+test::bar: SmallOrderedMap([(Const, 10000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#11: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#16: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 19660, Step: 0, Hole: 0, RangeCheck: 0})
-#18: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 19760, Step: 1, Hole: 0, RangeCheck: 0})
-#23: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9880, Step: 1, Hole: 2, RangeCheck: 0})
-#30: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 1, Hole: 4, RangeCheck: 0})
-#38: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9900, Step: 0, Hole: 0, RangeCheck: 0})
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#11: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#16: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 19660), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#18: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 19760), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#23: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9880), (Step, 1), (Hole, 2), (RangeCheck, 0)])
+#30: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 1), (Hole, 4), (RangeCheck, 0)])
+#38: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 30900, Step: 13, Hole: 4, RangeCheck: 0})
-test::bar: SmallOrderedMap({Const: 10000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 30900), (Step, 13), (Hole, 4), (RangeCheck, 0)])
+test::bar: SmallOrderedMap([(Const, 10000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 #5: 2
@@ -432,32 +432,32 @@ fn bar() {
 test::bar 10000
 
 //! > gas_solution_lp
-#0: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 4, RangeCheck: 1})
-#1: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9640, Step: 0, Hole: 0, RangeCheck: 0})
-#6: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#7: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 2, Hole: 0, RangeCheck: 0})
-#8: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 5, RangeCheck: 0})
-#12: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 10250, Step: 2, Hole: 0, RangeCheck: 0})
-#16: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 350, Step: 1, Hole: 3, RangeCheck: 1})
-#24: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#32: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9900, Step: 0, Hole: 0, RangeCheck: 0})
+#0: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 4), (RangeCheck, 1)])
+#1: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9640), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#6: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#7: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 2), (Hole, 0), (RangeCheck, 0)])
+#8: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 5), (RangeCheck, 0)])
+#12: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 10250), (Step, 2), (Hole, 0), (RangeCheck, 0)])
+#16: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 350), (Step, 1), (Hole, 3), (RangeCheck, 1)])
+#24: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#32: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 21280, Step: 14, Hole: 1, RangeCheck: 1})
-test::bar: SmallOrderedMap({Const: 10000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 21280), (Step, 14), (Hole, 1), (RangeCheck, 1)])
+test::bar: SmallOrderedMap([(Const, 10000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#0: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 4, RangeCheck: 1})
-#1: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#6: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#7: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 2, Hole: 0, RangeCheck: 0})
-#8: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9640, Step: 0, Hole: 5, RangeCheck: 0})
-#12: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 19890, Step: 2, Hole: 0, RangeCheck: 0})
-#16: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9990, Step: 1, Hole: 3, RangeCheck: 1})
-#24: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#32: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9900, Step: 0, Hole: 0, RangeCheck: 0})
+#0: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 4), (RangeCheck, 1)])
+#1: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#6: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#7: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 2), (Hole, 0), (RangeCheck, 0)])
+#8: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9640), (Step, 0), (Hole, 5), (RangeCheck, 0)])
+#12: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 19890), (Step, 2), (Hole, 0), (RangeCheck, 0)])
+#16: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9990), (Step, 1), (Hole, 3), (RangeCheck, 1)])
+#24: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#32: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 21280, Step: 14, Hole: 1, RangeCheck: 1})
-test::bar: SmallOrderedMap({Const: 10000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 21280), (Step, 14), (Hole, 1), (RangeCheck, 1)])
+test::bar: SmallOrderedMap([(Const, 10000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 #12: 5
@@ -618,32 +618,32 @@ fn bar() {
 test::bar 2000
 
 //! > gas_solution_lp
-#4: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 2, Hole: 0, RangeCheck: 1})
-#6: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#7: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 700, Step: 4, Hole: 0, RangeCheck: 0})
-#8: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 7, RangeCheck: 0})
-#12: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1550, Step: 0, Hole: 2, RangeCheck: 0})
-#16: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1900, Step: 1, Hole: 0, RangeCheck: 0})
-#20: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 3, RangeCheck: 1})
-#28: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1900, Step: 0, Hole: 0, RangeCheck: 0})
+#4: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 2), (Hole, 0), (RangeCheck, 1)])
+#6: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#7: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 700), (Step, 4), (Hole, 0), (RangeCheck, 0)])
+#8: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 7), (RangeCheck, 0)])
+#12: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1550), (Step, 0), (Hole, 2), (RangeCheck, 0)])
+#16: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1900), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#20: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 3), (RangeCheck, 1)])
+#28: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 2940, Step: 10, Hole: 7, RangeCheck: 1})
-test::bar: SmallOrderedMap({Const: 2000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 2940), (Step, 10), (Hole, 7), (RangeCheck, 1)])
+test::bar: SmallOrderedMap([(Const, 2000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#4: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 2, Hole: 0, RangeCheck: 1})
-#6: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#7: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 700, Step: 4, Hole: 0, RangeCheck: 0})
-#8: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 7, RangeCheck: 0})
-#12: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1550, Step: 0, Hole: 2, RangeCheck: 0})
-#16: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1900, Step: 1, Hole: 0, RangeCheck: 0})
-#20: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 3, RangeCheck: 1})
-#28: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1900, Step: 0, Hole: 0, RangeCheck: 0})
+#4: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 2), (Hole, 0), (RangeCheck, 1)])
+#6: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#7: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 700), (Step, 4), (Hole, 0), (RangeCheck, 0)])
+#8: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 7), (RangeCheck, 0)])
+#12: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1550), (Step, 0), (Hole, 2), (RangeCheck, 0)])
+#16: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1900), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#20: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 3), (RangeCheck, 1)])
+#28: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 2940, Step: 10, Hole: 7, RangeCheck: 1})
-test::bar: SmallOrderedMap({Const: 2000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 2940), (Step, 10), (Hole, 7), (RangeCheck, 1)])
+test::bar: SmallOrderedMap([(Const, 2000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 #12: 5
@@ -795,30 +795,30 @@ test::bar 10000
 test::foo 100000
 
 //! > gas_solution_lp
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#10: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 79200, Step: 0, Hole: 5, RangeCheck: 0})
-#13: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#15: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 89170, Step: 1, Hole: 0, RangeCheck: 0})
-#20: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 2, RangeCheck: 0})
-#24: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#27: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9980, Step: 1, Hole: 0, RangeCheck: 0})
-#30: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9900, Step: 0, Hole: 0, RangeCheck: 0})
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#10: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 79200), (Step, 0), (Hole, 5), (RangeCheck, 0)])
+#13: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#15: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 89170), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#20: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 2), (RangeCheck, 0)])
+#24: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#27: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9980), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#30: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 100000, Step: 10, Hole: 5, RangeCheck: 0})
-test::bar: SmallOrderedMap({Const: 10000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 100000), (Step, 10), (Hole, 5), (RangeCheck, 0)])
+test::bar: SmallOrderedMap([(Const, 10000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#10: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 79200, Step: 0, Hole: 5, RangeCheck: 0})
-#13: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#15: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 89170, Step: 1, Hole: 0, RangeCheck: 0})
-#20: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 2, RangeCheck: 0})
-#24: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#27: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9980, Step: 1, Hole: 0, RangeCheck: 0})
-#30: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 9900, Step: 0, Hole: 0, RangeCheck: 0})
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#10: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 79200), (Step, 0), (Hole, 5), (RangeCheck, 0)])
+#13: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#15: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 89170), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#20: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 2), (RangeCheck, 0)])
+#24: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#27: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9980), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#30: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 9900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 100000, Step: 10, Hole: 5, RangeCheck: 0})
-test::bar: SmallOrderedMap({Const: 10000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 100000), (Step, 10), (Hole, 5), (RangeCheck, 0)])
+test::bar: SmallOrderedMap([(Const, 10000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 #13: 3
@@ -932,18 +932,18 @@ fn foo() -> u128 {
 }
 
 //! > gas_solution_lp
-#0: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 180, Step: 2, Hole: 0, RangeCheck: 0})
-#1: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 2, RangeCheck: 0})
-#14: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 1, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
+#0: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 180), (Step, 2), (Hole, 0), (RangeCheck, 0)])
+#1: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 2), (RangeCheck, 0)])
+#14: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 1), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Bitwise: 1, Const: 990, Step: 9, Hole: 2, RangeCheck: 1})
+test::foo: SmallOrderedMap([(Bitwise, 1), (Const, 990), (Step, 9), (Hole, 2), (RangeCheck, 1)])
 
 //! > gas_solution_linear
-#0: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 1, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 90, Step: 1, Hole: 0, RangeCheck: 0})
-#1: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 1, RangeCheck: 0})
-#14: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
+#0: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 1), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 90), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+#1: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 1), (RangeCheck, 0)])
+#14: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 1680, Step: 16, Hole: 1, RangeCheck: 1})
+test::foo: SmallOrderedMap([(Const, 1680), (Step, 16), (Hole, 1), (RangeCheck, 1)])
 
 //! > ap_solution_lp
 #14: 2
@@ -1058,20 +1058,20 @@ fn bar() {
 }
 
 //! > gas_solution_lp
-#4: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 9, RangeCheck: 0})
-#12: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#14: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 3, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1310, Step: 14, Hole: 0, RangeCheck: 0})
+#4: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 9), (RangeCheck, 0)])
+#12: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#14: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 3), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1310), (Step, 14), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Bitwise: 3, Const: 2600, Step: 26, Hole: 9, RangeCheck: 0})
-test::bar: SmallOrderedMap({Bitwise: 1, Const: 500, Step: 5, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Bitwise, 3), (Const, 2600), (Step, 26), (Hole, 9), (RangeCheck, 0)])
+test::bar: SmallOrderedMap([(Bitwise, 1), (Const, 500), (Step, 5), (Hole, 0), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#4: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 9, RangeCheck: 0})
-#12: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#14: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 3, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1310, Step: 14, Hole: 0, RangeCheck: 0})
+#4: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 9), (RangeCheck, 0)])
+#12: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#14: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 3), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1310), (Step, 14), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Bitwise: 3, Const: 2600, Step: 26, Hole: 9, RangeCheck: 0})
-test::bar: SmallOrderedMap({Bitwise: 1, Const: 500, Step: 5, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Bitwise, 3), (Const, 2600), (Step, 26), (Hole, 9), (RangeCheck, 0)])
+test::bar: SmallOrderedMap([(Bitwise, 1), (Const, 500), (Step, 5), (Hole, 0), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 #12: 9
@@ -1209,22 +1209,22 @@ fn foo(cond: bool) {
 }
 
 //! > gas_solution_lp
-#1: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#6: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#12: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 10470, Step: 117, Hole: 0, RangeCheck: 0})
-#28: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 123, RangeCheck: 0})
+#1: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#6: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#12: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 10470), (Step, 117), (Hole, 0), (RangeCheck, 0)])
+#28: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 123), (RangeCheck, 0)])
 
-test::function_with_branch_align: SmallOrderedMap({Const: 710, Step: 3, Hole: 41, RangeCheck: 0})
-test::foo: SmallOrderedMap({Const: 13600, Step: 136, Hole: 123, RangeCheck: 0})
+test::function_with_branch_align: SmallOrderedMap([(Const, 710), (Step, 3), (Hole, 41), (RangeCheck, 0)])
+test::foo: SmallOrderedMap([(Const, 13600), (Step, 136), (Hole, 123), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#1: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#6: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#12: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 10670, Step: 119, Hole: 0, RangeCheck: 0})
-#28: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 123, RangeCheck: 0})
+#1: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#6: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#12: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 10670), (Step, 119), (Hole, 0), (RangeCheck, 0)])
+#28: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 123), (RangeCheck, 0)])
 
-test::function_with_branch_align: SmallOrderedMap({Const: 200, Step: 2, Hole: 0, RangeCheck: 0})
-test::foo: SmallOrderedMap({Const: 13600, Step: 136, Hole: 123, RangeCheck: 0})
+test::function_with_branch_align: SmallOrderedMap([(Const, 200), (Step, 2), (Hole, 0), (RangeCheck, 0)])
+test::foo: SmallOrderedMap([(Const, 13600), (Step, 136), (Hole, 123), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 #1: 41
@@ -1902,16 +1902,16 @@ fn bar() {
 test::bar 2000
 
 //! > gas_solution_lp
-#9: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1900, Step: 0, Hole: 0, RangeCheck: 0})
+#9: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 6300, Step: 6, Hole: 0, RangeCheck: 0})
-test::bar: SmallOrderedMap({Const: 2000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 6300), (Step, 6), (Hole, 0), (RangeCheck, 0)])
+test::bar: SmallOrderedMap([(Const, 2000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#9: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 1900, Step: 0, Hole: 0, RangeCheck: 0})
+#9: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 1900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 6300, Step: 6, Hole: 0, RangeCheck: 0})
-test::bar: SmallOrderedMap({Const: 2000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 6300), (Step, 6), (Hole, 0), (RangeCheck, 0)])
+test::bar: SmallOrderedMap([(Const, 2000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 
@@ -2002,30 +2002,30 @@ test::bar20000 20000
 test::bar1000 1000
 
 //! > gas_solution_lp
-#0: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#4: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#8: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#9: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#13: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 19900, Step: 0, Hole: 0, RangeCheck: 0})
-#16: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 900, Step: 0, Hole: 0, RangeCheck: 0})
+#0: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#4: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#8: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#9: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#13: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 19900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#16: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 43100, Step: 12, Hole: 0, RangeCheck: 0})
-test::bar20000: SmallOrderedMap({Const: 20000, Step: 1, Hole: 0, RangeCheck: 0})
-test::bar1000: SmallOrderedMap({Const: 1000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 43100), (Step, 12), (Hole, 0), (RangeCheck, 0)])
+test::bar20000: SmallOrderedMap([(Const, 20000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+test::bar1000: SmallOrderedMap([(Const, 1000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > gas_solution_linear
-#0: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#4: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#5: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 0, Step: 0, Hole: 0, RangeCheck: 0})
-#8: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 18700, Step: 0, Hole: 0, RangeCheck: 0})
-#9: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 18700, Step: 0, Hole: 0, RangeCheck: 0})
-#13: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 19900, Step: 0, Hole: 0, RangeCheck: 0})
-#16: SmallOrderedMap({Pedersen: 0, Poseidon: 0, Bitwise: 0, EcOp: 0, AddMod: 0, MulMod: 0, Blake: 0, Const: 900, Step: 0, Hole: 0, RangeCheck: 0})
+#0: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#4: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#5: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 0), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#8: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 18700), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#9: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 18700), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#13: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 19900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
+#16: SmallOrderedMap([(Pedersen, 0), (Poseidon, 0), (Bitwise, 0), (EcOp, 0), (AddMod, 0), (MulMod, 0), (Blake, 0), (Const, 900), (Step, 0), (Hole, 0), (RangeCheck, 0)])
 
-test::foo: SmallOrderedMap({Const: 20500, Step: 12, Hole: 0, RangeCheck: 0})
-test::bar20000: SmallOrderedMap({Const: 20000, Step: 1, Hole: 0, RangeCheck: 0})
-test::bar1000: SmallOrderedMap({Const: 1000, Step: 1, Hole: 0, RangeCheck: 0})
+test::foo: SmallOrderedMap([(Const, 20500), (Step, 12), (Hole, 0), (RangeCheck, 0)])
+test::bar20000: SmallOrderedMap([(Const, 20000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
+test::bar1000: SmallOrderedMap([(Const, 1000), (Step, 1), (Hole, 0), (RangeCheck, 0)])
 
 //! > ap_solution_lp
 


### PR DESCRIPTION
## Summary

Replace `vector-map` dependency with a custom implementation of `SmallOrderedMap` that uses a single `Vec<(Key, Value)>` for better cache locality. This change updates the serialization format from `{key: value}` to `[(key, value)]` in test data.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The current implementation of `SmallOrderedMap` relies on the external `vector-map` crate. By implementing our own version using a single vector of key-value pairs, we can improve cache locality and have more control over the implementation details. This is especially beneficial for small maps, which is the primary use case for this data structure.

---

## What was the behavior or documentation before?

Previously, `SmallOrderedMap` was a thin wrapper around `vector_map::VecMap`. The serialization format in test data used curly braces notation like `{key: value}`.

---

## What is the behavior or documentation after?

Now `SmallOrderedMap` is a custom implementation that uses a single `Vec<(Key, Value)>` for storage. The serialization format in test data has been updated to use the tuple notation `[(key, value)]`. All functionality remains the same, but with potentially better performance due to improved cache locality.

---

## Additional context

This change removes a dependency while maintaining the same API, which should simplify the codebase and reduce external dependencies. The implementation provides all the necessary methods that were previously available through the `vector-map` crate.