### PR TITLE
fix(parser): clarify consecutive comparison diagnostics

### DIFF
--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -221,14 +221,22 @@ Did you mean to write `{identifier}!{left}...{right}'?",
                 "A trailing `|` is not allowed in an or-pattern.".to_string()
             }
             ParserDiagnosticKind::ConsecutiveMathOperators { first_op, second_op } => {
-                format!(
-                    "Consecutive comparison operators are not allowed: {} followed by {}. If this \
-                     was intended as a chained comparison, rewrite it with `&&` (for example, `a \
-                     < b && b < c`). If this appears in a generic path, you may be missing `::` \
-                     (for example, `foo::<T>(...)`).",
+                let message = format!(
+                    "Consecutive comparison operators are not allowed: {} followed by {}.",
                     self.kind_to_string(*first_op),
                     self.kind_to_string(*second_op)
-                )
+                );
+                if *first_op == SyntaxKind::TerminalLT && *second_op == SyntaxKind::TerminalGT {
+                    format!(
+                        "{message} If this appears in a generic path, you may be missing `::` \
+                         (for example, `foo::<T>(...)`)."
+                    )
+                } else {
+                    format!(
+                        "{message} If this was intended as a chained comparison, rewrite it with \
+                         `&&` (for example, `a < b && b < c`)."
+                    )
+                }
             }
             ParserDiagnosticKind::ExpectedSemicolonOrBody => {
                 "Expected either ';' or '{' after module name. Use ';' for an external module \

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -222,7 +222,10 @@ Did you mean to write `{identifier}!{left}...{right}'?",
             }
             ParserDiagnosticKind::ConsecutiveMathOperators { first_op, second_op } => {
                 format!(
-                    "Consecutive comparison operators are not allowed: {} followed by {}",
+                    "Consecutive comparison operators are not allowed: {} followed by {}. If this \
+                     was intended as a chained comparison, rewrite it with `&&` (for example, `a \
+                     < b && b < c`). If this appears in a generic path, you may be missing `::` \
+                     (for example, `foo::<T>(...)`).",
                     self.kind_to_string(*first_op),
                     self.kind_to_string(*second_op)
                 )

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -93,12 +93,14 @@ impl<'a> ParserDiagnostic<'a> {
         )
     }
 
+    /// Returns the operator text for comparisons that can be rewritten as explicit conjunctions.
     fn ordering_operator_text(kind: SyntaxKind) -> Option<&'static str> {
         match kind {
             SyntaxKind::TerminalLT => Some("<"),
             SyntaxKind::TerminalGT => Some(">"),
             SyntaxKind::TerminalLE => Some("<="),
             SyntaxKind::TerminalGE => Some(">="),
+            SyntaxKind::TerminalEqEq => Some("=="),
             _ => None,
         }
     }
@@ -241,15 +243,13 @@ Did you mean to write `{identifier}!{left}...{right}'?",
                         "{message} If this appears in a generic path, you may be missing `::` \
                          (for example, `foo::<T>(...)`)."
                     )
-                } else if *first_op == *second_op {
-                    if let Some(op) = Self::ordering_operator_text(*first_op) {
-                        format!(
-                            "{message} If this was intended as a chained comparison, rewrite it \
-                             with `&&` (for example, `a {op} b && b {op} c`)."
-                        )
-                    } else {
-                        message
-                    }
+                } else if let Some(op1) = Self::ordering_operator_text(*first_op)
+                    && let Some(op2) = Self::ordering_operator_text(*second_op)
+                {
+                    format!(
+                        "{message} If this was intended as a chained comparison, rewrite it with \
+                         `&&` (for example, `a {op1} b && b {op2} c`)."
+                    )
                 } else {
                     message
                 }

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -92,6 +92,16 @@ impl<'a> ParserDiagnostic<'a> {
             }
         )
     }
+
+    fn ordering_operator_text(kind: SyntaxKind) -> Option<&'static str> {
+        match kind {
+            SyntaxKind::TerminalLT => Some("<"),
+            SyntaxKind::TerminalGT => Some(">"),
+            SyntaxKind::TerminalLE => Some("<="),
+            SyntaxKind::TerminalGE => Some(">="),
+            _ => None,
+        }
+    }
 }
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ParserDiagnosticKind {
@@ -231,11 +241,17 @@ Did you mean to write `{identifier}!{left}...{right}'?",
                         "{message} If this appears in a generic path, you may be missing `::` \
                          (for example, `foo::<T>(...)`)."
                     )
