### PR TITLE
Reduce redundant clone in syntax-codegen Variants::AllTokens path

### DIFF
--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -229,7 +229,10 @@ fn generate_ast_code() -> rust::Tokens {
                     Variants::List(variants) => variants,
                     Variants::AllTokens => all_tokens
                         .iter()
-                        .map(|node| Variant { name: node.name.clone(), kind: node.name.clone() })
+                        .map(|node| {
+                            let n = node.name.clone();
+                            Variant { name: n.clone(), kind: n }
+                        })
                         .collect(),
                 };
                 gen_enum_code(name, variants_list, missing_variant)


### PR DESCRIPTION
Summary
- **What:** Remove duplicate `node.name.clone()` when building `Variant` in `generate_ast_code()`.
- **Where:** `crates/cairo-lang-syntax-codegen/src/generator.rs`, `Variants::AllTokens` branch.
- **Why:** The same value was cloned twice for `name` and `kind`; one clone into a local and reuse avoids redundant work.
Change
- **Before:** `.map(|node| Variant { name: node.name.clone(), kind: node.name.clone() })`
- **After:** One `node.name.clone()` stored in `n`, then `Variant { name: n.clone(), kind: n }`.