### PR TITLE
Bump nightly version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-02-27
+          toolchain: nightly-2026-03-01
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - run: |
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2026-02-27
+          toolchain: nightly-2026-03-01
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --profile=ci-dev -p cairo-lang-syntax-codegen
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2026-02-27
+          toolchain: nightly-2026-03-01
       - uses: Swatinem/rust-cache@v2
       - run: scripts/rust_fmt.sh --check
 
@@ -169,7 +169,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
-          toolchain: nightly-2026-02-27
+          toolchain: nightly-2026-03-01
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/clippy.sh
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-02-27
+          toolchain: nightly-2026-03-01
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/docs.sh

--- a/crates/cairo-lang-lowering/src/ids.rs
+++ b/crates/cairo-lang-lowering/src/ids.rs
@@ -1,9 +1,11 @@
 use cairo_lang_debug::DebugWithDb;
+use cairo_lang_defs as defs;
 use cairo_lang_defs::ids::{
     NamedLanguageElementId, TopLevelLanguageElementId, TraitFunctionId, UnstableSalsaId,
 };
 use cairo_lang_diagnostics::{DiagnosticAdded, DiagnosticNote, Maybe};
 use cairo_lang_proc_macros::{DebugWithDb, HeapSize, SemanticObject};
+use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::corelib::CorelibSemantic;
 use cairo_lang_semantic::items::functions::{FunctionsSemantic, ImplGenericFunctionId};
 use cairo_lang_semantic::items::imp::ImplLongId;
@@ -20,7 +22,6 @@ use salsa::Database;
 use semantic::items::functions::GenericFunctionId;
 use semantic::substitution::{GenericSubstitution, SubstitutionRewriter};
 use semantic::{ExprVar, Mutability};
-use {cairo_lang_defs as defs, cairo_lang_semantic as semantic};
 
 use crate::Location;
 use crate::db::LoweringGroup;

--- a/crates/cairo-lang-lowering/src/lower/context.rs
+++ b/crates/cairo-lang-lowering/src/lower/context.rs
@@ -1,8 +1,10 @@
 use std::ops::{Deref, DerefMut, Index};
 
+use cairo_lang_defs as defs;
 use cairo_lang_defs::ids::LanguageElementId;
 use cairo_lang_diagnostics::{DiagnosticAdded, Maybe};
 use cairo_lang_filesystem::ids::SmolStrId;
+use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::ConcreteVariant;
 use cairo_lang_semantic::expr::fmt::ExprFormatter;
 use cairo_lang_semantic::items::enm::SemanticEnumEx;
@@ -19,7 +21,6 @@ use salsa::Database;
 use semantic::corelib::{core_module, get_ty_by_name};
 use semantic::types::wrap_in_snapshots;
 use semantic::{ExprVarMemberPath, MatchArmSelector, TypeLongId};
-use {cairo_lang_defs as defs, cairo_lang_semantic as semantic};
 
 use super::block_builder::BlockBuilder;
 use super::generators;

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1,7 +1,9 @@
 use cairo_lang_debug::DebugWithDb;
+use cairo_lang_defs as defs;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_diagnostics::{Diagnostics, Maybe};
 use cairo_lang_filesystem::ids::SmolStrId;
