### PR TITLE
perf: avoid extra allocation in contract module error

### DIFF
--- a/crates/cairo-lang-starknet/src/contract.rs
+++ b/crates/cairo-lang-starknet/src/contract.rs
@@ -255,7 +255,7 @@ fn get_generated_contract_module<'db>(
         Some(ModuleItemId::Submodule(generated_module_id)) => {
             Ok(ModuleId::Submodule(generated_module_id))
         }
-        _ => anyhow::bail!(format!("Failed to get generated module {}.", contract_name.long(db))),
+        _ => anyhow::bail!("Failed to get generated module {}.", contract_name.long(db)),
     }
 }
 


### PR DESCRIPTION
## Summary

This change passes the format string and arguments directly to `anyhow::bail!`, keeping the same error text while avoiding the extra allocation.

---

## Type of change

- [x] Performance improvement
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously get_generated_contract_module used `bail!(format!(...))`, which allocated an intermediate String just to format the error message. This added unnecessary overhead on the error path.
 

