### PR TITLE
fix: avoid clone in lower_expr_desnap by matching LoweredExpr by value

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1224,8 +1224,8 @@ fn lower_expr_desnap<'db>(
     log::trace!("Lowering a desnap: {:?}", expr.debug(&ctx.expr_formatter));
     let location = ctx.get_location(expr.stable_ptr.untyped());
     let expr = lower_expr(ctx, builder, expr.inner)?;
-    if let LoweredExpr::Snapshot { expr, .. } = &expr {
-        return Ok(expr.as_ref().clone());
+    if let LoweredExpr::Snapshot { expr, .. } = expr {
+        return Ok(*expr);
     }
     let input = expr.as_var_usage(ctx, builder)?;
 


### PR DESCRIPTION
 ## Summary

  In `lower_expr_desnap`, when the inner expression is already a `LoweredExpr::Snapshot`, the previous code matched by reference and called `expr.as_ref().clone()` to return the inner value. This PR matches by value instead and uses `*expr` to move out of the `Box`, eliminating the clone entirely.

  ---

  ## Type of change

  - [x] Performance improvement

  ---

  ## Why is this change needed?

  `LoweredExpr` is a recursive enum with variants like `Tuple { exprs: Vec<LoweredExpr> }` and `FixedSizeArray { exprs: Vec<LoweredExpr> }`. Cloning it performs a full heap allocation and element-wise deep copy whose cost grows with nesting depth. The clone was never necessary — `expr` is not used after the early return, so ownership can be taken directly.

  ---

  ## What was the behavior or documentation before?

  `lower_expr_desnap` cloned the entire `LoweredExpr` tree on the desnap-of-snapshot fast path.

  ---

  ## What is the behavior or documentation after?

  The inner `LoweredExpr` is moved out of the `Box` with `*expr`. No allocation or copy occurs.

  ---

  ## Related issue or discussion (if any)

  Related to the pattern addressed in #9691.

  ---

  ## Additional context

  The desnap fast path (`@expr` immediately followed by desnap) is not uncommon in Cairo code. The fix is a one-line change with no semantic difference.