### PR TITLE
performance(sierra-gas): Made cost ops not require rhs clone.

### DIFF
--- a/crates/cairo-lang-sierra-gas/src/objects.rs
+++ b/crates/cairo-lang-sierra-gas/src/objects.rs
@@ -1,8 +1,9 @@
+use std::ops::Neg;
+
 use cairo_lang_sierra::extensions::circuit::CircuitInfo;
 use cairo_lang_sierra::extensions::gas::{BuiltinCostsType, CostTokenMap, CostTokenType};
 use cairo_lang_sierra::ids::ConcreteTypeId;
 use cairo_lang_utils::casts::IntoOrPanic;
-use cairo_lang_utils::collection_arithmetics::{AddCollection, SubCollection};
 
 use crate::core_libfunc_cost_base::FunctionCostInfo;
 
@@ -76,22 +77,14 @@ impl PreCost {
         Self(CostTokenMap::from_iter([(token_type, n)]))
     }
 }
-
-/// Adds two [PreCost] instances.
-impl std::ops::Add for PreCost {
+impl Neg for PreCost {
     type Output = Self;
 
-    fn add(self, rhs: Self) -> Self::Output {
-        PreCost(self.0.add_collection(rhs.0))
-    }
-}
-
-/// Subtracts two [PreCost] instances.
-impl std::ops::Sub for PreCost {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        PreCost(self.0.sub_collection(rhs.0))
+    fn neg(mut self) -> Self::Output {
+        for (_k, v) in self.0.iter_mut() {
+            *v = -*v;
+        }
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

Refactored the `CostTypeTrait` to use method-based operations instead of static functions, improving the API ergonomics. The trait now defines operations like `add_with`, `sub_with`, `min_with`, `max_with`, and `rectify` that operate on `self` rather than taking references as parameters. This change simplifies the code by making operations more intuitive and reduces the need for cloning.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation of `CostTypeTrait` used static functions that required cloning and reference passing, making the code more verbose and harder to follow. By switching to method-based operations that work on `self`, the code becomes more idiomatic and easier to understand, while potentially reducing unnecessary cloning operations.

---

## What was the behavior or documentation before?

Previously, operations on cost types were performed using static functions like `CostType::min2(value1, value2)` and `CostType::max(values)`, which required reference passing and often additional cloning.

---

## What is the behavior or documentation after?

Now operations are performed using methods on the values themselves, like `value1.min_with(&value2)` and `value.rectify()`, making the code more readable and reducing the need for cloning. The implementation also leverages existing collection arithmetic utilities for better performance.

---

## Additional context

This refactoring maintains the same functionality while making the code more idiomatic Rust. It also removes unnecessary implementations like standalone `Add` and `Sub` traits in favor of the more consistent method-based approach.