### PR TITLE
Making sure to not inifinitely recursively extract generics.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -1214,8 +1214,12 @@ impl<'db, 'id> Inference<'db, 'id> {
         }
 
         let mut neg_impl_generic_params = OrderedHashSet::default();
+        let mut visited_types = OrderedHashSet::default();
         for garg in generic_args {
-            if garg.extract_generic_params(self.db, &mut neg_impl_generic_params).is_err() {
+            if garg
+                .extract_generic_params(self.db, &mut neg_impl_generic_params, &mut visited_types)
+                .is_err()
+            {
                 return Ok(SolutionSet::Ambiguous(
                     Ambiguity::NegativeImplWithUnsupportedExtractedArgs(*garg),
                 ));

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -146,31 +146,33 @@ impl<'db> ConstValueId<'db> {
     }
 
     /// A utility function for extracting the generic parameters arguments from a ConstValueId.
+    /// Uses memoization via `visited` to avoid re-traversing shared subtypes in DAG structures.
     pub fn extract_generic_params(
         &self,
         db: &'db dyn Database,
         generic_parameters: &mut OrderedHashSet<GenericParamId<'db>>,
+        visited: &mut OrderedHashSet<TypeId<'db>>,
     ) -> Maybe<()> {
         match self.long(db) {
             ConstValue::Int(_, type_id) | ConstValue::Struct(_, type_id) => {
-                type_id.long(db).extract_generic_params(db, generic_parameters)?
+                type_id.extract_generic_params(db, generic_parameters, visited)?
             }
             ConstValue::Enum(_, const_value_id) => {
-                const_value_id.ty(db)?.long(db).extract_generic_params(db, generic_parameters)?
+                const_value_id.ty(db)?.extract_generic_params(db, generic_parameters, visited)?
             }
             ConstValue::NonZero(const_value_id) => {
-                const_value_id.extract_generic_params(db, generic_parameters)?
+                const_value_id.extract_generic_params(db, generic_parameters, visited)?
             }
             ConstValue::Generic(generic_param_id) => {
                 generic_parameters.insert(*generic_param_id);
             }
             ConstValue::ImplConstant(impl_constant_id) => {
                 for garg in impl_constant_id.impl_id().concrete_trait(db)?.generic_args(db) {
-                    garg.extract_generic_params(db, generic_parameters)?;
+                    garg.extract_generic_params(db, generic_parameters, visited)?;
                 }
             }
             ConstValue::Var(_, type_id) => {
-                type_id.long(db).extract_generic_params(db, generic_parameters)?
+                type_id.extract_generic_params(db, generic_parameters, visited)?
             }
             ConstValue::Missing(diagnostic_added) => return Err(*diagnostic_added),
         }

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -102,26 +102,28 @@ impl<'db> GenericArgumentId<'db> {
     }
 
     /// A utility function for extracting the generic parameters arguments from a GenericArgumentId.
+    /// Uses memoization via `visited` to avoid re-traversing shared subtypes in DAG structures.
     pub fn extract_generic_params(
         &self,
         db: &'db dyn Database,
         generic_parameters: &mut OrderedHashSet<GenericParamId<'db>>,
+        visited: &mut OrderedHashSet<TypeId<'db>>,
     ) -> Maybe<()> {
         match self {
             GenericArgumentId::Type(ty) => {
-                ty.long(db).extract_generic_params(db, generic_parameters)?
+                ty.extract_generic_params(db, generic_parameters, visited)?
             }
             GenericArgumentId::Constant(const_value_id) => {
-                const_value_id.extract_generic_params(db, generic_parameters)?;
+                const_value_id.extract_generic_params(db, generic_parameters, visited)?;
             }
             GenericArgumentId::Impl(impl_id) => {
                 for garg in impl_id.concrete_trait(db)?.generic_args(db) {
-                    garg.extract_generic_params(db, generic_parameters)?;
+                    garg.extract_generic_params(db, generic_parameters, visited)?;
                 }
             }
             GenericArgumentId::NegImpl(negative_impl_id) => {
                 for garg in negative_impl_id.concrete_trait(db)?.generic_args(db) {
-                    garg.extract_generic_params(db, generic_parameters)?;
+                    garg.extract_generic_params(db, generic_parameters, visited)?;
                 }
             }
         }

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -210,24 +210,26 @@ impl<'db> TypeLongId<'db> {
     }
 
     /// A utility function for extracting the generic parameters arguments from TypeLongId.
+    /// Uses memoization via `visited` to avoid re-traversing shared subtypes in DAG structures.
     pub fn extract_generic_params(
         &self,
         db: &'db dyn Database,
         generic_parameters: &mut OrderedHashSet<GenericParamId<'db>>,
+        visited: &mut OrderedHashSet<TypeId<'db>>,
     ) -> Maybe<()> {
         match self {
             TypeLongId::Concrete(concrete_type_id) => {
                 for garg in concrete_type_id.generic_args(db) {
-                    garg.extract_generic_params(db, generic_parameters)?;
+                    garg.extract_generic_params(db, generic_parameters, visited)?;
                 }
             }
             TypeLongId::Tuple(tys) => {
                 for ty in tys {
-                    ty.long(db).extract_generic_params(db, generic_parameters)?
+                    ty.extract_generic_params(db, generic_parameters, visited)?
                 }
             }
             TypeLongId::Snapshot(ty) => {
-                ty.long(db).extract_generic_params(db, generic_parameters)?
+                ty.extract_generic_params(db, generic_parameters, visited)?
             }
             TypeLongId::GenericParameter(generic_param) => {
                 generic_parameters.insert(*generic_param);
@@ -235,12 +237,12 @@ impl<'db> TypeLongId<'db> {
             TypeLongId::Var(_) => {}
             TypeLongId::Coupon(_) => {}
             TypeLongId::FixedSizeArray { type_id, .. } => {
-                type_id.long(db).extract_generic_params(db, generic_parameters)?
+                type_id.extract_generic_params(db, generic_parameters, visited)?
             }
             TypeLongId::ImplType(impl_type_id) => {
                 let concrete_trait_id = impl_type_id.impl_id.concrete_trait(db)?;
                 for garg in concrete_trait_id.generic_args(db) {
-                    garg.extract_generic_params(db, generic_parameters)?;
+                    garg.extract_generic_params(db, generic_parameters, visited)?;
                 }
             }
             TypeLongId::Closure(closure_ty) => {
@@ -249,12 +251,28 @@ impl<'db> TypeLongId<'db> {
                     &closure_ty.captured_types,
                     std::iter::once(&closure_ty.ret_ty)
                 ) {
-                    ty.long(db).extract_generic_params(db, generic_parameters)?
+                    ty.extract_generic_params(db, generic_parameters, visited)?
                 }
             }
             TypeLongId::Missing(diag_added) => return Err(*diag_added),
         };
         Ok(())
+    }
+}
+
+impl<'db> TypeId<'db> {
+    /// A utility function for extracting the generic parameters arguments from TypeId.
+    /// Uses memoization via `visited` to avoid re-traversing shared subtypes in DAG structures.
+    pub fn extract_generic_params(
+        self,
+        db: &'db dyn Database,
+        generic_parameters: &mut OrderedHashSet<GenericParamId<'db>>,
+        visited: &mut OrderedHashSet<TypeId<'db>>,
+    ) -> Maybe<()> {
+        if !visited.insert(self) {
+            return Ok(());
+        }
+        self.long(db).extract_generic_params(db, generic_parameters, visited)
     }
 }
 impl<'db> DebugWithDb<'db> for TypeLongId<'db> {


### PR DESCRIPTION
## Summary

Adds memoization to generic parameter extraction to prevent infinite recursion when traversing cyclic type structures. The `extract_generic_params` methods now accept a `visited` parameter to track already-processed types and avoid re-traversing shared subtypes in DAG structures.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The generic parameter extraction logic could enter infinite recursion when encountering cyclic type references or shared subtypes in complex type hierarchies. This would cause stack overflow errors during semantic analysis of certain Cairo programs with recursive or mutually referential type definitions.

---

## What was the behavior or documentation before?

The `extract_generic_params` methods would traverse type structures without tracking visited nodes, potentially leading to infinite recursion on cyclic references and redundant processing of shared subtypes.

---

## What is the behavior or documentation after?

The methods now use a `visited` set to memoize already-processed types, preventing infinite recursion and avoiding redundant traversal of shared subtypes. A new `TypeId::extract_generic_params` method handles the memoization logic before delegating to `TypeLongId::extract_generic_params`.

---

## Related issue or discussion (if any)

---

## Additional context

This change affects the semantic analysis phase of the Cairo compiler and ensures robust handling of complex type hierarchies without performance degradation from redundant traversals.

Fixes issue #9711.