### PR TITLE
Remove redundant state reset in TestBuilder

### DIFF
--- a/crates/cairo-lang-test-utils/src/parse_test_file.rs
+++ b/crates/cairo-lang-test-utils/src/parse_test_file.rs
@@ -129,7 +129,6 @@ impl TestBuilder {
                 self.current_test_name.as_ref().unwrap_or(&"<unknown>".into())
             );
             attributes.insert(tag.name, tag.content.trim().to_string());
-            self.current_tag = None;
         }
     }
 
@@ -409,7 +408,7 @@ pub fn run_test_file(
     let mut failed_tests = Vec::new();
     for (test_name, mut test) in tests {
         if !test_name.contains(&filter) {
-            new_tests.insert(test_name.to_string(), test);
+            new_tests.insert(test_name, test);
             continue;
         }
         let line_num = test.line_num;


### PR DESCRIPTION
Why: close_open_tag already clears current_tag via take(), so the extra current_tag = None was dead code.
What: Removed the redundant assignment to keep the function minimal and clear.
