### PR TITLE
Added some more info prints, and more graceful crashing.

### DIFF
--- a/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
+++ b/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
@@ -168,6 +168,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some(fullnode_url) = args.fullnode_url {
         let client = FullNodeClient::new(fullnode_url.clone());
         let max_end_block = client.post::<_, u64>("starknet_blockNumber", ()).await? + 1;
+        eprintln!("Latest block #{max_end_block}.");
         let fullnode_args = args.fullnode_args.unwrap();
         let (start_block, end_block) = if let Some(last_n_blocks) = fullnode_args.last_n_blocks {
             let end_block = max_end_block;
@@ -177,6 +178,12 @@ async fn main() -> anyhow::Result<()> {
             let start_block =
                 fullnode_args.start_block.with_context(|| "no start block provided")?;
             let mut end_block = fullnode_args.end_block.with_context(|| "no end block provided")?;
+            if max_end_block < start_block {
+                anyhow::bail!(
+                    "provided `start-block` {start_block} is greater than the max possible block \
+                     {max_end_block}. Quitting."
+                );
+            }
             if max_end_block < end_block {
                 eprintln!(
                     "provided `end-block` {end_block} is greater than the max possible block \


### PR DESCRIPTION
## Summary

Added error handling and improved logging in the Sierra upgrade validation tool. The PR adds:

1. A log message displaying the latest block number when connecting to a fullnode
2. A validation check that prevents execution when the provided `start-block` is greater than the maximum possible block
3. An error message that clearly explains the issue when this validation fails

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

## Why is this change needed?

The Sierra upgrade validation tool previously lacked proper validation for the `start-block` parameter. While it checked if the `end-block` was greater than the maximum possible block, it didn't perform the same check for the `start-block`. This could lead to confusing behavior when users provided an invalid starting block number.

## What was the behavior or documentation before?

Previously, the tool would only validate that the `end-block` parameter was not greater than the maximum possible block. If a user provided a `start-block` that was greater than the latest block, the tool would proceed without any warning, potentially leading to unexpected results.

## What is the behavior or documentation after?

Now the tool:
1. Logs the latest block number for better visibility
2. Validates that the `start-block` is not greater than the maximum possible block
3. Provides a clear error message when validation fails, explaining exactly what went wrong

## Additional context

This change improves the user experience by providing better feedback and preventing invalid configurations from being processed.