### PR TITLE
feat: add cairo-to-cache and cache-to-sierra compile benchmarks

### DIFF
--- a/tests/benches/compile.rs
+++ b/tests/benches/compile.rs
@@ -3,7 +3,12 @@ use std::path::PathBuf;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::setup_project;
-use cairo_lang_compiler::{CompilerConfig, compile_cairo_project_at_path, ensure_diagnostics};
+use cairo_lang_compiler::{
+    CompilerConfig, compile_cairo_project_at_path, compile_prepared_db_program, ensure_diagnostics,
+};
+use cairo_lang_filesystem::db::{files_group_input, set_crate_configs_input};
+use cairo_lang_filesystem::ids::{BlobLongId, CrateInput};
+use cairo_lang_lowering::cache::generate_crate_cache;
 use cairo_lang_lowering::optimizations::config::Optimizations;
 use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_test_runner::{TestRunConfig, TestRunner};
@@ -64,6 +69,54 @@ fn bench_compile(c: &mut Criterion) {
             .unwrap()
             .run()
             .unwrap()
+        })
+    });
+
+    // Phase: source → cache (compile + serialize lowering to bytes, no Sierra generation).
+    group.bench_function("fib: cairo-to-cache", |b| {
+        let path = examples.join("fib.cairo");
+        b.iter(|| {
+            let mut db = RootDatabase::builder()
+                .with_optimizations(Optimizations::enabled_with_default_movable_functions(
+                    InliningStrategy::Default,
+                ))
+                .detect_corelib()
+                .build()
+                .unwrap();
+            let inputs = setup_project(&mut db, &path).unwrap();
+            let crate_ids = CrateInput::into_crate_ids(&db, inputs);
+            generate_crate_cache(&db, crate_ids[0]).unwrap()
+        })
+    });
+
+    // Phase: cached lowering → Sierra (Sierra generation with pre-compiled lowering cache).
+    group.bench_function("fib: cache-to-sierra", |b| {
+        let path = examples.join("fib.cairo");
+        let mut db = RootDatabase::builder()
+            .with_optimizations(Optimizations::enabled_with_default_movable_functions(
+                InliningStrategy::Default,
+            ))
+            .detect_corelib()
+            .build()
+            .unwrap();
+        let inputs = setup_project(&mut db, &path).unwrap();
+        let crate_ids = CrateInput::into_crate_ids(&db, inputs);
+        let cache_bytes = generate_crate_cache(&db, crate_ids[0]).unwrap();
+        b.iter(|| {
+            let mut db = RootDatabase::builder()
+                .with_optimizations(Optimizations::enabled_with_default_movable_functions(
+                    InliningStrategy::Default,
+                ))
+                .detect_corelib()
+                .build()
+                .unwrap();
+            let inputs = setup_project(&mut db, &path).unwrap();
+            let mut crate_configs = files_group_input(&db).crate_configs(&db).clone().unwrap();
+            crate_configs.get_mut(&inputs[0]).unwrap().cache_file =
+                Some(BlobLongId::Virtual(cache_bytes.clone()));
+            set_crate_configs_input(&mut db, Some(crate_configs));
+            let crate_ids = CrateInput::into_crate_ids(&db, inputs);
+            compile_prepared_db_program(&db, crate_ids, CompilerConfig::default()).unwrap()
         })
     });
 


### PR DESCRIPTION
### TL;DR

Added two new benchmarks to measure the performance of the lowering cache pipeline for Cairo compilation.

### What changed?

Two new benchmark functions were added to the compile benchmark suite:

- **`fib: cairo-to-cache`** — measures the time to compile Cairo source to a serialized lowering cache (bytes), without Sierra generation.
- **`fib: cache-to-sierra`** — measures the time to generate Sierra from a pre-compiled lowering cache, isolating the cost of Sierra generation from the full compilation pipeline.

### How to test?

Run the compile benchmarks:

```sh
cargo bench --bench compile
```

The two new benchmark entries (`fib: cairo-to-cache` and `fib: cache-to-sierra`) will appear in the output alongside the existing benchmarks.

### Why make this change?

The lowering cache splits the compilation pipeline into two distinct phases. These benchmarks allow measuring each phase independently, making it possible to quantify the performance impact of caching lowering results and to track regressions or improvements in each phase separately.