### PR TITLE
refactor(lowering): remove unused dataflow analysis core module

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/mod.rs
+++ b/crates/cairo-lang-lowering/src/analysis/mod.rs
@@ -4,7 +4,6 @@
 //! optimization passes and semantic checks.
 
 mod backward;
-mod core;
 
 pub use backward::BackAnalysis;
 


### PR DESCRIPTION
Removes the unused `analysis::core` module containing `DataflowAnalyzer` trait and related types that were never utilized in the codebase.
