### PR TITLE
feat: add diagnostics phase benchmark

### DIFF
--- a/tests/benches/compile.rs
+++ b/tests/benches/compile.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
 
-use cairo_lang_compiler::{CompilerConfig, compile_cairo_project_at_path};
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
+use cairo_lang_compiler::project::setup_project;
+use cairo_lang_compiler::{CompilerConfig, compile_cairo_project_at_path, ensure_diagnostics};
+use cairo_lang_lowering::optimizations::config::Optimizations;
 use cairo_lang_lowering::utils::InliningStrategy;
 use criterion::{Criterion, criterion_group, criterion_main};
 
@@ -10,6 +14,7 @@ fn bench_compile(c: &mut Criterion) {
     let mut group = c.benchmark_group("compile");
     group.sample_size(10);
 
+    // Phase: source → Sierra (full IR generation).
     group.bench_function("fib", |b| {
         let path = workspace_root.join("examples").join("fib.cairo");
         b.iter(|| {
@@ -20,6 +25,22 @@ fn bench_compile(c: &mut Criterion) {
             )
             .unwrap()
         });
+    });
+
+    // Phase: source → diagnostics (no Sierra generation).
+    group.bench_function("fib_diagnostics", |b| {
+        let path = workspace_root.join("examples").join("fib.cairo");
+        b.iter(|| {
+            let mut db = RootDatabase::builder()
+                .with_optimizations(Optimizations::enabled_with_default_movable_functions(
+                    InliningStrategy::Default,
+                ))
+                .detect_corelib()
+                .build()
+                .unwrap();
+            setup_project(&mut db, &path).unwrap();
+            ensure_diagnostics(&db, &mut DiagnosticsReporter::ignoring()).unwrap()
+        })
     });
 
     group.finish();


### PR DESCRIPTION
### TL;DR

Added a new benchmark that measures only the diagnostic phase (source → diagnostics) without Sierra generation.

### What changed?

A new benchmark function `fib_diagnostics` was added alongside the existing `fib` benchmark. While `fib` measures the full source → Sierra compilation pipeline, `fib_diagnostics` isolates the cost of setting up the project and running diagnostics checks without proceeding to Sierra IR generation.

### How to test?

Run the compile benchmarks:

```
cargo bench --bench compile
```

Both `fib` and `fib_diagnostics` results will appear in the `compile` benchmark group.

### Why make this change?

Separating the diagnostic phase from full compilation allows for more granular performance profiling. This makes it easier to identify whether regressions or improvements are occurring in the front-end analysis stage versus the Sierra code generation stage.