### PR TITLE
performance(sierra-gas): Smaller equivalent costs map.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/compute_costs.rs
+++ b/crates/cairo-lang-sierra-gas/src/compute_costs.rs
@@ -105,7 +105,7 @@ impl CostTypeTrait for PreCost {
     fn rectify(value: &Self) -> Self {
         // Keys are unique since we're iterating over value's keys.
         PreCost(CostTokenMap::unchecked_from_iter(
-            value.0.iter().map(|(token_type, val)| (*token_type, std::cmp::max(*val, 0))),
+            value.0.iter().filter_map(|(k, v)| (*v > 0).then_some((*k, *v))),
         ))
     }
 }


### PR DESCRIPTION
## Summary

Optimized the `rectify` method in `PreCost` implementation by replacing a map-and-max operation with a filter-map approach. Instead of iterating through all values and replacing negative values with zero, the new implementation simply filters out negative values entirely, keeping only non-negative entries in the resulting cost map.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The current implementation of `rectify` in `PreCost` iterates through all values and replaces negative values with zero. This is inefficient since we're keeping entries with zero values in the map. The new implementation filters out negative values entirely, which reduces the size of the resulting map and improves performance.

---

## What was the behavior or documentation before?

Previously, the `rectify` method would iterate through all entries in the cost map and replace any negative values with zero, keeping all entries in the map.

---

## What is the behavior or documentation after?

Now, the `rectify` method filters out any entries with negative values, keeping only entries with non-negative values in the resulting map. This reduces the map size and improves performance.

---

## Additional context

This change maintains the same functional behavior while making the code more efficient. The Sierra gas computation will produce the same results, but with potentially fewer entries in the cost maps.