### PR TITLE
feat: add per-rule err field to MacroRuleData, skip expansion on broken rules

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -794,6 +794,9 @@ fn expand_inline_macro<'db>(
                 InlineMacroNoMatchingRule(macro_path.identifier(db)),
             ));
         };
+        // If the rule has declaration-time errors, skip expansion to avoid panics on malformed
+        // rules.
+        rule.err?;
         let mut matcher_ctx =
             MatcherContext { captures, placeholder_to_rep_id, ..Default::default() };
         let expanded_code = expand_macro_rule(ctx.db, rule, &mut matcher_ctx)?;

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -139,6 +139,17 @@ fn priv_macro_call_data<'db>(
             parent_macro_call_data,
         });
     };
+    // If the rule has declaration-time errors, skip expansion to avoid panics on malformed rules.
+    if let Err(diag_added) = rule.err {
+        return Ok(MacroCallData {
+            macro_call_module: Err(diag_added),
+            diagnostics: diagnostics.build(),
+            defsite_module_id,
+            callsite_module_id,
+            expansion_mappings: Arc::new([]),
+            parent_macro_call_data,
+        });
+    }
     let mut matcher_ctx = MatcherContext { captures, placeholder_to_rep_id, ..Default::default() };
     let expanded_code = expand_macro_rule(db, rule, &mut matcher_ctx).unwrap();
     let generated_file_id = FileLongId::Virtual(VirtualFile {

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -76,6 +76,9 @@ pub struct MacroDeclarationData<'db> {
 pub struct MacroRuleData<'db> {
     pub pattern: ast::WrappedMacro<'db>,
     pub expansion: ast::MacroElements<'db>,
+    /// Set to `Err` when this rule has semantic errors (e.g., undefined placeholders).
+    /// Callers must skip expansion when this is `Err`.
+    pub err: Maybe<()>,
 }
 
 /// The possible kinds of placeholders in a macro rule.
@@ -157,16 +160,18 @@ fn priv_macro_declaration_data<'db>(
             }));
 
         let used_placeholders = collect_expansion_placeholders(db, expansion.as_syntax_node());
-        // Verify all used placeholders are defined
+        // Verify all used placeholders are defined. Track whether any error was reported so
+        // callers can skip expansion of broken rules.
+        let mut rule_err: Maybe<()> = Ok(());
         for (placeholder_ptr, used_placeholder) in used_placeholders {
             if !defined_placeholders.contains(&used_placeholder) {
-                diagnostics.report(
+                rule_err = Err(diagnostics.report(
                     placeholder_ptr,
                     SemanticDiagnosticKind::UndefinedMacroPlaceholder(used_placeholder),
-                );
+                ));
             }
         }
-        rules.push(MacroRuleData { pattern, expansion });
+        rules.push(MacroRuleData { pattern, expansion, err: rule_err });
     }
     let resolver_data = Arc::new(resolver.data);
     Ok(MacroDeclarationData { diagnostics: diagnostics.build(), attributes, resolver_data, rules })


### PR DESCRIPTION
## Summary

Added error tracking to macro rules to prevent panics during expansion when rules contain declaration-time errors such as undefined placeholders. The system now skips expansion of malformed macro rules instead of attempting to process them.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Macro rules with semantic errors (like undefined placeholders) were causing panics during expansion because the system attempted to process malformed rules. This created crashes instead of graceful error handling when developers made mistakes in macro definitions.

---

## What was the behavior or documentation before?

When a macro rule contained declaration-time errors such as undefined placeholders, the expansion process would panic when trying to process the malformed rule, leading to compiler crashes.

---

## What is the behavior or documentation after?

Macro rules with declaration-time errors are now tracked with an error flag. When expansion is attempted on these rules, the system detects the error condition and skips expansion gracefully, returning appropriate error diagnostics instead of panicking.

---

## Related issue or discussion (if any)

---

## Additional context

The fix adds an `err` field to `MacroRuleData` that tracks whether the rule has semantic errors. Both inline macro expansion and macro call processing now check this field before attempting expansion, ensuring robust error handling throughout the macro system.