### PR TITLE
Remove outdated WIP label from ABI link

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/memory-model.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/memory-model.adoc
@@ -91,7 +91,7 @@ specification and may evolve. Refer to the ABI page when stabilized.
 
 See also:
 
-- xref:application-binary-interface.adoc[Application binary interface] (WIP)
+- xref:application-binary-interface.adoc[Application binary interface]
 
 == Implementation reference
 


### PR DESCRIPTION
 ## Summary
 Removes the `(WIP)` marker from the Application Binary Interface (ABI) reference link in the memory model documentation.
---
## Type of change
- [x] Documentation change with concrete technical impact
 ---
 ## Why is this change needed?
 The ABI documentation has matured and is frequently referenced as a stable source. Retaining the "Work In Progress" label is now misleading and may cause developers to doubt the reliability of the specification.
 ---
 ## What was the behavior or documentation before?
  The link was suffixed with `(WIP)`.
 ---
 ## What is the behavior or documentation after?
  The link is presented as a finalized reference.
 ---
 ## Additional context
  This aligns the documentation with the current stability status of the Starknet ABI.