### PR TITLE
(feat): Creating forward analysis for the dataflow framework

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/forward.rs
+++ b/crates/cairo-lang-lowering/src/analysis/forward.rs
@@ -1,0 +1,141 @@
+//! Forward dataflow analysis runner.
+//!
+//! This module provides `FwdAnalysis`, which traverses the control flow graph in forward
+//! (topological) order, computing dataflow information from function entry to exits.
+use crate::analysis::core::{DataflowAnalyzer, Direction, Edge};
+use crate::{BlockEnd, BlockId, Lowered};
+
+/// Forward analysis runner.
+///
+/// Traverses the CFG in topological order (from entry towards exits), processing
+/// statements in forward order within each block.
+///
+/// The runner automatically handles:
+/// - Block/statement traversal via `transfer_block`
+/// - Variable remapping at gotos (via `transfer_edge`)
+/// - State distribution to match arms (via `transfer_edge`)
+/// - State joining at convergence points (via `merge`)
+pub struct ForwardDataflowAnalysis<'db, 'a, TAnalyzer: DataflowAnalyzer<'db, 'a>> {
+    lowered: &'a Lowered<'db>,
+    pub analyzer: TAnalyzer,
+    /// Number of predecessors for each block (pre-computed).
+    predecessor_counts: Vec<usize>,
+    /// Incoming edges: (source_block_id, info). Cleared when block is processed.
+    incoming: Vec<Option<TAnalyzer::Info>>,
+}
+
+impl<'db, 'a, TAnalyzer: DataflowAnalyzer<'db, 'a>> ForwardDataflowAnalysis<'db, 'a, TAnalyzer> {
+    /// Creates a new FwdAnalysis instance.
+    pub fn new(lowered: &'a Lowered<'db>, analyzer: TAnalyzer) -> Self {
+        debug_assert!(
+            TAnalyzer::DIRECTION == Direction::Forward,
+            "FwdAnalysis requires an analyzer with DIRECTION == Forward"
+        );
+        let predecessor_counts = compute_predecessor_counts(lowered);
+        let incoming = vec![None; lowered.blocks.len()];
+        Self { lowered, analyzer, predecessor_counts, incoming }
+    }
+
+    /// Runs the forward analysis and returns the exit info for each block.
+    ///
+    /// For acyclic CFGs, this processes blocks in topological order.
+    /// Returns the exit info Vec indexed by BlockId.
+    pub fn run(&mut self) -> Vec<Option<TAnalyzer::Info>> {
+        let n_blocks = self.lowered.blocks.len();
+        let mut block_info: Vec<Option<TAnalyzer::Info>> = vec![None; n_blocks];
+
+        // Root block has 0 predecessors, so it's immediately ready.
+        let root_id = BlockId::root();
+        self.incoming[root_id.0] =
+            Some(self.analyzer.initial_info(root_id, &self.lowered.blocks[root_id].end));
+        let mut ready: Vec<BlockId> = vec![root_id];
+
+        while let Some(block_id) = ready.pop() {
+            let block = &self.lowered.blocks[block_id];
+
+            // Get entry info from incoming edges.
+            let mut info = self.incoming[block_id.0].clone().unwrap();
+
+            // Process block.
+            self.analyzer.visit_block_start(&mut info, block_id, block);
+            self.analyzer.transfer_block(&mut info, block_id, block);
+
+            // Transfer to successors and check readiness.
+            self.propagate_to_successors(block_id, &info, &mut ready);
+
+            block_info[block_id.0] = Some(info);
+        }
+
+        block_info
+    }
+
+    /// Propagate info to all successors and mark them ready if all predecessors are done.
+    fn propagate_to_successors(
+        &mut self,
+        block_id: BlockId,
+        info: &TAnalyzer::Info,
+        ready: &mut Vec<BlockId>,
+    ) {
+        let block = &self.lowered.blocks[block_id];
+        match &block.end {
+            BlockEnd::Goto(target, remapping) => {
+                let edge = Edge::Goto { target: *target, remapping };
+                let target_info = self.analyzer.transfer_edge(info, &edge);
+                self.add_and_maybe_ready(*target, target_info, ready);
+            }
+            BlockEnd::Match { info: match_info } => {
+                for arm in match_info.arms() {
+                    let edge = Edge::MatchArm { arm, match_info };
+                    let arm_info = self.analyzer.transfer_edge(info, &edge);
+                    self.add_and_maybe_ready(arm.block_id, arm_info, ready);
+                }
+            }
+            BlockEnd::Return(..) | BlockEnd::Panic(_) => {
+                // Terminal blocks, no successors.
+            }
+            BlockEnd::NotSet => unreachable!("Block end not set"),
+        }
+    }
+
+    /// Add incoming info and mark target ready if all predecessors have contributed.
+    ///
+    /// When multiple predecessors contribute to a block, their info is merged.
+    fn add_and_maybe_ready(
+        &mut self,
+        target: BlockId,
+        info: TAnalyzer::Info,
+        ready: &mut Vec<BlockId>,
+    ) {
+        let merged_info = match self.incoming[target.0].take() {
+            Some(existing) => self.analyzer.merge(self.lowered, (target, 0), existing, info),
+            None => info,
+        };
+        self.incoming[target.0] = Some(merged_info);
+        self.predecessor_counts[target.0] -= 1;
+        if self.predecessor_counts[target.0] == 0 {
+            ready.push(target);
+        }
+    }
+}
+
+/// Computes the number of predecessors for each block.
+fn compute_predecessor_counts(lowered: &Lowered<'_>) -> Vec<usize> {
+    let n_blocks = lowered.blocks.len();
+    let mut counts = vec![0usize; n_blocks];
+
+    for (_, block) in lowered.blocks.iter() {
+        match &block.end {
+            BlockEnd::Goto(target, _) => {
+                counts[target.0] += 1;
+            }
+            BlockEnd::Match { info } => {
+                for arm in info.arms() {
+                    counts[arm.block_id.0] += 1;
+                }
+            }
+            BlockEnd::Return(..) | BlockEnd::Panic(_) | BlockEnd::NotSet => {}
+        }
+    }
+
+    counts
+}