+use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::corelib::{
     CorelibSemantic, ErrorPropagationType, bounded_int_ty, get_enum_concrete_variant,
     try_get_ty_by_name, unwrap_error_propagation_type, validate_literal,
@@ -44,7 +46,6 @@ use semantic::{
     ExprFunctionCallArg, ExprId, ExprPropagateError, ExprVarMemberPath, GenericArgumentId,
     MatchArmSelector, SemanticDiagnostic, TypeLongId,
 };
-use {cairo_lang_defs as defs, cairo_lang_semantic as semantic};
 
 use self::block_builder::{BlockBuilder, SealedBlockBuilder, SealedGotoCallsite};
 use self::context::{

--- a/crates/cairo-lang-lowering/src/lower/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/lower/test_utils.rs
@@ -1,4 +1,5 @@
-use {cairo_lang_defs as defs, cairo_lang_semantic as semantic};
+use cairo_lang_defs as defs;
+use cairo_lang_semantic as semantic;
 
 use super::context::{EncapsulatingLoweringContext, LoweringContext};
 use crate::ids::{EnrichedSemanticSignature, FunctionWithBodyLongId};

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use std::vec::IntoIter;
 
 use ark_ff::{BigInteger, PrimeField};
+use ark_secp256k1 as secp256k1;
+use ark_secp256r1 as secp256r1;
 use cairo_lang_casm::hints::{CoreHint, DeprecatedHint, ExternalHint, Hint, StarknetHint};
 use cairo_lang_casm::operand::{
     BinOpOperand, CellRef, DerefOrImmediate, Operation, Register, ResOperand,
@@ -42,7 +44,6 @@ use num_integer::{ExtendedGcd, Integer};
 use num_traits::{Signed, ToPrimitive, Zero};
 use rand::Rng;
 use starknet_types_core::felt::{Felt as Felt252, NonZeroFelt};
-use {ark_secp256k1 as secp256k1, ark_secp256r1 as secp256r1};
 
 use self::contract_address::calculate_contract_address;
 use self::dict_manager::DictSquashExecScope;

--- a/crates/cairo-lang-sierra-generator/src/block_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/block_generator.rs
@@ -4,16 +4,17 @@ mod test;
 
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::flag::FlagsGroup;
+use cairo_lang_lowering as lowering;
 use cairo_lang_lowering::BlockId;
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::ids::LocationId;
+use cairo_lang_sierra as sierra;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use itertools::{chain, enumerate, zip_eq};
 use lowering::analysis::StatementLocation;
 use lowering::{MatchArm, VarUsage};
 use sierra::extensions::lib_func::SierraApChange;
 use sierra::program;
-use {cairo_lang_lowering as lowering, cairo_lang_sierra as sierra};
 
 use crate::block_generator::sierra::ids::ConcreteLibfuncId;
 use crate::db::SierraGenGroup;

--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -3,15 +3,16 @@ use std::sync::Arc;
 use cairo_lang_diagnostics::{Maybe, MaybeAsRef};
 use cairo_lang_filesystem::flag::FlagsGroup;
 use cairo_lang_filesystem::ids::{CrateId, Tracked};
+use cairo_lang_lowering as lowering;
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::panic::PanicSignatureInfo;
+use cairo_lang_semantic as semantic;
 use cairo_lang_sierra::extensions::lib_func::SierraApChange;
 use cairo_lang_sierra::extensions::{ConcreteType, GenericTypeEx};
 use cairo_lang_sierra::ids::ConcreteTypeId;
 use lowering::ids::ConcreteFunctionWithBodyId;
 use salsa::plumbing::FromId;
 use salsa::{Database, Id};
-use {cairo_lang_lowering as lowering, cairo_lang_semantic as semantic};
 
 use crate::program_generator::{self, SierraProgramWithDebug};
 use crate::replace_ids::SierraIdReplacer;

--- a/crates/cairo-lang-sierra-generator/src/test_utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/test_utils.rs
@@ -1,12 +1,15 @@
 use std::sync::{LazyLock, Mutex};
 
+use cairo_lang_defs as defs;
 use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
 use cairo_lang_defs::ids::ModuleId;
 use cairo_lang_filesystem::db::{init_dev_corelib, init_files_group};
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::flag::{Flag, FlagsGroup};
 use cairo_lang_filesystem::ids::FlagLongId;
+use cairo_lang_lowering as lowering;
 use cairo_lang_lowering::db::{LoweringGroup, lowering_group_input};
+use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::corelib::CorelibSemantic;
 use cairo_lang_semantic::db::{PluginSuiteInput, SemanticGroup, init_semantic_group};
 use cairo_lang_semantic::test_utils::setup_test_crate;
@@ -18,7 +21,6 @@ use lowering::ids::ConcreteFunctionWithBodyLongId;
 use lowering::optimizations::config::Optimizations;
 use salsa::{Database, Setter};
 use semantic::inline_macros::get_default_plugin_suite;
-use {cairo_lang_defs as defs, cairo_lang_lowering as lowering, cairo_lang_semantic as semantic};
 
 use crate::db::SierraGenGroup;
 use crate::pre_sierra::{self, LabelLongId};

--- a/crates/cairo-lang-sierra-generator/src/utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/utils.rs
@@ -1,7 +1,10 @@
 use cairo_lang_debug::DebugWithDb;
+use cairo_lang_defs as defs;
 use cairo_lang_defs::ids::NamedLanguageElementId;
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::ids::Tracked;
+use cairo_lang_lowering as lowering;
+use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::items::constant::ConstValueId;
 use cairo_lang_sierra::extensions::const_type::{
     ConstAsBoxLibfunc, ConstAsImmediateLibfunc, ConstType,
@@ -20,7 +23,6 @@ use salsa::Database;
 use semantic::items::constant::ConstValue;
 use semantic::items::functions::GenericFunctionId;
 use smol_str::SmolStr;
-use {cairo_lang_defs as defs, cairo_lang_lowering as lowering, cairo_lang_semantic as semantic};
 
 use crate::db::{SierraGenGroup, SierraGeneratorTypeLongId};
 use crate::pre_sierra;

--- a/crates/cairo-lang-starknet/src/contract.rs
+++ b/crates/cairo-lang-starknet/src/contract.rs
@@ -6,6 +6,8 @@ use cairo_lang_defs::ids::{
 };
 use cairo_lang_diagnostics::ToOption;
 use cairo_lang_filesystem::ids::{CrateId, SmolStrId};
+use cairo_lang_lowering as lowering;
+use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::GenericArgumentId;
 use cairo_lang_semantic::items::constant::ConstantSemantic;
 use cairo_lang_semantic::items::free_function::FreeFunctionSemantic;
@@ -32,7 +34,6 @@ use itertools::chain;
 use salsa::Database;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt as Felt252;
-use {cairo_lang_lowering as lowering, cairo_lang_semantic as semantic};
 
 use crate::aliased::Aliased;
 use crate::compile::{SemanticEntryPoints, extract_semantic_entrypoints};

--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -49,7 +49,7 @@ pub fn reformat_rust_code(text: String) -> String {
 }
 pub fn reformat_rust_code_inner(text: String) -> String {
     let sh = Shell::new().unwrap();
-    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-02-27");
+    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-03-01");
     let cmd_with_args = cmd.arg("--config-path").arg(project_root().join("rustfmt.toml"));
     let mut stdout = cmd_with_args.stdin(text).read().unwrap();
     if !stdout.ends_with('\n') {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The `rustfmt` configuration used by Cairo requires a nightly version of Rust.
 You can install the nightly version by running:
 
 ```sh
-rustup install nightly-2026-02-27
+rustup install nightly-2026-03-01
 ```
 
 ## Running Tests

--- a/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
@@ -35,5 +35,5 @@ You can install the nightly version by running:
 
 [source,bash]
 ----
-rustup install nightly-2026-02-27
+rustup install nightly-2026-03-01
 ----

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,11 +23,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2026-02-27",
+#         "nightly-2026-03-01",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2024",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2026-02-27".
+# and run "rustup toolchain install nightly-2026-03-01".

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-02-27}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-03-01}"
 
 cargo clippy "$@" --all-targets --all-features -- -D warnings -D future-incompatible \
     -D nonstandard-style -D rust-2018-idioms -D unused

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-02-27}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-03-01}"
 
 RUSTDOCFLAGS="-Dwarnings" cargo doc --document-private-items --no-deps --all-features

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-02-27}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-03-01}"
 
 cargo fmt --all -- "$@"


### PR DESCRIPTION
## Summary

Updates the Rust nightly toolchain from `nightly-2026-02-27` to `nightly-2026-03-01` across CI workflows, build scripts, documentation, and import statement formatting.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This change updates the project to use a newer nightly Rust toolchain version, which is necessary to maintain compatibility with the latest Rust features and ensure consistent formatting and linting behavior across the codebase.

---

## What was the behavior or documentation before?

The project was using Rust nightly toolchain version `nightly-2026-02-27` for CI builds, formatting, clippy linting, and documentation generation.

---

## What is the behavior or documentation after?

The project now uses Rust nightly toolchain version `nightly-2026-03-01` for all build processes, and import statements have been reformatted to place individual imports on separate lines instead of using brace-grouped imports.

---

## Related issue or discussion (if any)

---

## Additional context

This update includes changes to:
- GitHub Actions CI workflows for testing, formatting, clippy, and documentation
- Build scripts for formatting, linting, and docs generation
- Contributing documentation and prerequisites
- Import statement formatting across multiple crates to follow updated rustfmt rules