### PR TITLE
docs: link method calls from function calls documentation

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/function-calls.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/function-calls.adoc
@@ -20,6 +20,7 @@ increment(ref a.b)
 A call expression evaluates to the value returned by the function.
 The expression's type is the return type of the function.
 For example, the expression `is_le(1, 3)` evaluates to `true`, and its type is `bool`.
+For method call syntax using dot notation, see xref:method-calls.adoc[Method calls].
 
 == Arguments
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                       
                                                                                                                                                                   
  Add a direct cross-reference from the function calls documentation to the dedicated method calls page.                                                           
                                                                                                                                                                   
  ---                                                                                                                                                              
                                                                                                                                                                   
  ## Type of change                                                                                                                                                
                                                                                                                                                                   
  Please check **one**:                                                                                                                                            
                                                                                                                                                                   
  - [ ] Bug fix (fixes incorrect behavior)                                                                                                                         
  - [ ] New feature
  - [ ] Performance improvement                                                                                                                                    
  - [x] Documentation change with concrete technical impact                                                                                                        
  - [ ] Style, wording, formatting, or typo-only change                                                                                                            
                                                                                                                                                                   
  > ⚠️ Note:                                                                                                                                                        
  > To keep maintainer workload sustainable, we generally do **not** accept PRs that                                                                               
  > are only minor wording, grammar, formatting, or style changes.                                                                                                 
  > Such PRs may be closed without detailed review.                                                                                                                
                                                                                                                                                                   
  ---                                                                                                                                                              
                                                                                                                                                                   
  ## Why is this change needed?                                                                                                                                    
                                                                                                                                                                   
  The `function-calls.adoc` page explains regular call syntax and arguments, but it does not point readers to the dedicated `method-calls.adoc` page.              
                                                                                                                                                                   
  As a result, readers who start from the function calls reference do not get a direct path to the method-call-specific syntax and behavior documentation.         
                                                                                                                                                                   
  ---                                                                                                                                                              
                                                                                                                                                                   
  ## What was the behavior or documentation before?                                                                                                                
                                                                                                                                                                   
  The function calls page documented call syntax, arguments, evaluation order, and named arguments, but it stopped there without linking to the method calls reference page.                                                                                                                                                  
                                                                                                                                                                   
  ---                                                                                                                                                              
                                                                                                                                                                   
  ## What is the behavior or documentation after?                                                                                                                  
                                                                                                                                                                   
  The function calls page now includes a direct cross-reference to `method-calls.adoc`, making it easier for readers to discover the dedicated method call documentation from the general call syntax page.                                                                                                                 
                                                                                                                                                                   
  ---                                                                                                                                                              
                                                                                                                                                                   
  ## Related issue or discussion (if any)                                                                                                                          
                                                                                                                                                                   
  N/A                                                                                                                                                              
                                                                                                                                                                   
  ---                                                                                                                                                              
                                                                                                                                                                   
  ## Additional context                                                                                                                                            
                                                                                                                                                                   
  This is a minimal documentation-only change in `docs/reference/src/components/cairo/modules/language_constructs/pages/function-calls.adoc`.                      
  It follows the same cross-reference style already used in related language construct pages.     