### PR TITLE
feat: emit E1031 diagnostic for macro repetition group missing operator

### DIFF
--- a/crates/cairo-lang-parser/src/diagnostic.rs
+++ b/crates/cairo-lang-parser/src/diagnostic.rs
@@ -127,6 +127,7 @@ pub enum ParserDiagnosticKind {
     ConsecutiveMathOperators { first_op: SyntaxKind, second_op: SyntaxKind },
     ExpectedSemicolonOrBody,
     LowPrecedenceOperatorInIfLet { op: SyntaxKind },
+    MissingMacroRepetitionOperator,
 }
 
 impl<'a> DiagnosticEntry<'a> for ParserDiagnostic<'a> {
@@ -239,6 +240,10 @@ Did you mean to write `{identifier}!{left}...{right}'?",
                     self.kind_to_string(*op)
                 )
             }
+            ParserDiagnosticKind::MissingMacroRepetitionOperator => {
+                "Missing macro repetition operator. Expected `?`, `+`, or `*` after `$(...)`."
+                    .to_string()
+            }
         }
     }
 
@@ -279,6 +284,7 @@ Did you mean to write `{identifier}!{left}...{right}'?",
             ParserDiagnosticKind::ConsecutiveMathOperators { .. } => error_code!(E1028),
             ParserDiagnosticKind::ExpectedSemicolonOrBody => error_code!(E1029),
             ParserDiagnosticKind::LowPrecedenceOperatorInIfLet { .. } => error_code!(E1030),
+            ParserDiagnosticKind::MissingMacroRepetitionOperator => error_code!(E1031),
         })
     }
 

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -795,7 +795,9 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                             }
                             SyntaxKind::TerminalPlus => self.take::<TerminalPlus<'_>>().into(),
                             SyntaxKind::TerminalMul => self.take::<TerminalMul<'_>>().into(),
-                            _ => MacroRepetitionOperator::missing(self.db),
+                            _ => self.create_and_report_missing::<MacroRepetitionOperator<'_>>(
+                                ParserDiagnosticKind::MissingMacroRepetitionOperator,
+                            ),
                         };
                         Ok(MacroRepetition::new_green(
                             self.db, dollar, lparen, elements, rparen, separator, operator,

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/macro_declaration
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/macro_declaration
@@ -252,3 +252,76 @@ error[E1008]: Missing tokens. Expected a macro rule parameter kind.
     │       │       └── semicolon (kind: TokenSemicolon): ';'
     │       └── rbrace (kind: TokenRBrace): '}'
     └── eof (kind: TokenEndOfFile).
+
+//! > ==========================================================================
+
+//! > Test macro definition with repetition missing operator.
+
+//! > test_runner_name
+test_partial_parser_tree(expect_diagnostics: true)
+
+//! > cairo_code
+macro macro_name {
+    ($($x:expr)) => {
+        $($x)*
+    };
+}
+
+//! > top_level_kind
+
+//! > ignored_kinds
+
+//! > expected_diagnostics
+error[E1031]: Missing macro repetition operator. Expected `?`, `+`, or `*` after `$(...)`.
+ --> dummy_file.cairo:2:16
+    ($($x:expr)) => {
+               ^
+
+//! > expected_tree
+└── root (kind: SyntaxFile)
+    ├── items (kind: ModuleItemList)
+    │   └── child #0 (kind: ItemMacroDeclaration)
+    │       ├── attributes (kind: AttributeList) []
+    │       ├── visibility (kind: VisibilityDefault) []
+    │       ├── macro_kw (kind: TokenMacro): 'macro'
+    │       ├── name (kind: TokenIdentifier): 'macro_name'
+    │       ├── lbrace (kind: TokenLBrace): '{'
+    │       ├── rules (kind: MacroRulesList)
+    │       │   └── child #0 (kind: MacroRule)
+    │       │       ├── lhs (kind: ParenthesizedMacro)
+    │       │       │   ├── lparen (kind: TokenLParen): '('
+    │       │       │   ├── elements (kind: MacroElements)
+    │       │       │   │   └── child #0 (kind: MacroRepetition)
+    │       │       │   │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       ├── lparen (kind: TokenLParen): '('
+    │       │       │   │       ├── elements (kind: MacroElements)
+    │       │       │   │       │   └── child #0 (kind: MacroParam)
+    │       │       │   │       │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       │       ├── name (kind: TokenIdentifier): 'x'
+    │       │       │   │       │       └── kind (kind: ParamKind)
+    │       │       │   │       │           ├── colon (kind: TokenColon): ':'
+    │       │       │   │       │           └── kind (kind: ParamExpr)
+    │       │       │   │       │               └── expr (kind: TokenIdentifier): 'expr'
+    │       │       │   │       ├── rparen (kind: TokenRParen): ')'
+    │       │       │   │       ├── separator (kind: OptionTerminalCommaEmpty) []
+    │       │       │   │       └── operator: Missing []
+    │       │       │   └── rparen (kind: TokenRParen): ')'
+    │       │       ├── fat_arrow (kind: TokenMatchArrow): '=>'
+    │       │       ├── rhs (kind: BracedMacro)
+    │       │       │   ├── lbrace (kind: TokenLBrace): '{'
+    │       │       │   ├── elements (kind: MacroElements)
+    │       │       │   │   └── child #0 (kind: MacroRepetition)
+    │       │       │   │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       ├── lparen (kind: TokenLParen): '('
+    │       │       │   │       ├── elements (kind: MacroElements)
+    │       │       │   │       │   └── child #0 (kind: MacroParam)
+    │       │       │   │       │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       │       ├── name (kind: TokenIdentifier): 'x'
+    │       │       │   │       │       └── kind (kind: OptionParamKindEmpty) []
+    │       │       │   │       ├── rparen (kind: TokenRParen): ')'
+    │       │       │   │       ├── separator (kind: OptionTerminalCommaEmpty) []
+    │       │       │   │       └── operator (kind: TokenMul): '*'
+    │       │       │   └── rbrace (kind: TokenRBrace): '}'
+    │       │       └── semicolon (kind: TokenSemicolon): ';'
+    │       └── rbrace (kind: TokenRBrace): '}'
+    └── eof (kind: TokenEndOfFile).


### PR DESCRIPTION
## Summary

Added a new parser diagnostic for missing macro repetition operators in Cairo macro definitions. When a macro repetition pattern `$(...)` is not followed by a required operator (`?`, `+`, or `*`), the parser now reports error E1031 with a clear message explaining the expected syntax.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, when a macro repetition pattern `$(...)` was missing its required repetition operator, the parser would silently create a missing node without providing any diagnostic feedback to the user. This left developers without clear guidance on what syntax was expected, making macro debugging difficult.

---

## What was the behavior or documentation before?

The parser would silently handle missing macro repetition operators by creating a missing AST node, providing no error message or guidance to the developer about the required syntax.

---

## What is the behavior or documentation after?

The parser now emits error E1031 with the message "Missing macro repetition operator. Expected `?`, `+`, or `*` after `$(...)`." when a macro repetition pattern lacks the required operator, clearly indicating what syntax is needed.

---

## Related issue or discussion (if any)

---

## Additional context

This change improves the developer experience when writing Cairo macros by providing clear, actionable error messages for a common syntax error. The diagnostic follows the existing error code numbering scheme (E1031) and includes comprehensive test coverage.