### PR TITLE
feat: automate crate publishing and yanking on GitHub release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,20 @@ on:
       - "v*"
 
 jobs:
+  publish_crates:
+    name: Publish crates to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish crates
+        run: ./scripts/release_crates.sh
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   release:
     name: Publish for ${{ matrix.os }}
+    needs: publish_crates
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/scripts/crates_list.sh
+++ b/scripts/crates_list.sh
@@ -1,0 +1,56 @@
+# Ordered list of crates to publish. A crate must appear after all its dependencies.
+# Sourced by release_crates.sh and yank_crates.sh.
+CRATES=(
+    cairo-lang-utils
+    cairo-lang-debug
+    cairo-lang-proc-macros
+    cairo-lang-filesystem
+    cairo-lang-diagnostics
+    cairo-lang-syntax
+    cairo-lang-syntax-codegen
+    cairo-lang-parser
+    cairo-lang-defs
+    cairo-lang-formatter
+    cairo-lang-test-utils
+    cairo-lang-casm
+    cairo-lang-eq-solver
+    cairo-lang-project
+    cairo-lang-sierra
+    cairo-lang-sierra-type-size
+    cairo-lang-sierra-ap-change
+    cairo-lang-sierra-gas
+    cairo-lang-sierra-to-casm
+    cairo-lang-plugins
+    cairo-lang-semantic
+    cairo-lang-lowering
+    cairo-lang-sierra-generator
+    cairo-lang-runnable-utils
+    cairo-lang-compiler
+    cairo-lang-starknet-classes
+    cairo-lang-starknet
+    cairo-lang-executable-plugin
+    cairo-lang-executable
+    cairo-lang-runner
+    cairo-lang-test-plugin
+    cairo-lang-test-runner
+    cairo-lang-execute-utils
+    cairo-lang-doc
+    cairo-compile
+    cairo-format
+    cairo-run
+    cairo-execute
+    cairo-test
+    cairo-size-profiler
+    sierra-compile
+    starknet-compile
+    starknet-sierra-compile
+)
+
+# Assert that the list is kept in sync with the workspace
+# (workspace crate count minus 5 crates that are for internal use only).
+NUM_CRATES_IN_WORKSPACE=$(find crates/ -name Cargo.toml | wc -l)
+if [ "${#CRATES[@]}" -ne "$((NUM_CRATES_IN_WORKSPACE - 5))" ]; then
+    echo "The number of crates to publish is not equal to the number of crates in the workspace,"
+    echo "new crates were probably added, please update the list of crates to publish."
+    exit 1
+fi

--- a/scripts/release_crates.sh
+++ b/scripts/release_crates.sh
@@ -9,64 +9,18 @@ else
     SKIP_FIRST=0
 fi
 
-# Define a list of the crates to be published.
-# The order of the crates is important, as a crate must be published after its dependencies.
-CRATES_TO_PUBLISH=(
-    cairo-lang-utils
-    cairo-lang-debug
-    cairo-lang-proc-macros
-    cairo-lang-filesystem
-    cairo-lang-diagnostics
-    cairo-lang-syntax
-    cairo-lang-syntax-codegen
-    cairo-lang-parser
-    cairo-lang-defs
-    cairo-lang-formatter
-    cairo-lang-test-utils
-    cairo-lang-casm
-    cairo-lang-eq-solver
-    cairo-lang-project
-    cairo-lang-sierra
-    cairo-lang-sierra-type-size
-    cairo-lang-sierra-ap-change
-    cairo-lang-sierra-gas
-    cairo-lang-sierra-to-casm
-    cairo-lang-plugins
-    cairo-lang-semantic
-    cairo-lang-lowering
-    cairo-lang-sierra-generator
-    cairo-lang-runnable-utils
-    cairo-lang-compiler
-    cairo-lang-starknet-classes
-    cairo-lang-starknet
-    cairo-lang-executable-plugin
-    cairo-lang-executable
-    cairo-lang-runner
-    cairo-lang-test-plugin
-    cairo-lang-test-runner
-    cairo-lang-execute-utils
-    cairo-lang-doc
-    cairo-compile
-    cairo-format
-    cairo-run
-    cairo-execute
-    cairo-test
-    cairo-size-profiler
-    sierra-compile
-    starknet-compile
-    starknet-sierra-compile
-)
-
-# Assert that the number of crates to publish is equal to the number of crates in the workspace
-# - 5 (the number of crates that are for internal use only).
-NUM_CRATES_IN_WORKSPACE=$(find crates/ -name Cargo.toml | wc -l)
-if [ "${#CRATES_TO_PUBLISH[@]}" -ne "$((NUM_CRATES_IN_WORKSPACE - 5))" ]; then
-    echo "The number of crates to publish is not equal to the number of crates in the workspace,"
-    echo "new crates were probably added, please update the list of crates to publish."
-    exit 1
-fi
+source "$(dirname "$0")/crates_list.sh"
 
 # Publish the crates.
-for CRATE in "${CRATES_TO_PUBLISH[@]:$SKIP_FIRST}"; do
-    cargo publish --package "$CRATE" || exit 1
+for CRATE in "${CRATES[@]:$SKIP_FIRST}"; do
+    output=$(cargo publish --package "$CRATE" 2>&1)
+    exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        if echo "$output" | grep -qi "already exists\|already uploaded"; then
+            echo "Skipping $CRATE (already published)."
+        else
+            echo "$output" >&2
+            exit 1
+        fi
+    fi
 done

--- a/scripts/yank_crates.sh
+++ b/scripts/yank_crates.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Yanks all crates from crates.io for a given version.
+# Usage: yank_crates.sh <version>
+#
+# Must be run after a failed release_crates.sh to undo partially published crates.
+# Crates that were not published are skipped with a warning.
+
+if [ -z "$1" ]; then
+    echo "Error: version argument is required (e.g. 2.17.0)."
+    exit 1
+fi
+VERSION="$1"
+
+source "$(dirname "$0")/crates_list.sh"
+
+for CRATE in "${CRATES[@]}"; do
+    output=$(cargo yank --version "$VERSION" "$CRATE" 2>&1)
+    if [ $? -ne 0 ]; then
+        if echo "$output" | grep -qi "not found\|does not exist"; then
+            echo "Skipping $CRATE@$VERSION (not published)."
+        else
+            echo "$output" >&2
+            exit 1
+        fi
+    fi
+done


### PR DESCRIPTION
- Add publish_crates CI job that runs release_crates.sh on v* tag push
- Gate binary release job on publish_crates succeeding
- Extract shared crate list (with workspace count assertion) into crates_list.sh
- Add yank_crates.sh for rolling back a partial publish