### PR TITLE
Remove unused ParamEx import in StarkNet component plugin

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/component.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/component.rs
@@ -18,7 +18,7 @@ use crate::plugin::consts::{
     GENERIC_CONTRACT_STATE_NAME, HAS_COMPONENT_TRAIT, STORAGE_STRUCT_NAME,
 };
 use crate::plugin::storage::handle_storage_struct;
-use crate::plugin::utils::{AstPathExtract, GenericParamExtract, ParamEx};
+use crate::plugin::utils::{AstPathExtract, GenericParamExtract};
 
 /// Accumulated data specific for component generation.
 #[derive(Default)]


### PR DESCRIPTION
Drop unused ParamEx import from component.rs to keep the StarkNet plugin dependency list minimal
No logic changes; code generation flow remains unchanged