### PR TITLE
fix: use cached `ident.long()` in `next_concrete`

### DIFF
--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -2189,7 +2189,7 @@ impl<'db, 'a> Resolution<'db, 'a> {
 
         let ident = identifier.text(db);
 
-        if identifier.text(db).long(db) == SELF_TYPE_KW {
+        if ident.long(db) == SELF_TYPE_KW {
             return Err(self.diagnostics.report(identifier.stable_ptr(db), SelfMustBeFirst));
         }
 


### PR DESCRIPTION
## Summary

Replaced `identifier.text(db).long(db)` with `ident.long(db)` to use the already-cached value.

---

## Type of change

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

In `next_concrete` method, `identifier.text(db)` was called twice in succession - once to store in `ident` variable (line 2190), and again unnecessarily on line 2192 when checking for `SELF_TYPE_KW`. Since `text()` involves salsa database lookups, this caused redundant work.