### PR TITLE
docs: correct path to assignment operator traits in arithmetic operators doc

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
@@ -139,7 +139,7 @@ fn main() {
 == Assignment operators
 
 Cairo also provides compound assignment operators (`+=`, `-=`, `*=`, `/=`, `%=`) via traits in
-`core::ops`. See `core::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign}`.
+`core::ops::arith`. See `core::ops::arith::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign}`.
 
 == References (source)
 


### PR DESCRIPTION
## Summary

Updated the assignment operators section to reference the correct module path core::ops::arith instead of core::ops, ensuring users can correctly locate and import the assignment operator traits.

---

## Type of change

Please check **one**:

- [x] Documentation change with concrete technical impact

---

## Why is this change needed?

The documentation incorrectly referenced the assignment operator traits (AddAssign, SubAssign, etc.) as being located in core::ops, but these traits are actually defined in the core::ops::arith submodule. This could mislead users trying to import these traits.