### PR TITLE
refactor(tests): Remove unused DerefMut import from e2e_test.rs

### DIFF
--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -1,4 +1,3 @@
-use std::ops::DerefMut;
 use std::sync::{LazyLock, Mutex};
 
 use cairo_lang_compiler::db::RootDatabase;


### PR DESCRIPTION
Remove unused `std::ops::DerefMut` import from `tests/e2e_test.rs`.
