### PR TITLE
refactor(lowering): Using `as_mut` instead of `take` + assignment.

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1565,19 +1565,16 @@ fn lower_expr_loop<'db>(
     .intern(db);
 
     // Generate the function.
-    let encapsulating_ctx = ctx.encapsulating_ctx.take().unwrap();
-    let loop_ctx = LoopContext { loop_expr_id, early_return_info: early_return_info.clone() };
+    let encapsulating_ctx = ctx.encapsulating_ctx.as_mut().unwrap();
     let lowered = lower_loop_function(
         encapsulating_ctx,
         function,
         loop_signature.clone(),
-        loop_ctx,
+        LoopContext { loop_expr_id, early_return_info: early_return_info.clone() },
         ctx.return_type,
     )
     .map_err(LoweringFlowError::Failed)?;
-    // TODO(spapini): Recursive call.
     encapsulating_ctx.lowerings.insert(GeneratedFunctionKey::Loop(stable_ptr), lowered);
-    ctx.encapsulating_ctx = Some(encapsulating_ctx);
     let call_loop_expr = call_loop_func_ex(
         ctx,
         loop_signature,
@@ -1949,16 +1946,14 @@ fn add_capture_destruct_impl<'db>(
 
     let location_id = LocationId::from_stable_location(db, location);
 
-    let encapsulating_ctx = ctx.encapsulating_ctx.take().unwrap();
+    let encapsulating_ctx = ctx.encapsulating_ctx.as_mut().unwrap();
     let return_type = signature.return_type;
     let lowered_impl_res = get_destruct_lowering(
         LoweringContext::new(encapsulating_ctx, function_id, signature, return_type)?,
         location_id,
         closure_info,
-    );
-    // Restore the encapsulating context before unwrapping the result.
-    ctx.encapsulating_ctx = Some(encapsulating_ctx);
-    ctx.lowerings.insert(func_key, lowered_impl_res?);
+    )?;
+    ctx.lowerings.insert(func_key, lowered_impl_res);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Replaces the pattern of `take()`-ing `encapsulating_ctx` out of `ctx`, using it, and then restoring it back via `ctx.encapsulating_ctx = Some(encapsulating_ctx)` with direct mutable borrows using `as_mut().unwrap()`. This eliminates the temporary ownership dance in both `lower_expr_loop` and `add_capture_destruct_impl`, and removes the now-unnecessary `TODO` comment about recursive calls.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous code temporarily moved `encapsulating_ctx` out of `ctx` using `.take()`, operated on it, and then manually restored it with `ctx.encapsulating_ctx = Some(...)`. This pattern was fragile — if an early return or error occurred between the `take()` and the restore, `ctx.encapsulating_ctx` would be left as `None`. In `add_capture_destruct_impl`, this was explicitly worked around by restoring the context before unwrapping the result. Using `as_mut().unwrap()` avoids this issue entirely by borrowing mutably without transferring ownership.

---

## What was the behavior or documentation before?

`encapsulating_ctx` was moved out of `ctx` with `.take()`, used, and then explicitly put back with `ctx.encapsulating_ctx = Some(encapsulating_ctx)`. In `add_capture_destruct_impl`, the restore had to happen before the error was propagated to avoid leaving `ctx` in an invalid state.

---

## What is the behavior or documentation after?

`encapsulating_ctx` is borrowed mutably in place via `as_mut().unwrap()`, removing the need to restore it afterward. Error propagation with `?` now works directly without any special ordering concerns.

---

## Related issue or discussion (if any)

None.

---

## Additional context

The removed `TODO(spapini): Recursive call.` comment in `lower_expr_loop` is no longer relevant given the refactored ownership model.