### PR TITLE
feat(orizi): Added macro declaration time diagnostics.

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1175,6 +1175,22 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::UndefinedMacroPlaceholder(name) => {
                 format!("Undefined macro placeholder: '{}'.", name.long(db))
             }
+            SemanticDiagnosticKind::MacroPlaceholderRepDepthMismatch { name, required, actual } => {
+                format!(
+                    "Macro placeholder '{}' requires {} repetition level(s) in the expansion, but \
+                     is used at level {}.",
+                    name.long(db),
+                    required,
+                    actual
+                )
+            }
+            SemanticDiagnosticKind::MacroPlaceholderRepDriverMismatch(name) => {
+                format!(
+                    "Macro placeholder '{}' is from a different repetition than the one driving \
+                     this expansion block.",
+                    name.long(db)
+                )
+            }
             SemanticDiagnosticKind::UserDefinedInlineMacrosDisabled => {
                 "User defined inline macros are disabled in the current crate.".into()
             }
@@ -1446,6 +1462,8 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::TypeConstraintsSyntaxNotEnabled => error_code!(E2191),
             SemanticDiagnosticKind::PatternMissingArgs(_) => error_code!(E2192),
             SemanticDiagnosticKind::UndefinedMacroPlaceholder(_) => error_code!(E2193),
+            SemanticDiagnosticKind::MacroPlaceholderRepDepthMismatch { .. } => error_code!(E2198),
+            SemanticDiagnosticKind::MacroPlaceholderRepDriverMismatch(_) => error_code!(E2199),
             SemanticDiagnosticKind::UserDefinedInlineMacrosDisabled => error_code!(E2194),
             SemanticDiagnosticKind::NonNeverLetElseType => error_code!(E2195),
             SemanticDiagnosticKind::OnlyTypeOrConstParamsInNegImpl => error_code!(E2196),
@@ -1863,6 +1881,12 @@ pub enum SemanticDiagnosticKind<'db> {
     TypeConstraintsSyntaxNotEnabled,
     PatternMissingArgs(ast::ExprPath<'db>),
     UndefinedMacroPlaceholder(SmolStrId<'db>),
+    MacroPlaceholderRepDepthMismatch {
+        name: SmolStrId<'db>,
+        required: usize,
+        actual: usize,
+    },
+    MacroPlaceholderRepDriverMismatch(SmolStrId<'db>),
     UserDefinedInlineMacrosDisabled,
     NonNeverLetElseType,
     OnlyTypeOrConstParamsInNegImpl,

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -2420,3 +2420,121 @@ macro test_macro {
 }
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test repetition placeholder used outside repetition in expansion.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    m!();
+}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($($x:expr),*) => { $x };
+}
+
+//! > expected_diagnostics
+error[E2198]: Macro placeholder 'x' requires 1 repetition level(s) in the expansion, but is used at level 0.
+ --> lib.cairo:2:25
+    ($($x:expr),*) => { $x };
+                        ^^
+
+//! > ==========================================================================
+
+//! > Test rep placeholder used inside a nested repetition in expansion (valid).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {
+    m!(1, 2, 3);
+}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($($x:expr),*) => { $($x)* };
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test depth-0 placeholder used inside a repetition driven by a depth-1 var (valid).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {
+    m!(1 + 2, 3, 4);
+}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($x:expr, $($y:expr),*) => { $($x + $y),* };
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test cross-repetition placeholder mixing in expansion (E2199).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($($x:expr),* ; $($y:expr),*) => { $($x + $y),* };
+}
+
+//! > expected_diagnostics
+error[E2199]: Macro placeholder 'y' is from a different repetition than the one driving this expansion block.
+ --> lib.cairo:2:47
+    ($($x:expr),* ; $($y:expr),*) => { $($x + $y),* };
+                                              ^^
+
+//! > ==========================================================================
+
+//! > Test cross-repetition placeholder mixing with mismatched outer context (prefix check).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($($x:expr),* ; $($($y:expr),*),*) => { $($($x + $y),*),* };
+}
+
+//! > expected_diagnostics
+error[E2199]: Macro placeholder 'y' is from a different repetition than the one driving this expansion block.
+ --> lib.cairo:2:54
+    ($($x:expr),* ; $($($y:expr),*),*) => { $($($x + $y),*),* };
+                                                     ^^

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -15,7 +15,6 @@ use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use salsa::Database;
 
 use crate::SemanticDiagnostic;
@@ -136,42 +135,28 @@ fn priv_macro_declaration_data<'db>(
         let pattern = rule_syntax.lhs(db);
         let expansion = rule_syntax.rhs(db).elements(db);
         let pattern_elements = get_macro_elements(db, pattern.clone());
