### PR TITLE
performance(syntax): Removing usage of vec-map for direct implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,7 +1090,6 @@ dependencies = [
  "serde",
  "tracing",
  "unescaper",
- "vector-map",
 ]
 
 [[package]]

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -17,7 +17,6 @@ num-traits = { workspace = true, default-features = true }
 salsa.workspace = true
 serde = { workspace = true, default-features = true }
 unescaper.workspace = true
-vector-map.workspace = true
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }


### PR DESCRIPTION
## Summary

Removed the `vector-map` dependency from `cairo-lang-syntax` and replaced its usage in `SyntaxNode::children` with a standard Vec-based implementation. The change replaces `VecMap` with a simple vector of tuples and manual lookup logic to achieve the same functionality.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] Performance improvement
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Removing the `vector-map` dependency simplifies the codebase and reduces external dependencies. The implementation using standard Vec operations is more straightforward and likely more efficient for the specific use case in the `children` method.

---

## What was the behavior or documentation before?

The code was using `VecMap` from the `vector-map` crate to track key fields and their counts when processing syntax node children.

---

## What is the behavior or documentation after?

The same functionality is now implemented using a simple Vec of tuples with manual lookup, achieving the same result without the external dependency.