### PR TITLE
fix(proc-macros): correct impl generics comment in DebugWithDb derive

### DIFF
--- a/crates/cairo-lang-proc-macros/src/debug.rs
+++ b/crates/cairo-lang-proc-macros/src/debug.rs
@@ -42,7 +42,7 @@ fn emit_struct_debug(
 ) -> TokenStream2 {
     let (pat, prints) = emit_fields_debug(db, name.to_string(), &structure.fields);
 
-    // a) impl-side generics  = original + 'a + T
+    // a) impl-side generics = original + 'db
     let impl_generics = create_impl_generics(name, generics);
     let (impl_g, _, where_g) = impl_generics.split_for_impl();
 


### PR DESCRIPTION
## Summary

Fixes an outdated comment in the `DebugWithDb` derive macro that incorrectly stated impl generics include `'a + T`, when in fact only the `'db` lifetime is added. The comment now accurately reflects the actual behavior of the `create_impl_generics` function.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The comment on line 45 of `crates/cairo-lang-proc-macros/src/debug.rs` contained incorrect information about what generics are added to the impl block. It stated `original + 'a + T`, but the actual implementation only adds the `'db` lifetime. This misleading comment could confuse developers trying to understand how the macro works, especially when comparing it to similar code in `rewriter.rs` where `T` and `Error` parameters are actually added.

---

## What was the behavior or documentation before?

The comment read:ust
// a) impl-side generics  = original + 'a + TThis suggested that both a lifetime `'a` and a type parameter `T` were being added, which is incorrect.

---

## What is the behavior or documentation after?

The comment now correctly states:
// a) impl-side generics = original + 'dbThis accurately reflects that only the `'db` lifetime is added to the impl generics, matching both the implementation in `create_impl_generics` and its documentation.

---

## Related issue or discussion (if any)

<!-- None -->

---

## Additional context

The `create_impl_generics` function (lines 189-204) correctly documents its behavior: "The impl generics are the original generics plus a lifetime 'db." The trait `DebugWithDb<'db>` only requires the `'db` lifetime parameter, not a type parameter `T`. This fix aligns the inline comment with both the function's documentation and its actual implementation.