### PR TITLE
refactor(sierra-ap-change): remove unused StatementIdx from ApTrackingBase::EnableStatement

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/compute.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/compute.rs
@@ -34,8 +34,7 @@ impl<TokenUsages: Fn(CostTokenType) -> usize> InvocationApChangeInfoProvider
 #[derive(Clone, Debug)]
 enum ApTrackingBase {
     FunctionStart(FunctionId),
-    #[expect(dead_code)]
-    EnableStatement(StatementIdx),
+    EnableStatement,
 }
 
 /// The information for ap tracking of a statement.


### PR DESCRIPTION
Removes dead code from the `ApTrackingBase` enum by eliminating the unused `StatementIdx` payload in the `EnableStatement` variant.
