### PR TITLE
docs: fix vague snapshot reference in linear-types.adoc

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_semantics/pages/linear-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/pages/linear-types.adoc
@@ -33,7 +33,8 @@ fn main() {
 }
 ----
 
-Note: the snapshot operator `@` (See the docs about snapshot) is considered not moving a value.
+Note: the snapshot operator `@` (see xref:memory-model.adoc##snapshots-and-desnap[Snapshots and desnap])
+is considered not moving a value.
 
 == Clone
 Sometimes a value can't be trivially copied, but we can still use code to build a copy of it.


### PR DESCRIPTION
## Summary

Replaced the vague text with a proper AsciiDoc xref link pointing to the "Snapshots and desnap" section in memory-model.adoc

---

## Type of change

Please check **one**:

- [x] Documentation change with concrete technical impact

---

## Why is this change needed?

The documentation contained a vague reference "See the docs about snapshot" without specifying where to find it, making it difficult for readers to locate the relevant information.

---

## What was the behavior or documentation before?

Absence of link (not convenient)

---

## What is the behavior or documentation after?

Added link

---


