### PR TITLE
Refactored get_unspent_gas testing libfunc.

### DIFF
--- a/corelib/src/test/testing_test.cairo
+++ b/corelib/src/test/testing_test.cairo
@@ -143,8 +143,7 @@ fn test_get_unspent_gas() {
     let _three = identity(one + two);
     let after = crate::testing::get_unspent_gas();
     let expected_cost = 100 // `one + two`.
-        + 300 // `identity(...)`.
-        + 2600; // `get_unspent_gas()`.
+    + 300; // `identity(...)`.
     assert_eq!(prev - after, expected_cost);
 }
 

--- a/crates/cairo-lang-casm/src/cell_expression.rs
+++ b/crates/cairo-lang-casm/src/cell_expression.rs
@@ -1,5 +1,7 @@
+use cairo_lang_utils::bigint::BigIntAsHex;
 use cairo_lang_utils::try_extract_matches;
 use num_bigint::BigInt;
+use num_traits::Zero;
 use num_traits::cast::ToPrimitive;
 
 use crate::ap_change::ApplyApChange;
@@ -89,27 +91,19 @@ impl CellExpression {
     pub fn to_buffer(&self, required_slack: i16) -> Option<CellExpression> {
         let (base, offset) = self.to_deref_with_offset()?;
         offset.to_i16()?.checked_add(required_slack)?;
-        if offset == 0 {
-            Some(CellExpression::Deref(base))
-        } else {
-            Some(CellExpression::BinOp {
-                op: CellOperator::Add,
-                a: base,
-                b: DerefOrImmediate::Immediate(offset.into()),
-            })
-        }
+        Some(Self::add_with_const(base, offset))
     }
 
     /// Returns a cell expression which is the sum of `cell` and `value`.
     /// If the value is zero, returns the cell itself.
-    pub fn add_with_const(cell: CellRef, value: i16) -> CellExpression {
-        if value == 0 {
+    pub fn add_with_const(cell: CellRef, value: impl Into<BigInt> + Zero) -> CellExpression {
+        if value.is_zero() {
             CellExpression::Deref(cell)
         } else {
             CellExpression::BinOp {
                 op: CellOperator::Add,
                 a: cell,
-                b: DerefOrImmediate::Immediate(value.into()),
+                b: DerefOrImmediate::Immediate(BigIntAsHex { value: value.into() }),
             }
         }
     }

--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -206,7 +206,10 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
                 vec![ApChange::Known(0)]
             }
             GasConcreteLibfunc::GetUnspentGas(_) => {
-                vec![ApChange::Known(BuiltinCostsType::cost_computation_steps(false, |_| 2) + 1)]
+                vec![ApChange::Known(BuiltinCostsType::cost_computation_steps(
+                    false,
+                    |token_type| info_provider.token_usages(token_type),
+                ))]
             }
             GasConcreteLibfunc::BuiltinWithdrawGas(_) => {
                 let cost_computation_ap_change: usize =

--- a/crates/cairo-lang-sierra-gas/src/compute_costs.rs
+++ b/crates/cairo-lang-sierra-gas/src/compute_costs.rs
@@ -330,6 +330,12 @@ fn analyze_gas_statements<
             for (token_type, amount) in SpecificCostContext::into_full_cost_iter(cost) {
                 assert_eq!(variable_values.insert((idx, token_type), amount), None);
             }
+        } else if let BranchCost::GetUnspentGas = branch_cost {
+            for (token_type, amount) in
+                SpecificCostContext::into_full_cost_iter(wallet_value.clone())
+            {
+                assert_eq!(variable_values.insert((idx, token_type), amount), None);
+            }
         } else if let BranchCost::FunctionCost { sign: BranchCostSign::Add, .. } = branch_cost {
             // If the refund can be fully used, the wallet value will be the same as
             // `branch_requirement`. Otherwise, wallet value will be zero and the difference
@@ -744,7 +750,9 @@ impl SpecificCostContextTrait<PreCost> for PreCostContext {
     ) -> WalletInfo<PreCost> {
         let branch_cost = match branch_cost {
             BranchCost::Regular { const_cost: _, pre_cost } => pre_cost.clone(),
-            BranchCost::BranchAlign | BranchCost::RedepositGas => Default::default(),
+            BranchCost::BranchAlign | BranchCost::RedepositGas | BranchCost::GetUnspentGas => {
+                Default::default()
+            }
             BranchCost::FunctionCost { const_cost: _, function, sign } => {
                 let func_cost = wallet_at_fn(function.entry_point).value;
                 match sign {
@@ -881,7 +889,7 @@ impl<CostType: PostCostTypeEx, GetApChangeFn: Fn(StatementIdx) -> usize>
                 }
                 cost
             }
-            BranchCost::RedepositGas => {
+            BranchCost::RedepositGas | BranchCost::GetUnspentGas => {
                 CostType::from_const_cost(&self.compute_redeposit_gas_cost(idx))
             }
         };

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -255,13 +255,7 @@ pub fn core_libfunc_cost(
             ],
             RedepositGas(_) => vec![BranchCost::RedepositGas],
             GetAvailableGas(_) => vec![ConstCost::default().into()],
-            GetUnspentGas(_) => vec![
-                ConstCost::steps(
-                    BuiltinCostsType::cost_computation_steps(false, |_| 2).into_or_panic::<i32>()
-                        + 1,
-                )
-                .into(),
-            ],
+            GetUnspentGas(_) => vec![BranchCost::GetUnspentGas],
             BuiltinWithdrawGas(_) => {
                 vec![
                     BranchCost::WithdrawGas(WithdrawGasBranchInfo {
@@ -743,6 +737,12 @@ impl BranchCost {
                     base
                 }
             }
+            BranchCost::GetUnspentGas => ops.const_cost(ConstCost::steps(
+                BuiltinCostsType::cost_computation_steps(false, |token_type| {
+                    info_provider.token_usages(token_type)
+                })
+                .into_or_panic(),
+            )),
         }
     }
 
@@ -780,6 +780,7 @@ impl BranchCost {
             BranchCost::BranchAlign | BranchCost::RedepositGas => {
                 precost_statement_vars_cost(ops).collect()
             }
+            BranchCost::GetUnspentGas => Default::default(),
             BranchCost::WithdrawGas(info) => {
                 if info.success {
                     precost_statement_vars_cost(ops).map(|(k, v)| (k, -v)).collect()

--- a/crates/cairo-lang-sierra-gas/src/objects.rs
+++ b/crates/cairo-lang-sierra-gas/src/objects.rs
@@ -111,6 +111,8 @@ pub enum BranchCost {
     WithdrawGas(WithdrawGasBranchInfo),
     /// The cost of the `redeposit_gas` libfunc.
     RedepositGas,
+    /// The cost of the `get_unspent_gas` libfunc.
+    GetUnspentGas,
 }
 
 /// Information about a branch of a `withdraw_gas` libfunc.

--- a/crates/cairo-lang-sierra-to-casm/src/compiler.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/compiler.rs
@@ -706,6 +706,7 @@ pub fn validate_metadata(
                     GasConcreteLibfunc::WithdrawGas(_)
                         | GasConcreteLibfunc::BuiltinWithdrawGas(_)
                         | GasConcreteLibfunc::RedepositGas(_)
+                        | GasConcreteLibfunc::GetUnspentGas(_)
                 )
         ) {
             return Err(CompilationError::StatementNotSupportingGasVariables(*idx));

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/gas.rs
@@ -1,6 +1,5 @@
 use cairo_lang_casm::builder::{CasmBuilder, Var};
-use cairo_lang_casm::cell_expression::{CellExpression, CellOperator};
-use cairo_lang_casm::operand::DerefOrImmediate;
+use cairo_lang_casm::cell_expression::CellExpression;
 use cairo_lang_casm::{casm_build_extend, cell_ref};
 use cairo_lang_sierra::extensions::gas::{CostTokenType, GasConcreteLibfunc};
 use cairo_lang_sierra_gas::core_libfunc_cost::InvocationCostInfoProvider;
@@ -97,6 +96,22 @@ fn build_withdraw_gas(
 fn build_redeposit_gas(
     builder: CompiledInvocationBuilder<'_>,
 ) -> Result<CompiledInvocation, InvocationError> {
+    build_calculate_unspent_gas(builder, true)
+}
+
+/// Handles the get_unspent_gas invocation.
+fn build_get_unspent_gas(
+    builder: CompiledInvocationBuilder<'_>,
+) -> Result<CompiledInvocation, InvocationError> {
+    build_calculate_unspent_gas(builder, false)
+}
+
+/// Common implementation for redeposit_gas and get_unspent_gas.
+/// If `is_redeposit` is true, the new gas value is returned as the gas builtin.
+fn build_calculate_unspent_gas(
+    builder: CompiledInvocationBuilder<'_>,
+    is_redeposit: bool,
+) -> Result<CompiledInvocation, InvocationError> {
     let [gas_counter] = builder.try_get_single_cells()?;
     builder.validate_token_vars_availability()?;
     let requested_count = builder.token_usages(CostTokenType::Const);
@@ -105,18 +120,21 @@ fn build_redeposit_gas(
         let gas_counter_value =
             gas_counter.to_deref().ok_or(InvocationError::InvalidReferenceExpressionForArgument)?;
 
-        return Ok(builder.build_only_reference_changes(
-            [if requested_count == 0 {
-                ReferenceExpression::from_cell(CellExpression::Deref(gas_counter_value))
-            } else {
-                ReferenceExpression::from_cell(CellExpression::BinOp {
-                    op: CellOperator::Add,
-                    a: gas_counter_value,
-                    b: DerefOrImmediate::Immediate(requested_count.into()),
-                })
-            }]
-            .into_iter(),
+        let updated_gas = ReferenceExpression::from_cell(CellExpression::add_with_const(
+            gas_counter_value,
+            requested_count,
         ));
+        return Ok(if is_redeposit {
+            builder.build_only_reference_changes([updated_gas].into_iter())
+        } else {
+            builder.build_only_reference_changes(
+                [
+                    ReferenceExpression::from_cell(CellExpression::Deref(gas_counter_value)),
+                    updated_gas,
+                ]
+                .into_iter(),
+            )
+        });
     }
     let mut casm_builder = CasmBuilder::with_capacity(16, 0);
     add_input_variables! {casm_builder,
@@ -132,52 +150,15 @@ fn build_redeposit_gas(
     casm_build_extend! {casm_builder,
         let updated_gas = gas_counter + total_requested_count;
     };
+    let (outputs, extra_costs): (&[&[Var]], _) = if is_redeposit {
+        (&[&[updated_gas]], Some([requested_count as i32]))
+    } else {
+        (&[&[gas_counter], &[updated_gas]], None)
+    };
     Ok(builder.build_from_casm_builder_ex(
         casm_builder,
-        [("Fallthrough", &[&[updated_gas]], None)],
-        CostValidationInfo { builtin_infos: vec![], extra_costs: Some([requested_count as i32]) },
-        pre_instructions,
-    ))
-}
-
-/// Handles the get_unspent_gas invocation.
-fn build_get_unspent_gas(
-    builder: CompiledInvocationBuilder<'_>,
-) -> Result<CompiledInvocation, InvocationError> {
-    let [gas_counter] = builder.try_get_single_cells()?;
-    let mut casm_builder = CasmBuilder::with_capacity(16, 0);
-    add_input_variables! {casm_builder,
-        deref gas_counter;
-    };
-    let (pre_instructions, cost_builtin_ptr) = add_cost_builtin_ptr_fetch_code(&mut casm_builder);
-
-    let get_token_count = |token: CostTokenType| {
-        if let GasWallet::Value(wallet) = &builder.environment.gas_wallet {
-            wallet.get(&token).copied().unwrap_or_default()
-        } else {
-            0
-        }
-    };
-    casm_build_extend! {casm_builder,
-        tempvar builtin_cost = cost_builtin_ptr;
-        const const_count = get_token_count(CostTokenType::Const);
-        tempvar total_unspent = gas_counter + const_count;
-    };
-    let mut total_unspent = total_unspent;
-    for token_type in CostTokenType::iter_precost() {
-        let index = token_type.offset_in_builtin_costs();
-        casm_build_extend! {casm_builder,
-            tempvar single_cost = builtin_cost[index];
-            const count = get_token_count(*token_type);
-            tempvar multi_cost = single_cost * count;
-            tempvar updated_total_unspent = total_unspent + multi_cost;
-        };
-        total_unspent = updated_total_unspent;
-    }
-    Ok(builder.build_from_casm_builder_ex(
-        casm_builder,
-        [("Fallthrough", &[&[gas_counter], &[total_unspent]], None)],
-        Default::default(),
+        [("Fallthrough", outputs, None)],
+        CostValidationInfo { builtin_infos: vec![], extra_costs },
         pre_instructions,
     ))
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/gas.rs
@@ -156,7 +156,7 @@ impl NoGenericArgsGenericLibfunc for GetUnspentGasLibfunc {
                 },
                 OutputVarInfo {
                     ty: context.get_concrete_type(Uint128Type::id(), &[])?,
-                    ref_info: OutputVarReferenceInfo::SimpleDerefs,
+                    ref_info: OutputVarReferenceInfo::Deferred(DeferredOutputKind::Generic),
                 },
             ],
             SierraApChange::Known { new_vars_only: false },

--- a/tests/e2e_test_data/libfuncs/gas
+++ b/tests/e2e_test_data/libfuncs/gas
@@ -928,3 +928,230 @@ store_temp<core::option::Option::<()>>([26]) -> ([26]);
 return([8], [9], [2], [3], [26]);
 
 test::foo@F0([0]: RangeCheck, [1]: GasBuiltin, [2]: Bitwise, [3]: Pedersen, [4]: BuiltinCosts) -> (RangeCheck, GasBuiltin, Bitwise, Pedersen, core::option::Option::<()>);
+
+//! > ==========================================================================
+
+//! > get_unspent_gas libfunc
+
+//! > test_runner_name
+SmallE2ETestRunnerSkipAddGas
+
+//! > cairo_code
+extern fn get_unspent_gas() -> u128 implicits(GasBuiltin) nopanic;
+
+fn foo(x: felt252) -> u128 {
+    if x == 0 {
+        let gas = get_unspent_gas();
+        bar();
+        bar();
+        bar();
+        gas
+    } else {
+        get_unspent_gas()
+    }
+}
+
+#[inline(never)]
+fn bar() {}
+
+//! > casm
+[fp + -3] = [ap + 0] + 0, ap++;
+jmp rel 12 if [ap + -1] != 0;
+call rel 16;
+call rel 14;
+call rel 12;
+[ap + 0] = [fp + -4], ap++;
+[ap + 0] = [fp + -4] + 800, ap++;
+ret;
+ap += 6;
+[ap + 0] = [fp + -4], ap++;
+[ap + 0] = [fp + -4] + 200, ap++;
+ret;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 1000})
+test::bar: SmallOrderedMap({})
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type NonZero<felt252> = NonZero<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 0> = Const<felt252, 0> [storable: false, drop: false, dup: false, zero_sized: false];
+
+libfunc const_as_immediate<Const<felt252, 0>> = const_as_immediate<Const<felt252, 0>>;
+libfunc felt252_sub = felt252_sub;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc felt252_is_zero = felt252_is_zero;
+libfunc branch_align = branch_align;
+libfunc get_unspent_gas = get_unspent_gas;
+libfunc function_call<user@test::bar> = function_call<user@test::bar>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<u128> = store_temp<u128>;
+libfunc drop<NonZero<felt252>> = drop<NonZero<felt252>>;
+
+F0:
+const_as_immediate<Const<felt252, 0>>() -> ([2]);
+felt252_sub([1], [2]) -> ([3]);
+store_temp<felt252>([3]) -> ([3]);
+felt252_is_zero([3]) { fallthrough() F0_B0([4]) };
+branch_align() -> ();
+get_unspent_gas([0]) -> ([5], [6]);
+function_call<user@test::bar>() -> ();
+function_call<user@test::bar>() -> ();
+function_call<user@test::bar>() -> ();
+store_temp<GasBuiltin>([5]) -> ([5]);
+store_temp<u128>([6]) -> ([6]);
+return([5], [6]);
+F0_B0:
+branch_align() -> ();
+drop<NonZero<felt252>>([4]) -> ();
+get_unspent_gas([0]) -> ([7], [8]);
+store_temp<GasBuiltin>([7]) -> ([7]);
+store_temp<u128>([8]) -> ([8]);
+return([7], [8]);
+F1:
+return();
+
+test::foo@F0([0]: GasBuiltin, [1]: felt252) -> (GasBuiltin, u128);
+test::bar@F1() -> ();
+
+//! > ==========================================================================
+
+//! > get_unspent_gas libfunc with builtin costs
+
+//! > test_runner_name
+SmallE2ETestRunnerSkipAddGas
+
+//! > cairo_code
+extern fn get_unspent_gas() -> u128 implicits(GasBuiltin) nopanic;
+
+fn foo(x: felt252) -> u128 {
+    if x == 0 {
+        let gas = get_unspent_gas();
+        1 & 2_u128;
+        1 & 2_u128;
+        pedersen::pedersen(1, 1);
+        gas
+    } else {
+        get_unspent_gas()
+    }
+}
+
+//! > function_costs
+test::foo: SmallOrderedMap({Bitwise: 2, Pedersen: 1, Const: 2700})
+
+//! > casm
+[fp + -3] = [ap + 0] + 0, ap++;
+jmp rel 39 if [ap + -1] != 0;
+call rel 45;
+[ap + 0] = [ap + -1] + 44, ap++;
+[ap + 0] = [[ap + -1] + 0], ap++;
+[ap + 0] = [[ap + -1] + 0], ap++;
+[ap + 0] = [ap + -1] + 2500, ap++;
+[ap + 0] = [[ap + -3] + 1], ap++;
+[ap + 0] = [ap + -1] * 2, ap++;
+[ap + 0] = [ap + -1] + [ap + -3], ap++;
+[ap + 0] = 1, ap++;
+[ap + 0] = 2, ap++;
+[ap + -2] = [[fp + -5] + 0];
+[ap + -1] = [[fp + -5] + 1];
+[ap + 0] = 1, ap++;
+[ap + 0] = 2, ap++;
+[ap + -2] = [[fp + -5] + 5];
+[ap + -1] = [[fp + -5] + 6];
+[ap + 0] = 1, ap++;
+[ap + 0] = 1, ap++;
+[ap + -2] = [[fp + -4] + 0];
+[ap + -1] = [[fp + -4] + 1];
+[ap + 0] = [fp + -6], ap++;
+[ap + 0] = [fp + -5] + 10, ap++;
+[ap + 0] = [fp + -4] + 3, ap++;
+[ap + 0] = [fp + -6] + [ap + -10], ap++;
+ret;
+ap += 15;
+[ap + 0] = [fp + -6], ap++;
+[ap + 0] = [fp + -5], ap++;
+[ap + 0] = [fp + -4], ap++;
+[ap + 0] = [fp + -6] + 400, ap++;
+ret;
+
+//! > sierra_code
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type Pedersen = Pedersen [storable: true, drop: false, dup: false, zero_sized: false];
+type Const<felt252, 1> = Const<felt252, 1> [storable: false, drop: false, dup: false, zero_sized: false];
+type Bitwise = Bitwise [storable: true, drop: false, dup: false, zero_sized: false];
+type Const<u128, 2> = Const<u128, 2> [storable: false, drop: false, dup: false, zero_sized: false];
+type Const<u128, 1> = Const<u128, 1> [storable: false, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type NonZero<felt252> = NonZero<felt252> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<felt252, 0> = Const<felt252, 0> [storable: false, drop: false, dup: false, zero_sized: false];
+
+libfunc const_as_immediate<Const<felt252, 0>> = const_as_immediate<Const<felt252, 0>>;
+libfunc felt252_sub = felt252_sub;
+libfunc store_temp<felt252> = store_temp<felt252>;
+libfunc felt252_is_zero = felt252_is_zero;
+libfunc branch_align = branch_align;
+libfunc get_unspent_gas = get_unspent_gas;
+libfunc const_as_immediate<Const<u128, 1>> = const_as_immediate<Const<u128, 1>>;
+libfunc const_as_immediate<Const<u128, 2>> = const_as_immediate<Const<u128, 2>>;
+libfunc dup<u128> = dup<u128>;
+libfunc store_temp<u128> = store_temp<u128>;
+libfunc bitwise = bitwise;
+libfunc drop<u128> = drop<u128>;
+libfunc const_as_immediate<Const<felt252, 1>> = const_as_immediate<Const<felt252, 1>>;
+libfunc dup<felt252> = dup<felt252>;
+libfunc pedersen = pedersen;
+libfunc drop<felt252> = drop<felt252>;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc store_temp<Bitwise> = store_temp<Bitwise>;
+libfunc store_temp<Pedersen> = store_temp<Pedersen>;
+libfunc drop<NonZero<felt252>> = drop<NonZero<felt252>>;
+
+F0:
+const_as_immediate<Const<felt252, 0>>() -> ([4]);
+felt252_sub([3], [4]) -> ([5]);
+store_temp<felt252>([5]) -> ([5]);
+felt252_is_zero([5]) { fallthrough() F0_B0([6]) };
+branch_align() -> ();
+get_unspent_gas([0]) -> ([7], [8]);
+const_as_immediate<Const<u128, 1>>() -> ([9]);
+const_as_immediate<Const<u128, 2>>() -> ([10]);
+dup<u128>([9]) -> ([9], [11]);
+dup<u128>([10]) -> ([10], [12]);
+store_temp<u128>([11]) -> ([11]);
+store_temp<u128>([12]) -> ([12]);
+bitwise([1], [11], [12]) -> ([13], [14], [15], [16]);
+drop<u128>([14]) -> ();
+drop<u128>([15]) -> ();
+drop<u128>([16]) -> ();
+store_temp<u128>([9]) -> ([9]);
+store_temp<u128>([10]) -> ([10]);
+bitwise([13], [9], [10]) -> ([17], [18], [19], [20]);
+drop<u128>([18]) -> ();
+drop<u128>([19]) -> ();
+drop<u128>([20]) -> ();
+const_as_immediate<Const<felt252, 1>>() -> ([21]);
+dup<felt252>([21]) -> ([21], [22]);
+store_temp<felt252>([22]) -> ([22]);
+store_temp<felt252>([21]) -> ([21]);
+pedersen([2], [22], [21]) -> ([23], [24]);
+drop<felt252>([24]) -> ();
+store_temp<GasBuiltin>([7]) -> ([7]);
+store_temp<Bitwise>([17]) -> ([17]);
+store_temp<Pedersen>([23]) -> ([23]);
+store_temp<u128>([8]) -> ([8]);
+return([7], [17], [23], [8]);
+F0_B0:
+branch_align() -> ();
+drop<NonZero<felt252>>([6]) -> ();
+get_unspent_gas([0]) -> ([25], [26]);
+store_temp<GasBuiltin>([25]) -> ([25]);
+store_temp<Bitwise>([1]) -> ([1]);
+store_temp<Pedersen>([2]) -> ([2]);
+store_temp<u128>([26]) -> ([26]);
+return([25], [1], [2], [26]);
+
+test::foo@F0([0]: GasBuiltin, [1]: Bitwise, [2]: Pedersen, [3]: felt252) -> (GasBuiltin, Bitwise, Pedersen, u128);


### PR DESCRIPTION
Made its value be kept during calculation, as snapshots of the current wallet values.

SIERRA_UPDATE_NO_CHANGE_TAG=No change to approved libfuncs.