### PR TITLE
(bugfix): Matching on a constant value to retain ssa form

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -26,7 +26,7 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::{Intern, extract_matches, require, try_extract_matches};
-use itertools::{chain, zip_eq};
+use itertools::{Itertools, chain, zip_eq};
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::cast::ToPrimitive;
@@ -912,16 +912,22 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
                 && let Ok(mut ty) = value.ty(db)
                 && let Some(mut stmt) = self.try_generate_const_statement(*value, output)
             {
-                // Adding snapshot taking statements for snapshots.
-                for _ in 0..n_snapshots {
-                    let non_snap_var = Variable::with_default_context(db, ty, location);
-                    ty = TypeLongId::Snapshot(ty).intern(db);
-                    let pre_snap = self.variables.alloc(non_snap_var);
-                    stmt.outputs_mut()[0] = pre_snap;
-                    let take_snap = snapshot_stmt(self.variables, pre_snap, output);
-                    statements.push(core::mem::replace(&mut stmt, take_snap));
-                }
+                let snapshot_vars = (0..n_snapshots)
+                    .map(|_| {
+                        let old_ty = ty;
+                        ty = TypeLongId::Snapshot(ty).intern(db);
+                        self.variables.alloc(Variable::with_default_context(db, old_ty, location))
+                    })
+                    .chain([output])
+                    .collect::<Vec<_>>();
+                // First var is the input, and needs to equal to the output of the const statement.
+                stmt.outputs_mut()[0] = snapshot_vars[0];
                 statements.push(stmt);
+                // Adding snapshot taking statements for snapshots.
+                statements.extend(snapshot_vars.into_iter().tuple_windows().map(
+                    |(pre_snap, post_snap)| snapshot_stmt(self.variables, pre_snap, post_snap),
+                ));
+
                 return Some(BlockEnd::Goto(arm.block_id, Default::default()));
             }
         } else if let VarInfo::Enum { variant, payload } = var_info.as_ref() {

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
@@ -6449,6 +6449,93 @@ End:
 
 //! > ==========================================================================
 
+//! > Match enum on double snapshot of const enum.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function_code
+fn foo() -> felt252 {
+    let v = @(@Some(1));
+    match v {
+        Some(v) => **v,
+        None => 0,
+    }
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 1
+  (v1: core::option::Option::<core::felt252>) <- Option::Some(v0)
+  (v2: core::option::Option::<core::felt252>, v3: @core::option::Option::<core::felt252>) <- snapshot(v1)
+  (v4: @core::option::Option::<core::felt252>, v5: @@core::option::Option::<core::felt252>) <- snapshot(v3)
+End:
+  Match(match_enum(v5) {
+    Option::Some(v6) => blk1,
+    Option::None(v7) => blk2,
+  })
+
+blk1:
+Statements:
+  (v8: @core::felt252) <- desnap(v6)
+  (v9: core::felt252) <- desnap(v8)
+End:
+  Goto(blk3, {v9 -> v10})
+
+blk2:
+Statements:
+  (v11: core::felt252) <- 0
+End:
+  Goto(blk3, {v11 -> v10})
+
+blk3:
+Statements:
+End:
+  Return(v10)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 1
+  (v1: core::option::Option::<core::felt252>) <- Option::Some(v0)
+  (v2: core::option::Option::<core::felt252>, v3: @core::option::Option::<core::felt252>) <- snapshot(v1)
+  (v4: @core::option::Option::<core::felt252>, v5: @@core::option::Option::<core::felt252>) <- snapshot(v3)
+  (v12: core::felt252) <- 1
+  (v14: core::felt252, v13: @core::felt252) <- snapshot(v12)
+  (v15: @core::felt252, v6: @@core::felt252) <- snapshot(v13)
+End:
+  Goto(blk1, {})
+
+blk1:
+Statements:
+  (v8: @core::felt252) <- desnap(v6)
+  (v9: core::felt252) <- desnap(v8)
+End:
+  Goto(blk3, {v9 -> v10})
+
+blk2:
+Statements:
+  (v11: core::felt252) <- 0
+End:
+  Goto(blk3, {v11 -> v10})
+
+blk3:
+Statements:
+End:
+  Return(v10)
+
+//! > ==========================================================================
+
 //! > Felt252 add const fold.
 
 //! > test_runner_name


### PR DESCRIPTION
## Summary

Fixed the const folding optimization for multiple snapshot operations by properly chaining snapshot variables and using `tuple_windows()` to create sequential snapshot statements.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation of const folding for multiple snapshots had incorrect variable handling. It was reusing the same output variable for all snapshot operations instead of properly chaining them, which could lead to incorrect lowered IR generation when dealing with nested snapshots like `@@Some(1)`.

---

## What was the behavior or documentation before?

The const folding optimization would incorrectly handle multiple snapshot operations by reusing variables and not properly establishing the chain of snapshot transformations from the original value to the final nested snapshot type.

---

## What is the behavior or documentation after?

The optimization now correctly generates a sequence of snapshot operations where each snapshot statement takes the output of the previous one as input, properly transforming a constant value through multiple levels of snapshots (e.g., `felt252` → `@felt252` → `@@felt252`).

---

## Related issue or discussion (if any)

---

## Additional context

The fix involves:
- Pre-allocating all necessary snapshot variables with correct types
- Using `tuple_windows()` from itertools to pair consecutive variables
- Ensuring the first variable connects to the const statement output and the last variable matches the expected output
- Added a test case for double snapshot of const enum to verify the fix