### PR TITLE
refactor(lowering): remove unnecessary Vec allocation in merge_match

### DIFF
--- a/crates/cairo-lang-lowering/src/borrow_check/mod.rs
+++ b/crates/cairo-lang-lowering/src/borrow_check/mod.rs
@@ -234,10 +234,8 @@ impl<'db, 'mt> Analyzer<'db, '_> for BorrowChecker<'db, 'mt, '_> {
         match_info: &MatchInfo<'db>,
         infos: impl Iterator<Item = Self::Info>,
     ) -> Self::Info {
-        let infos: Vec<_> = infos.collect();
-        let arm_demands = zip_eq(match_info.arms(), &infos)
-            .map(|(arm, demand)| {
-                let mut demand = demand.clone();
+        let arm_demands = zip_eq(match_info.arms(), infos)
+            .map(|(arm, mut demand)| {
                 demand.variables_introduced(self, &arm.var_ids, (None, block_id));
                 (demand, (Some(DropPosition::Diverge(*match_info.location())), block_id))
             })


### PR DESCRIPTION
## Summary

Changes:
- Removed `let infos: Vec<_> = infos.collect()`
- Changed `&infos` to `infos` in `zip_eq` call
- Removed `.clone()` call on demand since we now own the value directly

---

## Type of change

- [x] Performance improvement

---

## Why is this change needed?

The previous implementation collected iterator into a Vec just to borrow it again, forcing an unnecessary `.clone()` on each demand. All other `merge_match`https://github.com/starkware-libs/cairo/blob/bdf1b29fd3b6bb3a653852bc13777953fb11307e/crates/cairo-lang-lowering/src/destructs.rs#L236-L263 implementations in the codebase pass the iterator directly to `zip_eq` and take ownership without cloning.
