### PR TITLE
docs: fix broken xref links in let-statement

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/let-statement.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/let-statement.adoc
@@ -17,7 +17,7 @@ insufficient type information is available for definite inference.
 
 == Patterns
 
-The `let` statement uses xref:pages/patterns.adoc[patterns] to bind values to variables.
+The `let` statement uses xref:patterns.adoc[patterns] to bind values to variables.
 Patterns allow you to destructure data and bind their components to variables.
 
 Simple variable binding:
@@ -47,7 +47,7 @@ let (x, _, z) = (1, 2, 3);  // Ignore second value
 let Point { x, y: _ } = point;  // Ignore y field
 ----
 
-See xref:pages/patterns.adoc[Patterns] for more details.
+See xref:patterns.adoc[Patterns] for more details.
 
 == Mutability
 
@@ -63,7 +63,7 @@ let mut y = 5;
 y = 6;  // OK: y is mutable
 ----
 
-Mutable variables can be reassigned using xref:pages/assignment-statement.adoc[assignment].
+Mutable variables can be reassigned using xref:assignment-statement.adoc[assignment].
 
 Mutability can be combined with patterns:
 [source,cairo]
@@ -77,7 +77,7 @@ y = 20;  // OK
 ====
 Mutability in Cairo is local to the variable binding.
 Reassigning a mutable variable does not affect other references to the value.
-See xref:pages/variables.adoc[Variables] for more details.
+See xref:variables.adoc[Variables] for more details.
 ====
 
 == Variable scope and shadowing


### PR DESCRIPTION
 ## Summary
 Fixed broken internal `xref` links in the `let-statement.adoc` file by removing the incorrect `pages/` prefix from relative paths.
 ---
## Type of change
 Please check **one**:
 - [ ] Bug fix (fixes incorrect behavior)
 - [ ] New feature
 - [ ] Performance improvement
 - [x] Documentation change with concrete technical impact
 - [ ] Style, wording, formatting, or typo-only change
 ---
## Why is this change needed?
The links to `patterns.adoc`, `assignment-statement.adoc`, and `variables.adoc` were broken. Since `let-statement.adoc` is already located inside the `pages/` directory, the `xref:pages/...` notation caused the documentation generator to look for a non-existent nested `pages/pages/` directory. This prevented users from navigating between related language construct pages.
 ---
 ## What was the behavior or documentation before?
 Documentation contained dead links using the path `xref:pages/patterns.adoc`, which resolved to an invalid file location.
---
 ## What is the behavior or documentation after?
 Links now use the correct relative path `xref:patterns.adoc`, allowing for seamless navigation to the referenced sections.
 ---
 ## Related issue or discussion (if any)
Similar to the fixes implemented in #9537.
 ---
## Additional context
 Ensuring all cross-references in the reference manual are functional is critical for developer onboarding and usability.