### PR TITLE
bugfix(formatter): Made formatter keep `;` when causes ambiguity.

### DIFF
--- a/crates/cairo-lang-formatter/test_data/cairo_files/test1.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/test1.cairo
@@ -64,3 +64,16 @@ fn if_let_test() {
 impl DropMyImplCoupon<T> of Drop<MyImpl::<T>::trait_fn::Coupon>;
 impl DropMyImplCoupon<T> of Drop<MyImpl::<T>::trait_fn>;
 impl DropMyImplCoupon<T> of Drop<MyImpl::<T>>;
+
+// Test that semicolons are preserved when next statement starts with a post operator.
+fn semicolon_preservation_test() {
+    // Semicolon should be preserved - next starts with [ (array literal vs indexing)
+    if true { return; };
+    [1, 2, 3];
+    // Semicolon should be preserved - next starts with - (negation vs subtraction)
+    if true { return; };
+    -5;
+    // Semicolon should be removed - next starts with identifier (not a post operator)
+    if true { return; };
+    foo();
+}

--- a/crates/cairo-lang-formatter/test_data/expected_results/test1.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/test1.cairo
@@ -74,3 +74,22 @@ fn if_let_test() {
 impl DropMyImplCoupon<T> of Drop<MyImpl::<T>::trait_fn::Coupon>;
 impl DropMyImplCoupon<T> of Drop<MyImpl::<T>::trait_fn>;
 impl DropMyImplCoupon<T> of Drop<MyImpl<T>>;
+
+// Test that semicolons are preserved when next statement starts with a post operator.
+fn semicolon_preservation_test() {
+    // Semicolon should be preserved - next starts with [ (array literal vs indexing)
+    if true {
+        return;
+    };
+    [1, 2, 3];
+    // Semicolon should be preserved - next starts with - (negation vs subtraction)
+    if true {
+        return;
+    };
+    -5;
+    // Semicolon should be removed - next starts with identifier (not a post operator)
+    if true {
+        return;
+    }
+    foo();
+}


### PR DESCRIPTION
## Summary

Fixed the Cairo formatter to preserve semicolons when necessary to prevent ambiguity with post operators. The formatter now keeps semicolons after block expressions when the next statement starts with a post operator (like `[` or `-`) to avoid parsing errors where these operators could be misinterpreted as array indexing or subtraction operations.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The Cairo formatter was incorrectly removing semicolons in cases where they were necessary to disambiguate between different operators. This could lead to code that compiled before formatting but failed after formatting, particularly when a statement ending with a block expression was followed by a statement starting with a post operator.

---

## What was the behavior or documentation before?

The formatter would remove semicolons after block expressions (if, match, for, etc.) regardless of what came next, which could cause parsing errors when the next statement started with a character that could be interpreted as a post operator.

---

## What is the behavior or documentation after?

The formatter now preserves semicolons after block expressions when the next statement starts with a post operator (like `[` for array literals or `-` for negation). This prevents ambiguity and ensures the code maintains its original meaning after formatting.

---

## Additional context

Added test cases that demonstrate the correct preservation of semicolons in ambiguous situations, such as when a block expression is followed by an array literal or a negation operation.