### PR TITLE
corelib: remove unused integer import from EthAddress

### DIFF
--- a/corelib/src/starknet/eth_address.cairo
+++ b/corelib/src/starknet/eth_address.cairo
@@ -4,8 +4,6 @@
 //! primitives, such as signatures and L1 <-> L2 messages.
 
 use core::debug::PrintTrait;
-#[allow(unused_imports)]
-use core::integer::{U128TryIntoNonZero, U256TryIntoFelt252, u128_safe_divmod};
 use core::serde::Serde;
 use core::traits::{Into, TryInto};
 


### PR DESCRIPTION
Remove an unused core::integer import and its unused_imports allowance in eth_address.cairo.
Reduce dead code and keep the module’s dependencies minimal.