### PR TITLE
Added e2e tests of blake improvement.

### DIFF
--- a/corelib/src/test/hash_test.cairo
+++ b/corelib/src/test/hash_test.cairo
@@ -1,4 +1,4 @@
-use crate::blake::{blake2s_compress, blake2s_finalize};
+use crate::blake::{blake2s_compress, blake2s_finalize, blake2s_finalize_guarantees};
 use crate::hash::{HashStateExTrait, HashStateTrait};
 use crate::poseidon::PoseidonTrait;
 use crate::test::test_utils::assert_eq;
@@ -94,18 +94,12 @@ fn test_blake2s() {
     let msg = BoxTrait::new([0_u32; 16]);
     let byte_count = 64_u32;
     assert_eq!(
-        blake2s_compress(state, byte_count, msg).unbox(),
-        [
-            0xe816e42a, 0x7d9875d8, 0xfda62c55, 0xa2c6f449, 0xca7af611, 0xdd2f7629, 0xbcd92323,
-            0x15c3ab3b,
-        ],
+        to_u256(blake2s_compress(state, byte_count, msg)),
+        0x2ae416e8d875987d552ca6fd49f4c6a211f67aca29762fdd2323d9bc3babc315,
     );
     assert_eq!(
-        blake2s_finalize(state, byte_count, msg).unbox(),
-        [
-            0x7a59305, 0x56b8b489, 0xbe3bb37e, 0x58ec6ba0, 0x2f53d5d3, 0x26cd7988, 0xde14c740,
-            0x3e3f372e,
-        ],
+        to_u256(blake2s_finalize(state, byte_count, msg)),
+        0x593a50789b4b8567eb33bbea06bec58d3d5532f8879cd2640c714de2e373f3e,
     );
 }
 
