### PR TITLE
(feat): Added punctiuation checkin script for rust comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,14 @@ jobs:
       - run: >
           scripts/validate_error_codes.sh
 
+  # Check that doc comment blocks end with punctuation.
+  doc-comment-punctuation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: >
+          scripts/check_comment_punctuation.py crates
+
   # Check for unnecessary dependencies.
   udeps:
     runs-on: ubuntu-latest

--- a/crates/bin/cairo-test/src/main.rs
+++ b/crates/bin/cairo-test/src/main.rs
@@ -37,7 +37,7 @@ struct Args {
     #[arg(long, default_value_t = false)]
     starknet: bool,
     /// Whether to run the profiler, and what results to produce. See
-    /// [cairo_lang_runner::profiling::ProfilerConfig]
+    /// [cairo_lang_runner::profiling::ProfilerConfig].
     #[arg(short, long, default_value_t, value_enum)]
     run_profiler: RunProfilerConfigArg,
     /// Whether to disable gas calculation.

--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -88,7 +88,7 @@ struct Args {
     #[arg(short, long)]
     no_gas: bool,
 
-    /// Use the executable plugin suite instead of the Starknet suite
+    /// Use the executable plugin suite instead of the Starknet suite.
     #[arg(short, long)]
     executable: bool,
 

--- a/crates/cairo-lang-debug/src/debug.rs
+++ b/crates/cairo-lang-debug/src/debug.rs
@@ -282,7 +282,7 @@ where
 
 /// This is used by the macro generated code.
 /// If the field type implements `DebugWithDb`, uses that, otherwise, uses `Debug`.
-/// That's the "has impl" trick <https://github.com/nvzqz/impls#how-it-works>
+/// That's the "has impl" trick <https://github.com/nvzqz/impls#how-it-works>.
 #[doc(hidden)]
 pub mod helper {
     use std::fmt;

--- a/crates/cairo-lang-diagnostics/src/diagnostics.rs
+++ b/crates/cairo-lang-diagnostics/src/diagnostics.rs
@@ -277,7 +277,7 @@ impl<'db, TEntry: DiagnosticEntry<'db> + salsa::Update> Diagnostics<'db, TEntry>
         if self.has_errors() { Err(DiagnosticAdded) } else { Ok(()) }
     }
 
-    /// Checks if there are no entries inside `Diagnostics`
+    /// Checks if there are no entries inside `Diagnostics`.
     pub fn is_empty(&self) -> bool {
         self.0.leaves.is_empty() && self.0.subtrees.iter().all(|subtree| subtree.is_empty())
     }

--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -54,9 +54,9 @@ impl DocumentationCommentToken {
 
 /// Helper struct for formatting possibly nested Markdown lists.
 struct DocCommentListItem {
-    /// Ordered list item separator
+    /// Ordered list item separator.
     delimiter: Option<u64>,
-    /// Flag for an ordered list
+    /// Flag for an ordered list.
     is_ordered_list: bool,
 }
 

--- a/crates/cairo-lang-executable/src/compile.rs
+++ b/crates/cairo-lang-executable/src/compile.rs
@@ -66,7 +66,7 @@ pub struct ExecutableConfig {
     pub unsafe_panic: bool,
 
     /// An optional list of builtins to use in the entry code (if its none the builtins will be
-    /// inferred from the param_types)
+    /// inferred from the param_types).
     pub builtin_list: Option<Vec<BuiltinName>>,
 }
 

--- a/crates/cairo-lang-filesystem/src/span.rs
+++ b/crates/cairo-lang-filesystem/src/span.rs
@@ -186,7 +186,7 @@ impl TextSpan {
         Self::cursor(self.start)
     }
 
-    /// Returns self.start..self.end as [`Range<usize>`]
+    /// Returns self.start..self.end as [`Range<usize>`].
     pub fn to_str_range(&self) -> Range<usize> {
         self.start.0.0 as usize..self.end.0.0 as usize
     }

--- a/crates/cairo-lang-lowering/src/destructs.rs
+++ b/crates/cairo-lang-lowering/src/destructs.rs
@@ -37,15 +37,15 @@ pub type DestructAdderDemand = Demand<VariableId, (), PanicState>;
 /// The add destruct flow type, used for grouping of destruct calls.
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 enum AddDestructFlowType {
-    /// Plain destruct
+    /// Plain destruct.
     Plain,
-    /// Panic destruct following the creation of a panic variable (or return of a panic variable)
+    /// Panic destruct following the creation of a panic variable (or return of a panic variable).
     PanicVar,
     /// Panic destruct following a match of PanicResult.
     PanicPostMatch,
 }
 
-/// Context for the destructor call addition phase,
+/// Context for the destructor call addition phase.
 pub struct DestructAdder<'db, 'a> {
     db: &'db dyn Database,
     lowered: &'a Lowered<'db>,

--- a/crates/cairo-lang-lowering/src/ids.rs
+++ b/crates/cairo-lang-lowering/src/ids.rs
@@ -538,7 +538,7 @@ impl<'a> DebugWithDb<'a> for SpecializedFunction<'a> {
 pub struct EnrichedSemanticSignature<'db> {
     /// Input params.
     pub params: Vec<semantic::ExprVarMemberPath<'db>>,
-    /// Extra returns - e.g. ref params
+    /// Extra returns - e.g. ref params.
     pub extra_rets: Vec<semantic::ExprVarMemberPath<'db>>,
     /// Return type.
     pub return_type: semantic::TypeId<'db>,
@@ -606,7 +606,7 @@ semantic::add_rewrite!(<'a, 'b>, SubstitutionRewriter<'a, 'b>, DiagnosticAdded, 
 pub struct Signature<'db> {
     /// Input params.
     pub params: Vec<LoweredParam<'db>>, // Vec<semantic::ExprVarMemberPath<'db>>,
-    /// Extra returns - e.g. ref params
+    /// Extra returns - e.g. ref params.
     pub extra_rets: Vec<semantic::ExprVarMemberPath<'db>>,
     /// Return type.
     pub return_type: semantic::TypeId<'db>,

--- a/crates/cairo-lang-lowering/src/lower/context.rs
+++ b/crates/cairo-lang-lowering/src/lower/context.rs
@@ -127,7 +127,7 @@ pub struct LoopEarlyReturnInfo<'db> {
 
 /// Context for lowering a loop.
 pub struct LoopContext<'db> {
-    /// The loop expression
+    /// The loop expression.
     pub loop_expr_id: semantic::ExprId,
     /// Optional info related to early return from the loop.
     pub early_return_info: Option<LoopEarlyReturnInfo<'db>>,

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1134,7 +1134,7 @@ fn lower_expr_tuple<'db>(
     Ok(LoweredExpr::Tuple { exprs: inputs, location })
 }
 
-/// Lowers an expression of type [semantic::ExprFixedSizeArray]
+/// Lowers an expression of type [semantic::ExprFixedSizeArray].
 fn lower_expr_fixed_size_array<'db>(
     ctx: &mut LoweringContext<'db, '_>,
     expr: &semantic::ExprFixedSizeArray<'db>,

--- a/crates/cairo-lang-lowering/src/objects.rs
+++ b/crates/cairo-lang-lowering/src/objects.rs
@@ -657,6 +657,6 @@ pub enum LoweringStage {
     /// `baseline_optimization_strategy`.
     PostBaseline,
     /// Lowering with all of the optimizations - specifically, adds the stages at
-    /// `final_optimization_strategy`
+    /// `final_optimization_strategy`.
     Final,
 }

--- a/crates/cairo-lang-lowering/src/optimizations/cse.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/cse.rs
@@ -38,7 +38,7 @@ struct CseContext<'db> {
     /// Maps expression keys to the variable that holds the result of that expression in the
     /// current block.
     expression_map: UnorderedHashMap<ExpressionKey<'db>, Vec<VariableId>>,
-    /// Maps variables to their replacement (for variables that have been eliminated)
+    /// Maps variables to their replacement (for variables that have been eliminated).
     var_replacements: UnorderedHashMap<VariableId, VariableId>,
     /// A mapping from new non-snapshot variables after taking snapshot, to the original variable
     /// the snapshot was taken from. Used to canonicalize the variable after taking snapshot.
@@ -107,7 +107,7 @@ impl<'db> CseContext<'db> {
         }
     }
 
-    /// Resolves a variable through the replacement chain
+    /// Resolves a variable through the replacement chain.
     fn resolve_var(&self, var: VariableId) -> VariableId {
         match self.var_replacements.get(&var).or_else(|| self.snapshot_remappings.get(&var)) {
             Some(&replacement) => self.resolve_var(replacement),
@@ -116,7 +116,7 @@ impl<'db> CseContext<'db> {
     }
 
     /// Determines if a function is pure and safe to optimize
-    /// For now, we're conservative and only optimize very basic operations
+    /// For now, we're conservative and only optimize very basic operations.
     fn is_pure_function(&self, _function: &FunctionId<'db>) -> bool {
         // TODO: Implement logic to determine if a function is pure
         // For now, we're being conservative and not optimizing any function calls

--- a/crates/cairo-lang-lowering/src/optimizations/match_optimizer.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/match_optimizer.rs
@@ -318,7 +318,7 @@ fn try_get_fix_info<'db>(
 }
 
 pub struct FixInfo<'db> {
-    /// The location that needs to be fixed,
+    /// The location that needs to be fixed.
     statement_location: (BlockId, usize),
     /// The block with the match statement that we want to jump over.
     match_block: BlockId,

--- a/crates/cairo-lang-lowering/src/optimizations/reboxing.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/reboxing.rs
@@ -47,11 +47,11 @@ pub enum ReboxingValue {
 /// Represents a candidate for reboxing optimization.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ReboxCandidate {
-    /// The reboxing data
+    /// The reboxing data.
     pub source: ReboxingValue,
-    /// The reboxed variable (output of into_box)
+    /// The reboxed variable (output of into_box).
     pub reboxed_var: VariableId,
-    /// Location where into_box call occurs (block_id, stmt_idx)
+    /// Location where into_box call occurs (block_id, stmt_idx).
     pub into_box_location: StatementLocation,
 }
 

--- a/crates/cairo-lang-lowering/src/optimizations/return_optimization.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/return_optimization.rs
@@ -140,7 +140,7 @@ impl<'db, 'a> ReturnOptimizerContext<'db, 'a> {
         }
     }
 
-    /// Returns true if the variable is droppable
+    /// Returns true if the variable is droppable.
     fn is_droppable(&self, var_id: VariableId) -> bool {
         self.lowered.variables[var_id].info.droppable.is_ok()
     }
@@ -362,7 +362,7 @@ impl<'db> ValueInfo<'db> {
 
 /// Information about the current state of the analyzer.
 /// Used to track the value that should be returned from the function at the current
-/// analysis point
+/// analysis point.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReturnInfo<'db> {
     returned_vars: Vec<ValueInfo<'db>>,
@@ -390,7 +390,7 @@ impl<'db> AnalyzerInfo<'db> {
         *self = Self::invalidated();
     }
 
-    /// Applies the given function to the returned_vars
+    /// Applies the given function to the returned_vars.
     fn apply<F>(&mut self, f: &F)
     where
         F: Fn(&VarUsage<'db>) -> ValueInfo<'db>,

--- a/crates/cairo-lang-lowering/src/optimizations/split_structs.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/split_structs.rs
@@ -40,7 +40,7 @@ type SplitMapping = UnorderedHashMap<VariableId, SplitInfo>;
 /// Keeps track of the variables that were reconstructed.
 /// If the value is None the variable was reconstructed at the first usage.
 /// If the value is Some(Block_id) then the variable needs to be reconstructed at the end of
-/// `block_id`
+/// `block_id`.
 type ReconstructionMapping = OrderedHashMap<VariableId, Option<BlockId>>;
 
 /// Returns a mapping from variables that should be split to the variables resulting from the split.

--- a/crates/cairo-lang-parser/src/colored_printer.rs
+++ b/crates/cairo-lang-parser/src/colored_printer.rs
@@ -6,7 +6,7 @@ use salsa::Database;
 
 struct ColoredPrinter<'a> {
     db: &'a dyn Database,
-    /// Whether to also print empty and missing tokens/nodes
+    /// Whether to also print empty and missing tokens/nodes.
     verbose: bool,
     result: String,
 }

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -563,7 +563,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         )
     }
 
-    /// Expected pattern: `<ParenthesizedParamList><ReturnTypeClause>`
+    /// Expected pattern: `<ParenthesizedParamList><ReturnTypeClause>`.
     fn expect_function_signature(&mut self) -> FunctionSignatureGreen<'a> {
         let lparen = self.parse_token::<TerminalLParen<'_>>();
         let params = self.parse_param_list();
@@ -1104,7 +1104,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is Function.
-    /// Expected pattern: `<FunctionDeclaration>`
+    /// Expected pattern: `<FunctionDeclaration>`.
     fn expect_function_declaration(
         &mut self,
         optional_const: OptionTerminalConstGreen<'a>,
@@ -1114,7 +1114,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is Function.
-    /// Expected pattern: `<FunctionDeclaration>`
+    /// Expected pattern: `<FunctionDeclaration>`.
     fn expect_function_declaration_ex(
         &mut self,
         optional_const: OptionTerminalConstGreen<'a>,
@@ -1135,7 +1135,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is Function.
-    /// Expected pattern: `<FunctionDeclaration><Block>`
+    /// Expected pattern: `<FunctionDeclaration><Block>`.
     fn expect_item_function_with_body(
         &mut self,
         attributes: AttributeListGreen<'a>,
@@ -1216,7 +1216,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is Function.
-    /// Expected pattern: `<FunctionDeclaration><SemiColon>`
+    /// Expected pattern: `<FunctionDeclaration><SemiColon>`.
     fn expect_trait_item_function(
         &mut self,
         attributes: AttributeListGreen<'a>,
@@ -1756,7 +1756,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is LParen.
-    /// Expected pattern: `<ArgListParenthesized>`
+    /// Expected pattern: `<ArgListParenthesized>`.
     fn expect_function_call(&mut self, path: ExprPathGreen<'a>) -> ExprFunctionCallGreen<'a> {
         let func_name = path;
         let parenthesized_args = self.expect_parenthesized_argument_list();
@@ -1764,7 +1764,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is TerminalNot.
-    /// Expected pattern: `!<WrappedArgList>`
+    /// Expected pattern: `!<WrappedArgList>`.
     fn expect_macro_call(&mut self, path: ExprPathGreen<'a>) -> ExprInlineMacroGreen<'a> {
         let bang = self.take::<TerminalNot<'_>>();
         let macro_name = path;
@@ -2013,7 +2013,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is LParen.
-    /// Expected pattern: `\(<ArgList>\)`
+    /// Expected pattern: `\(<ArgList>\)`.
     fn expect_parenthesized_argument_list(&mut self) -> ArgListParenthesizedGreen<'a> {
         self.expect_wrapped_argument_list::<TerminalLParen<'_>, TerminalRParen<'_>, _, _>(
             ArgListParenthesized::new_green,
@@ -2021,7 +2021,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Tries to parse parenthesized argument list.
-    /// Expected pattern: `\(<ArgList>\)`
+    /// Expected pattern: `\(<ArgList>\)`.
     fn try_parse_parenthesized_argument_list(&mut self) -> OptionArgListParenthesizedGreen<'a> {
         if self.peek().kind == SyntaxKind::TerminalLParen {
             self.expect_parenthesized_argument_list().into()
@@ -2138,7 +2138,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is LBrace.
-    /// Expected pattern: `<StructArgListBraced>`
+    /// Expected pattern: `<StructArgListBraced>`.
     fn expect_constructor_call(&mut self, path: ExprPathGreen<'a>) -> ExprStructCtorCallGreen<'a> {
         let ctor_name = path;
         let args = self.expect_struct_ctor_argument_list_braced();
@@ -2226,7 +2226,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is DotDot.
-    /// Expected pattern: `\.\.<Expr>`
+    /// Expected pattern: `\.\.<Expr>`.
     fn expect_struct_argument_tail(&mut self) -> StructArgTailGreen<'a> {
         let dotdot = self.take::<TerminalDotDot<'_>>(); // ..
         // TODO(yuval): consider changing this to SimpleExpr once it exists.
@@ -3239,7 +3239,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is LT.
-    /// Expected pattern: `\< <GenericArgList> \>`
+    /// Expected pattern: `\< <GenericArgList> \>`.
     fn expect_generic_args(&mut self) -> GenericArgsGreen<'a> {
         let langle = self.take::<TerminalLT<'_>>();
         let generic_args = GenericArgList::new_green(
@@ -3256,7 +3256,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is LT.
-    /// Expected pattern: `\< <GenericParamList> \>`
+    /// Expected pattern: `\< <GenericParamList> \>`.
     fn expect_generic_params(&mut self) -> WrappedGenericParamListGreen<'a> {
         let langle = self.take::<TerminalLT<'_>>();
         let generic_params = GenericParamList::new_green(
@@ -3325,7 +3325,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Assumes the current token is LBrack.
-    /// Expected pattern: `[ <associated_item_constraints_list> ]>`
+    /// Expected pattern: `[ <associated_item_constraints_list> ]>`.
     fn expect_associated_item_constraints(&mut self) -> AssociatedItemConstraintsGreen<'a> {
         let lbrack = self.take::<TerminalLBrack<'_>>();
         let associated_item_constraints_list = AssociatedItemConstraintList::new_green(

--- a/crates/cairo-lang-parser/src/test_utils.rs
+++ b/crates/cairo-lang-parser/src/test_utils.rs
@@ -46,17 +46,17 @@ pub fn create_virtual_file<'a>(
 }
 
 /// Mocked struct which implements [cairo_lang_primitive_token::ToPrimitiveTokenStream]
-/// Its main purpose is being used for testing the [crate::parser::Parser::parse_token_stream]
+/// Its main purpose is being used for testing the [crate::parser::Parser::parse_token_stream].
 #[derive(Debug, Clone)]
 pub struct MockTokenStream {
-    /// Field that holds all the tokens that are part of the stream
+    /// Field that holds all the tokens that are part of the stream.
     pub tokens: Vec<MockToken>,
 }
 
-/// Represents a token inside the [MockTokenStream]
+/// Represents a token inside the [MockTokenStream].
 #[derive(Debug, Default, Clone)]
 pub struct MockToken {
-    /// Just a text of a given [MockToken]
+    /// Just a text of a given [MockToken].
     pub content: String,
     /// Its offsets are related to the other tokens present in the same [MockTokenStream].
     pub span: TextSpan,
@@ -67,7 +67,7 @@ impl MockToken {
         Self { content, span }
     }
 
-    /// Create a token based on [SyntaxNode]
+    /// Create a token based on [SyntaxNode].
     pub fn from_syntax_node(db: &dyn Database, node: SyntaxNode<'_>) -> MockToken {
         MockToken::new(node.get_text(db).to_string(), node.span(db))
     }

--- a/crates/cairo-lang-parser/src/utils.rs
+++ b/crates/cairo-lang-parser/src/utils.rs
@@ -66,7 +66,7 @@ impl SimpleParserDatabase {
 
     /// Parses a token stream (based on whole file) and returns its syntax root.
     /// It's very similar to [Self::parse_virtual_with_diagnostics], but instead of taking a content
-    /// as a string, it takes a type that implements [ToPrimitiveTokenStream] trait
+    /// as a string, it takes a type that implements [ToPrimitiveTokenStream] trait.
     pub fn parse_token_stream(
         &self,
         token_stream: &dyn ToPrimitiveTokenStream<Iter = impl Iterator<Item = PrimitiveToken>>,

--- a/crates/cairo-lang-runnable-utils/src/builder.rs
+++ b/crates/cairo-lang-runnable-utils/src/builder.rs
@@ -225,7 +225,7 @@ impl RunnableBuilder {
         create_entry_code_from_params(&param_types, &return_types, code_offset, config)
     }
 
-    /// Converts array of `ConcreteTypeId`s into corresponding `GenericTypeId`s and their sizes
+    /// Converts array of `ConcreteTypeId`s into corresponding `GenericTypeId`s and their sizes.
     pub fn generic_id_and_size_from_concrete(
         &self,
         types: &[ConcreteTypeId],
@@ -260,7 +260,7 @@ pub struct EntryCodeConfig {
     pub allow_unsound: bool,
 
     /// An optional list of builtins to use in the entry code (if its none the builtins will be
-    /// inferred from the param_types)
+    /// inferred from the param_types).
     pub builtin_list: Option<Vec<BuiltinName>>,
 }
 impl EntryCodeConfig {

--- a/crates/cairo-lang-runner/src/casm_run/contract_address.rs
+++ b/crates/cairo-lang-runner/src/casm_run/contract_address.rs
@@ -7,7 +7,7 @@ const ADDR_BOUND: NonZeroFelt252 =
         "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00",
     ));
 
-/// Cairo string of "STARKNET_CONTRACT_ADDRESS"
+/// Cairo string of "STARKNET_CONTRACT_ADDRESS".
 const CONTRACT_ADDRESS_PREFIX: Felt252 =
     Felt252::from_hex_unchecked("0x535441524b4e45545f434f4e54524143545f41444452455353");
 

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -232,7 +232,7 @@ impl SierraCasmRunner {
         })
     }
 
-    /// Extract inner type if `ty` is a panic wrapper
+    /// Extract inner type if `ty` is a panic wrapper.
     fn inner_type_from_panic_wrapper(
         &self,
         ty: &GenericTypeId,

--- a/crates/cairo-lang-runner/src/profiling.rs
+++ b/crates/cairo-lang-runner/src/profiling.rs
@@ -672,7 +672,7 @@ impl<'a> ProfilingInfoProcessor<'a> {
         )
     }
 
-    /// Process Sierra statement weights in the scope of a particular call stack
+    /// Process Sierra statement weights in the scope of a particular call stack.
     fn process_scoped_sierra_statement_weights(
         &self,
         raw_profiling_info: &ProfilingInfo,

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -232,13 +232,13 @@ struct InnerContext<'db> {
 /// Kinds of inner context.
 #[derive(Debug, Clone)]
 enum InnerContextKind<'db> {
-    /// Context inside a `loop`
+    /// Context inside a `loop`.
     Loop { type_merger: FlowMergeTypeHelper<'db> },
-    /// Context inside a `while` loop
+    /// Context inside a `while` loop.
     While,
-    /// Context inside a `for` loop
+    /// Context inside a `for` loop.
     For,
-    /// Context inside a `closure`
+    /// Context inside a `closure`.
     Closure,
 }
 

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -123,7 +123,7 @@ impl<'db> ImplVar<'db> {
     }
 }
 
-/// A negative impl variable
+/// A negative impl variable.
 #[derive(
     Clone, Debug, PartialEq, Eq, Hash, DebugWithDb, SemanticObject, HeapSize, salsa::Update,
 )]
@@ -357,7 +357,7 @@ struct PendingInferenceError<'db> {
     stable_ptr: Option<SyntaxStablePtrId<'db>>,
 }
 
-/// A mapping of an impl var's trait items to concrete items
+/// A mapping of an impl var's trait items to concrete items.
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, SemanticObject, salsa::Update)]
 pub struct ImplVarTraitItemMappings<'db> {
     /// The trait types of the impl var.

--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -720,7 +720,7 @@ impl<'db> DebugWithDb<'db> for ConcreteFunction<'db> {
 pub struct Signature<'db> {
     pub params: Vec<semantic::Parameter<'db>>,
     pub return_type: semantic::TypeId<'db>,
-    /// Implicit parameters
+    /// Implicit parameters.
     pub implicits: Vec<semantic::TypeId<'db>>,
     #[dont_rewrite]
     pub panicable: bool,

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -4364,7 +4364,7 @@ pub trait ImplSemantic<'db>: Database {
     ) -> Maybe<Arc<ResolverData<'db>>> {
         Ok(self.priv_impl_function_body_data(impl_function_id)?.resolver_data.clone())
     }
-    /// Private query to compute data about an impl function definition (declaration + body)
+    /// Private query to compute data about an impl function definition (declaration + body).
     fn priv_impl_function_body_data(
         &'db self,
         impl_function_id: ImplFunctionId<'db>,

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -1453,7 +1453,7 @@ pub trait TraitSemantic<'db>: Database {
         self.priv_trait_function_body_data(trait_function_id)
             .map(|x| x.map(|y| y.resolver_data.clone()))
     }
-    /// Private query to compute data about a trait function definition (declaration + body)
+    /// Private query to compute data about a trait function definition (declaration + body).
     fn priv_trait_function_body_data(
         &'db self,
         trait_function_id: TraitFunctionId<'db>,

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -1679,7 +1679,7 @@ enum ResolvedBase<'db> {
     Module(ModuleId<'db>),
     /// The base module is a crate.
     Crate(CrateId<'db>),
-    /// The base module to address is the statement
+    /// The base module to address is the statement.
     StatementEnvironment(ResolvedGenericItem<'db>),
     /// The item is imported using global use.
     FoundThroughGlobalUse { item_info: ModuleItemInfo<'db>, containing_module: ModuleId<'db> },

--- a/crates/cairo-lang-sierra-generator/src/ap_tracking.rs
+++ b/crates/cairo-lang-sierra-generator/src/ap_tracking.rs
@@ -47,7 +47,7 @@ pub fn get_ap_tracking_configuration(
 
 /// Context for the ap tracking analysis.
 /// This analysis is used to determine where ap tracking should be enabled/disabled
-/// based on `vars_of_interest`
+/// based on `vars_of_interest`.
 struct ApTrackingAnalysisContext {
     /// The variables that require ap alignment.
     pub vars_of_interest: OrderedHashSet<VariableId>,

--- a/crates/cairo-lang-sierra-to-casm/src/lib.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/lib.rs
@@ -1,4 +1,4 @@
-//! CASM backend. Compiles from Sierra down to CASM. See [cairo_lang_sierra] and [cairo_lang_casm]
+//! CASM backend. Compiles from Sierra down to CASM. See [cairo_lang_sierra] and [cairo_lang_casm].
 
 pub mod annotations;
 pub mod circuit;

--- a/crates/cairo-lang-sierra-to-casm/src/references.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/references.rs
@@ -101,7 +101,7 @@ pub struct ReferenceExpression {
 }
 
 impl ReferenceExpression {
-    /// Builds a reference expression containing only a single cell
+    /// Builds a reference expression containing only a single cell.
     pub fn from_cell(cell_expr: CellExpression) -> Self {
         Self { cells: vec![cell_expr] }
     }

--- a/crates/cairo-lang-sierra/src/extensions/error.rs
+++ b/crates/cairo-lang-sierra/src/extensions/error.rs
@@ -18,7 +18,7 @@ pub enum SpecializationError {
     #[error("index is out of the relevant range")]
     IndexOutOfRange {
         index: BigInt,
-        /// Range is [0, range_size - 1]
+        /// Range is [0, range_size - 1].
         range_size: usize,
     },
     #[error("Could not find the requested function")]

--- a/crates/cairo-lang-sierra/src/extensions/modules/circuit.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/circuit.rs
@@ -241,7 +241,7 @@ impl NamedType for CircuitInputAccumulator {
     }
 }
 
-/// A type that can be used as a circuit modulus (a u384 that is not zero or one)
+/// A type that can be used as a circuit modulus (a u384 that is not zero or one).
 #[derive(Default)]
 pub struct CircuitModulus {}
 impl NoGenericArgsGenericType for CircuitModulus {

--- a/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
@@ -170,7 +170,7 @@ impl NoGenericArgsGenericLibfunc for GetUnspentGasLibfunc {
 pub type CostTokenMap<Value> = SmallOrderedMap<CostTokenType, Value>;
 
 /// Represents different types of costs.
-/// Note that if you add a type here you should update 'iter_precost'
+/// Note that if you add a type here you should update 'iter_precost'.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CostTokenType {
     /// A compile time known cost unit. This is a linear combination of the runtime tokens

--- a/crates/cairo-lang-starknet/src/plugin/derive/event.rs
+++ b/crates/cairo-lang-starknet/src/plugin/derive/event.rs
@@ -333,7 +333,7 @@ fn handle_enum<'db>(
     Some((event_impl, StarknetEventAuxData { event_data }))
 }
 
-/// Generates code to emit an event for a field
+/// Generates code to emit an event for a field.
 fn append_field<'db>(member_kind: EventFieldKind, field: RewriteNode<'db>) -> RewriteNode<'db> {
     match member_kind {
         EventFieldKind::Nested | EventFieldKind::Flat => RewriteNode::interpolate_patched(

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
@@ -130,7 +130,7 @@ impl<'db> ComponentsGenerationData<'db> {
         RewriteNode::new_modified(has_component_impls)
     }
 
-    /// Validate the component
+    /// Validate the component.
     fn validate_component(
         &self,
         db: &'db dyn Database,

--- a/crates/cairo-lang-syntax/src/node/helpers.rs
+++ b/crates/cairo-lang-syntax/src/node/helpers.rs
@@ -637,7 +637,7 @@ impl<'a> WrappedArgListHelper<'a> for WrappedArgList<'a> {
 }
 
 pub trait WrappedGenericParamListHelper<'a> {
-    /// Checks whether there are 0 generic parameters
+    /// Checks whether there are 0 generic parameters.
     fn is_empty(&'a self, db: &'a dyn Database) -> bool;
 }
 impl<'a> WrappedGenericParamListHelper<'a> for ast::WrappedGenericParamList<'a> {
@@ -648,7 +648,7 @@ impl<'a> WrappedGenericParamListHelper<'a> for ast::WrappedGenericParamList<'a> 
 
 pub trait OptionWrappedGenericParamListHelper<'a> {
     /// Checks whether there are 0 generic parameters. True either when the generic params clause
-    /// doesn't exist or when it's empty
+    /// doesn't exist or when it's empty.
     fn is_empty(&'a self, db: &'a dyn Database) -> bool;
 }
 impl<'a> OptionWrappedGenericParamListHelper<'a> for ast::OptionWrappedGenericParamList<'a> {

--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -213,7 +213,7 @@ mod impl_parity_scale_codec {
             core::mem::size_of::<u8>() + bits / 8 + if bits.is_multiple_of(8) { 0 } else { 1 }
         }
 
-        /// /!\ Warning this function panics if the number encoded is too big (>= 2**504)
+        /// /!\ Warning this function panics if the number encoded is too big (>= 2**504).
         fn encode_to<T: parity_scale_codec::Output + ?Sized>(&self, dest: &mut T) {
             let (sign, data) = self.value.to_bytes_le();
             assert!(data.len() <= 63, "Can't encode numbers longer than 63 bytes");

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components.rs
@@ -16,7 +16,7 @@ pub trait ComputeScc: GraphNode {
 /// additional state for the algorithm.
 #[derive(Default, PartialEq, Eq, Hash, Clone)]
 struct SccAlgoNode<Node: GraphNode> {
-    /// The wrapped GraphNode
+    /// The wrapped GraphNode.
     node: Node,
     /// The index of the node in the algorithm. The smaller the index, the earlier the node was
     /// reached.

--- a/scripts/check_comment_punctuation.py
+++ b/scripts/check_comment_punctuation.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Check that the final line of each doc comment block ends with punctuation.
+
+Scans .rs files under crates/ for doc comment blocks (/// or //!) and
+reports any block whose last non-blank comment line does NOT end with punctuation.
+
+Exclusions (non-prose that doesn't need punctuation):
+- Lines inside code fences (``` blocks)
+- Empty comment lines
+- Lines that look like code examples
+- Markdown headers (# ...)
+- Lines ending with `:` (introducing a code block or list)
+- Bullet/list items (* ..., - ...)
+- Math expressions / ranges
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List
+
+
+def is_doc_comment(line: str) -> bool:
+    stripped = line.lstrip()
+    return stripped.startswith("///") or stripped.startswith("//!")
+
+
+def extract_comment_text(line: str) -> str:
+    """Extract the text content after /// or //! and whether it was indented."""
+    stripped = line.lstrip()
+    if stripped.startswith("///") or stripped.startswith("//!"):
+        return stripped[3:]
+    return ""
+
+
+def should_skip_line(text: str) -> bool:
+    """Return True if this final comment line should be excluded from the check."""
+    skip = (
+        # Code fences
+        text.strip().startswith("```")
+        # Indented
+        or text.startswith("  ")
+        or text.startswith("\t")
+        # Markdown headers
+        or re.match(r"^\s*#+\s", text) is not None
+        # Bullet/list items
+        or re.match(r"^\s*[\*\-]\s", text) is not None
+        # Lines ending with `:` (introducing examples/code blocks)
+        or text.rstrip().endswith(":")
+        # Lines that are entirely a backtick-wrapped code reference (e.g. `SomeType<T>`)
+        or re.match(r"^`[^`]+`$", text.strip()) is not None
+        # Math expressions: lines that are just numbers/operators
+        or re.match(r"^[\d\s\+\-\*\/\(\)\[\]<>,]+$", text) is not None
+        # Comments starting with `----`
+        or re.match(r"^\s*----", text) is not None
+    )
+
+    # Code indicators
+    code_indicators = [
+        ";",
+        "{",
+        "}",
+    ]
+    for indicator in code_indicators:
+        if indicator in text:
+            skip = True
+
+    return skip
+
+
+def check_file(lines: List[str]) -> list[tuple[int, str]]:
+    """Check text for doc comment blocks whose final line doesn't end with punctuation.
+
+    Returns list of (line_number, final_comment_text).
+    """
+    violations = []
+
+    i = 0
+
+    while i < len(lines):
+        if not is_doc_comment(lines[i]):
+            i += 1
+            continue
+
+        # Collect all consecutive doc comment lines.
+        block_lines = []  # (line_number, text)
+
+        # Track code fences and find the last non-blank, non-code text line.
+        in_code_fence = False
+        last_text_line = None  # (line_number, text)
+        while i < len(lines) and is_doc_comment(lines[i]):
+            text = extract_comment_text(lines[i])
+            i += 1
+            block_lines.append((i, text))  # 1-indexed line number
+            if text.strip().startswith("```"):
+                in_code_fence = not in_code_fence
+            if in_code_fence or not text.strip() or text.strip().startswith("```"):
+                continue
+            last_text_line = (i, text)
+
+        if last_text_line is None:
+            continue
+
+        lineno, text = last_text_line
+
+        # Skip indented lines (example output)
+        if should_skip_line(text):
+            continue
+
+        # Single-line doc blocks that start lowercase are labels, not prose.
+        if len(block_lines) == 1 and text.strip() and text.strip()[0].islower():
+            continue
+
+        # Check if it ends with proper punctuation (period, question mark, or exclamation)
+        stripped_text = text.strip()
+        if not stripped_text.endswith((".", "?", "!")):
+            violations.append((lineno, text))
+
+    return violations
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check that the final line of each doc comment block ends with punctuation."
+    )
+    parser.add_argument(
+        "root",
+        type=Path,
+        help="Project root directory.",
+    )
+    args = parser.parse_args()
+
+    project_root = args.root.resolve()
+    if not project_root.exists():
+        print(f"Error: {project_root} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    all_violations = []  # (line_number, text, filepath)
+    file_count = 0
+
+    for root, dirs, files in os.walk(project_root):
+        for fname in sorted(files):
+            if not fname.endswith(".rs"):
+                continue
+            filepath = os.path.join(root, fname)
+            with open(filepath) as f:
+                text = f.readlines()
+                file_count += 1
+                for lineno, comment_text in check_file(text):
+                    all_violations.append((lineno, comment_text, filepath))
+
+    # Group by the ending character for analysis.
+    endings = {}
+    for lineno, text, filepath in all_violations:
+        last_char = text.rstrip()[-1] if text.rstrip() else "(empty)"
+        endings.setdefault(last_char, []).append((lineno, text, filepath))
+
+    print(f"Scanned {file_count} .rs files under crates/")
+    print(f"Found {len(all_violations)} doc comment blocks NOT ending with period")
+    print()
+
+    # Print summary by ending character.
+    print("=== Summary by ending character ===")
+    for char, items in sorted(endings.items(), key=lambda x: -len(x[1])):
+        print(f"  '{char}': {len(items)} occurrences")
+    print()
+
+    # Print all violations.
+    print("=== All violations ===")
+    for lineno, text, filepath in sorted(all_violations, key=lambda x: x[2]):
+        rel_path = os.path.relpath(filepath, project_root)
+        print(f"{rel_path}:{lineno}: {text}")
+
+    if all_violations:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Added a new CI check to ensure doc comment blocks end with proper punctuation. The script `check_comment_punctuation.py` scans `.rs` files and reports doc comments that don't end with a period, question mark, or exclamation point. This PR also fixes numerous existing doc comments across the codebase to ensure they end with proper punctuation.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Consistent punctuation in documentation comments improves readability and maintains a professional standard throughout the codebase. This automated check ensures that all new doc comments follow this convention, making the documentation more consistent and easier to read.

---

## What was the behavior or documentation before?

Many doc comments throughout the codebase were missing ending punctuation, leading to inconsistent documentation style.

---

## What is the behavior or documentation after?

All doc comments now end with proper punctuation (period, question mark, or exclamation point). The new CI check will prevent future doc comments from being added without proper punctuation.

---

## Additional context

The script is intelligent enough to skip checking lines that don't need punctuation, such as code examples, markdown headers, bullet points, and math expressions. This ensures we only enforce punctuation on actual prose documentation.