### PR TITLE
feature(sierra): Added a split fn from u128 to u32 guarantees.

### DIFF
--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -438,6 +438,9 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
                     + if &libfunc.range.upper - 1 == u128::MAX.into() { 0 } else { 1 };
                 vec![ApChange::Known(ap_change)]
             }
+            BoundedIntConcreteLibfunc::U128ToU32Guarantees(_) => {
+                vec![ApChange::Known(9)]
+            }
         },
         Circuit(CircuitConcreteLibfunc::TryIntoCircuitModulus(_)) => {
             vec![ApChange::Known(1), ApChange::Known(1)]

--- a/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/core_libfunc_cost_base.rs
@@ -560,6 +560,9 @@ pub fn core_libfunc_cost(
                     + if &libfunc.range.upper - 1 == u128::MAX.into() { 0 } else { 1 };
                 vec![ConstCost { steps, holes: 0, range_checks: 2, range_checks96: 0 }.into()]
             }
+            BoundedIntConcreteLibfunc::U128ToU32Guarantees(_) => {
+                vec![ConstCost::steps(7).into()]
+            }
         },
         Circuit(libfunc) => match libfunc {
             CircuitConcreteLibfunc::AddInput(_) => {

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/int/bounded.rs
@@ -49,6 +49,7 @@ pub fn build(
         BoundedIntConcreteLibfunc::GuaranteeVerify(libfunc) => {
             build_guarantee_verify(builder, libfunc)
         }
+        BoundedIntConcreteLibfunc::U128ToU32Guarantees(_) => build_u128_to_u32_guarantees(builder),
     }
 }
 
@@ -278,5 +279,50 @@ fn build_guarantee_verify(
             }],
             extra_costs: None,
         },
+    ))
+}
+
+/// Build u128 split into 4 u32 guarantees.
+/// Splits a u128 into 4 u32 values using iterative DivMod hints.
+fn build_u128_to_u32_guarantees(
+    builder: CompiledInvocationBuilder<'_>,
+) -> Result<CompiledInvocation, InvocationError> {
+    let [value] = builder.try_get_single_cells()?;
+
+    let mut casm_builder = CasmBuilder::with_capacity(20, 12);
+    add_input_variables!(casm_builder, deref value;);
+
+    let pow2_32: BigInt = BigInt::one().shl(32);
+
+    casm_build_extend! {casm_builder,
+        const pow2_32 = pow2_32;
+        tempvar w1_w2_w3_shifted;
+        tempvar w2_w3_shifted;
+        tempvar w3_shifted;
+        tempvar w1_w2_w3;
+        tempvar w2_w3;
+        tempvar w0;
+        tempvar w1;
+        tempvar w2;
+        tempvar w3;
+
+        hint DivMod { lhs: value, rhs: pow2_32 } into { quotient: w1_w2_w3, remainder: w0 };
+        hint DivMod { lhs: w1_w2_w3, rhs: pow2_32 } into { quotient: w2_w3, remainder: w1 };
+        hint DivMod { lhs: w2_w3, rhs: pow2_32 } into { quotient: w3, remainder: w2 };
+        ap += 3;
+
+        // Verify reconstruction using Horner's method.
+        assert w1_w2_w3_shifted = w1_w2_w3 * pow2_32;
+        assert value = w1_w2_w3_shifted + w0;
+        assert w2_w3_shifted = w2_w3 * pow2_32;
+        assert w1_w2_w3 = w2_w3_shifted + w1;
+        assert w3_shifted = w3 * pow2_32;
+        assert w2_w3 = w3_shifted + w2;
+    };
+
+    Ok(builder.build_from_casm_builder(
+        casm_builder,
+        [("Fallthrough", &[&[w0], &[w1], &[w2], &[w3]], None)],
+        Default::default(),
     ))
 }

--- a/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
@@ -6,6 +6,7 @@ use num_bigint::{BigInt, ToBigInt};
 use num_traits::{One, Signed, ToPrimitive, Zero};
 use starknet_types_core::felt::Felt as Felt252;
 
