### PR TITLE
Optimize Sha256 state handle libfunc signatures

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/syscalls.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/syscalls.rs
@@ -214,7 +214,7 @@ impl NoGenericArgsGenericLibfunc for Sha256StateHandleInitLibfunc {
             ],
             vec![OutputVarInfo {
                 ty: context.get_concrete_type(Sha256StateHandleType::id(), &[])?,
-                ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
+                ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 0 },
             }],
             SierraApChange::Known { new_vars_only: false },
         ))
@@ -238,7 +238,7 @@ impl NoGenericArgsGenericLibfunc for Sha256StateHandleDigestLibfunc {
             ],
             vec![OutputVarInfo {
                 ty: sha256_state_handle_unwrapped_type(context)?,
-                ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
+                ref_info: OutputVarReferenceInfo::SameAsParam { param_idx: 0 },
             }],
             SierraApChange::Known { new_vars_only: false },
         ))


### PR DESCRIPTION
 ## Summary
Updates `Sha256StateHandleInit` and `Sha256StateHandleDigest` to use `OutputVarReferenceInfo::SameAsParam` instead of `Deferred`.
---
 ## Type of change
 - [x] Performance improvement
 ---
## Why is this change needed?
 Both libfuncs are implemented as `build_identity` in `cairo-lang-sierra-to-casm`. Using `SameAsParam` accurately reflects that the output is the same as the input word. This allows the Sierra compiler to reuse variable cells and registry allocations, eliminating unnecessary moves in the generated CASM.
 ---
 ## What was the behavior or documentation before?
 Used `Deferred(Generic)`, which treats the output as a new variable requiring its own allocation/handling by the compiler.
 ---
 ## What is the behavior or documentation after?
Uses `SameAsParam { param_idx: 0 }`, enabling zero-cost type casting at the Sierra level.
 ---
## Additional context
 Evidence: `crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs` maps `Sha256StateHandleInit` directly to `build_identity`.