### PR TITLE
Updated version of the used `typos` and handled its changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: crate-ci/typos@v1.41.0
+      - uses: crate-ci/typos@v1.43.0
 
   docs:
     runs-on: ubuntu-latest

--- a/_typos.toml
+++ b/_typos.toml
@@ -3,3 +3,4 @@
 ba = "ba"
 bimap = "bimap"
 compilability = "compilability"
+consts = "consts"


### PR DESCRIPTION
## Summary

Upgraded the `typos` GitHub Action from v1.41.0 to v1.43.0 and added "consts" to the list of allowed words in the `_typos.toml` configuration file.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The PR updates the typos checker to the latest version to benefit from any bug fixes and improvements in the newer release. Additionally, it adds "consts" to the allowed words list to prevent false positives in the typo checking process, as this is a valid programming term used in the codebase.

---

## What was the behavior or documentation before?

The CI was using an older version of the typos checker (v1.41.0) and "consts" was potentially being flagged as a typo.

---

## What is the behavior or documentation after?

The CI now uses the latest version of the typos checker (v1.43.0) and "consts" is properly recognized as a valid term, preventing false positives in typo detection.

---

## Additional context

This change helps maintain the CI infrastructure by keeping dependencies up to date while also improving the accuracy of the typo checking by recognizing common programming terminology.