### PR TITLE
Drop stale 🚧 doc markers

### DIFF
--- a/docs/reference/src/components/cairo/modules/appendices/nav.adoc
+++ b/docs/reference/src/components/cairo/modules/appendices/nav.adoc
@@ -1,5 +1,5 @@
 // Appendices
 * Appendices
-** xref:pages/full-grammar.adoc[Full grammar 🚧]
+** xref:pages/full-grammar.adoc[Full grammar]
 ** xref:pages/contribution-guidelines.adoc[Contribution guidelines]
 ** xref:pages/security.adoc[Security]

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc
@@ -69,6 +69,6 @@ Invalid examples (illustrative):
 == Related
 
 - xref:expressions.adoc[Expressions]
-- xref:array-types.adoc[Array types] (🚧)
-- xref:slice-types.adoc[Slice types] (🚧)
+- xref:array-types.adoc[Array types]
+- xref:slice-types.adoc[Slice types]
 - xref:tuple-expressions.adoc[Tuple expressions]


### PR DESCRIPTION
  ## Summary

  Remove outdated under-construction markers (`🚧`) from:
  - `docs/reference/src/components/cairo/modules/appendices/nav.adoc` (`Full grammar`)
  - `docs/reference/src/components/cairo/modules/language_constructs/pages/array-expressions.adoc` (`Array types`, `Slice
  types` links)

  ---

  ## Type of change

  Please check **one**:

  - [ ] Bug fix (fixes incorrect behavior)
  - [ ] New feature
  - [ ] Performance improvement
  - [x] Documentation change with concrete technical impact
  - [ ] Style, wording, formatting, or typo-only change

  ---

  ## Why is this change needed?

  These markers currently communicate that key docs are still incomplete, which is no longer true and misleads users/contributors about docs maturity and where gaps remain.

  Concrete evidence:
  - `full-grammar.adoc` was completed in #9387.
  - `array-types.adoc` and `slice-types.adoc` are already substantial reference pages.

  So this PR fixes inaccurate documentation status signals, not just wording.

  ---


  Navigation/related links labeled mature docs as `🚧` (under construction), implying they were still unfinished.

  ---

  ## What is the behavior or documentation after?

  Those specific links no longer show `🚧`, so status now matches current documentation completeness.

  ---

  ## Related issue or discussion (if any)

  Related precedent: #9573, #9568, #9521 (similar cleanup of outdated WIP markers).

  ---

  ## Additional context

  Scope is intentionally minimal and label-only:
  - no semantic documentation changes
  - no link target changes
  - only removal of stale status markers