### PR TITLE
chore: remove redundant `use std::option::Option` import

### DIFF
--- a/crates/cairo-lang-doc/src/documentable_formatter.rs
+++ b/crates/cairo-lang-doc/src/documentable_formatter.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::fmt::Write;
-use std::option::Option;
 
 use cairo_lang_defs::ids::{
     ConstantId, EnumId, ExternFunctionId, ExternTypeId, FreeFunctionId, ImplAliasId,


### PR DESCRIPTION
## Summary

Removes the unused `use std::option::Option;` statement from documentable_formatter.rs to clean up the import section.

---

## Type of change

- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?


The `Option` type is already available in the standard library prelude, making the explicit import redundant and unnecessary.
