### PR TITLE
perf: eliminate redundant clone in store_variables invocation handling

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/store_variables/mod.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/mod.rs
@@ -146,11 +146,10 @@ impl<'db> AddStoreVariableStatements<'db> {
         let mut state_opt = state_opt;
         match &statement.statement {
             pre_sierra::Statement::Sierra(GenStatement::Invocation(invocation)) => {
-                let libfunc_id = invocation.libfunc_id.clone();
-                let signature = get_libfunc_signature(libfunc_id.clone());
+                let signature = get_libfunc_signature(invocation.libfunc_id.clone());
                 let mut state = state_opt.unwrap_or_default();
 
-                let libfunc_long_id = self.db.lookup_concrete_lib_func(&libfunc_id);
+                let libfunc_long_id = self.db.lookup_concrete_lib_func(&invocation.libfunc_id);
                 let arg_states = match libfunc_long_id.generic_id.0.as_str() {
                     FunctionCallLibfunc::STR_ID | CouponCallLibfunc::STR_ID => {
                         // The arguments were already stored using `push_values`.


### PR DESCRIPTION
  ## Summary

  The `libfunc_id` intermediate variable was cloned twice: once from `invocation.libfunc_id` to create the variable, then again when passing it to `get_libfunc_signature`. Since the variable is only used once more (as a reference to `lookup_concrete_lib_func`), we can clone directly into the function call and borrow `&invocation.libfunc_id` for the lookup instead.

  ## Type of change

  - [x] Performance improvement

  ## Why is this change needed?

  `ConcreteLibfuncId` contains `Option<SmolStr>`, making clones non-trivial. This happens in the Sierra generation hot path — once per instruction in every function being compiled. The first clone was pointless since the intermediate variable only served to be cloned again and then borrowed once.

  ## What was the behavior or documentation before?

  Two clones of `ConcreteLibfuncId` per invocation statement.

  One clone (unavoidable for `get_libfunc_signature`), with direct borrowing for the lookup.

  ## What is the behavior or documentation after?

  One clone (unavoidable for `get_libfunc_signature`), with direct borrowing for the lookup.