+use super::int::unsigned128::Uint128Type;
 use super::non_zero::{NonZeroType, nonzero_ty};
 use super::range_check::RangeCheckType;
 use super::utils::{Range, reinterpret_cast_signature};
@@ -18,8 +19,8 @@ use crate::extensions::lib_func::{
 use crate::extensions::type_specialization_context::TypeSpecializationContext;
 use crate::extensions::types::TypeInfo;
 use crate::extensions::{
-    ConcreteType, NamedLibfunc, NamedType, OutputVarReferenceInfo, SignatureBasedConcreteLibfunc,
-    SpecializationError, args_as_single_type, args_as_two_types,
+    ConcreteType, NamedLibfunc, NamedType, NoGenericArgsGenericLibfunc, OutputVarReferenceInfo,
+    SignatureBasedConcreteLibfunc, SpecializationError, args_as_single_type, args_as_two_types,
 };
 use crate::ids::{ConcreteTypeId, GenericTypeId};
 use crate::program::GenericArg;
@@ -88,6 +89,7 @@ define_libfunc_hierarchy! {
         IsZero(BoundedIntIsZeroLibfunc),
         WrapNonZero(BoundedIntWrapNonZeroLibfunc),
         GuaranteeVerify(BoundedIntGuaranteeVerifyLibfunc),
+        U128ToU32Guarantees(U128ToU32GuaranteesLibfunc),
     }, BoundedIntConcreteLibfunc
 }
 
@@ -625,6 +627,46 @@ pub fn bounded_int_guarantee_ty(
         BoundedIntGuaranteeType::ID,
         &[GenericArg::Value(min), GenericArg::Value(max)],
     )
+}
+
+/// Libfunc for splitting a u128 into 4 u32 guarantees.
+/// Returns 4 BoundedIntGuarantee<0, 2^32-1> values (from low to high).
+#[derive(Default)]
+pub struct U128ToU32GuaranteesLibfunc {}
+impl NoGenericArgsGenericLibfunc for U128ToU32GuaranteesLibfunc {
+    const STR_ID: &'static str = "u128_to_u32_guarantees";
+
+    fn specialize_signature(
+        &self,
+        context: &dyn SignatureSpecializationContext,
+    ) -> Result<LibfuncSignature, SpecializationError> {
+        let u128_ty = context.get_concrete_type(Uint128Type::id(), &[])?;
+        let u32_guarantee_ty =
+            bounded_int_guarantee_ty(context, BigInt::ZERO, BigInt::from(u32::MAX))?;
+
+        Ok(LibfuncSignature::new_non_branch(
+            vec![u128_ty],
+            vec![
+                OutputVarInfo {
+                    ty: u32_guarantee_ty.clone(),
+                    ref_info: OutputVarReferenceInfo::SimpleDerefs,
+                },
+                OutputVarInfo {
+                    ty: u32_guarantee_ty.clone(),
+                    ref_info: OutputVarReferenceInfo::SimpleDerefs,
+                },
+                OutputVarInfo {
+                    ty: u32_guarantee_ty.clone(),
+                    ref_info: OutputVarReferenceInfo::SimpleDerefs,
+                },
+                OutputVarInfo {
+                    ty: u32_guarantee_ty,
+                    ref_info: OutputVarReferenceInfo::SimpleDerefs,
+                },
+            ],
+            SierraApChange::Known { new_vars_only: false },
+        ))
+    }
 }
 
 /// Extracts min and max values from generic args.

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
@@ -216,6 +216,7 @@
         "u128_safe_divmod",
         "u128_sqrt",
         "u128_to_felt252",
+        "u128_to_u32_guarantees",
         "u128s_from_felt252",
         "u16_bitwise",
         "u16_const",

--- a/tests/e2e_test_data/libfuncs/bounded_int
+++ b/tests/e2e_test_data/libfuncs/bounded_int
@@ -1130,3 +1130,59 @@ store_temp<RangeCheck>([2]) -> ([2]);
 return([2]);
 
 test::foo@F0([0]: RangeCheck, [1]: BoundedIntGuarantee<0, 4294967295>) -> (RangeCheck);
