### PR TITLE
docs: remove outdated WIP label from memory model ABI reference

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/memory-model.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/memory-model.adoc
@@ -83,11 +83,11 @@ The assembler and runner code define instruction flags and memory helpers that d
 semantics at execution time (e.g., `ApUpdate`, `FpUpdate`, creating new segments, reading/writing
 buffers).
 
-== Out of scope / WIP
+== Out of scope
 
 This page intentionally does not fix the exact Application Binary Interface (ABI) layout or a
 formal, stable layout for all composite types in VM memory. Those details are covered by the ABI
-specification and may evolve. Refer to the ABI page when stabilized.
+specification and may evolve. Refer to the ABI page.
 
 See also:
 


### PR DESCRIPTION
## Summary
Removes the "WIP" label from the "Out of scope" section in the memory model documentation and updates the text to reference the ABI page directly, removing the implication that the ABI specification is still pending stabilization.
---
## Type of change
-  Documentation change with concrete technical impact
---
## Why is this change needed?
 The ABI documentation is now considered stable (as reflected in recent updates like #9568). However, the memory model documentation still contained a "WIP" header and text instructing readers to refer to the ABI page "when stabilized." This information is incorrect and misleading, as it implies the ABI spec is currently incomplete or unstable.
---
## What was the behavior or documentation before?
  - Section Header: `== Out of scope / WIP`
  - Text: "...Refer to the ABI page when stabilized."
---
## What is the behavior or documentation after?
- Section Header: `== Out of scope`
- Text: "...Refer to the ABI page."
---
## Related issue or discussion (if any)
 Follow-up to PR #9568 which removed the WIP label from the ABI link itself.
---
## Additional context
 This ensures consistency across the reference documentation regarding the maturity of the ABI specification.