### PR TITLE
Bumped version to v2.17.0-rc.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cairo-compile"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-execute"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-format"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-test-utils",
  "cairo-lang-utils",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-proc-macros",
  "cairo-lang-test-utils",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-doc"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-debug",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-test-utils",
  "cairo-lang-utils",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-executable"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-casm",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-executable-plugin"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-defs",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-execute-utils"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-casm",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-proc-macros",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "assert_matches",
  "cairo-lang-debug",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anstream",
  "cairo-lang-diagnostics",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -769,7 +769,7 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "bimap",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-test-utils",
  "cairo-lang-utils",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-runner"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-proc-macros",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-test-utils",
  "hashbrown 0.16.1",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-run"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-size-profiler"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-test"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "generate-syntax"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "cairo-lang-syntax-codegen",
  "cairo-lang-utils",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "get-lowering"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -3752,7 +3752,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sierra-compile"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-sierra",
@@ -3849,7 +3849,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starknet-compile"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-sierra-compile"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-sierra",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-sierra-extract-code"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "cairo-lang-starknet-classes",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-sierra-upgrade-validate"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ license = "Apache-2.0"
 license-file = "LICENSE"
 repository = "https://github.com/starkware-libs/cairo/"
 rust-version = "1.86"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 
 [workspace.dependencies]
 anyhow = "1.0.98"

--- a/corelib/Scarb.lock
+++ b/corelib/Scarb.lock
@@ -3,4 +3,4 @@ version = 1
 
 [[package]]
 name = "core"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"

