### PR TITLE
refactor(semantic): clone only keys in finalize_as_scope()

### DIFF
--- a/crates/cairo-lang-semantic/src/usage/mod.rs
+++ b/crates/cairo-lang-semantic/src/usage/mod.rs
@@ -88,7 +88,7 @@ impl<'db> Usage<'db> {
     /// Removes usage that was introduced current block and usage that is already covered
     /// by containing variables.
     pub fn finalize_as_scope(&mut self) {
-        for (member_path, _) in self.usage.clone() {
+        for member_path in self.usage.keys().cloned().collect::<Vec<_>>() {
             // Prune introductions from usages.
             if self.introductions.contains(&member_path.base_var()) {
                 self.usage.swap_remove(&member_path);
@@ -105,7 +105,7 @@ impl<'db> Usage<'db> {
                 }
             }
         }
-        for (member_path, _) in self.snap_usage.clone() {
+        for member_path in self.snap_usage.keys().cloned().collect::<Vec<_>>() {
             // Prune usages from snap_usage.
             if self.usage.contains_key(&member_path) {
                 self.snap_usage.swap_remove(&member_path);
@@ -129,7 +129,7 @@ impl<'db> Usage<'db> {
                 }
             }
         }
-        for (member_path, _) in self.changes.clone() {
+        for member_path in self.changes.keys().cloned().collect::<Vec<_>>() {
             // Prune introductions from changes.
             if self.introductions.contains(&member_path.base_var()) {
                 self.changes.swap_remove(&member_path);


### PR DESCRIPTION
## Summary

Changed all three loops (usage, snap_usage, changes) to collect only keys into a Vec before iteration. This eliminates unnecessary cloning of values and reduces memory allocations.

---

## Type of change

Please check **one**:

- [z] Performance improvement

---

## Why is this change needed?


The finalize_as_scope() method was cloning entire OrderedHashMap instances  (with all their values) just to iterate while modifying. This is wasteful  since we only need the keys - the values (ExprVarMemberPath) are never used in the loop body.