### PR TITLE
refactor(lowering): Remove unused macro re-exports from optimizations module

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/mod.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/mod.rs
@@ -5,8 +5,6 @@ macro_rules! debug {
         tracing::debug!(target: "optimization", $($arg)*)
     };
 }
-#[allow(unused_imports)]
-pub(crate) use debug;
 
 /// Macro for trace logging with "optimization" target.
 #[allow(unused)]
@@ -15,8 +13,6 @@ macro_rules! trace {
         tracing::trace!(target: "optimization", $($arg)*)
     };
 }
-#[allow(unused_imports)]
-pub(crate) use trace;
 
 pub mod branch_inversion;
 pub mod cancel_ops;


### PR DESCRIPTION
Removes unused `pub(crate) use` statements for `debug` and `trace` macros in the optimizations module, eliminating the need for `#[allow(unused_imports)]` suppressions.