### PR TITLE
Updating `enum_boxed_match` according to audit.

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -303,8 +303,8 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
             EnumConcreteLibfunc::BoxedMatch(EnumBoxedMatchConcreteLibfunc {
                 signature, ..
             }) => {
-                // For zero or one variants, no instructions are generated (no branching needed)
-                // For other cases, we need 1 AP change for loading the variant selector
+                // For zero or one variants, no instructions are generated (no branching needed).
+                // For other cases, we need 1 AP change for loading the variant selector.
                 let n = signature.branch_signatures.len();
                 if n <= 1 { vec![ApChange::Known(0); n] } else { vec![ApChange::Known(1); n] }
             }

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -407,14 +407,12 @@ pub fn core_libfunc_cost(
                 signature, ..
             }) => {
                 // BoxedMatch needs to load the variant selector with a double-deref (1 step)
-                // plus the regular match cost - but only when branching is actually needed
-                let n = signature.branch_signatures.len();
-                match n {
+                // plus the regular match cost - but only when branching is actually needed.
+                match signature.branch_signatures.len() {
                     0 => vec![],
-                    1 => vec![ConstCost::default().into()], // No branching needed for single
-                    // variant
+                    1 => vec![ConstCost::default().into()],
                     2 => vec![ConstCost::steps(2).into(); 2],
-                    _ => chain!(
+                    n => chain!(
                         iter::once(ConstCost::steps(2).into()),
                         itertools::repeat_n(ConstCost::steps(3).into(), n - 1)
                     )

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -2,9 +2,9 @@ use std::iter;
 
 use cairo_lang_casm::ap_change::ApplyApChange;
 use cairo_lang_casm::builder::CasmBuilder;
-use cairo_lang_casm::cell_expression::{CellExpression, CellOperator};
-use cairo_lang_casm::instructions::Instruction;
-use cairo_lang_casm::operand::{CellRef, DerefOrImmediate};
+use cairo_lang_casm::cell_expression::CellExpression;
+use cairo_lang_casm::instructions::{AssertEqInstruction, Instruction, InstructionBody};
+use cairo_lang_casm::operand::{CellRef, ResOperand};
 use cairo_lang_casm::{casm, casm_build_extend, casm_extend, cell_ref};
 use cairo_lang_sierra::extensions::ConcreteLibfunc;
 use cairo_lang_sierra::extensions::enm::{
@@ -419,7 +419,7 @@ fn build_enum_boxed_match(
 ) -> Result<CompiledInvocation, InvocationError> {
     let num_branches = builder.invocation.branches.len();
 
-    // Handle zero variants case - no instructions needed for uninhabited type
+    // Handle zero variants case - no instructions needed for uninhabited type.
     if num_branches == 0 {
         return Ok(builder.build(
             vec![],
@@ -428,68 +428,74 @@ fn build_enum_boxed_match(
         ));
     }
 
-    let [cell] = builder.try_get_single_cells()?;
-    let cell_ref = cell.to_deref().ok_or(InvocationError::InvalidReferenceExpressionForArgument)?;
+    let [input_ptr] = builder.try_get_single_cells()?;
+    let (mut boxed_enum_ptr, orig_offset) = input_ptr
+        .to_deref_with_offset()
+        .ok_or(InvocationError::InvalidReferenceExpressionForArgument)?;
 
-    // Calculate the size of each variant
-    let mut variant_sizes: Vec<i16> = Vec::new();
-    for variant_ty in &libfunc.variants {
-        let variant_size = *builder
-            .program_info
-            .type_sizes
-            .get(variant_ty)
-            .ok_or(InvocationError::InvalidReferenceExpressionForArgument)?;
-        variant_sizes.push(variant_size);
+    let orig_offset: i16 = orig_offset
+        .try_into()
+        .ok()
+        .ok_or(InvocationError::InvalidReferenceExpressionForArgument)?;
+
+    // For single variant enums, no branching is needed - just return the variant box.
+    if num_branches == 1 {
+        // The box should point to: base_addr + 1 (selector).
+        let variant_box = CellExpression::add_with_const(boxed_enum_ptr, orig_offset + 1);
+        let output_expressions_for_branch =
+            [ReferenceExpression::from_cell(variant_box)].into_iter();
+        return Ok(builder.build(vec![], vec![], [output_expressions_for_branch].into_iter()));
     }
 
-    // The enum size is 1 (selector) + max(variant_sizes)
-    let max_variant_size = variant_sizes.iter().max().copied().unwrap_or(0);
+    // Calculate the size of each variant.
+    let variant_sizes: Vec<i16> = libfunc
+        .variants
+        .iter()
+        .map(|variant_ty| builder.program_info.type_sizes.get(variant_ty).copied())
+        .collect::<Option<_>>()
+        .ok_or(InvocationError::InvalidReferenceExpressionForArgument)?;
 
-    let output_cellref = if num_branches > 1 {
-        let mut adjusted = cell_ref;
-        assert!(adjusted.apply_known_ap_change(1));
-        adjusted
-    } else {
-        cell_ref
-    };
+    // The enum size is 1 (selector) + max(variant_sizes).
+    let max_variant_size = *variant_sizes.iter().max().unwrap();
 
-    // For each branch, we need to create a reference to Box<Variant>
-    // The variant data starts at offset 1 + padding to skip to the variant
+    // Load the variant selector into a temporary - this is a double deref.
+    let instructions = vec![Instruction {
+        body: InstructionBody::AssertEq(AssertEqInstruction {
+            a: cell_ref!([ap]),
+            b: ResOperand::DoubleDeref(boxed_enum_ptr, orig_offset),
+        }),
+        inc_ap: true,
+        hints: vec![],
+    }];
+
+    // Fix boxed_enum_ptr to account for the `inc_ap` above.
+    assert!(boxed_enum_ptr.apply_known_ap_change(1));
+
+    // For each branch, we need to create a reference to Box<Variant>.
+    // The variant data starts at offset 1 + padding to skip to the variant.
     let output_expressions_for_branches = variant_sizes.iter().map(|&variant_size| {
-        // Calculate padding: the variant is right-aligned in the enum's value space
+        // Calculate padding: the variant is right-aligned in the enum's value space.
         let padding = max_variant_size - variant_size;
-        // The box should point to: base_addr + 1 (selector) + padding
-        let variant_offset = 1 + padding;
-        let variant_box = CellExpression::BinOp {
-            op: CellOperator::Add,
-            a: output_cellref,
-            b: DerefOrImmediate::Immediate(variant_offset.into()),
-        };
+        // The box should point to: base_addr + 1 (selector) + padding.
+        let variant_box = CellExpression::add_with_const(boxed_enum_ptr, orig_offset + 1 + padding);
 
         vec![ReferenceExpression::from_cell(variant_box)].into_iter()
     });
 
-    // For single variant enums, no branching is needed - just return the variant box
-    if num_branches == 1 {
-        return Ok(builder.build(vec![], vec![], output_expressions_for_branches));
-    }
-
-    // Load the variant selector into a temporary - this is a double deref
-    let instructions = casm! { [ap] = [[&cell_ref]], ap++; }.instructions;
     let variant_selector_cell = cell_ref!([ap - 1]);
 
     if num_branches == 2 {
         build_enum_match_short_ex(
             builder,
             variant_selector_cell,
-            output_expressions_for_branches.into_iter().map(|v| v.into_iter()),
+            output_expressions_for_branches,
             instructions,
         )
     } else {
         build_enum_match_long_ex(
             builder,
             variant_selector_cell,
-            output_expressions_for_branches.into_iter().map(|v| v.into_iter()),
+            output_expressions_for_branches,
             instructions,
         )
     }

--- a/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/structure.rs
@@ -14,7 +14,7 @@
 use cairo_lang_utils::try_extract_matches;
 
 use super::snapshot::snapshot_ty;
-use super::utils::{boxed_ty_with_optional_snapshot, peel_snapshot};
+use super::utils::peel_snapshot;
 use crate::define_libfunc_hierarchy;
 use crate::extensions::boxing::box_ty;
 use crate::extensions::lib_func::{
@@ -23,6 +23,7 @@ use crate::extensions::lib_func::{
 };
 use crate::extensions::type_specialization_context::TypeSpecializationContext;
 use crate::extensions::types::TypeInfo;
+use crate::extensions::utils::ty_with_optional_snapshot;
 use crate::extensions::{
     ConcreteType, NamedLibfunc, NamedType, OutputVarReferenceInfo, SignatureBasedConcreteLibfunc,
     SpecializationError, args_as_single_type,
@@ -321,7 +322,10 @@ impl StructBoxedDeconstructLibfunc {
         for member_ty in member_types.by_ref() {
             let ref_info = OutputVarReferenceInfo::SameAsParam { param_idx: 0 };
             outputs.push(OutputVarInfo {
-                ty: boxed_ty_with_optional_snapshot(context, member_ty.clone(), is_snapshot)?,
+                ty: box_ty(
+                    context,
+                    ty_with_optional_snapshot(context, member_ty.clone(), is_snapshot)?,
+                )?,
                 ref_info,
             });
             if !context.get_type_info(&member_ty)?.zero_sized {
@@ -332,7 +336,7 @@ impl StructBoxedDeconstructLibfunc {
         for member_ty in member_types {
             let ref_info = OutputVarReferenceInfo::Deferred(DeferredOutputKind::AddConst);
             outputs.push(OutputVarInfo {
-                ty: boxed_ty_with_optional_snapshot(context, member_ty, is_snapshot)?,
+                ty: box_ty(context, ty_with_optional_snapshot(context, member_ty, is_snapshot)?)?,
                 ref_info,
             });
         }

--- a/crates/cairo-lang-sierra/src/extensions/modules/utils.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/utils.rs
@@ -7,7 +7,6 @@ use num_traits::One;
 use starknet_types_core::felt::CAIRO_PRIME_BIGINT;
 
 use super::bounded_int::BoundedIntType;
-use super::boxing::box_ty;
 use super::bytes31::Bytes31Type;
 use super::int::signed::{Sint8Type, Sint16Type, Sint32Type, Sint64Type};
 use super::int::signed128::Sint128Type;
@@ -143,12 +142,11 @@ pub fn peel_snapshot<'a>(
     }
 }
 
-/// Helper to create a boxed output variable for unpack operations.
-pub fn boxed_ty_with_optional_snapshot(
+/// Helper to optionally wrap a type with `Snapshot<>`.
+pub fn ty_with_optional_snapshot(
     context: &dyn SignatureSpecializationContext,
-    component_ty: ConcreteTypeId,
+    ty: ConcreteTypeId,
     is_snapshot: bool,
 ) -> Result<ConcreteTypeId, SpecializationError> {
-    let inner_type = if is_snapshot { snapshot_ty(context, component_ty)? } else { component_ty };
-    box_ty(context, inner_type)
+    if is_snapshot { snapshot_ty(context, ty) } else { Ok(ty) }
 }

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/audited.json
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/audited.json
@@ -64,6 +64,7 @@
       "ec_state_try_finalize_nz": null,
       "emit_event_syscall": null,
       "enable_ap_tracking": null,
+      "enum_boxed_match": { "major": 1, "minor": 8, "patch": 0 },
       "enum_from_bounded_int": null,
       "enum_init": null,
       "enum_match": null,

--- a/tests/e2e_test_data/libfuncs/enum
+++ b/tests/e2e_test_data/libfuncs/enum
@@ -506,42 +506,34 @@ enum Single {
     Value: felt252,
 }
 
-enum BoxedSingle {
-    Value: Box<felt252>,
-}
+extern fn enum_boxed_match<T>(e: Box<T>) -> Box<felt252> nopanic;
 
-extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedSingle nopanic;
-
-fn foo(e: Box<Single>) -> BoxedSingle {
+fn foo(e: Box<Single>) -> Box<felt252> {
     enum_boxed_match(e)
 }
 
 //! > casm
-[ap + 0] = 0, ap++;
 [ap + 0] = [fp + -3] + 1, ap++;
 ret;
 
 //! > function_costs
-test::foo: SmallOrderedMap({Const: 200})
+test::foo: SmallOrderedMap({Const: 100})
 
 //! > sierra_code
 type Box<test::Single> = Box<test::Single> [storable: true, drop: true, dup: true, zero_sized: false];
-type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
-type test::BoxedSingle = Enum<ut@test::BoxedSingle, Box<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
 type test::Single = Enum<ut@test::Single, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
 
 libfunc enum_boxed_match<test::Single> = enum_boxed_match<test::Single>;
-libfunc enum_init<test::BoxedSingle, 0> = enum_init<test::BoxedSingle, 0>;
-libfunc store_temp<test::BoxedSingle> = store_temp<test::BoxedSingle>;
+libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
 
 F0:
 enum_boxed_match<test::Single>([0]) -> ([1]);
-enum_init<test::BoxedSingle, 0>([1]) -> ([2]);
-store_temp<test::BoxedSingle>([2]) -> ([2]);
-return([2]);
+store_temp<Box<felt252>>([1]) -> ([1]);
+return([1]);
 
-test::foo@F0([0]: Box<test::Single>) -> (test::BoxedSingle);
+test::foo@F0([0]: Box<test::Single>) -> (Box<felt252>);
 
 //! > ==========================================================================
 
@@ -746,6 +738,171 @@ store_temp<test::BoxedData>([4]) -> ([4]);
 return([4]);
 
 test::foo@F0([0]: Box<test::Data>) -> (test::BoxedData);
+
+//! > ==========================================================================
+
+//! > boxed match enum with 1 variant - reuse value.
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+enum A {
+    Value: felt252,
+}
+
+enum B {
+    Value: A,
+}
+
+mod a {
+    extern fn enum_boxed_match<T>(e: Box<T>) -> Box<felt252> nopanic;
+}
+
+mod b {
+    extern fn enum_boxed_match<T>(e: Box<T>) -> Box<super::A> nopanic;
+}
+
+fn foo(x: Box<B>) -> Box<felt252> {
+    a::enum_boxed_match(b::enum_boxed_match(x))
+}
+
+//! > casm
+[ap + 0] = [fp + -3] + 2, ap++;
+ret;
+
+//! > sierra_code
+type Box<test::B> = Box<test::B> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type test::A = Enum<ut@test::A, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::B = Enum<ut@test::B, test::A> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<test::A> = Box<test::A> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_boxed_match<test::B> = enum_boxed_match<test::B>;
+libfunc enum_boxed_match<test::A> = enum_boxed_match<test::A>;
+libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
+
+F0:
+enum_boxed_match<test::B>([0]) -> ([1]);
+enum_boxed_match<test::A>([1]) -> ([2]);
+store_temp<Box<felt252>>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: Box<test::B>) -> (Box<felt252>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 100})
+
+//! > ==========================================================================
+
+//! > boxed match enum with 2 variant - reuse value.
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+enum A {
+    Value1: felt252,
+    Value2: felt252,
+}
+
+enum B {
+    Value1: A,
+    Value2: (A, felt252, felt252),
+}
+
+mod a {
+    enum A {
+        Value1: Box<felt252>,
+        Value2: Box<felt252>,
+    }
+    extern fn enum_boxed_match<T>(e: Box<T>) -> A nopanic;
+}
+
+mod b {
+    enum B {
+        Value1: Box<super::A>,
+        Value2: Box<(super::A, felt252, felt252)>,
+    }
+    extern fn enum_boxed_match<T>(e: Box<T>) -> B nopanic;
+}
+
+fn foo(x: Box<B>) -> Box<felt252> {
+    match b::enum_boxed_match(x) {
+        b::B::Value1(value) => match a::enum_boxed_match(value) {
+            a::A::Value1(value) => value,
+            a::A::Value2(value) => value,
+        },
+        b::B::Value2((value, _, _)) => match a::enum_boxed_match(value) {
+            a::A::Value1(value) => value,
+            a::A::Value2(value) => value,
+        },
+    }
+}
+
+//! > casm
+[ap + 0] = [[fp + -3] + 0], ap++;
+jmp rel 11 if [ap + -1] != 0;
+[ap + 0] = [[fp + -3] + 3], ap++;
+jmp rel 5 if [ap + -1] != 0;
+[ap + 0] = [fp + -3] + 4, ap++;
+ret;
+[ap + 0] = [fp + -3] + 4, ap++;
+ret;
+[ap + 0] = [[fp + -3] + 1], ap++;
+jmp rel 5 if [ap + -1] != 0;
+[ap + 0] = [fp + -3] + 2, ap++;
+ret;
+[ap + 0] = [fp + -3] + 2, ap++;
+ret;
+
+//! > sierra_code
+type Box<test::B> = Box<test::B> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type test::A = Enum<ut@test::A, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<test::A, felt252, felt252> = Struct<ut@Tuple, test::A, felt252, felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<felt252> = Box<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type test::B = Enum<ut@test::B, test::A, Tuple<test::A, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Tuple<test::A, felt252, felt252>> = Box<Tuple<test::A, felt252, felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<test::A> = Box<test::A> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_boxed_match<test::B> = enum_boxed_match<test::B>;
+libfunc branch_align = branch_align;
+libfunc enum_boxed_match<test::A> = enum_boxed_match<test::A>;
+libfunc store_temp<Box<felt252>> = store_temp<Box<felt252>>;
+libfunc struct_boxed_deconstruct<Tuple<test::A, felt252, felt252>> = struct_boxed_deconstruct<Tuple<test::A, felt252, felt252>>;
+libfunc drop<Box<felt252>> = drop<Box<felt252>>;
+
+F0:
+enum_boxed_match<test::B>([0]) { fallthrough([1]) F0_B1([2]) };
+branch_align() -> ();
+enum_boxed_match<test::A>([1]) { fallthrough([3]) F0_B0([4]) };
+branch_align() -> ();
+store_temp<Box<felt252>>([3]) -> ([3]);
+return([3]);
+F0_B0:
+branch_align() -> ();
+store_temp<Box<felt252>>([4]) -> ([4]);
+return([4]);
+F0_B1:
+branch_align() -> ();
+struct_boxed_deconstruct<Tuple<test::A, felt252, felt252>>([2]) -> ([5], [6], [7]);
+drop<Box<felt252>>([6]) -> ();
+drop<Box<felt252>>([7]) -> ();
+enum_boxed_match<test::A>([5]) { fallthrough([8]) F0_B2([9]) };
+branch_align() -> ();
+store_temp<Box<felt252>>([8]) -> ([8]);
+return([8]);
+F0_B2:
+branch_align() -> ();
+store_temp<Box<felt252>>([9]) -> ([9]);
+return([9]);
+
+test::foo@F0([0]: Box<test::B>) -> (Box<felt252>);
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 500})
 
 //! > ==========================================================================
 


### PR DESCRIPTION
## Summary

Improved the implementation of `enum_boxed_match` libfunc to handle single-variant enums more efficiently. This PR fixes the code generation for boxed enum matching, particularly for the case of enums with a single variant where no branching is needed.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The current implementation of `enum_boxed_match` was not correctly handling single-variant enums. It was generating unnecessary code for the single-variant case, which should be a simple pass-through operation without branching logic.

---

## What was the behavior or documentation before?

Previously, the `enum_boxed_match` libfunc was generating unnecessary code for single-variant enums, treating them similarly to multi-variant enums which require branching logic.

---

## What is the behavior or documentation after?

Now, for single-variant enums, the `enum_boxed_match` libfunc generates simpler, more efficient code that directly returns the variant box without any branching. The implementation also includes better handling of offsets and cleaner code for the multi-variant cases.

---

## Additional context

Added several test cases to verify the correct behavior for single-variant and multi-variant boxed enum matching. The changes also include some refactoring to improve code clarity and maintainability, particularly in the utility functions for type handling.