### PR TITLE
Document unsupported bitwise compound assignment operators

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
@@ -140,6 +140,8 @@ fn main() {
 
 Cairo also provides compound assignment operators (`+=`, `-=`, `*=`, `/=`, `%=`) via traits in
 `core::ops`. See `core::ops::{AddAssign, SubAssign, MulAssign, DivAssign, RemAssign}`.
+Bitwise and shift compound assignment operators (`&=`, `^=`, `|=`, `<<=`, `>>=`) are not
+supported; see xref:bitwise-operators.adoc[Bitwise operators].
 
 == References (source)
 


### PR DESCRIPTION
## Summary

Document in the arithmetic operators reference that bitwise and shift compound assignment operators are not supported, and link readers to the dedicated bitwise operators page.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The arithmetic operators page currently lists the supported compound assignment operators
(`+=`, `-=`, `*=`, `/=`, `%=`), but it does not state that the analogous bitwise and shift forms
(`&=`, `^=`, `|=`, `<<=`, `>>=`) are not available.

That omission can leave readers with the wrong impression that all common `op=` variants are
supported, even though the current language docs and implementation only cover arithmetic
compound assignment traits.

---

## What was the behavior or documentation before?

The page documented arithmetic compound assignment operators through `core::ops::{AddAssign,
SubAssign, MulAssign, DivAssign, RemAssign}`, but it did not define the unsupported boundary for
bitwise and shift compound assignment operators or point readers to the dedicated bitwise
operators page.

---

## What is the behavior or documentation after?

The page now explicitly states that bitwise and shift compound assignment operators are not
supported and adds a direct cross-reference to `bitwise-operators.adoc` for the full operator
support status.

---

## Related issue or discussion (if any)

Related docs context:
- https://github.com/starkware-libs/cairo/pull/9219

---

## Additional context

This is a minimal docs-only change with concrete technical impact: it closes a support-boundary
gap on the arithmetic operators page and aligns it with the existing bitwise operators and
operator expressions documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that clarifies operator support boundaries without affecting code or behavior.
> 
> **Overview**
> Updates the arithmetic operators reference to explicitly state that bitwise and shift compound assignment operators (`&=`, `^=`, `|=`, `<<=`, `>>=`) are **not supported**.
> 
> Adds a cross-reference to `bitwise-operators.adoc` so readers can find the correct bitwise operator support details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7611fab1f71c8b1bad4850fd2b0747e1fc1f7f43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->