+                } else if *first_op == *second_op {
+                    if let Some(op) = Self::ordering_operator_text(*first_op) {
+                        format!(
+                            "{message} If this was intended as a chained comparison, rewrite it \
+                             with `&&` (for example, `a {op} b && b {op} c`)."
+                        )
+                    } else {
+                        message
+                    }
                 } else {
-                    format!(
-                        "{message} If this was intended as a chained comparison, rewrite it with \
-                         `&&` (for example, `a < b && b < c`)."
-                    )
+                    message
                 }
             }
             ParserDiagnosticKind::ExpectedSemicolonOrBody => {

--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -101,6 +101,7 @@ impl<'a> ParserDiagnostic<'a> {
             SyntaxKind::TerminalLE => Some("<="),
             SyntaxKind::TerminalGE => Some(">="),
             SyntaxKind::TerminalEqEq => Some("=="),
+            SyntaxKind::TerminalNeq => Some("!="),
             _ => None,
         }
     }

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
@@ -78,7 +78,7 @@ StatementExpr
 //! > ignored_kinds
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '<' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`). If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
+error[E1028]: Consecutive comparison operators are not allowed: '<' followed by '>'. If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
  --> dummy_file.cairo:2:14
     3 < 1    > 5
              ^
@@ -113,7 +113,7 @@ StatementExpr
 //! > ignored_kinds
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '==' followed by '=='. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`). If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
+error[E1028]: Consecutive comparison operators are not allowed: '==' followed by '=='. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`).
  --> dummy_file.cairo:2:12
     1 == 1 == 1
            ^

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
@@ -78,7 +78,7 @@ StatementExpr
 //! > ignored_kinds
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '<' followed by '>'
+error[E1028]: Consecutive comparison operators are not allowed: '<' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`). If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
  --> dummy_file.cairo:2:14
     3 < 1    > 5
              ^
@@ -93,4 +93,39 @@ error[E1028]: Consecutive comparison operators are not allowed: '<' followed by 
     │   │   └── rhs (kind: TokenLiteralNumber): '1'
     │   ├── op (kind: TokenGT): '>'
     │   └── rhs (kind: TokenLiteralNumber): '5'
