### PR TITLE
docs: fix negation trait module paths

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/negation-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/negation-operators.adoc
@@ -103,9 +103,9 @@ appropriate trait:
 [cols="1,2,2,2",options="header"]
 |===
 | Symbol | Operation   | Accepted types             | Overloading trait
-| `-`    | Arithmetic negation | `felt252`, `i*` family     | `core::ops::Neg`
-| `!`    | Logical NOT | `bool`                     | `core::ops::Not`
-| `~`    | Bitwise NOT | Integer types              | `core::ops::BitNot`
+| `-`    | Arithmetic negation | `felt252`, `i*` family     | `core::traits::Neg`
+| `!`    | Logical NOT | `bool`                     | `core::traits::Not`
+| `~`    | Bitwise NOT | Integer types              | `core::traits::BitNot`
 |===
 
 == Related


### PR DESCRIPTION
This updates the negation overloading table to use `core::traits::{Neg, Not, BitNot}`, aligning the reference text with the actual corelib trait definitions.