### PR TITLE
bugfix(starknet): Removed intermediate names from event generated code.

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
@@ -1128,10 +1128,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("Log") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Log(val));
+            return Option::Some(Event::Log(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
@@ -375,16 +375,10 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("AwesomeEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::AwesomeEvent(val));
+            return Option::Some(Event::AwesomeEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("BestEventEver") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::BestEventEver(val));
+            return Option::Some(Event::BestEventEver(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -425,13 +419,7 @@ impl AwesomeEventIsEvent of starknet::Event<AwesomeEvent> {
     fn deserialize(
         ref keys: Span<felt252>, ref data: Span<felt252>,
     ) -> Option<AwesomeEvent> {
-                let x = core::serde::Serde::deserialize(
-                    ref data
-                )?;
-                let data = core::serde::Serde::deserialize(
-                    ref data
-                )?;
-        Option::Some(AwesomeEvent {x, data, })
+        Option::Some(AwesomeEvent {x: core::serde::Serde::deserialize(ref data)?, data: core::serde::Serde::deserialize(ref data)?, })
     }
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -10034,10 +10034,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("CompEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::CompEvent(val));
+            return Option::Some(Event::CompEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -15150,10 +15147,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("CompEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::CompEvent(val));
+            return Option::Some(Event::CompEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -17347,10 +17341,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("CompEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::CompEvent(val));
+            return Option::Some(Event::CompEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/events
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/events
@@ -110,13 +110,7 @@ impl AIsEvent of starknet::Event<A> {
     fn deserialize(
         ref keys: Span<felt252>, ref data: Span<felt252>,
     ) -> Option<A> {
-                let x = core::serde::Serde::deserialize(
-                    ref data
-                )?;
-                let data = core::serde::Serde::deserialize(
-                    ref keys
-                )?;
-        Option::Some(A {x, data, })
+        Option::Some(A {x: core::serde::Serde::deserialize(ref data)?, data: core::serde::Serde::deserialize(ref keys)?, })
     }
 }
 impl AStore<> of starknet::Store::<A> {
@@ -280,10 +274,7 @@ impl BIsEvent of starknet::Event<B> {
     fn deserialize(
         ref keys: Span<felt252>, ref data: Span<felt252>,
     ) -> Option<B> {
-                let x = core::serde::Serde::deserialize(
-                    ref data
-                )?;
-        Option::Some(B {x, })
+        Option::Some(B {x: core::serde::Serde::deserialize(ref data)?, })
     }
 }
 
@@ -328,10 +319,7 @@ impl NestedEventEnumIsEvent of starknet::Event<NestedEventEnum> {
     ) -> Option<NestedEventEnum> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("B") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(NestedEventEnum::B(val));
+            return Option::Some(NestedEventEnum::B(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -441,16 +429,10 @@ impl MyEventEnumIsEvent of starknet::Event<MyEventEnum> {
         }
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("A") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(MyEventEnum::A(val));
+            return Option::Some(MyEventEnum::A(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("B") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(MyEventEnum::B(val));
+            return Option::Some(MyEventEnum::B(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/external_event
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/external_event
@@ -90,16 +90,10 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("AwesomeEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::AwesomeEvent(val));
+            return Option::Some(Event::AwesomeEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("BestEventEver") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::BestEventEver(val));
+            return Option::Some(Event::BestEventEver(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
@@ -1933,10 +1933,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("CompEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::CompEvent(val));
+            return Option::Some(Event::CompEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/mintable
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/mintable
@@ -367,22 +367,13 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20(val));
+            return Option::Some(Event::ERC20(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Ownable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Ownable(val));
+            return Option::Some(Event::Ownable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Mintable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Mintable(val));
+            return Option::Some(Event::Mintable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -1348,22 +1339,13 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20(val));
+            return Option::Some(Event::ERC20(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Ownable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Ownable(val));
+            return Option::Some(Event::Ownable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Mintable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Mintable(val));
+            return Option::Some(Event::Mintable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/multi_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/multi_component
@@ -416,28 +416,16 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20(val));
+            return Option::Some(Event::ERC20(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Ownable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Ownable(val));
+            return Option::Some(Event::Ownable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Mintable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Mintable(val));
+            return Option::Some(Event::Mintable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Upgradable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Upgradable(val));
+            return Option::Some(Event::Upgradable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -1457,28 +1445,16 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20(val));
+            return Option::Some(Event::ERC20(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Ownable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Ownable(val));
+            return Option::Some(Event::Ownable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Mintable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Mintable(val));
+            return Option::Some(Event::Mintable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Upgradable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Upgradable(val));
+            return Option::Some(Event::Upgradable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/ownable_erc20
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/ownable_erc20
@@ -283,16 +283,10 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20(val));
+            return Option::Some(Event::ERC20(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Ownable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Ownable(val));
+            return Option::Some(Event::Ownable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -603,16 +597,10 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20(val));
+            return Option::Some(Event::ERC20(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Ownable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Ownable(val));
+            return Option::Some(Event::Ownable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/upgradable_counter
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/upgradable_counter
@@ -368,28 +368,16 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("CounterIncreased") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::CounterIncreased(val));
+            return Option::Some(Event::CounterIncreased(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("CounterDecreased") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::CounterDecreased(val));
+            return Option::Some(Event::CounterDecreased(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("UpgradableEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::UpgradableEvent(val));
+            return Option::Some(Event::UpgradableEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("OwnableEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::OwnableEvent(val));
+            return Option::Some(Event::OwnableEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -424,10 +412,7 @@ impl CounterIncreasedIsEvent of starknet::Event<CounterIncreased> {
     fn deserialize(
         ref keys: Span<felt252>, ref data: Span<felt252>,
     ) -> Option<CounterIncreased> {
-                let amount = core::serde::Serde::deserialize(
-                    ref data
-                )?;
-        Option::Some(CounterIncreased {amount, })
+        Option::Some(CounterIncreased {amount: core::serde::Serde::deserialize(ref data)?, })
     }
 }
 impl CounterDecreasedDrop<> of core::traits::Drop::<CounterDecreased>;
@@ -440,10 +425,7 @@ impl CounterDecreasedIsEvent of starknet::Event<CounterDecreased> {
     fn deserialize(
         ref keys: Span<felt252>, ref data: Span<felt252>,
     ) -> Option<CounterDecreased> {
-                let amount = core::serde::Serde::deserialize(
-                    ref data
-                )?;
-        Option::Some(CounterDecreased {amount, })
+        Option::Some(CounterDecreased {amount: core::serde::Serde::deserialize(ref data)?, })
     }
 }
 #[doc(hidden)]
@@ -1481,28 +1463,16 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("CounterIncreased") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::CounterIncreased(val));
+            return Option::Some(Event::CounterIncreased(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("CounterDecreased") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::CounterDecreased(val));
+            return Option::Some(Event::CounterDecreased(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("UpgradableEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::UpgradableEvent(val));
+            return Option::Some(Event::UpgradableEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("OwnableEvent") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::OwnableEvent(val));
+            return Option::Some(Event::OwnableEvent(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -1537,10 +1507,7 @@ impl CounterIncreasedIsEvent of starknet::Event<CounterIncreased> {
     fn deserialize(
         ref keys: Span<felt252>, ref data: Span<felt252>,
     ) -> Option<CounterIncreased> {
-                let amount = core::serde::Serde::deserialize(
-                    ref data
-                )?;
-        Option::Some(CounterIncreased {amount, })
+        Option::Some(CounterIncreased {amount: core::serde::Serde::deserialize(ref data)?, })
     }
 }
 impl CounterDecreasedDrop<> of core::traits::Drop::<CounterDecreased>;
@@ -1553,10 +1520,7 @@ impl CounterDecreasedIsEvent of starknet::Event<CounterDecreased> {
     fn deserialize(
         ref keys: Span<felt252>, ref data: Span<felt252>,
     ) -> Option<CounterDecreased> {
-                let amount = core::serde::Serde::deserialize(
-                    ref data
-                )?;
-        Option::Some(CounterDecreased {amount, })
+        Option::Some(CounterDecreased {amount: core::serde::Serde::deserialize(ref data)?, })
     }
 }
 #[doc(hidden)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
@@ -416,10 +416,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -1062,16 +1059,10 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("Comp1Event") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Comp1Event(val));
+            return Option::Some(Event::Comp1Event(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Comp2Event") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Comp2Event(val));
+            return Option::Some(Event::Comp2Event(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -1729,16 +1720,10 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("Comp1Event") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Comp1Event(val));
+            return Option::Some(Event::Comp1Event(starknet::Event::deserialize(ref keys, ref data)?));
         }
         if __selector__ == selector!("Comp2Event") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Comp2Event(val));
+            return Option::Some(Event::Comp2Event(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
@@ -333,10 +333,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -734,10 +731,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -1123,10 +1117,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -1525,10 +1516,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -1989,10 +1977,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -2388,10 +2373,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -2778,10 +2760,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -3333,10 +3312,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ABC") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ABC(val));
+            return Option::Some(Event::ABC(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -4253,10 +4229,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("Comp1Event") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Comp1Event(val));
+            return Option::Some(Event::Comp1Event(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_erc20
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_erc20
@@ -226,10 +226,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20Token") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20Token(val));
+            return Option::Some(Event::ERC20Token(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -477,10 +474,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20Token") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20Token(val));
+            return Option::Some(Event::ERC20Token(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_erc20_mini
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_erc20_mini
@@ -215,10 +215,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20Token") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20Token(val));
+            return Option::Some(Event::ERC20Token(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -455,10 +452,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("ERC20Token") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::ERC20Token(val));
+            return Option::Some(Event::ERC20Token(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_ownable
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_ownable
@@ -273,10 +273,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("Ownable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Ownable(val));
+            return Option::Some(Event::Ownable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }
@@ -568,10 +565,7 @@ impl EventIsEvent of starknet::Event<Event> {
     ) -> Option<Event> {
         let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
         if __selector__ == selector!("Ownable") {
-                let val = starknet::Event::deserialize(
-                    ref keys, ref data
-                )?;
-                return Option::Some(Event::Ownable(val));
+            return Option::Some(Event::Ownable(starknet::Event::deserialize(ref keys, ref data)?));
         }
         Option::None
     }


### PR DESCRIPTION
## Summary

Simplified the event deserialization code by removing intermediate variables and directly inlining deserialization calls. This refactoring reduces code verbosity while maintaining the same functionality. Additionally it removes the possible shadowing of vars by the macro generated code.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The event deserialization code was unnecessarily verbose, with multiple intermediate variables and separate functions that made the code harder to read and maintain. This change streamlines the code by directly using the deserialization results where needed, making the generated code more concise.

---

## What was the behavior or documentation before?

Previously, the code would generate separate statements for deserializing each field and then use those variables in the constructor. For example:

```rust
let x = core::serde::Serde::deserialize(ref data)?;
let data = core::serde::Serde::deserialize(ref keys)?;
Option::Some(A {x, data, })
```

---

## What is the behavior or documentation after?

Now, the deserialization is inlined directly in the struct initialization, making the code more concise:

```rust
Option::Some(A {
    x: core::serde::Serde::deserialize(ref data)?, 
    data: core::serde::Serde::deserialize(ref keys)?, 
})
```

---

## Additional context

This change introduces a new helper function `deserialize_member_code` that returns the appropriate deserialization code string based on the field kind, which is then used directly in the struct initialization. This approach reduces code duplication and makes the generated code more maintainable.