### PR TITLE
refactor(orizi): Made apply optimizations trait based.

### DIFF
--- a/crates/bin/get-lowering/src/main.rs
+++ b/crates/bin/get-lowering/src/main.rs
@@ -22,6 +22,7 @@ use cairo_lang_lowering::ids::{
     GeneratedFunctionKey,
 };
 use cairo_lang_lowering::optimizations::scrub_units::scrub_units;
+use cairo_lang_lowering::optimizations::strategy::ApplyOptimization;
 use cairo_lang_lowering::panic::lower_panics;
 use cairo_lang_lowering::{Lowered, LoweringStage};
 use cairo_lang_semantic::ConcreteImplLongId;

--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis_test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis_test.rs
@@ -9,7 +9,7 @@ use super::equality_analysis::EqualityAnalysis;
 use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::{LoweringDatabaseForTesting, formatted_lowered};
 
 cairo_lang_test_utils::test_file_test!(
@@ -37,16 +37,18 @@ fn test_equality_analysis(
     let lowered = db.lowered_body(function_id, LoweringStage::PreOptimizations);
 
     let (lowering_str, analysis_state_str) = if let Ok(mut lowered) = lowered.cloned() {
-        OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut lowered).unwrap();
-        OptimizationPhase::ApplyInlining { enable_const_folding: false }
-            .apply(db, function_id, &mut lowered)
-            .unwrap();
-        OptimizationPhase::ReturnOptimization.apply(db, function_id, &mut lowered).unwrap();
-        OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut lowered).unwrap();
-        OptimizationPhase::ReorderStatements.apply(db, function_id, &mut lowered).unwrap();
-        OptimizationPhase::BranchInversion.apply(db, function_id, &mut lowered).unwrap();
-        OptimizationPhase::OptimizeMatches.apply(db, function_id, &mut lowered).unwrap();
-        OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut lowered).unwrap();
+        [
+            OptimizationPhase::ReorganizeBlocks,
+            OptimizationPhase::ApplyInlining { enable_const_folding: false },
+            OptimizationPhase::ReturnOptimization,
+            OptimizationPhase::ReorganizeBlocks,
+            OptimizationPhase::ReorderStatements,
+            OptimizationPhase::BranchInversion,
+            OptimizationPhase::OptimizeMatches,
+            OptimizationPhase::ReorganizeBlocks,
+        ]
+        .apply(db, function_id, &mut lowered)
+        .unwrap();
 
         let lowering_str = formatted_lowered(db, Some(&lowered));
         let block_states = EqualityAnalysis::analyze(db, &lowered);

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -35,7 +35,7 @@ use crate::inline::statements_weights::{ApproxCasmInlineWeight, InlineWeight};
 use crate::lower::{MultiLowering, lower_semantic_function};
 use crate::optimizations::config::Optimizations;
 use crate::optimizations::scrub_units::scrub_units;
-use crate::optimizations::strategy::OptimizationStrategyId;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationStrategyId};
 use crate::panic::lower_panics;
 use crate::specialization::specialized_function_lowered;
 use crate::{
@@ -487,12 +487,12 @@ fn lowered_body<'db>(
         }
         LoweringStage::PostBaseline => {
             let mut lowered = db.lowered_body(function, LoweringStage::PreOptimizations)?.clone();
-            db.baseline_optimization_strategy().apply_strategy(db, function, &mut lowered)?;
+            db.baseline_optimization_strategy().apply(db, function, &mut lowered)?;
             lowered
         }
         LoweringStage::Final => {
             let mut lowered = db.lowered_body(function, LoweringStage::PostBaseline)?.clone();
-            db.final_optimization_strategy().apply_strategy(db, function, &mut lowered)?;
+            db.final_optimization_strategy().apply(db, function, &mut lowered)?;
             lowered
         }
     })

