### PR TITLE
chore: update comment in formatter_impl.rs

### DIFF
--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -780,9 +780,10 @@ impl fmt::Display for CommentLine {
     }
 }
 
-/// Formats a comment to fit in the line width. There are no merges of lines, as this is not clear
-/// when to merge two lines the user chose to write on separate lines, so all original line breaks
-/// are preserved.
+/// Formats a comment to fit in the line width. Original line breaks chosen by the user are
+/// preserved. However, when the formatter itself breaks a line and the broken line appears to
+/// continue (ending with an alphanumeric character or comma), the fragments are re-merged before
+/// re-wrapping.
 fn format_leading_comment(content: &str, cur_indent: usize, max_line_width: usize) -> String {
     let mut formatted_comment = String::new();
     let mut prev_comment_line = CommentLine::from_string("".to_string());


### PR DESCRIPTION
The doc comment says:

> "There are no merges of lines, as this is not clear when to merge two lines the user chose to write on separate lines, so all original line breaks are preserved."

But the code *does* merge lines when `last_line_broken` is true and `prev_comment_line.is_open_line()` returns true — it prepends the previous broken line's content to the current line. So the comment contradicts the implementation.

The function preserves *user-written* line breaks but merges lines that were *broken by the formatter itself* (when the previous broken line ends with an alphanumeric char or comma, indicating continuation). The fix should clarify this distinction.

Replace:
```
/// Formats a comment to fit in the line width. There are no merges of lines, as this is not clear
/// when to merge two lines the user chose to write on separate lines, so all original line breaks
/// are preserved.
```

With:
```
/// Formats a comment to fit in the line width. Original line breaks chosen by the user are
/// preserved. However, when the formatter itself breaks a line and the broken line appears to
/// continue (ending with an alphanumeric character or comma), the fragments are re-merged before
/// re-wrapping.
```