@@ -122,10 +116,67 @@ fn test_blake2s_with_abc() {
     // Message `abc` padded with zeros.
     let msg = BoxTrait::new(['cba', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     assert_eq!(
-        blake2s_finalize(state, 3, msg).unbox(),
+        to_u256(blake2s_finalize(state, 3, msg)),
+        0x508c5e8c327c14e2e1a72ba34eeb452f37458b209ed63a294d999b4c86675982,
+    );
+}
+
+#[test]
+fn test_blake2s_split_and_guarantees() {
+    // hashing `abc` as it is done in RFC 7693 Appendix B.
+    // Initial state is the IV, with keylen 0 and output length 32.
+    let state = BoxTrait::new(
         [
-            0x8c5e8c50, 0xe2147c32, 0xa32ba7e1, 0x2f45eb4e, 0x208b4537, 0x293ad69e, 0x4c9b994d,
-            0x82596786,
+            0x6A09E667 ^ (0x01010000 ^ 0x20), 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F,
+            0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
         ],
     );
+    assert_eq!(
+        to_u256(blake2s_finalize_guarantees(state, 3, msg::from_felt252s('cba', 0))),
+        0x508c5e8c327c14e2e1a72ba34eeb452f37458b209ed63a294d999b4c86675982,
+    );
+    assert_eq!(
+        to_u256(
+            blake2s_finalize_guarantees(
+                state, 32, msg::from_felt252s('\x0543210zyxwvutsrqponmlkjihgfedcba', 0),
+            ),
+        ),
+        0x39b7197928a66cd232d8c5b74d02215a21386228e772076eaf544395b5d32c03,
+    );
+}
+
+fn to_u256(value: Box<[u32; 8]>) -> u256 {
+    let mut result: u256 = 0;
+    for word in value.unbox().span() {
+        result *= 0x100000000;
+        result += (0x1000000 * (*word % 0x100)).into();
+        result += (0x10000 * (*word / 0x100 % 0x100)).into();
+        result += (0x100 * (*word / 0x10000 % 0x100)).into();
+        result += (*word / 0x1000000 % 0x100).into();
+    }
+    result
+}
+
+mod msg {
+    #[feature("bounded-int-utils")]
+    type U32Guarantee =
+        core::internal::bounded_int::BoundedIntGuarantee<0, 0xffffffff>;
+    pub extern fn u128_to_u32_guarantees(
+        value: u128,
+    ) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) nopanic;
+
+    pub fn from_felt252s(a: felt252, b: felt252) -> Box<[U32Guarantee; 16]> {
+        let a: u256 = a.into();
+        let b: u256 = b.into();
+        let (a_w0, a_w1, a_w2, a_w3) = u128_to_u32_guarantees(a.low);
+        let (a_w4, a_w5, a_w6, a_w7) = u128_to_u32_guarantees(a.high);
+        let (b_w0, b_w1, b_w2, b_w3) = u128_to_u32_guarantees(b.low);
+        let (b_w4, b_w5, b_w6, b_w7) = u128_to_u32_guarantees(b.high);
+        BoxTrait::new(
+            [
+                a_w0, a_w1, a_w2, a_w3, a_w4, a_w5, a_w6, a_w7, b_w0, b_w1, b_w2, b_w3, b_w4, b_w5,
+                b_w6, b_w7,
+            ],
+        )
+    }
 }

--- a/tests/e2e_test_data/libfuncs/blake
+++ b/tests/e2e_test_data/libfuncs/blake
@@ -173,3 +173,239 @@ blake2s_finalize_guarantees([0], [1], [2]) -> ([3]);
 return([3]);
 
 test::foo@F0([0]: Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>, [1]: u32, [2]: Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>) -> (Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>);
+
+//! > ==========================================================================
+
+//! > blake2s hash two felt252s
+
+//! > test_comments
+
+//! > test_runner_name
+SmallE2ETestRunner(future_sierra: true)
+
+//! > cairo_code
+use core::blake::{Blake2sInputGuarantee, Blake2sState, blake2s_finalize_guarantees};
+
+#[feature("bounded-int-utils")]
+type U32Guarantee =
+    core::internal::bounded_int::BoundedIntGuarantee<0, 0xffffffff>;
+extern fn u128_to_u32_guarantees(
+    value: u128,
+) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) nopanic;
+
+fn hash_two_felt252s(state: Blake2sState, a: felt252, b: felt252) -> Blake2sState {
+    let a: u256 = a.into();
+    let b: u256 = b.into();
+    let (a_low_w0, a_low_w1, a_low_w2, a_low_w3) = u128_to_u32_guarantees(a.low);
+    let (a_high_w0, a_high_w1, a_high_w2, a_high_w3) = u128_to_u32_guarantees(a.high);
+    let (b_low_w0, b_low_w1, b_low_w2, b_low_w3) = u128_to_u32_guarantees(b.low);
+    let (b_high_w0, b_high_w1, b_high_w2, b_high_w3) = u128_to_u32_guarantees(b.high);
+    let msg: Blake2sInputGuarantee = BoxTrait::new(
+        [
+            a_low_w0, a_low_w1, a_low_w2, a_low_w3, a_high_w0, a_high_w1, a_high_w2, a_high_w3,
+            b_low_w0, b_low_w1, b_low_w2, b_low_w3, b_high_w0, b_high_w1, b_high_w2, b_high_w3,
+        ],
+    );
+    blake2s_finalize_guarantees(state, 64, msg)
+}
+
+//! > casm
+ap += 16;
+%{ memory[ap + 0] = memory[fp + -4] < 340282366920938463463374607431768211456 %}
+jmp rel 22 if [ap + 0] != 0, ap++;
+%{ (memory[ap + 3], memory[ap + 4]) = divmod(memory[fp + -4], 340282366920938463463374607431768211456) %}
+[ap + 3] = [[fp + -6] + 0], ap++;
+[ap + 3] = [[fp + -6] + 1], ap++;
+[ap + -2] = [ap + 1] * 340282366920938463463374607431768211456, ap++;
+[fp + -4] = [ap + -3] + [ap + 1], ap++;
+[ap + -3] = [ap + -1] + -10633823966279327296825105735305134080, ap++;
+jmp rel 6 if [ap + -4] != 0;
+[ap + -3] = [ap + -1] + 340282366920938463463374607431768211455;
+jmp rel 4;
+[ap + -3] = [ap + -2] + 329648542954659136166549501696463077376;
+[ap + -3] = [[fp + -6] + 2];
+jmp rel 14 if [ap + -2] != 0;
+[fp + -1] = [fp + -1] + 1;
+[fp + -4] = [[fp + -6] + 0];
+ap += 5;
+[ap + 0] = [fp + -6] + 1, ap++;
+[ap + 0] = [fp + -4], ap++;
+[ap + 0] = 0, ap++;
+jmp rel 6;
+[ap + 0] = [fp + -6] + 3, ap++;
+[ap + 0] = [ap + -2], ap++;
+[ap + 0] = [ap + -4], ap++;
+%{ memory[ap + 0] = memory[fp + -3] < 340282366920938463463374607431768211456 %}
+jmp rel 22 if [ap + 0] != 0, ap++;
+%{ (memory[ap + 3], memory[ap + 4]) = divmod(memory[fp + -3], 340282366920938463463374607431768211456) %}
+[ap + 3] = [[ap + -4] + 0], ap++;
+[ap + 3] = [[ap + -5] + 1], ap++;
+[ap + -2] = [ap + 1] * 340282366920938463463374607431768211456, ap++;
+[fp + -3] = [ap + -3] + [ap + 1], ap++;
+[ap + -3] = [ap + -1] + -10633823966279327296825105735305134080, ap++;
+jmp rel 6 if [ap + -4] != 0;
+[ap + -3] = [ap + -1] + 340282366920938463463374607431768211455;
+jmp rel 4;
+[ap + -3] = [ap + -2] + 329648542954659136166549501696463077376;
+[ap + -3] = [[ap + -9] + 2];
+jmp rel 14 if [ap + -2] != 0;
+[fp + -1] = [fp + -1] + 1;
+[fp + -3] = [[ap + -4] + 0];
+ap += 5;
+[ap + 0] = [ap + -9] + 1, ap++;
+[ap + 0] = [fp + -3], ap++;
+[ap + 0] = 0, ap++;
+jmp rel 6;
+[ap + 0] = [ap + -9] + 3, ap++;
+[ap + 0] = [ap + -2], ap++;
+[ap + 0] = [ap + -4], ap++;
+%{ (memory[ap + 3], memory[ap + 5]) = divmod(memory[ap + -11], 4294967296) %}
+%{ (memory[ap + 4], memory[ap + 6]) = divmod(memory[ap + 3], 4294967296) %}
+%{ (memory[ap + 8], memory[ap + 7]) = divmod(memory[ap + 4], 4294967296) %}
+ap += 3;
+[ap + -3] = [ap + 0] * 4294967296, ap++;
+[ap + -15] = [ap + -4] + [ap + 1], ap++;
+[ap + -4] = [ap + -1] * 4294967296, ap++;
+[ap + -3] = [ap + -5] + [ap + 0], ap++;
+[ap + -5] = [ap + 1] * 4294967296, ap++;
+[ap + -4] = [ap + -6] + [ap + -1], ap++;
+%{ (memory[ap + 3], memory[ap + 5]) = divmod(memory[ap + -19], 4294967296) %}
+%{ (memory[ap + 4], memory[ap + 6]) = divmod(memory[ap + 3], 4294967296) %}
+%{ (memory[ap + 8], memory[ap + 7]) = divmod(memory[ap + 4], 4294967296) %}
+ap += 3;
+[ap + -3] = [ap + 0] * 4294967296, ap++;
+[ap + -23] = [ap + -4] + [ap + 1], ap++;
+[ap + -4] = [ap + -1] * 4294967296, ap++;
+[ap + -3] = [ap + -5] + [ap + 0], ap++;
+[ap + -5] = [ap + 1] * 4294967296, ap++;
+[ap + -4] = [ap + -6] + [ap + -1], ap++;
+%{ (memory[ap + 3], memory[ap + 5]) = divmod(memory[ap + -20], 4294967296) %}
+%{ (memory[ap + 4], memory[ap + 6]) = divmod(memory[ap + 3], 4294967296) %}
+%{ (memory[ap + 8], memory[ap + 7]) = divmod(memory[ap + 4], 4294967296) %}
+ap += 3;
+[ap + -3] = [ap + 0] * 4294967296, ap++;
+[ap + -24] = [ap + -4] + [ap + 1], ap++;
+[ap + -4] = [ap + -1] * 4294967296, ap++;
+[ap + -3] = [ap + -5] + [ap + 0], ap++;
+[ap + -5] = [ap + 1] * 4294967296, ap++;
+[ap + -4] = [ap + -6] + [ap + -1], ap++;
+%{ (memory[ap + 3], memory[ap + 5]) = divmod(memory[ap + -28], 4294967296) %}
+%{ (memory[ap + 4], memory[ap + 6]) = divmod(memory[ap + 3], 4294967296) %}
+%{ (memory[ap + 8], memory[ap + 7]) = divmod(memory[ap + 4], 4294967296) %}
+ap += 3;
+[ap + -3] = [ap + 0] * 4294967296, ap++;
+[ap + -32] = [ap + -4] + [ap + 1], ap++;
+[ap + -4] = [ap + -1] * 4294967296, ap++;
+[ap + -3] = [ap + -5] + [ap + 0], ap++;
+[ap + -5] = [ap + 1] * 4294967296, ap++;
+[ap + -4] = [ap + -6] + [ap + -1], ap++;
+[fp + 0] = [ap + -31];
+[fp + 1] = [ap + -30];
+[fp + 2] = [ap + -29];
+[fp + 3] = [ap + -28];
+[fp + 4] = [ap + -22];
+[fp + 5] = [ap + -21];
+[fp + 6] = [ap + -20];
+[fp + 7] = [ap + -19];
+[fp + 8] = [ap + -13];
+[fp + 9] = [ap + -12];
+[fp + 10] = [ap + -11];
+[fp + 11] = [ap + -10];
+[fp + 12] = [ap + -4];
+[fp + 13] = [ap + -3];
+[fp + 14] = [ap + -2];
+[fp + 15] = [ap + -1];
+call rel 9;
+[ap + 0] = 64, ap++;
+[ap + 0] = [ap + -3], ap++;
+%{
+if '__boxed_segment' not in globals():
+    __boxed_segment = segments.add()
+memory[ap + 0] = __boxed_segment
+__boxed_segment += 8
+%}
+blake2s[state=[fp + -5], message=[ap + -1], byte_count=[ap + -2], finalize=true] => [ap + 0], ap++;
+[ap + 0] = [ap + -44], ap++;
+[ap + 0] = [ap + -2], ap++;
+ret;
+
+//! > function_costs
+test::hash_two_felt252s: SmallOrderedMap({Blake: 1, Const: 8320})
+
+//! > sierra_code
+type BoundedIntGuarantee<0, 4294967295> = BoundedIntGuarantee<0, 4294967295> [storable: true, drop: false, dup: false, zero_sized: false];
+type Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>> = Struct<ut@Tuple, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>> [storable: true, drop: false, dup: false, zero_sized: false];
+type Uninitialized<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = Uninitialized<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> [storable: false, drop: true, dup: false, zero_sized: false];
+type Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> = Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Const<u32, 64> = Const<u32, 64> [storable: false, drop: false, dup: false, zero_sized: false];
+type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<u32, u32, u32, u32, u32, u32, u32, u32> = Struct<ut@Tuple, u32, u32, u32, u32, u32, u32, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
+type Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> [storable: true, drop: false, dup: false, zero_sized: false];
+type Const<u128, 0> = Const<u128, 0> [storable: false, drop: false, dup: false, zero_sized: false];
+type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type RangeCheck = RangeCheck [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc alloc_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = alloc_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>;
+libfunc finalize_locals = finalize_locals;
+libfunc u128s_from_felt252 = u128s_from_felt252;
+libfunc branch_align = branch_align;
+libfunc const_as_immediate<Const<u128, 0>> = const_as_immediate<Const<u128, 0>>;
+libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
+libfunc store_temp<u128> = store_temp<u128>;
+libfunc jump = jump;
+libfunc u128_to_u32_guarantees = u128_to_u32_guarantees;
+libfunc struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>;
+libfunc store_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = store_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>;
+libfunc local_into_box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = local_into_box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>;
+libfunc const_as_immediate<Const<u32, 64>> = const_as_immediate<Const<u32, 64>>;
+libfunc store_temp<u32> = store_temp<u32>;
+libfunc store_temp<Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>> = store_temp<Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>>;
+libfunc blake2s_finalize_guarantees = blake2s_finalize_guarantees;
+libfunc store_temp<Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>> = store_temp<Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>>;
+
+F0:
+alloc_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>() -> ([5]);
+finalize_locals() -> ();
+u128s_from_felt252([0], [2]) { fallthrough([6], [7]) F0_B0([8], [9], [10]) };
+branch_align() -> ();
+const_as_immediate<Const<u128, 0>>() -> ([11]);
+store_temp<RangeCheck>([6]) -> ([12]);
+store_temp<u128>([7]) -> ([13]);
+store_temp<u128>([11]) -> ([14]);
+jump() { F0_B1() };
+F0_B0:
+branch_align() -> ();
+store_temp<RangeCheck>([8]) -> ([12]);
+store_temp<u128>([10]) -> ([13]);
+store_temp<u128>([9]) -> ([14]);
+F0_B1:
+u128s_from_felt252([12], [3]) { fallthrough([15], [16]) F0_B2([17], [18], [19]) };
+branch_align() -> ();
+const_as_immediate<Const<u128, 0>>() -> ([20]);
+store_temp<RangeCheck>([15]) -> ([21]);
+store_temp<u128>([16]) -> ([22]);
+store_temp<u128>([20]) -> ([23]);
+jump() { F0_B3() };
+F0_B2:
+branch_align() -> ();
+store_temp<RangeCheck>([17]) -> ([21]);
+store_temp<u128>([19]) -> ([22]);
+store_temp<u128>([18]) -> ([23]);
+F0_B3:
+u128_to_u32_guarantees([13]) -> ([24], [25], [26], [27]);
+u128_to_u32_guarantees([14]) -> ([28], [29], [30], [31]);
+u128_to_u32_guarantees([22]) -> ([32], [33], [34], [35]);
+u128_to_u32_guarantees([23]) -> ([36], [37], [38], [39]);
+struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([24], [25], [26], [27], [28], [29], [30], [31], [32], [33], [34], [35], [36], [37], [38], [39]) -> ([4]);
+store_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([5], [4]) -> ([4]);
+local_into_box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([4]) -> ([40]);
+const_as_immediate<Const<u32, 64>>() -> ([41]);
+store_temp<u32>([41]) -> ([41]);
+store_temp<Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>>([40]) -> ([40]);
+blake2s_finalize_guarantees([1], [41], [40]) -> ([42]);
+store_temp<RangeCheck>([21]) -> ([21]);
+store_temp<Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>>([42]) -> ([42]);
+return([21], [42]);
+
+test::hash_two_felt252s@F0([0]: RangeCheck, [1]: Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>, [2]: felt252, [3]: felt252) -> (RangeCheck, Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>);


### PR DESCRIPTION
## Summary

Enhanced Blake2s hash tests with new utility functions and comprehensive test coverage. Added `blake2s_finalize_guarantees` import, converted test assertions to use `u256` format instead of raw arrays, and introduced a new test for the guarantees-based Blake2s function with proper message construction utilities.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The existing Blake2s tests were using raw array comparisons and lacked coverage for the guarantees-based Blake2s functions. This change provides better test coverage and more readable assertions by converting hash outputs to `u256` format, while also adding comprehensive tests for the `blake2s_finalize_guarantees` function.

---

## What was the behavior or documentation before?

Tests compared Blake2s hash outputs as raw `u32` arrays and only tested the basic `blake2s_compress` and `blake2s_finalize` functions. There was no test coverage for `blake2s_finalize_guarantees` or utility functions for message construction.

---

## What is the behavior or documentation after?

Tests now compare hash outputs as `u256` values for better readability, include comprehensive testing of `blake2s_finalize_guarantees` with proper message construction from `felt252` values, and provide utility functions for converting between different data formats used in Blake2s operations.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The changes include a new `to_u256` conversion function and a `msg` module with utilities for constructing Blake2s input messages from `felt252` values using bounded integer guarantees. The test data also includes new end-to-end test cases for hashing two `felt252` values, demonstrating practical usage patterns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to test code and e2e fixtures, with no production hashing implementation modified. Main risk is test brittleness due to new u256 formatting and bounded-int guarantee message construction.
> 
> **Overview**
> Updates Blake2s unit tests to assert outputs as a single `u256` value (via a new `to_u256` helper) instead of raw `[u32; 8]` arrays.
> 
> Adds new coverage for `blake2s_finalize_guarantees`, including utilities to build `Blake2sInputGuarantee` messages from two `felt252` values using bounded-int guarantees, and extends the Blake e2e fixture to exercise hashing two `felt252`s with the guarantees-based finalize path (future Sierra enabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bef1691f7a1c745298a4ca7fb3445da445149ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->