### PR TITLE
refactor(lower): remove unnecessary nested braces in `lower_expr_fixed_size_array`

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1165,11 +1165,9 @@ fn lower_expr_fixed_size_array<'db>(
             // If there are multiple elements, the type must be copyable as we copy the var `size`
             // times.
             if size > 1 && ctx.variables[var_usage.var_id].info.copyable.is_err() {
-                {
-                    return Err(LoweringFlowError::Failed(
-                        ctx.diagnostics.report(expr.stable_ptr.0, FixedSizeArrayNonCopyableType),
-                    ));
-                }
+                return Err(LoweringFlowError::Failed(
+                    ctx.diagnostics.report(expr.stable_ptr.0, FixedSizeArrayNonCopyableType),
+                ));
             }
             let expr = LoweredExpr::AtVariable(var_usage);
             vec![expr; size]


### PR DESCRIPTION
## Summary

Removed the unnecessary inner block, simplifying the code structure without changing any behavior.

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `lower_expr_fixed_size_array` function had redundant double curly braces around a return statement inside an if block. These served no semantic purpose and were likely a leftover from refactoring.