### PR TITLE
perf: use Entry API in add_drop to reduce hash lookups

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/lifetime.rs
+++ b/crates/cairo-lang-sierra-generator/src/lifetime.rs
@@ -90,11 +90,7 @@ pub struct VariableLifetimeResult {
 impl VariableLifetimeResult {
     /// Registers where a drop statement should appear.
     fn add_drop(&mut self, var_id: SierraGenVar, drop_location: DropLocation) {
-        if let Some(vars) = self.drops.get_mut(&drop_location) {
-            vars.push(var_id);
-        } else {
-            self.drops.insert(drop_location, vec![var_id]);
-        }
+        self.drops.entry(drop_location).or_default().push(var_id);
     }
 }
 


### PR DESCRIPTION
## Summary

Replaced the `get_mut` + `insert` pattern with `entry(...).or_default().push(...)` which performs a single lookup. This is a minor optimization that follows the idiomatic Rust pattern already used elsewhere in the codebase.

---

## Type of change

Please check **one**:

- [x] Performance improvement


---

## Why is this change needed?

The `add_drop` function in `VariableLifetimeResult` was performing two hash map lookups when a drop location didn't exist: first `get_mut()` to check for the key, then `insert()` if absent. This is inefficient as it hashes the key twice and does unnecessary work.
 
