### PR TITLE
(feat): Added tracking on enums as part of equality analysis

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis_test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis_test.rs
@@ -1,5 +1,6 @@
 //! File-based tests for the equality analysis.
 
+use cairo_lang_debug::DebugWithDb;
 use cairo_lang_semantic::test_utils::setup_test_function;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -41,7 +42,7 @@ fn test_equality_analysis(
             .iter()
             .enumerate()
             .filter_map(|(i, s)| s.as_ref().map(|state| (i, state)))
-            .map(|(block_idx, state)| format!("Block {block_idx}:\n{state:?}"))
+            .map(|(block_idx, state)| format!("Block {block_idx}:\n{:?}", state.debug(db)))
             .collect::<Vec<_>>()
             .join("\n\n");
 

--- a/crates/cairo-lang-lowering/src/analysis/test_data/equality
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/equality
@@ -179,8 +179,6 @@ Block 0:
 
 //! > Test enum construct tracks variant
 
-//! > TODO(eytan-starkware): Track enum variant and inner value relationship
-
 //! > test_runner_name
 test_equality_analysis
 
@@ -211,7 +209,7 @@ End:
 
 //! > analysis_state
 Block 0:
-(empty)
+A(v0) = v1
 
 //! > ==========================================================================
 
@@ -321,10 +319,10 @@ Block 0:
 (empty)
 
 Block 1:
-(empty)
+Some(v1) = v0
 
 Block 2:
-(empty)
+None(v2) = v0
 
 //! > ==========================================================================
 
@@ -511,6 +509,160 @@ End:
 //! > analysis_state
 Block 0:
 Box(v1) = v0, Box(v2) = v3
+
+//! > ==========================================================================
+
+//! > Test enum construct with same variant across branches preserves info after merge
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > function_code
+fn foo(cond: bool, x: felt252) -> felt252 {
+    // Construct same enum variant in both branches
+    let e = if cond {
+        MyEnum::A(x)
+    } else {
+        MyEnum::A(x)
+    };
+
+    // Force the value to be used after merge
+    use_enum(e);
+    x
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+
+#[inline(never)]
+fn use_enum(e: MyEnum) {}
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool, v1: core::felt252
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v2) => blk1,
+    bool::True(v3) => blk2,
+  })
+
+blk1:
+Statements:
+  (v4: test::MyEnum) <- MyEnum::A(v1)
+End:
+  Goto(blk3, {v4 -> v5})
+
+blk2:
+Statements:
+  (v6: test::MyEnum) <- MyEnum::A(v1)
+End:
+  Goto(blk3, {v6 -> v5})
+
+blk3:
+Statements:
+  () <- test::use_enum(v5)
+End:
+  Return(v1)
+
+//! > analysis_state
+Block 0:
+(empty)
+
+Block 1:
+A(v1) = v4, False(v2) = v0
+
+Block 2:
+A(v1) = v6, True(v3) = v0
+
+Block 3:
+A(v1) = v5
+
+//! > ==========================================================================
+
+//! > Test enum construct with different variants across branches loses enum info after merge
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > function_code
+fn foo(cond: bool, x: felt252, y: felt252) -> felt252 {
+    // Construct different enum variants in branches
+    let e = if cond {
+        MyEnum::A(x)
+    } else {
+        MyEnum::B(y)
+    };
+
+    // Force the value to be used after merge
+    use_enum(e);
+    x
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+
+#[inline(never)]
+fn use_enum(e: MyEnum) {}
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool, v1: core::felt252, v2: core::felt252
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v3) => blk1,
+    bool::True(v4) => blk2,
+  })
+
+blk1:
+Statements:
+  (v5: test::MyEnum) <- MyEnum::B(v2)
+End:
+  Goto(blk3, {v5 -> v6})
+
+blk2:
+Statements:
+  (v7: test::MyEnum) <- MyEnum::A(v1)
+End:
+  Goto(blk3, {v7 -> v6})
+
+blk3:
+Statements:
+  () <- test::use_enum(v6)
+End:
+  Return(v1)
+
+//! > analysis_state
+Block 0:
+(empty)
+
+Block 1:
+B(v2) = v5, False(v3) = v0
+
+Block 2:
+A(v1) = v7, True(v4) = v0
+
+Block 3:
+(empty)
 
 //! > ==========================================================================
 


### PR DESCRIPTION
## Summary

Enhances the equality analysis to track enum constructs and match relationships. The analysis now maintains a hashcons for enum variants, allowing it to detect when two enum constructs with the same variant and equivalent inputs should produce equivalent outputs. This enables more precise tracking of enum values across branches and through match statements.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The equality analysis previously didn't track relationships between enum variants and their inner values. This limited the optimizer's ability to detect equivalent enum values and perform optimizations across match statements and branches. By tracking these relationships, we can enable more aggressive optimizations for code that uses enums.

---

## What was the behavior or documentation before?

The equality analysis would not track relationships between enum variants and their inner values. When an enum was constructed or matched against, this information was lost, preventing optimizations that depend on knowing the relationship between the enum and its contents.

---

## What is the behavior or documentation after?

The equality analysis now:
- Tracks enum constructs via a hashcons mechanism
- Preserves enum relationships across branches when the same variant is used
- Recognizes when a match arm extracts a value that was previously used to construct the enum
- Properly handles the merging of enum information at control flow join points

---

## Additional context

This is part of ongoing work to improve the optimizer's ability to reason about higher-level constructs in Cairo. The implementation uses both forward and reverse mappings to efficiently track enum relationships in both directions.