### PR TITLE
refactor(sierra): Made all sierra functions expect StatenentIdx without &.

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/compute.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/compute.rs
@@ -244,7 +244,7 @@ impl<'a, TokenUsages: Fn(StatementIdx, CostTokenType) -> usize>
         let Some(base_info) = self.infos[idx.0].tracking_info.clone() else {
             return;
         };
-        if matches!(self.program.get_statement(&idx), Some(Statement::Return(_))) {
+        if matches!(self.program.get_statement(idx), Some(Statement::Return(_))) {
             if let ApTrackingBase::FunctionStart(id) = base_info.base
                 && let Some(func_change) = self.function_ap_change.get(&id)
             {
@@ -306,8 +306,7 @@ impl<'a, TokenUsages: Fn(StatementIdx, CostTokenType) -> usize>
     /// Calculates the branches for all statements.
     fn calc_branches(&mut self) -> Result<(), ApChangeError> {
         for idx in (0..self.program.statements.len()).map(StatementIdx) {
-            let Statement::Invocation(invocation) = self.program.get_statement(&idx).unwrap()
-            else {
+            let Statement::Invocation(invocation) = self.program.get_statement(idx).unwrap() else {
                 continue;
             };
             let libfunc = self.program_info.registry.get_libfunc(&invocation.libfunc_id)?;
@@ -320,7 +319,7 @@ impl<'a, TokenUsages: Fn(StatementIdx, CostTokenType) -> usize>
             )
             .into_iter()
             .zip(&invocation.branches)
-            .map(|(ap_change, branch_info)| (ap_change, idx.next(&branch_info.target)))
+            .map(|(ap_change, branch_info)| (ap_change, idx.next(branch_info.target)))
             .collect();
         }
         Ok(())

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost.rs
@@ -39,14 +39,14 @@ impl CostOperations for Ops<'_> {
 /// Values with unknown values will return as None.
 pub fn core_libfunc_cost<InfoProvider: InvocationCostInfoProvider>(
     gas_info: &GasInfo,
-    idx: &StatementIdx,
+    idx: StatementIdx,
     libfunc: &CoreConcreteLibfunc,
     info_provider: &InfoProvider,
 ) -> Vec<CostTokenMap<i64>> {
     core_libfunc_cost_base::core_libfunc_cost(libfunc, info_provider)
         .into_iter()
         .map(|v| {
-            let ops = &mut Ops { gas_info, idx: *idx };
+            let ops = &mut Ops { gas_info, idx };
             let mut costs = v.precost(ops);
             let postcost = v.postcost(ops, info_provider);
             if postcost != 0 {

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_expr.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_expr.rs
@@ -29,7 +29,7 @@ impl CostOperations for Ops<'_> {
         function: &FunctionCostInfo,
         token_type: CostTokenType,
     ) -> Option<Self::CostValueType> {
-        Some(self.statement_future_cost.get_future_cost(&function.entry_point)[&token_type].clone())
+        Some(self.statement_future_cost.get_future_cost(function.entry_point)[&token_type].clone())
     }
 
     fn statement_var_cost(&self, token_type: CostTokenType) -> Option<Self::CostValueType> {
@@ -40,7 +40,7 @@ impl CostOperations for Ops<'_> {
 /// Returns an expression for the gas cost for core libfuncs.
 pub fn core_libfunc_precost_expr<InfoProvider: CostInfoProvider>(
     statement_future_cost: &mut dyn StatementFutureCost,
-    idx: &StatementIdx,
+    idx: StatementIdx,
     libfunc: &CoreConcreteLibfunc,
     info_provider: &InfoProvider,
 ) -> Vec<CostExprMap> {
@@ -51,7 +51,7 @@ pub fn core_libfunc_precost_expr<InfoProvider: CostInfoProvider>(
         // Coupon refund is not supported (zero refund).
         vec![Default::default()]
     } else {
-        let ops = &mut Ops { statement_future_cost, idx: *idx };
+        let ops = &mut Ops { statement_future_cost, idx };
         core_libfunc_cost(libfunc, info_provider).into_iter().map(|v| v.precost(ops)).collect()
     }
 }
@@ -59,7 +59,7 @@ pub fn core_libfunc_precost_expr<InfoProvider: CostInfoProvider>(
 /// Returns an expression for the gas cost for core libfuncs.
 pub fn core_libfunc_postcost_expr<InfoProvider: InvocationCostInfoProvider>(
     statement_future_cost: &mut dyn StatementFutureCost,
-    idx: &StatementIdx,
+    idx: StatementIdx,
     libfunc: &CoreConcreteLibfunc,
     info_provider: &InfoProvider,
 ) -> Vec<CostExprMap> {
@@ -67,7 +67,7 @@ pub fn core_libfunc_postcost_expr<InfoProvider: InvocationCostInfoProvider>(
         // Coupon refund is not supported (zero refund).
         vec![Default::default()]
     } else {
-        let ops = &mut Ops { statement_future_cost, idx: *idx };
+        let ops = &mut Ops { statement_future_cost, idx };
         core_libfunc_cost(libfunc, info_provider)
             .into_iter()
             .map(|v| {

--- a/crates/cairo-lang-sierra-gas/src/gas_info.rs
+++ b/crates/cairo-lang-sierra-gas/src/gas_info.rs
@@ -73,7 +73,7 @@ impl GasInfo {
         {
             if val != 0
                 && !matches!(
-                    program.get_statement(&idx),
+                    program.get_statement(idx),
                     Some(Statement::Invocation(x))
                     if Some(&x.libfunc_id) == branch_align_id
                 )

--- a/crates/cairo-lang-sierra-gas/src/lib.rs
+++ b/crates/cairo-lang-sierra-gas/src/lib.rs
@@ -211,9 +211,9 @@ pub fn calc_gas_postcost_info<ApChangeVarValue: Fn(StatementIdx) -> usize>(
                 &InvocationCostInfoProviderForEqGen {
                     type_sizes: &program_info.type_sizes,
                     token_usages: |token_type| {
-                        precost_gas_info.variable_values[&(*idx, token_type)].into_or_panic()
+                        precost_gas_info.variable_values[&(idx, token_type)].into_or_panic()
                     },
-                    ap_change_var_value: || ap_change_var_value(*idx),
+                    ap_change_var_value: || ap_change_var_value(idx),
                 },
             )
         },
@@ -243,7 +243,7 @@ pub fn calc_gas_postcost_info<ApChangeVarValue: Fn(StatementIdx) -> usize>(
 
 /// Calculates gas information. Used for both precost and postcost.
 fn calc_gas_info_inner<
-    GetCost: Fn(&mut dyn StatementFutureCost, &StatementIdx, &ConcreteLibfuncId) -> Vec<CostExprMap>,
+    GetCost: Fn(&mut dyn StatementFutureCost, StatementIdx, &ConcreteLibfuncId) -> Vec<CostExprMap>,
 >(
     program: &Program,
     get_cost: GetCost,
@@ -290,7 +290,7 @@ fn calc_gas_info_inner<
         for v in token_equations.iter().flat_map(|eq| eq.var_to_coef.keys()).unique() {
             minimization_vars[match v {
                 Var::LibfuncImplicitGasVariable(idx, _) => {
-                    match program.get_statement(idx).unwrap() {
+                    match program.get_statement(*idx).unwrap() {
                         Statement::Invocation(invocation) => {
                             match registry.get_libfunc(&invocation.libfunc_id).unwrap() {
                                 CoreConcreteLibfunc::BranchAlign(_) => 2,
@@ -356,7 +356,7 @@ fn calc_gas_info_inner<
 pub fn compute_postcost_info<CostType: PostCostTypeEx>(
     program: &Program,
     program_info: &ProgramRegistryInfo,
-    get_ap_change_fn: &impl Fn(&StatementIdx) -> usize,
+    get_ap_change_fn: &impl Fn(StatementIdx) -> usize,
     precost_gas_info: &GasInfo,
     enforced_function_costs: &OrderedHashMap<FunctionId, CostType>,
 ) -> Result<GasInfo, CostError> {

--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -605,7 +605,7 @@ pub fn compile(
                     zip_eq(&invocation.branches, compiled_invocation.results)
                         .zip(all_updated_annotations)
                 {
-                    let destination_statement_idx = statement_idx.next(&branch_info.target);
+                    let destination_statement_idx = statement_idx.next(branch_info.target);
                     if branching_libfunc
                         && !is_branch_align(
                             &program_info.registry,
@@ -676,21 +676,21 @@ pub fn validate_metadata(
     }
 
     // Get the libfunc for the given statement index, or an error.
-    let get_libfunc = |idx: &StatementIdx| -> Result<&CoreConcreteLibfunc, CompilationError> {
+    let get_libfunc = |idx: StatementIdx| -> Result<&CoreConcreteLibfunc, CompilationError> {
         if let Statement::Invocation(invocation) =
-            program.get_statement(idx).ok_or(CompilationError::MetadataStatementOutOfBound(*idx))?
+            program.get_statement(idx).ok_or(CompilationError::MetadataStatementOutOfBound(idx))?
         {
             registry
                 .get_libfunc(&invocation.libfunc_id)
                 .map_err(CompilationError::ProgramRegistryError)
         } else {
-            Err(CompilationError::StatementNotSupportingApChangeVariables(*idx))
+            Err(CompilationError::StatementNotSupportingApChangeVariables(idx))
         }
     };
 
     // Statement validations.
     for idx in metadata.ap_change_info.variable_values.keys() {
-        if !matches!(get_libfunc(idx)?, CoreConcreteLibfunc::BranchAlign(_)) {
+        if !matches!(get_libfunc(*idx)?, CoreConcreteLibfunc::BranchAlign(_)) {
             return Err(CompilationError::StatementNotSupportingApChangeVariables(*idx));
         }
     }
@@ -699,7 +699,7 @@ pub fn validate_metadata(
             return Err(CompilationError::MetadataNegativeGasVariable);
         }
         if !matches!(
-            get_libfunc(idx)?,
+            get_libfunc(*idx)?,
             CoreConcreteLibfunc::BranchAlign(_)
                 | CoreConcreteLibfunc::Coupon(CouponConcreteLibfunc::Refund(_))
                 | CoreConcreteLibfunc::Gas(

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
@@ -391,7 +391,7 @@ impl CompiledInvocationBuilder<'_> {
         >,
     ) -> CompiledInvocation {
         let gas_changes =
-            core_libfunc_cost(&self.program_info.metadata.gas_info, &self.idx, self.libfunc, &self);
+            core_libfunc_cost(&self.program_info.metadata.gas_info, self.idx, self.libfunc, &self);
 
         let branch_signatures = self.libfunc.branch_signatures();
         assert_eq!(
@@ -517,7 +517,7 @@ impl CompiledInvocationBuilder<'_> {
             );
         }
         let gas_changes =
-            core_libfunc_cost(&self.program_info.metadata.gas_info, &self.idx, self.libfunc, &self)
+            core_libfunc_cost(&self.program_info.metadata.gas_info, self.idx, self.libfunc, &self)
                 .into_iter()
                 .map(|costs| costs.get(&CostTokenType::Const).copied().unwrap_or_default());
         let mut final_costs: [ConstCost; BRANCH_COUNT] =

--- a/crates/cairo-lang-sierra-to-casm/src/metadata.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/metadata.rs
@@ -127,7 +127,7 @@ pub fn calc_metadata(
         compute_postcost_info(
             program,
             program_info,
-            &|idx| ap_change_info.variable_values.get(idx).copied().unwrap_or_default(),
+            &|idx| ap_change_info.variable_values.get(&idx).copied().unwrap_or_default(),
             &pre_gas_info,
             &enforced_function_costs,
         )
@@ -158,7 +158,7 @@ pub fn calc_metadata(
         let post_gas_info_runtime = compute_postcost_info::<ConstCost>(
             program,
             program_info,
-            &|idx| ap_change_info.variable_values.get(idx).copied().unwrap_or_default(),
+            &|idx| ap_change_info.variable_values.get(&idx).copied().unwrap_or_default(),
             &pre_gas_info,
             &Default::default(),
         )?;

--- a/crates/cairo-lang-sierra/src/program.rs
+++ b/crates/cairo-lang-sierra/src/program.rs
@@ -126,7 +126,7 @@ pub struct Program {
     pub funcs: Vec<Function>,
 }
 impl Program {
-    pub fn get_statement(&self, id: &StatementIdx) -> Option<&Statement> {
+    pub fn get_statement(&self, id: StatementIdx) -> Option<&Statement> {
         self.statements.get(id.0)
     }
 
@@ -236,10 +236,10 @@ pub struct Param {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct StatementIdx(pub usize);
 impl StatementIdx {
-    pub fn next(&self, target: &BranchTarget) -> StatementIdx {
+    pub fn next(&self, target: BranchTarget) -> StatementIdx {
         match target {
             BranchTarget::Fallthrough => StatementIdx(self.0 + 1),
-            BranchTarget::Statement(id) => *id,
+            BranchTarget::Statement(id) => id,
         }
     }
 }
@@ -301,7 +301,7 @@ pub struct GenBranchInfo<StatementId> {
     pub results: Vec<VarId>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum GenBranchTarget<StatementId> {
     /// Continues a run to the next statement.
     Fallthrough,

--- a/crates/cairo-lang-sierra/src/program_registry.rs
+++ b/crates/cairo-lang-sierra/src/program_registry.rs
@@ -216,7 +216,7 @@ impl<TType: GenericType, TLibfunc: GenericLibfunc> ProgramRegistry<TType, TLibfu
                     dst: index,
                 }));
             }
-            let next = index.next(&invocation_branch.target);
+            let next = index.next(invocation_branch.target);
             if next.0 >= program.statements.len() {
                 return Err(Box::new(ProgramRegistryError::JumpOutOfRange(index)));
             }

--- a/crates/cairo-lang-sierra/src/simulation/mod.rs
+++ b/crates/cairo-lang-sierra/src/simulation/mod.rs
@@ -89,7 +89,7 @@ impl SimulationContext<'_> {
         loop {
             let statement = self
                 .program
-                .get_statement(&current_statement_id)
+                .get_statement(current_statement_id)
                 .ok_or(SimulationError::StatementOutOfBounds(current_statement_id))?;
             match statement {
                 Statement::Return(ids) => {
@@ -111,7 +111,7 @@ impl SimulationContext<'_> {
                     })?;
                     let libfunc = self.registry.get_libfunc(&invocation.libfunc_id)?;
                     let (outputs, chosen_branch) = self.simulate_libfunc(
-                        &current_statement_id,
+                        current_statement_id,
                         libfunc,
                         inputs,
                         current_statement_id,
@@ -120,7 +120,7 @@ impl SimulationContext<'_> {
                     state.put_vars(izip!(branch_info.results.iter(), outputs)).map_err(
                         |error| SimulationError::EditStateError(error, current_statement_id),
                     )?;
-                    current_statement_id = current_statement_id.next(&branch_info.target);
+                    current_statement_id = current_statement_id.next(branch_info.target);
                 }
             }
         }
@@ -129,7 +129,7 @@ impl SimulationContext<'_> {
     /// inputs.
     fn simulate_libfunc(
         &self,
-        idx: &StatementIdx,
+        idx: StatementIdx,
         libfunc: &CoreConcreteLibfunc,
         inputs: Vec<CoreValue>,
         current_statement_id: StatementIdx,
@@ -137,7 +137,7 @@ impl SimulationContext<'_> {
         core::simulate(
             libfunc,
             inputs,
-            || self.statement_gas_info.get(idx).copied(),
+            || self.statement_gas_info.get(&idx).copied(),
             |function_id, inputs| {
                 self.simulate_function(function_id, inputs).map_err(|error| {
                     LibfuncSimulationError::FunctionSimulationError(

--- a/crates/cairo-lang-starknet-classes/src/contract_segmentation.rs
+++ b/crates/cairo-lang-starknet-classes/src/contract_segmentation.rs
@@ -163,7 +163,7 @@ impl FunctionInfo {
         match statement {
             Statement::Invocation(invocation) => {
                 for branch in &invocation.branches {
-                    let next_statement_idx = StatementIdx(idx).next(&branch.target).0;
+                    let next_statement_idx = StatementIdx(idx).next(branch.target).0;
                     if next_statement_idx < self.entry_point {
                         return Err(SegmentationError::JumpOutsideFunction(StatementIdx(idx)));
                     }


### PR DESCRIPTION
## Summary

Refactored the Sierra codebase to pass `StatementIdx` by value instead of by reference. This change simplifies function signatures and improves code clarity by treating `StatementIdx` as a lightweight value type rather than a reference.

---

## Type of change

Please check **one**:

- [x] Performance improvement
- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`StatementIdx` is a small value type (just a wrapper around a `usize`), so passing it by reference creates unnecessary indirection. Passing it by value is possibly more efficient and leads to cleaner code. This change also makes the API more consistent by treating `StatementIdx` as a value type throughout the codebase.

---

## What was the behavior or documentation before?

Functions were accepting `StatementIdx` by reference (`&StatementIdx`), requiring callers to take references to statement indices and creating unnecessary indirection for a simple value type.

---

## What is the behavior or documentation after?

Functions now accept `StatementIdx` by value, which is more efficient for this small type and results in cleaner code. The `BranchTarget` enum is now also treated as a value type with the `Copy` trait implemented.

---

## Additional context

This change affects multiple crates in the Sierra ecosystem, including `cairo-lang-sierra-ap-change`, `cairo-lang-sierra-gas`, and `cairo-lang-sierra-to-casm`. The change is purely mechanical and doesn't affect functionality, but improves code clarity and potentially performance by removing unnecessary indirection.