### PR TITLE
perf(lowering): avoid cloning concrete enum variants in extern lowering

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/context.rs
+++ b/crates/cairo-lang-lowering/src/lower/context.rs
@@ -349,10 +349,10 @@ impl<'db> LoweredExprExternEnum<'db> {
             .concrete_enum_variants(self.concrete_enum_id)
             .map_err(LoweringFlowError::Failed)?;
 
-        let mut arm_var_ids = vec![];
+        let mut arm_var_ids = Vec::with_capacity(concrete_variants.len());
         let (sealed_blocks, block_ids): (Vec<_>, Vec<_>) = concrete_variants
-            .clone()
-            .into_iter()
+            .iter()
+            .copied()
             .map(|concrete_variant| {
                 let mut subscope = builder.child_block_builder(ctx.blocks.alloc_empty());
                 let block_id = subscope.block_id;


### PR DESCRIPTION
## Summary

Replaced the cloned iteration with iter().copied() and preallocated arm_var_ids using Vec::with_capacity(concrete_variants.len()). Behavior is unchanged; this is a small performance cleanup that removes redundant work.

---

## Type of change

- [x] Performance improvement

---

## Why is this change needed?

LoweredExprExternEnum::as_var_usage cloned the whole concrete_variants vector before iteration (clone().into_iter()), even though the elements are Copy and only read access is needed. This introduced unnecessary allocation and copying on every extern-enum lowering path.