--- a/corelib/Scarb.toml
+++ b/corelib/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 edition = "2025_12"
 experimental-features = [
   "associated_item_constraints",
@@ -14,4 +14,4 @@ experimental-features = [
 no-core = true
 
 [dev-dependencies]
-cairo_test = "2.17.0-rc.3"
+cairo_test = "2.17.0-rc.4"

--- a/corelib/cairo_project.toml
+++ b/corelib/cairo_project.toml
@@ -3,7 +3,7 @@ core = "src"
 
 [config.global]
 edition = "2025_12"
-version = "2.17.0-rc.3"
+version = "2.17.0-rc.4"
 
 [config.global.experimental_features]
 associated_item_constraints = true

--- a/crates/bin/cairo-compile/Cargo.toml
+++ b/crates/bin/cairo-compile/Cargo.toml
@@ -13,9 +13,9 @@ log.workspace = true
 mimalloc = { workspace = true, optional = true }
 tracing.workspace = true
 
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 

--- a/crates/bin/cairo-execute/Cargo.toml
+++ b/crates/bin/cairo-execute/Cargo.toml
@@ -8,14 +8,14 @@ description = "Executable for creating executables and running them for the Cair
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-debug = { path = "../../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-executable = { path = "../../cairo-lang-executable", version = "=2.17.0-rc.3" }
-cairo-lang-execute-utils = { path = "../../cairo-lang-execute-utils", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-runnable-utils = { path = "../../cairo-lang-runnable-utils", version = "=2.17.0-rc.3" }
-cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "=2.17.0-rc.3" }
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-debug = { path = "../../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-executable = { path = "../../cairo-lang-executable", version = "=2.17.0-rc.4" }
+cairo-lang-execute-utils = { path = "../../cairo-lang-execute-utils", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-runnable-utils = { path = "../../cairo-lang-runnable-utils", version = "=2.17.0-rc.4" }
+cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "=2.17.0-rc.4" }
 cairo-vm = { workspace = true, features = ["clap"] }
 clap.workspace = true
 num-bigint.workspace = true

--- a/crates/bin/cairo-format/Cargo.toml
+++ b/crates/bin/cairo-format/Cargo.toml
@@ -14,8 +14,8 @@ log.workspace = true
 mimalloc = { workspace = true, optional = true }
 tracing.workspace = true
 
-cairo-lang-formatter = { path = "../../cairo-lang-formatter", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-formatter = { path = "../../cairo-lang-formatter", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 

--- a/crates/bin/cairo-run/Cargo.toml
+++ b/crates/bin/cairo-run/Cargo.toml
@@ -11,12 +11,12 @@ anyhow.workspace = true
 clap.workspace = true
 mimalloc = { workspace = true, optional = true }
 
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "=2.17.0-rc.3" }
-cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "=2.17.0-rc.3" }
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "=2.17.0-rc.4" }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "=2.17.0-rc.4" }
 
 [features]
 mimalloc = ["dep:mimalloc"]

--- a/crates/bin/cairo-size-profiler/Cargo.toml
+++ b/crates/bin/cairo-size-profiler/Cargo.toml
@@ -11,20 +11,20 @@ anyhow.workspace = true
 clap.workspace = true
 mimalloc = { workspace = true, optional = true }
 
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-defs = { path = "../../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-executable = { path = "../../cairo-lang-executable", version = "=2.17.0-rc.3" }
-cairo-lang-executable-plugin = { path = "../../cairo-lang-executable-plugin", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-runnable-utils = { path = "../../cairo-lang-runnable-utils", version = "=2.17.0-rc.3" }
-cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "=2.17.0-rc.3" }
-cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-defs = { path = "../../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-executable = { path = "../../cairo-lang-executable", version = "=2.17.0-rc.4" }
+cairo-lang-executable-plugin = { path = "../../cairo-lang-executable-plugin", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-runnable-utils = { path = "../../cairo-lang-runnable-utils", version = "=2.17.0-rc.4" }
+cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-generator = { path = "../../cairo-lang-sierra-generator", version = "=2.17.0-rc.4" }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.4" }
 itertools = { workspace = true, default-features = true }
 salsa.workspace = true
 

--- a/crates/bin/cairo-test/Cargo.toml
+++ b/crates/bin/cairo-test/Cargo.toml
@@ -11,9 +11,9 @@ anyhow.workspace = true
 clap.workspace = true
 mimalloc = { workspace = true, optional = true }
 
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.17.0-rc.3" }
-cairo-lang-test-runner = { path = "../../cairo-lang-test-runner", version = "=2.17.0-rc.3" }
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-runner = { path = "../../cairo-lang-runner", version = "=2.17.0-rc.4" }
+cairo-lang-test-runner = { path = "../../cairo-lang-test-runner", version = "=2.17.0-rc.4" }
 
 [features]
 mimalloc = ["dep:mimalloc"]

--- a/crates/bin/generate-syntax/Cargo.toml
+++ b/crates/bin/generate-syntax/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 log.workspace = true
 tracing.workspace = true
 
-cairo-lang-syntax-codegen = { path = "../../cairo-lang-syntax-codegen", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-syntax-codegen = { path = "../../cairo-lang-syntax-codegen", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }

--- a/crates/bin/get-lowering/Cargo.toml
+++ b/crates/bin/get-lowering/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "2.17.0-rc.3" }
-cairo-lang-debug = { path = "../../cairo-lang-debug", version = "2.17.0-rc.3" }
-cairo-lang-defs = { path = "../../cairo-lang-defs", version = "2.17.0-rc.3" }
-cairo-lang-executable-plugin = { path = "../../cairo-lang-executable-plugin", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../../cairo-lang-semantic", version = "=2.17.0-rc.3" }
-cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "=2.17.0-rc.3" }
-cairo-lang-test-plugin = { path = "../../cairo-lang-test-plugin", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "2.17.0-rc.4" }
+cairo-lang-debug = { path = "../../cairo-lang-debug", version = "2.17.0-rc.4" }
+cairo-lang-defs = { path = "../../cairo-lang-defs", version = "2.17.0-rc.4" }
+cairo-lang-executable-plugin = { path = "../../cairo-lang-executable-plugin", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../../cairo-lang-semantic", version = "=2.17.0-rc.4" }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "=2.17.0-rc.4" }
+cairo-lang-test-plugin = { path = "../../cairo-lang-test-plugin", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.4" }
 clap.workspace = true
 convert_case.workspace = true
 itertools.workspace = true

--- a/crates/bin/sierra-compile/Cargo.toml
+++ b/crates/bin/sierra-compile/Cargo.toml
@@ -14,10 +14,10 @@ log.workspace = true
 mimalloc = { workspace = true, optional = true }
 tracing.workspace = true
 
-cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-to-casm = { path = "../../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-type-size = { path = "../../cairo-lang-sierra-type-size", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-to-casm = { path = "../../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-type-size = { path = "../../cairo-lang-sierra-type-size", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 

--- a/crates/bin/starknet-compile/Cargo.toml
+++ b/crates/bin/starknet-compile/Cargo.toml
@@ -11,9 +11,9 @@ anyhow.workspace = true
 clap.workspace = true
 mimalloc = { workspace = true, optional = true }
 
-cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "=2.17.0-rc.3" }
-cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "=2.17.0-rc.3" }
+cairo-lang-compiler = { path = "../../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-starknet = { path = "../../cairo-lang-starknet", version = "=2.17.0-rc.4" }
+cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "=2.17.0-rc.4" }
 
 [features]
 mimalloc = ["dep:mimalloc"]

--- a/crates/bin/starknet-sierra-compile/Cargo.toml
+++ b/crates/bin/starknet-sierra-compile/Cargo.toml
@@ -13,9 +13,9 @@ mimalloc = { workspace = true, optional = true }
 serde = { workspace = true, default-features = true }
 serde_json.workspace = true
 
-cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-sierra = { path = "../../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "serde",
 ] }
 

--- a/crates/bin/starknet-sierra-extract-code/Cargo.toml
+++ b/crates/bin/starknet-sierra-extract-code/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "=2.17.0-rc.3" }
+cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "=2.17.0-rc.4" }
 clap.workspace = true
 mimalloc = { workspace = true, optional = true }
 serde_json.workspace = true

--- a/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
+++ b/crates/bin/starknet-sierra-upgrade-validate/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 async-channel = "2.5.0"
-cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-starknet-classes = { path = "../../cairo-lang-starknet-classes", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "serde",
 ] }
 clap.workspace = true

--- a/crates/cairo-lang-casm/Cargo.toml
+++ b/crates/cairo-lang-casm/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Cairo assembly encoding."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", default-features = false }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", default-features = false }
 indoc.workspace = true
 num-bigint = { workspace = true }
 num-traits = { workspace = true }

--- a/crates/cairo-lang-compiler/Cargo.toml
+++ b/crates/cairo-lang-compiler/Cargo.toml
@@ -8,20 +8,20 @@ description = "Cairo compiler."
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.3" }
-cairo-lang-project = { path = "../cairo-lang-project", version = "=2.17.0-rc.3" }
-cairo-lang-runnable-utils = { path = "../cairo-lang-runnable-utils", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.3", features = [
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.4" }
+cairo-lang-project = { path = "../cairo-lang-project", version = "=2.17.0-rc.4" }
+cairo-lang-runnable-utils = { path = "../cairo-lang-runnable-utils", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.4", features = [
   "testing",
 ] }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 indoc.workspace = true
 rayon.workspace = true
 salsa.workspace = true

--- a/crates/cairo-lang-debug/Cargo.toml
+++ b/crates/cairo-lang-debug/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Debug utilities for query objects."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 id-arena.workspace = true

--- a/crates/cairo-lang-defs/Cargo.toml
+++ b/crates/cairo-lang-defs/Cargo.toml
@@ -7,13 +7,13 @@ license-file.workspace = true
 description = "Handling of definitions of language items in Cairo."
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.3" }
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.4" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 itertools = { workspace = true, default-features = true }

--- a/crates/cairo-lang-diagnostics/Cargo.toml
+++ b/crates/cairo-lang-diagnostics/Cargo.toml
@@ -7,10 +7,10 @@ license-file.workspace = true
 description = "Diagnostic utilities."
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 itertools = { workspace = true, default-features = true }

--- a/crates/cairo-lang-doc/Cargo.toml
+++ b/crates/cairo-lang-doc/Cargo.toml
@@ -7,15 +7,15 @@ license-file.workspace = true
 description = "A collection of documentation processing utilities for the Cairo programming language."
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-formatter = { path = "../cairo-lang-formatter", version = "=2.17.0-rc.3" }
-cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-formatter = { path = "../cairo-lang-formatter", version = "=2.17.0-rc.4" }
+cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 itertools.workspace = true

--- a/crates/cairo-lang-eq-solver/Cargo.toml
+++ b/crates/cairo-lang-eq-solver/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Equation solving for Sierra generation."
 
 [dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 good_lp.workspace = true

--- a/crates/cairo-lang-executable-plugin/Cargo.toml
+++ b/crates/cairo-lang-executable-plugin/Cargo.toml
@@ -8,21 +8,21 @@ license-file.workspace = true
 description = "Cairo executable plugin."
 
 [dependencies]
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 salsa.workspace = true
 
 [dev-dependencies]
-cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "=2.17.0-rc.3", features = [
+cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "=2.17.0-rc.4", features = [
   "testing",
 ] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 indoc.workspace = true

--- a/crates/cairo-lang-executable/Cargo.toml
+++ b/crates/cairo-lang-executable/Cargo.toml
@@ -8,19 +8,19 @@ description = "Cairo executable artifact."
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.3", default-features = true, features = [
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.4", default-features = true, features = [
   "serde",
 ] }
-cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-executable-plugin = { path = "../cairo-lang-executable-plugin", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-runnable-utils = { path = "../cairo-lang-runnable-utils", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-executable-plugin = { path = "../cairo-lang-executable-plugin", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-runnable-utils = { path = "../cairo-lang-runnable-utils", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 cairo-vm.workspace = true
@@ -34,6 +34,6 @@ cairo-lang-compiler = { path = "../cairo-lang-compiler" }
 cairo-lang-debug = { path = "../cairo-lang-debug" }
 cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }

--- a/crates/cairo-lang-execute-utils/Cargo.toml
+++ b/crates/cairo-lang-execute-utils/Cargo.toml
@@ -8,10 +8,10 @@ description = "Some utilities for the Cairo-Execute binary crate."
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.3" }
-cairo-lang-executable = { path = "../cairo-lang-executable", version = "=2.17.0-rc.3" }
-cairo-lang-runner = { path = "../cairo-lang-runner", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.4" }
+cairo-lang-executable = { path = "../cairo-lang-executable", version = "=2.17.0-rc.4" }
+cairo-lang-runner = { path = "../cairo-lang-runner", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 cairo-vm.workspace = true
 num-bigint.workspace = true
 serde_json.workspace = true

--- a/crates/cairo-lang-filesystem/Cargo.toml
+++ b/crates/cairo-lang-filesystem/Cargo.toml
@@ -7,9 +7,9 @@ license-file.workspace = true
 description = "Virtual filesystem for the compiler."
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = ["serde"] }
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = ["serde"] }
 itertools.workspace = true
 path-clean.workspace = true
 salsa.workspace = true

--- a/crates/cairo-lang-formatter/Cargo.toml
+++ b/crates/cairo-lang-formatter/Cargo.toml
@@ -8,11 +8,11 @@ description = "Cairo formatter."
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 diffy.workspace = true
 ignore.workspace = true
 itertools = { workspace = true, default-features = true }

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -8,14 +8,14 @@ description = "Cairo lowering phase."
 
 [dependencies]
 assert_matches.workspace = true
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 id-arena.workspace = true

--- a/crates/cairo-lang-parser/Cargo.toml
+++ b/crates/cairo-lang-parser/Cargo.toml
@@ -7,12 +7,12 @@ license-file.workspace = true
 description = "Cairo parser."
 
 [dependencies]
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
 cairo-lang-primitive-token.workspace = true
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-syntax-codegen = { path = "../cairo-lang-syntax-codegen", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-syntax-codegen = { path = "../cairo-lang-syntax-codegen", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 colored.workspace = true
@@ -24,7 +24,7 @@ unescaper.workspace = true
 
 [dev-dependencies]
 anstream = "0.6.19"
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
 indoc.workspace = true
 pretty_assertions.workspace = true

--- a/crates/cairo-lang-plugins/Cargo.toml
+++ b/crates/cairo-lang-plugins/Cargo.toml
@@ -10,12 +10,12 @@ description = "Cairo core plugin implementations."
 testing = []
 
 [dependencies]
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 indent.workspace = true

--- a/crates/cairo-lang-proc-macros/Cargo.toml
+++ b/crates/cairo-lang-proc-macros/Cargo.toml
@@ -17,7 +17,7 @@ normal = ["cairo-lang-debug"]
 
 [dependencies]
 # This is used only for docs.
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
 proc-macro2.workspace = true
 quote.workspace = true
 salsa.workspace = true
@@ -25,5 +25,5 @@ syn.workspace = true
 
 
 [dev-dependencies]
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 expect-test = "1.5.1"

--- a/crates/cairo-lang-project/Cargo.toml
+++ b/crates/cairo-lang-project/Cargo.toml
@@ -7,8 +7,8 @@ license-file.workspace = true
 description = "Cairo project specification. For example, crates and flags used for compilation."
 
 [dependencies]
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 serde = { workspace = true, default-features = true }
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cairo-lang-runnable-utils/Cargo.toml
+++ b/crates/cairo-lang-runnable-utils/Cargo.toml
@@ -7,13 +7,13 @@ license-file.workspace = true
 description = "Helpers for creating cairo runnable artifact."
 
 [dependencies]
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 cairo-vm.workspace = true
 thiserror.workspace = true
 

--- a/crates/cairo-lang-runner/Cargo.toml
+++ b/crates/cairo-lang-runner/Cargo.toml
@@ -11,14 +11,14 @@ ark-ff.workspace = true
 ark-secp256k1.workspace = true
 ark-secp256r1.workspace = true
 
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-runnable-utils = { path = "../cairo-lang-runnable-utils", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.3" }
-cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-runnable-utils = { path = "../cairo-lang-runnable-utils", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.4" }
+cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 cairo-vm.workspace = true

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -10,18 +10,18 @@ description = "Cairo semantic model."
 testing = ["dep:cairo-lang-test-utils", "dep:toml"]
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.3" }
-cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "=2.17.0-rc.3" }
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-test-utils = { path = "../cairo-lang-test-utils", version = "=2.17.0-rc.3", optional = true, features = [
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.4" }
+cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "=2.17.0-rc.4" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-test-utils = { path = "../cairo-lang-test-utils", version = "=2.17.0-rc.4", optional = true, features = [
   "testing",
 ] }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 id-arena.workspace = true

--- a/crates/cairo-lang-sierra-ap-change/Cargo.toml
+++ b/crates/cairo-lang-sierra-ap-change/Cargo.toml
@@ -7,10 +7,10 @@ license-file.workspace = true
 description = "Sierra AP change computation."
 
 [dependencies]
-cairo-lang-eq-solver = { path = "../cairo-lang-eq-solver", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-eq-solver = { path = "../cairo-lang-eq-solver", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true, default-features = true }

--- a/crates/cairo-lang-sierra-gas/Cargo.toml
+++ b/crates/cairo-lang-sierra-gas/Cargo.toml
@@ -7,10 +7,10 @@ license-file.workspace = true
 description = "Sierra gas computation."
 
 [dependencies]
-cairo-lang-eq-solver = { path = "../cairo-lang-eq-solver", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-eq-solver = { path = "../cairo-lang-eq-solver", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true, default-features = true }

--- a/crates/cairo-lang-sierra-generator/Cargo.toml
+++ b/crates/cairo-lang-sierra-generator/Cargo.toml
@@ -11,19 +11,19 @@ description = "Sierra code generation from lowered Cairo representation."
 testing = ["dep:cairo-lang-test-utils"]
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-test-utils = { path = "../cairo-lang-test-utils", version = "=2.17.0-rc.3", optional = true, features = [
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-test-utils = { path = "../cairo-lang-test-utils", version = "=2.17.0-rc.4", optional = true, features = [
   "testing",
 ] }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 itertools = { workspace = true, default-features = true }

--- a/crates/cairo-lang-sierra-to-casm/Cargo.toml
+++ b/crates/cairo-lang-sierra-to-casm/Cargo.toml
@@ -8,12 +8,12 @@ description = "Emitting of CASM instructions from Sierra code."
 
 [dependencies]
 assert_matches.workspace = true
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = ["serde"] }
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-ap-change = { path = "../cairo-lang-sierra-ap-change", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-gas = { path = "../cairo-lang-sierra-gas", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = ["serde"] }
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }

--- a/crates/cairo-lang-sierra-type-size/Cargo.toml
+++ b/crates/cairo-lang-sierra-type-size/Cargo.toml
@@ -7,5 +7,5 @@ license-file.workspace = true
 description = "Sierra type sizes computation."
 
 [dependencies]
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }

--- a/crates/cairo-lang-sierra/Cargo.toml
+++ b/crates/cairo-lang-sierra/Cargo.toml
@@ -13,7 +13,7 @@ regex = "1"
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "schemars",
   "serde",
 ] }

--- a/crates/cairo-lang-starknet-classes/Cargo.toml
+++ b/crates/cairo-lang-starknet-classes/Cargo.toml
@@ -7,13 +7,13 @@ license-file.workspace = true
 description = "Starknet definitions for contract classes."
 
 [dependencies]
-cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.3", default-features = true, features = [
+cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.17.0-rc.4", default-features = true, features = [
   "serde",
 ] }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-type-size = { path = "../cairo-lang-sierra-type-size", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 convert_case.workspace = true

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -8,19 +8,19 @@ description = "Starknet capabilities and utilities on top of Cairo."
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.3" }
-cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.3" }
-cairo-lang-starknet-classes = { path = "../cairo-lang-starknet-classes", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = ["serde"] }
+cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-diagnostics = { path = "../cairo-lang-diagnostics", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.4" }
+cairo-lang-plugins = { path = "../cairo-lang-plugins", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.4" }
+cairo-lang-starknet-classes = { path = "../cairo-lang-starknet-classes", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = ["serde"] }
 const_format.workspace = true
 indent.workspace = true
 indoc.workspace = true

--- a/crates/cairo-lang-syntax-codegen/Cargo.toml
+++ b/crates/cairo-lang-syntax-codegen/Cargo.toml
@@ -15,7 +15,7 @@ xshell.workspace = true
 
 [dev-dependencies]
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 tracing.workspace = true

--- a/crates/cairo-lang-syntax/Cargo.toml
+++ b/crates/cairo-lang-syntax/Cargo.toml
@@ -7,11 +7,11 @@ license-file.workspace = true
 description = "Cairo syntax representation."
 
 [dependencies]
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
 cairo-lang-primitive-token.workspace = true
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3", features = [
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 itertools.workspace = true

--- a/crates/cairo-lang-test-plugin/Cargo.toml
+++ b/crates/cairo-lang-test-plugin/Cargo.toml
@@ -8,19 +8,19 @@ description = "Cairo test compilation plugin."
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.3" }
-cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.3" }
-cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.3" }
-cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "=2.17.0-rc.3" }
-cairo-lang-starknet-classes = { path = "../cairo-lang-starknet-classes", version = "=2.17.0-rc.3" }
-cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-defs = { path = "../cairo-lang-defs", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.17.0-rc.4" }
+cairo-lang-parser = { path = "../cairo-lang-parser", version = "=2.17.0-rc.4" }
+cairo-lang-semantic = { path = "../cairo-lang-semantic", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-generator = { path = "../cairo-lang-sierra-generator", version = "=2.17.0-rc.4" }
+cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "=2.17.0-rc.4" }
+cairo-lang-starknet-classes = { path = "../cairo-lang-starknet-classes", version = "=2.17.0-rc.4" }
+cairo-lang-syntax = { path = "../cairo-lang-syntax", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }

--- a/crates/cairo-lang-test-runner/Cargo.toml
+++ b/crates/cairo-lang-test-runner/Cargo.toml
@@ -8,15 +8,15 @@ description = "Cairo tests runner. Used to run tests written in Cairo."
 
 [dependencies]
 anyhow.workspace = true
-cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.3" }
-cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.3" }
-cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.3" }
-cairo-lang-runner = { path = "../cairo-lang-runner", version = "=2.17.0-rc.3" }
-cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.3" }
-cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.3" }
-cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "=2.17.0-rc.3" }
-cairo-lang-test-plugin = { path = "../cairo-lang-test-plugin", version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.3" }
+cairo-lang-compiler = { path = "../cairo-lang-compiler", version = "=2.17.0-rc.4" }
+cairo-lang-debug = { path = "../cairo-lang-debug", version = "=2.17.0-rc.4" }
+cairo-lang-filesystem = { path = "../cairo-lang-filesystem", version = "=2.17.0-rc.4" }
+cairo-lang-runner = { path = "../cairo-lang-runner", version = "=2.17.0-rc.4" }
+cairo-lang-sierra = { path = "../cairo-lang-sierra", version = "=2.17.0-rc.4" }
+cairo-lang-sierra-to-casm = { path = "../cairo-lang-sierra-to-casm", version = "=2.17.0-rc.4" }
+cairo-lang-starknet = { path = "../cairo-lang-starknet", version = "=2.17.0-rc.4" }
+cairo-lang-test-plugin = { path = "../cairo-lang-test-plugin", version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.17.0-rc.4" }
 colored.workspace = true
 itertools = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }

--- a/crates/cairo-lang-test-utils/Cargo.toml
+++ b/crates/cairo-lang-test-utils/Cargo.toml
@@ -19,9 +19,9 @@ testing = [
 ]
 
 [dependencies]
-cairo-lang-formatter = { path = "../cairo-lang-formatter", optional = true, version = "=2.17.0-rc.3" }
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", optional = true, version = "=2.17.0-rc.3" }
-cairo-lang-utils = { path = "../cairo-lang-utils", optional = true, version = "=2.17.0-rc.3", features = [
+cairo-lang-formatter = { path = "../cairo-lang-formatter", optional = true, version = "=2.17.0-rc.4" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", optional = true, version = "=2.17.0-rc.4" }
+cairo-lang-utils = { path = "../cairo-lang-utils", optional = true, version = "=2.17.0-rc.4", features = [
   "tracing",
 ] }
 colored = { workspace = true, optional = true }
@@ -29,7 +29,7 @@ log = { workspace = true, optional = true }
 pretty_assertions = { workspace = true, optional = true }
 
 [dev-dependencies]
-cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.3" }
+cairo-lang-proc-macros = { path = "../cairo-lang-proc-macros", version = "=2.17.0-rc.4" }
 cairo-lang-utils = { path = "../cairo-lang-utils", features = ["tracing"] }
 colored.workspace = true
 log.workspace = true

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCARB_REPO="https://github.com/software-mansion/scarb"
 
-CURRENT_VERSION='2.17.0-rc.3'
+CURRENT_VERSION='2.17.0-rc.4'
 NEW_VERSION="$@"
 
 # NOTE: These two functions were copied from asdf-scarb.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,7 +24,7 @@ cairo-lang-sierra = { path = "../crates/cairo-lang-sierra" }
 cairo-lang-sierra-gas = { path = "../crates/cairo-lang-sierra-gas" }
 cairo-lang-sierra-generator = { path = "../crates/cairo-lang-sierra-generator" }
 cairo-lang-sierra-to-casm = { path = "../crates/cairo-lang-sierra-to-casm", features = ["testing"] }
-cairo-lang-sierra-type-size = { path = "../crates/cairo-lang-sierra-type-size", version = "=2.17.0-rc.3" }
+cairo-lang-sierra-type-size = { path = "../crates/cairo-lang-sierra-type-size", version = "=2.17.0-rc.4" }
 cairo-lang-syntax = { path = "../crates/cairo-lang-syntax" }
 cairo-lang-test-utils = { path = "../crates/cairo-lang-test-utils", features = ["testing"] }
 cairo-lang-utils = { path = "../crates/cairo-lang-utils", features = ["tracing"] }


### PR DESCRIPTION
SIERRA_UPDATE_NO_CHANGE_TAG=toml change only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump/update of `Cargo.toml`/Scarb metadata and lockfiles with no functional code changes. Main risk is accidental dependency/version skew across workspace crates.
> 
> **Overview**
> Bumps the workspace and corelib package versions from `2.17.0-rc.3` to `2.17.0-rc.4`.
> 
> Updates all workspace crates and binaries to pin internal `cairo-lang-*` dependencies to `=2.17.0-rc.4`, refreshes `Cargo.lock`, and updates version references in corelib Scarb configs and `scripts/bump_version.sh` (plus the `tests` crate pin).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95b7d32af14ef15bcc4ec87eeab80e0ea994a2b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->