### PR TITLE
refactor(codegen): eliminate unnecessary spec clone in AST generator

### DIFF
--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -219,20 +219,17 @@ fn generate_ast_code() -> rust::Tokens {
         #[path = "ast_ext.rs"]
         mod ast_ext;
     };
-    let all_token_names: Vec<String> = spec
+    let all_token_variants: Vec<_> = spec
         .iter()
         .filter(|node| matches!(node.kind, NodeKind::Terminal { .. }))
-        .map(|node| node.name.clone())
+        .map(|node| Variant { name: node.name.clone(), kind: node.name.clone() })
         .collect();
     for Node { name, kind } in spec {
         tokens.extend(match kind {
             NodeKind::Enum { variants, missing_variant } => {
                 let variants_list = match variants {
                     Variants::List(variants) => variants,
-                    Variants::AllTokens => all_token_names
-                        .iter()
-                        .map(|name| Variant { name: name.clone(), kind: name.clone() })
-                        .collect(),
+                    Variants::AllTokens => all_token_variants.clone(),
                 };
                 gen_enum_code(name, variants_list, missing_variant)
             }


### PR DESCRIPTION
## Summary

Changed `all_tokens: Vec<&Node>` (requiring `spec_clone`) to `all_token_names: Vec<String>` which collects only the names of terminal nodes. This eliminates the expensive clone while preserving the same functionality.

---

## Type of change

Please check **one**:

- [ ] Performance improvement

---

## Why is this change needed?


The `generate_ast_code()` function was cloning the entire `spec: Vec<Node>`  just to filter terminal names for the `Variants::AllTokens` case. This was inefficient since:
1. `AllTokens` is used only once (for `TokenNode` enum)
2. Only terminal names were needed, not the whole Node structures
3. The clone happened unconditionally for every code generation run