### PR TITLE
fix: correct misleading doc comments

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -144,7 +144,7 @@ pub struct StarknetState {
     logs: HashMap<Felt252, ContractLogs>,
     /// The simulated execution info.
     exec_info: ExecutionInfo,
-    /// A mock history, mapping block number to the class hash.
+    /// A mock history, mapping block number to the block hash.
     block_hash: HashMap<u64, Felt252>,
 }
 impl StarknetState {
@@ -986,7 +986,7 @@ impl CairoHintProcessor<'_> {
         Ok(SyscallResult::Success(vec![]))
     }
 
-    /// Executes the `send_message_to_l1_event_syscall` syscall.
+    /// Executes the `send_message_to_l1_syscall` syscall.
     fn send_message_to_l1(
         &mut self,
         gas_counter: &mut usize,


### PR DESCRIPTION
## Summary

Fixed two documentation comment typos in casm_run/mod.rs to accurately reflect what the code does.

---

## Type of change

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The comments for `block_hash` field and `send_message_to_l1` syscall contained errors that didn't match the actual code behavior:
- `block_hash` was documented as mapping to "class hash" instead of "block hash"
- `send_message_to_l1` had "event" erroneously inserted in the syscall name
