### PR TITLE
docs: add method call reference to functions documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc
@@ -111,7 +111,6 @@ tail expression `x + N` whose value is the return value of the function.
 == Calling a function
 
 See xref:function-calls.adoc[Function calls].
-For method call syntax, see xref:method-calls.adoc[Method calls].
 
 == Methods and self
 
@@ -156,6 +155,8 @@ let mut counter = Counter { value: 0 };
 counter.increment();  // Calls increment with ref self
 let value = counter.get_value();  // Calls get_value with snapshot
 ----
+
+For the full method call syntax and method lookup behavior, see xref:method-calls.adoc[Method calls].
 
 == Function attributes
 


### PR DESCRIPTION
 ## Summary                                                                                                                                          
                                                                                                                                                      
  Add a direct cross-reference from the functions documentation to the dedicated method calls page.                                                   
                                                                                                                                                      
  ---                                                                                                                                                 
                                                                                                                                                      
  ## Type of change                                                                                                                                   
                                                                                                                                                      
  Please check **one**:                                                                                                                               
                                                                                                                                                      
  - [ ] Bug fix (fixes incorrect behavior)                                                                                                            
  - [ ] New feature                                                                                                                                   
  - [ ] Performance improvement                                                                                                                       
  - [x] Documentation change with concrete technical impact                                                                                           
  - [ ] Style, wording, formatting, or typo-only change                                                                                               
                                                                                                                                                      
  ---                                                                                                                                                 
                                                                                                                                                      
  ## Why is this change needed?                                                                                                                       
                                                                                                                                                      
  The functions documentation explains methods, `self`, and dot-call usage, but it does not link to the dedicated `method-calls.adoc` page.           
  As a result, readers who arrive at the functions page do not get a direct path to the full method call syntax and behavior documentation.           
                                                                                                                                                      
  ---                                                                                                                                                 
                                                                                                                                                      
  ## What was the behavior or documentation before?                                                                                                   
                                                                                                                                                      
  The functions page introduced method syntax and showed examples such as `counter.increment()` and `counter.get_value()`, but it stopped there without pointing readers to the dedicated method calls reference page.                                                                              

  ---                                                                                                                                                 
                                                                                                                                                      
  ## What is the behavior or documentation after?                                                                                                     
  explicit for readers who start from the functions overview.

  ---

  ## Related issue or discussion (if any)

  N/A

  ## Additional context

  This is a minimal documentation-only change in `docs/reference/src/components/cairo/modules/language_constructs/pages/functions.adoc`.
  It follows the existing cross-reference style already used in other language construct pages, and it improves reference navigation for users reading the documentation top-down.