### PR TITLE
perf: avoid redundant escape_node call in assert macro

### DIFF
--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -57,7 +57,6 @@ impl InlineMacroExprPlugin for AssertMacro {
             };
         };
         let f = "__formatter_for_assert_macro__";
-        let value_escaped = escape_node(db, value.as_syntax_node());
         let mut builder = PatchBuilder::new(db, syntax);
         builder.add_modified(RewriteNode::interpolate_patched(
             &formatdoc! {
@@ -69,6 +68,7 @@ impl InlineMacroExprPlugin for AssertMacro {
             &[("value".to_string(), RewriteNode::from_ast_trimmed(&value))].into(),
         ));
         if arguments.len() == 0 {
+            let value_escaped = escape_node(db, value.as_syntax_node());
             builder.add_str(&formatdoc!(
                 "core::result::ResultTrait::<(), core::fmt::Error>::unwrap(write!({f}, \
                  \"assertion failed: `{value_escaped}`.\"));\n",


### PR DESCRIPTION
## Summary

Moved the escape_node call for value_escaped into the branch that generates the default assertion message, so it is only evaluated when actually needed.

---

## Type of change

Please check **one**:


- [x] Performance improvement


---

## Why is this change needed?

- The assert inline macro always called escape_node on the condition expression, even when a custom error message was provided.
- This caused unnecessary string processing and allocation during compilation for assert! calls that never used the default "assertion failed: ..." message.
 

