### PR TITLE
perf(encoder): avoid unnecessary BigInt cloning in encode()

### DIFF
--- a/crates/cairo-lang-casm/src/encoder.rs
+++ b/crates/cairo-lang-casm/src/encoder.rs
@@ -32,7 +32,7 @@ const OPCODE_ASSERT_EQ_BIT: i32 = 14;
 const OPCODE_EXT_OFFSET: u64 = 63;
 
 impl InstructionRepr {
-    pub fn encode(&self) -> Vec<BigInt> {
+    pub fn encode(self) -> Vec<BigInt> {
         // Convert the offsets from possibly negative numbers in the range [-2^15, 2^15)
         // to positive numbers in the range [0, 2^16) centered around 2^15.
         let off0_enc: u64 = ((self.off0 as i32) + (1 << (OFFSET_BITS - 1))) as u64;
@@ -125,10 +125,6 @@ impl InstructionRepr {
             }
             OpcodeExtension::QM31 => bigint_encoding |= BigInt::from(3) << OPCODE_EXT_OFFSET,
         };
-        if let Some(imm) = self.imm.clone() {
-            vec![bigint_encoding, imm]
-        } else {
-            vec![bigint_encoding]
-        }
+        if let Some(imm) = self.imm { vec![bigint_encoding, imm] } else { vec![bigint_encoding] }
     }
 }


### PR DESCRIPTION
## Summary


Changed `encode(&self)` to `encode(self)` to allow moving the `BigInt` value directly without cloning. Removed the `.clone()` call on `self.imm`. This eliminates the extra allocation while maintaining the same output behavior.


---

## Type of change

Please check **one**:


- [x] Performance improvement

---

## Why is this change needed?

The `encode()` method was taking `&self` and cloning `self.imm` (BigInt) when an immediate value was present. Since [InstructionRepr]https://github.com/starkware-libs/cairo/blob/fd9cc11559a81b5d1bc113e1360765b6b164c850/crates/cairo-lang-casm/src/assembler.rs#L68-L84 is always created temporarily and never reused after encoding, this cloning is unnecessary overhead, especially for large immediate values.


---


