### PR TITLE
refactor: remove unnecessary clone of otherwise_filter

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
@@ -615,7 +615,7 @@ fn create_node_for_value<'db>(
     };
 
     // First, construct a node that handles the otherwise patterns.
-    let mut current_node = build_node_callback(graph, otherwise_filter.clone(), "_".into());
+    let mut current_node = build_node_callback(graph, otherwise_filter, "_".into());
 
     // Go over the literals (in reverse order), and construct a chain of [BooleanIf] nodes that
     // handle each literal.


### PR DESCRIPTION
## Summary

Removed `.clone()` and pass `otherwise_filter` by value.

---

## Type of change

- [x] Performance improvement

---

## Why is this change needed?

`otherwise_filter` was cloned before being passed to `build_node_callback`, but it is never used after that call — each literal in `literals_map` already has the otherwise indices baked into its own filter. The clone was redundant.
