### PR TITLE
fix: migrate ClassHash from deprecated class_hash_const to TryInto

### DIFF
--- a/corelib/src/starknet/class_hash.cairo
+++ b/corelib/src/starknet/class_hash.cairo
@@ -55,8 +55,9 @@ pub(crate) impl ClassHashIntoFelt252 of Into<ClassHash, felt252> {
 }
 
 impl ClassHashZero of core::num::traits::Zero<ClassHash> {
+    #[feature("deprecated-starknet-consts")]
     fn zero() -> ClassHash {
-        0.try_into().unwrap()
+        class_hash_const::<0>()
     }
 
     #[inline]


### PR DESCRIPTION
## Summary

Migrates `ClassHashZero::zero()` from deprecated `class_hash_const` to `TryInto::try_into` and updates documentation examples.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

`ClassHashZero::zero()` uses deprecated `class_hash_const` which requires a feature gate. The deprecation notice recommends `TryInto::try_into` instead. Documentation examples also show the deprecated approach.

---

## What was the behavior or documentation before?

- `ClassHashZero::zero()` used `class_hash_const::<0>()` with `#[feature("deprecated-starknet-consts")]`
- Documentation examples showed `class_hash_const` as the primary method

---

## What is the behavior or documentation after?

- `ClassHashZero::zero()` uses `0.try_into().unwrap()` without feature gate
- Documentation examples use `TryInto::try_into`

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

`TryInto::try_into` for `ClassHash` is `const fn` and works in const context, as demonstrated in `const_test.cairo`. The same pattern should be applied to `ContractAddress` for consistency.