### PR TITLE
corelib: add byte_reverse for u16/u32/u64

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -306,6 +306,39 @@ pub(crate) extern const fn u128_is_zero(a: u128) -> IsZeroResult<u128> implicits
 
 pub extern fn u128_byte_reverse(input: u128) -> u128 implicits(Bitwise) nopanic;
 
+/// Reverses the byte order of a `u16` value.
+///
+/// # Examples
+///
+/// ```
+/// assert!(u16_byte_reverse(0x0102) == 0x0201);
+/// ```
+pub fn u16_byte_reverse(input: u16) -> u16 {
+    (u128_byte_reverse(input.into()) / 0x10000000000000000000000000000_u128).try_into().unwrap()
+}
+
+/// Reverses the byte order of a `u32` value.
+///
+/// # Examples
+///
+/// ```
+/// assert!(u32_byte_reverse(0x01020304) == 0x04030201);
+/// ```
+pub fn u32_byte_reverse(input: u32) -> u32 {
+    (u128_byte_reverse(input.into()) / 0x1000000000000000000000000_u128).try_into().unwrap()
+}
+
+/// Reverses the byte order of a `u64` value.
+///
+/// # Examples
+///
+/// ```
+/// assert!(u64_byte_reverse(0x0102030405060708) == 0x0807060504030201);
+/// ```
+pub fn u64_byte_reverse(input: u64) -> u64 {
+    (u128_byte_reverse(input.into()) / 0x10000000000000000_u128).try_into().unwrap()
+}
+
 /// The 8-bit unsigned integer type.
 pub extern type u8;
 

--- a/corelib/src/test/integer_test.cairo
+++ b/corelib/src/test/integer_test.cairo
@@ -1254,6 +1254,33 @@ fn test_u128_byte_reverse() {
 }
 
 #[test]
+fn test_u16_byte_reverse() {
+    assert_eq(@integer::u16_byte_reverse(0x0102), @0x0201, 'Wrong byte reverse');
+    assert_eq(@integer::u16_byte_reverse(0x0000), @0x0000, 'Wrong byte reverse');
+    assert_eq(@integer::u16_byte_reverse(0xffff), @0xffff, 'Wrong byte reverse');
+}
+
+#[test]
+fn test_u32_byte_reverse() {
+    assert_eq(@integer::u32_byte_reverse(0x01020304), @0x04030201, 'Wrong byte reverse');
+    assert_eq(@integer::u32_byte_reverse(0x00000000), @0x00000000, 'Wrong byte reverse');
+    assert_eq(@integer::u32_byte_reverse(0xffffffff), @0xffffffff, 'Wrong byte reverse');
+}
+
+#[test]
+fn test_u64_byte_reverse() {
+    assert_eq(
+        @integer::u64_byte_reverse(0x0102030405060708), @0x0807060504030201, 'Wrong byte reverse',
+    );
+    assert_eq(
+        @integer::u64_byte_reverse(0x0000000000000000), @0x0000000000000000, 'Wrong byte reverse',
+    );
+    assert_eq(
+        @integer::u64_byte_reverse(0xffffffffffffffff), @0xffffffffffffffff, 'Wrong byte reverse',
+    );
+}
+
+#[test]
 fn test_i8_operators() {
     assert_eq(@1_i8, @1_i8, '1 == 1');
     assert_ne(@1_i8, @2_i8, '1 != 2');


### PR DESCRIPTION
Closes #3589. Thin wrappers over u128_byte_reverse.