### PR TITLE
Added a check for unsupported const operation on generic and impl constants

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -650,3 +650,59 @@ const AND_SHORT_CIRCUIT: () = assert(!(false && boom()));
 const OR_SHORT_CIRCUIT: () = assert(true || boom());
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Evaluate const functions with const impls.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait Foo {
+    const VALUE: felt252;
+}
+impl AFoo of Foo {
+    const VALUE: felt252 = 42;
+}
+impl AnotherFoo<impl F: Foo> of Foo {
+    const VALUE: felt252 = F::VALUE + 1;
+}
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:8:28
+    const VALUE: felt252 = F::VALUE + 1;
+                           ^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Use const impls as other consts.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait Foo {
+    const VALUE: felt252;
+}
+impl AFoo of Foo {
+    const VALUE: felt252 = 42;
+}
+impl AnotherFoo<impl F: Foo> of Foo {
+    const VALUE: felt252 = F::VALUE;
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -897,15 +897,32 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             return bool_value(args[0] == self.false_const);
         }
 
+        let mut all_args_concrete = true;
         let args = match args
             .into_iter()
-            .map(|arg| NumericArg::try_new(db, arg))
+            .map(|arg| {
+                // Track if any argument is not fully concrete (e.g., ImplConstant with a generic
+                // impl parameter) so we can report a diagnostic if NumericArg conversion fails.
+                if !arg.is_fully_concrete(db) && !matches!(arg.long(db), ConstValue::Missing(_)) {
+                    all_args_concrete = false;
+                }
+                NumericArg::try_new(db, arg)
+            })
             .collect::<Option<Vec<_>>>()
         {
             Some(args) => args,
-            // Diagnostic can be skipped as we would either have a semantic error for a bad arg for
-            // the function, or the arg itself couldn't have been calculated.
-            None => return to_missing(skip_diagnostic()),
+            None => {
+                return to_missing(if all_args_concrete {
+                    // Diagnostic can be skipped as there would be a semantic error for a bad arg,
+                    // or the arg itself is Missing.
+                    skip_diagnostic()
+                } else {
+                    self.diagnostics.report(
+                        expr.stable_ptr.untyped(),
+                        SemanticDiagnosticKind::UnsupportedConstant,
+                    )
+                });
+            }
         };
         let value = match imp.function {
             id if id == self.neg_fn => -&args[0].v,


### PR DESCRIPTION
## Summary

Added validation to prevent generic impl constants from being used in constant expressions. The compiler now reports an error when attempting to use constants from generic impl parameters (like `F::VALUE` where `F` is a generic impl) in constant contexts, as these cannot be evaluated at compile time.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Constants that reference generic impl parameters cannot be evaluated at compile time because the concrete implementation is not known during constant evaluation. Previously, the compiler was not properly validating these cases, which could lead to compilation issues or incorrect behavior.

---

## What was the behavior or documentation before?

The compiler would accept constant expressions that referenced generic impl constants without proper validation, potentially causing issues during compilation when these expressions couldn't be evaluated.

---

## What is the behavior or documentation after?

The compiler now properly validates constant expressions and reports error E2127 ("This expression is not supported as constant") when encountering constants from generic impl parameters that cannot be evaluated at compile time.

---

## Related issue or discussion (if any)

---

## Additional context

The fix includes a new test case that demonstrates the error being properly reported for the pattern `const VALUE: felt252 = F::VALUE + 1` where `F` is a generic impl parameter.