### PR TITLE
refactor(sierra-gas): inlined small functions that are only used once.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -788,46 +788,6 @@ impl BranchCost {
     }
 }
 
-/// Returns a postcost value for a libfunc - the cost of step token.
-/// This is a helper function to implement costing both for creating
-/// gas equations and getting actual gas cost after having a solution.
-// TODO(orizi): Remove this function once it's not used.
-pub fn core_libfunc_postcost<Ops: CostOperations, InfoProvider: InvocationCostInfoProvider>(
-    ops: &mut Ops,
-    libfunc: &CoreConcreteLibfunc,
-    info_provider: &InfoProvider,
-) -> Vec<CostTokenMap<Ops::CostValueType>>
-where
-    Ops::CostValueType: std::ops::Add<Ops::CostValueType, Output = Ops::CostValueType>
-        + std::ops::Sub<Ops::CostValueType, Output = Ops::CostValueType>
-        + std::ops::Neg<Output = Ops::CostValueType>
-        + HasZero,
-{
-    core_libfunc_cost(libfunc, info_provider)
-        .into_iter()
-        .map(|v| CostTokenMap::from_iter([(CostTokenType::Const, v.postcost(ops, info_provider))]))
-        .collect()
-}
-
-/// Returns a precost value for a libfunc - the cost of non-step tokens.
-/// This is a helper function to implement costing both for creating
-/// gas equations and getting actual gas cost after having a solution.
-// TODO(orizi): Remove this function once it's not used.
-pub fn core_libfunc_precost<Ops: CostOperations, InfoProvider: CostInfoProvider>(
-    ops: &mut Ops,
-    libfunc: &CoreConcreteLibfunc,
-    info_provider: &InfoProvider,
-) -> Vec<CostTokenMap<Ops::CostValueType>>
-where
-    Ops::CostValueType: std::ops::Add<Ops::CostValueType, Output = Ops::CostValueType>
-        + std::ops::Sub<Ops::CostValueType, Output = Ops::CostValueType>
-        + std::ops::Neg<Output = Ops::CostValueType>
-        + HasZero
-        + Eq,
-{
-    core_libfunc_cost(libfunc, info_provider).into_iter().map(|v| v.precost(ops)).collect()
-}
-
 /// Returns the sum of statement variables for all the requested tokens.
 fn precost_statement_vars_cost<Ops: CostOperations>(
     ops: &Ops,


### PR DESCRIPTION
## Summary

Removed unused helper functions `core_libfunc_postcost` and `core_libfunc_precost` from the Sierra gas module, and inlined their functionality directly into the calling functions in `core_libfunc_cost_expr.rs`. This simplifies the codebase by eliminating deprecated functions that were marked with TODOs for removal.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The codebase contained deprecated helper functions that were marked with TODOs for removal. These functions were intermediaries that added unnecessary complexity. By removing them and inlining their functionality directly where needed, we simplify the code and potentially improve performance by eliminating function call overhead.

---

## What was the behavior or documentation before?

The code used two helper functions (`core_libfunc_postcost` and `core_libfunc_precost`) that were marked with TODOs for removal, indicating they were deprecated but still in use.

---

## What is the behavior or documentation after?

The functionality of these helper functions has been inlined directly into the calling functions in `core_libfunc_cost_expr.rs`, maintaining the same behavior while simplifying the codebase.