### PR TITLE
docs: clarify README starknet-compile usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,7 @@ For running tests specifically, see here: [cairo-test](./crates/cairo-lang-test-
 
 ### Compiling Starknet Contracts
 
-Compile a single-file Starknet contract to a Sierra ContractClass:
-```bash
-cargo run --bin starknet-compile -- --single-file /path/to/input.cairo /path/to/output.json
-```
-Use `--single-file` when `path` points to a `.cairo` file.
-
-Or compile from a crate/project path:
+Compile a Starknet contract from a crate/project path to a Sierra ContractClass:
 ```bash
 cargo run --bin starknet-compile -- /path/to/input/crate /path/to/output.json
 ```
@@ -96,6 +90,11 @@ cargo run --bin starknet-compile -- /path/to/input/crate /path/to/output.json
 If multiple contracts are defined in the same crate/project, specify `--contract-path`:
 ```bash
 cargo run --bin starknet-compile -- /path/to/input/crate /path/to/output.json --contract-path path::to::contract
+```
+
+For a single-file `.cairo` input, use `--single-file`:
+```bash
+cargo run --bin starknet-compile -- --single-file /path/to/input.cairo /path/to/output.json
 ```
 
 Compile a Sierra ContractClass to a CASM CompiledClass:


### PR DESCRIPTION
Clarify the README `starknet-compile` section to distinguish single-file and crate/project usage paths, reducing copy-paste command confusion for new users.