### PR TITLE
(bug fix): Pass github token to benchmarking action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,10 +83,10 @@ jobs:
           output-file-path: benchmark-output.txt
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: false
-          fail-on-alert: false
+          fail-on-alert: true
           alert-threshold: '150%'
-          summary-always: true
 
       - name: Push results to gh-pages
         run: git push origin gh-pages


### PR DESCRIPTION
## Summary

Updated GitHub Actions workflow configuration for benchmarking by:
- Adding `github-token` parameter with the `GITHUB_TOKEN` secret
- Enabling `fail-on-alert` to make the workflow fail when benchmarks exceed the threshold
- Removing the `summary-always` parameter

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The benchmark workflow was not properly configured to fail when performance regressions were detected. This change ensures that CI will fail when benchmarks exceed the 150% alert threshold, making performance regressions more visible and actionable.

---

## What was the behavior or documentation before?

Previously, the workflow would continue to run even when benchmarks exceeded the alert threshold, and it was configured to always generate a summary regardless of results.

---

## What is the behavior or documentation after?

Now the workflow will:
- Properly authenticate using the GitHub token
- Fail when benchmarks exceed the 150% alert threshold
- Only generate summaries when needed (default behavior)

---

## Additional context

This change helps catch performance regressions earlier in the development process by making the CI pipeline fail when significant benchmark degradations are detected.