### PR TITLE
perf: Remove unnecessary Vec allocation in split_structs

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/split_structs.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/split_structs.rs
@@ -168,11 +168,9 @@ fn rebuild_blocks(lowered: &mut Lowered<'_>, split: SplitMapping) {
                     if let Some(output_split) =
                         split.get(&ctx.var_remapper.map_var_id(stmt.input.var_id))
                     {
-                        for (output, new_var) in
-                            zip_eq(stmt.outputs.iter().copied(), output_split.vars.iter().copied())
-                        {
+                        for (output, new_var) in zip_eq(&stmt.outputs, &output_split.vars) {
                             assert!(
-                                ctx.var_remapper.renamed_vars.insert(output, new_var).is_none()
+                                ctx.var_remapper.renamed_vars.insert(*output, *new_var).is_none()
                             )
                         }
                     } else {


### PR DESCRIPTION
The `output_split.vars.to_vec()` call unnecessarily allocates a new Vec on the heap when iterating with `zip_eq`. Since `VariableId` implements `Copy` (via `Id<VariableMarker>` from id_arena), we can use `.copied()` on both iterators to avoid the allocation entirely.

Changes:
- Replaced `stmt.outputs.iter()` with `stmt.outputs.iter().copied()`
- Replaced `output_split.vars.to_vec()` with `output_split.vars.iter().copied()`