### PR TITLE
refactor(utils): simplify byte size calculation in BigIntAsHex encoding

### DIFF
--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -210,7 +210,7 @@ mod impl_parity_scale_codec {
             // sign + len packed in the same byte, it allows numbers of byte size up to 63 (2**504),
             // data.
             let bits = self.value.bits() as usize;
-            core::mem::size_of::<u8>() + bits / 8 + if bits.is_multiple_of(8) { 0 } else { 1 }
+            core::mem::size_of::<u8>() + bits.div_ceil(8)
         }
 
         /// /!\ Warning this function panics if the number encoded is too big (>= 2**504)


### PR DESCRIPTION
Replace manual ceiling division implementation with `div_ceil` method in `BigIntAsHex::size_hint()`.
