### PR TITLE
chore: remove unused enum sub-pointers patch values

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/storage_interfaces.rs
+++ b/crates/cairo-lang-starknet/src/plugin/storage_interfaces.rs
@@ -783,7 +783,6 @@ fn add_node_enum_impl<'db>(
         builder.add_modified(RewriteNode::interpolate_patched(
             &storage_node_info.node_constructor_field_init_code(false, &variant),
             &[
-                ("object_name".to_string(), enum_name.clone()),
                 ("field_name".to_string(), RewriteNode::from_ast_trimmed(&variant.name(db))),
                 ("field_index".to_string(), RewriteNode::text(&variant_selector.to_string())),
             ]


### PR DESCRIPTION
## Summary

This PR removes those unused patch values and the redundant `field_type` computation in enum impl generation.


---

## Type of change


- [x] Style, wording, formatting, or typo-only change


---

## Why is this change needed?

storage_interfaces.rs had unused interpolation inputs in enum sub-pointers code generation.
In `add_node_enum_impl`, `field_type` was computed and passed into the patch map but never used by the template.
In `add_node_enum_definition`, `object_name` was also passed but never referenced.

