### PR TITLE
fix: remove redundant #[allow(unused_mut)] attributes

### DIFF
--- a/crates/cairo-lang-proc-macros/src/lib.rs
+++ b/crates/cairo-lang-proc-macros/src/lib.rs
@@ -67,7 +67,6 @@ pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn interned(attr: TokenStream, item: TokenStream) -> TokenStream {
     let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
-    #[allow(unused_mut)]
     let mut args: Punctuated<Meta, Token![,]> =
         if attr.is_empty() { Punctuated::new() } else { parser.parse(attr).unwrap() };
 
@@ -92,7 +91,6 @@ pub fn interned(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn tracked(attr: TokenStream, item: TokenStream) -> TokenStream {
     let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
-    #[allow(unused_mut)]
     let mut args: Punctuated<Meta, Token![,]> =
         if attr.is_empty() { Punctuated::new() } else { parser.parse(attr).unwrap() };
 


### PR DESCRIPTION
## Summary

- Remove #[allow(unused_mut)] from `interned`
- Remove #[allow(unused_mut)] from `tracked`

---

## Type of change

Please check **one**:


- [ ] Style, wording, formatting, or typo-only change


---

## Why is this change needed?

The `#[allow(unused_mut)]` attributes were incorrectly suppressing compiler warnings for variables that actually needed to be mutable. The `args` variable is mutated via `args.push(heap_size)` in both functions, making `mut` required and the allow attribute redundant.


