### PR TITLE
(refactor): Migrate gas_redeposit to DataflowAnalyzer

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/gas_redeposit.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/gas_redeposit.rs
@@ -5,16 +5,17 @@ mod test;
 use cairo_lang_filesystem::flag::FlagsGroup;
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_semantic::{ConcreteVariant, corelib};
-use itertools::{Itertools, zip_eq};
+use itertools::Itertools;
 use salsa::Database;
 
-use crate::analysis::{Analyzer, BackAnalysis, StatementLocation};
+use crate::analysis::core::StatementLocation;
+use crate::analysis::{DataflowAnalyzer, DataflowBackAnalysis, Direction, Edge};
 use crate::ids::{ConcreteFunctionWithBodyId, LocationId, SemanticFunctionIdEx};
 use crate::implicits::FunctionImplicitsTrait;
 use crate::panic::PanicSignatureInfo;
 use crate::{
-    BlockId, Lowered, MatchInfo, Statement, StatementCall, StatementEnumConstruct, VarRemapping,
-    VarUsage, VariableId,
+    BlockEnd, BlockId, Lowered, Statement, StatementCall, StatementEnumConstruct, VarUsage,
+    VariableId,
 };
 
 /// Adds redeposit gas actions.
@@ -55,9 +56,8 @@ pub fn gas_redeposit<'db>(
     if panic_sig.always_panic {
         return;
     }
-    let ctx = GasRedepositContext { fixes: vec![], err_variant: panic_sig.err_variant };
-    let mut analysis = BackAnalysis::new(lowered, ctx);
-    analysis.get_root_info();
+    let mut ctx = GasRedepositContext { err_variant: panic_sig.err_variant, fixes: vec![] };
+    DataflowBackAnalysis::new(lowered, &mut ctx).run();
 
     let redeposit_gas = corelib::get_function_id(
         db,
@@ -66,7 +66,7 @@ pub fn gas_redeposit<'db>(
         vec![],
     )
     .lowered(db);
