### PR TITLE
(feat): Updated claude md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
-Please read AGENTS.md for project-specific guidelines.
+Do not read or grep crates/cairo-lang-syntax/src/node/ast.rs. Instead read crates/cairo-lang-syntax-codegen/src/generator.rs.
+
+When finishing a feature, run ./scripts/rust_fmt.sh and ./scripts/clippy.sh.


### PR DESCRIPTION
## Summary

Updated CLAUDE.md with two important developer guidelines:
1. Directs developers to read `crates/cairo-lang-syntax-codegen/src/generator.rs` instead of `crates/cairo-lang-syntax/src/node/ast.rs`
2. Adds instruction to run formatting and linting scripts (`./scripts/rust_fmt.sh` and `./scripts/clippy.sh`) after completing features

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Documentation change with concrete technical impact
- [ ] Performance improvement
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The updated documentation provides critical guidance for developers to:
1. Reference the correct source file when working with syntax components
2. Ensure code quality by running formatting and linting tools after feature completion

These guidelines will help prevent common development mistakes and maintain code quality standards.

---

## What was the behavior or documentation before?

Previously, CLAUDE.md only referenced AGENTS.md for project-specific guidelines without providing specific development workflow instructions.

---

## What is the behavior or documentation after?

CLAUDE.md now contains specific technical guidance about which files to reference for syntax work and explicit instructions for running quality checks after feature completion.

---

## Additional context

These documentation changes will help new contributors avoid common pitfalls in the development workflow and ensure consistent code quality across contributions.