### PR TITLE
Remove redundant to_owned() call on Copy type in get_enum_size

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -406,7 +406,7 @@ fn get_enum_size(
     program_info: &ProgramInfo<'_>,
     concrete_enum_type: &ConcreteTypeId,
 ) -> Option<i16> {
-    Some(program_info.type_sizes.get(concrete_enum_type)?.to_owned())
+    Some(*program_info.type_sizes.get(concrete_enum_type)?)
 }
 
 /// Generates CASM instructions for matching a boxed enum into individual boxed variants.


### PR DESCRIPTION
Remove unnecessary `to_owned()` call on `i16` value in `get_enum_size()` function.
