### PR TITLE
docs: clarify mixed comparison/equality in operator precedence

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/operator-precedence.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/operator-precedence.adoc
@@ -76,6 +76,11 @@ Write it with logical conjunctions instead:
 let all_equal = a == b && b == c;
 ----
 
+Mixed consecutive comparison/equality operators are also not supported
+(for example, `a < b == c` or `a == b < c`).
+Use explicit conjunctions or parenthesized boolean comparisons to express intent.
+The parser reports these forms as `E1028` (consecutive comparison operators).
+
 == Related
 
 - xref:operator-expressions.adoc[Operator expressions]


### PR DESCRIPTION
## Summary

Document that mixed consecutive comparison/equality operators such as `a < b == c` and `a == b < c` are also unsupported in the operator precedence reference, and point readers to explicit conjunctions or parenthesized boolean comparisons instead.

---

## Type of change

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The operator precedence page currently groups comparison and equality operators in the same precedence row and explains left-to-right associativity, but it only documents unsupported homogeneous chains such as `a < b < c` and `a == b == c`. That leaves a real ambiguity for mixed forms like `a < b == c` and `a == b < c`, which users can reasonably expect to parse from the precedence table alone. The parser rejects these forms with `E1028`.

---

## What was the behavior or documentation before?

The page did not state that mixed consecutive comparison/equality operators are rejected.

---

## What is the behavior or documentation after?

The page explicitly documents that mixed forms such as `a < b == c` and `a == b < c` are unsupported and points to explicit conjunctions or parenthesized boolean comparisons instead.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

This matches the parser behavior for consecutive comparison/equality operators and follows the recent `docs: clarify ...` operator-documentation pattern already merged in this repository.