### PR TITLE
refactor(ap-change): remove unused payload from EnableStatement tracking base

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/compute.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/compute.rs
@@ -34,8 +34,7 @@ impl<TokenUsages: Fn(CostTokenType) -> usize> InvocationApChangeInfoProvider
 #[derive(Clone, Debug)]
 enum ApTrackingBase {
     FunctionStart(FunctionId),
-    #[expect(dead_code)]
-    EnableStatement(StatementIdx),
+    EnableStatement,
 }
 
 /// The information for ap tracking of a statement.


### PR DESCRIPTION
Remove unused StatementIdx payload from ApTrackingBase::EnableStatement.
Replace EnableStatement(StatementIdx) with unit variant EnableStatement.
Drop obsolete #[expect(dead_code)] attribute that is no longer needed.