-        // Collect defined placeholders from pattern
-        let defined_placeholders =
-            OrderedHashSet::<_>::from_iter(pattern_elements.elements(db).filter_map(|element| {
-                match element {
-                    ast::MacroElement::Param(param) => {
-                        Some(param.name(db).as_syntax_node().get_text_without_trivia(db))
-                    }
-                    ast::MacroElement::Repetition(repetition) => repetition
-                        .elements(db)
-                        .elements(db)
-                        .filter_map(|inner_element| match inner_element {
-                            ast::MacroElement::Param(inner_param) => Some(
-                                inner_param.name(db).as_syntax_node().get_text_without_trivia(db),
-                            ),
-                            _ => None,
-                        })
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .next(),
-                    _ => None,
-                }
-            }));
+        // Collect the repetition path (outermost-to-innermost pattern rep IDs) for every
+        // placeholder defined in the pattern.
+        let mut placeholder_paths: OrderedHashMap<SmolStrId<'db>, Vec<usize>> = Default::default();
+        let mut next_rep_id = 0;
+        collect_placeholder_paths(
+            db,
+            pattern_elements.elements(db),
+            &mut vec![],
+            &mut next_rep_id,
+            &mut placeholder_paths,
+        );
 
-        let used_placeholders = collect_expansion_placeholders(db, expansion.as_syntax_node());
-        // Verify all used placeholders are defined. Track whether any error was reported so
-        // callers can skip expansion of broken rules.
-        let mut rule_err: Maybe<()> = Ok(());
-        for (placeholder_ptr, used_placeholder) in used_placeholders {
-            if !defined_placeholders.contains(&used_placeholder) {
-                rule_err = Err(diagnostics.report(
-                    placeholder_ptr,
-                    SemanticDiagnosticKind::UndefinedMacroPlaceholder(used_placeholder),
-                ));
-            }
-        }
-        rules.push(MacroRuleData { pattern, expansion, err: rule_err });
+        let mut ctx = ExpansionCheckCtx {
+            db,
+            known_path: &[],
+            curr_rep_depth: 0,
+            placeholder_paths: &placeholder_paths,
+            diagnostics: &mut diagnostics,
+            rule_err: Ok(()),
+        };
+        ctx.check_node(expansion.as_syntax_node());
+        rules.push(MacroRuleData { pattern, expansion, err: ctx.rule_err });
     }
     let resolver_data = Arc::new(resolver.data);
     Ok(MacroDeclarationData { diagnostics: diagnostics.build(), attributes, resolver_data, rules })
@@ -211,32 +196,121 @@ fn extract_placeholder<'db>(
     None
 }
 
-/// Helper function to collect all placeholder names used in a macro expansion.
-fn collect_expansion_placeholders<'db>(
+/// Assigns a unique ID to every `$()` repetition block in the pattern (left-to-right DFS order)
+/// and records, for each placeholder, its path: the ordered list of ancestor repetition IDs from
+/// outermost to innermost. The resulting map is used by [`ExpansionCheckCtx`] to validate the
+/// expansion.
+fn collect_placeholder_paths<'db>(
     db: &'db dyn Database,