--- a/crates/cairo-lang-lowering/src/analysis/mod.rs
+++ b/crates/cairo-lang-lowering/src/analysis/mod.rs
@@ -4,16 +4,18 @@
 //! optimization passes and semantic checks.
 
 pub mod backward;
-pub mod core;
-
-pub use core::{DataflowAnalyzer, Direction, Edge};
-
 pub use backward::{BackAnalysis, DataflowBackAnalysis};
 
-use crate::{Block, BlockId, MatchInfo, Statement, VarRemapping, VarUsage};
+pub mod core;
+pub use core::{DataflowAnalyzer, Direction, Edge, StatementLocation};
 
-/// Location of a lowering statement inside a block.
-pub type StatementLocation = (BlockId, usize);
+pub mod forward;
+pub use forward::ForwardDataflowAnalysis;
+
+#[cfg(test)]
+mod test;
+
+use crate::{Block, BlockId, MatchInfo, Statement, VarRemapping, VarUsage};
 
 /// Analyzer trait to implement for each specific analysis.
 #[allow(unused_variables)]

--- a/crates/cairo-lang-lowering/src/analysis/test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/test.rs
@@ -1,0 +1,191 @@
+//! Tests for the dataflow analysis framework.
+
+use std::collections::HashSet;
+
+use cairo_lang_semantic::test_utils::setup_test_function;
+use cairo_lang_utils::Intern;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+
+use super::core::{DataflowAnalyzer, Direction, StatementLocation};
+use super::forward::ForwardDataflowAnalysis;
+use crate::db::LoweringGroup;
+use crate::ids::FunctionWithBodyLongId;
+use crate::test_utils::LoweringDatabaseForTesting;
+use crate::{Block, BlockEnd, BlockId, Lowered};
+
+// ============================================================================
+// Block-level Analysis: Count blocks (demonstrates transfer_block override)
+// ============================================================================
+
+/// A simple block-level analyzer that counts blocks.
+/// Demonstrates overriding transfer_block for coarse-grained analysis.
+#[derive(Default)]
+struct BlockCounter {
+    block_count: usize,
+}
+
+impl<'db, 'a> DataflowAnalyzer<'db, 'a> for BlockCounter {
+    type Info = usize; // Count of blocks seen
+
+    const DIRECTION: Direction = Direction::Forward;
+
+    fn initial_info(&mut self, _block_id: BlockId, _block_end: &'a BlockEnd<'db>) -> Self::Info {
+        0
+    }
+
+    fn merge(
+        &mut self,
+        _lowered: &Lowered<'db>,
+        _statement_location: StatementLocation,
+        info1: Self::Info,
+        info2: Self::Info,
+    ) -> Self::Info {
+        info1.max(info2)
+    }
+
+    // Override transfer_block for block-level analysis (no statement iteration)
+    fn transfer_block(
+        &mut self,
+        info: &mut Self::Info,
+        _block_id: BlockId,
+        _block: &'a Block<'db>,
+    ) {
+        self.block_count += 1;
+        *info += 1;
+    }
+}
+
+// ============================================================================
+// Statement-level Analysis: Track reachable blocks (uses default transfer_block)
+// ============================================================================
+
+/// A simple forward analyzer that tracks which blocks are reachable.
+/// Demonstrates using default transfer_block with statement-level transfer_stmt.
+#[derive(Default)]
+struct ReachabilityAnalyzer {
+    reachable_blocks: HashSet<BlockId>,
+}
+
+impl<'db, 'a> DataflowAnalyzer<'db, 'a> for ReachabilityAnalyzer {
+    type Info = HashSet<BlockId>; // Set of blocks visited to reach this point
+
+    const DIRECTION: Direction = Direction::Forward;
+
+    fn initial_info(&mut self, _block_id: BlockId, _block_end: &'a BlockEnd<'db>) -> Self::Info {
+        HashSet::new()
+    }
+
+    fn merge(
+        &mut self,
+        _lowered: &Lowered<'db>,
+        _statement_location: StatementLocation,
+        info1: Self::Info,
+        info2: Self::Info,
+    ) -> Self::Info {
+        // Union of two reachability sets
+        let mut result = info1;
+        result.extend(info2);
+        result
+    }
+
+    // Uses default transfer_block which iterates statements.
+    // transfer_stmt is no-op (default) since reachability doesn't change at statements.
+
+    fn visit_block_start(&mut self, info: &mut Self::Info, block_id: BlockId, _block: &Block<'db>) {
+        self.reachable_blocks.insert(block_id);
+        info.insert(block_id);
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn test_block_level_analysis() {
+    let db = LoweringDatabaseForTesting::default();
+    let inputs = OrderedHashMap::from([
+        (
+            "function_code".to_string(),
+            "fn foo(x: bool) -> felt252 { if x { 1 } else { 2 } }".to_string(),
+        ),
+        ("function_name".to_string(), "foo".to_string()),
+        ("module_code".to_string(), "".to_string()),
+    ]);
+    let (test_function, _) = setup_test_function(&db, &inputs).split();
+    let lowered = db
+        .function_with_body_lowering(
+            FunctionWithBodyLongId::Semantic(test_function.function_id).intern(&db),
+        )
+        .unwrap();
+
+    let analyzer = BlockCounter::default();
+    let mut analysis = ForwardDataflowAnalysis::new(lowered, analyzer);
+    let _ = analysis.run();
+
+    // Block-level analyzer should have counted multiple blocks
+    assert!(
+        analysis.analyzer.block_count >= 2,
+        "Expected at least 2 blocks, got {}",
+        analysis.analyzer.block_count
+    );
+}
+
+#[test]
+fn test_forward_single_block() {
+    let db = LoweringDatabaseForTesting::default();
+    let inputs = OrderedHashMap::from([
+        ("function_code".to_string(), "fn foo() {}".to_string()),
+        ("function_name".to_string(), "foo".to_string()),
+        ("module_code".to_string(), "".to_string()),
+    ]);
+    let (test_function, _) = setup_test_function(&db, &inputs).split();
+    let lowered = db
+        .function_with_body_lowering(
+            FunctionWithBodyLongId::Semantic(test_function.function_id).intern(&db),
+        )
+        .unwrap();
+
+    let analyzer = ReachabilityAnalyzer::default();
+    let mut analysis = ForwardDataflowAnalysis::new(lowered, analyzer);
+    let _ = analysis.run();
+
+    // Should have visited at least the root block
+    assert!(!analysis.analyzer.reachable_blocks.is_empty());
+    assert!(analysis.analyzer.reachable_blocks.contains(&BlockId::root()));
+}
+
+#[test]
+fn test_forward_with_branching() {
+    let db = LoweringDatabaseForTesting::default();
+    // A function with branching creates multiple blocks
+    let inputs = OrderedHashMap::from([
+        (
+            "function_code".to_string(),
+            "fn foo(x: bool) -> felt252 { if x { 1 } else { 2 } }".to_string(),
+        ),
+        ("function_name".to_string(), "foo".to_string()),
+        ("module_code".to_string(), "".to_string()),
+    ]);
+    let (test_function, _) = setup_test_function(&db, &inputs).split();
+    let lowered = db
+        .function_with_body_lowering(
+            FunctionWithBodyLongId::Semantic(test_function.function_id).intern(&db),
+        )
+        .unwrap();
+
+    let analyzer = ReachabilityAnalyzer::default();
+    let mut analysis = ForwardDataflowAnalysis::new(lowered, analyzer);
+    let exit_info = analysis.run().clone();
+
+    // With branching, should visit multiple blocks
+    assert!(
+        analysis.analyzer.reachable_blocks.len() >= 2,
+        "Expected at least 2 reachable blocks with branching"
+    );
+
+    // All processed blocks should have exit info
+    for block_id in &analysis.analyzer.reachable_blocks {
+        assert!(exit_info[block_id.0].is_some(), "Block {:?} should have exit info", block_id);
+    }
+}


### PR DESCRIPTION
## Summary

Added a forward dataflow analysis framework to complement the existing backward analysis. This implementation traverses the control flow graph in topological order (from entry towards exits), processing statements in forward order within each block.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The codebase already had a backward dataflow analysis framework, but lacked a forward analysis counterpart. Forward analysis is essential for many compiler optimizations and static analyses that need to follow program execution flow from entry to exit points. This implementation enables writing analyzers that track information as it flows through the program in execution order.

---

## What is the behavior or documentation after?

The PR adds:
- A `ForwardDataflowAnalysis` class that traverses the CFG in topological order
- Support for block/statement traversal, variable remapping, state distribution to match arms, and state joining
- Comprehensive test cases demonstrating both block-level and statement-level analyses
- Removed `#[expect(dead_code)]` attributes from the core analysis components that are now used

The implementation also includes two example analyzers in the test module:
1. A block counter that demonstrates block-level analysis
2. A reachability analyzer that tracks which blocks are reachable

---

## Additional context

This implementation completes the dataflow analysis framework by providing both forward and backward analysis capabilities, which are fundamental building blocks for various compiler optimizations and static analyses.