### PR TITLE
fix: remove duplicate db query in `priv_global_use_semantic_data_tracked_initial`

### DIFF
--- a/crates/cairo-lang-semantic/src/items/us.rs
+++ b/crates/cairo-lang-semantic/src/items/us.rs
@@ -329,8 +329,7 @@ fn priv_global_use_semantic_data_tracked_initial<'db>(
 ) -> Maybe<UseGlobalData<'db>> {
     let mut diagnostics = SemanticDiagnostics::new(global_use_id.parent_module(db));
     let global_use_ast = db.module_global_use_by_id(global_use_id)?;
-    let star_ast = ast::UsePath::Star(global_use_ast.clone());
-    let segments = get_use_path_segments(db, star_ast)?;
+    let segments = get_use_path_segments(db, ast::UsePath::Star(global_use_ast.clone()))?;
     let err = if segments.segments.len() == 1 {
         // `use bad_name::*`, will attempt to find `bad_name` in the current module's global
         // uses, which includes the global use `use bad_name::*` (itself) - but we don't want to


### PR DESCRIPTION
## Summary

Reused the already-fetched `global_use_ast` variable instead of making a redundant database query.

---

## Type of change

- [x] Performance improvement

---

## Why is this change needed?

The `priv_global_use_semantic_data_tracked_initial` function called `db.module_global_use_by_id()` twice in succession, even though the result was already stored in `global_use_ast`. While salsa caches query results, this pattern is inconsistent with the main function `priv_global_use_semantic_data` and wastes a cache lookup.
