### PR TITLE
bugfix(semantic): Made enum variants stable even if there are redefinitions.

### DIFF
--- a/crates/cairo-lang-lowering/src/test_data/enums
+++ b/crates/cairo-lang-lowering/src/test_data/enums
@@ -42,3 +42,48 @@ Statements:
   (v5: test::MyEnum) <- MyEnum::B(v4)
 End:
   Return(v5)
+
+//! > ==========================================================================
+
+//! > Multiple variants with the same name.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > module_code
+enum MyEnum {
+    Dup: felt252,
+    Dup: felt252,
+}
+
+//! > function_code
+fn foo(v: MyEnum) -> felt252 {
+    match v {
+        MyEnum::Dup(x) => x,
+    }
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+error[E2051]: Redefinition of variant "Dup" on enum "MyEnum".
+ --> lib.cairo:3:5
+    Dup: felt252,
+    ^^^^^^^^^^^^
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: test::MyEnum
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    MyEnum::Dup(v1) => blk1,
+  })
+
+blk1:
+Statements:
+End:
+  Return(v1)

--- a/crates/cairo-lang-semantic/src/items/enm_test.rs
+++ b/crates/cairo-lang-semantic/src/items/enm_test.rs
@@ -69,7 +69,7 @@ fn test_enum() {
     assert_eq!(
         actual,
         indoc! {"
-            a: VariantId(test::A::a), ty: (),
+            a: VariantId(test::A::a), ty: core::felt252,
             b: VariantId(test::A::b), ty: (core::felt252, core::felt252),
             c: VariantId(test::A::c), ty: ()"}
     );

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -18897,3 +18897,137 @@ impls:
 impl StorageStorageBaseMutDrop<> of core::traits::Drop::<StorageStorageBaseMut>;
 #[doc(hidden)]
 impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
+
+//! > ==========================================================================
+
+//! > Test event with duplicate variants.
+
+//! > test_runner_name
+ExpandContractTestRunner(expect_diagnostics: true)
+
+//! > cairo_code
+#[derive(Drop, starknet::Event)]
+struct SomeCase {
+    value: felt252,
+}
+
+#[event]
+#[derive(Drop, starknet::Event)]
+enum Event {
+    SomeCase: SomeCase,
+    SomeCase: SomeCase,
+}
+
+//! > generated_cairo_code
+lib.cairo:
+
+#[derive(Drop, starknet::Event)]
+struct SomeCase {
+    value: felt252,
+}
+
+#[event]
+#[derive(Drop, starknet::Event)]
+enum Event {
+    SomeCase: SomeCase,
+    SomeCase: SomeCase,
+}
+
+lib.cairo:1:10
+#[derive(Drop, starknet::Event)]
+         ^^^^
+impls:
+
+impl SomeCaseDrop<> of core::traits::Drop::<SomeCase>;
+
+
+lib.cairo:1:16
+#[derive(Drop, starknet::Event)]
+               ^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl SomeCaseIsEvent of starknet::Event<SomeCase> {
+    fn append_keys_and_data(
+        self: @SomeCase, ref keys: Array<felt252>, ref data: Array<felt252>
+    ) {
+            core::serde::Serde::serialize(self.value, ref data);
+    }
+    fn deserialize(
+        ref keys: Span<felt252>, ref data: Span<felt252>,
+    ) -> Option<SomeCase> {
+        Option::Some(SomeCase {value: core::serde::Serde::deserialize(ref data)?, })
+    }
+}
+
+
+lib.cairo:7:10
+#[derive(Drop, starknet::Event)]
+         ^^^^
+impls:
+
+impl EventDrop<> of core::traits::Drop::<Event>;
+
+
+lib.cairo:7:16
+#[derive(Drop, starknet::Event)]
+               ^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl EventIsEvent of starknet::Event<Event> {
+    fn append_keys_and_data(
+        self: @Event, ref keys: Array<felt252>, ref data: Array<felt252>
+    ) {
+        match self {
+            Event::SomeCase(val) => {
+                core::array::ArrayTrait::append(ref keys, selector!("SomeCase"));
+                starknet::Event::append_keys_and_data(
+                    val, ref keys, ref data
+                );
+            },
+            Event::SomeCase(val) => {
+                core::array::ArrayTrait::append(ref keys, selector!("SomeCase"));
+                starknet::Event::append_keys_and_data(
+                    val, ref keys, ref data
+                );
+            },
+        }
+    }
+    fn deserialize(
+        ref keys: Span<felt252>, ref data: Span<felt252>,
+    ) -> Option<Event> {
+        let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
+        if __selector__ == selector!("SomeCase") {
+            return Option::Some(Event::SomeCase(starknet::Event::deserialize(ref keys, ref data)?));
+        }
+        if __selector__ == selector!("SomeCase") {
+            return Option::Some(Event::SomeCase(starknet::Event::deserialize(ref keys, ref data)?));
+        }
+        Option::None
+    }
+}
+impl EventSomeCaseIntoEvent of Into<SomeCase, Event> {
+    fn into(self: SomeCase) -> Event {
+        Event::SomeCase(self)
+    }
+}
+impl EventSomeCaseIntoEvent of Into<SomeCase, Event> {
+    fn into(self: SomeCase) -> Event {
+        Event::SomeCase(self)
+    }
+}
+
+//! > expected_diagnostics
+error[E2118]: The name `EventSomeCaseIntoEvent` is defined multiple times.
+ --> lib.cairo:7:16
+#[derive(Drop, starknet::Event)]
+               ^^^^^^^^^^^^^^^
+
+error[E2051]: Redefinition of variant "SomeCase" on enum "Event".
+ --> lib.cairo:10:5
+    SomeCase: SomeCase,
+    ^^^^^^^^^^^^^^^^^^
+
+warning[E3004]: Unreachable pattern arm.
+ --> lib.cairo:7:16
+#[derive(Drop, starknet::Event)]
+               ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Fixed a bug in enum variant handling to properly detect and report duplicate variants. The PR ensures that when an enum has multiple variants with the same name, the compiler correctly identifies this as an error and prevents the second variant from being added to the semantic model. Added a test case to verify this behavior.

---

## Type of change

- [x] Bug fix (fixes incorrect behavior)

---

## Why is this change needed?

When an enum had multiple variants with the same name, the compiler would silently accept the duplicate variants, leading to unpredictable behavior. This could cause issues in pattern matching and other operations that rely on unique variant names.

---

## What was the behavior or documentation before?

Previously, when an enum had duplicate variant names, both variants would be added to the semantic model with different indices. This could lead to confusing behavior in match statements and other code that relied on unique variant names.

---

## What is the behavior or documentation after?

Now, the compiler properly detects duplicate variant names and reports them as errors. Only the first occurrence of a variant name is added to the semantic model, ensuring consistent behavior. A test case has been added to verify this functionality.