### PR TITLE
Removed auto-imported std imports.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::hash::Hash;
+use std::mem;
 use std::sync::Arc;
-use std::{mem, panic, vec};
 
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::db::DefsGroup;


### PR DESCRIPTION
## Summary

Removed unused imports `panic` and `vec` from the `imp.rs` file while keeping the necessary `mem` import.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The code was importing unused modules `panic` and `vec` which are not used in the implementation. This cleanup removes unnecessary imports to improve code cleanliness and potentially reduce compilation time slightly.

---

## What was the behavior or documentation before?

The file was importing unused modules:
```rust
use std::{mem, panic, vec};
```

---

## What is the behavior or documentation after?

Only the necessary `mem` module is imported:
```rust
use std::mem;
```

---

## Additional context

This is a small cleanup that helps maintain code quality by removing unused imports. While the impact is minimal, keeping imports clean helps with code readability and maintenance.