--- a/crates/cairo-lang-lowering/src/inline/test.rs
+++ b/crates/cairo-lang-lowering/src/inline/test.rs
@@ -5,7 +5,7 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::{LoweringDatabaseForTesting, formatted_lowered};
 
 cairo_lang_test_utils::test_file_test!(

--- a/crates/cairo-lang-lowering/src/optimizations/branch_inversion_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/branch_inversion_test.rs
@@ -7,7 +7,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -31,10 +31,12 @@ fn test_branch_inversion(
     let mut before = db.lowered_body(function_id, LoweringStage::Monomorphized).unwrap().clone();
 
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
-    OptimizationPhase::ApplyInlining { enable_const_folding: true }
-        .apply(db, function_id, &mut before)
-        .unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
+    [
+        OptimizationPhase::ApplyInlining { enable_const_folding: true },
+        OptimizationPhase::ReorganizeBlocks,
+    ]
+    .apply(db, function_id, &mut before)
+    .unwrap();
 
     let mut after = before.clone();
     OptimizationPhase::BranchInversion.apply(db, function_id, &mut after).unwrap();

--- a/crates/cairo-lang-lowering/src/optimizations/cancel_ops_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/cancel_ops_test.rs
@@ -7,7 +7,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -37,11 +37,13 @@ fn test_cancel_ops(
 
     let mut before = db.lowered_body(function_id, LoweringStage::PreOptimizations).unwrap().clone();
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
-    OptimizationPhase::ApplyInlining { enable_const_folding: true }
-        .apply(db, function_id, &mut before)
-        .unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::ReorderStatements.apply(db, function_id, &mut before).unwrap();
+    [
+        OptimizationPhase::ApplyInlining { enable_const_folding: true },
+        OptimizationPhase::ReorganizeBlocks,
+        OptimizationPhase::ReorderStatements,
+    ]
+    .apply(db, function_id, &mut before)
+    .unwrap();
 
     let mut after = before.clone();
     OptimizationPhase::CancelOps.apply(db, function_id, &mut after).unwrap();

--- a/crates/cairo-lang-lowering/src/optimizations/const_folding_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding_test.rs
@@ -8,7 +8,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -46,12 +46,14 @@ fn test_match_optimizer(
             )
         })
         .clone();
-    OptimizationPhase::ApplyInlining { enable_const_folding: false }
-        .apply(db, function_id, &mut before)
-        .unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::CancelOps.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
+    [
+        OptimizationPhase::ApplyInlining { enable_const_folding: false },
+        OptimizationPhase::ReorganizeBlocks,
+        OptimizationPhase::CancelOps,
+        OptimizationPhase::ReorganizeBlocks,
+    ]
+    .apply(db, function_id, &mut before)
+    .unwrap();
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
 
     let mut after = before.clone();

--- a/crates/cairo-lang-lowering/src/optimizations/dedup_blocks_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/dedup_blocks_test.rs
@@ -8,7 +8,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -31,14 +31,16 @@ fn test_dedup_blocks(
 
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
     let mut before = db.lowered_body(function_id, LoweringStage::PreOptimizations).unwrap().clone();
-    OptimizationPhase::ApplyInlining { enable_const_folding: true }
-        .apply(db, function_id, &mut before)
-        .unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::ReorderStatements.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::OptimizeMatches.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::ReorderStatements.apply(db, function_id, &mut before).unwrap();
+    [
+        OptimizationPhase::ApplyInlining { enable_const_folding: true },
+        OptimizationPhase::ReorganizeBlocks,
+        OptimizationPhase::ReorderStatements,
+        OptimizationPhase::OptimizeMatches,
+        OptimizationPhase::ReorganizeBlocks,
+        OptimizationPhase::ReorderStatements,
+    ]
+    .apply(db, function_id, &mut before)
+    .unwrap();
 
     let mut after = before.clone();
     dedup_blocks(&mut after);

--- a/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic_test.rs
@@ -9,7 +9,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(

--- a/crates/cairo-lang-lowering/src/optimizations/match_optimizer_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/match_optimizer_test.rs
@@ -7,7 +7,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -31,11 +31,13 @@ fn test_match_optimizer(
 
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
     let mut before = db.lowered_body(function_id, LoweringStage::PreOptimizations).unwrap().clone();
-    OptimizationPhase::ApplyInlining { enable_const_folding: true }
-        .apply(db, function_id, &mut before)
-        .unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::ReorderStatements.apply(db, function_id, &mut before).unwrap();
+    [
+        OptimizationPhase::ApplyInlining { enable_const_folding: true },
+        OptimizationPhase::ReorganizeBlocks,
+        OptimizationPhase::ReorderStatements,
+    ]
+    .apply(db, function_id, &mut before)
+    .unwrap();
 
     let mut after = before.clone();
     OptimizationPhase::OptimizeMatches.apply(db, function_id, &mut after).unwrap();

--- a/crates/cairo-lang-lowering/src/optimizations/reboxing_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/reboxing_test.rs
@@ -8,7 +8,7 @@ use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
 use crate::optimizations::reboxing::{apply_reboxing_candidates, find_reboxing_candidates};
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -30,12 +30,13 @@ fn test_reboxing_analysis(
     let function_id =
         ConcreteFunctionWithBodyId::from_semantic(db, test_function.concrete_function_id);
     if let Ok(mut before) = db.lowered_body(function_id, LoweringStage::PreOptimizations).cloned() {
-        OptimizationPhase::ApplyInlining { enable_const_folding: true }
-            .apply(db, function_id, &mut before)
-            .unwrap();
-        OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
-
-        OptimizationPhase::ReorderStatements.apply(db, function_id, &mut before).unwrap();
+        [
+            OptimizationPhase::ApplyInlining { enable_const_folding: true },
+            OptimizationPhase::ReorganizeBlocks,
+            OptimizationPhase::ReorderStatements,
+        ]
+        .apply(db, function_id, &mut before)
+        .unwrap();
         let mut after = before.clone();
 
         let formatter = LoweredFormatter::new(db, &after.variables);

--- a/crates/cairo-lang-lowering/src/optimizations/reorder_statements_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/reorder_statements_test.rs
@@ -7,7 +7,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -31,10 +31,12 @@ fn test_reorder_statements(
     let mut before = db.lowered_body(function_id, LoweringStage::Monomorphized).unwrap().clone();
 
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
-    OptimizationPhase::ApplyInlining { enable_const_folding: true }
-        .apply(db, function_id, &mut before)
-        .unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
+    [
+        OptimizationPhase::ApplyInlining { enable_const_folding: true },
+        OptimizationPhase::ReorganizeBlocks,
+    ]
+    .apply(db, function_id, &mut before)
+    .unwrap();
 
     let mut after = before.clone();
     OptimizationPhase::ReorderStatements.apply(db, function_id, &mut after).unwrap();

--- a/crates/cairo-lang-lowering/src/optimizations/return_optimization_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/return_optimization_test.rs
@@ -7,7 +7,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -31,11 +31,13 @@ fn test_return_optimizer(
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
 
     let mut before = db.lowered_body(function_id, LoweringStage::PreOptimizations).unwrap().clone();
-    OptimizationPhase::ApplyInlining { enable_const_folding: true }
-        .apply(db, function_id, &mut before)
-        .unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::ReorderStatements.apply(db, function_id, &mut before).unwrap();
+    [
+        OptimizationPhase::ApplyInlining { enable_const_folding: true },
+        OptimizationPhase::ReorganizeBlocks,
+        OptimizationPhase::ReorderStatements,
+    ]
+    .apply(db, function_id, &mut before)
+    .unwrap();
 
     let mut after = before.clone();
     OptimizationPhase::ReturnOptimization.apply(db, function_id, &mut after).unwrap();

--- a/crates/cairo-lang-lowering/src/optimizations/split_structs_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/split_structs_test.rs
@@ -7,7 +7,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
@@ -38,11 +38,13 @@ fn test_split_structs(
     let mut before = db.lowered_body(function_id, LoweringStage::PreOptimizations).unwrap().clone();
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
 
-    OptimizationPhase::ApplyInlining { enable_const_folding: true }
-        .apply(db, function_id, &mut before)
-        .unwrap();
-    OptimizationPhase::ReorganizeBlocks.apply(db, function_id, &mut before).unwrap();
-    OptimizationPhase::ReorderStatements.apply(db, function_id, &mut before).unwrap();
+    [
+        OptimizationPhase::ApplyInlining { enable_const_folding: true },
+        OptimizationPhase::ReorganizeBlocks,
+        OptimizationPhase::ReorderStatements,
+    ]
+    .apply(db, function_id, &mut before)
+    .unwrap();
 
     let mut after = before.clone();
     OptimizationPhase::SplitStructs.apply(db, function_id, &mut after).unwrap();

--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -62,11 +62,21 @@ pub enum OptimizationPhase<'db> {
     },
 }
 
-impl<'db> OptimizationPhase<'db> {
-    /// Applies the optimization phase to the lowering.
+/// Trait for application of an optimization phase or strategy on a lowered function.
+pub trait ApplyOptimization<'db> {
+    /// Applies the optimization to the lowering.
     ///
     /// Assumes `lowered` is a lowering of `function`.
-    pub fn apply(
+    fn apply(
+        &self,
+        db: &'db dyn Database,
+        function: ConcreteFunctionWithBodyId<'db>,
+        lowered: &mut Lowered<'db>,
+    ) -> Maybe<()>;
+}
+
+impl<'db> ApplyOptimization<'db> for OptimizationPhase<'db> {
+    fn apply(
         &self,
         db: &'db dyn Database,
         function: ConcreteFunctionWithBodyId<'db>,
@@ -104,12 +114,12 @@ impl<'db> OptimizationPhase<'db> {
             OptimizationPhase::SubStrategy { strategy, iterations } => {
                 for _ in 1..*iterations {
                     let before = lowered.clone();
-                    strategy.apply_strategy(db, function, lowered)?;
+                    strategy.apply(db, function, lowered)?;
                     if *lowered == before {
                         return Ok(());
                     }
                 }
-                strategy.apply_strategy(db, function, lowered)?
+                strategy.apply(db, function, lowered)?
             }
         }
         Ok(())
@@ -122,21 +132,31 @@ define_short_id!(OptimizationStrategyId, OptimizationStrategy<'db>);
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update, HeapSize)]
 pub struct OptimizationStrategy<'db>(pub Vec<OptimizationPhase<'db>>);
 
-impl<'db> OptimizationStrategyId<'db> {
-    /// Applies the optimization strategy phase to the lowering.
-    ///
-    /// Assumes `lowered` is a lowering of `function`.
-    pub fn apply_strategy(
-        self,
+impl<'db> ApplyOptimization<'db> for [OptimizationPhase<'db>] {
+    fn apply(
+        &self,
         db: &'db dyn Database,
         function: ConcreteFunctionWithBodyId<'db>,
         lowered: &mut Lowered<'db>,
     ) -> Maybe<()> {
-        for phase in &self.long(db).0 {
+        for phase in self {
             phase.apply(db, function, lowered)?;
         }
-
         Ok(())
+    }
+}
+
+impl<'db> ApplyOptimization<'db> for OptimizationStrategyId<'db> {
+    /// Applies the optimization strategy phase to the lowering.
+    ///
+    /// Assumes `lowered` is a lowering of `function`.
+    fn apply(
+        &self,
+        db: &'db dyn Database,
+        function: ConcreteFunctionWithBodyId<'db>,
+        lowered: &mut Lowered<'db>,
+    ) -> Maybe<()> {
+        self.long(db).0.apply(db, function, lowered)
     }
 }
 

--- a/crates/cairo-lang-lowering/src/optimizations/trim_unreachable_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/trim_unreachable_test.rs
@@ -7,7 +7,7 @@ use crate::LoweringStage;
 use crate::db::LoweringGroup;
 use crate::fmt::LoweredFormatter;
 use crate::ids::ConcreteFunctionWithBodyId;
-use crate::optimizations::strategy::OptimizationPhase;
+use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(


### PR DESCRIPTION
## Summary

Introduces a new `ApplyOptimization` trait to unify the interface for applying optimization phases and strategies to lowered functions. This trait is implemented for `OptimizationPhase`, `OptimizationStrategyId`, and slices of optimization phases, allowing for more flexible and consistent optimization application patterns.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The existing optimization system had inconsistent interfaces for applying optimizations. Individual optimization phases used an `apply` method, while optimization strategies used `apply_strategy`. This inconsistency made it difficult to work with different types of optimizations uniformly and required different calling patterns depending on the optimization type.

---

## What was the behavior or documentation before?

Before this change:
- `OptimizationPhase` had an `apply` method
- `OptimizationStrategyId` had an `apply_strategy` method  
- Multiple optimization phases had to be applied individually with separate method calls
- Test code contained repetitive chains of individual `apply` calls

---

## What is the behavior or documentation after?

After this change:
- All optimization types implement the unified `ApplyOptimization` trait with a single `apply` method
- Arrays of optimization phases can be applied as a single operation using the trait
- Test code can use more concise array syntax to apply multiple optimizations
- The interface is consistent across all optimization types

---

## Related issue or discussion (if any)

None specified.

---

## Additional context

This refactoring significantly simplifies test code by allowing arrays of optimization phases to be applied in a single call, replacing verbose chains of individual method calls. The trait-based approach also provides better extensibility for future optimization types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lowering/optimization plumbing by changing how optimization strategies/phases are invoked; while intended as a mechanical refactor, mistakes could alter optimization ordering/execution and thus final IR output.
> 
> **Overview**
> Introduces a new `ApplyOptimization` trait to standardize how optimization phases and strategies are applied, replacing the previous `OptimizationStrategyId::apply_strategy` API with a single `apply` entrypoint.
> 
> Updates the lowering pipeline (`LoweringStage::PostBaseline`/`Final`) and the `get-lowering` debug tool to use the new trait-based `apply`, and refactors multiple lowering/optimization tests to apply sequences of `OptimizationPhase` via slice/array `.apply(...)` instead of repeated individual calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441ff848f1c103f77369d84e27f9c16919c47305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->