### PR TITLE
refactor(semantic): Added `with_finally` and used it for restoring contexts.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -38,6 +38,7 @@ use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 use cairo_lang_utils::{
     self as utils, Intern, OptionHelper, extract_matches, require, try_extract_matches,
+    with_finally,
 };
 use itertools::{Itertools, chain, zip_eq};
 use num_bigint::BigInt;
@@ -878,31 +879,37 @@ fn compute_expr_inline_macro_semantic<'db>(
     syntax: &ast::ExprInlineMacro<'db>,
 ) -> Maybe<Expr<'db>> {
     let prev_macro_call_data = ctx.resolver.macro_call_data.clone();
-    let InlineMacroExpansion { content, name, info } = expand_inline_macro(ctx, syntax)?;
-    let new_file_id = FileLongId::Virtual(VirtualFile {
-        parent: Some(syntax.stable_ptr(ctx.db).untyped().span_in_file(ctx.db)),
-        name: SmolStrId::from(ctx.db, name),
-        content: SmolStrId::from(ctx.db, content),
-        code_mappings: info.mappings.clone(),
-        kind: FileKind::Expr,
-        original_item_removed: true,
-    })
-    .intern(ctx.db);
-    ctx.resolver.files.push(new_file_id);
-    let expr_syntax = ctx.db.file_expr_syntax(new_file_id)?;
-    let parser_diagnostics = ctx.db.file_syntax_diagnostics(new_file_id);
-    if let Err(diag_added) = parser_diagnostics.check_error_free() {
-        for diag in parser_diagnostics.get_diagnostics_without_duplicates(ctx.db) {
-            ctx.diagnostics.report(
-                syntax.stable_ptr(ctx.db),
-                SemanticDiagnosticKind::MacroGeneratedCodeParserDiagnostic(diag),
-            );
-        }
-        return Err(diag_added);
-    }
-    let expr = ctx.run_in_macro_subscope(|ctx| compute_expr_semantic(ctx, &expr_syntax), info);
-    ctx.resolver.macro_call_data = prev_macro_call_data;
-    Ok(expr.expr)
+    with_finally(
+        ctx,
+        |ctx| {
+            let InlineMacroExpansion { content, name, info } = expand_inline_macro(ctx, syntax)?;
+            let new_file_id = FileLongId::Virtual(VirtualFile {
+                parent: Some(syntax.stable_ptr(ctx.db).untyped().span_in_file(ctx.db)),
+                name: SmolStrId::from(ctx.db, name),
+                content: SmolStrId::from(ctx.db, content),
+                code_mappings: info.mappings.clone(),
+                kind: FileKind::Expr,
+                original_item_removed: true,
+            })
+            .intern(ctx.db);
+            ctx.resolver.files.push(new_file_id);
+            let expr_syntax = ctx.db.file_expr_syntax(new_file_id)?;
+            let parser_diagnostics = ctx.db.file_syntax_diagnostics(new_file_id);
+            if let Err(diag_added) = parser_diagnostics.check_error_free() {
+                for diag in parser_diagnostics.get_diagnostics_without_duplicates(ctx.db) {
+                    ctx.diagnostics.report(
+                        syntax.stable_ptr(ctx.db),
+                        SemanticDiagnosticKind::MacroGeneratedCodeParserDiagnostic(diag),
+                    );
+                }
+                return Err(diag_added);
+            }
+            Ok(ctx.run_in_macro_subscope(|ctx| compute_expr_semantic(ctx, &expr_syntax), info).expr)
+        },
+        |ctx| {
+            ctx.resolver.macro_call_data = prev_macro_call_data;
+        },
+    )
 }
 
 /// Computes the semantic model of a tail expression, handling inline macros recursively and
@@ -917,27 +924,30 @@ fn compute_tail_semantic<'db>(
 
     let db = ctx.db;
     let expr = tail.expr(db);
-    let res = match &expr {
-        ast::Expr::InlineMacro(inline_macro_syntax) => {
-            match expand_macro_for_statement(ctx, inline_macro_syntax, true, statements_ids) {
-                Ok(Some(expr_and_id)) => expr_and_id,
-                Ok(None) => unreachable!("Tail expression should not be None"),
-                Err(diag_added) => {
-                    let expr = Expr::Missing(ExprMissing {
-                        ty: TypeId::missing(db, diag_added),
-                        stable_ptr: expr.stable_ptr(db),
-                        diag_added,
-                    });
-                    ExprAndId { id: ctx.arenas.exprs.alloc(expr.clone()), expr }
+    with_finally(
+        ctx,
+        |ctx| match &expr {
+            ast::Expr::InlineMacro(inline_macro_syntax) => {
+                match expand_macro_for_statement(ctx, inline_macro_syntax, true, statements_ids) {
+                    Ok(Some(expr_and_id)) => expr_and_id,
+                    Ok(None) => unreachable!("Tail expression should not be None"),
+                    Err(diag_added) => {
+                        let expr = Expr::Missing(ExprMissing {
+                            ty: TypeId::missing(db, diag_added),
+                            stable_ptr: expr.stable_ptr(db),
+                            diag_added,
+                        });
+                        ExprAndId { id: ctx.arenas.exprs.alloc(expr.clone()), expr }
+                    }
                 }
             }
-        }
-        _ => compute_expr_semantic(ctx, &expr),
-    };
-
-    // Pop the statement's attributes from the context.
-    ctx.restore_features(feature_restore);
-    res
+            _ => compute_expr_semantic(ctx, &expr),
+        },
+        |ctx| {
+            // Pop the statement's attributes from the context.
+            ctx.restore_features(feature_restore);
+        },
+    )
 }
 
 /// Expands an inline macro used in statement position, computes its semantic model, and extends
@@ -949,55 +959,63 @@ fn expand_macro_for_statement<'db>(
     statements_ids: &mut Vec<StatementId>,
 ) -> Maybe<Option<ExprAndId<'db>>> {
     let prev_macro_call_data = ctx.resolver.macro_call_data.clone();
