### PR TITLE
Fix starknet-compile single-file example

### DIFF
--- a/docs/reference/src/components/cairo/modules/getting_started/pages/compiling-starknet-contracts.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/compiling-starknet-contracts.adoc
@@ -4,7 +4,7 @@ Compile a Starknet Contract to a Sierra ContractClass:
 
 [source,bash]
 ----
-cargo run --bin starknet-compile -- /path/to/input.cairo /path/to/output.json
+cargo run --bin starknet-compile -- --single-file /path/to/input.cairo /path/to/output.json
 ----
 
 Or specify the contract path if multiple contracts are defined in the same project:


### PR DESCRIPTION
  ## Summary

  Fix the `starknet-compile` getting-started example by adding `--single-file` for `.cairo` file input.

  ---

  ## Type of change

  Please check **one**:

  - [ ] Bug fix (fixes incorrect behavior)
  - [ ] New feature
  - [ ] Style, wording, formatting, or typo-only change

  ## Why is this change needed?

  The previous command used a file path (`/path/to/input.cairo`) without `--single-file`. `starknet-compile` validates path type and rejects file input when this flag is missing, so users copying the docs hit an immediate error.

  ---

  ## What was the behavior or documentation before?

  The docs showed:

  `cargo run --bin starknet-compile -- /path/to/input.cairo /path/to/output.json`

  This is inconsistent with current CLI validation for file paths.

  ---

  ## What is the behavior or documentation after?

  `cargo run --bin starknet-compile -- --single-file /path/to/input.cairo /path/to/output.json`

  The example is executable and consistent with current CLI behavior (and with the README example).

  ---

  ## Related issue or discussion (if any)

  N/A

  ---

  ## Additional context

  This is a one-line docs correction with direct technical impact: it prevents copy-paste command failures in the getting-started flow.