### PR TITLE
performance(ci): Made cairo tests run in release.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,30 +123,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: scripts/cairo_fmt.sh --check
 
-  parallel-cairo-tests:
+  # Checks that all Cairo code tests run correctly.
+  cairotest:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cmd:
-          - corelib/
-          - tests/bug_samples --starknet
-          - crates/cairo-lang-starknet/cairo_level_tests/ --starknet
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: |
-          cargo run --profile=ci-dev --bin cairo-test -- ${{ matrix.cmd }}
-  # Checks that all Cairo code tests run correctly.
-  cairotest:
-    if: ${{ always() }}
-    needs: parallel-cairo-tests
-    runs-on: ubuntu-latest
-    steps:
-      - if: needs.parallel-cairo-tests.result == 'success'
-        run: exit 0
-      - if: needs.parallel-cairo-tests.result != 'success'
-        run: exit 1
+          cargo run --profile=release --bin cairo-test -- corelib/
+      - run: |
+          cargo run --profile=release --bin cairo-test -- tests/bug_samples --starknet
+      - run: |
+          cargo run --profile=release --bin cairo-test -- crates/cairo-lang-starknet/cairo_level_tests/ --starknet
 
   # Checks that error codes are not duplicated.
   error-code-check:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,19 @@ jobs:
       - run: >
           scripts/clippy.sh
 
+  cairotest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          cargo run --profile=ci-dev --bin cairo-test -- corelib/
+      - run: |
+          cargo run --profile=ci-dev --bin cairo-test -- tests/bug_samples --starknet
+      - run: |
+          cargo run --profile=ci-dev --bin cairo-test -- crates/cairo-lang-starknet/cairo_level_tests/ --starknet
+
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Changed CI workflow by removing the parallel-cairo-tests job and integrating its functionality directly into the cairotest job. The tests that were previously run in parallel are now executed sequentially in the cairotest job, but being run in release. Also added a cairotest job to the nightly workflow that runs the same Cairo tests with the ci-dev profile.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The current CI ran in ci-dev, which is much slower. This change enhances the CI process to run in release. Additionally, adding the cairotest job to the nightly workflow ensures these tests are run regularly with the ci-dev profile.

---

## What was the behavior or documentation before?

Cairo tests were run in parallel in a separate job (parallel-cairo-tests) with a matrix strategy, and the cairotest job only checked if the parallel job succeeded. The nightly workflow did not include Cairo tests.

---

## What is the behavior or documentation after?

The cairotest job now directly runs all the Cairo tests sequentially without depending on a separate parallel job. The same tests are also run in the nightly workflow with the ci-dev profile.

---

## Additional context

This change simplifies the CI workflow structure while maintaining the same test coverage. Running the tests sequentially might take slightly longer but eliminates the overhead of managing parallel jobs.