### PR TITLE
Bumped nightly version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-03-01
+          toolchain: nightly-2026-04-09
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - run: |
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2026-03-01
+          toolchain: nightly-2026-04-09
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --profile=ci-dev -p cairo-lang-syntax-codegen
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2026-03-01
+          toolchain: nightly-2026-04-09
       - uses: Swatinem/rust-cache@v2
       - run: scripts/rust_fmt.sh --check
 
@@ -169,7 +169,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
-          toolchain: nightly-2026-03-01
+          toolchain: nightly-2026-04-09
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/clippy.sh
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-03-01
+          toolchain: nightly-2026-04-09
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/docs.sh

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -695,9 +695,7 @@ fn impl_generic_param_semantic<'db>(
         });
     let type_constraints = concrete_trait
         .ok()
-        .and_then(|concrete_trait| {
-            item_constraints.map(|type_constraints| (concrete_trait, type_constraints))
-        })
+        .zip(item_constraints)
         .map(|(concrete_trait_id, constraints)| {
             let mut map = OrderedHashMap::default();
 

--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -49,7 +49,7 @@ pub fn reformat_rust_code(text: String) -> String {
 }
 pub fn reformat_rust_code_inner(text: String) -> String {
     let sh = Shell::new().unwrap();
-    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-03-01");
+    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-04-09");
     let cmd_with_args = cmd.arg("--config-path").arg(project_root().join("rustfmt.toml"));
     let mut stdout = cmd_with_args.stdin(text).read().unwrap();
     if !stdout.ends_with('\n') {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The `rustfmt` configuration used by Cairo requires a nightly version of Rust.
 You can install the nightly version by running:
 
 ```sh
-rustup install nightly-2026-03-01
+rustup install nightly-2026-04-09
 ```
 
 ## Running Tests

--- a/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
@@ -35,5 +35,5 @@ You can install the nightly version by running:
 
 [source,bash]
 ----
-rustup install nightly-2026-03-01
+rustup install nightly-2026-04-09
 ----

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,11 +23,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2026-03-01",
+#         "nightly-2026-04-09",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2024",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2026-03-01".
+# and run "rustup toolchain install nightly-2026-04-09".

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-03-01}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-09}"
 
 cargo clippy "$@" --all-targets --all-features -- -D warnings -D future-incompatible \
     -D nonstandard-style -D rust-2018-idioms -D unused

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-03-01}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-09}"
 
 RUSTDOCFLAGS="-Dwarnings" cargo doc --document-private-items --no-deps --all-features

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-03-01}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-09}"
 
 cargo fmt --all -- "$@"


### PR DESCRIPTION
## Summary

Updates the Rust nightly toolchain from `nightly-2026-03-01` to `nightly-2026-04-09` across CI workflows, build scripts, documentation, and code generation tools. Also refactors a chain of `and_then` and `map` operations to use the more concise `zip` method in the generics module.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

This change updates the project to use a newer nightly Rust toolchain version, which may include bug fixes, performance improvements, or new features that the project wants to leverage. The code refactoring improves readability by using a more idiomatic Rust pattern.

---

## What was the behavior or documentation before?

The project was using Rust nightly toolchain version `nightly-2026-03-01` across all CI jobs, scripts, and documentation. The generics code used a verbose `and_then` followed by `map` pattern to combine two `Option` values.

---

## What is the behavior or documentation after?

The project now uses Rust nightly toolchain version `nightly-2026-04-09` consistently. The generics code uses the more concise `zip` method to combine `Option` values, which is functionally equivalent but more readable.

---

## Related issue or discussion (if any)

---

## Additional context

This toolchain update ensures all development environments and CI systems use the same Rust nightly version, maintaining consistency across the project. The code refactoring in the generics module follows Rust best practices for combining `Option` types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a toolchain bump across CI and dev scripts; risk is moderate because a new nightly can introduce formatting/lint/doc build deltas or new compiler regressions in CI.
> 
> **Overview**
> Bumps the pinned Rust nightly toolchain from `nightly-2026-03-01` to `nightly-2026-04-09` across CI (`ci.yml`), formatting/codegen (`cairo-lang-syntax-codegen`), helper scripts (`rust_fmt.sh`, `clippy.sh`, `docs.sh`), and contributor/docs instructions.
> 
> Also makes a small semantics refactor in `impl_generic_param_semantic` by replacing an `Option`-combining `and_then` chain with `zip`, preserving behavior while simplifying the type-constraint construction logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447ae559ffe5d2ea90dde2a05275336f6eb62cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->