-    let InlineMacroExpansion { content, name, info } = expand_inline_macro(ctx, syntax)?;
-    let new_file_id = FileLongId::Virtual(VirtualFile {
-        parent: Some(syntax.stable_ptr(ctx.db).untyped().span_in_file(ctx.db)),
-        name: SmolStrId::from(ctx.db, name),
-        content: SmolStrId::from_arcstr(ctx.db, &content),
-        code_mappings: info.mappings.clone(),
-        kind: FileKind::StatementList,
-        original_item_removed: true,
-    })
-    .intern(ctx.db);
-    ctx.resolver.files.push(new_file_id);
-    let parser_diagnostics = ctx.db.file_syntax_diagnostics(new_file_id);
-    if let Err(diag_added) = parser_diagnostics.check_error_free() {
-        for diag in parser_diagnostics.get_diagnostics_without_duplicates(ctx.db) {
-            ctx.diagnostics.report(
-                syntax.stable_ptr(ctx.db),
-                SemanticDiagnosticKind::MacroGeneratedCodeParserDiagnostic(diag),
-            );
-        }
-        return Err(diag_added);
-    }
-    let statement_list = ctx.db.file_statement_list_syntax(new_file_id)?;
-    let (parsed_statements, tail) = statements_and_tail(ctx.db, statement_list);
-    let result = ctx.run_in_macro_subscope(
+    with_finally(
+        ctx,
         |ctx| {
-            compute_statements_semantic_and_extend(ctx, parsed_statements, statements_ids);
-            if is_tail {
-                if let Some(tail_expr) = tail {
-                    Ok(Some(compute_tail_semantic(ctx, &tail_expr, statements_ids)))
-                } else {
-                    Err(ctx.diagnostics.report_after(syntax.stable_ptr(ctx.db), MissingSemicolon))
+            let InlineMacroExpansion { content, name, info } = expand_inline_macro(ctx, syntax)?;
+            let new_file_id = FileLongId::Virtual(VirtualFile {
+                parent: Some(syntax.stable_ptr(ctx.db).untyped().span_in_file(ctx.db)),
+                name: SmolStrId::from(ctx.db, name),
+                content: SmolStrId::from_arcstr(ctx.db, &content),
+                code_mappings: info.mappings.clone(),
+                kind: FileKind::StatementList,
+                original_item_removed: true,
+            })
+            .intern(ctx.db);
+            ctx.resolver.files.push(new_file_id);
+            let parser_diagnostics = ctx.db.file_syntax_diagnostics(new_file_id);
+            if let Err(diag_added) = parser_diagnostics.check_error_free() {
+                for diag in parser_diagnostics.get_diagnostics_without_duplicates(ctx.db) {
+                    ctx.diagnostics.report(
+                        syntax.stable_ptr(ctx.db),
+                        SemanticDiagnosticKind::MacroGeneratedCodeParserDiagnostic(diag),
+                    );
                 }
-            } else {
-                if let Some(tail_expr) = tail {
-                    let expr = compute_expr_semantic(ctx, &tail_expr.expr(ctx.db));
-                    statements_ids.push(ctx.arenas.statements.alloc(semantic::Statement::Expr(
-                        semantic::StatementExpr {
-                            expr: expr.id,
-                            stable_ptr: tail_expr.stable_ptr(ctx.db).into(),
-                        },
-                    )));
-                }
-                Ok(None)
+                return Err(diag_added);
             }
+            let statement_list = ctx.db.file_statement_list_syntax(new_file_id)?;
+            let (parsed_statements, tail) = statements_and_tail(ctx.db, statement_list);
+            ctx.run_in_macro_subscope(
+                |ctx| {
+                    compute_statements_semantic_and_extend(ctx, parsed_statements, statements_ids);
+                    if is_tail {
+                        if let Some(tail_expr) = tail {
+                            Ok(Some(compute_tail_semantic(ctx, &tail_expr, statements_ids)))
+                        } else {
+                            Err(ctx
+                                .diagnostics
+                                .report_after(syntax.stable_ptr(ctx.db), MissingSemicolon))
+                        }
+                    } else {
+                        if let Some(tail_expr) = tail {
+                            let expr = compute_expr_semantic(ctx, &tail_expr.expr(ctx.db));
+                            statements_ids.push(ctx.arenas.statements.alloc(
+                                semantic::Statement::Expr(semantic::StatementExpr {
+                                    expr: expr.id,
+                                    stable_ptr: tail_expr.stable_ptr(ctx.db).into(),
+                                }),
+                            ));
+                        }
+                        Ok(None)
+                    }
+                },
+                info,
+            )
         },
-        info,
-    );
-    ctx.resolver.macro_call_data = prev_macro_call_data;
-    result
+        |ctx| {
+            ctx.resolver.macro_call_data = prev_macro_call_data;
+        },
+    )
 }
 
 fn compute_expr_unary_semantic<'db>(
@@ -4482,360 +4500,390 @@ pub fn compute_and_append_statement_semantic<'db>(
 ) -> Maybe<()> {
     // Push the statement's attributes into the context, restored after the computation is resolved.
     let feature_restore = ctx.add_features_from_statement(&syntax);
-
-    let db = ctx.db;
-    let _ = match &syntax {
-        ast::Statement::Let(let_syntax) => {
-            let rhs_syntax = &let_syntax.rhs(db);
-            let (rhs_expr, ty) = match let_syntax.type_clause(db) {
-                ast::OptionTypeClause::Empty(_) => {
-                    let rhs_expr = compute_expr_semantic(ctx, rhs_syntax);
-                    let inferred_type = rhs_expr.ty();
-                    (rhs_expr, inferred_type)
-                }
-                ast::OptionTypeClause::TypeClause(type_clause) => {
-                    let var_type_path = type_clause.ty(db);
-                    let explicit_type = resolve_type_ex(
-                        db,
-                        ctx.diagnostics,
-                        ctx.resolver,
-                        &var_type_path,
-                        ResolutionContext::Statement(&mut ctx.environment),
-                    );
-
-                    let rhs_expr = compute_expr_semantic(ctx, rhs_syntax);
-                    let inferred_type = ctx.reduce_ty(rhs_expr.ty());
-                    if !inferred_type.is_missing(db) {
-                        let inference = &mut ctx.resolver.inference();
-                        let _ = inference.conform_ty_for_diag(
-                            inferred_type,
-                            explicit_type,
-                            ctx.diagnostics,
-                            || rhs_syntax.stable_ptr(db).untyped(),
-                            |actual_ty, expected_ty| WrongArgumentType { expected_ty, actual_ty },
-                        );
-                    }
-                    (rhs_expr, explicit_type)
-                }
-            };
-            let rhs_expr_id = rhs_expr.id;
-
-            let else_clause = match let_syntax.let_else_clause(db) {
-                ast::OptionLetElseClause::Empty(_) => None,
-                ast::OptionLetElseClause::LetElseClause(else_clause) => {
-                    let else_block_syntax = else_clause.else_block(db);
-                    let else_block_stable_ptr = else_block_syntax.stable_ptr(db);
-
-                    let else_block =
-                        compute_expr_semantic(ctx, &ast::Expr::Block(else_block_syntax));
-
-                    if else_block.ty() != never_ty(db) {
-                        // Report the error, but continue processing.
-                        ctx.diagnostics.report(else_block_stable_ptr, NonNeverLetElseType);
-                    }
-
-                    Some(else_block.id)
-                }
-            };
-
-            let pattern = compute_pattern_semantic(
-                ctx,
-                &let_syntax.pattern(db),
-                ty,
-                &UnorderedHashMap::default(),
-            );
-            let variables = pattern.variables(&ctx.arenas.patterns);
-            let mut variable_names_in_pattern = UnorderedHashSet::<_>::default();
-            for v in variables {
-                if !variable_names_in_pattern.insert(v.name) {
-                    ctx.diagnostics
-                        .report(v.stable_ptr, VariableDefinedMultipleTimesInPattern(v.name));
-                }
-                let var_def = Binding::LocalVar(v.var.clone());
-                if let Some(old_var) = ctx.environment.variables.insert(v.name, var_def.clone()) {
-                    if matches!(old_var, Binding::LocalItem(_)) {
-                        return Err(ctx
-                            .diagnostics
-                            .report(v.stable_ptr, MultipleDefinitionforBinding(v.name)));
-                    }
-                    add_unused_binding_warning(
-                        ctx.diagnostics,
-                        ctx.db,
-                        &ctx.environment.used_variables,
-                        v.name,
-                        &old_var,
-                        &ctx.resolver.data.feature_config,
-                    );
-                }
-                if ctx.macro_defined_var_unhygienic
-                    && let Some(macro_info) = &mut ctx.environment.macro_info
-                {
-                    macro_info.vars_to_expose.push((v.name, var_def.clone()));
-                }
-                let _ = ctx.variable_tracker.insert(var_def);
-            }
-            statements.push(ctx.arenas.statements.alloc(semantic::Statement::Let(
-                semantic::StatementLet {
-                    pattern: pattern.id,
-                    expr: rhs_expr_id,
-                    else_clause,
-                    stable_ptr: syntax.stable_ptr(db),
-                },
-            )));
-            Ok(()) as Maybe<()>
-        }
-        ast::Statement::Expr(stmt_expr_syntax) => {
-            let expr_syntax = stmt_expr_syntax.expr(db);
-            if let ast::Expr::InlineMacro(inline_macro_syntax) = &expr_syntax {
-                expand_macro_for_statement(ctx, inline_macro_syntax, false, statements)?;
-            } else {
-                let expr = compute_expr_semantic(ctx, &expr_syntax);
-                if matches!(stmt_expr_syntax.semicolon(db), ast::OptionTerminalSemicolon::Empty(_))
-                    && !matches!(
-                        expr_syntax,
-                        ast::Expr::Block(_)
-                            | ast::Expr::If(_)
-                            | ast::Expr::Match(_)
-                            | ast::Expr::Loop(_)
-                            | ast::Expr::While(_)
-                            | ast::Expr::For(_)
-                    )
-                {
-                    ctx.diagnostics.report_after(expr_syntax.stable_ptr(db), MissingSemicolon);
-                }
-                let ty: TypeId<'_> = expr.ty();
-                if let TypeLongId::Concrete(concrete) = ty.long(db)
-                    && concrete.is_must_use(db)?
-                {
-                    ctx.diagnostics.report(expr_syntax.stable_ptr(db), UnhandledMustUseType(ty));
-                }
-                if let Expr::FunctionCall(expr_function_call) = &expr.expr {
-                    let generic_function_id =
-                        expr_function_call.function.long(db).function.generic_function;
-                    if generic_function_id.is_must_use(db)? {
-                        ctx.diagnostics
-                            .report(expr_syntax.stable_ptr(db), UnhandledMustUseFunction);
-                    }
-                }
-                statements.push(ctx.arenas.statements.alloc(semantic::Statement::Expr(
-                    semantic::StatementExpr { expr: expr.id, stable_ptr: syntax.stable_ptr(db) },
-                )));
-            }
-            Ok(())
-        }
-        ast::Statement::Continue(continue_syntax) => {
-            if !ctx.is_inside_loop() {
-                return Err(ctx
-                    .diagnostics
-                    .report(continue_syntax.stable_ptr(db), ContinueOnlyAllowedInsideALoop));
-            }
-            statements.push(ctx.arenas.statements.alloc(semantic::Statement::Continue(
-                semantic::StatementContinue { stable_ptr: syntax.stable_ptr(db) },
-            )));
-            Ok(())
-        }
-        ast::Statement::Return(return_syntax) => {
-            let (expr_option, expr_ty, stable_ptr) = match return_syntax.expr_clause(db) {
-                ast::OptionExprClause::Empty(empty_clause) => {
-                    (None, unit_ty(db), empty_clause.stable_ptr(db).untyped())
-                }
-                ast::OptionExprClause::ExprClause(expr_clause) => {
-                    let expr_syntax = expr_clause.expr(db);
-                    let expr = compute_expr_semantic(ctx, &expr_syntax);
-                    (Some(expr.id), expr.ty(), expr_syntax.stable_ptr(db).untyped())
-                }
-            };
-            let expected_ty = match &ctx.inner_ctx {
-                None => ctx.get_return_type().ok_or_else(|| {
-                    ctx.diagnostics.report(
-                        return_syntax.stable_ptr(db),
-                        UnsupportedOutsideOfFunction(
-                            UnsupportedOutsideOfFunctionFeatureName::ReturnStatement,
-                        ),
-                    )
-                })?,
-                Some(ctx) => ctx.return_type,
-            };
-
-            let expected_ty = ctx.reduce_ty(expected_ty);
-            let expr_ty = ctx.reduce_ty(expr_ty);
-            if !expected_ty.is_missing(db) && !expr_ty.is_missing(db) {
-                let inference = &mut ctx.resolver.inference();
-                let _ = inference.conform_ty_for_diag(
-                    expr_ty,
-                    expected_ty,
-                    ctx.diagnostics,
-                    || stable_ptr,
-                    |actual_ty, expected_ty| WrongReturnType { expected_ty, actual_ty },
-                );
-            }
-            statements.push(ctx.arenas.statements.alloc(semantic::Statement::Return(
-                semantic::StatementReturn { expr_option, stable_ptr: syntax.stable_ptr(db) },
-            )));
-            Ok(())
-        }
-        ast::Statement::Break(break_syntax) => {
-            let (expr_option, ty, stable_ptr) = match break_syntax.expr_clause(db) {
-                ast::OptionExprClause::Empty(expr_empty) => {
-                    (None, unit_ty(db), expr_empty.stable_ptr(db).untyped())
-                }
-                ast::OptionExprClause::ExprClause(expr_clause) => {
-                    let expr_syntax = expr_clause.expr(db);
-                    let expr = compute_expr_semantic(ctx, &expr_syntax);
-
-                    (Some(expr.id), expr.ty(), expr.stable_ptr().untyped())
-                }
-            };
-            let ty = ctx.reduce_ty(ty);
-
-            if !ctx.is_inside_loop() {
-                return Err(ctx
-                    .diagnostics
-                    .report(break_syntax.stable_ptr(db), BreakOnlyAllowedInsideALoop));
-            }
-
-            if let Some(inner_ctx) = &mut ctx.inner_ctx {
-                match &mut inner_ctx.kind {
-                    InnerContextKind::Loop { type_merger, .. } => {
-                        type_merger.try_merge_types(
-                            ctx.db,
-                            ctx.diagnostics,
-                            &mut ctx.resolver.inference(),
-                            ty,
-                            stable_ptr,
-                        );
-                    }
-                    InnerContextKind::While | InnerContextKind::For => {
-                        if expr_option.is_some() {
-                            ctx.diagnostics.report(
-                                break_syntax.stable_ptr(db),
-                                BreakWithValueOnlyAllowedInsideALoop,
+    with_finally(
+        ctx,
+        |ctx| {
+            let db = ctx.db;
+            match &syntax {
+                ast::Statement::Let(let_syntax) => {
+                    let rhs_syntax = &let_syntax.rhs(db);
+                    let (rhs_expr, ty) = match let_syntax.type_clause(db) {
+                        ast::OptionTypeClause::Empty(_) => {
+                            let rhs_expr = compute_expr_semantic(ctx, rhs_syntax);
+                            let inferred_type = rhs_expr.ty();
+                            (rhs_expr, inferred_type)
+                        }
+                        ast::OptionTypeClause::TypeClause(type_clause) => {
+                            let var_type_path = type_clause.ty(db);
+                            let explicit_type = resolve_type_ex(
+                                db,
+                                ctx.diagnostics,
+                                ctx.resolver,
+                                &var_type_path,
+                                ResolutionContext::Statement(&mut ctx.environment),
                             );
-                        };
-                    }
-                    InnerContextKind::Closure => unreachable!("Not inside a loop."),
-                }
-            }
 
-            statements.push(ctx.arenas.statements.alloc(semantic::Statement::Break(
-                semantic::StatementBreak { expr_option, stable_ptr: syntax.stable_ptr(db) },
-            )));
-            Ok(())
-        }
-        ast::Statement::Item(stmt_item_syntax) => {
-            let item_syntax = &stmt_item_syntax.item(db);
-            match item_syntax {
-                ast::ModuleItem::Constant(const_syntax) => {
-                    let lhs = const_syntax.type_clause(db).ty(db);
-                    let rhs = const_syntax.value(db);
-                    let rhs_expr = compute_expr_semantic(ctx, &rhs);
-                    let explicit_type = resolve_type_ex(
-                        db,
-                        ctx.diagnostics,
-                        ctx.resolver,
-                        &lhs,
-                        ResolutionContext::Statement(&mut ctx.environment),
-                    );
-                    let rhs_resolved_expr = resolve_const_expr_and_evaluate(
-                        db,
-                        ctx,
-                        &rhs_expr,
-                        stmt_item_syntax.stable_ptr(db).untyped(),
-                        explicit_type,
-                        false,
-                    );
-                    let name_syntax = const_syntax.name(db);
-                    let name = name_syntax.text(db);
-                    let rhs_id =
-                        StatementConstLongId(ctx.resolver.module_id, const_syntax.stable_ptr(db));
-                    let var_def = Binding::LocalItem(LocalItem {
-                        id: StatementItemId::Constant(rhs_id.intern(db)),
-                        kind: StatementItemKind::Constant(
-                            rhs_resolved_expr,
-                            rhs_resolved_expr.ty(db)?,
-                        ),
-                    });
-                    add_value_to_statement_environment(
-                        ctx,
-                        name,
-                        var_def,
-                        name_syntax.stable_ptr(db),
-                    );
-                }
-                ast::ModuleItem::Use(use_syntax) => {
-                    for leaf in get_all_path_leaves(db, use_syntax) {
-                        let stable_ptr = leaf.stable_ptr(db);
-                        let resolved_item = ctx.resolver.resolve_use_path(
-                            ctx.diagnostics,
-                            ast::UsePath::Leaf(leaf),
-                            ResolutionContext::Statement(&mut ctx.environment),
-                        )?;
-                        let var_def_id = StatementItemId::Use(
-                            StatementUseLongId(ctx.resolver.module_id, stable_ptr).intern(db),
-                        );
-                        let name = var_def_id.name(db);
-                        match resolved_item {
-                            ResolvedGenericItem::GenericConstant(const_id) => {
-                                let const_value_id = db.constant_const_value(const_id)?;
-                                let var_def = Binding::LocalItem(LocalItem {
-                                    id: var_def_id,
-                                    kind: StatementItemKind::Constant(
-                                        const_value_id,
-                                        const_value_id.ty(db)?,
-                                    ),
-                                });
-                                add_value_to_statement_environment(ctx, name, var_def, stable_ptr);
+                            let rhs_expr = compute_expr_semantic(ctx, rhs_syntax);
+                            let inferred_type = ctx.reduce_ty(rhs_expr.ty());
+                            if !inferred_type.is_missing(db) {
+                                let inference = &mut ctx.resolver.inference();
+                                let _ = inference.conform_ty_for_diag(
+                                    inferred_type,
+                                    explicit_type,
+                                    ctx.diagnostics,
+                                    || rhs_syntax.stable_ptr(db).untyped(),
+                                    |actual_ty, expected_ty| WrongArgumentType {
+                                        expected_ty,
+                                        actual_ty,
+                                    },
+                                );
                             }
-                            item @ (ResolvedGenericItem::GenericType(_)
-                            | ResolvedGenericItem::Module(_)) => {
-                                add_item_to_statement_environment(ctx, name, item, stable_ptr);
+                            (rhs_expr, explicit_type)
+                        }
+                    };
+                    let rhs_expr_id = rhs_expr.id;
+
+                    let else_clause = match let_syntax.let_else_clause(db) {
+                        ast::OptionLetElseClause::Empty(_) => None,
+                        ast::OptionLetElseClause::LetElseClause(else_clause) => {
+                            let else_block_syntax = else_clause.else_block(db);
+                            let else_block_stable_ptr = else_block_syntax.stable_ptr(db);
+
+                            let else_block =
+                                compute_expr_semantic(ctx, &ast::Expr::Block(else_block_syntax));
+
+                            if else_block.ty() != never_ty(db) {
+                                // Report the error, but continue processing.
+                                ctx.diagnostics.report(else_block_stable_ptr, NonNeverLetElseType);
                             }
-                            ResolvedGenericItem::GenericFunction(_)
-                            | ResolvedGenericItem::GenericTypeAlias(_)
-                            | ResolvedGenericItem::GenericImplAlias(_)
-                            | ResolvedGenericItem::Variant(_)
-                            | ResolvedGenericItem::Trait(_)
-                            | ResolvedGenericItem::Impl(_)
-                            | ResolvedGenericItem::Variable(_)
-                            | ResolvedGenericItem::TraitItem(_)
-                            | ResolvedGenericItem::Macro(_) => {
+
+                            Some(else_block.id)
+                        }
+                    };
+
+                    let pattern = compute_pattern_semantic(
+                        ctx,
+                        &let_syntax.pattern(db),
+                        ty,
+                        &UnorderedHashMap::default(),
+                    );
+                    let variables = pattern.variables(&ctx.arenas.patterns);
+                    let mut variable_names_in_pattern = UnorderedHashSet::<_>::default();
+                    for v in variables {
+                        if !variable_names_in_pattern.insert(v.name) {
+                            ctx.diagnostics.report(
+                                v.stable_ptr,
+                                VariableDefinedMultipleTimesInPattern(v.name),
+                            );
+                        }
+                        let var_def = Binding::LocalVar(v.var.clone());
+                        if let Some(old_var) =
+                            ctx.environment.variables.insert(v.name, var_def.clone())
+                        {
+                            if matches!(old_var, Binding::LocalItem(_)) {
                                 return Err(ctx
                                     .diagnostics
-                                    .report(stable_ptr, UnsupportedUseItemInStatement));
+                                    .report(v.stable_ptr, MultipleDefinitionforBinding(v.name)));
+                            }
+                            add_unused_binding_warning(
+                                ctx.diagnostics,
+                                ctx.db,
+                                &ctx.environment.used_variables,
+                                v.name,
+                                &old_var,
+                                &ctx.resolver.data.feature_config,
+                            );
+                        }
+                        if ctx.macro_defined_var_unhygienic
+                            && let Some(macro_info) = &mut ctx.environment.macro_info
+                        {
+                            macro_info.vars_to_expose.push((v.name, var_def.clone()));
+                        }
+                        let _ = ctx.variable_tracker.insert(var_def);
+                    }
+                    statements.push(ctx.arenas.statements.alloc(semantic::Statement::Let(
+                        semantic::StatementLet {
+                            pattern: pattern.id,
+                            expr: rhs_expr_id,
+                            else_clause,
+                            stable_ptr: syntax.stable_ptr(db),
+                        },
+                    )));
+                    Ok(())
+                }
+                ast::Statement::Expr(stmt_expr_syntax) => {
+                    let expr_syntax = stmt_expr_syntax.expr(db);
+                    if let ast::Expr::InlineMacro(inline_macro_syntax) = &expr_syntax {
+                        expand_macro_for_statement(ctx, inline_macro_syntax, false, statements)?;
+                    } else {
+                        let expr = compute_expr_semantic(ctx, &expr_syntax);
+                        if matches!(
+                            stmt_expr_syntax.semicolon(db),
+                            ast::OptionTerminalSemicolon::Empty(_)
+                        ) && !matches!(
+                            expr_syntax,
+                            ast::Expr::Block(_)
+                                | ast::Expr::If(_)
+                                | ast::Expr::Match(_)
+                                | ast::Expr::Loop(_)
+                                | ast::Expr::While(_)
+                                | ast::Expr::For(_)
+                        ) {
+                            ctx.diagnostics
+                                .report_after(expr_syntax.stable_ptr(db), MissingSemicolon);
+                        }
+                        let ty: TypeId<'_> = expr.ty();
+                        if let TypeLongId::Concrete(concrete) = ty.long(db)
+                            && concrete.is_must_use(db)?
+                        {
+                            ctx.diagnostics
+                                .report(expr_syntax.stable_ptr(db), UnhandledMustUseType(ty));
+                        }
+                        if let Expr::FunctionCall(expr_function_call) = &expr.expr {
+                            let generic_function_id =
+                                expr_function_call.function.long(db).function.generic_function;
+                            if generic_function_id.is_must_use(db)? {
+                                ctx.diagnostics
+                                    .report(expr_syntax.stable_ptr(db), UnhandledMustUseFunction);
                             }
                         }
+                        statements.push(ctx.arenas.statements.alloc(semantic::Statement::Expr(
+                            semantic::StatementExpr {
+                                expr: expr.id,
+                                stable_ptr: syntax.stable_ptr(db),
+                            },
+                        )));
                     }
+                    Ok(())
                 }
-                ast::ModuleItem::Module(_)
-                | ast::ModuleItem::FreeFunction(_)
-                | ast::ModuleItem::ExternFunction(_)
-                | ast::ModuleItem::ExternType(_)
-                | ast::ModuleItem::Trait(_)
-                | ast::ModuleItem::Impl(_)
-                | ast::ModuleItem::ImplAlias(_)
-                | ast::ModuleItem::Struct(_)
-                | ast::ModuleItem::Enum(_)
-                | ast::ModuleItem::TypeAlias(_)
-                | ast::ModuleItem::InlineMacro(_)
-                | ast::ModuleItem::HeaderDoc(_)
-                | ast::ModuleItem::MacroDeclaration(_) => {
-                    return Err(ctx
-                        .diagnostics
-                        .report(stmt_item_syntax.stable_ptr(db), UnsupportedItemInStatement));
+                ast::Statement::Continue(continue_syntax) => {
+                    if !ctx.is_inside_loop() {
+                        return Err(ctx.diagnostics.report(
+                            continue_syntax.stable_ptr(db),
+                            ContinueOnlyAllowedInsideALoop,
+                        ));
+                    }
+                    statements.push(ctx.arenas.statements.alloc(semantic::Statement::Continue(
+                        semantic::StatementContinue { stable_ptr: syntax.stable_ptr(db) },
+                    )));
+                    Ok(())
+                }
+                ast::Statement::Return(return_syntax) => {
+                    let (expr_option, expr_ty, stable_ptr) = match return_syntax.expr_clause(db) {
+                        ast::OptionExprClause::Empty(empty_clause) => {
+                            (None, unit_ty(db), empty_clause.stable_ptr(db).untyped())
+                        }
+                        ast::OptionExprClause::ExprClause(expr_clause) => {
+                            let expr_syntax = expr_clause.expr(db);
+                            let expr = compute_expr_semantic(ctx, &expr_syntax);
+                            (Some(expr.id), expr.ty(), expr_syntax.stable_ptr(db).untyped())
+                        }
+                    };
+                    let expected_ty = match &ctx.inner_ctx {
+                        None => ctx.get_return_type().ok_or_else(|| {
+                            ctx.diagnostics.report(
+                                return_syntax.stable_ptr(db),
+                                UnsupportedOutsideOfFunction(
+                                    UnsupportedOutsideOfFunctionFeatureName::ReturnStatement,
+                                ),
+                            )
+                        })?,
+                        Some(ctx) => ctx.return_type,
+                    };
+
+                    let expected_ty = ctx.reduce_ty(expected_ty);
+                    let expr_ty = ctx.reduce_ty(expr_ty);
+                    if !expected_ty.is_missing(db) && !expr_ty.is_missing(db) {
+                        let inference = &mut ctx.resolver.inference();
+                        let _ = inference.conform_ty_for_diag(
+                            expr_ty,
+                            expected_ty,
+                            ctx.diagnostics,
+                            || stable_ptr,
+                            |actual_ty, expected_ty| WrongReturnType { expected_ty, actual_ty },
+                        );
+                    }
+                    statements.push(ctx.arenas.statements.alloc(semantic::Statement::Return(
+                        semantic::StatementReturn {
+                            expr_option,
+                            stable_ptr: syntax.stable_ptr(db),
+                        },
+                    )));
+                    Ok(())
+                }
+                ast::Statement::Break(break_syntax) => {
+                    let (expr_option, ty, stable_ptr) = match break_syntax.expr_clause(db) {
+                        ast::OptionExprClause::Empty(expr_empty) => {
+                            (None, unit_ty(db), expr_empty.stable_ptr(db).untyped())
+                        }
+                        ast::OptionExprClause::ExprClause(expr_clause) => {
+                            let expr_syntax = expr_clause.expr(db);
+                            let expr = compute_expr_semantic(ctx, &expr_syntax);
+
+                            (Some(expr.id), expr.ty(), expr.stable_ptr().untyped())
+                        }
+                    };
+                    let ty = ctx.reduce_ty(ty);
+
+                    if !ctx.is_inside_loop() {
+                        return Err(ctx
+                            .diagnostics
+                            .report(break_syntax.stable_ptr(db), BreakOnlyAllowedInsideALoop));
+                    }
+
+                    if let Some(inner_ctx) = &mut ctx.inner_ctx {
+                        match &mut inner_ctx.kind {
+                            InnerContextKind::Loop { type_merger, .. } => {
+                                type_merger.try_merge_types(
+                                    ctx.db,
+                                    ctx.diagnostics,
+                                    &mut ctx.resolver.inference(),
+                                    ty,
+                                    stable_ptr,
+                                );
+                            }
+                            InnerContextKind::While | InnerContextKind::For => {
+                                if expr_option.is_some() {
+                                    ctx.diagnostics.report(
+                                        break_syntax.stable_ptr(db),
+                                        BreakWithValueOnlyAllowedInsideALoop,
+                                    );
+                                };
+                            }
+                            InnerContextKind::Closure => unreachable!("Not inside a loop."),
+                        }
+                    }
+
+                    statements.push(ctx.arenas.statements.alloc(semantic::Statement::Break(
+                        semantic::StatementBreak { expr_option, stable_ptr: syntax.stable_ptr(db) },
+                    )));
+                    Ok(())
+                }
+                ast::Statement::Item(stmt_item_syntax) => {
+                    let item_syntax = &stmt_item_syntax.item(db);
+                    match item_syntax {
+                        ast::ModuleItem::Constant(const_syntax) => {
+                            let lhs = const_syntax.type_clause(db).ty(db);
+                            let rhs = const_syntax.value(db);
+                            let rhs_expr = compute_expr_semantic(ctx, &rhs);
+                            let explicit_type = resolve_type_ex(
+                                db,
+                                ctx.diagnostics,
+                                ctx.resolver,
+                                &lhs,
+                                ResolutionContext::Statement(&mut ctx.environment),
+                            );
+                            let rhs_resolved_expr = resolve_const_expr_and_evaluate(
+                                db,
+                                ctx,
+                                &rhs_expr,
+                                stmt_item_syntax.stable_ptr(db).untyped(),
+                                explicit_type,
+                                false,
+                            );
+                            let name_syntax = const_syntax.name(db);
+                            let name = name_syntax.text(db);
+                            let rhs_id = StatementConstLongId(
+                                ctx.resolver.module_id,
+                                const_syntax.stable_ptr(db),
+                            );
+                            let var_def = Binding::LocalItem(LocalItem {
+                                id: StatementItemId::Constant(rhs_id.intern(db)),
+                                kind: StatementItemKind::Constant(
+                                    rhs_resolved_expr,
+                                    rhs_resolved_expr.ty(db)?,
+                                ),
+                            });
+                            add_value_to_statement_environment(
+                                ctx,
+                                name,
+                                var_def,
+                                name_syntax.stable_ptr(db),
+                            );
+                        }
+                        ast::ModuleItem::Use(use_syntax) => {
+                            for leaf in get_all_path_leaves(db, use_syntax) {
+                                let stable_ptr = leaf.stable_ptr(db);
+                                let resolved_item = ctx.resolver.resolve_use_path(
+                                    ctx.diagnostics,
+                                    ast::UsePath::Leaf(leaf),
+                                    ResolutionContext::Statement(&mut ctx.environment),
+                                )?;
+                                let var_def_id = StatementItemId::Use(
+                                    StatementUseLongId(ctx.resolver.module_id, stable_ptr)
+                                        .intern(db),
+                                );
+                                let name = var_def_id.name(db);
+                                match resolved_item {
+                                    ResolvedGenericItem::GenericConstant(const_id) => {
+                                        let const_value_id = db.constant_const_value(const_id)?;
+                                        let var_def = Binding::LocalItem(LocalItem {
+                                            id: var_def_id,
+                                            kind: StatementItemKind::Constant(
+                                                const_value_id,
+                                                const_value_id.ty(db)?,
+                                            ),
+                                        });
+                                        add_value_to_statement_environment(
+                                            ctx, name, var_def, stable_ptr,
+                                        );
+                                    }
+                                    item @ (ResolvedGenericItem::GenericType(_)
+                                    | ResolvedGenericItem::Module(_)) => {
+                                        add_item_to_statement_environment(
+                                            ctx, name, item, stable_ptr,
+                                        );
+                                    }
+                                    ResolvedGenericItem::GenericFunction(_)
+                                    | ResolvedGenericItem::GenericTypeAlias(_)
+                                    | ResolvedGenericItem::GenericImplAlias(_)
+                                    | ResolvedGenericItem::Variant(_)
+                                    | ResolvedGenericItem::Trait(_)
+                                    | ResolvedGenericItem::Impl(_)
+                                    | ResolvedGenericItem::Variable(_)
+                                    | ResolvedGenericItem::TraitItem(_)
+                                    | ResolvedGenericItem::Macro(_) => {
+                                        return Err(ctx
+                                            .diagnostics
+                                            .report(stable_ptr, UnsupportedUseItemInStatement));
+                                    }
+                                }
+                            }
+                        }
+                        ast::ModuleItem::Module(_)
+                        | ast::ModuleItem::FreeFunction(_)
+                        | ast::ModuleItem::ExternFunction(_)
+                        | ast::ModuleItem::ExternType(_)
+                        | ast::ModuleItem::Trait(_)
+                        | ast::ModuleItem::Impl(_)
+                        | ast::ModuleItem::ImplAlias(_)
+                        | ast::ModuleItem::Struct(_)
+                        | ast::ModuleItem::Enum(_)
+                        | ast::ModuleItem::TypeAlias(_)
+                        | ast::ModuleItem::InlineMacro(_)
+                        | ast::ModuleItem::HeaderDoc(_)
+                        | ast::ModuleItem::MacroDeclaration(_) => {
+                            return Err(ctx.diagnostics.report(
+                                stmt_item_syntax.stable_ptr(db),
+                                UnsupportedItemInStatement,
+                            ));
+                        }
+                        // Diagnostics reported on syntax level already.
+                        ast::ModuleItem::Missing(_) => return Err(skip_diagnostic()),
+                    }
+                    statements.push(ctx.arenas.statements.alloc(semantic::Statement::Item(
+                        semantic::StatementItem { stable_ptr: syntax.stable_ptr(db) },
+                    )));
+                    Ok(())
                 }
                 // Diagnostics reported on syntax level already.
-                ast::ModuleItem::Missing(_) => return Err(skip_diagnostic()),
+                ast::Statement::Missing(_) => Err(skip_diagnostic()),
             }
-            statements.push(ctx.arenas.statements.alloc(semantic::Statement::Item(
-                semantic::StatementItem { stable_ptr: syntax.stable_ptr(db) },
-            )));
-            Ok(())
-        }
-        // Diagnostics reported on syntax level already.
-        ast::Statement::Missing(_) => return Err(skip_diagnostic()),
-    };
-    ctx.restore_features(feature_restore);
-    Ok(())
+        },
+        |ctx| {
+            ctx.restore_features(feature_restore);
+        },
+    )
 }
 /// Adds an item to the statement environment and reports a diagnostic if the item is already
 /// defined.

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -151,6 +151,18 @@ macro_rules! define_short_id {
     };
 }
 
+/// Performs the given `action` and then calls `finally`, returning the action's result.
+/// Useful for restoring states post running of an action.
+pub fn with_finally<Ctx, R>(
+    ctx: &mut Ctx,
+    action: impl FnOnce(&mut Ctx) -> R,
+    finally: impl FnOnce(&mut Ctx),
+) -> R {
+    let result = action(ctx);
+    finally(ctx);
+    result
+}
+
 /// Returns `Some(())` if the condition is true, otherwise `None`.
 ///
 /// Useful in functions returning `None` on some condition:


### PR DESCRIPTION
## Summary

Introduces a `with_finally` utility function in `cairo-lang-utils` that executes an `action` closure and guarantees a `finally` cleanup closure runs afterward, returning the action's result. This is then used in `compute.rs` to replace the previous pattern of manually restoring state (e.g., `ctx.resolver.macro_call_data`, `feature_restore`) after early returns or errors in `compute_expr_inline_macro_semantic`, `compute_tail_semantic`, `expand_macro_for_statement`, and `compute_and_append_statement_semantic`. Previously, state restoration could be skipped if an early `return Err(...)` was hit before the cleanup line; now cleanup is always guaranteed to run.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

In several semantic computation functions, state such as `ctx.resolver.macro_call_data` and feature flags were restored at the end of the function body. However, early `return Err(...)` paths (e.g., when parser diagnostics contain errors) would exit before the restoration code, leaving the context in a dirty state. The `with_finally` pattern ensures cleanup always runs regardless of whether the action succeeds or returns early.

---

## What was the behavior or documentation before?

State restoration (e.g., resetting `macro_call_data` or calling `restore_features`) was done manually at the end of each function. Early error returns bypassed these cleanup steps, potentially leaving the semantic context in an inconsistent state.

---

## What is the behavior or documentation after?

State restoration is now wrapped in a `with_finally` call, guaranteeing the cleanup closure executes after the action completes — whether it returns `Ok` or `Err`.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `with_finally` function is intentionally simple: it takes a mutable context reference, an action closure, and a finally closure, runs the action, unconditionally runs the finally, and returns the action's result.