### PR TITLE
refactor: remove unused lifetime from ElementList::elements

### DIFF
--- a/crates/cairo-lang-syntax/src/node/element_list.rs
+++ b/crates/cairo-lang-syntax/src/node/element_list.rs
@@ -21,7 +21,7 @@ impl<'db, T: TypedSyntaxNode<'db>> ElementList<'db, T, 1> {
     pub fn elements_vec(&self, db: &'db dyn Database) -> Vec<T> {
         self.elements(db).collect()
     }
-    pub fn elements<'a: 'db>(
+    pub fn elements(
         &self,
         db: &'db dyn Database,
     ) -> impl ExactSizeIterator<Item = T> + DoubleEndedIterator + use<'db, T> {


### PR DESCRIPTION
## Summary

Remove the redundant 'a lifetime parameter from the elements method of ElementList<'db, T, 1>, keeping the use<'db, T> bound intact and aligning the method signature with the STEP=2 implementation.

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?


`ElementList<'db, T, 1>::elements` declared an extra 'a: 'db lifetime parameter that was never used in the signature, the return type, or the body. This added noise to the API and could trigger compiler warnings without providing any additional safety or behavior.
