### PR TITLE
docs: add compilation error example for case sensitivity

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/identifiers.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/identifiers.adoc
@@ -34,6 +34,16 @@ fn main() {
 }
 ----
 
+Attempting to use an identifier with incorrect case results in a compilation error:
+
+[source,cairo]
+----
+fn main() {
+    let value = 1;
+    // let result = Value;  // Error: unresolved identifier 'Value'
+}
+----
+
 == Unused Variables
 
 Identifiers starting with an underscore indicate intentionally unused variables


### PR DESCRIPTION
## Summary

Adds a compilation error example to the "Case Sensitivity" section demonstrating that using an identifier with incorrect case results in a compilation error.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The "Case Sensitivity" section showed that different case variants create distinct identifiers, but didn't demonstrate what happens when developers use an identifier with incorrect case. This could cause confusion for developers who don't realize that incorrect case usage results in a compilation error.

---

## What was the behavior or documentation before?

The section only contained an example showing that `value`, `Value`, and `VALUE` are distinct identifiers, without showing the compilation error that occurs when using incorrect case.

---

## What is the behavior or documentation after?

The section now includes an example demonstrating that using an identifier with incorrect case (e.g., `Value` when only `value` is defined) results in a compilation error. The example follows the same error notation style used elsewhere in the documentation.

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

The example uses the same comment-based error notation (`// Error: ...`) that is used consistently throughout the Cairo documentation.