### PR TITLE
feat(orizi): Add no-progress guard to macro repetition matching.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -2360,3 +2360,63 @@ error[E2156]: Inline macro `not::a::path::format` not found.
  --> lib.cairo:2:5
     not::a::path::format!("");
     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test macro with empty inner repetition body (would loop infinitely without no-progress guard).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > crate_settings
+edition = "2024_07"
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = true
+
+//! > function_code
+fn foo() {
+    test_macro!();
+}
+
+//! > function_name
+foo
+
+//! > module_code
+macro test_macro {
+    ($()*) => { 1 };
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test macro with repetition over empty subtrees (would fail to match without the subtree progress fix).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > crate_settings
+edition = "2024_07"
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = true
+
+//! > function_code
+fn foo() {
+    test_macro!(() ());
+}
+
+//! > function_name
+foo
+
+//! > module_code
+macro test_macro {
+    ($(())*) => { 1 };
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -267,6 +267,9 @@ pub fn is_macro_rule_match<'db>(
 /// Helper function for [expand_macro_rule].
 /// Traverses the macro expansion and replaces the placeholders with the provided values,
 /// while collecting the result in `res_buffer`.
+/// Returns `Some(true)` if the match succeeded and some input was consumed,
+/// `Some(false)` if the match succeeded but no input was consumed (empty match),
+/// and `None` if the match failed.
 fn is_macro_rule_match_ex<'db>(
     db: &'db dyn Database,
     matcher_elements: ast::MacroElements<'db>,
@@ -275,10 +278,12 @@ fn is_macro_rule_match_ex<'db>(
     >,
     ctx: &mut MatcherContext<'db>,
     consume_all_input: bool,
-) -> Option<()> {
+) -> Option<bool> {
+    let mut advanced = false;
     for matcher_element in matcher_elements.elements(db) {
         match matcher_element {
             ast::MacroElement::Token(matcher_token) => {
+                advanced = true;
                 let input_token = input_iter.next()?;
                 match input_token {
                     ast::TokenTree::Token(token_tree_leaf) => {
@@ -296,6 +301,7 @@ fn is_macro_rule_match_ex<'db>(
                 }
             }
             ast::MacroElement::Param(param) => {
+                advanced = true;
                 let placeholder_kind: PlaceholderKind =
                     if let ast::OptionParamKind::ParamKind(param_kind) = param.kind(db) {
                         param_kind.kind(db).into()
@@ -370,6 +376,7 @@ fn is_macro_rule_match_ex<'db>(
                 }
             }
             ast::MacroElement::Subtree(matcher_subtree) => {
+                advanced = true;
                 let input_token = input_iter.next()?;
                 if let ast::TokenTree::Subtree(input_subtree) = input_token {
                     let inner_elements = get_macro_elements(db, matcher_subtree.subtree(db));
@@ -404,17 +411,16 @@ fn is_macro_rule_match_ex<'db>(
                 loop {
                     let mut inner_ctx = ctx.clone();
                     let mut temp_iter = input_iter.clone();
-                    if is_macro_rule_match_ex(
+                    let Some(true) = is_macro_rule_match_ex(
                         db,
                         elements.clone(),
                         &mut temp_iter,
                         &mut inner_ctx,
                         false,
-                    )
-                    .is_none()
-                    {
+                    ) else {
                         break;
-                    }
+                    };
+                    advanced = true;
                     *ctx = inner_ctx;
                     *input_iter = temp_iter;
                     match_count += 1;
@@ -449,7 +455,7 @@ fn is_macro_rule_match_ex<'db>(
     if consume_all_input && input_iter.next().is_some() {
         return None;
     }
-    Some(())
+    Some(advanced)
 }
 
 fn validate_repetition_operator_constraints(ctx: &MatcherContext<'_>) -> bool {


### PR DESCRIPTION
## Summary

Fixed infinite loop vulnerability in macro expansion by adding a progress guard that tracks whether input is consumed during repetition matching. The fix prevents macros with empty repetition bodies (like `$()*`) from looping indefinitely by ensuring each iteration consumes at least one token.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Macros with empty repetition bodies would cause infinite loops during expansion. For example, a macro pattern like `$()*` would match zero tokens repeatedly without making progress, causing the compiler to hang indefinitely.

---

## What was the behavior or documentation before?

The macro matcher would loop infinitely when encountering repetition patterns that could match zero tokens, as there was no mechanism to detect when no progress was being made during matching.

---

## What is the behavior or documentation after?

The macro matcher now tracks whether input tokens are consumed during each iteration of repetition matching. If a repetition iteration succeeds but consumes no input, the loop terminates, preventing infinite loops while still allowing valid empty matches.

---

## Related issue or discussion (if any)

---

## Additional context

The fix modifies the return type of `is_macro_rule_match_ex` to return `Option<bool>` where the boolean indicates whether input was consumed. A test case was added to verify that macros with empty repetition bodies no longer cause infinite loops.