### PR TITLE
fix(casm): use i16 arithmetic in get_ref_and_inc for consistency

### DIFF
--- a/crates/cairo-lang-casm/src/builder.rs
+++ b/crates/cairo-lang-casm/src/builder.rs
@@ -360,7 +360,7 @@ impl CasmBuilder {
             CellExpression::BinOp {
                 op: CellOperator::Add,
                 a: cell,
-                b: deref_or_immediate!(BigInt::from(offset) + 1),
+                b: deref_or_immediate!(offset + 1),
             },
         );
         self.add_var(CellExpression::DoubleDeref(cell, offset))


### PR DESCRIPTION
## Summary

Changed `get_ref_and_inc` to style of `buffer_get_and_inc`https://github.com/starkware-libs/cairo/blob/661df684cb9f5e14b24d0cd0a0b78166c92185ab/crates/cairo-lang-casm/src/builder.rs#L379 for consistency and a slight performance gain.

---

## Type of change

- [x] Performance improvement

---

## Why is this change needed?

Unlike `buffer_get_and_inc`, which uses a simple i16 addition (offset + 1), here an extra BigInt allocation is created to convert i16 to BigInt when adding 1. Both functions do the same thing, but with different efficiency.
