### PR TITLE
fixed negative impls to not solve when trait is not var free

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/closure
@@ -271,10 +271,10 @@ fn bar<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>
 }
 
 //! > expected_diagnostics
-error[E2308]: `core::ops::function::FnOnceImpl::<{closure@lib.cairo:5:13: 5:16}, (core::integer::u32,), core::traits::DestructFromDrop::<{closure@lib.cairo:5:13: 5:16}, Generated core::traits::Drop::<{closure@lib.cairo:5:13: 5:16}>>, Generated core::ops::function::Fn::<{closure@lib.cairo:5:13: 5:16}, (core::integer::u32,)>>::Output` type mismatch: `core::felt252` and `core::integer::u128`.
- --> lib.cairo:10:23
-    let _k: felt252 = bar(c);
-                      ^^^
+error[E2308]: `core::ops::function::FnOnceImpl::<{closure@lib.cairo:5:13: 5:16}, (core::integer::u32,), core::traits::DestructFromDrop::<{closure@lib.cairo:5:13: 5:16}, Generated core::traits::Drop::<{closure@lib.cairo:5:13: 5:16}>>, Generated core::ops::function::Fn::<{closure@lib.cairo:5:13: 5:16}, (core::integer::u32,)>>::Output` type mismatch: `core::integer::u128` and `core::felt252`.
+ --> lib.cairo:9:39
+    let _f: u128 = core::ops::FnOnce::call(c, (2,));
+                                      ^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
+++ b/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
@@ -331,7 +331,32 @@ pub impl ImplBad<const C: u32, -TypeEqual<A<C>, A<0>>> of Bad {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::Bad.
+error[E2313]: Cannot infer trait core::metaprogramming::TypeEqual::<test::A::<?0>, test::A::<0>>. First generic argument must be known.
  --> lib.cairo:7:10
     Bad::bad();
          ^^^
+
+//! > ==========================================================================
+
+//! > Test negative impl with generic param that is not var free.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo(a: u32) -> (u32, u32) {
+    let s0 = array![a].span();
+    let s1 = array![a + 1].span();
+    let cols = array![s0, s1].span();
+
+    let [mut c0, mut c1] = (*cols.try_into().unwrap()).unbox();
+
+    (*c0.pop_front().unwrap(), *c1.pop_front().unwrap())
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics


### PR DESCRIPTION
## Summary

Fix inference for negative impls with non-var-free traits by returning an ambiguity result instead of attempting to infer the trait arguments. This prevents the inference system from forcing arguments to find an implementation when a negative impl is present.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a trait is not var-free (contains generic parameters), the inference system could force arguments to find an implementation, ignoring negative impls. This caused incorrect behavior in trait resolution where negative implementations should have been considered.

---

## What was the behavior or documentation before?

The inference system would attempt to resolve traits with generic parameters even when negative impls were present, potentially leading to incorrect trait resolution.

---

## What is the behavior or documentation after?

For non-var-free traits, the system now returns an ambiguity result (`WillNotInfer`) instead of attempting to infer the trait arguments. This ensures negative impls are properly considered during trait resolution.

The PR also includes a test case that demonstrates the fix for a previously failing operation with spans and arrays.