### PR TITLE
fix: remove unused lifetime parameters from inline weight helpers

### DIFF
--- a/crates/cairo-lang-lowering/src/inline/statements_weights.rs
+++ b/crates/cairo-lang-lowering/src/inline/statements_weights.rs
@@ -63,11 +63,11 @@ impl<'db> ApproxCasmInlineWeight<'db> {
         tys.into_iter().map(|ty| self.db.type_size(ty)).sum()
     }
     /// Calculate the total size of the given variables.
-    fn vars_size<'b, I: IntoIterator<Item = &'db VariableId>>(&self, vars: I) -> usize {
+    fn vars_size<I: IntoIterator<Item = &'db VariableId>>(&self, vars: I) -> usize {
         self.tys_total_size(vars.into_iter().map(|v| self.lowered.variables[*v].ty))
     }
     /// Calculate the total size of the given inputs.
-    fn inputs_size<'b, I: IntoIterator<Item = &'db VarUsage<'db>>>(&self, vars: I) -> usize {
+    fn inputs_size<I: IntoIterator<Item = &'db VarUsage<'db>>>(&self, vars: I) -> usize {
         self.vars_size(vars.into_iter().map(|v| &v.var_id))
     }
 }


### PR DESCRIPTION
## Summary

Simplified vars_size and inputs_size signatures to be generic only over the iterator type whose items are &'db VariableId / &'db VarUsage<'db>, removing the redundant 'b lifetime parameter while preserving behavior.

---

## Type of change


- [x] Style, wording, formatting, or typo-only change


---

## Why is this change needed?

Helper methods in ApproxCasmInlineWeight declared an extra lifetime parameter ('b) that was never used in their signatures or bodies. This added noise to the API and could trigger unused lifetime warnings under stricter settings.
