### PR TITLE
refactor(vec-map): Removed dependency on vec map totally.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,7 +1090,6 @@ dependencies = [
  "serde",
  "tracing",
  "unescaper",
- "vector-map",
 ]
 
 [[package]]
@@ -4587,15 +4586,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vector-map"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b34e878e32c750bb4253be124adb9da1dc93ca5d98c210787badf1e1ccdca7"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ opt-level = 3
 opt-level = 3
 [profile.ci-dev.package."tokio"]
 opt-level = 3
-[profile.ci-dev.package."vector-map"]
-opt-level = 3
 [profile.ci-dev.package."mimalloc"]
 opt-level = 3
 [profile.ci-dev.package."libmimalloc-sys"]
@@ -160,7 +158,6 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "time"] }
 typetag = "0.2"
 unescaper = "0.1.6"
-vector-map = { version = "1.0.2", features = ["serde_impl"] }
 xshell = "0.2.7"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -17,7 +17,6 @@ num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
 serde = { workspace = true, default-features = true }
 unescaper.workspace = true
-vector-map.workspace = true
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -5,9 +5,9 @@ use cairo_lang_filesystem::ids::{FileId, SmolStrId};
 use cairo_lang_filesystem::span::{TextOffset, TextPosition, TextSpan, TextWidth};
 use cairo_lang_proc_macros::{DebugWithDb, HeapSize};
 use cairo_lang_utils::require;
+use cairo_lang_utils::small_ordered_map::SmallOrderedMap;
 use salsa::Database;
 use salsa::plumbing::AsId;
-use vector_map::VecMap;
 
 use self::ast::TriviaGreen;
 use self::green::GreenNode;
@@ -310,7 +310,7 @@ impl<'a> SyntaxNode<'a> {
         let self_green = self.green_node(db);
         let children = self_green.children();
         let mut res: Vec<SyntaxNode<'_>> = Vec::with_capacity(children.len());
-        let mut key_map = VecMap::<_, usize>::new();
+        let mut key_map = SmallOrderedMap::<_, usize>::new();
         for green_id in children {
             let green = green_id.long(db);
             let width = green.width(db);


### PR DESCRIPTION
## Summary

Removed the `vector-map` dependency from the project. This involved:
- Removing it from the main `Cargo.toml` dependencies
- Removing it from the optimization profile in `Cargo.toml`
- Removing it from `cairo-lang-syntax` crate dependencies
- Replacing `VecMap` usage with `SmallOrderedMap` from the project's own utils

## Type of change

Please check **one**:

- [x] Performance improvement
- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This PR replaces the external `vector-map` dependency with our own internal `SmallOrderedMap` implementation. This reduces external dependencies and allows us to use a more tailored data structure that better fits our specific use cases.

---

## What was the behavior or documentation before?

The codebase was using `VecMap` from the `vector-map` crate for ordered map operations in the syntax node implementation.

---

## What is the behavior or documentation after?

The codebase now uses our own `SmallOrderedMap` implementation from `cairo-lang-utils`, which is more optimized for our specific use cases.

---

## Additional context

This change is part of ongoing efforts to reduce external dependencies and optimize performance by using more specialized internal data structures.