### PR TITLE
docs: clarify unsupported chained comparisons across operator pages

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/comparison-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/comparison-operators.adoc
@@ -38,6 +38,16 @@ Relational operators share the same precedence level as equality operators (`==`
 
 This is defined in link:{cairo-repo}/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs].
 
+== Chained comparisons
+
+Chained comparisons such as `a < b < c` are not supported.
+Write them with an explicit conjunction instead:
+
+[source,cairo]
+----
+let in_range = a < b && b < c;
+----
+
 == Examples
 
 === Primitives

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/equality-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/equality-operators.adoc
@@ -33,6 +33,16 @@
  
  This is defined in link:{cairo-repo}/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs].
  
+ == Chained equality
+ 
+ Chained equality such as `a == b == c` is not supported.
+ Write it as explicit conjunctions:
+ 
+ [source,cairo]
+ ----
+ let all_equal = a == b && b == c;
+ ----
+ 
  == Examples
  
  === Primitives

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/operator-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/operator-expressions.adoc
@@ -71,6 +71,10 @@ Use parentheses to override the default precedence: `(2 + 3) * 4`.
 See xref:operator-precedence.adoc[Operator precedence] for the complete
 precedence table and associativity rules.
 
+Chained comparisons such as `a < b < c` are not supported.
+Write them as separate comparisons combined with `&&`, for example:
+`a < b && b < c`.
+
 == Implementing operators for custom types
 
 Most binary operators in Cairo (arithmetics, comparison, bitwise, etc.) are


### PR DESCRIPTION
Add explicit notes that chained comparison and chained equality forms are unsupported in operator documentation pages, and provide the `&&` rewrite pattern to prevent common parser errors.