### PR TITLE
Remove stale semantics markers

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_semantics/nav.adoc
+++ b/docs/reference/src/components/cairo/modules/language_semantics/nav.adoc
@@ -1,7 +1,7 @@
 // Language semantics
 * Language Semantics
-** xref:pages/memory-model.adoc[Memory model 🚧]
-** xref:pages/constant-evaluation.adoc[Constant evaluation 🚧]
-** xref:pages/application-binary-interface.adoc[Application binary interface 🚧]
-** xref:pages/runtime.adoc[Runtime 🚧]
+** xref:pages/memory-model.adoc[Memory model]
+** xref:pages/constant-evaluation.adoc[Constant evaluation]
+** xref:pages/application-binary-interface.adoc[Application binary interface]
+** xref:pages/runtime.adoc[Runtime]
 ** xref:pages/linear-types.adoc[Linear Types]


### PR DESCRIPTION
  ## Summary

  Remove outdated `🚧` markers from Language Semantics navigation entries:

  - `Memory model`
  - `Constant evaluation`
  - `Application binary interface`
  - `Runtime`

  ---

  ## Type of change

  Please check **one**:

  - [ ] Bug fix (fixes incorrect behavior)
  - [ ] New feature
  - [x] Documentation change with concrete technical impact
  - [ ] Performance improvement

  ---

  The nav currently signals these pages as "under construction", which is outdated and misleading for users and contributors.

  These pages are already substantial and actively maintained (for example, recent updates include `#9573` for memory model and `#9475` for ABI). Keeping `🚧` in nav incorrectly suggests missing/immature documentation and distorts contribution priorities.

  ---

  ## What was the behavior or documentation before?

  Language Semantics nav showed `🚧` on four entries even though their target pages are already mature reference docs.

  ---

  ## What is the behavior or documentation after?

  Those four nav entries no longer show `🚧`.
  Link targets and page content remain unchanged.
  Related cleanup precedent:
  - #9521

  ---

  ## Additional context

  Scope is intentionally minimal and safe: nav labels only, no semantic doc changes.
  Validation scripts passed:
  - `./scripts/rust_fmt.sh`
  - `./scripts/clippy.sh`