### PR TITLE
refactor(starknet): Creating an entry-point function name once.

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/entry_point.rs
+++ b/crates/cairo-lang-starknet/src/plugin/entry_point.rs
@@ -139,9 +139,8 @@ pub fn handle_entry_point<'db, 'a>(
 ) {
     let declaration = item_function.declaration(db);
     let name_node = declaration.name(db);
-    if entry_point_kind == EntryPointKind::Constructor
-        && name_node.text(db).long(db) != CONSTRUCTOR_NAME
-    {
+    let function_name = name_node.text(db).long(db);
+    if entry_point_kind == EntryPointKind::Constructor && function_name != CONSTRUCTOR_NAME {
         diagnostics.push(PluginDiagnostic::error(
             name_node.stable_ptr(db),
             format!("The constructor function must be called `{CONSTRUCTOR_NAME}`."),
@@ -179,7 +178,6 @@ pub fn handle_entry_point<'db, 'a>(
                 }
                 EntryPointKind::External => &mut data.external_functions,
             };
-            let function_name = name_node.text(db).long(db);
             generated.push(
                 RewriteNode::text(&format!(
                     "\n    pub use super::{wrapper_function_name} as {function_name};",


### PR DESCRIPTION
## Summary

Refactored the entry point handling in the Starknet plugin to extract the function name variable earlier, avoiding duplicate computation. The function name is now stored in a variable at the beginning of the function and reused later, improving code readability and efficiency.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] Performance improvement
- [ ] New feature
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The current implementation computes the function name twice - once when checking if a constructor has the correct name, and again when generating the public use statement. This small refactoring extracts the function name into a variable that can be reused, making the code more efficient and easier to maintain.

---

## What was the behavior or documentation before?

The function name was computed twice using `name_node.text(db).long(db)` - once for the constructor name validation and again when generating the public use statement.

---

## What is the behavior or documentation after?

The function name is now computed once at the beginning of the function and stored in a variable that is reused throughout the function, eliminating the duplicate computation.