### PR TITLE
docs: note unsupported shift and bitwise assignment operators

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/bitwise-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/bitwise-operators.adoc
@@ -12,6 +12,10 @@ operator `~`. All of them are trait-driven by the corresponding traits in `core:
 - `lhs ^ rhs` → `T` (bitwise XOR)
 - `~operand` → `T` (bitwise NOT)
 
+Shift operators (`<<`, `>>`) are not supported yet.
+Compound bitwise assignment operators (`&=`, `^=`, `|=`) and shift assignment
+operators (`<<=`, `>>=`) are also not supported.
+
 == Semantics
 
 The semantics of bitwise operators are trait-driven via `core::traits`:


### PR DESCRIPTION
## Summary

Add explicit support-boundary notes to the bitwise operators reference page, stating that shift operators and bitwise/shift compound assignment operators are not supported.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The current page lists bitwise operator syntax but does not explicitly declare that `<<`, `>>`,
`&=`, `^=`, `|=`, `<<=`, and `>>=` are unsupported, which can lead readers to assume these forms
are available and then hit parser/semantic errors during compilation.

---

## What was the behavior or documentation before?

The page documented `&`, `|`, `^`, and `~` semantics but did not provide a direct unsupported
boundary statement for shift operators and related compound assignment operators.

---

## What is the behavior or documentation after?

The page now clearly states that shift operators are not supported and that bitwise/shift compound
assignment operators are also not supported, so readers can distinguish supported and unsupported
operator forms before writing code.

---

## Related issue or discussion (if any)

Related merged docs context:
- https://github.com/starkware-libs/cairo/pull/9055
- https://github.com/starkware-libs/cairo/pull/9727

---

## Additional context

This is a minimal docs-only change with concrete technical impact: it closes a support-boundary
gap in a core language reference page and reduces avoidable compile-time errors caused by
unsupported operator assumptions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that clarifies language support boundaries without affecting runtime or compiler behavior.
> 
> **Overview**
> Adds explicit notes to the bitwise operators reference page that shift operators (`<<`, `>>`) and compound bitwise/shift assignment forms (`&=`, `^=`, `|=`, `<<=`, `>>=`) are not currently supported, reducing confusion from attempting unsupported syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c1d3aa2c4b168b574c85e745dc2ff44cb964955. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->