### PR TITLE
docs: rewrite comments documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/comments.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/comments.adoc
@@ -1,10 +1,57 @@
 = Comments
 
-Comments follow the general C++/Rust style of line (`//`) comments.
+Cairo supports three types of comments: line comments, doc comments, and
+module-level doc comments.
+All comments follow the general C++/Rust style.
 
-== Example
+== Line Comments
+
+Line comments begin with `//` and continue to the end of the line.
+They are used for explanatory notes within code:
 
 [source,cairo]
 ----
-// Comment.
+// Test simple access.
+let ba: ByteArray = "AB";
+let span = ba.span();
 ----
+
+== Doc Comments
+
+Doc comments begin with `///` and are used to document items like types,
+functions, and traits.
+They appear directly before the item they document:
+
+[source,cairo]
+----
+/// A `Box` is a type that points to a wrapped value.
+/// It allows for cheap moving around of the value, as its size is small, and may wrap a large size.
+pub extern type Box<T>;
+----
+
+Doc comments support markdown formatting and are typically used to generate
+documentation.
+
+== Module-level Doc Comments
+
+Module-level doc comments begin with `//!` and document the containing module
+itself.
+They typically appear at the top of a file:
+
+[source,cairo]
+----
+//! Overloadable operators.
+//!
+//! Implementing these traits allows you to overload certain operators.
+//!
+//! > Note: Other overloadable operators are also defined in the
+//! > [`core::traits`] module.
+----
+
+Module-level doc comments provide an overview of the module's purpose and
+contents.
+
+== Related
+
+- xref:items.adoc[Items] — Elements that can be documented
+- xref:module.adoc[Modules] — Module organization


### PR DESCRIPTION
## Summary

Rewrote the comments documentation to include doc comments (`///`) and module-level comments (`//!`), providing a complete overview of commenting styles.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The previous documentation only mentioned line comments (`//`) and ignored documentation comments, which are essential for documenting APIs.

---

## What was the behavior or documentation before?

The file contained a single sentence about line comments.

---

## What is the behavior or documentation after?

The file now details all three comment types with examples showing how to use them for code explanation and documentation generation.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

<!--
Anything else reviewers should know.
If this is a documentation PR, explain why this change is important for users.
-->