### PR TITLE
Minor inference refactoring.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
@@ -240,10 +240,10 @@ impl<'db> SemanticRewriter<TypeLongId<'db>, NoError> for Canonicalizer<'db> {
             return value.default_rewrite(self);
         }
         let next_id = LocalTypeVarId(self.to_canonic.type_var_mapping.len());
-        *value = TypeLongId::Var(TypeVar {
+        *var = TypeVar {
             id: *self.to_canonic.type_var_mapping.entry(var.id).or_insert(next_id),
             inference_id: InferenceId::Canonical,
-        });
+        };
         Ok(RewriteResult::Modified)
     }
 }
@@ -392,7 +392,7 @@ impl<'db> SemanticRewriter<TypeLongId<'db>, NoError> for Embedder<'db, '_, '_> {
             .type_var_mapping
             .entry(var.id)
             .or_insert_with(|| self.inference.new_type_var_raw(None).id);
-        *value = TypeLongId::Var(self.inference.type_vars[new_id.0]);
+        *var = self.inference.type_vars[new_id.0];
         Ok(RewriteResult::Modified)
     }
 }
@@ -541,7 +541,7 @@ impl<'db> SemanticRewriter<TypeLongId<'db>, MapperError> for Mapper<'db, '_> {
             .get(&var.id)
             .copied()
             .ok_or(MapperError(InferenceVar::Type(var.id)))?;
-        *value = TypeLongId::Var(TypeVar { id, inference_id: self.mapping.target_inference_id });
+        *var = TypeVar { id, inference_id: self.mapping.target_inference_id };
         Ok(RewriteResult::Modified)
     }
 }

--- a/crates/cairo-lang-semantic/src/expr/inference/conform.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/conform.rs
@@ -802,11 +802,11 @@ impl<'db> Inference<'db, '_> {
             }
             TypeLongId::Tuple(tys) => tys.iter().any(|ty| self.internal_ty_contains_var(*ty, var)),
             TypeLongId::Snapshot(ty) => self.internal_ty_contains_var(*ty, var),
-            TypeLongId::Var(new_var) => {
-                if InferenceVar::Type(new_var.id) == var {
+            TypeLongId::Var(ty_var) => {
+                if InferenceVar::Type(ty_var.id) == var {
                     return true;
                 }
-                if let Some(ty) = self.type_assignment.get(&new_var.id) {
+                if let Some(ty) = self.type_assignment.get(&ty_var.id) {
                     return self.internal_ty_contains_var(*ty, var);
                 }
                 false


### PR DESCRIPTION
## Summary

Refactored type variable rewriting in semantic analysis to directly modify `TypeVar` objects instead of wrapping them in `TypeLongId::Var`. This change affects the `Canonicalizer`, `Embedder`, and `Mapper` implementations, as well as variable naming in the `internal_ty_contains_var` method.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation was unnecessarily verbose and indirect when rewriting type variables. Instead of directly modifying the `TypeVar` object, it was creating a new `TypeLongId::Var` wrapper, which added unnecessary complexity to the code.

---

## What was the behavior or documentation before?

Type variable rewriting operations would assign `*value = TypeLongId::Var(TypeVar { ... })` and use generic variable names like `new_var` in pattern matching.

---

## What is the behavior or documentation after?

Type variable rewriting operations now directly assign `*var = TypeVar { ... }` and use more descriptive variable names like `ty_var` in pattern matching.

---

## Related issue or discussion (if any)

---

## Additional context

This refactoring improves code readability and maintainability by removing unnecessary indirection in type variable handling within the semantic analysis inference system.