### PR TITLE
Fix function debug info

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info.rs
+++ b/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info.rs
@@ -37,7 +37,9 @@ use crate::debug_info::function_debug_info::serializable::{
     CairoVariableName, SerializableAllFunctionsDebugInfo, SerializableFunctionDebugInfo,
     SierraFunctionId, SierraVarId,
 };
-use crate::debug_info::{SourceCodeSpan, SourceFileFullPath, maybe_code_location};
+use crate::debug_info::{
+    SourceCodeLocation, SourceCodeSpan, SourceFileFullPath, maybe_code_location,
+};
 
 pub mod serializable;
 
@@ -85,8 +87,7 @@ impl<'db> FunctionDebugInfo<'db> {
         db: &'db dyn Database,
     ) -> Option<SerializableFunctionDebugInfo> {
         let (function_file_path, function_code_span) = self.extract_location(db)?;
-        let sierra_to_cairo_variable =
-            self.extract_variables_mapping(db, &function_file_path, &function_code_span);
+        let sierra_to_cairo_variable = self.extract_variables_mapping(db);
 
         Some(SerializableFunctionDebugInfo {
             function_file_path,
@@ -101,8 +102,6 @@ impl<'db> FunctionDebugInfo<'db> {
     fn extract_variables_mapping(
         &self,
         db: &'db dyn Database,
-        function_file_path: &SourceFileFullPath,
-        function_code_span: &SourceCodeSpan,
     ) -> HashMap<SierraVarId, (CairoVariableName, SourceCodeSpan)> {
         self.variables_locations
             .iter()
@@ -142,22 +141,23 @@ impl<'db> FunctionDebugInfo<'db> {
                     ),
                     x => x.stable_location(db),
                 };
-
-                let (path, span, _) = maybe_code_location(db, location)?;
-
-                // Sanity check.
-                // TODO(pm): check if it occurs at all except for inlined function calls.
-                if !(function_file_path == &path && function_code_span.contains(&span)) {
-                    return None;
-                }
-
                 let user_location = location.span_in_file(db).user_location(db);
+
                 let var_name = user_location
                     .span
                     .take(db.file_content(user_location.file_id).unwrap())
                     .to_string();
 
-                Some((SierraVarId(sierra_var.id), (var_name, span)))
+                let position = user_location.span.position_in_file(db, user_location.file_id)?;
+                let source_location = SourceCodeSpan {
+                    start: SourceCodeLocation {
+                        col: position.start.col,
+                        line: position.start.line,
+                    },
+                    end: SourceCodeLocation { col: position.end.col, line: position.end.line },
+                };
+
+                Some((SierraVarId(sierra_var.id), (var_name, source_location)))
             })
             .collect()
     }


### PR DESCRIPTION
This sanity check actually broke the debug info for snforge test functions since `function_code_span` is a call site in their case, not a function body

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized changes to debug-info extraction logic; main impact is different/expanded variable span reporting, which could affect debugger tooling output but not compilation/runtime behavior.
> 
> **Overview**
> Fixes Sierra function debug-info extraction so variable-to-source mappings are no longer discarded when the variable definition span falls outside the extracted `function_code_span` (e.g., snforge test functions where the span can represent a call site).
> 
> `extract_variables_mapping` now derives variable `SourceCodeSpan` directly from the variable’s `user_location` (using `position_in_file`) and drops the previous `maybe_code_location`-based sanity check and the need to thread the function’s file/span into the mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5466d33ad13a4749e91d3002e04a11f53d2c6cee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->