### PR TITLE
fix: correct doc comment for flag_panic_backtrace

### DIFF
--- a/crates/cairo-lang-filesystem/src/flag.rs
+++ b/crates/cairo-lang-filesystem/src/flag.rs
@@ -68,7 +68,7 @@ fn flag_numeric_match_optimization_min_arms_threshold(db: &dyn salsa::Database) 
     )
 }
 
-/// Returns the value of the `unsafe_panic` flag, or `false` if the flag is not set.
+/// Returns the value of the `panic_backtrace` flag, or `false` if the flag is not set.
 #[salsa::tracked]
 fn flag_panic_backtrace(db: &dyn salsa::Database) -> bool {
     extract_flag_value!(db, PANIC_BACKTRACE, PanicBacktrace).unwrap_or_default()


### PR DESCRIPTION
**Description:**

The doc comment for `flag_panic_backtrace` incorrectly stated "Returns the value of the `unsafe_panic` flag" due to a copy-paste error from the `flag_unsafe_panic` function below it. Updated to correctly reference `panic_backtrace`.