### PR TITLE
fix: remove unreachable branch in Snapshot handling

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/cancel_ops.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/cancel_ops.rs
@@ -262,10 +262,6 @@ impl<'db, 'a> CancelOpsContext<'db, 'a> {
                     self.stmts_to_remove.push(statement_location);
                     self.rename_var(stmt.original(), stmt.input.var_id);
                     stmt.input.var_id
-                } else if desnaps.is_empty()
-                    && self.lowered.variables[stmt.input.var_id].info.copyable.is_err()
-                {
-                    stmt.original()
                 } else {
                     stmt.input.var_id
                 };


### PR DESCRIPTION
## Summary

The logic is now simplified to just use `stmt.input.var_id` in the else case, which produces identical behavior

---

## Type of change

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The else-if branch at lines 265-268 was dead code. It checked for `desnaps.is_empty()` but the subsequent loop for desnap in desnaps would never execute in that case, making the assigned value of `new_var` unused. 

---