+
+//! > ==========================================================================
+
+//! > u128_to_u32_guarantees libfunc.
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+extern type BoundedIntGuarantee<const MIN: felt252, const MAX: felt252>;
+type U32Guarantee = BoundedIntGuarantee<0, 0xffffffff>;
+
+extern fn u128_to_u32_guarantees(
+    value: u128,
+) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) nopanic;
+
+fn foo(value: u128) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) {
+    u128_to_u32_guarantees(value)
+}
+
+//! > casm
+%{ (memory[ap + 3], memory[ap + 5]) = divmod(memory[fp + -3], 4294967296) %}
+%{ (memory[ap + 4], memory[ap + 6]) = divmod(memory[ap + 3], 4294967296) %}
+%{ (memory[ap + 8], memory[ap + 7]) = divmod(memory[ap + 4], 4294967296) %}
+ap += 3;
+[ap + -3] = [ap + 0] * 4294967296, ap++;
+[fp + -3] = [ap + -4] + [ap + 1], ap++;
+[ap + -4] = [ap + -1] * 4294967296, ap++;
+[ap + -3] = [ap + -5] + [ap + 0], ap++;
+[ap + -5] = [ap + 1] * 4294967296, ap++;
+[ap + -4] = [ap + -6] + [ap + -1], ap++;
+[ap + 0] = [ap + -4], ap++;
+[ap + 0] = [ap + -4], ap++;
+[ap + 0] = [ap + -4], ap++;
+[ap + 0] = [ap + -4], ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 1100})
+
+//! > sierra_code
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedIntGuarantee<0, 4294967295> = BoundedIntGuarantee<0, 4294967295> [storable: true, drop: false, dup: false, zero_sized: false];
+type Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>> = Struct<ut@Tuple, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>> [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc u128_to_u32_guarantees = u128_to_u32_guarantees;
+libfunc struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>;
+libfunc store_temp<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = store_temp<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>;
+
+F0:
+u128_to_u32_guarantees([0]) -> ([1], [2], [3], [4]);
+struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([1], [2], [3], [4]) -> ([5]);
+store_temp<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([5]) -> ([5]);
+return([5]);
+
+test::foo@F0([0]: u128) -> (Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>);


### PR DESCRIPTION
## Summary

Adds a new `u128_to_u32_guarantees` libfunc that splits a u128 value into four u32 guarantee values using iterative DivMod hints and verification.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This libfunc provides an efficient way to decompose u128 values into their constituent u32 parts with mathematical guarantees, which is useful for operations that need to work with smaller integer components or for cryptographic applications that require bounded integer guarantees.

---

## What was the behavior or documentation before?

There was no built-in way to split a u128 into guaranteed u32 components in the Sierra instruction set.

---

## What is the behavior or documentation after?

The new `u128_to_u32_guarantees` libfunc takes a u128 input and returns four `BoundedIntGuarantee<0, 4294967295>` values representing the u32 components. The implementation uses DivMod hints to perform the splitting and verifies the reconstruction using Horner's method. The libfunc has an AP change cost of 9 and a gas cost of 7 steps.

---

## Related issue or discussion (if any)

None specified.

---

## Additional context

The implementation includes comprehensive test coverage and the libfunc has been added to the allowed libfuncs list for Starknet classes. The verification process ensures mathematical correctness by reconstructing the original u128 value from the four u32 components.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Sierra libfunc with custom CASM generation and new AP/gas accounting, which could affect compilation determinism and cost metering if the implementation or constants are incorrect.
> 
> **Overview**
> Adds a new Sierra libfunc, `u128_to_u32_guarantees`, that decomposes a `u128` into four `BoundedIntGuarantee<0, 2^32-1>` outputs.
> 
> Implements CASM lowering using iterative `DivMod` hints plus reconstruction asserts, wires the new variant through bounded-int libfunc specialization, and assigns fixed metering (`ApChange::Known(9)` and `ConstCost::steps(7)`). The libfunc is added to Starknet’s `allowed_libfuncs` list and covered by a new bounded-int e2e test vector.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc7d5801d8175fc36e299f004ed5ee3dc59c04f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->