### PR TITLE
Remove unnecessary trait bounds from Eq impl for OrderedHashMap

### DIFF
--- a/crates/cairo-lang-utils/src/ordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/ordered_hash_map.rs
@@ -123,7 +123,7 @@ impl<Key: Eq, Value: Eq, BH> PartialEq for OrderedHashMap<Key, Value, BH> {
     }
 }
 
-impl<Key: Hash + Eq, Value: Eq, BH: BuildHasher> Eq for OrderedHashMap<Key, Value, BH> {}
+impl<Key: Eq, Value: Eq, BH> Eq for OrderedHashMap<Key, Value, BH> {}
 
 impl<Key: Hash, Value: Hash, BH> Hash for OrderedHashMap<Key, Value, BH> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
Removes redundant `Hash` and `BuildHasher` trait bounds from the `Eq` implementation for `OrderedHashMap<Key, Value, BH>`.
