### PR TITLE
refactor: remove redundant clone in UnboxLibfuncWrapped::specialize_signature

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs
@@ -114,17 +114,14 @@ impl SignatureAndTypeGenericLibfunc for UnboxLibfuncWrapped {
         context: &dyn SignatureSpecializationContext,
         ty: ConcreteTypeId,
     ) -> Result<LibfuncSignature, SpecializationError> {
-        let is_zero_sized = context.get_type_info(&ty)?.zero_sized;
+        let ref_info = if context.get_type_info(&ty)?.zero_sized {
+            OutputVarReferenceInfo::ZeroSized
+        } else {
+            OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic)
+        };
         Ok(LibfuncSignature::new_non_branch(
             vec![box_ty(context, ty.clone())?],
-            vec![OutputVarInfo {
-                ty,
-                ref_info: if is_zero_sized {
-                    OutputVarReferenceInfo::ZeroSized
-                } else {
-                    OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic)
-                },
-            }],
+            vec![OutputVarInfo { ty, ref_info }],
             SierraApChange::Known { new_vars_only: true },
         ))
     }


### PR DESCRIPTION
## Summary

- Fetch `zero_sized` property before `box_ty()` call
- Remove second `.clone()` by moving `ty` directly into `OutputVarInfo`
- Reduces unnecessary allocations in boxing signature specialization

---

## Type of change

- [x] Performance improvement

---

## Why is this change needed?

The original code had two `.clone()` calls on `ty`:
1. One for `box_ty()`https://github.com/starkware-libs/cairo/blob/34c341267dbe1a994c131e889d427976b374cbfc/crates/cairo-lang-sierra/src/extensions/modules/boxing.rs#L52-L58 consumption
2. One for `OutputVarInfo.ty` before borrow in `get_type_info()`

