### PR TITLE
fix: remove redundant `collect_extra_allowed_attributes` call

### DIFF
--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -1271,12 +1271,10 @@ pub fn validate_attributes_flat<'db, Item: QueryAttrs<'db> + TypedSyntaxNode<'db
     item: &Item,
     plugin_diagnostics: &mut Vec<PluginDiagnostic<'db>>,
 ) {
-    let local_extra_attributes = collect_extra_allowed_attributes(db, item, plugin_diagnostics);
     for attr in item.attributes_elements(db) {
         let attr_text = attr.attr(db).as_syntax_node().get_text_without_trivia(db);
         if !(allowed_attributes.contains(&attr_text)
-            || extra_allowed_attributes.contains(&attr_text)
-            || local_extra_attributes.contains(&attr_text))
+            || extra_allowed_attributes.contains(&attr_text))
         {
             plugin_diagnostics.push(PluginDiagnostic::error(
                 attr.stable_ptr(db),


### PR DESCRIPTION
## Summary

Removed the redundant `collect_extra_allowed_attributes` call from `validate_attributes_flat` and use the passed `extra_allowed_attributes` parameter directly. This eliminates duplicate work while maintaining the same validation behavior.

---

## Type of change

- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `validate_attributes_flat` function redundantly called `collect_extra_allowed_attributes` internally, even though the caller `validate_attributes` already collected these attributes and passed them as the `extra_allowed_attributes` parameter. This caused:
1. Double work for top-level items - attributes were collected twice
2. Unnecessary calls for nested items (trait functions, struct fields, enum variants) which cannot have `#[allow(...)]` attributes anyway

---




