### PR TITLE
performance(lowering): Removed many interim vectors for extern fn processing.

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/external.rs
+++ b/crates/cairo-lang-lowering/src/lower/external.rs
@@ -1,4 +1,7 @@
+use std::slice;
+
 use cairo_lang_semantic as semantic;
+use itertools::Itertools;
 
 use super::LoweredExpr;
 use super::context::LoweringContext;
@@ -8,14 +11,14 @@ use crate::{VarUsage, VariableId};
 /// Given a return type of an external function, gets the real output variable types for that call.
 /// For example, an external function that returns a tuple, has an output variable for each tuple
 /// entry.
-pub fn extern_facade_return_tys<'db>(
-    ctx: &mut LoweringContext<'db, '_>,
-    ret_ty: semantic::TypeId<'db>,
-) -> Vec<semantic::TypeId<'db>> {
-    if let semantic::TypeLongId::Tuple(tys) = ret_ty.long(ctx.db) {
-        tys.to_vec()
+pub fn extern_facade_return_tys<'ret, 'db: 'ret>(
+    db: &'db dyn salsa::Database,
+    ret_ty: &'ret semantic::TypeId<'db>,
+) -> &'ret [semantic::TypeId<'db>] {
+    if let semantic::TypeLongId::Tuple(tys) = ret_ty.long(db) {
+        tys
     } else {
-        vec![ret_ty]
+        slice::from_ref(ret_ty)
     }
 }
 
@@ -26,7 +29,7 @@ pub fn extern_facade_return_tys<'db>(
 pub fn extern_facade_expr<'db>(
     ctx: &mut LoweringContext<'db, '_>,
     ty: semantic::TypeId<'db>,
-    returns: Vec<VariableId>,
+    returns: impl ExactSizeIterator<Item = VariableId>,
     location: LocationId<'db>,
 ) -> LoweredExpr<'db> {
     if let semantic::TypeLongId::Tuple(subtypes) = ty.long(ctx.db) {
@@ -34,13 +37,14 @@ pub fn extern_facade_expr<'db>(
         // TODO(ilya): Use tuple item location for each item.
         LoweredExpr::Tuple {
             exprs: returns
-                .into_iter()
                 .map(|var_id| LoweredExpr::AtVariable(VarUsage { var_id, location }))
                 .collect(),
             location,
         }
     } else {
-        assert_eq!(returns.len(), 1);
-        LoweredExpr::AtVariable(VarUsage { var_id: returns.into_iter().next().unwrap(), location })
+        let Ok(var_id) = returns.exactly_one() else {
+            panic!("Expected exactly one output variable for non-tuple return type");
+        };
+        LoweredExpr::AtVariable(VarUsage { var_id, location })
     }
 }

--- a/crates/cairo-lang-lowering/src/lower/flow_control/lower_graph/lower_node.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/lower_graph/lower_node.rs
@@ -242,22 +242,19 @@ fn handle_extern_match<'db>(
             let mut child_builder = ctx.create_child_builder(&builder);
             let ty = flow_control_var.ty(ctx.graph);
 
-            let input_tys = match_extern_variant_arm_input_types(ctx.ctx, ty, lowered_extern_enum);
-            let mut input_vars = input_tys
-                .into_iter()
-                .map(|ty| ctx.ctx.new_var(VarRequest { ty, location }))
-                .collect_vec();
-
-            let input_vars_to_report = input_vars.clone();
+            let input_vars_to_report =
+                match_extern_variant_arm_input_types(ctx.ctx.db, &ty, lowered_extern_enum)
+                    .map(|ty| ctx.ctx.new_var(VarRequest { ty, location }))
+                    .collect_vec();
             // Bind the variant inner values to semantic variables.
-            match_extern_arm_ref_args_bind(
+            let returns = match_extern_arm_ref_args_bind(
                 ctx.ctx,
-                &mut input_vars,
+                &input_vars_to_report,
                 lowered_extern_enum,
                 &mut child_builder,
             );
 
-            let variant_expr = extern_facade_expr(ctx.ctx, ty, input_vars, location);
+            let variant_expr = extern_facade_expr(ctx.ctx, ty, returns.iter().copied(), location);
 
             // Since `extern_facade_expr` returns either
             // (a) `LoweredExpr::AtVariable` or


### PR DESCRIPTION
## Summary

Refactored the `extern_facade_return_tys` function to return a slice instead of a vector, improving performance by avoiding unnecessary allocations. Also modified `extern_facade_expr` to accept an iterator instead of a vector, allowing for more flexible usage patterns. Updated all call sites to accommodate these changes, resulting in cleaner code that avoids unnecessary vector allocations and copies.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation was creating unnecessary vector allocations when processing extern function return types. By changing the return type to a slice and accepting iterators instead of vectors, we reduce memory allocations and improve performance in the lowering phase.

---

## What was the behavior or documentation before?

Previously, `extern_facade_return_tys` would always allocate a new vector even when returning a single type, and `extern_facade_expr` required a fully constructed vector to be passed in, leading to additional allocations and copies.

---

## What is the behavior or documentation after?

Now `extern_facade_return_tys` returns a slice (either a reference to the existing tuple types or a single-element slice), and `extern_facade_expr` accepts any exact-size iterator of variable IDs, allowing callers to avoid unnecessary allocations.

---

## Additional context

This change is part of ongoing efforts to optimize the compiler's memory usage and performance. The modifications maintain the same functionality while reducing allocations in the hot path of the lowering phase.