### PR TITLE
docs: clarify mixed comparison/equality operators

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/comparison-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/comparison-operators.adoc
@@ -48,6 +48,16 @@ Write them with an explicit conjunction instead:
 let in_range = a < b && b < c;
 ----
 
+Mixed consecutive comparison/equality operators are also not supported, for example
+`a < b == c` or `a == b < c`.
+Make the intent explicit with conjunctions or parentheses:
+
+[source,cairo]
+----
+let in_range_and_equal = a < b && b == c;
+let bool_comparison = (a < b) == expected;
+----
+
 == Examples
 
 === Primitives


### PR DESCRIPTION
## Summary

Document that mixed consecutive comparison/equality operators such as `a < b == c` and `a == b < c` are also unsupported on the comparison operators page, and show the supported conjunction/parenthesized alternatives.

---

## Type of change

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The comparison operators page currently explains that `a < b < c` is unsupported, but it does not mention that mixed consecutive comparison/equality operators are rejected as well. Because the same page also says that comparison and equality operators share a precedence level, readers can reasonably infer that forms like `a < b == c` are valid. The parser rejects these expressions with `E1028`.

---

## What was the behavior or documentation before?

The page only documented unsupported chained comparisons such as `a < b < c`.

---

## What is the behavior or documentation after?

The page also documents unsupported mixed forms such as `a < b == c` and `a == b < c`, and
shows explicit conjunction/parenthesized alternatives.

---

## Related issue or discussion (if any)

N/A

---

## Additional context
