### PR TITLE
refactor: unify pattern mismatch diagnostics into single BadPatternFo…

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
@@ -1448,17 +1448,17 @@ Root: 7
 0 ArmExpr { expr: ExprId(1) }
 
 //! > semantic_diagnostics
-error[E2105]: Unexpected type for tuple pattern. "core::felt252" is not a tuple.
+error[E2103]: Mismatched types: pattern cannot match against type "core::felt252".
  --> lib.cairo:3:13
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
             ^^
 
-error[E2105]: Unexpected type for tuple pattern. "core::option::Option::<(core::felt252, core::felt252)>" is not a tuple.
+error[E2103]: Mismatched types: pattern cannot match against type "core::option::Option::<(core::felt252, core::felt252)>".
  --> lib.cairo:3:20
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
                    ^^
 
-error[E2103]: Unexpected type for enum pattern. "(core::felt252, core::felt252)" is not an enum.
+error[E2103]: Mismatched types: pattern cannot match against type "(core::felt252, core::felt252)".
  --> lib.cairo:3:35
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
                                   ^^^^

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -726,22 +726,9 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::UnusedImport(use_id) => {
                 format!("Unused import: `{}`", use_id.full_path(db))
             }
-            SemanticDiagnosticKind::UnexpectedEnumPattern(ty) => {
-                format!(r#"Unexpected type for enum pattern. "{}" is not an enum."#, ty.format(db),)
-            }
-            SemanticDiagnosticKind::UnexpectedStructPattern(ty) => {
+            SemanticDiagnosticKind::BadPatternForInputType(ty) => {
                 format!(
-                    r#"Unexpected type for struct pattern. "{}" is not a struct."#,
-                    ty.format(db),
-                )
-            }
-            SemanticDiagnosticKind::UnexpectedTuplePattern(ty) => {
-                format!(r#"Unexpected type for tuple pattern. "{}" is not a tuple."#, ty.format(db),)
-            }
-            SemanticDiagnosticKind::UnexpectedFixedSizeArrayPattern(ty) => {
-                format!(
-                    "Unexpected type for fixed size array pattern. \"{}\" is not a fixed size \
-                     array or a span.",
+                    "Mismatched types: pattern cannot match against type \"{}\".",
                     ty.format(db),
                 )
             }
@@ -1367,10 +1354,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::UnusedImport(_) => error_code!(E2100),
             SemanticDiagnosticKind::RedundantModifier { .. } => error_code!(E2101),
             SemanticDiagnosticKind::ReferenceLocalVariable => error_code!(E2102),
-            SemanticDiagnosticKind::UnexpectedEnumPattern(_) => error_code!(E2103),
-            SemanticDiagnosticKind::UnexpectedStructPattern(_) => error_code!(E2104),
-            SemanticDiagnosticKind::UnexpectedTuplePattern(_) => error_code!(E2105),
-            SemanticDiagnosticKind::UnexpectedFixedSizeArrayPattern(_) => error_code!(E2106),
+            SemanticDiagnosticKind::BadPatternForInputType(_) => error_code!(E2103),
             SemanticDiagnosticKind::WrongNumberOfTupleElements { .. } => error_code!(E2107),
             SemanticDiagnosticKind::WrongNumberOfFixedSizeArrayElements { .. } => {
                 error_code!(E2108)
@@ -1733,10 +1717,7 @@ pub enum SemanticDiagnosticKind<'db> {
         previous_modifier: SmolStrId<'db>,
     },
     ReferenceLocalVariable,
-    UnexpectedEnumPattern(semantic::TypeId<'db>),
-    UnexpectedStructPattern(semantic::TypeId<'db>),
-    UnexpectedTuplePattern(semantic::TypeId<'db>),
-    UnexpectedFixedSizeArrayPattern(semantic::TypeId<'db>),
+    BadPatternForInputType(semantic::TypeId<'db>),
     WrongNumberOfTupleElements {
         expected: usize,
         actual: usize,

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -2937,7 +2937,7 @@ fn maybe_compute_pattern_semantic<'db>(
                     ty.check_not_missing(ctx.db)?;
                     Err(ctx
                         .diagnostics
-                        .report(pattern_struct.stable_ptr(db), UnexpectedStructPattern(ty)))
+                        .report(pattern_struct.stable_ptr(db), BadPatternForInputType(ty)))
                 })?;
             let params = pattern_struct.params(db);
             let pattern_param_asts = params.elements(db);
@@ -3024,7 +3024,6 @@ fn maybe_compute_pattern_semantic<'db>(
             pattern_syntax,
             ty,
             or_pattern_variables_map,
-            |ty: TypeId<'db>| UnexpectedTuplePattern(ty),
             |expected, actual| WrongNumberOfTupleElements { expected, actual },
         ),
         ast::Pattern::FixedSizeArray(_) => compute_tuple_like_pattern_semantic(
@@ -3032,7 +3031,6 @@ fn maybe_compute_pattern_semantic<'db>(
             pattern_syntax,
             ty,
             or_pattern_variables_map,
-            |ty: TypeId<'db>| UnexpectedFixedSizeArrayPattern(ty),
             |expected, actual| WrongNumberOfFixedSizeArrayElements { expected, actual },
         ),
         ast::Pattern::False(pattern_false) => {
@@ -3133,7 +3131,6 @@ fn compute_tuple_like_pattern_semantic<'db>(
     pattern_syntax: &ast::Pattern<'db>,
     ty: TypeId<'db>,
     or_pattern_variables_map: &UnorderedHashMap<SmolStrId<'db>, LocalVariable<'db>>,
-    unexpected_pattern: fn(TypeId<'db>) -> SemanticDiagnosticKind<'db>,
     wrong_number_of_elements: fn(usize, usize) -> SemanticDiagnosticKind<'db>,
 ) -> Pattern<'db> {
     let db = ctx.db;
@@ -3163,7 +3160,7 @@ fn compute_tuple_like_pattern_semantic<'db>(
     )
     .unwrap_or_else(|| {
         TypeLongId::Missing(
-            ctx.diagnostics.report(pattern_syntax.stable_ptr(db), unexpected_pattern(ty)),
+            ctx.diagnostics.report(pattern_syntax.stable_ptr(db), BadPatternForInputType(ty)),
         )
     });
     let mut inner_tys = match long_ty {
@@ -3272,7 +3269,7 @@ fn extract_concrete_enum_from_pattern_and_validate<'db>(
             // Don't add a diagnostic if the type is missing.
             // A diagnostic should've already been added.
             ty.check_not_missing(ctx.db)?;
-            Err(ctx.diagnostics.report(pattern.stable_ptr(ctx.db), UnexpectedEnumPattern(ty)))
+            Err(ctx.diagnostics.report(pattern.stable_ptr(ctx.db), BadPatternForInputType(ty)))
         })?;
     // Check that these are the same enums.
     let pattern_enum = concrete_enum_id.enum_id(ctx.db);

--- a/crates/cairo-lang-semantic/src/expr/test_data/let_else
+++ b/crates/cairo-lang-semantic/src/expr/test_data/let_else
@@ -36,12 +36,12 @@ error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "test:
     let MyEnum::A(x): felt252 = MyEnum::A(7) else {
                                 ^^^^^^^^^^^^
 
-error[E2103]: Unexpected type for enum pattern. "core::felt252" is not an enum.
+error[E2103]: Mismatched types: pattern cannot match against type "core::felt252".
  --> lib.cairo:11:9
     let MyEnum::A(x): felt252 = MyEnum::A(7) else {
         ^^^^^^^^^^^^
 
-error[E2103]: Unexpected type for enum pattern. "core::felt252" is not an enum.
+error[E2103]: Mismatched types: pattern cannot match against type "core::felt252".
  --> lib.cairo:14:9
     let MyEnum::A(x): felt252 = 7 else {
         ^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/let_statement
+++ b/crates/cairo-lang-semantic/src/expr/test_data/let_statement
@@ -153,12 +153,12 @@ error[E0006]: Function not found.
     let (a, b, c) = undefined();
                     ^^^^^^^^^
 
-error[E2106]: Unexpected type for fixed size array pattern. "(<missing>, <missing>, <missing>)" is not a fixed size array or a span.
+error[E2103]: Mismatched types: pattern cannot match against type "(<missing>, <missing>, <missing>)".
  --> lib.cairo:3:9
     let [d, e, f] = (a, b, c);
         ^^^^^^^^^
 
-error[E2105]: Unexpected type for tuple pattern. "[<missing>; 3]" is not a tuple.
+error[E2103]: Mismatched types: pattern cannot match against type "[<missing>; 3]".
  --> lib.cairo:4:9
     let (g, h, i) = [d, e, f];
         ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/pattern
+++ b/crates/cairo-lang-semantic/src/expr/test_data/pattern
@@ -203,7 +203,7 @@ fn foo(s: (felt252, felt252, felt252)) {
 foo
 
 //! > expected_diagnostics
-error[E2106]: Unexpected type for fixed size array pattern. "(core::felt252, core::felt252, core::felt252)" is not a fixed size array or a span.
+error[E2103]: Mismatched types: pattern cannot match against type "(core::felt252, core::felt252, core::felt252)".
  --> lib.cairo:2:9
     let [_a, _b, _c] = s;
         ^^^^^^^^^^^^
@@ -224,7 +224,7 @@ fn foo(s: [felt252; 3]) {
 foo
 
 //! > expected_diagnostics
-error[E2105]: Unexpected type for tuple pattern. "[core::felt252; 3]" is not a tuple.
+error[E2103]: Mismatched types: pattern cannot match against type "[core::felt252; 3]".
  --> lib.cairo:2:9
     let (_a, _b, _c) = s;
         ^^^^^^^^^^^^
@@ -385,7 +385,7 @@ struct MyStruct<T> {
 }
 
 //! > expected_diagnostics
-error[E2106]: Unexpected type for fixed size array pattern. "test::MyStruct::<core::integer::u8>" is not a fixed size array or a span.
+error[E2103]: Mismatched types: pattern cannot match against type "test::MyStruct::<core::integer::u8>".
  --> lib.cairo:5:9
     let [_x, _y] = s;
         ^^^^^^^^
@@ -412,7 +412,7 @@ foo
 //! > module_code
 
 //! > expected_diagnostics
-error[E2106]: Unexpected type for fixed size array pattern. "core::array::Array::<core::integer::u8>" is not a fixed size array or a span.
+error[E2103]: Mismatched types: pattern cannot match against type "core::array::Array::<core::integer::u8>".
  --> lib.cairo:4:9
         [_x, _y, _z] => {},
         ^^^^^^^^^^^^


### PR DESCRIPTION
…rInputType variant

Consolidate UnexpectedEnumPattern, UnexpectedStructPattern, UnexpectedTuplePattern, and UnexpectedFixedSizeArrayPattern into a single BadPatternForInputType diagnostic. The pattern-specific messages were unnecessarily granular — the type is already shown in the error message, making the specific pattern kind redundant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes semantic diagnostic variants, error codes, and messages for pattern/type mismatches, which may break tests or downstream tooling that matches specific diagnostic codes/text.
> 
> **Overview**
> Unifies several pattern/type mismatch diagnostics (`UnexpectedEnumPattern`, `UnexpectedStructPattern`, `UnexpectedTuplePattern`, `UnexpectedFixedSizeArrayPattern`) into a single semantic diagnostic: `BadPatternForInputType`.
> 
> Updates pattern semantic computation to report the unified diagnostic for enum/struct/tuple/array pattern mismatches, and revises tests/fixtures to expect the new `E2103` message (`"Mismatched types: pattern cannot match against type ..."`) instead of the previous pattern-specific errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5305a07bdcdcdad64d8d102a97a9963e69170c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->