### PR TITLE
fix: check `values.contains_key` before `get_type_info`

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/circuit.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/circuit.rs
@@ -1063,12 +1063,11 @@ fn get_circuit_info(
         .collect();
 
     while let Some((ty, first_visit)) = stack.pop() {
-        let long_id = &context.get_type_info(&ty)?.long_id;
-
         if values.contains_key(&ty) {
-            // The value was already processed.
             continue;
         }
+
+        let long_id = &context.get_type_info(&ty)?.long_id;
 
         let gate_inputs = long_id
             .generic_args


### PR DESCRIPTION
## Summary

Moved the `values.contains_key()` check before `get_type_info()` call to avoid redundant lookups, matching the pattern used in `parse_circuit_inputs.`

---

## Type of change

Please check **one**:

- [x] Performance improvement

---

## Why is this change needed?


 In `get_circuit_info`, `context.get_type_info()` was called before checking if the value was already processed. Since the same gate can appear multiple times in the stack (shared inputs), this caused unnecessary lookups when the value already existed in `values`.
