### PR TITLE
Docs: Add link to missing content list in index page

### DIFF
--- a/docs/reference/src/components/cairo/modules/ROOT/pages/index.adoc
+++ b/docs/reference/src/components/cairo/modules/ROOT/pages/index.adoc
@@ -23,7 +23,7 @@ This documentation site is a work in progress. You are very welcome to contribut
 documentation by link:https://github.com/starkware-libs/cairo/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22[submitting a pull request].
 
 Please see xref:how-to-contribute.adoc[here] for a list of missing content and learn more about
-how to contribute by reading the xref:../appendices/pages/contribution-guidelines.adoc[Contribution guidelines] of this
+how to contribute by reading the xref:../../appendices/pages/contribution-guidelines.adoc[Contribution guidelines] of this
 site.
 
 |===


### PR DESCRIPTION
## Summary

This PR updates the index page to include a direct link to the `how-to-contribute` page, which lists the missing documentation content. This helps potential contributors easily find areas where they can help.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, the main page linked to the contribution guidelines but not to the specific list of missing content in `how-to-contribute.adoc`. This change improves the visibility of "help wanted" documentation tasks, making it easier for new contributors to find where they can contribute.

---

## What was the behavior or documentation before?

The index page only linked to `contribution-guidelines.adoc` and the issue tracker.

---

## What is the behavior or documentation after?

The index page now includes a specific link to `how-to-contribute.adoc` for a list of missing content, alongside the `contribution-guidelines.adoc` link.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

This makes the "Documentation contributions needed" section more accessible from the landing page.