### PR TITLE
performance(starknet-classes): Simplify decompression by using bit alignment of encoding.

### DIFF
--- a/crates/cairo-lang-utils/src/casts.rs
+++ b/crates/cairo-lang-utils/src/casts.rs
@@ -15,5 +15,7 @@ impl IntoOrPanic for i32 {}
 impl IntoOrPanic for u32 {}
 impl IntoOrPanic for i64 {}
 impl IntoOrPanic for u64 {}
+impl IntoOrPanic for i128 {}
+impl IntoOrPanic for u128 {}
 impl IntoOrPanic for isize {}
 impl IntoOrPanic for usize {}


### PR DESCRIPTION
## Summary

Optimized the `decompress` function in `felt252_vec_compression.rs` by replacing the manual limb-by-limb division with a more efficient bit manipulation approach. The new implementation uses a bit mask and shifting operations to extract values from the packed data, which is more performant than the previous division-based algorithm. Also extended the `IntoOrPanic` trait to support `i128` and `u128` types.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation of the `decompress` function used a relatively expensive division operation for each word extraction. By leveraging the fact that the padded code size is a power of 2, we can use more efficient bit manipulation operations (masking and shifting) to achieve the same result with better performance.

---

## What was the behavior or documentation before?

The previous implementation used a manual 4-limb long division approach to extract values from packed data, which was less efficient, especially for large inputs.

---

## What is the behavior or documentation after?

The new implementation uses bit manipulation (masking and shifting) to extract values from the packed data, which is more efficient. It also adds `i128` and `u128` implementations for the `IntoOrPanic` trait to support the new code.

---

## Additional context

This optimization maintains the same functionality while improving performance. The approach takes advantage of the fact that the padded code size is a power of 2, allowing us to use bit operations instead of division.