### PR TITLE
refactor(ensure-no_std): consolidate duplicate use statements

### DIFF
--- a/ensure-no_std/src/main.rs
+++ b/ensure-no_std/src/main.rs
@@ -19,6 +19,4 @@ pub extern "C" fn _start() -> ! {
 static ALLOC: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 
 #[expect(unused_imports)]
-use cairo_lang_casm;
-#[expect(unused_imports)]
-use cairo_lang_utils;
+use {cairo_lang_casm, cairo_lang_utils};


### PR DESCRIPTION
Consolidates two separate `use` statements with duplicate `#[expect(unused_imports)]` attributes into a single grouped import.