-    node: SyntaxNode<'db>,
-) -> Vec<(SyntaxStablePtrId<'db>, SmolStrId<'db>)> {
-    let mut placeholders = Vec::new();
-    if node.kind(db) == SyntaxKind::MacroParam {
-        let path_node = MacroParam::from_syntax_node(db, node);
-        if let Some(placeholder_name) = extract_placeholder(db, &path_node) {
-            placeholders.push((path_node.stable_ptr(db).untyped(), placeholder_name));
-            return placeholders;
+    elements: impl IntoIterator<Item = ast::MacroElement<'db>>,
+    current_path: &mut Vec<usize>,
+    next_rep_id: &mut usize,
+    result: &mut OrderedHashMap<SmolStrId<'db>, Vec<usize>>,
+) {
+    for element in elements {
+        match element {
+            ast::MacroElement::Param(param) => {
+                result.insert(
+                    param.name(db).as_syntax_node().get_text_without_trivia(db),
+                    current_path.clone(),
+                );
+            }
+            ast::MacroElement::Repetition(rep) => {
+                let rep_id = *next_rep_id;
+                *next_rep_id += 1;
+                current_path.push(rep_id);
+                let inner = rep.elements(db).elements(db);
+                collect_placeholder_paths(db, inner, current_path, next_rep_id, result);
+                assert_eq!(current_path.pop(), Some(rep_id));
+            }
+            ast::MacroElement::Subtree(subtree) => {
+                let inner = get_macro_elements(db, subtree.subtree(db)).elements(db);
+                collect_placeholder_paths(db, inner, current_path, next_rep_id, result);
+            }
+            ast::MacroElement::Token(_) => {}
         }
     }
-    if node.kind(db) == SyntaxKind::MacroRepetition {
-        let repetition = ast::MacroRepetition::from_syntax_node(db, node);
-        for element in repetition.elements(db).elements(db) {
-            placeholders.extend(collect_expansion_placeholders(db, element.as_syntax_node()));
+}
+
+/// Context for validating placeholder usage in a macro rule's expansion.
+struct ExpansionCheckCtx<'db, 'a> {
+    db: &'db dyn Database,
+    /// Maps each placeholder name to its pattern path: the sequence of repetition IDs
+    /// (outermost to innermost) of the `$()` blocks it is nested in within the pattern.
+    placeholder_paths: &'a OrderedHashMap<SmolStrId<'db>, Vec<usize>>,
+    /// Number of `$()` expansion blocks currently entered. Used for E2198 depth checks
+    /// and to trim `known_path` when exiting a block.
+    curr_rep_depth: usize,
+    /// The deepest placeholder path seen so far within the current expansion scope.
+    /// New placeholders at the same depth are validated against this prefix (E2199).
+    /// Invariant: `known_path.len() <= curr_rep_depth`.
+    /// Trimmed to `curr_rep_depth` on `$()` exit so sibling blocks start fresh.
+    known_path: &'a [usize],
+    diagnostics: &'a mut SemanticDiagnostics<'db>,
+    /// `Err` if any diagnostic has been emitted; callers skip expansion when set.
+    rule_err: Maybe<()>,
+}
+
+impl<'db> ExpansionCheckCtx<'db, '_> {
+    /// Validates placeholder usage by recursively traversing `node`.
+    ///
+    /// Two kinds of errors are reported:
+    /// * Depth mismatch (E2198): placeholder used at fewer expansion levels than its pattern depth.
+    /// * Context mismatch (E2199): placeholder from a different repetition than the driving one.
+    fn check_node(&mut self, node: SyntaxNode<'db>) {
+        let db = self.db;
+        if let Some(param) = MacroParam::cast(db, node) {
+            if let Some(name) = extract_placeholder(db, &param) {
+                let ptr = param.stable_ptr(db).untyped();
+                match self.placeholder_paths.get(&name) {
+                    None => {
+                        self.rule_err = Err(self
+                            .diagnostics
+                            .report(ptr, SemanticDiagnosticKind::UndefinedMacroPlaceholder(name)));
+                    }
+                    Some(path) => {
+                        if path.len() > self.curr_rep_depth {
+                            self.rule_err = Err(self.diagnostics.report(
+                                ptr,
+                                SemanticDiagnosticKind::MacroPlaceholderRepDepthMismatch {
+                                    name,
+                                    required: path.len(),
+                                    actual: self.curr_rep_depth,
+                                },
+                            ));
+                        } else {
+                            let cmp_size = path.len().min(self.known_path.len());
+                            if path[..cmp_size] != self.known_path[..cmp_size] {
+                                self.rule_err = Err(self.diagnostics.report(
+                                    ptr,
+                                    SemanticDiagnosticKind::MacroPlaceholderRepDriverMismatch(name),
+                                ));
+                            } else if path.len() > self.known_path.len() {
+                                self.known_path = path;
+                            }
+                        }
+                    }
+                }
+            }
+            return;
         }
-        return placeholders;
-    }
-    if !node.kind(db).is_terminal() {
-        for child in node.get_children(db).iter() {
-            placeholders.extend(collect_expansion_placeholders(db, *child));
+
+        if let Some(repetition) = ast::MacroRepetition::cast(db, node) {
+            self.curr_rep_depth += 1;
+            for element in repetition.elements(db).elements(db) {
+                self.check_node(element.as_syntax_node());
+            }
+            self.curr_rep_depth -= 1;
+            if self.curr_rep_depth < self.known_path.len() {
+                // Trimming `self.known_path` so it won't leak between different repetitions.
+                self.known_path = &self.known_path[..self.curr_rep_depth];
+            }
+        } else if !node.kind(db).is_terminal() {
+            for child in node.get_children(db).iter() {
+                self.check_node(*child);
+            }
         }
     }
-    placeholders
 }
 
 /// Given a macro declaration and an input token tree, checks if the input the given rule, and


### PR DESCRIPTION
## Summary

Adds validation for macro placeholder usage in expansion patterns, introducing two new error types: E2198 for depth mismatches when placeholders are used at incorrect repetition levels, and E2199 for cross-repetition placeholder mixing where placeholders from different repetitions are used together.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The macro system was not properly validating placeholder usage in expansion patterns, allowing invalid macro definitions that could lead to incorrect expansions or runtime errors. Specifically, it wasn't catching cases where:
1. Placeholders from repetition patterns were used outside their required repetition context
2. Placeholders from different repetition blocks were mixed together in the same expansion

---

## What was the behavior or documentation before?

The macro system only checked if placeholders used in expansions were defined somewhere in the pattern, but didn't validate the repetition context or nesting depth requirements.

---

## What is the behavior or documentation after?

The macro system now performs comprehensive validation of placeholder usage:
- Error E2198 is reported when a placeholder requires a certain repetition depth but is used at a shallower level
- Error E2199 is reported when placeholders from different repetition contexts are mixed in the same expansion block
- Proper tracking of repetition paths ensures placeholders are only used in compatible contexts

---

## Related issue or discussion (if any)

---

## Additional context

The implementation replaces the simple placeholder collection approach with a more sophisticated system that tracks repetition paths and validates usage context during expansion checking. This prevents malformed macro definitions from being accepted and provides clear error messages for common macro authoring mistakes.