### PR TITLE
perf: remove unnecessary clone of local_variables in function_generator

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/function_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/function_generator.rs
@@ -69,8 +69,7 @@ fn get_function_ap_change_and_code<'db>(
         analyze_ap_change_result;
 
     // Get lifetime information.
-    let local_variables = variables_info.local_variables.clone();
-    let lifetime = find_variable_lifetime(lowered_function, &local_variables)?;
+    let lifetime = find_variable_lifetime(lowered_function, &variables_info.local_variables)?;
 
     let mut context = ExprGeneratorContext::new(
         db,


### PR DESCRIPTION
  ## Summary

  Removes an unnecessary clone of `variables_info.local_variables` in `generate_function_code`. The `OrderedHashSet` was cloned into a temporary variable solely to pass `&local_variables` to `find_variable_lifetime`, but the function doesn't retain the reference beyond the call. We can pass `&variables_info.local_variables` directly since `variables_info` isn't moved until later.

  ---

  ## Type of change

  - [x] Performance improvement

  ---

  ## Why is this change needed?

  `OrderedHashSet` cloning involves heap allocation and element-wise copying. This code path executes for every function being compiled, so eliminating the allocation has measurable impact. The clone serves no purpose — `find_variable_lifetime` returns `Maybe<VariableLifetimeResult>` which doesn't borrow from its `local_vars` parameter, and `variables_info` is only moved on line 81, well after the borrow ends.

  ---

  ## What was the behavior or documentation before?

  `local_variables` was cloned from `variables_info.local_variables` on every function.

  ---

  ## What is the behavior or documentation after?

  The reference is passed directly without cloning.

  ---

  ## Related issue or discussion (if any)

  Related to the pattern addressed in #9691.