### PR TITLE
docs: update keyword categories for for, macro, and in

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/keywords.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/keywords.adoc
@@ -89,8 +89,3 @@ in
 ----
 
 Used in `for` loop syntax: `for <pattern> in <expression>`.
-
-[NOTE]
-====
-No contextual keywords are in use for now.
-====


### PR DESCRIPTION
## Summary

- Moved `for` and `macro` from reserved to strict keywords
- Moved `in` to contextual keywords with explanation of its use in `for <pattern> in <expression>` syntax
- Updated the NOTE in contextual keywords section

---

## Type of change

Please check **one**:

- [x] Documentation change with concrete technical impact


---

## Why is this change needed?

The documentation incorrectly listed `for`, `macro`, and `in` as reserved keywords (not yet used). However, these keywords are fully implemented in the Cairo compiler: `for` loops and `macro` declarations are actively used in production code and the standard library. The `in` keyword is used as part of the `for` loop syntax. This mismatch between documentation and actual implementation was misleading users.