### PR TITLE
perf(sierra): Remove unnecessary string clone in serde test

### DIFF
--- a/crates/cairo-lang-sierra/tests/serde_test.rs
+++ b/crates/cairo-lang-sierra/tests/serde_test.rs
@@ -20,7 +20,7 @@ fn test_sierra_serde_json(
     inputs: &OrderedHashMap<String, String>,
     _args: &OrderedHashMap<String, String>,
 ) -> TestRunnerResult {
-    let prog: VersionedProgram = serde_json::from_str(&inputs["pretty_json"].clone())
+    let prog: VersionedProgram = serde_json::from_str(inputs["pretty_json"].as_str())
         .expect("Could not deserialize VersionedProgram.");
     let json = serde_json::to_string_pretty(&prog).expect("Could not serialize VersionedProgram.");
     TestRunnerResult::success(OrderedHashMap::from([("pretty_json".into(), json)]))


### PR DESCRIPTION
Removes an unnecessary `.clone()` call when deserializing JSON in the Sierra serde test.