-    for (block_id, location) in analysis.analyzer.fixes {
+    for (block_id, location) in ctx.fixes {
         let block = &mut lowered.blocks[block_id];
 
         // The `redeposit_gas` function is added at the beginning of the block as it result in
@@ -86,13 +86,14 @@ pub fn gas_redeposit<'db>(
 }
 
 pub struct GasRedepositContext<'db> {
-    /// The list of blocks where we need to insert redeposit_gas.
-    fixes: Vec<(BlockId, LocationId<'db>)>,
     /// The panic error variant.
     pub err_variant: ConcreteVariant<'db>,
+    /// Locations where we need to insert redeposit_gas.
+    pub fixes: Vec<(BlockId, LocationId<'db>)>,
 }
 
-#[derive(Clone, PartialEq, Debug)]
+/// Redeposit state for a point in the program.
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum RedepositState {
     /// Gas might be burned if we don't redeposit.
     Required,
@@ -104,16 +105,42 @@ pub enum RedepositState {
     Return(VariableId),
 }
 
-impl<'db> Analyzer<'db, '_> for GasRedepositContext<'db> {
+impl<'db, 'a> DataflowAnalyzer<'db, 'a> for GasRedepositContext<'db> {
     type Info = RedepositState;
+    const DIRECTION: Direction = Direction::Backward;
 
-    fn visit_stmt(
+    fn initial_info(&mut self, _block_id: BlockId, block_end: &'a BlockEnd<'db>) -> Self::Info {
+        // If the function has multiple returns with different gas costs, gas will get burned unless
+        // we redeposit it.
+        // If however, this return corresponds to a panic, we don't redeposit due to code size
+        // concerns.
+        match block_end {
+            BlockEnd::Return(vars, _) => match vars.last() {
+                Some(VarUsage { var_id, location: _ }) => RedepositState::Return(*var_id),
+                None => RedepositState::Required,
+            },
+            _ => RedepositState::Unnecessary,
+        }
+    }
+
+    fn merge(
+        &mut self,
+        _lowered: &Lowered<'db>,
+        _statement_location: StatementLocation,
+        _info1: Self::Info,
+        _info2: Self::Info,
+    ) -> Self::Info {
+        // `redeposit_gas` was added, no need to add it until the next convergence point.
+        RedepositState::Unnecessary
+    }
+
+    fn transfer_stmt(
         &mut self,
         info: &mut Self::Info,
         _statement_location: StatementLocation,
-        stmt: &Statement<'db>,
+        stmt: &'a Statement<'db>,
     ) {
-        let RedepositState::Return(var_id) = info else {
+        let RedepositState::Return(var_id) = *info else {
             return;
         };
 
@@ -122,50 +149,25 @@ impl<'db> Analyzer<'db, '_> for GasRedepositContext<'db> {
             return;
         };
 
-        if output == var_id && *variant == self.err_variant {
+        if *output == var_id && *variant == self.err_variant {
             *info = RedepositState::Unnecessary;
         }
     }
 
-    fn visit_goto(
-        &mut self,
-        info: &mut Self::Info,
-        _statement_location: StatementLocation,
-        _target_block_id: BlockId,
-        _remapping: &VarRemapping<'db>,
-    ) {
-        // A goto is a convergence point, gas will get burned unless it is redeposited before the
-        // convergence.
-        *info = RedepositState::Required
-    }
-
-    fn merge_match(
-        &mut self,
-        _st: StatementLocation,
-        match_info: &MatchInfo<'db>,
-        infos: impl Iterator<Item = Self::Info>,
-    ) -> Self::Info {
-        for (info, arm) in zip_eq(infos, match_info.arms()) {
-            match info {
-                RedepositState::Return(_) | RedepositState::Required => {
+    fn transfer_edge(&mut self, info: &Self::Info, edge: &Edge<'db, 'a>) -> Self::Info {
+        match edge {
+            Edge::Goto { .. } => {
+                // A goto is a convergence point, gas will get burned unless it is redeposited
+                // before the convergence.
+                RedepositState::Required
+            }
+            Edge::MatchArm { arm, match_info } => {
+                if let RedepositState::Return(_) | RedepositState::Required = *info {
                     self.fixes.push((arm.block_id, *match_info.location()));
                 }
-                RedepositState::Unnecessary => {}
+                RedepositState::Unnecessary
             }
-        }
-
-        // `redeposit_gas` was added, no need to add it until the next convergence point.
-        RedepositState::Unnecessary
-    }
-
-    fn info_from_return(&mut self, _: StatementLocation, vars: &[VarUsage<'db>]) -> Self::Info {
-        // If the function has multiple returns with different gas costs, gas will get burned unless
-        // we redeposit it.
-        // If however, this return corresponds to a panic, we don't redeposit due to code size
-        // concerns.
-        match vars.last() {
-            Some(VarUsage { var_id, location: _ }) => RedepositState::Return(*var_id),
-            None => RedepositState::Required,
+            _ => *info,
         }
     }
 }


### PR DESCRIPTION
## Summary

Refactored the gas redeposit optimization to use the new dataflow analysis framework. The implementation now uses `DataflowBackAnalysis` instead of the previous `BackAnalysis` approach, with appropriate changes to the analyzer interface. The `GasRedepositContext` structure was updated to implement the `DataflowAnalyzer` trait with backward direction flow analysis.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This change modernizes the gas redeposit optimization to use the more efficient dataflow analysis framework. The previous implementation used an older analysis approach that was less structured. By migrating to the dataflow framework, we get better performance characteristics and a more maintainable implementation that follows the project's current analysis patterns.

---

## What was the behavior or documentation before?

The gas redeposit optimization previously used the `BackAnalysis` framework with custom visitor methods for analyzing control flow. It had a less structured approach to tracking state changes and determining where gas redeposit operations should be inserted.

---

## What is the behavior or documentation after?

The optimization now uses the `DataflowBackAnalysis` framework with clearly defined transfer functions and merge operations. The `RedepositState` is now explicitly marked as `Copy`, and the implementation follows the standard dataflow analysis pattern with direction specification and proper edge handling.

---

## Additional context

This change is part of the ongoing effort to standardize analysis approaches across the compiler. The functionality remains the same, but the implementation is now more consistent with other analyses in the codebase.