### PR TITLE
refactor(vecs): Removed vectors all around.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "cairo-lang-proc-macros",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
+ "itertools 0.14.0",
  "num-bigint",
  "num-traits",
  "pretty_assertions",

--- a/crates/bin/cairo-execute/src/main.rs
+++ b/crates/bin/cairo-execute/src/main.rs
@@ -410,7 +410,7 @@ struct DebugData<'a> {
 /// Encodes the trace entry by entry as triplets of `u64`s.
 fn write_relocated_trace(
     path: &PathBuf,
-    relocated_trace: &Vec<RelocatedTraceEntry>,
+    relocated_trace: &[RelocatedTraceEntry],
 ) -> Result<(), io::Error> {
     let mut writer = io::BufWriter::with_capacity(3 * 1024 * 1024, std::fs::File::create(path)?);
     for entry in relocated_trace {

--- a/crates/cairo-lang-doc/src/documentable_formatter.rs
+++ b/crates/cairo-lang-doc/src/documentable_formatter.rs
@@ -589,8 +589,7 @@ impl<'db> HirDisplay<'db> for MacroDeclarationId<'db> {
                 WrappedMacro::Parenthesized(m) => ("(", m.elements(f.db), ")"),
             };
             let macro_match = elements
-                .elements_vec(f.db)
-                .iter()
+                .elements(f.db)
                 .map(|element| element.as_syntax_node().get_text(f.db))
                 .join("")
                 .split_whitespace()

--- a/crates/cairo-lang-lowering/src/implicits/mod.rs
+++ b/crates/cairo-lang-lowering/src/implicits/mod.rs
@@ -211,10 +211,8 @@ fn lower_function_blocks_implicits<'db>(
                     MatchInfo::Extern(stmt) => {
                         let callee_implicits = ctx.db.function_implicits(stmt.function)?;
 
-                        let indices =
-                            callee_implicits.iter().map(|ty| ctx.implicit_index[ty]).collect_vec();
-
-                        let implicit_input_vars = indices.iter().map(|i| implicits[*i]);
+                        let implicit_input_vars =
+                            callee_implicits.iter().map(|ty| implicits[ctx.implicit_index[ty]]);
                         stmt.inputs.splice(0..0, implicit_input_vars);
                         let location = stmt.location.with_auto_generation_note(ctx.db, "implicits");
 

--- a/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
@@ -297,7 +297,7 @@ fn create_node_for_enum<'db>(
 fn create_node_for_tuple<'db>(
     params: CreateNodeParams<'db, '_, '_>,
     input_var: FlowControlVar,
-    types: &Vec<TypeId<'db>>,
+    types: &[TypeId<'db>],
     wrapping_info: PatternWrappingInfo,
 ) -> NodeId {
     let CreateNodeParams { ctx, graph, patterns, build_node_callback, location } = params;
@@ -381,10 +381,10 @@ fn create_node_for_struct<'db>(
 /// `struct_members` is the list of members of the struct, or `None` if the type is a tuple.
 fn create_node_for_tuple_inner<'db>(
     params: CreateNodeParams<'db, '_, '_>,
-    inner_vars: &Vec<FlowControlVar>,
-    types: &Vec<TypeId<'db>>,
+    inner_vars: &[FlowControlVar],
+    types: &[TypeId<'db>],
     item_idx: usize,
-    struct_members: Option<&Vec<&semantic::Member<'db>>>,
+    struct_members: Option<&[&semantic::Member<'db>]>,
 ) -> NodeId {
     let CreateNodeParams { ctx, graph, patterns, build_node_callback, location } = params;
 

--- a/crates/cairo-lang-lowering/src/objects/blocks.rs
+++ b/crates/cairo-lang-lowering/src/objects/blocks.rs
@@ -77,7 +77,7 @@ impl<'db> Blocks<'db> {
         Self(vec![])
     }
 
-    pub fn get(&self) -> &Vec<Block<'db>> {
+    pub fn get(&self) -> &[Block<'db>] {
         &self.0
     }
 

--- a/crates/cairo-lang-lowering/src/optimizations/dedup_blocks.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/dedup_blocks.rs
@@ -304,7 +304,7 @@ pub fn dedup_blocks<'db>(lowered: &mut Lowered<'db>) {
     }
 
     let mut new_goto_block =
-        |block_id, inputs: &Vec<VarUsage<'db>>, target_inputs: &Vec<VarUsage<'db>>| {
+        |block_id, inputs: &[VarUsage<'db>], target_inputs: &[VarUsage<'db>]| {
             new_blocks.push(Block {
                 statements: vec![],
                 end: BlockEnd::Goto(

--- a/crates/cairo-lang-lowering/src/optimizations/remappings.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/remappings.rs
@@ -89,7 +89,7 @@ impl<'db> Rebuilder<'db> for Context {
 /// Implementation of the [Context::set_used] method, used directly on the members, so can be
 /// partially mutable.
 fn set_used_impl(
-    dest_to_srcs: &Vec<Vec<VariableId>>,
+    dest_to_srcs: &[Vec<VariableId>],
     var_representatives: &mut Vec<Option<VariableId>>,
     variable_used: &mut Vec<bool>,
     var: VariableId,
@@ -106,7 +106,7 @@ fn set_used_impl(
 /// Implementation of the [Context::map_var_id] method, used directly on the members, so can be
 /// partially mutable.
 fn map_var_id_impl(
-    dest_to_srcs: &Vec<Vec<VariableId>>,
+    dest_to_srcs: &[Vec<VariableId>],
     var_representatives: &mut Vec<Option<VariableId>>,
     var: VariableId,
 ) -> VariableId {

--- a/crates/cairo-lang-lowering/src/panic/mod.rs
+++ b/crates/cairo-lang-lowering/src/panic/mod.rs
@@ -80,7 +80,7 @@ pub fn lower_panics<'db>(
     .unwrap();
     let mut ctx = PanicLoweringContext {
         variables,
-        block_queue: VecDeque::from(lowered.blocks.get().clone()),
+        block_queue: VecDeque::from_iter(lowered.blocks.get().iter().cloned()),
         flat_blocks: BlocksBuilder::new(),
         panic_info,
     };

--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -906,7 +906,7 @@ fn ast_param_to_semantic<'db>(
     };
 
     let mutability =
-        modifiers::compute_mutability(diagnostics, db, &ast_param.modifiers(db).elements_vec(db));
+        modifiers::compute_mutability(diagnostics, db, ast_param.modifiers(db).elements(db));
 
     semantic::Parameter { id, name: name.text(db), ty, mutability, stable_ptr: name.stable_ptr(db) }
 }

--- a/crates/cairo-lang-semantic/src/items/modifiers.rs
+++ b/crates/cairo-lang-semantic/src/items/modifiers.rs
@@ -11,7 +11,7 @@ use crate::diagnostic::{SemanticDiagnostics, SemanticDiagnosticsBuilder};
 pub fn compute_mutability<'db>(
     diagnostics: &mut SemanticDiagnostics<'db>,
     db: &'db dyn Database,
-    modifier_list: &[Modifier<'db>],
+    modifier_list: impl IntoIterator<Item = Modifier<'db>>,
 ) -> Mutability {
     let mut mutability = Mutability::Immutable;
 

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -1750,8 +1750,7 @@ impl<'db, 'a> Resolution<'db, 'a> {
 
         let mut cur_offset =
             ExpansionOffset::new(path.offset(db).expect("Trying to resolve an empty path."));
-        let elements_vec = path.to_segments(db);
-        let mut segments = elements_vec.into_iter().peekable();
+        let mut segments = path.to_segments(db).into_iter().peekable();
         let mut cur_macro_call_data = resolver.macro_call_data.as_ref();
         let mut path_defining_module = resolver.data.module_id;
         // Climb up the macro call data while the current resolved path is being mapped to an

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -12,6 +12,7 @@ cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.15.0"
 cairo-lang-primitive-token.workspace = true
 cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.15.0" }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.15.0", features = ["tracing"] }
+itertools.workspace = true
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
 salsa.workspace = true

--- a/crates/cairo-lang-syntax/src/node/element_list.rs
+++ b/crates/cairo-lang-syntax/src/node/element_list.rs
@@ -24,7 +24,7 @@ impl<'db, T: TypedSyntaxNode<'db>> ElementList<'db, T, 1> {
     pub fn elements(
         &self,
         db: &'db dyn Database,
-    ) -> impl ExactSizeIterator<Item = T> + DoubleEndedIterator + use<'db, T> {
+    ) -> impl ExactSizeIterator<Item = T> + DoubleEndedIterator + Clone + use<'db, T> {
         self.node.get_children(db).iter().copied().map(move |x| T::from_syntax_node(db, x))
     }
     pub fn has_tail(&self, _db: &dyn Database) -> bool {
@@ -38,7 +38,7 @@ impl<'db, T: TypedSyntaxNode<'db>> ElementList<'db, T, 2> {
     pub fn elements(
         &self,
         db: &'db dyn Database,
-    ) -> impl ExactSizeIterator<Item = T> + DoubleEndedIterator + use<'db, T> {
+    ) -> impl ExactSizeIterator<Item = T> + DoubleEndedIterator + Clone + use<'db, T> {
         self.node
             .get_children(db)
             .iter()


### PR DESCRIPTION
## Summary

Refactored code to use slices and iterators instead of vectors where appropriate, improving code quality and performance.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This PR replaces several instances of unnecessary vector allocations with slices and iterators. In many places, the code was creating temporary vectors when iterating over collections, which is inefficient. By using slices and iterators directly, we avoid these allocations and improve performance.

---

## What was the behavior or documentation before?

The code was using `Vec` in many places where slices or iterators would be more appropriate:
- Using `elements_vec(db)` followed by iteration
- Passing `&Vec<T>` instead of `&[T]` in function signatures
- Creating temporary vectors just to iterate over them
- Using `split_first()` on vectors when iterators would be cleaner

---

## What is the behavior or documentation after?

- Changed function parameters from `&Vec<T>` to `&[T]` where appropriate
- Replaced `elements_vec(db)` with `elements(db)` to avoid unnecessary vector allocations
- Used iterator methods like `exactly_one()` instead of pattern matching on slices
- Added `Clone` trait bound to element iterators to support more flexible usage
- Added `itertools` dependency to `cairo-lang-syntax` to support these changes

---

## Additional context

This change is part of ongoing efforts to make the Cairo compiler more efficient by reducing unnecessary allocations. The changes are particularly beneficial in hot code paths that process AST nodes frequently.