### PR TITLE
performance(casm): Made less calculations in Bigint and conversions to it.

### DIFF
--- a/crates/cairo-lang-casm/src/builder.rs
+++ b/crates/cairo-lang-casm/src/builder.rs
@@ -360,7 +360,7 @@ impl CasmBuilder {
             CellExpression::BinOp {
                 op: CellOperator::Add,
                 a: cell,
-                b: deref_or_immediate!(BigInt::from(offset) + 1),
+                b: deref_or_immediate!(i32::from(offset) + 1),
             },
         );
         self.add_var(CellExpression::DoubleDeref(cell, offset))
@@ -376,7 +376,7 @@ impl CasmBuilder {
             CellExpression::BinOp {
                 op: CellOperator::Add,
                 a: base,
-                b: deref_or_immediate!(offset + 1),
+                b: deref_or_immediate!(i32::from(offset) + 1),
             },
         );
         (base, offset)
@@ -564,7 +564,7 @@ impl CasmBuilder {
             label,
             InstructionBody::Call(CallInstruction {
                 relative: true,
-                target: deref_or_immediate!(0),
+                target: deref_or_immediate!(BigInt::ZERO),
             }),
             false,
         );


### PR DESCRIPTION
## Summary

Changed numeric type handling in the Cairo assembly builder:
1. Replaced `BigInt::from(offset) + 1` with `i32::from(offset) + 1` in two locations
2. Replaced the literal `0` with `BigInt::ZERO` in the call instruction target

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

## Why is this change needed?

This PR addresses type consistency issues in the Cairo assembly builder. Using `i32::from()` instead of `BigInt::from()` ensures proper type handling for offsets, preventing potential overflow or conversion issues. Similarly, using `BigInt::ZERO` instead of a literal `0` provides better type safety and consistency with the rest of the codebase.

## What was the behavior or documentation before?

The code was using inconsistent numeric types, with some operations using `BigInt` and others using literals, which could lead to unexpected behavior or type conversion issues.

## What is the behavior or documentation after?

The code now consistently uses appropriate types: `i32` for offset calculations and `BigInt::ZERO` for the call instruction target, improving type safety and code clarity.