### PR TITLE
Bumped nightly version and fixed required changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-12-05
+          toolchain: nightly-2026-02-27
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - run: |
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2025-12-05
+          toolchain: nightly-2026-02-27
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --profile=ci-dev -p cairo-lang-syntax-codegen
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2025-12-05
+          toolchain: nightly-2026-02-27
       - uses: Swatinem/rust-cache@v2
       - run: scripts/rust_fmt.sh --check
 
@@ -169,7 +169,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
-          toolchain: nightly-2025-12-05
+          toolchain: nightly-2026-02-27
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/clippy.sh
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-12-05
+          toolchain: nightly-2026-02-27
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/docs.sh

--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -230,12 +230,11 @@ pub fn parse_documentation_comment(documentation_comment: &str) -> Vec<Documenta
                 TagEnd::List(_) => {
                     list_nesting.pop();
                 }
-                TagEnd::Item => {
+                TagEnd::Item
                     if !matches!(last_two_events[0], Some(Event::End(_)))
-                        | !matches!(last_two_events[1], Some(Event::End(_)))
-                    {
-                        tokens.push(DocumentationCommentToken::Content("\n".to_string()));
-                    }
+                        | !matches!(last_two_events[1], Some(Event::End(_))) =>
+                {
+                    tokens.push(DocumentationCommentToken::Content("\n".to_string()));
                 }
                 TagEnd::TableHead => {
                     tokens.push(DocumentationCommentToken::Content(format!(

--- a/crates/cairo-lang-runnable-utils/src/builder.rs
+++ b/crates/cairo-lang-runnable-utils/src/builder.rs
@@ -311,13 +311,11 @@ pub fn create_entry_code_from_params(
     let mut helper = EntryCodeHelper::new(config);
     if let Some(builtin_list) = &helper.config.builtin_list {
         helper.builtins = builtin_list.clone();
-        let mut builtin_offset = 3;
-        for builtin_name in helper.builtins.iter().rev() {
+        for (builtin_offset, builtin_name) in (3..).zip(helper.builtins.iter().rev()) {
             helper.builtin_vars.insert(
                 *builtin_name,
                 helper.ctx.add_var(CellExpression::Deref(cell_ref!([fp - builtin_offset]))),
             );
-            builtin_offset += 1;
         }
     } else {
         helper.process_builtins(param_types);

--- a/crates/cairo-lang-semantic/src/expr/inference/conform.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/conform.rs
@@ -120,16 +120,14 @@ impl<'db> InferenceConform<'db> for Inference<'db, '_> {
         match long_ty1 {
             TypeLongId::Var(var) => return Ok((self.assign_ty(*var, ty0)?, 0)),
             TypeLongId::Missing(_) => return Ok((ty1, 0)),
-            TypeLongId::Snapshot(inner_ty) => {
-                if ty0_is_self {
-                    if *inner_ty == ty0 {
-                        return Ok((ty1, 1));
-                    }
-                    if !matches!(ty0.long(self.db), TypeLongId::Snapshot(_))
-                        && let TypeLongId::Var(var) = inner_ty.long(self.db)
-                    {
-                        return Ok((self.assign_ty(*var, ty0)?, 1));
-                    }
+            TypeLongId::Snapshot(inner_ty) if ty0_is_self => {
+                if *inner_ty == ty0 {
+                    return Ok((ty1, 1));
+                }
+                if !matches!(ty0.long(self.db), TypeLongId::Snapshot(_))
+                    && let TypeLongId::Var(var) = inner_ty.long(self.db)
+                {
+                    return Ok((self.assign_ty(*var, ty0)?, 1));
                 }
             }
             TypeLongId::ImplType(impl_type) => {

--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -158,7 +158,7 @@ impl CairoProgram {
             if !instruction.hints.is_empty() {
                 hints.push((bytecode.len(), instruction.hints.clone()))
             }
-            bytecode.extend(instruction.assemble().encode().into_iter())
+            bytecode.extend(instruction.assemble().encode())
         }
         let [ref ret_bytecode] = Instruction::new(InstructionBody::Ret(RetInstruction {}), false)
             .assemble()
@@ -176,7 +176,7 @@ impl CairoProgram {
                 "All footer instructions must have no hints since these cannot be added to the \
                  hints dict."
             );
-            bytecode.extend(instruction.assemble().encode().into_iter())
+            bytecode.extend(instruction.assemble().encode())
         }
         AssembledCairoProgram { bytecode, hints }
     }

--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -49,7 +49,7 @@ pub fn reformat_rust_code(text: String) -> String {
 }
 pub fn reformat_rust_code_inner(text: String) -> String {
     let sh = Shell::new().unwrap();
-    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2025-12-05");
+    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-02-27");
     let cmd_with_args = cmd.arg("--config-path").arg(project_root().join("rustfmt.toml"));
     let mut stdout = cmd_with_args.stdin(text).read().unwrap();
     if !stdout.ends_with('\n') {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The `rustfmt` configuration used by Cairo requires a nightly version of Rust.
 You can install the nightly version by running:
 
 ```sh
-rustup install nightly-2025-12-05
+rustup install nightly-2026-02-27
 ```
 
 ## Running Tests

--- a/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
@@ -35,5 +35,5 @@ You can install the nightly version by running:
 
 [source,bash]
 ----
-rustup install nightly-2025-12-05
+rustup install nightly-2026-02-27
 ----

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,11 +23,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2025-12-05",
+#         "nightly-2026-02-27",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2024",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2025-12-05".
+# and run "rustup toolchain install nightly-2026-02-27".

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2025-12-05}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-02-27}"
 
 cargo clippy "$@" --all-targets --all-features -- -D warnings -D future-incompatible \
     -D nonstandard-style -D rust-2018-idioms -D unused

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2025-12-05}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-02-27}"
 
 RUSTDOCFLAGS="-Dwarnings" cargo doc --document-private-items --no-deps --all-features

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2025-12-05}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-02-27}"
 
 cargo fmt --all -- "$@"


### PR DESCRIPTION
## Summary

Updates the Rust nightly toolchain from `nightly-2025-12-05` to `nightly-2026-02-27` across CI workflows, build scripts, documentation, and configuration files. Also applies code fixes that are required from the newer toolchain version.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The project needs to stay current with Rust nightly toolchain versions to ensure compatibility with the latest language features and formatting rules. The toolchain version was outdated and needed to be bumped to a more recent nightly build.

---

## What was the behavior or documentation before?

The project was using `nightly-2025-12-05` toolchain version across all CI jobs, scripts, and documentation.

---

## What is the behavior or documentation after?

The project now uses `nightly-2026-02-27` toolchain version consistently. Code has been reformatted according to the newer toolchain's formatting rules, including changes to conditional expressions, iterator usage, and match statements.

