### PR TITLE
fix: remove unnecessary vector clone in closure capture

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -372,9 +372,8 @@ impl<'db> BlockBuilder<'db> {
                 .eq(inputs.iter().map(|var_usage| &ctx.variables[var_usage.var_id].ty))
         );
 
-        let var_usage =
-            generators::StructConstruct { inputs: inputs.clone(), ty: expr.ty, location }
-                .add(ctx, &mut self.statements);
+        let var_usage = generators::StructConstruct { inputs, ty: expr.ty, location }
+            .add(ctx, &mut self.statements);
 
         (var_usage, ClosureInfo { members, snapshots })
     }


### PR DESCRIPTION
## Summary

Removed the `.clone()` call since the vector is moved into `StructConstruct::add` and never used after that point.

---

## Type of change

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

In the capture function, the inputs vector was being cloned when passed to `StructConstruct`, even though it was not used afterwards - causing an unnecessary heap allocation.
