### PR TITLE
refactor: unify hashcons reverse maps and class_info into a single ClassInfo struct

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
@@ -3,8 +3,9 @@
 //! This module tracks semantic equivalence between variables as information flows through the
 //! program. Two variables are equivalent if they hold the same value. Additionally, the analysis
 //! tracks `Box`/unbox, snapshot/desnap, and struct/array construct relationships between
-//! equivalence classes. Arrays reuse the struct hashcons infrastructure since both map
-//! `(TypeId, Vec<VariableId>)` — array pop operations act as destructures.
+//! equivalence classes via unified forward/reverse maps. Arrays reuse the struct construct
+//! representation since both map `(TypeId, Vec<VariableId>)` — array pop operations act as
+//! destructures.
 
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{ExternFunctionId, NamedLanguageElementId};
@@ -20,50 +21,65 @@ use crate::{
     BlockEnd, BlockId, Lowered, MatchArm, MatchExternInfo, MatchInfo, Statement, VariableId,
 };
 
-/// Tracks relationships between equivalence classes.
-#[derive(Clone, Debug, Default)]
-struct ClassInfo {
-    /// If this class has a boxed version, the representative of that class.
-    boxed_class: Option<VariableId>,
-    /// If this class has an unboxed version, the representative of that class.
-    unboxed_class: Option<VariableId>,
-    /// If this class has a snapshot version, the representative of that class.
-    snapshot_class: Option<VariableId>,
-    /// If this class is a snapshot, the representative of the original class.
-    original_class: Option<VariableId>,
+/// A relationship between equivalence classes, carrying its payload data.
+/// Hashable so it can be used as a forward map key.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+enum Relation<'db> {
+    Box(VariableId),
+    Snapshot(VariableId),
+    EnumConstruct(ConcreteVariant<'db>, VariableId),
+    StructConstruct(TypeId<'db>, Vec<VariableId>),
 }
 
-impl ClassInfo {
-    /// Returns all variables referenced by this ClassInfo's relationships.
+impl<'db> Relation<'db> {
+    /// Returns an iterator over all variables referenced by this relation.
     fn referenced_vars(&self) -> impl Iterator<Item = VariableId> + '_ {
-        [self.boxed_class, self.original_class, self.snapshot_class, self.unboxed_class]
-            .into_iter()
-            .flatten()
-    }
-
-    /// Returns true if this ClassInfo has no relationships.
-    fn is_empty(&self) -> bool {
-        self.referenced_vars().next().is_none()
-    }
-
-    /// Merges another ClassInfo into this one.
-    /// When both have the same relationship type, calls union_fn to merge the related classes.
-    fn merge(
-        self,
-        other: Self,
-        union_fn: &mut impl FnMut(VariableId, VariableId) -> VariableId,
-    ) -> Self {
-        let mut merge_field = |new: Option<VariableId>, old: Option<VariableId>| match (new, old) {
-            (Some(new_val), Some(old_val)) if new_val != old_val => {
-                Some(union_fn(new_val, old_val))
+        let (single, fields): (Option<VariableId>, &[VariableId]) = match self {
+            Relation::Box(v) | Relation::Snapshot(v) | Relation::EnumConstruct(_, v) => {
+                (Some(*v), &[])
             }
-            (new, old) => new.or(old),
+            Relation::StructConstruct(_, vs) => (None, vs),
         };
-        Self {
-            boxed_class: merge_field(self.boxed_class, other.boxed_class),
-            unboxed_class: merge_field(self.unboxed_class, other.unboxed_class),
-            snapshot_class: merge_field(self.snapshot_class, other.snapshot_class),
-            original_class: merge_field(self.original_class, other.original_class),
+        single.into_iter().chain(fields.iter().copied())
+    }
+
+    /// Returns a new Relation with all input variables resolved to their current representatives.
+    fn with_fresh_reps(self, state: &mut EqualityState<'_>) -> Self {
+        match self {
+            Relation::Box(v) => Relation::Box(state.find(v)),
+            Relation::Snapshot(v) => Relation::Snapshot(state.find(v)),
+            Relation::EnumConstruct(variant, v) => Relation::EnumConstruct(variant, state.find(v)),
+            Relation::StructConstruct(ty, fields) => {
+                Relation::StructConstruct(ty, fields.into_iter().map(|v| state.find(v)).collect())
+            }
+        }
+    }
+
+    /// Merges two reverse relationships (self and other are proven equal).
+    /// When both exist with the same kind, propagates equality through inputs.
+    /// Always returns a valid relation (self if no merge needed).
+    fn union_equal_relations(self, other: Option<Self>, uf: &mut EqualityState<'_>) -> Self {
+        let Some(other_rel) = other else { return self };
+        match (&self, &other_rel) {
+            (Relation::Box(a), Relation::Box(b)) if a != b => Relation::Box(uf.union(*a, *b)),
+            (Relation::Snapshot(a), Relation::Snapshot(b)) if a != b => {
+                Relation::Snapshot(uf.union(*a, *b))
+            }
+            (Relation::EnumConstruct(v1, a), Relation::EnumConstruct(v2, b))
+                if v1 == v2 && a != b =>
+            {
+                Relation::EnumConstruct(*v1, uf.union(*a, *b))
+            }
+            (Relation::StructConstruct(t1, a), Relation::StructConstruct(t2, b))
+                if t1 == t2 && a.len() == b.len() =>
+            {
+                Relation::StructConstruct(
+                    *t1,
+                    a.iter().zip(b).map(|(x1, x2)| uf.union(*x1, *x2)).collect(),
+                )
+            }
+            // Same values or different kinds: keep self.
+            _ => self,
         }
     }
 }
@@ -80,33 +96,18 @@ pub struct EqualityState<'db> {
     /// Union-find parent map. If a variable is not in the map, it is its own representative.
     union_find: OrderedHashMap<VariableId, VariableId>,
 
-    /// For each equivalence class representative, track relationships only if they exist.
-    class_info: OrderedHashMap<VariableId, ClassInfo>,
-
-    /// Hashcons for enum constructs: maps (variant, input_rep) -> output_rep.
-    /// This allows us to detect when two enum constructs with the same variant
-    /// and equivalent inputs should produce equivalent outputs.
+    /// Forward map: Relation(...) -> output representative.
     ///
-    /// Keys use representatives at insertion time. In SSA form each variable is defined
-    /// exactly once, so representatives cannot change within a block and keys stay valid
-    /// without migration during `union`. At merge points the maps are rebuilt from scratch.
-    enum_hashcons: OrderedHashMap<(ConcreteVariant<'db>, VariableId), VariableId>,
+    /// Keys use representatives at insertion time. In SSA form, representatives are generally
+    /// stable within a block, so keys stay valid without migration during `union`. A union
+    /// *can* change a representative to a lower ID, which may cause a subsequent identical
+    /// construct to miss the earlier entry — this is a known imprecision (conservative, not
+    /// unsound). At merge points the maps are rebuilt from scratch.
+    forward: OrderedHashMap<Relation<'db>, VariableId>,
 
-    /// Reverse hashcons for enum constructs: maps output_rep -> (variant, input_rep).
-    /// This allows efficient lookup when matching on an enum to find the original input.
-    enum_hashcons_rev: OrderedHashMap<VariableId, (ConcreteVariant<'db>, VariableId)>,
-
-    /// Hashcons for struct/array constructs: maps (type, [field_reps...]) -> output_rep.
-    /// This allows us to detect when two constructs with the same type
-    /// and equivalent fields/elements should produce equivalent outputs.
-    /// Arrays reuse this same infrastructure — `array_new`/`array_append` chains are recorded
-    /// as constructs keyed by the array type, and `array_pop_front` acts as a destructure.
-    struct_hashcons: OrderedHashMap<(TypeId<'db>, Vec<VariableId>), VariableId>,
-
-    /// Reverse hashcons for struct/array constructs: maps output_rep -> (type,
-    /// [field_reps/element_reps...]).
-    /// This allows efficient lookup when destructuring a struct or popping from an array.
-    struct_hashcons_rev: OrderedHashMap<VariableId, (TypeId<'db>, Vec<VariableId>)>,
+    /// Reverse map: output representative -> Relation.
+    /// Records how each class was produced. A class has at most one reverse relationship.
+    reverse: OrderedHashMap<VariableId, Relation<'db>>,
 }
 
 impl<'db> EqualityState<'db> {
@@ -115,29 +116,27 @@ impl<'db> EqualityState<'db> {
         self.union_find.get(&var).copied().unwrap_or(var)
     }
 
-    /// Gets the class info for a variable, returning a default if not present.
-    fn get_class_info(&self, var: VariableId) -> ClassInfo {
-        self.class_info.get(&var).cloned().unwrap_or_default()
-    }
-
     /// Finds the representative of a variable's equivalence class.
-    /// Uses path compression for efficiency.
-    fn find(&mut self, var: VariableId) -> VariableId {
-        let parent = self.get_parent(var);
-        if parent != var {
-            let root = self.find(parent);
-            // Path compression: point directly to root.
-            self.union_find.insert(var, root);
-            root
-        } else {
-            var
+    /// Uses path splitting for efficiency: each node is redirected to its grandparent.
+    fn find(&mut self, mut var: VariableId) -> VariableId {
+        let mut parent = self.get_parent(var);
+        while parent != var {
+            let grandparent = self.get_parent(parent);
+            self.union_find.insert(var, grandparent);
+            var = parent;
+            parent = grandparent;
         }
+        var
     }
 
     /// Finds the representative without modifying the structure.
-    pub(crate) fn find_immut(&self, var: VariableId) -> VariableId {
-        let parent = self.get_parent(var);
-        if parent != var { self.find_immut(parent) } else { var }
+    pub(crate) fn find_immut(&self, mut var: VariableId) -> VariableId {
+        let mut parent = self.get_parent(var);
+        while parent != var {
+            var = parent;
+            parent = self.get_parent(var);
+        }
+        var
     }
 
     /// Unions two variables into the same equivalence class.
@@ -152,7 +151,7 @@ impl<'db> EqualityState<'db> {
         }
 
         // Always choose the lower ID as the new root to maintain canonical form.
-        // This ensures hashcons keys remain valid since lower IDs are defined earlier.
+        // This ensures forward map keys remain valid since lower IDs are defined earlier.
         let (new_root, old_root) =
             if root_a.index() < root_b.index() { (root_a, root_b) } else { (root_b, root_a) };
 
@@ -161,121 +160,93 @@ impl<'db> EqualityState<'db> {
         // Update old_root to point to new_root.
         self.union_find.insert(old_root, new_root);
 
-        // Merge class info: since A == B, we have Box(A) == Box(B), @A == @B, etc.
-        // Recursive unions inside merge() only affect related classes (which have strictly
-        // one-step increment in information in forward analysis), so they never deposit class_info
-        // back at new_root.
-        let old_info = self.class_info.swap_remove(&old_root).unwrap_or_default();
-        let new_info = self.class_info.swap_remove(&new_root).unwrap_or_default();
-        let merged = new_info.merge(old_info, &mut |a, b| self.union(a, b));
-        if !merged.is_empty() {
-            let final_root = self.find(new_root);
-            self.class_info.insert(final_root, merged);
+        // Merge reverse entries for both roots.
+        let old_reverse = self.reverse.swap_remove(&old_root);
+        let new_reverse = self.reverse.swap_remove(&new_root);
+        let merged_reverse = match (new_reverse, old_reverse) {
+            (Some(new_rev), old) => Some(new_rev.union_equal_relations(old, self)),
+            (None, old) => old,
+        };
+
+        // TODO(eytan-starkware): Forward Struct/Enum entries aren't re-keyed during union.
+        //    Doing so would require congruence closure (updating all entries whose inputs
+        //    changed). The consequence is missed hashcons hits — conservative, not unsound.
+        //    We also don't invalidate forward entries that become inconsistent (e.g., two
+        //    different enum variants mapping to the now-merged class). These stale entries
+        //    are harmless as this code should be unreachable.
+        // Merge forward Box/Snapshot entries for both roots.
+        let constructors = [Relation::Box, Relation::Snapshot];
+        for ctor in constructors {
+            let old_fwd = self.forward.swap_remove(&ctor(old_root));
+            let new_fwd = self.forward.swap_remove(&ctor(new_root));
+            let merged = match (new_fwd, old_fwd) {
+                (Some(t1), Some(t2)) => Some(self.union(t1, t2)),
+                (Some(t), None) | (None, Some(t)) => Some(t),
+                (None, None) => None,
+            };
+            if let Some(target) = merged {
+                let final_root = self.find(new_root);
+                let target_rep = self.find(target);
+                self.forward.insert(ctor(final_root), target_rep);
+            }
+        }
+
+        let final_root = self.find(new_root);
+        if let Some(merged_reverse) = merged_reverse {
+            self.reverse.insert(final_root, merged_reverse);
         }
 
         self.find(new_root)
     }
 
-    /// Looks up a related variable through a ClassInfo field accessor.
-    fn get_related(
-        &mut self,
-        var: VariableId,
-        field: fn(&mut ClassInfo) -> &mut Option<VariableId>,
-    ) -> Option<VariableId> {
-        let rep = self.find(var);
-        let mut info = self.get_class_info(rep);
-        let related = (*field(&mut info))?;
-        Some(self.find(related))
-    }
+    /// Records a relation: forward maps `relation -> output`, reverse maps `output -> relation`.
+    /// If the same relation already maps to an existing output, unions them.
+    /// If the output already has a reverse, merges inputs via `union_equal_relations`.
+    fn set_relation(&mut self, relation: Relation<'db>, output: VariableId) {
+        // Refresh reps — callers may pass stale IDs, and this maximizes forward hits.
+        let relation = relation.with_fresh_reps(self);
 
-    /// Sets a bidirectional relationship between two variables' equivalence classes.
-    /// If inputs already have a relationship of the same kind, unions with the existing class.
-    fn set_relationship(
-        &mut self,
-        var_a: VariableId,
-        var_b: VariableId,
-        field_a_to_b: fn(&mut ClassInfo) -> &mut Option<VariableId>,
-        field_b_to_a: fn(&mut ClassInfo) -> &mut Option<VariableId>,
-    ) {
-        // Union with existing relationships if present.
-        if let Some(existing) = self.get_related(var_a, field_a_to_b) {
-            self.union(var_b, existing);
-        }
-        if let Some(existing) = self.get_related(var_b, field_b_to_a) {
-            self.union(var_a, existing);
-        }
-
-        // Re-find after potential unions — representatives may have changed.
-        let rep_a = self.find(var_a);
-        let rep_b = self.find(var_b);
-
-        *field_a_to_b(self.class_info.entry(rep_a).or_default()) = Some(rep_b);
-        *field_b_to_a(self.class_info.entry(rep_b).or_default()) = Some(rep_a);
-    }
-
-    /// Sets a box relationship: boxed_var = Box(unboxed_var).
-    fn set_box_relationship(&mut self, unboxed_var: VariableId, boxed_var: VariableId) {
-        self.set_relationship(
-            unboxed_var,
-            boxed_var,
-            |ci| &mut ci.boxed_class,
-            |ci| &mut ci.unboxed_class,
-        );
-    }
-
-    /// Sets a snapshot relationship: snapshot_var = @original_var.
-    fn set_snapshot_relationship(&mut self, original_var: VariableId, snapshot_var: VariableId) {
-        self.set_relationship(
-            original_var,
-            snapshot_var,
-            |ci| &mut ci.snapshot_class,
-            |ci| &mut ci.original_class,
-        );
-    }
-
-    /// Records an enum construct: output = Variant(input).
-    /// If we've already seen the same variant with an equivalent input, unions the outputs.
-    fn set_enum_construct(
-        &mut self,
-        variant: ConcreteVariant<'db>,
-        input: VariableId,
-        output: VariableId,
-    ) {
-        let input_rep = self.find(input);
-        let output_rep = self.find(output);
-
-        match self.enum_hashcons.entry((variant, input_rep)) {
-            cairo_lang_utils::ordered_hash_map::Entry::Occupied(entry) => {
-                let existing_output = *entry.get();
-                self.union(existing_output, output);
-                // Union may have changed the representative. Update the reverse map
-                // so that transfer_edge lookups via find() hit the current representative.
-                let new_output_rep = self.find(existing_output);
-                self.enum_hashcons_rev.swap_remove(&existing_output);
-                self.enum_hashcons_rev.insert(new_output_rep, (variant, input_rep));
-            }
-            cairo_lang_utils::ordered_hash_map::Entry::Vacant(entry) => {
-                entry.insert(output_rep);
-                self.enum_hashcons_rev.insert(output_rep, (variant, input_rep));
-            }
-        }
-    }
-
-    /// Records a struct construct: output = StructType(inputs...).
-    /// If we've already seen the same type with equivalent inputs, unions the outputs.
-    fn set_struct_construct(
-        &mut self,
-        ty: TypeId<'db>,
-        input_reps: Vec<VariableId>,
-        output: VariableId,
-    ) {
-        let key = (ty, input_reps);
-        if let Some(&existing_output) = self.struct_hashcons.get(&key) {
+        // Forward dedup: if this exact relation already maps to an output, union them.
+        if let Some(&existing_output) = self.forward.get(&relation) {
             self.union(existing_output, output);
-        } else {
-            let output_rep = self.find(output);
-            self.struct_hashcons.insert(key.clone(), output_rep);
-            self.struct_hashcons_rev.insert(output_rep, key);
+        }
+
+        // Reverse merge: if output already has a reverse, merge inputs and use the result.
+        let output_rep = self.find(output);
+        let existing = self.reverse.swap_remove(&output_rep);
+        let relation = relation.union_equal_relations(existing, self);
+
+        // Insert with current reps (may be slightly stale after unions above).
+        let output_rep = self.find(output);
+        self.forward.insert(relation.clone(), output_rep);
+        self.reverse.insert(output_rep, relation);
+    }
+
+    /// Looks up the struct construct info for a representative (immutable).
+    fn get_struct_construct_immut(
+        &self,
+        rep: VariableId,
+    ) -> Option<(TypeId<'db>, Vec<VariableId>)> {
+        match self.reverse.get(&rep)? {
+            Relation::StructConstruct(ty, fields) => Some((*ty, fields.clone())),
+            _ => None,
+        }
+    }
+
+    /// Looks up the struct construct info for a variable (mutable, uses find for path compression).
+    fn get_struct_construct(&mut self, var: VariableId) -> Option<(TypeId<'db>, Vec<VariableId>)> {
+        let rep = self.find(var);
+        self.get_struct_construct_immut(rep)
+    }
+
+    /// Looks up the enum construct info for a representative (immutable).
+    fn get_enum_construct_immut(
+        &self,
+        rep: VariableId,
+    ) -> Option<(ConcreteVariant<'db>, VariableId)> {
+        match self.reverse.get(&rep)? {
+            Relation::EnumConstruct(variant, input) => Some((*variant, *input)),
+            _ => None,
         }
     }
 }
@@ -286,22 +257,24 @@ impl<'db> DebugWithDb<'db> for EqualityState<'db> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db Self::Db) -> std::fmt::Result {
         let v = |id: VariableId| format!("v{}", self.find_immut(id).index());
         let mut lines = Vec::<String>::new();
-        for (&rep, info) in self.class_info.iter() {
-            if let Some(s) = info.snapshot_class {
-                lines.push(format!("@{} = {}", v(rep), v(s)));
+        for (relation, &output) in self.forward.iter() {
+            match relation {
+                Relation::Snapshot(source) => {
+                    lines.push(format!("@{} = {}", v(*source), v(output)));
+                }
+                Relation::Box(source) => {
+                    lines.push(format!("Box({}) = {}", v(*source), v(output)));
+                }
+                Relation::EnumConstruct(variant, input) => {
+                    let name = variant.id.name(db).to_string(db);
+                    lines.push(format!("{name}({}) = {}", v(*input), v(output)));
+                }
+                Relation::StructConstruct(ty, inputs) => {
+                    let type_name = ty.format(db);
+                    let fields = inputs.iter().map(|&id| v(id)).collect::<Vec<_>>().join(", ");
+                    lines.push(format!("{type_name}({fields}) = {}", v(output)));
+                }
             }
-            if let Some(b) = info.boxed_class {
-                lines.push(format!("Box({}) = {}", v(rep), v(b)));
-            }
-        }
-        for (&(variant, input), &output) in self.enum_hashcons.iter() {
-            let name = variant.id.name(db).to_string(db);
-            lines.push(format!("{name}({}) = {}", v(input), v(output)));
-        }
-        for ((ty, inputs), &output) in self.struct_hashcons.iter() {
-            let type_name = ty.format(db);
-            let fields = inputs.iter().map(|&id| v(id)).collect::<Vec<_>>().join(", ");
-            lines.push(format!("{type_name}({fields}) = {}", v(output)));
         }
         for &var in self.union_find.keys() {
             let rep = self.find_immut(var);
@@ -363,7 +336,7 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
 
     /// Handles extern match arms for array operations.
     ///
-    /// Array pop operations act as "destructures" on the struct-hashcons representation:
+    /// Array pop operations act as "destructures" on the struct construct representation:
     /// - `array_pop_front` / `array_pop_front_consume`: On the Some arm, if the input array was
     ///   tracked as `[e0, e1, ..., eN]`, the popped element (boxed) is `Box(e0)` and the remaining
     ///   array is `[e1, ..., eN]`.
@@ -414,29 +387,25 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
                 let input_arr = extern_info.inputs[0].var_id;
                 let remaining_arr = arm.var_ids[0];
                 let boxed_elem = arm.var_ids[1];
-
-                let arr_rep = info.find(input_arr);
-                if let Some((ty, elems)) = info.struct_hashcons_rev.get(&arr_rep).cloned()
+                if let Some((ty, elems)) = info.get_struct_construct(input_arr)
                     && let Some((&first, rest)) = elems.split_first()
                 {
-                    // Popped element is boxed: boxed_elem = Box(first_element)
-                    info.set_box_relationship(first, boxed_elem);
-                    // Remaining array is the tail
+                    info.set_relation(Relation::Box(first), boxed_elem);
                     let rest_reps: Vec<_> = rest.iter().map(|&v| info.find(v)).collect();
-                    info.set_struct_construct(ty, rest_reps, remaining_arr);
+                    info.set_relation(Relation::StructConstruct(ty, rest_reps), remaining_arr);
                 }
             } else {
                 // None arm for array_pop_front: var_ids = [original_arr]. Union with input.
                 // None arm for array_pop_front_consume: var_ids = [].
                 let old_array_var = extern_info.inputs[0].var_id;
                 let ty = self.lowered.variables[old_array_var].ty;
-                // TODO(eytan-starkware): This introduces a backedge to our hashcons updates,
+                // TODO(eytan-starkware): This introduces a backedge to our forward map updates,
                 //    so we might need to support updating the structures accordingly.
-                //    For example, if this is empty after a pop, then we know previous array was a
-                //    singleton.
-                info.set_struct_construct(ty, vec![], old_array_var);
-                if let [empty_array_var] = arm.var_ids[..] {
-                    info.union(old_array_var, empty_array_var);
+                //    For example, if this is empty after a pop, then we know previous array
+                //    was a singleton.
+                info.set_relation(Relation::StructConstruct(ty, vec![]), old_array_var);
+                if let [original_arr] = arm.var_ids[..] {
+                    info.union(original_arr, old_array_var);
                 }
             }
         } else if id == self.array_snapshot_pop_front || id == self.array_snapshot_pop_back {
@@ -446,21 +415,18 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
                 let remaining_snap_arr = arm.var_ids[0];
                 let boxed_snap_elem = arm.var_ids[1];
 
-                // The input is @Array<T>. Look up the tracked elements.
-                // Two paths: (1) the input snapshot was created via `snapshot(arr)` where `arr`
-                // has a struct-hashcons entry under `Array<T>`, or (2) the input is itself a
-                // remaining snapshot array from a prior snapshot pop, stored directly in the
-                // struct hashcons under its snapshot type `@Array<T>`.
+                // Look up tracked elements via snapshot reverse relationship or direct lookup.
                 let snap_rep = info.find(input_snap_arr);
-                let elems_opt = info
-                    .class_info
-                    .get(&snap_rep)
-                    .and_then(|ci| ci.original_class)
+                let original_rep = match info.reverse.get(&snap_rep) {
+                    Some(Relation::Snapshot(v)) => Some(*v),
+                    _ => None,
+                };
+                let elems_opt = original_rep
                     .and_then(|orig| {
                         let orig = info.find_immut(orig);
-                        info.struct_hashcons_rev.get(&orig).cloned()
+                        info.get_struct_construct_immut(orig)
                     })
-                    .or_else(|| info.struct_hashcons_rev.get(&snap_rep).cloned());
+                    .or_else(|| info.get_struct_construct_immut(snap_rep));
 
                 if let Some((_orig_ty, elems)) = elems_opt {
                     let pop_front = id == self.array_snapshot_pop_front;
@@ -472,42 +438,44 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
                         (last, init)
                     };
 
-                    // The popped element is `Box<@T>`. The box wraps the *snapshot* of the
-                    // original element. We can only record this relationship if a variable
-                    // for `@elem` already exists (i.e., elem has a snapshot class).
-                    // TODO(eytan-starkware): Support relationships even no variable to represent
-                    // `@elem` yet.
+                    // The popped element is `Box<@T>`. Record the box relationship against
+                    // the snapshot class of `elem` if it exists.
+                    // TODO(eytan-starkware): Support relationships even when no variable
+                    // represents `@elem` yet.
                     let elem_rep = info.find(elem);
-                    if let Some(snap_of_elem) =
-                        info.class_info.get(&elem_rep).and_then(|ci| ci.snapshot_class)
-                    {
-                        info.set_box_relationship(snap_of_elem, boxed_snap_elem);
+                    if let Some(&snap_of_elem) = info.forward.get(&Relation::Snapshot(elem_rep)) {
+                        info.set_relation(Relation::Box(snap_of_elem), boxed_snap_elem);
                     }
 
                     // Record the remaining snapshot array under its snapshot type
                     // (`@Array<T>`). This is a hack: `@Array<T>` is not a struct, but we
-                    // reuse `struct_hashcons` to store element info for it. This also
-                    // requires the two-path lookup above (path 2).
+                    // reuse struct construct tracking to store element info for it. This
+                    // also requires the two-path lookup above (path 2).
                     // TODO(eytan-starkware): Once placeholder vars are supported, store
-                    //    this as a proper `Array<T>` linked via `original_class` instead,
-                    //    since we may not have a var representing the non-snapshot array at the
-                    // moment.
+                    //    this as a proper `Array<T>` linked via the reverse map instead,
+                    //    since we may not have a var representing the non-snapshot array
+                    //    at the moment.
                     let snap_ty = self.lowered.variables[remaining_snap_arr].ty;
                     let rest_reps: Vec<_> = rest.iter().map(|&v| info.find(v)).collect();
-                    info.set_struct_construct(snap_ty, rest_reps, remaining_snap_arr);
+                    info.set_relation(
+                        Relation::StructConstruct(snap_ty, rest_reps),
+                        remaining_snap_arr,
+                    );
                 }
             } else {
-                // None arm: var_ids = [original_snap_arr]. Snapshot array was empty.
+                // None arm: record empty snapshot array and union output with input.
                 let old_snap_arr = extern_info.inputs[0].var_id;
                 let snap_ty = self.lowered.variables[old_snap_arr].ty;
-                info.set_struct_construct(snap_ty, vec![], old_snap_arr);
-                info.union(arm.var_ids[0], old_snap_arr);
+                info.set_relation(Relation::StructConstruct(snap_ty, vec![]), old_snap_arr);
+                if let [original_snap_arr] = arm.var_ids[..] {
+                    info.union(original_snap_arr, old_snap_arr);
+                }
             }
         }
     }
 }
 
-/// Returns an iterator over all variables with equality ir relationship information in the equality
+/// Returns an iterator over all variables with equality or relationship information in the equality
 /// states.
 fn merge_referenced_vars<'db, 'a>(
     info1: &'a EqualityState<'db>,
@@ -515,60 +483,18 @@ fn merge_referenced_vars<'db, 'a>(
 ) -> impl Iterator<Item = VariableId> + 'a {
     let union_find_vars = info1.union_find.keys().chain(info2.union_find.keys()).copied();
 
-    let class_info_vars = info1
-        .class_info
-        .values()
-        .chain(info2.class_info.values())
-        .flat_map(ClassInfo::referenced_vars);
+    let forward_vars =
+        info1.forward.iter().chain(info2.forward.iter()).flat_map(|(relation, &output)| {
+            relation.referenced_vars().chain(std::iter::once(output))
+        });
 
-    let enum_vars = info1
-        .enum_hashcons
+    let reverse_vars = info1
+        .reverse
         .iter()
-        .chain(info2.enum_hashcons.iter())
-        .flat_map(|(&(_, input), &output)| [input, output]);
+        .chain(info2.reverse.iter())
+        .flat_map(|(&rep, relation)| std::iter::once(rep).chain(relation.referenced_vars()));
 
-    let struct_vars =
-        info1.struct_hashcons.iter().chain(info2.struct_hashcons.iter()).flat_map(
-            |((_, inputs), &output)| inputs.iter().copied().chain(std::iter::once(output)),
-        );
-
-    union_find_vars.chain(class_info_vars).chain(enum_vars).chain(struct_vars)
-}
-
-/// Preserves only class relationships (box/snapshot) that exist in both branches.
-fn merge_class_relationships(
-    info1: &EqualityState<'_>,
-    info2: &EqualityState<'_>,
-    intersections: &OrderedHashMap<VariableId, Vec<(VariableId, VariableId)>>,
-    result: &mut EqualityState<'_>,
-) {
-    for (&var, class1) in info1.class_info.iter() {
-        for &(var_rep2, intersection_var) in intersections.get(&var).unwrap_or(&vec![]) {
-            let Some(class2) = info2.class_info.get(&var_rep2) else {
-                continue;
-            };
-
-            if let Some(boxed_rep) = find_intersection_rep_opt(
-                info1,
-                info2,
-                intersections,
-                class1.boxed_class,
-                class2.boxed_class,
-            ) {
-                result.set_box_relationship(intersection_var, boxed_rep);
-            }
-
-            if let Some(snap_rep) = find_intersection_rep_opt(
-                info1,
-                info2,
-                intersections,
-                class1.snapshot_class,
-                class2.snapshot_class,
-            ) {
-                result.set_snapshot_relationship(intersection_var, snap_rep);
-            }
-        }
-    }
+    union_find_vars.chain(forward_vars).chain(reverse_vars)
 }
 
 /// Finds an intersection representative: given a rep in info1 and a rep in info2,
@@ -583,77 +509,88 @@ fn find_intersection_rep(
     })
 }
 
-/// Like [`find_intersection_rep`], but accepts optional reps and resolves them through the
-/// respective states. Returns `None` if either rep is `None` or no intersection exists.
-fn find_intersection_rep_opt(
-    info1: &EqualityState<'_>,
-    info2: &EqualityState<'_>,
-    intersections: &OrderedHashMap<VariableId, Vec<(VariableId, VariableId)>>,
-    rep1: Option<VariableId>,
-    rep2: Option<VariableId>,
-) -> Option<VariableId> {
-    find_intersection_rep(intersections, info1.find_immut(rep1?), info2.find_immut(rep2?))
-}
-
-/// Preserves enum hashcons entries that exist in both branches.
-/// An entry survives if both input and output have intersection representatives, and info2 has the
-/// same relation.
-fn merge_enum_hashcons<'db>(
+/// Preserves relations that exist in both branches.
+/// All relation types are looked up via the forward map, which retains all entries.
+fn merge_relations<'db>(
     info1: &EqualityState<'db>,
     info2: &EqualityState<'db>,
     intersections: &OrderedHashMap<VariableId, Vec<(VariableId, VariableId)>>,
     result: &mut EqualityState<'db>,
 ) {
-    for (&(variant, input1), &output1) in info1.enum_hashcons.iter() {
-        for &(input_rep2, input_intersection) in intersections.get(&input1).unwrap_or(&vec![]) {
-            let output2 = info2.enum_hashcons.get(&(variant, input_rep2)).copied();
-            let Some(output_intersection) =
-                find_intersection_rep_opt(info1, info2, intersections, Some(output1), output2)
-            else {
-                continue;
-            };
-
-            result.set_enum_construct(variant, input_intersection, output_intersection);
+    // Iterate all forward entries from info1 and find matching entries in info2.
+    // We use forward (not reverse) because reverse holds only the latest relation per output,
+    // while forward retains all entries and is the authoritative source.
+    for (relation, &output1) in info1.forward.iter() {
+        match relation {
+            Relation::Box(source1) | Relation::Snapshot(source1) => {
+                for &(source2, intersection_var) in intersections.get(source1).unwrap_or(&vec![]) {
+                    let relation2 = match relation {
+                        Relation::Box(_) => Relation::Box(source2),
+                        Relation::Snapshot(_) => Relation::Snapshot(source2),
+                        _ => unreachable!(),
+                    };
+                    let Some(&output2) = info2.forward.get(&relation2) else { continue };
+                    if let Some(output_intersection) = find_intersection_rep(
+                        intersections,
+                        info1.find_immut(output1),
+                        info2.find_immut(output2),
+                    ) {
+                        let result_relation = match relation {
+                            Relation::Box(_) => Relation::Box(result.find(intersection_var)),
+                            Relation::Snapshot(_) => {
+                                Relation::Snapshot(result.find(intersection_var))
+                            }
+                            _ => unreachable!(),
+                        };
+                        result.set_relation(result_relation, output_intersection);
+                    }
+                }
+            }
+            Relation::EnumConstruct(variant, input1) => {
+                for &(input2, input_intersection) in
+                    intersections.get(&info1.find_immut(*input1)).unwrap_or(&vec![])
+                {
+                    let relation2 = Relation::EnumConstruct(*variant, input2);
+                    let Some(&output2) = info2.forward.get(&relation2) else { continue };
+                    if let Some(output_intersection) = find_intersection_rep(
+                        intersections,
+                        info1.find_immut(output1),
+                        info2.find_immut(output2),
+                    ) {
+                        result.set_relation(
+                            Relation::EnumConstruct(*variant, input_intersection),
+                            output_intersection,
+                        );
+                    }
+                }
+            }
+            Relation::StructConstruct(ty, fields1) => {
+                let fields2: Vec<_> = fields1.iter().map(|&v| info2.find_immut(v)).collect();
+                let Some(&output2) =
+                    info2.forward.get(&Relation::StructConstruct(*ty, fields2.clone()))
+                else {
+                    continue;
+                };
+                let result_fields: Option<Vec<_>> = fields1
+                    .iter()
+                    .zip(&fields2)
+                    .map(|(&v1, &v2)| {
+                        find_intersection_rep(intersections, info1.find_immut(v1), v2)
+                    })
+                    .collect();
+                let Some(result_fields) = result_fields else { continue };
+                if let Some(output_intersection) = find_intersection_rep(
+                    intersections,
+                    info1.find_immut(output1),
+                    info2.find_immut(output2),
+                ) {
+                    result.set_relation(
+                        Relation::StructConstruct(*ty, result_fields),
+                        output_intersection,
+                    );
+                }
+            }
         }
-    }
-}
-
-/// Preserves struct hashcons entries that exist in both branches.
-/// An entry survives if all inputs and output have intersection representatives, and info2 has the
-/// same relation.
-fn merge_struct_hashcons<'db>(
-    info1: &EqualityState<'db>,
-    info2: &EqualityState<'db>,
-    intersections: &OrderedHashMap<VariableId, Vec<(VariableId, VariableId)>>,
-    result: &mut EqualityState<'db>,
-) {
-    for ((ty, inputs1), &output1) in info1.struct_hashcons.iter() {
-        let input_reps2: Vec<_> = inputs1.iter().map(|&v| info2.find_immut(v)).collect();
-
-        let Some(&output2) = info2.struct_hashcons.get(&(*ty, input_reps2.clone())) else {
-            continue;
-        };
-
-        let result_inputs: Option<Vec<_>> = inputs1
-            .iter()
-            .zip(&input_reps2)
-            .map(|(&v, &rep2)| {
-                find_intersection_rep(intersections, info1.find_immut(v), info2.find_immut(rep2))
-            })
-            .collect();
-        let Some(result_inputs) = result_inputs else {
-            continue;
-        };
-
-        let Some(output_intersection) = find_intersection_rep(
-            intersections,
-            info1.find_immut(output1),
-            info2.find_immut(output2),
-        ) else {
-            continue;
-        };
-
-        result.set_struct_construct(*ty, result_inputs, output_intersection);
     }
 }
 
@@ -709,11 +646,7 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
             intersections.entry(rep1).or_default().push((rep2, result.find(vars[0])));
         }
 
-        merge_class_relationships(&info1, &info2, &intersections, &mut result);
-
-        merge_enum_hashcons(&info1, &info2, &intersections, &mut result);
-
-        merge_struct_hashcons(&info1, &info2, &intersections, &mut result);
+        merge_relations(&info1, &info2, &intersections, &mut result);
 
         result
     }
@@ -727,49 +660,47 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
         match stmt {
             Statement::Snapshot(snapshot_stmt) => {
                 info.union(snapshot_stmt.original(), snapshot_stmt.input.var_id);
-                info.set_snapshot_relationship(
-                    snapshot_stmt.input.var_id,
+                info.set_relation(
+                    Relation::Snapshot(snapshot_stmt.input.var_id),
                     snapshot_stmt.snapshot(),
                 );
             }
 
             Statement::Desnap(desnap_stmt) => {
-                info.set_snapshot_relationship(desnap_stmt.output, desnap_stmt.input.var_id);
+                info.set_relation(Relation::Snapshot(desnap_stmt.output), desnap_stmt.input.var_id);
             }
 
             Statement::IntoBox(into_box_stmt) => {
-                info.set_box_relationship(into_box_stmt.input.var_id, into_box_stmt.output);
+                info.set_relation(Relation::Box(into_box_stmt.input.var_id), into_box_stmt.output);
             }
 
             Statement::Unbox(unbox_stmt) => {
-                info.set_box_relationship(unbox_stmt.output, unbox_stmt.input.var_id);
+                info.set_relation(Relation::Box(unbox_stmt.output), unbox_stmt.input.var_id);
             }
 
             Statement::EnumConstruct(enum_stmt) => {
-                // output = Variant(input): track via hashcons
+                // output = Variant(input): track via forward map
                 // If we've already seen this variant with an equivalent input, the outputs are
                 // equal.
-                info.set_enum_construct(
-                    enum_stmt.variant,
-                    enum_stmt.input.var_id,
+                info.set_relation(
+                    Relation::EnumConstruct(enum_stmt.variant, enum_stmt.input.var_id),
                     enum_stmt.output,
                 );
             }
 
             Statement::StructConstruct(struct_stmt) => {
-                // output = StructType(inputs...): track via hashcons
+                // output = StructType(inputs...): track via forward map
                 // If we've already seen the same struct type with equivalent inputs, the outputs
                 // are equal.
                 let ty = self.lowered.variables[struct_stmt.output].ty;
                 let input_reps = struct_stmt.inputs.iter().map(|i| info.find(i.var_id)).collect();
-                info.set_struct_construct(ty, input_reps, struct_stmt.output);
+                info.set_relation(Relation::StructConstruct(ty, input_reps), struct_stmt.output);
             }
 
             Statement::StructDestructure(struct_stmt) => {
                 // (outputs...) = struct_destructure(input)
                 // 1. If input was previously constructed, union outputs with original fields.
-                let input_rep = info.find(struct_stmt.input.var_id);
-                if let Some((_, field_reps)) = info.struct_hashcons_rev.get(&input_rep).cloned() {
+                if let Some((_, field_reps)) = info.get_struct_construct(struct_stmt.input.var_id) {
                     for (&output, &field_rep) in struct_stmt.outputs.iter().zip(field_reps.iter()) {
                         info.union(output, field_rep);
                     }
@@ -777,21 +708,28 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
                 // 2. Record: struct_construct(outputs) == input (for future constructs).
                 let ty = self.lowered.variables[struct_stmt.input.var_id].ty;
                 let output_reps = struct_stmt.outputs.iter().map(|&v| info.find(v)).collect();
-                info.set_struct_construct(ty, output_reps, struct_stmt.input.var_id);
+                info.set_relation(
+                    Relation::StructConstruct(ty, output_reps),
+                    struct_stmt.input.var_id,
+                );
             }
 
             Statement::Call(call_stmt) => {
                 let Some((id, _)) = call_stmt.function.get_extern(self.db) else { return };
                 if id == self.array_new {
                     let ty = self.lowered.variables[call_stmt.outputs[0]].ty;
-                    info.set_struct_construct(ty, vec![], call_stmt.outputs[0]);
-                } else if id == self.array_append {
-                    let arr_rep = info.find(call_stmt.inputs[0].var_id);
-                    if let Some((ty, elems)) = info.struct_hashcons_rev.get(&arr_rep).cloned() {
-                        let mut new_elems = elems;
-                        new_elems.push(info.find(call_stmt.inputs[1].var_id));
-                        info.set_struct_construct(ty, new_elems, call_stmt.outputs[0]);
-                    }
+                    info.set_relation(Relation::StructConstruct(ty, vec![]), call_stmt.outputs[0]);
+                } else if id == self.array_append
+                    && let Some((ty, elems)) = info.get_struct_construct(call_stmt.inputs[0].var_id)
+                {
+                    // Only track append if the input array is already tracked. Arrays from
+                    // function parameters or external calls are conservatively ignored.
+                    let mut new_elems = elems;
+                    new_elems.push(info.find(call_stmt.inputs[1].var_id));
+                    info.set_relation(
+                        Relation::StructConstruct(ty, new_elems),
+                        call_stmt.outputs[0],
+                    );
                 }
             }
 
@@ -821,14 +759,14 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
                     // happen after optimizations merge states from different branches.
                     let output_rep = new_info.find(matched_var);
                     if let Some((old_variant, input)) =
-                        new_info.enum_hashcons_rev.get(&output_rep).copied()
+                        new_info.get_enum_construct_immut(output_rep)
                         && variant == old_variant
                     {
                         new_info.union(arm_var, input);
                     }
 
                     // Record the relationship: matched_var = Variant(arm_var)
-                    new_info.set_enum_construct(variant, arm_var, matched_var);
+                    new_info.set_relation(Relation::EnumConstruct(variant, arm_var), matched_var);
                 }
 
                 // For extern matches on array operations, track pop/destructure relationships.

--- a/crates/cairo-lang-lowering/src/analysis/test_data/equality
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/equality
@@ -1415,3 +1415,44 @@ Box(v4) = v2
 
 Block 2:
 ()() = v5, core::array::Array::<core::felt252>() = v0, v0 = v3, v0 = v6
+
+//! > ==========================================================================
+
+//! > Test boxed enum constructs with different variants do not spuriously union inputs
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > function_code
+fn foo(x: felt252, y: felt252) {
+    let a = Option::Some(x);
+    let b: Option<felt252> = Option::None;
+    let box_a = BoxTrait::new(a);
+    let box_b = BoxTrait::new(b);
+    use_boxes(box_a, box_b);
+}
+
+//! > function_name
+foo
+
+//! > module_code
+extern fn use_boxes(a: Box<Option<felt252>>, b: Box<Option<felt252>>) nopanic;
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252
+blk0 (root):
+Statements:
+  (v2: core::option::Option::<core::felt252>) <- Option::Some(v0)
+  (v3: ()) <- struct_construct()
+  (v4: core::option::Option::<core::felt252>) <- Option::None(v3)
+  (v5: core::box::Box::<core::option::Option::<core::felt252>>) <- into_box(v2)
+  (v6: core::box::Box::<core::option::Option::<core::felt252>>) <- into_box(v4)
+  () <- test::use_boxes(v5, v6)
+End:
+  Return()
+
+//! > analysis_state
+Block 0:
+()() = v3, Box(v2) = v5, Box(v4) = v6, None(v3) = v4, Some(v0) = v2


### PR DESCRIPTION
## Summary

Refactored the equality analysis module to replace separate tracking structures (ClassInfo, enum_hashcons, struct_hashcons) with unified forward/reverse maps using a single Relation enum. This consolidates box/unbox, snapshot/desnap, enum construct, and struct construct relationships into a more cohesive design.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation used multiple separate data structures to track different types of relationships between equivalence classes, leading to complex merge logic and potential inconsistencies. The scattered approach made it difficult to maintain and reason about the relationships uniformly.

---

## What was the behavior or documentation before?

The equality analysis tracked relationships using:
- `ClassInfo` struct with separate optional fields for boxed_class, unboxed_class, snapshot_class, original_class
- Separate `enum_hashcons` and `enum_hashcons_rev` maps for enum constructs
- Separate `struct_hashcons` and `struct_hashcons_rev` maps for struct/array constructs
- Complex merge logic that handled each relationship type separately

---

## What is the behavior or documentation after?

The equality analysis now uses:
- A single `Relation` enum that represents all relationship types (Box, Snapshot, EnumConstruct, StructConstruct)
- Unified `forward` map from Relation to output representative
- Unified `reverse` map from output representative to Relation
- Simplified merge logic that handles all relationship types uniformly through the Relation abstraction
- Path splitting optimization for union-find operations instead of path compression

---

## Related issue or discussion (if any)

None specified.

---

## Additional context

This refactoring maintains the same semantic behavior while providing a cleaner internal representation. The change also includes a test case demonstrating that boxed enum constructs with different variants correctly avoid spurious input unions, showing the robustness of the new approach.