### PR TITLE
perf(lowering): remove redundant clone in implicits goto remapping

### DIFF
--- a/crates/cairo-lang-lowering/src/implicits/mod.rs
+++ b/crates/cairo-lang-lowering/src/implicits/mod.rs
@@ -172,24 +172,18 @@ fn lower_function_blocks_implicits<'db>(
                 unreachable!("Panics should have been stripped in a previous phase.")
             }
             BlockEnd::Goto(block_id, remapping) => {
-                let target_implicits = ctx
-                    .implicit_vars_for_block
-                    .entry(*block_id)
-                    .or_insert_with(|| {
+                let target_implicits =
+                    ctx.implicit_vars_for_block.entry(*block_id).or_insert_with(|| {
                         alloc_implicits(
                             ctx.db,
                             &mut ctx.lowered.variables,
                             &ctx.implicits_tys,
                             ctx.location,
                         )
-                    })
-                    .clone();
+                    });
                 let old_remapping = std::mem::take(&mut remapping.remapping);
                 remapping.remapping = chain!(
-                    zip_eq(
-                        target_implicits.into_iter().map(|var_usage| var_usage.var_id),
-                        implicits
-                    ),
+                    zip_eq(target_implicits.iter().map(|var_usage| var_usage.var_id), implicits),
                     old_remapping
                 )
                 .collect();


### PR DESCRIPTION
## Summary

- Removed the redundant `.clone()` on `target_implicits`.
- Switched remapping construction to iterate by reference (`iter()`) and read `var_id` directly.

---

## Type of change


- [x] Performance improvement

---

## Why is this change needed?

In implicits lowering, the `BlockEnd::Goto` path cloned the target implicits vector only to read `var_id`s for remapping.  
This added unnecessary allocation/copy work in a hot path without changing behavior.
 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance-only change that removes an unnecessary allocation/copy in `BlockEnd::Goto` remapping construction without altering lowering semantics.
> 
> **Overview**
> Removes a redundant `.clone()` when computing implicit-variable remapping for `BlockEnd::Goto` during implicits lowering.
> 
> The remapping now iterates over `target_implicits` by reference (`iter()` + `var_id`) instead of cloning the vector, reducing overhead in a hot path while preserving behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10aad0506670be05732e26cfa03f4f5ab89cbe6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->