### PR TITLE
refactor: cache duplicate concrete_function_signature call in lower_expr_loop

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1454,18 +1454,20 @@ fn lower_expr_loop<'db>(
             ..
         }) => {
             let var_id = lower_expr(ctx, builder, expr_id)?.as_var_usage(ctx, builder)?;
+            let into_iter_return_type =
+                db.concrete_function_signature(into_iter).unwrap().return_type;
             let into_iter_call = generators::Call {
                 function: into_iter.lowered(db),
                 inputs: vec![var_id],
                 coupon_input: None,
                 extra_ret_tys: vec![],
-                ret_tys: vec![db.concrete_function_signature(into_iter).unwrap().return_type],
+                ret_tys: vec![into_iter_return_type],
                 location: ctx.get_location(stable_ptr.untyped()),
             }
             .add(ctx, &mut builder.statements);
             let into_iter_var = into_iter_call.returns.into_iter().next().unwrap();
             let sem_var = LocalVariable {
-                ty: db.concrete_function_signature(into_iter).unwrap().return_type,
+                ty: into_iter_return_type,
                 is_mut: true,
                 id: extract_matches!(into_iter_member_path.base_var(), VarId::Local),
                 allow_unused: true, // Synthetic variables should never generate unused warnings.


### PR DESCRIPTION
## Summary

Extracted the return type into a local `into_iter_return_type` variable and reuse it, matching the existing pattern in `lower_for_loop` (line 198) where the signature is cached before use.

---

## Type of change

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`db.concrete_function_signature(into_iter)` was called twice with the same argument in the `Expr::For` branch of `lower_expr_loop`
 - once for `ret_tys` in the generators::Call and once for `ty` in LocalVariable. While salsa caches the result, the second call still performs an unnecessary cache lookup and `.unwrap()`.

---



