### PR TITLE
refactor: propagate parent_macro_call_data through all macro call error paths

### DIFF
--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -54,7 +54,6 @@ fn priv_macro_call_data<'db>(
     {
         let (content, mapping) = expose_content_and_mapping(db, macro_call_syntax.arguments(db))?;
         let code_mappings: Arc<[CodeMapping]> = [mapping].into();
-        let parent_macro_call_data = resolver.macro_call_data;
         let generated_file_id = FileLongId::Virtual(VirtualFile {
             parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),
             name: macro_name,
@@ -73,7 +72,7 @@ fn priv_macro_call_data<'db>(
             defsite_module_id: callsite_module_id,
             callsite_module_id,
             expansion_mappings: code_mappings,
-            parent_macro_call_data,
+            parent_macro_call_data: resolver.macro_call_data,
         });
     }
     let mut diagnostics = SemanticDiagnostics::new(callsite_module_id);
@@ -95,7 +94,7 @@ fn priv_macro_call_data<'db>(
                 defsite_module_id: callsite_module_id,
                 callsite_module_id,
                 expansion_mappings: Arc::new([]),
-                parent_macro_call_data: None,
+                parent_macro_call_data: resolver.macro_call_data,
             });
         }
         Err(diag_added) => {
@@ -105,11 +104,12 @@ fn priv_macro_call_data<'db>(
                 defsite_module_id: callsite_module_id,
                 callsite_module_id,
                 expansion_mappings: Arc::new([]),
-                parent_macro_call_data: None,
+                parent_macro_call_data: resolver.macro_call_data,
             });
         }
     };
     let defsite_module_id = macro_declaration_id.parent_module(db);
+    let parent_macro_call_data = resolver.macro_call_data;
     let macro_rules = match db.macro_declaration_rules(macro_declaration_id) {
         Ok(rules) => rules,
         Err(diag_added) => {
@@ -119,7 +119,7 @@ fn priv_macro_call_data<'db>(
                 defsite_module_id,
                 callsite_module_id,
                 expansion_mappings: Arc::new([]),
-                parent_macro_call_data: None,
+                parent_macro_call_data,
             });
         }
     };
@@ -136,12 +136,11 @@ fn priv_macro_call_data<'db>(
             defsite_module_id,
             callsite_module_id,
             expansion_mappings: Arc::new([]),
-            parent_macro_call_data: None,
+            parent_macro_call_data,
         });
     };
     let mut matcher_ctx = MatcherContext { captures, placeholder_to_rep_id, ..Default::default() };
     let expanded_code = expand_macro_rule(db, rule, &mut matcher_ctx).unwrap();
-    let parent_macro_call_data = resolver.macro_call_data;
     let generated_file_id = FileLongId::Virtual(VirtualFile {
         parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),
         name: macro_name,


### PR DESCRIPTION
## Summary

Refactored macro call data handling to consistently use `resolver.macro_call_data` for parent macro call tracking instead of mixing direct assignment with `None` values and redundant variable declarations.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The code was inconsistently handling parent macro call data, sometimes setting it to `None` and sometimes using `resolver.macro_call_data`. This inconsistency could lead to incorrect macro expansion context tracking, where nested macro calls might lose their parent context information.

---

## What was the behavior or documentation before?

Parent macro call data was inconsistently assigned - some code paths set `parent_macro_call_data` to `None` while others used `resolver.macro_call_data`. There were also redundant variable declarations where `parent_macro_call_data` was assigned from `resolver.macro_call_data` but not used consistently.

---

## What is the behavior or documentation after?

All macro call data structures now consistently use `resolver.macro_call_data` for the `parent_macro_call_data` field, ensuring proper parent-child relationships are maintained throughout macro expansion chains. Redundant variable declarations have been removed or moved to appropriate locations.

---

## Related issue or discussion (if any)

---

## Additional context

This change ensures that macro expansion context is properly preserved across nested macro calls, which is important for correct error reporting and debugging information in the Cairo language compiler.