### PR TITLE
docs: Fix incorrect comment for flag_panic_backtrace

### DIFF
--- a/crates/cairo-lang-filesystem/src/flag.rs
+++ b/crates/cairo-lang-filesystem/src/flag.rs
@@ -68,7 +68,7 @@ fn flag_numeric_match_optimization_min_arms_threshold(db: &dyn salsa::Database) 
     )
 }
 
-/// Returns the value of the `unsafe_panic` flag, or `false` if the flag is not set.
+/// Returns the value of the `panic_backtrace` flag, or `false` if the flag is not set.
 #[salsa::tracked]
 fn flag_panic_backtrace(db: &dyn salsa::Database) -> bool {
     extract_flag_value!(db, PANIC_BACKTRACE, PanicBacktrace).unwrap_or_default()


### PR DESCRIPTION
## Summary

Fixed the comment to correctly reference the `panic_backtrace` flag that the function actually returns.

---

## Type of change

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?


The doc comment for `flag_panic_backtrace` was a copy-paste error from `flag_unsafe_panic` below, incorrectly stating it returns the `unsafe_panic` flag instead of `panic_backtrace`.
---


