### PR TITLE
Removed clone in test runner.

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/test.rs
+++ b/crates/cairo-lang-starknet/src/plugin/test.rs
@@ -125,7 +125,7 @@ impl TestFileRunner for ExpandContractFromCrateTestRunner {
     ) -> TestRunnerResult {
         let db = SHARED_DB_WITH_CONTRACTS.lock().unwrap().snapshot();
         let contract_file_id =
-            FileLongId::OnDisk(PathBuf::from(inputs["contract_file_name"].clone())).intern(&db);
+            FileLongId::OnDisk(PathBuf::from(&inputs["contract_file_name"])).intern(&db);
         let contract_module_ids = db.file_modules(contract_file_id).unwrap();
         let mut diagnostic_items = vec![];
         let result = contract_module_ids


### PR DESCRIPTION
## Summary

Removed useless extra clone.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The current implementation unnecessarily clones the string from the inputs map before passing it to `PathBuf::from()`. This is inefficient since `PathBuf::from()` can accept a reference to a string, making the clone operation redundant. This change helps avoid unnecessary memory allocation.

---

## What was the behavior or documentation before?

The code was cloning the string value from the inputs map before creating a PathBuf:
```rust
FileLongId::OnDisk(PathBuf::from(inputs["contract_file_name"].clone())).intern(&db);
```

---

## What is the behavior or documentation after?

The code now passes a reference to the string value directly:
```rust
FileLongId::OnDisk(PathBuf::from(&inputs["contract_file_name"])).intern(&db);
```