### PR TITLE
(bug-fix): Benchmark criterion specific params to criterion only

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run benchmarks
         run: |
           set -o pipefail
-          cargo bench -- --output-format bencher 2>&1 | tee benchmark-output.txt
+          cargo bench --bench compile -- --output-format bencher 2>&1 | tee benchmark-output.txt
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b

--- a/crates/cairo-lang-compiler/Cargo.toml
+++ b/crates/cairo-lang-compiler/Cargo.toml
@@ -28,5 +28,3 @@ salsa.workspace = true
 semver.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true
-
-[dev-dependencies]


### PR DESCRIPTION
## Summary

Updated the nightly benchmark workflow to specifically target the `compile` benchmark instead of running all benchmarks. This prevents the empty "normal" benchmark runner from failing on the output format param.

Also removed the empty `[dev-dependencies]` section from the cairo-lang-compiler Cargo.toml file.

---

## Type of change

Please check **one**:

- [ ] Performance improvement
- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The nightly benchmark workflow was previously running all benchmarks, which is unnecessary and potentially time-consuming. By targeting only the `compile` benchmark, we can make the CI process more efficient. Additionally, removing the empty dev-dependencies section in the Cargo.toml file helps maintain clean configuration files.

---

## What was the behavior or documentation before?

The nightly workflow was running `cargo bench -- --output-format bencher` which would execute all benchmarks. The cairo-lang-compiler Cargo.toml contained an empty `[dev-dependencies]` section.

---

## What is the behavior or documentation after?

The nightly workflow now runs `cargo bench --bench compile -- --output-format bencher`, targeting only the compile benchmark. The empty `[dev-dependencies]` section has been removed from the Cargo.toml file.

---

## Additional context

This change makes the benchmark process more focused and efficient, which should reduce CI execution time.