### PR TITLE
feat: add cairo-to-testing benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,6 +4414,7 @@ dependencies = [
  "cairo-lang-sierra-to-casm",
  "cairo-lang-sierra-type-size",
  "cairo-lang-syntax",
+ "cairo-lang-test-runner",
  "cairo-lang-test-utils",
  "cairo-lang-utils",
  "criterion",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,6 +26,7 @@ cairo-lang-sierra-generator = { path = "../crates/cairo-lang-sierra-generator" }
 cairo-lang-sierra-to-casm = { path = "../crates/cairo-lang-sierra-to-casm", features = ["testing"] }
 cairo-lang-sierra-type-size = { path = "../crates/cairo-lang-sierra-type-size", version = "=2.17.0" }
 cairo-lang-syntax = { path = "../crates/cairo-lang-syntax" }
+cairo-lang-test-runner = { path = "../crates/cairo-lang-test-runner" }
 cairo-lang-test-utils = { path = "../crates/cairo-lang-test-utils", features = ["testing"] }
 cairo-lang-utils = { path = "../crates/cairo-lang-utils", features = ["tracing"] }
 criterion.workspace = true

--- a/tests/benches/compile.rs
+++ b/tests/benches/compile.rs
@@ -6,17 +6,18 @@ use cairo_lang_compiler::project::setup_project;
 use cairo_lang_compiler::{CompilerConfig, compile_cairo_project_at_path, ensure_diagnostics};
 use cairo_lang_lowering::optimizations::config::Optimizations;
 use cairo_lang_lowering::utils::InliningStrategy;
+use cairo_lang_test_runner::{TestRunConfig, TestRunner};
 use criterion::{Criterion, criterion_group, criterion_main};
 
 fn bench_compile(c: &mut Criterion) {
-    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).parent().unwrap().to_owned();
+    let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches").join("examples");
 
     let mut group = c.benchmark_group("compile");
     group.sample_size(10);
 
     // Phase: source → Sierra (full IR generation).
-    group.bench_function("fib", |b| {
-        let path = workspace_root.join("examples").join("fib.cairo");
+    group.bench_function("fib: cairo-to-sierra", |b| {
+        let path = examples.join("fib.cairo");
         b.iter(|| {
             compile_cairo_project_at_path(
                 &path,
@@ -28,8 +29,8 @@ fn bench_compile(c: &mut Criterion) {
     });
 
     // Phase: source → diagnostics (no Sierra generation).
-    group.bench_function("fib_diagnostics", |b| {
-        let path = workspace_root.join("examples").join("fib.cairo");
+    group.bench_function("fib: cairo-to-diagnostics", |b| {
+        let path = examples.join("fib.cairo");
         b.iter(|| {
             let mut db = RootDatabase::builder()
                 .with_optimizations(Optimizations::enabled_with_default_movable_functions(
@@ -40,6 +41,29 @@ fn bench_compile(c: &mut Criterion) {
                 .unwrap();
             setup_project(&mut db, &path).unwrap();
             ensure_diagnostics(&db, &mut DiagnosticsReporter::ignoring()).unwrap()
+        })
+    });
+
+    // Phase: source → test results (compile + execute all #[test] functions).
+    group.bench_function("fib: cairo-to-testing", |b| {
+        let path = examples.join("fib.cairo");
+        b.iter(|| {
+            TestRunner::new(
+                &path,
+                false,
+                false,
+                TestRunConfig {
+                    filter: String::new(),
+                    include_ignored: false,
+                    ignored: false,
+                    profiler_config: None,
+                    gas_enabled: true,
+                    print_resource_usage: false,
+                },
+            )
+            .unwrap()
+            .run()
+            .unwrap()
         })
     });
 

--- a/tests/benches/examples/fib.cairo
+++ b/tests/benches/examples/fib.cairo
@@ -1,0 +1,26 @@
+fn fib(a: felt252, b: felt252, n: felt252) -> felt252 {
+    match n {
+        0 => a,
+        _ => fib(b, a + b, n - 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fib;
+
+    #[test]
+    fn test_fib_0() {
+        assert!(fib(0, 1, 0) == 0);
+    }
+
+    #[test]
+    fn test_fib_5() {
+        assert!(fib(0, 1, 5) == 5);
+    }
+
+    #[test]
+    fn test_fib_10() {
+        assert!(fib(0, 1, 10) == 55);
+    }
+}


### PR DESCRIPTION
### TL;DR

Adds a new `cairo-to-testing` benchmark that measures the full compile-and-execute pipeline for Cairo test functions.

### What changed?

A new benchmark phase, `fib: cairo-to-testing`, has been added to the compile benchmark suite. This phase uses `TestRunner` to compile and execute all `#[test]` functions in the example file, covering the full source-to-test-results pipeline.

The existing benchmarks have been renamed for clarity:
- `fib` → `fib: cairo-to-sierra`
- `fib_diagnostics` → `fib: cairo-to-diagnostics`

The example `fib.cairo` file has been moved into a dedicated `tests/benches/examples/` directory and extended with a `tests` module containing three test cases (`test_fib_0`, `test_fib_5`, `test_fib_10`). The `cairo-lang-test-runner` crate has been added as a dependency to support the new benchmark.

### How to test?

Run the benchmarks with:

```
cargo bench --bench compile
```

### Why make this change?

The existing benchmarks only covered the source-to-Sierra and source-to-diagnostics compilation phases. Adding a source-to-testing benchmark provides visibility into the performance of the full pipeline, including test compilation and execution, making it easier to track regressions or improvements across the entire test workflow.