### PR TITLE
performance(sierra-gas): Added unchecked initialization, improving runtime marginally.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/compute_costs.rs
+++ b/crates/cairo-lang-sierra-gas/src/compute_costs.rs
@@ -716,7 +716,10 @@ pub struct PreCostContext {}
 
 impl SpecificCostContextTrait<PreCost> for PreCostContext {
     fn to_cost_map(cost: PreCost) -> CostTokenMap<i64> {
-        cost.0.into_iter().map(|(token_type, val)| (token_type, val as i64)).collect()
+        // Keys are unique since we're converting from another map.
+        CostTokenMap::unchecked_from_iter(
+            cost.0.into_iter().map(|(token_type, val)| (token_type, val as i64)),
+        )
     }
 
     fn into_full_cost_iter(cost: PreCost) -> impl Iterator<Item = (CostTokenType, i64)> {
@@ -813,7 +816,8 @@ impl<CostType: PostCostTypeEx, GetApChangeFn: Fn(&StatementIdx) -> usize>
         if cost == CostType::default() {
             Default::default()
         } else {
-            Self::into_full_cost_iter(cost).collect()
+            // Keys are unique since into_full_cost_iter iterates over each token type once.
+            CostTokenMap::unchecked_from_iter(Self::into_full_cost_iter(cost))
         }
     }
 

--- a/crates/cairo-lang-sierra-gas/src/objects.rs
+++ b/crates/cairo-lang-sierra-gas/src/objects.rs
@@ -70,11 +70,11 @@ impl std::ops::Sub for ConstCost {
 pub struct PreCost(pub CostTokenMap<i32>);
 impl PreCost {
     pub fn builtin(token_type: CostTokenType) -> Self {
-        Self(CostTokenMap::from_iter([(token_type, 1)]))
+        Self(CostTokenMap::from_single(token_type, 1))
     }
 
     pub fn n_builtins(token_type: CostTokenType, n: i32) -> Self {
-        Self(CostTokenMap::from_iter([(token_type, n)]))
+        Self(CostTokenMap::from_single(token_type, n))
     }
 }
 impl Neg for PreCost {

--- a/crates/cairo-lang-sierra-to-casm/src/metadata.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/metadata.rs
@@ -12,6 +12,7 @@ use cairo_lang_sierra_gas::{
 };
 use cairo_lang_sierra_type_size::ProgramRegistryInfo;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::small_ordered_map::SmallOrderedMap;
 use thiserror::Error;
 
 #[derive(Default)]
@@ -92,9 +93,10 @@ pub fn calc_metadata(
         .map(|(func, costs)| {
             (
                 func.clone(),
-                CostTokenType::iter_precost()
-                    .filter_map(|token| costs.get(token).map(|v| (*token, *v)))
-                    .collect(),
+                SmallOrderedMap::unchecked_from_iter(
+                    CostTokenType::iter_precost()
+                        .filter_map(|token| costs.get(token).map(|v| (*token, *v))),
+                ),
             )
         })
         .collect();
@@ -138,10 +140,10 @@ pub fn calc_metadata(
             .map(|(func, costs)| {
                 (
                     func.clone(),
-                    [CostTokenType::Const]
-                        .iter()
-                        .filter_map(|token| costs.get(token).map(|v| (*token, *v)))
-                        .collect(),
+                    costs
+                        .get(&CostTokenType::Const)
+                        .map(|v| SmallOrderedMap::from_single(CostTokenType::Const, *v))
+                        .unwrap_or_default(),
                 )
             })
             .collect();

--- a/crates/cairo-lang-utils/src/small_ordered_map.rs
+++ b/crates/cairo-lang-utils/src/small_ordered_map.rs
@@ -17,6 +17,24 @@ use alloc::vec::Vec;
 )]
 pub struct SmallOrderedMap<Key, Value>(Vec<(Key, Value)>);
 
+impl<Key, Value> SmallOrderedMap<Key, Value> {
+    /// Creates a map with a single key-value pair.
+    #[inline]
+    pub fn from_single(key: Key, value: Value) -> Self {
+        Self(vec![(key, value)])
+    }
+
+    /// Creates a map from an array of key-value pairs without checking for duplicate keys.
+    ///
+    /// # Safety
+    /// The caller must ensure that the input iterator does not contain duplicate keys.
+    /// If duplicates exist, behavior of lookups is unspecified (may return any matching entry).
+    #[inline]
+    pub fn unchecked_from_iter(iter: impl IntoIterator<Item = (Key, Value)>) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
 impl<Key: Eq, Value> SmallOrderedMap<Key, Value> {
     /// Creates a new empty map.
     pub fn new() -> Self {


### PR DESCRIPTION
## Summary

Optimized the `CostTokenMap` usage in the Sierra gas module by introducing specialized constructors and unchecked operations. Added new methods to `SmallOrderedMap` including `unchecked_from_vec`, `from_single`, and `unchecked_from_iter` to avoid redundant key uniqueness checks when we can guarantee uniqueness from the context. Updated the `PreCost::rectify` method to filter out negative values during construction rather than replacing them with zeros.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The Sierra gas module frequently creates and manipulates cost maps with known properties (like unique keys). The previous implementation was performing unnecessary checks and operations when constructing these maps, which impacts performance during compilation.

---

## What was the behavior or documentation before?

Previously, the code was using general-purpose map construction methods that always check for key uniqueness, even in cases where uniqueness was guaranteed by the context. Additionally, the `rectify` method was mapping negative values to zero instead of filtering them out.

---

## What is the behavior or documentation after?

The code now uses specialized constructors that skip redundant checks when key uniqueness is guaranteed. The `SmallOrderedMap` class has new methods that allow for more efficient construction in specific scenarios. The `rectify` method now filters out negative values entirely rather than replacing them with zeros.

---

## Additional context

These optimizations are particularly important for the gas calculation module since it's used extensively during compilation. The changes maintain the same behavior while reducing unnecessary operations.