### PR TITLE
fix: remove unnecessary variable in infer_trait_impl

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference/infers.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/infers.rs
@@ -467,9 +467,7 @@ impl<'db> InferenceEmbeddings<'db> for Inference<'db, '_> {
             stable_ptr,
             lookup_context,
         );
-        let x = self.db;
-
-        ImplImplId::new(impl_id, concrete_trait_impl.trait_impl(x), x)
+        ImplImplId::new(impl_id, concrete_trait_impl.trait_impl(self.db), self.db)
     }
 }
 


### PR DESCRIPTION
## Summary

Removed redundant variable in `infer_trait_impl`, now consistent with `infer_trait_constant` and other functions.

---

## Type of change

- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `infer_trait_impl` function had an unnecessary intermediate variable x to hold `self.db`, while all other similar functions in the file use `self.db` directly.

---


