### PR TITLE
refactor: Remove redundant String clone in test runner

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/test.rs
+++ b/crates/cairo-lang-starknet/src/plugin/test.rs
@@ -125,7 +125,7 @@ impl TestFileRunner for ExpandContractFromCrateTestRunner {
     ) -> TestRunnerResult {
         let db = SHARED_DB_WITH_CONTRACTS.lock().unwrap().snapshot();
         let contract_file_id = FileLongId::OnDisk(PathBuf::from(
-            inputs["contract_file_name"].as_str(),
+            &inputs["contract_file_name"].as_str(),
         ))
         .intern(&db);
         let contract_module_ids = db.file_modules(contract_file_id).unwrap();


### PR DESCRIPTION
Removes an unnecessary .clone() operation when creating PathBuf from test input, improving code efficiency and following Rust idioms.