### PR TITLE
Remove unnecessary `Hash + Eq` bounds from `DebugWithDb` impl for `OrderedHashSet`

### DIFF
--- a/crates/cairo-lang-debug/src/debug.rs
+++ b/crates/cairo-lang-debug/src/debug.rs
@@ -251,7 +251,7 @@ where
     }
 }
 
-impl<'db, V: Hash + Eq> DebugWithDb<'db> for OrderedHashSet<V>
+impl<'db, V> DebugWithDb<'db> for OrderedHashSet<V>
 where
     V: DebugWithDb<'db>,
 {


### PR DESCRIPTION
Removes redundant Hash + Eq trait bounds from the DebugWithDb implementation for OrderedHashSet<V>.