### PR TITLE
refactor(casm): Renamed `deref` macro to `cell_ref`.

### DIFF
--- a/crates/cairo-lang-casm/src/inline.rs
+++ b/crates/cairo-lang-casm/src/inline.rs
@@ -25,7 +25,7 @@ macro_rules! casm_extend {
     ($ctx:ident, $dst:tt = $a:tt $(+ $b0:tt)? $(* $b1:tt)? $(,$ap:ident++)? ; $($tok:tt)*) => {
         let body = $crate::instructions::InstructionBody::AssertEq(
             $crate::instructions::AssertEqInstruction {
-                a: $crate::deref!($dst),
+                a: $crate::cell_ref!($dst),
                 b: $crate::res!($a $(+ $b0)? $(* $b1)?),
             }
         );
@@ -76,7 +76,7 @@ macro_rules! casm_extend {
         let body = $crate::instructions::InstructionBody::Jnz(
             $crate::instructions::JnzInstruction {
                 jump_offset: $crate::deref_or_immediate!($target),
-                condition: $crate::deref!($cond),
+                condition: $crate::cell_ref!($cond),
             }
         );
         $crate::append_instruction!($ctx, body $(,$ap++)?);
@@ -86,7 +86,7 @@ macro_rules! casm_extend {
         let body = $crate::instructions::InstructionBody::Jnz(
             $crate::instructions::JnzInstruction {
                 jump_offset: $crate::deref_or_immediate!($target),
-                condition: $crate::deref!($cond),
+                condition: $crate::cell_ref!($cond),
             }
         );
         $crate::append_instruction!($ctx, body $(,$ap++)?);
@@ -107,14 +107,14 @@ macro_rules! casm_extend {
         $crate::casm_extend!($ctx, $($tok)*)
     };
     ($ctx:ident, %{ memory $dst:tt = segments . add ( ) %} $($tok:tt)*) => {
-        $ctx.current_hints.push($crate::hints::CoreHint::AllocSegment{dst: $crate::deref!($dst)}.into());
+        $ctx.current_hints.push($crate::hints::CoreHint::AllocSegment{dst: $crate::cell_ref!($dst)}.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
     ($ctx:ident, %{ memory $dst:tt = memory $lhs:tt < memory $rhs:tt %} $($tok:tt)*) => {
         $ctx.current_hints.push($crate::hints::CoreHint::TestLessThan{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            dst: $crate::deref!($dst),
+            dst: $crate::cell_ref!($dst),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -122,7 +122,7 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::TestLessThan{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            dst: $crate::deref!($dst),
+            dst: $crate::cell_ref!($dst),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -130,7 +130,7 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::TestLessThan{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            dst: $crate::deref!($dst),
+            dst: $crate::cell_ref!($dst),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -138,7 +138,7 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::TestLessThanOrEqual{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            dst: $crate::deref!($dst),
+            dst: $crate::cell_ref!($dst),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -146,7 +146,7 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::TestLessThanOrEqual{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            dst: $crate::deref!($dst),
+            dst: $crate::cell_ref!($dst),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -154,7 +154,7 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::TestLessThanOrEqual{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            dst: $crate::deref!($dst),
+            dst: $crate::cell_ref!($dst),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -163,8 +163,8 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::DivMod{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            quotient: $crate::deref!($quotient),
-            remainder: $crate::deref!($remainder),
+            quotient: $crate::cell_ref!($quotient),
+            remainder: $crate::cell_ref!($remainder),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -173,8 +173,8 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::DivMod{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            quotient: $crate::deref!($quotient),
-            remainder: $crate::deref!($remainder),
+            quotient: $crate::cell_ref!($quotient),
+            remainder: $crate::cell_ref!($remainder),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -183,8 +183,8 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::DivMod{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            quotient: $crate::deref!($quotient),
-            remainder: $crate::deref!($remainder),
+            quotient: $crate::cell_ref!($quotient),
+            remainder: $crate::cell_ref!($remainder),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -193,8 +193,8 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::CoreHint::DivMod{
             lhs: $crate::res!($lhs),
             rhs: $crate::res!($rhs),
-            quotient: $crate::deref!($quotient),
-            remainder: $crate::deref!($remainder),
+            quotient: $crate::cell_ref!($quotient),
+            remainder: $crate::cell_ref!($remainder),
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -202,14 +202,14 @@ macro_rules! casm_extend {
         $ctx.current_hints.push($crate::hints::StarknetHint::SystemCall {
             system: $crate::operand::ResOperand::BinOp($crate::operand::BinOpOperand {
                 op: cairo_lang_casm::operand::Operation::Add,
-                a: $crate::deref!($addr),
+                a: $crate::cell_ref!($addr),
                 b: $crate::deref_or_immediate!(num_bigint::BigInt::from($offset)),
             })}.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
     ($ctx:ident, %{ syscall_handler.syscall(syscall_ptr=memory $addr:tt) %} $($tok:tt)*) => {
         $ctx.current_hints.push($crate::hints::StarknetHint::SystemCall {
-            system: $crate::operand::ResOperand::Deref($crate::deref!($addr))
+            system: $crate::operand::ResOperand::Deref($crate::cell_ref!($addr))
         }.into());
         $crate::casm_extend!($ctx, $($tok)*)
     };
@@ -246,8 +246,9 @@ pub struct CasmContext {
     pub instructions: Vec<Instruction>,
 }
 
+/// Allows for defining cell references, similar to their casm definition.
 #[macro_export]
-macro_rules! deref {
+macro_rules! cell_ref {
     ([ap + $offset:expr]) => {
         $crate::operand::CellRef { register: $crate::reg!(ap), offset: $offset }
     };
@@ -293,7 +294,7 @@ macro_rules! reg {
 #[macro_export]
 macro_rules! deref_or_immediate {
     ([$a:ident $($op:tt $offset:expr)?]) => {
-        $crate::operand::DerefOrImmediate::Deref($crate::deref!([$a $($op $offset)?]))
+        $crate::operand::DerefOrImmediate::Deref($crate::cell_ref!([$a $($op $offset)?]))
     };
     ($a:expr) => {
         $crate::operand::DerefOrImmediate::from($a)
@@ -305,34 +306,34 @@ macro_rules! res {
     ($a:tt + $b:tt) => {
         $crate::operand::ResOperand::BinOp($crate::operand::BinOpOperand {
             op: $crate::operand::Operation::Add,
-            a: $crate::deref!($a),
+            a: $crate::cell_ref!($a),
             b: $crate::deref_or_immediate!($b),
         })
     };
     ($a:tt * $b:tt) => {
         $crate::operand::ResOperand::BinOp($crate::operand::BinOpOperand {
             op: $crate::operand::Operation::Mul,
-            a: $crate::deref!($a),
+            a: $crate::cell_ref!($a),
             b: $crate::deref_or_immediate!($b),
         })
     };
     ([[ap $($op:tt $offset:expr)?]]) => {
-        $crate::operand::ResOperand::DoubleDeref($crate::deref!([ap $($op $offset)?]), 0)
+        $crate::operand::ResOperand::DoubleDeref($crate::cell_ref!([ap $($op $offset)?]), 0)
     };
     ([[ap $($op:tt $offset:expr)?] + $outer:expr]) => {
-        $crate::operand::ResOperand::DoubleDeref($crate::deref!([ap $($op $offset)?]), $outer)
+        $crate::operand::ResOperand::DoubleDeref($crate::cell_ref!([ap $($op $offset)?]), $outer)
     };
     ([[ap $($op:tt $offset:expr)?] - $outer:expr]) => {
-        $crate::operand::ResOperand::DoubleDeref($crate::deref!([ap $($op $offset)?]), -$outer)
+        $crate::operand::ResOperand::DoubleDeref($crate::cell_ref!([ap $($op $offset)?]), -$outer)
     };
     ([[fp $($op:tt $offset:expr)?]]) => {
-        $crate::operand::ResOperand::DoubleDeref($crate::deref!([fp $($op $offset)?]), 0)
+        $crate::operand::ResOperand::DoubleDeref($crate::cell_ref!([fp $($op $offset)?]), 0)
     };
     ([[fp $($op:tt $offset:expr)?] + $outer:expr]) => {
-        $crate::operand::ResOperand::DoubleDeref($crate::deref!([fp $($op $offset)?]), $outer)
+        $crate::operand::ResOperand::DoubleDeref($crate::cell_ref!([fp $($op $offset)?]), $outer)
     };
     ([[fp $($op:tt $offset:expr)?] - $outer:expr]) => {
-        $crate::operand::ResOperand::DoubleDeref($crate::deref!([fp $($op $offset)?]), -$outer)
+        $crate::operand::ResOperand::DoubleDeref($crate::cell_ref!([fp $($op $offset)?]), -$outer)
     };
     ([[&$a:expr]]) => {
         $crate::operand::ResOperand::DoubleDeref($a, 0)

--- a/crates/cairo-lang-casm/src/inline_test.rs
+++ b/crates/cairo-lang-casm/src/inline_test.rs
@@ -7,12 +7,12 @@ use itertools::join;
 use pretty_assertions::assert_eq;
 
 use crate::instructions::Instruction;
-use crate::{casm, deref};
+use crate::{casm, cell_ref};
 
 #[test]
 fn test_assert() {
     let x = 1;
-    let y = deref!([fp + 5]);
+    let y = cell_ref!([fp + 5]);
     let z = 5;
 
     let ctx = casm! {

--- a/crates/cairo-lang-runnable-utils/src/builder.rs
+++ b/crates/cairo-lang-runnable-utils/src/builder.rs
@@ -3,7 +3,7 @@ use cairo_lang_casm::builder::{CasmBuilder, Var};
 use cairo_lang_casm::cell_expression::CellExpression;
 use cairo_lang_casm::hints::ExternalHint;
 use cairo_lang_casm::instructions::Instruction;
-use cairo_lang_casm::{ap_change, casm, casm_build_extend, deref};
+use cairo_lang_casm::{ap_change, casm, casm_build_extend, cell_ref};
 use cairo_lang_sierra::extensions::bitwise::BitwiseType;
 use cairo_lang_sierra::extensions::circuit::{AddModType, MulModType};
 use cairo_lang_sierra::extensions::core::{CoreLibfunc, CoreType};
@@ -315,7 +315,7 @@ pub fn create_entry_code_from_params(
         for builtin_name in helper.builtins.iter().rev() {
             helper.builtin_vars.insert(
                 *builtin_name,
-                helper.ctx.add_var(CellExpression::Deref(deref!([fp - builtin_offset]))),
+                helper.ctx.add_var(CellExpression::Deref(cell_ref!([fp - builtin_offset]))),
             );
             builtin_offset += 1;
         }
@@ -392,7 +392,7 @@ impl EntryCodeHelper {
             if param_types.iter().any(|(ty, _)| ty == builtin_ty) {
                 self.builtin_vars.insert(
                     *builtin_name,
-                    self.ctx.add_var(CellExpression::Deref(deref!([fp - builtin_offset]))),
+                    self.ctx.add_var(CellExpression::Deref(cell_ref!([fp - builtin_offset]))),
                 );
                 builtin_offset += 1;
                 self.builtins.push(*builtin_name);
@@ -400,7 +400,7 @@ impl EntryCodeHelper {
         }
         if !self.config.testing {
             let output_builtin_var =
-                self.ctx.add_var(CellExpression::Deref(deref!([fp - builtin_offset])));
+                self.ctx.add_var(CellExpression::Deref(cell_ref!([fp - builtin_offset])));
             self.builtin_vars.insert(BuiltinName::output, output_builtin_var);
             self.builtins.push(BuiltinName::output);
         }
@@ -514,7 +514,7 @@ impl EntryCodeHelper {
     fn process_output(&mut self, return_types: &[(GenericTypeId, i16)]) {
         let mut unprocessed_return_size = return_types.iter().map(|(_, size)| size).sum::<i16>();
         let mut next_unprocessed_deref = || {
-            let deref_cell = CellExpression::Deref(deref!([ap - unprocessed_return_size]));
+            let deref_cell = CellExpression::Deref(cell_ref!([ap - unprocessed_return_size]));
             assert!(unprocessed_return_size > 0);
             unprocessed_return_size -= 1;
             deref_cell

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -1,6 +1,6 @@
 use cairo_lang_casm::assembler::AssembledCairoProgram;
 use cairo_lang_casm::inline::CasmContext;
-use cairo_lang_casm::{casm, deref};
+use cairo_lang_casm::{casm, cell_ref};
 use cairo_lang_sierra_to_casm::compiler::{CairoProgram, CairoProgramDebugInfo};
 use cairo_lang_utils::byte_array::BYTE_ARRAY_MAGIC;
 use cairo_vm::vm::runners::cairo_runner::RunResources;
@@ -149,7 +149,7 @@ fn test_allocate_segment() {
     let program = assembled(casm! {
         [ap] = 1337, ap++;
         %{ memory[ap] = segments.add() %}
-        [ap - 1] = [[&deref!([ap])]];
+        [ap - 1] = [[&cell_ref!([ap])]];
         ret;
     });
     let (hints_dict, string_to_hint) = build_hints_dict(&program.hints);

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/test_utils.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/test_utils.rs
@@ -47,7 +47,7 @@ macro_rules! ref_expr_extend {
     ($cells:ident) => {};
     ($cells:ident, [$a:ident $($op:tt $offset:expr)?] $(, $tok:tt)*) => {
         $cells.push(
-            cairo_lang_casm::cell_expression::CellExpression::Deref(cairo_lang_casm::deref!([$a $($op $offset)?]))
+            cairo_lang_casm::cell_expression::CellExpression::Deref(cairo_lang_casm::cell_ref!([$a $($op $offset)?]))
         );
         $crate::ref_expr_extend!($cells $(, $tok)*)
     };
@@ -55,20 +55,20 @@ macro_rules! ref_expr_extend {
         $cells.push(
             cairo_lang_casm::cell_expression::CellExpression::BinOp {
                 op: $crate::cell_expr_operator!($operator),
-                a: cairo_lang_casm::deref!([$a $($op $offset)?]),
+                a: cairo_lang_casm::cell_ref!([$a $($op $offset)?]),
                 b: cairo_lang_casm::deref_or_immediate!($b),
         });
         $crate::ref_expr_extend!($cells $(, $tok)*)
     };
     ($cells:ident, [[$a:ident $($op:tt $offset:expr)?]] $(, $tok:tt)*) => {
         $cells.push(
-            cairo_lang_casm::cell_expression::CellExpression::DoubleDeref(cairo_lang_casm::deref!([$a $($op $offset)?]), 0)
+            cairo_lang_casm::cell_expression::CellExpression::DoubleDeref(cairo_lang_casm::cell_ref!([$a $($op $offset)?]), 0)
         );
         $crate::ref_expr_extend!($cells $(, $tok)*)
     };
     ($cells:ident, [[$a:ident $($op:tt $offset:expr)?] + $offset2:expr] $(, $tok:tt)*) => {
         $cells.push(
-            cairo_lang_casm::cell_expression::CellExpression::DoubleDeref(cairo_lang_casm::deref!([$a $($op $offset)?]), $offset2)
+            cairo_lang_casm::cell_expression::CellExpression::DoubleDeref(cairo_lang_casm::cell_ref!([$a $($op $offset)?]), $offset2)
         );
         $crate::ref_expr_extend!($cells $(, $tok)*)
     };


### PR DESCRIPTION
## Summary

Renamed the `deref!` macro to `cell_ref!` to better reflect its purpose of defining cell references in Cairo assembly. Updated all usages across the codebase to use the new name, and improved the documentation comment to clarify the macro's functionality.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The name `deref!` was misleading as the macro doesn't perform dereferencing but rather defines a cell reference. The new name `cell_ref!` more accurately describes what the macro does, making the code more self-documenting and easier to understand for developers working with Cairo assembly.

---

## What was the behavior or documentation before?

The macro was named `deref!` with no clear documentation about its purpose, which could lead to confusion about its functionality.

---

## What is the behavior or documentation after?

The macro is now named `cell_ref!` and includes a clear documentation comment: "Allows for defining cell references, similar to their casm definition." All usages throughout the codebase have been updated to use the new name.

---

## Additional context

This change is purely a renaming for clarity and doesn't affect functionality. It makes the codebase more maintainable by using more accurate terminology that aligns with Cairo assembly concepts.