+    └── semicolon (kind: OptionTerminalSemicolonEmpty) []
+
+//! > ==========================================================================
+
+//! > Test consecutive equality operators
+
+//! > test_runner_name
+test_partial_parser_tree(expect_diagnostics: true)
+
+//! > cairo_code
+fn f() -> bool {
+    1 == 1 == 1
+}
+
+//! > top_level_kind
+StatementExpr
+
+//! > ignored_kinds
+
+//! > expected_diagnostics
+error[E1028]: Consecutive comparison operators are not allowed: '==' followed by '=='. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`). If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
+ --> dummy_file.cairo:2:12
+    1 == 1 == 1
+           ^
+
+//! > expected_tree
+└── Top level kind: StatementExpr
+    ├── attributes (kind: AttributeList) []
+    ├── expr (kind: ExprBinary)
+    │   ├── lhs (kind: ExprBinary)
+    │   │   ├── lhs (kind: TokenLiteralNumber): '1'
+    │   │   ├── op (kind: TokenEqEq): '=='
+    │   │   └── rhs (kind: TokenLiteralNumber): '1'
+    │   ├── op (kind: TokenEqEq): '=='
+    │   └── rhs (kind: TokenLiteralNumber): '1'
     └── semicolon (kind: OptionTerminalSemicolonEmpty) []

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
@@ -113,7 +113,7 @@ StatementExpr
 //! > ignored_kinds
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '==' followed by '=='. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`).
+error[E1028]: Consecutive comparison operators are not allowed: '==' followed by '=='.
  --> dummy_file.cairo:2:12
     1 == 1 == 1
            ^

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
@@ -113,7 +113,7 @@ StatementExpr
 //! > ignored_kinds
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '==' followed by '=='.
+error[E1028]: Consecutive comparison operators are not allowed: '==' followed by '=='. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a == b && b == c`).
  --> dummy_file.cairo:2:12
     1 == 1 == 1
            ^

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/expr
@@ -129,3 +129,38 @@ error[E1028]: Consecutive comparison operators are not allowed: '==' followed by
     │   ├── op (kind: TokenEqEq): '=='
     │   └── rhs (kind: TokenLiteralNumber): '1'
     └── semicolon (kind: OptionTerminalSemicolonEmpty) []
+
+//! > ==========================================================================
+
+//! > Test consecutive inequality operators
+
+//! > test_runner_name
+test_partial_parser_tree(expect_diagnostics: true)
+
+//! > cairo_code
+fn f() -> bool {
+    1 != 1 != 1
+}
+
+//! > top_level_kind
+StatementExpr
+
+//! > ignored_kinds
+
+//! > expected_diagnostics
+error[E1028]: Consecutive comparison operators are not allowed: '!=' followed by '!='. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a != b && b != c`).
+ --> dummy_file.cairo:2:12
+    1 != 1 != 1
+           ^
+
+//! > expected_tree
+└── Top level kind: StatementExpr
+    ├── attributes (kind: AttributeList) []
+    ├── expr (kind: ExprBinary)
+    │   ├── lhs (kind: ExprBinary)
+    │   │   ├── lhs (kind: TokenLiteralNumber): '1'
+    │   │   ├── op (kind: TokenNeq): '!='
+    │   │   └── rhs (kind: TokenLiteralNumber): '1'
+    │   ├── op (kind: TokenNeq): '!='
+    │   └── rhs (kind: TokenLiteralNumber): '1'
+    └── semicolon (kind: OptionTerminalSemicolonEmpty) []

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -876,7 +876,7 @@ fn bar<T>(_a: T) {}
 //! > function_body
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '<' followed by '>'
+error[E1028]: Consecutive comparison operators are not allowed: '<' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`). If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
  --> lib.cairo:4:26
   let _fail = bar<felt252>(1);
                          ^

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -876,7 +876,7 @@ fn bar<T>(_a: T) {}
 //! > function_body
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '<' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`). If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
+error[E1028]: Consecutive comparison operators are not allowed: '<' followed by '>'. If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
  --> lib.cairo:4:26
   let _fail = bar<felt252>(1);
                          ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/operators
+++ b/crates/cairo-lang-semantic/src/expr/test_data/operators
@@ -41,7 +41,7 @@ fn foo(a: u128, b: bool) implicits(RangeCheck) {
 foo
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '>' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`). If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
+error[E1028]: Consecutive comparison operators are not allowed: '>' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`).
  --> lib.cairo:6:11
     a > a > a;
           ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/operators
+++ b/crates/cairo-lang-semantic/src/expr/test_data/operators
@@ -41,7 +41,7 @@ fn foo(a: u128, b: bool) implicits(RangeCheck) {
 foo
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '>' followed by '>'
+error[E1028]: Consecutive comparison operators are not allowed: '>' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`). If this appears in a generic path, you may be missing `::` (for example, `foo::<T>(...)`).
  --> lib.cairo:6:11
     a > a > a;
           ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/operators
+++ b/crates/cairo-lang-semantic/src/expr/test_data/operators
@@ -41,7 +41,7 @@ fn foo(a: u128, b: bool) implicits(RangeCheck) {
 foo
 
 //! > expected_diagnostics
-error[E1028]: Consecutive comparison operators are not allowed: '>' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a < b && b < c`).
+error[E1028]: Consecutive comparison operators are not allowed: '>' followed by '>'. If this was intended as a chained comparison, rewrite it with `&&` (for example, `a > b && b > c`).
  --> lib.cairo:6:11
     a > a > a;
           ^


### PR DESCRIPTION
Clarify E1028 for consecutive comparison operators by adding conditionalguidance for chained comparisons and possible missing `::` in generic paths, and update parser/semantic diagnostic test data with an additional `1 == 1 == 1` case.