### PR TITLE
Replace ids in tests

### DIFF
--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -76,6 +76,7 @@ impl<'db> TestRunner<'db> {
                 contract_crate_ids: None,
                 executable_crate_ids: None,
                 add_functions_debug_info: false,
+                replace_ids: false,
             },
         )?;
         Ok(Self { compiler, config, custom_hint_processor_factory: None })

--- a/crates/cairo-lang-test-runner/src/test.rs
+++ b/crates/cairo-lang-test-runner/src/test.rs
@@ -25,6 +25,7 @@ fn test_compiled_serialization() {
             contract_declarations: None,
             contract_crate_ids: None,
             executable_crate_ids: None,
+            replace_ids: false,
         },
     )
     .unwrap();


### PR DESCRIPTION
It would make coding `cairo-debugger` billion times easier (much better logs)