### PR TITLE
bugfix(semantic): Fixed const-impl-item type-diagnostics span.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -2697,7 +2697,7 @@ fn validate_impl_item_constant<'db>(
     let actual_ty = inference.rewrite(constant_ty).no_err();
     if expected_ty != actual_ty {
         diagnostics.report(
-            impl_constant_type_clause_ast.stable_ptr(db),
+            impl_constant_type_clause_ast.ty(db).stable_ptr(db),
             WrongType { expected_ty, actual_ty },
         );
     }

--- a/crates/cairo-lang-semantic/src/items/tests/trait_const
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_const
@@ -169,9 +169,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2039]: Expected type "core::integer::u32", found: "core::integer::i32".
- --> lib.cairo:5:12
+ --> lib.cairo:5:14
     const X: i32 = 9;
-           ^^^^^
+             ^^^
 
 //! > ==========================================================================
 


### PR DESCRIPTION
## Summary

Fixed the error location in trait constant type mismatch diagnostics. The error now points to the type annotation itself rather than the entire constant declaration.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a trait constant implementation had a type mismatch, the error diagnostic was pointing to the entire constant declaration rather than specifically to the type annotation. This made it harder for users to identify exactly where the type mismatch occurred.

---

## What was the behavior or documentation before?

Previously, when there was a type mismatch in a trait constant implementation, the error would point to the entire constant declaration line. For example, in the test case, the error pointed to `const X: i32 = 9;` rather than just the `i32` type.

---

## What is the behavior or documentation after?

Now the error points specifically to the type annotation (`i32` in the test case), making it clearer to users exactly what needs to be changed to fix the type mismatch.