### PR TITLE
feature(sierra): Added BoundedIntGuarantee and verify libfunc.

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -433,6 +433,11 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
             BoundedIntConcreteLibfunc::WrapNonZero(_) => {
                 vec![ApChange::Known(0)]
             }
+            BoundedIntConcreteLibfunc::GuaranteeVerify(libfunc) => {
+                let ap_change = if libfunc.range.lower.is_zero() { 0 } else { 1 }
+                    + if &libfunc.range.upper - 1 == u128::MAX.into() { 0 } else { 1 };
+                vec![ApChange::Known(ap_change)]
+            }
         },
         Circuit(CircuitConcreteLibfunc::TryIntoCircuitModulus(_)) => {
             vec![ApChange::Known(1), ApChange::Known(1)]

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -554,6 +554,12 @@ pub fn core_libfunc_cost(
             BoundedIntConcreteLibfunc::WrapNonZero(_) => {
                 vec![ConstCost::steps(0).into()]
             }
+            BoundedIntConcreteLibfunc::GuaranteeVerify(libfunc) => {
+                let steps = 2
+                    + if libfunc.range.lower.is_zero() { 0 } else { 1 }
+                    + if &libfunc.range.upper - 1 == u128::MAX.into() { 0 } else { 1 };
+                vec![ConstCost { steps, holes: 0, range_checks: 2, range_checks96: 0 }.into()]
+            }
         },
         Circuit(libfunc) => match libfunc {
             CircuitConcreteLibfunc::AddInput(_) => {

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/casts.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/casts.rs
@@ -204,7 +204,7 @@ fn add_downcast_overflow_both(
 }
 
 /// Validates that `value` is smaller than `bound`.
-fn validate_lt(casm_builder: &mut CasmBuilder, range_check: Var, value: Var, bound: &BigInt) {
+pub fn validate_lt(casm_builder: &mut CasmBuilder, range_check: Var, value: Var, bound: &BigInt) {
     casm_build_extend! {casm_builder,
         // value < bound  <=>  value + (2**128 - bound) < 2**128.
         const pos_shift = (BigInt::from(u128::MAX) + 1 - bound) as BigInt;
@@ -215,7 +215,7 @@ fn validate_lt(casm_builder: &mut CasmBuilder, range_check: Var, value: Var, bou
 
 /// Validates that `value` is greater or equal to `bound`.
 /// If `bound` is zero, only range checks without an additional calculation.
-fn validate_ge(casm_builder: &mut CasmBuilder, range_check: Var, value: Var, bound: &BigInt) {
+pub fn validate_ge(casm_builder: &mut CasmBuilder, range_check: Var, value: Var, bound: &BigInt) {
     casm_build_extend! {casm_builder,
         // value >= bound  <=>  value - bound >= 0.
         const bound = bound.clone();

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs
@@ -3,7 +3,7 @@ use std::ops::Shl;
 use cairo_lang_casm::builder::CasmBuilder;
 use cairo_lang_casm::casm_build_extend;
 use cairo_lang_sierra::extensions::bounded_int::{
-    BoundedIntConcreteLibfunc, BoundedIntDivRemAlgorithm,
+    BoundedIntConcreteLibfunc, BoundedIntDivRemAlgorithm, BoundedIntGuaranteeVerifyConcreteLibfunc,
 };
 use cairo_lang_sierra::extensions::felt252::Felt252BinaryOperator;
 use cairo_lang_sierra::extensions::gas::CostTokenType;
@@ -11,6 +11,7 @@ use cairo_lang_sierra::extensions::utils::Range;
 use num_bigint::BigInt;
 use num_traits::One;
 
+use crate::invocations::casts::{validate_ge, validate_lt};
 use crate::invocations::felt252::build_felt252_op_with_var;
 use crate::invocations::misc::{build_identity, build_is_zero};
 use crate::invocations::{
@@ -45,6 +46,9 @@ pub fn build(
         }
         BoundedIntConcreteLibfunc::IsZero(_) => build_is_zero(builder),
         BoundedIntConcreteLibfunc::WrapNonZero(_) => build_identity(builder),
+        BoundedIntConcreteLibfunc::GuaranteeVerify(libfunc) => {
+            build_guarantee_verify(builder, libfunc)
+        }
     }
 }
 
@@ -244,5 +248,35 @@ fn build_trim(
         casm_builder,
         [("Fallthrough", &[], None), ("Target", &[&[value]], Some(target_statement_id))],
         Default::default(),
+    ))
+}
+
+/// Build verification for a BoundedIntGuarantee.
+/// Performs range checks to verify the value is within the specified bounds.
+fn build_guarantee_verify(
+    builder: CompiledInvocationBuilder<'_>,
+    libfunc: &BoundedIntGuaranteeVerifyConcreteLibfunc,
+) -> Result<CompiledInvocation, InvocationError> {
+    let [range_check, value] = builder.try_get_single_cells()?;
+
+    let mut casm_builder = CasmBuilder::with_capacity(4, 2);
+    add_input_variables! {casm_builder,
+        buffer(2) range_check;
+        deref value;
+    };
+    casm_build_extend!(casm_builder, let orig_range_check = range_check;);
+    validate_ge(&mut casm_builder, range_check, value, &libfunc.range.lower);
+    validate_lt(&mut casm_builder, range_check, value, &libfunc.range.upper);
+    Ok(builder.build_from_casm_builder(
+        casm_builder,
+        [("Fallthrough", &[&[range_check]], None)],
+        CostValidationInfo {
+            builtin_infos: vec![BuiltinInfo {
+                cost_token_ty: CostTokenType::RangeCheck,
+                start: orig_range_check,
+                end: range_check,
+            }],
+            extra_costs: None,
+        },
     ))
 }

--- a/crates/cairo-lang-sierra-type-size/src/lib.rs
+++ b/crates/cairo-lang-sierra-type-size/src/lib.rs
@@ -90,6 +90,7 @@ pub fn get_type_size_map(
             | CoreTypeConcrete::SegmentArena(_)
             | CoreTypeConcrete::Bytes31(_)
             | CoreTypeConcrete::BoundedInt(_)
+            | CoreTypeConcrete::BoundedIntGuarantee(_)
             | CoreTypeConcrete::QM31(_) => 1,
             // Size 2.
             CoreTypeConcrete::Array(_)

--- a/crates/cairo-lang-sierra/src/extensions/core.rs
+++ b/crates/cairo-lang-sierra/src/extensions/core.rs
@@ -3,7 +3,7 @@ use super::array::{ArrayLibfunc, ArrayType};
 use super::bitwise::BitwiseType;
 use super::blake::{Blake2sState, BlakeLibfunc};
 use super::boolean::BoolLibfunc;
-use super::bounded_int::{BoundedIntLibfunc, BoundedIntType};
+use super::bounded_int::{BoundedIntGuaranteeType, BoundedIntLibfunc, BoundedIntType};
 use super::branch_align::BranchAlignLibfunc;
 use super::bytes31::{Bytes31Libfunc, Bytes31Type};
 use super::casts::CastLibfunc;
@@ -103,6 +103,7 @@ define_type_hierarchy! {
         Snapshot(SnapshotType),
         Bytes31(Bytes31Type),
         BoundedInt(BoundedIntType),
+        BoundedIntGuarantee(BoundedIntGuaranteeType),
         QM31(QM31Type),
     }, CoreTypeConcrete
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
@@ -3,7 +3,7 @@ use std::ops::Shl;
 use cairo_lang_utils::require;
 use itertools::Itertools;
 use num_bigint::{BigInt, ToBigInt};
-use num_traits::{One, Signed, Zero};
+use num_traits::{One, Signed, ToPrimitive, Zero};
 use starknet_types_core::felt::Felt as Felt252;
 
 use super::non_zero::{NonZeroType, nonzero_ty};
@@ -37,30 +37,34 @@ impl NamedType for BoundedIntType {
         _context: &dyn TypeSpecializationContext,
         args: &[GenericArg],
     ) -> Result<Self::Concrete, SpecializationError> {
-        let (min, max) = match args {
-            [GenericArg::Value(min), GenericArg::Value(max)] => (min.clone(), max.clone()),
-            [_, _] => return Err(SpecializationError::UnsupportedGenericArg),
-            _ => return Err(SpecializationError::WrongNumberOfGenericArgs),
-        };
-
-        let prime: BigInt = Felt252::prime().into();
-        if !(-&prime < min && min <= max && max < prime && &max - &min < prime) {
-            return Err(SpecializationError::UnsupportedGenericArg);
-        }
-
-        let long_id = Self::concrete_type_long_id(args);
-        let ty_info = TypeInfo {
-            long_id,
-            zero_sized: false,
-            storable: true,
-            droppable: true,
-            duplicatable: true,
-        };
-
-        Ok(Self::Concrete { info: ty_info, range: Range::closed(min, max) })
+        specialize_bounded_int_type(Self::ID, args, true, true)
     }
 }
 
+/// Type for BoundedIntGuarantee.
+/// A guarantee that a value is within the specified bounds.
+/// Unlike BoundedInt, this type is non-duplicatable and non-droppable.
+/// It must be verified via `bounded_int_guarantee_verify` to be consumed.
+/// Currently only supports u32 bounds (0 to 2^32-1).
+#[derive(Default)]
+pub struct BoundedIntGuaranteeType {}
+impl NamedType for BoundedIntGuaranteeType {
+    type Concrete = BoundedIntConcreteType;
+
+    const ID: GenericTypeId = GenericTypeId::new_inline("BoundedIntGuarantee");
+    fn specialize(
+        &self,
+        _context: &dyn TypeSpecializationContext,
+        args: &[GenericArg],
+    ) -> Result<Self::Concrete, SpecializationError> {
+        let (min, max) = extract_bounds(args)?;
+        // Currently only u32 guarantees are supported.
+        require(is_u32_range(min, max)).ok_or(SpecializationError::UnsupportedGenericArg)?;
+        specialize_bounded_int_type(Self::ID, args, false, false)
+    }
+}
+
+/// Shared concrete type for BoundedInt and BoundedIntGuarantee.
 pub struct BoundedIntConcreteType {
     pub info: TypeInfo,
     /// The range bounds for a value of this type.
@@ -83,6 +87,7 @@ define_libfunc_hierarchy! {
         TrimMax(BoundedIntTrimLibfunc<true>),
         IsZero(BoundedIntIsZeroLibfunc),
         WrapNonZero(BoundedIntWrapNonZeroLibfunc),
+        GuaranteeVerify(BoundedIntGuaranteeVerifyLibfunc),
     }, BoundedIntConcreteLibfunc
 }
 
@@ -544,6 +549,63 @@ impl SignatureOnlyGenericLibfunc for BoundedIntWrapNonZeroLibfunc {
     }
 }
 
+/// Libfunc for verifying a BoundedIntGuarantee.
+/// Consumes the guarantee and returns the underlying value as a BoundedInt.
+/// Generic args: [min, max] - the bounds of the guarantee.
+/// Currently only supports u32 bounds (0 to 2^32-1).
+#[derive(Default)]
+pub struct BoundedIntGuaranteeVerifyLibfunc {}
+impl NamedLibfunc for BoundedIntGuaranteeVerifyLibfunc {
+    type Concrete = BoundedIntGuaranteeVerifyConcreteLibfunc;
+
+    const STR_ID: &'static str = "bounded_int_guarantee_verify";
+
+    fn specialize_signature(
+        &self,
+        context: &dyn SignatureSpecializationContext,
+        args: &[GenericArg],
+    ) -> Result<LibfuncSignature, SpecializationError> {
+        let (min, max) = extract_bounds(args)?;
+        // Currently only u32 guarantees are supported.
+        require(is_u32_range(min, max)).ok_or(SpecializationError::UnsupportedGenericArg)?;
+
+        let range_check_ty = context.get_concrete_type(RangeCheckType::ID, &[])?;
+        let guarantee_ty = bounded_int_guarantee_ty(context, min.clone(), max.clone())?;
+
+        Ok(LibfuncSignature::new_non_branch_ex(
+            vec![
+                ParamSignature::new(range_check_ty.clone()).with_allow_add_const(),
+                ParamSignature::new(guarantee_ty),
+            ],
+            vec![OutputVarInfo::new_builtin(range_check_ty)],
+            SierraApChange::Known { new_vars_only: false },
+        ))
+    }
+
+    fn specialize(
+        &self,
+        context: &dyn SpecializationContext,
+        args: &[GenericArg],
+    ) -> Result<Self::Concrete, SpecializationError> {
+        let (min, max) = extract_bounds(args)?;
+        // Currently only u32 guarantees are supported.
+        require(is_u32_range(min, max)).ok_or(SpecializationError::UnsupportedGenericArg)?;
+
+        let range = Range::closed(min.clone(), max.clone());
+        Ok(Self::Concrete { range, signature: self.specialize_signature(context, args)? })
+    }
+}
+
+pub struct BoundedIntGuaranteeVerifyConcreteLibfunc {
+    pub range: Range,
+    signature: LibfuncSignature,
+}
+impl SignatureBasedConcreteLibfunc for BoundedIntGuaranteeVerifyConcreteLibfunc {
+    fn signature(&self) -> &LibfuncSignature {
+        &self.signature
+    }
+}
+
 /// Returns the concrete type for a BoundedInt<min, max>.
 pub fn bounded_int_ty(
     context: &dyn SignatureSpecializationContext,
@@ -551,4 +613,50 @@ pub fn bounded_int_ty(
     max: BigInt,
 ) -> Result<ConcreteTypeId, SpecializationError> {
     context.get_concrete_type(BoundedIntType::ID, &[GenericArg::Value(min), GenericArg::Value(max)])
+}
+
+/// Returns the concrete type for a BoundedIntGuarantee<min, max>.
+pub fn bounded_int_guarantee_ty(
+    context: &dyn SignatureSpecializationContext,
+    min: BigInt,
+    max: BigInt,
+) -> Result<ConcreteTypeId, SpecializationError> {
+    context.get_concrete_type(
+        BoundedIntGuaranteeType::ID,
+        &[GenericArg::Value(min), GenericArg::Value(max)],
+    )
+}
+
+/// Extracts min and max values from generic args.
+fn extract_bounds(args: &[GenericArg]) -> Result<(&BigInt, &BigInt), SpecializationError> {
+    match args {
+        [GenericArg::Value(min), GenericArg::Value(max)] => Ok((min, max)),
+        [_, _] => Err(SpecializationError::UnsupportedGenericArg),
+        _ => Err(SpecializationError::WrongNumberOfGenericArgs),
+    }
+}
+
+/// Checks if the given bounds match the u32 range.
+fn is_u32_range(min: &BigInt, max: &BigInt) -> bool {
+    min.is_zero() && max.to_u32() == Some(u32::MAX)
+}
+
+/// Helper to specialize bounded int types.
+fn specialize_bounded_int_type(
+    generic_id: GenericTypeId,
+    args: &[GenericArg],
+    droppable: bool,
+    duplicatable: bool,
+) -> Result<BoundedIntConcreteType, SpecializationError> {
+    let (min, max) = extract_bounds(args)?;
+
+    let prime: BigInt = Felt252::prime().into();
+    if !(-&prime < *min && min <= max && max < &prime && max - min < prime) {
+        return Err(SpecializationError::UnsupportedGenericArg);
+    }
+
+    let long_id = crate::program::ConcreteTypeLongId { generic_id, generic_args: args.to_vec() };
+    let ty_info = TypeInfo { long_id, zero_sized: false, storable: true, droppable, duplicatable };
+
+    Ok(BoundedIntConcreteType { info: ty_info, range: Range::closed(min.clone(), max.clone()) })
 }

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
@@ -24,6 +24,7 @@
         "bounded_int_add",
         "bounded_int_constrain",
         "bounded_int_div_rem",
+        "bounded_int_guarantee_verify",
         "bounded_int_is_zero",
         "bounded_int_mul",
         "bounded_int_sub",

--- a/tests/e2e_test_data/libfuncs/bounded_int
+++ b/tests/e2e_test_data/libfuncs/bounded_int
@@ -1089,3 +1089,44 @@ test::foo@F0([0]: u8) -> (core::internal::OptionRev::<test::BoundedInt::<0, 254>
 
 //! > function_costs
 test::foo: SmallOrderedMap({Const: 400})
+
+//! > ==========================================================================
+
+//! > bounded_int_guarantee_verify libfunc for u32.
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+extern type BoundedIntGuarantee<const MIN: felt252, const MAX: felt252>;
+extern fn bounded_int_guarantee_verify<const MIN: felt252, const MAX: felt252>(
+    value: BoundedIntGuarantee<MIN, MAX>,
+) implicits(RangeCheck) nopanic;
+
+fn foo(value: BoundedIntGuarantee<0, 0xffffffff>) {
+    bounded_int_guarantee_verify(value)
+}
+
+//! > casm
+[fp + -3] = [[fp + -4] + 0];
+[ap + 0] = [fp + -3] + 340282366920938463463374607427473244160, ap++;
+[ap + -1] = [[fp + -4] + 1];
+[ap + 0] = [fp + -4] + 2, ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 540})
+
+//! > sierra_code
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+type BoundedIntGuarantee<0, 4294967295> = BoundedIntGuarantee<0, 4294967295> [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc bounded_int_guarantee_verify<0, 4294967295> = bounded_int_guarantee_verify<0, 4294967295>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+
+F0:
+bounded_int_guarantee_verify<0, 4294967295>([0], [1]) -> ([2]);
+store_temp<RangeCheck>([2]) -> ([2]);
+return([2]);
+
+test::foo@F0([0]: RangeCheck, [1]: BoundedIntGuarantee<0, 4294967295>) -> (RangeCheck);


### PR DESCRIPTION
## Summary

Adds support for `BoundedIntGuarantee` type and `bounded_int_guarantee_verify` libfunc to the Cairo Sierra language. This introduces a non-duplicatable, non-droppable guarantee type that must be verified through range checks to be consumed, currently supporting u32 bounds (0 to 2^32-1).

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This change introduces a new type system feature that allows for compile-time guarantees about integer bounds that must be verified at runtime. The `BoundedIntGuarantee` type provides a way to represent values that are guaranteed to be within specific bounds, but unlike regular `BoundedInt` types, these guarantees must be explicitly verified through the `bounded_int_guarantee_verify` libfunc before the value can be used.

---

## What was the behavior or documentation before?

Before this change, only `BoundedInt` types existed, which were duplicatable and droppable. There was no mechanism for creating non-duplicatable guarantees that required explicit verification.

---

## What is the behavior or documentation after?

After this change:
- A new `BoundedIntGuarantee<MIN, MAX>` type is available that is non-duplicatable and non-droppable
- The `bounded_int_guarantee_verify` libfunc can be used to verify these guarantees, consuming the guarantee and performing range checks
- The verification has an AP change cost of 1 and a gas cost of 3 steps with 2 range checks
- Currently only u32 bounds (0 to 2^32-1) are supported for guarantees

---

## Related issue or discussion (if any)

<!-- No related issue mentioned in the diff -->

---

## Additional context

The implementation includes:
- Type system integration for the new guarantee type
- CASM generation for the verification libfunc that performs range checks using `validate_ge` and `validate_lt`
- Cost analysis showing the verification requires 3 steps and 2 range checks
- Integration with the allowed libfuncs list for Starknet classes
- Test coverage demonstrating the functionality with u32 bounds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new core type and libfunc that affect Sierra type specialization, CASM generation, and cost/AP accounting; mistakes could lead to incorrect verification or mispriced execution. Scope is limited (currently u32-only) and covered by an e2e test.
> 
> **Overview**
> Adds a new core Sierra type `BoundedIntGuarantee<MIN, MAX>` (non-drop/non-dup) and wires it into the core type hierarchy and type sizing.
> 
> Introduces `bounded_int_guarantee_verify` under the bounded-int module, with signature/specialization restricted to the u32 bounds case, and adds CASM lowering that enforces the bounds via `validate_ge`/`validate_lt` range checks.
> 
> Updates AP-change and gas-cost models for the new libfunc, exposes the shared cast-range-check helpers (`validate_ge`/`validate_lt`), allows the libfunc in Starknet’s `all.json`, and adds an e2e test fixture for the new verification path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b519f158bad093585722adc7f863b8422fe60e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->