### PR TITLE
docs: fix broken link and grammar in language constructs

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/bitwise-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/bitwise-operators.adoc
@@ -77,7 +77,7 @@ fn main() {
 }
 ----
 
-See xref:pages/boolean-operators.adoc[Boolean operators] for more details on the difference
+See xref:boolean-operators.adoc[Boolean operators] for more details on the difference
 between bitwise and logical operators on `bool`.
 
 === Manual implementation for a custom type

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/implicit-arguments.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/implicit-arguments.adoc
@@ -2,7 +2,7 @@
 
 Implicit arguments in Cairo are parameters that are automatically passed
 to functions without being explicitly specified at each call site.
-They provide context for low-level operation like range checking and gas tracking.
+They provide context for low-level operations like range checking and gas tracking.
 
 == Overview
 
@@ -59,7 +59,7 @@ extern fn withdraw_gas() -> Option<()> implicits(RangeCheck, GasBuiltin) nopanic
 ----
 
 The `GasBuiltin` implicit tracks computational resources
-to prevent infinite loop and excessive computation.
+to prevent infinite loops and excessive computation.
 
 === System
 
@@ -78,7 +78,7 @@ The `System` implicit provides access to Starknet's state and operations.
 == Automatic propagation
 
 Implicit arguments are automatically propagated through the call stack.
-When a function with implicits call another function that requires the same implicits,
+When a function with implicits calls another function that requires the same implicits,
 they're passed automatically:
 
 [source,cairo]
@@ -139,7 +139,7 @@ needed for the operation.
 
 == Notes
 
-* Implicits are used in Sierra libfuncs, which are defined as `extern` function
+* Implicits are used in Sierra libfuncs, which are defined as `extern` functions
   at the core library code
 * Most applications code doesn't need to explicitly manage implicits
 * The compiler automatically handles implicit threading through the call stack


### PR DESCRIPTION
## Summary
This PR fixes a broken internal link in the bitwise operators documentation and corrects several grammar/pluralization errors in the implicit arguments section.
---
## Type of change
Please check **one**:
- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change
---
## Why is this change needed?
 1. **Broken Link**: In `bitwise-operators.adoc`, the reference to boolean operators used an incorrect `pages/` prefix, leading to a dead link for users.
2. **Grammar Errors**: The `implicit-arguments.adoc` file contained several typos and subject-verb agreement issues (e.g., "function... call" instead of "calls", "infinite loop" instead of "loops") that detracted from the documentation's clarity and professionalism.
---
## What was the behavior or documentation before?
- In `bitwise-operators.adoc`, the link `xref:pages/boolean-operators.adoc` was broken.
- In `implicit-arguments.adoc`, text included "low-level operation", "implicits call", "infinite loop", and "extern function".
---
## What is the behavior or documentation after?
 - The link now correctly points to `xref:boolean-operators.adoc`.
- The grammar has been polished to "low-level operations", "implicits calls", "infinite loops", and "extern functions".
---
 ## Related issue or discussion (if any)
Continuation of documentation maintenance efforts similar to #9537.
---
## Additional context
 Fixing broken links ensures the reference manual remains a reliable source of truth, while grammar corrections improve readability for the developer community.