### PR TITLE
bugfix(semantic): Fix mishandling of `Self::` in impl-const-items.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -2684,7 +2684,9 @@ fn validate_impl_item_constant<'db>(
         })?;
     let concrete_trait_constant =
         ConcreteTraitConstantId::new_from_data(db, concrete_trait_id, trait_constant_id);
-    let concrete_trait_constant_ty = db.concrete_trait_constant_type(concrete_trait_constant)?;
+    let impl_def_substitution = db.impl_def_substitution(impl_def_id)?;
+    let concrete_trait_constant_ty = impl_def_substitution
+        .substitute(db, db.concrete_trait_constant_type(concrete_trait_constant)?)?;
 
     let impl_constant_type_clause_ast = impl_constant_ast.type_clause(db);
 

--- a/crates/cairo-lang-semantic/src/items/tests/trait_const
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_const
@@ -819,3 +819,28 @@ impl CopyRepeated<T, +Copy<T>> of Repeated<T> {
 }
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > impl constant type using Self::SIZE resolves correctly.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait SomeTrait {
+    const SIZE: usize;
+    const IDS: [felt252; Self::SIZE];
+}
+impl SomeImpl of SomeTrait {
+    const SIZE: usize = 2;
+    const IDS: [felt252; Self::SIZE] = [1, 2];
+}
+
+//! > expected_diagnostics


### PR DESCRIPTION
## Summary

Fixed a bug in trait constant type validation by properly substituting the concrete trait constant type with the implementation definition substitution. This ensures that trait constants using `Self::SIZE` in their type definition resolve correctly.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When implementing a trait with constants that reference other constants in their type definition (like array sizes using `Self::SIZE`), the type validation was failing because it wasn't properly substituting the implementation-specific values.

---

## What was the behavior or documentation before?

Previously, when validating an implementation of a trait constant, the code was using the concrete trait constant type directly without applying the implementation's substitutions. This would cause validation errors when trait constants used other trait constants in their type definitions.

---

## What is the behavior or documentation after?

Now, the implementation's substitution is applied to the concrete trait constant type during validation. This allows trait constants to correctly reference other constants like `Self::SIZE` in their type definitions, as demonstrated by the added test case.

---

## Additional context

The added test case demonstrates a common pattern where a trait defines a size constant and then uses it in the type of another constant (in this case, an array size). This pattern is now properly supported.