### PR TITLE
docs: clarify associativity and chained comparisons in operator prece…

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/operator-precedence.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/operator-precedence.adoc
@@ -1,8 +1,10 @@
 = Operator precedence
 
-Below is the table of operator precedence.
+Operator precedence defines how expressions with multiple operators are grouped
+when no parentheses are used.
+Operators listed higher in the table bind tighter (are evaluated first).
 
-The higher an operator is in the table, the earlier it is evaluated.
+Use parentheses to make evaluation order explicit when needed.
 
 [cols="1,1,1",options="header"]
 |===
@@ -26,3 +28,46 @@ The higher an operator is in the table, the earlier it is evaluated.
 
                                           `<\<=` `>>=` `&=` `^=` `\|=`   | Second line not yet supported.
 |===
+
+== Associativity
+
+When multiple binary operators from the same precedence group appear in one
+expression, they are parsed left to right.
+
+[source,cairo]
+----
+let x = 20 - 5 - 3; // Parsed as (20 - 5) - 3
+let y = 8 / 2 / 2;  // Parsed as (8 / 2) / 2
+----
+
+== Examples
+
+[source,cairo]
+----
+// Arithmetic binds tighter than comparison and logical operators.
+let a = 2 + 3 * 4 == 14 && true; // ((2 + (3 * 4)) == 14) && true
+
+// Prefix unary operators bind tighter than arithmetic operators.
+let b = -x * 2; // (-x) * 2
+
+// Postfix operators bind tighter than arithmetic operators.
+let c = arr[0] + 1; // (arr[0]) + 1
+
+// Use parentheses to override default precedence.
+let d = (2 + 3) * 4;
+----
+
+== Chained comparisons
+
+Chained comparisons such as `a < b < c` are not supported.
+Write them with logical conjunctions instead:
+
+[source,cairo]
+----
+let in_range = a < b && b < c;
+----
+
+== Related
+
+- xref:operator-expressions.adoc[Operator expressions]
+- xref:parentheses.adoc[Parenthesized expressions]


### PR DESCRIPTION
## Summary
Documents left-to-right associativity, provides concrete operator precedence examples, and explicitly clarifies that chained comparisons (`a < b < c`) are unsupported.

## Type of change
- [x] Documentation change with concrete technical impact

## Why is this change needed?
The previous documentation lacked associativity rules and practical examples, leaving precedence behavior ambiguous. Users frequently attempt chained comparisons (common in other languages), causing syntax errors. Documenting these specific constraints directly prevents compilation errors and clarifies non-obvious Cairo parsing behaviors.

## What was the behavior or documentation before?
Only a basic precedence table was provided, lacking associativity rules, examples, and chained comparison limitations.

## What is the behavior or documentation after?
Added distinct `Associativity`, `Examples`, and `Chained comparisons` sections to explicitly define parsing behavior and syntax limitations.