### PR TITLE
docs: fix snapshot conversion example to use non-copyable type

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/box-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/box-type.adoc
@@ -83,13 +83,16 @@ using `.as_snapshot()`:
 
 [source,cairo]
 ----
-let boxed_value = BoxTrait::new([1, 2, 3]);
-let snap_boxed = @boxed_value;         // @Box<[u32; 3]>
-let boxed_snap = snap_boxed.as_snapshot();  // Box<@[u32; 3]>
-let value_snap = boxed_snap.unbox();   // @[u32; 3]
+let boxed_value = BoxTrait::new(array![1, 2, 3]);
+let snap_boxed = @boxed_value;         // @Box<Array<felt252>>
+let boxed_snap = snap_boxed.as_snapshot();  // Box<@Array<felt252>>
+let value_snap = boxed_snap.unbox();   // @Array<felt252>
 ----
 
 This is useful when working with non-copyable types.
+Since `Array` is not copyable, `Box<Array<T>>` is also not copyable.
+However, `Box<@Array<T>>` is copyable because snapshots are always copyable.
+This allows you to copy a `Box` containing a non-copyable type when needed.
 
 == Dereferencing
 


### PR DESCRIPTION
## Summary

Fixes the snapshot conversion example in Box documentation to use a non-copyable type (`Array`) instead of a copyable fixed-size array. Adds explanation of why `as_snapshot()` is needed for non-copyable types.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The snapshot conversion example used `[1, 2, 3]` (a fixed-size array), which is copyable. This fails to demonstrate the actual use case for `as_snapshot()` with non-copyable types. The documentation states that snapshot conversion is "useful when working with non-copyable types," but the example doesn't show a non-copyable type, making the explanation confusing and potentially misleading for users trying to understand when and why to use this feature.

---

## What was the behavior or documentation before?

The example used:
let boxed_value = BoxTrait::new([1, 2, 3]);
let snap_boxed = @boxed_value;         // @Box<[u32; 3]>
let boxed_snap = snap_boxed.as_snapshot();  // Box<@[u32; 3]>
let value_snap = boxed_snap.unbox();   // @[u32; 3]This used a fixed-size array `[u32; 3]` which implements `Copy`, so `Box<[u32; 3]>` is also copyable. The example didn't demonstrate why snapshot conversion is needed for non-copyable types.

---

## What is the behavior or documentation after?

The example now uses:
let boxed_value = BoxTrait::new(array![1, 2, 3]);
let snap_boxed = @boxed_value;         // @Box<Array<felt252>>
let boxed_snap = snap_boxed.as_snapshot();  // Box<@Array<felt252>>
let value_snap = boxed_snap.unbox();   // @Array<felt252>This uses `Array<felt252>` which is non-copyable. The documentation now explains that `Box<Array<T>>` is not copyable, but `Box<@Array<T>>` is copyable because snapshots are always copyable, allowing you to copy a `Box` containing a non-copyable type when needed.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

This change aligns the example with the actual implementation in `corelib/src/box.cairo`, which uses `array![1, 2, 3]` in its documentation. The added explanation helps users understand the practical benefit: converting `@Box<Array<T>>` to `Box<@Array<T>>` enables copying the Box when working with non-copyable types, which is a common pattern in Cairo code.