### PR TITLE
(refactor): Updating analysis framework to be easier to use

### DIFF
--- a/crates/cairo-lang-lowering/src/objects.rs
+++ b/crates/cairo-lang-lowering/src/objects.rs
@@ -233,6 +233,18 @@ pub enum BlockEnd<'db> {
     },
 }
 
+impl<'db> BlockEnd<'db> {
+    /// Returns the location of this block end, if available.
+    pub fn location(&self) -> Option<LocationId<'db>> {
+        match self {
+            BlockEnd::Return(_, location) => Some(*location),
+            BlockEnd::Panic(var) => Some(var.location),
+            BlockEnd::Match { info } => Some(*info.location()),
+            BlockEnd::Goto(_, _) | BlockEnd::NotSet => None,
+        }
+    }
+}
+
 /// Lowered variable representation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Variable<'db> {


### PR DESCRIPTION
## Summary

Added a `block_entry_location` method to the `DataflowAnalyzer` trait to determine the appropriate location for block entry based on analysis direction. This method handles both backward and forward analysis cases, recursively finding locations when needed. Also modified the `merge` method signature to take the `lowered` parameter instead of a separate `location` parameter, and updated the `Edge` enum to use owned rather than referenced values for certain fields. Added a `location` method to `BlockEnd` to extract location information when available.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This change improves the dataflow analysis framework by providing a consistent way to determine block entry locations based on analysis direction. It simplifies the API by having the analyzer determine the appropriate location rather than requiring it to be passed separately, and makes ownership clearer by using owned values where appropriate.

---

## What was the behavior or documentation before?

Previously, the `merge` method required a separate location parameter, and there was no standardized way to determine block entry locations based on analysis direction.

---

## What is the behavior or documentation after?

Now the `DataflowAnalyzer` trait includes a `block_entry_location` method that handles both backward and forward analysis cases, recursively finding locations when needed. The `merge` method signature has been updated to take the `lowered` parameter instead of a separate `location` parameter.