### PR TITLE
(feat): def site analysis based on forward dataflow

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/def_site.rs
+++ b/crates/cairo-lang-lowering/src/analysis/def_site.rs
@@ -1,0 +1,103 @@
+//! Def-site analysis for lowered IR.
+//!
+//! Records where each variable is first defined as a `DefLocation`:
+//! either `BlockEntry` (parameters, goto remappings, match arm bindings)
+//! or `Statement` (output of a statement). Uses the forward analysis framework
+//! and all results are accumulated in the analyzer's global `def_sites` vector.
+
+use crate::analysis::DefLocation;
+use crate::analysis::core::{DataflowAnalyzer, Direction, Edge, StatementLocation};
+use crate::analysis::forward::ForwardDataflowAnalysis;
+use crate::{BlockEnd, BlockId, Lowered, Statement};
+
+/// Result of def-site analysis: the def location for each variable, indexed by arena index.
+#[derive(Debug)]
+pub struct DefSites(pub Vec<DefLocation>);
+
+impl std::ops::Deref for DefSites {
+    type Target = [DefLocation];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Forward analysis that records where each variable first becomes available.
+pub struct DefSiteAnalysis<'db, 'a> {
+    lowered: &'a Lowered<'db>,
+    /// First-available location for each variable, indexed by variable arena index.
+    /// Slots hold [`UNRESOLVED`] until the traversal reaches them; `analyze` asserts the
+    /// placeholder is gone before returning.
+    def_sites: Vec<DefLocation>,
+}
+
+/// Sentinel placeholder for `def_sites` slots before the traversal reaches them. Uses an
+/// out-of-range `BlockId` so it cannot collide with any real def location.
+const UNRESOLVED: DefLocation = DefLocation::Statement((BlockId(usize::MAX), usize::MAX));
+
+impl DefSiteAnalysis<'_, '_> {
+    /// Runs def-site analysis on a lowered function.
+    ///
+    /// Returns a vector indexed by variable arena index, mapping each variable to the
+    /// `DefLocation` where it first becomes available:
+    /// - `BlockEntry(block)`: available at block entry (parameters, goto remappings, match arm
+    ///   bindings).
+    /// - `Statement((block, i))`: available after statement `i` in `block`.
+    pub fn analyze(lowered: &Lowered<'_>) -> DefSites {
+        let analyzer =
+            DefSiteAnalysis { lowered, def_sites: vec![UNRESOLVED; lowered.variables.len()] };
+        let mut fwd = ForwardDataflowAnalysis::new(lowered, analyzer);
+        fwd.run();
+        assert!(
+            fwd.analyzer.def_sites.iter().all(|d| *d != UNRESOLVED),
+            "DefSiteAnalysis left variables unresolved"
+        );
+        DefSites(fwd.analyzer.def_sites)
+    }
+}
+
+impl<'db, 'a> DataflowAnalyzer<'db, 'a> for DefSiteAnalysis<'db, 'a> {
+    type Info = ();
+    const DIRECTION: Direction = Direction::Forward;
+
+    fn initial_info(&mut self, _block_id: BlockId, _block_end: &'a BlockEnd<'db>) -> Self::Info {
+        for &param in &self.lowered.parameters {
+            self.def_sites[param.index()] = DefLocation::BlockEntry(BlockId::root());
+        }
+    }
+
+    fn merge(
+        &mut self,
+        _lowered: &Lowered<'db>,
+        _statement_location: StatementLocation,
+        _info1: Self::Info,
+        _info2: Self::Info,
+    ) -> Self::Info {
+    }
+
+    fn transfer_stmt(
+        &mut self,
+        _info: &mut Self::Info,
+        statement_location: StatementLocation,
+        stmt: &'a Statement<'db>,
+    ) {
+        for &output in stmt.outputs() {
+            self.def_sites[output.index()] = DefLocation::Statement(statement_location);
+        }
+    }
+
+    fn transfer_edge(&mut self, _info: &Self::Info, edge: &Edge<'db, 'a>) -> Self::Info {
+        match edge {
+            Edge::Goto { target, remapping } => {
+                for (&dst, _) in remapping.iter() {
+                    self.def_sites[dst.index()] = DefLocation::BlockEntry(*target);
+                }
+            }
+            Edge::MatchArm { arm, .. } => {
+                for &var in &arm.var_ids {
+                    self.def_sites[var.index()] = DefLocation::BlockEntry(arm.block_id);
+                }
+            }
+            Edge::Return { .. } | Edge::Panic { .. } => {}
+        }
+    }
+}

--- a/crates/cairo-lang-lowering/src/analysis/def_site_test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/def_site_test.rs
@@ -1,0 +1,65 @@
+//! File-based tests for the def-site analysis.
+
+use cairo_lang_semantic::test_utils::setup_test_function;
+use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+
+use super::def_site::DefSiteAnalysis;
+use crate::LoweringStage;
+use crate::db::LoweringGroup;
+use crate::ids::ConcreteFunctionWithBodyId;
+use crate::test_utils::{LoweringDatabaseForTesting, formatted_lowered};
+
+cairo_lang_test_utils::test_file_test!(
+    def_site,
+    "src/analysis/test_data",
+    {
+        def_site: "def_site",
+    },
+    test_def_site_analysis
+);
+
+fn test_def_site_analysis(
+    inputs: &OrderedHashMap<String, String>,
+    _args: &OrderedHashMap<String, String>,
+) -> TestRunnerResult {
+    let db = &mut LoweringDatabaseForTesting::default();
+    let (test_function, semantic_diagnostics) = setup_test_function(db, inputs).split();
+
+    let function_id =
+        ConcreteFunctionWithBodyId::from_semantic(db, test_function.concrete_function_id);
+
+    let lowered = db.lowered_body(function_id, LoweringStage::PostBaseline);
+
+    let (lowering_str, result_str) = if let Ok(lowered) = lowered.cloned() {
+        let lowering_str = formatted_lowered(db, Some(&lowered));
+        (lowering_str, format!("{:#?}", DefSiteAnalysis::analyze(&lowered)))
+    } else {
+        ("Lowering failed.".to_string(), "".to_string())
+    };
+
+    TestRunnerResult::success(OrderedHashMap::from([
+        ("semantic_diagnostics".into(), semantic_diagnostics),
+        ("lowering".into(), lowering_str),
+        ("result".into(), result_str),
+    ]))
+}
+
+/// Verifies the `UNRESOLVED` assert fires when an arena slot is left unreached by the traversal
+/// (a regression guard for future passes that drop defs without compacting `lowered.variables`).
+#[test]
+#[should_panic(expected = "DefSiteAnalysis left variables unresolved")]
+fn unresolved_assert_fires() {
+    let db = &mut LoweringDatabaseForTesting::default();
+    let inputs = OrderedHashMap::from([
+        ("function_code".to_string(), "fn foo(x: felt252) -> felt252 { x }".to_string()),
+        ("function_name".to_string(), "foo".to_string()),
+    ]);
+    let test_function = setup_test_function(db, &inputs).split().0;
+    let function_id =
+        ConcreteFunctionWithBodyId::from_semantic(db, test_function.concrete_function_id);
+    let mut lowered = db.lowered_body(function_id, LoweringStage::PostBaseline).cloned().unwrap();
+    let extra = lowered.variables.iter().next().unwrap().1.clone();
+    lowered.variables.alloc(extra);
+    DefSiteAnalysis::analyze(&lowered);
+}

--- a/crates/cairo-lang-lowering/src/analysis/mod.rs
+++ b/crates/cairo-lang-lowering/src/analysis/mod.rs
@@ -4,6 +4,7 @@
 //! optimization passes and semantic checks.
 
 pub mod backward;
+pub mod def_site;
 pub use backward::{BackAnalysis, DataflowBackAnalysis};
 
 pub mod core;
@@ -14,11 +15,31 @@ pub mod forward;
 pub use forward::ForwardDataflowAnalysis;
 
 #[cfg(test)]
+mod def_site_test;
+#[cfg(test)]
 mod equality_analysis_test;
 #[cfg(test)]
 mod test;
 
 use crate::{Block, BlockId, MatchInfo, Statement, VarRemapping, VarUsage};
+
+/// Where a variable is defined.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DefLocation {
+    /// Defined by a statement at the given location.
+    Statement(StatementLocation),
+    /// Defined at block entry (parameter, goto remapping, or match arm binding).
+    BlockEntry(BlockId),
+}
+
+impl std::fmt::Debug for DefLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DefLocation::Statement((block, stmt_idx)) => write!(f, "stmt({block:?}, {stmt_idx})"),
+            DefLocation::BlockEntry(block) => write!(f, "entry({block:?})"),
+        }
+    }
+}
 
 /// Analyzer trait to implement for each specific analysis.
 #[allow(unused_variables)]

--- a/crates/cairo-lang-lowering/src/analysis/test_data/def_site
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/def_site
@@ -1,0 +1,258 @@
+//! > Test simple linear function with parameters and statement outputs
+
+//! > test_runner_name
+test_def_site_analysis
+
+//! > function_code
+fn foo(x: felt252, y: felt252) -> felt252 {
+    x + y
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252
+blk0 (root):
+Statements:
+  (v2: core::felt252) <- core::felt252_add(v0, v1)
+End:
+  Return(v2)
+
+//! > result
+DefSites(
+    [
+        entry(blk0),
+        entry(blk0),
+        stmt(blk0, 0),
+    ],
+)
+
+//! > ==========================================================================
+
+//! > Test match with arm variables
+
+//! > test_runner_name
+test_def_site_analysis
+
+//! > function_code
+fn foo(x: bool) -> felt252 {
+    if x {
+        1
+    } else {
+        2
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 2
+End:
+  Return(v3)
+
+blk2:
+Statements:
+  (v4: core::felt252) <- 1
+End:
+  Return(v4)
+
+//! > result
+DefSites(
+    [
+        entry(blk0),
+        entry(blk1),
+        entry(blk2),
+        stmt(blk1, 0),
+        stmt(blk2, 0),
+    ],
+)
+
+//! > ==========================================================================
+
+//! > Test branch and merge with goto remapping
+
+//! > test_runner_name
+test_def_site_analysis
+
+//! > function_code
+fn foo(x: bool) -> felt252 {
+    let y = if x {
+        1
+    } else {
+        2
+    };
+    y + 3
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 2
+End:
+  Goto(blk3, {v3 -> v4})
+
+blk2:
+Statements:
+  (v5: core::felt252) <- 1
+End:
+  Goto(blk3, {v5 -> v4})
+
+blk3:
+Statements:
+  (v6: core::felt252) <- 3
+  (v7: core::felt252) <- core::felt252_add(v4, v6)
+End:
+  Return(v7)
+
+//! > result
+DefSites(
+    [
+        entry(blk0),
+        entry(blk1),
+        entry(blk2),
+        stmt(blk1, 0),
+        entry(blk3),
+        stmt(blk2, 0),
+        stmt(blk3, 0),
+        stmt(blk3, 1),
+    ],
+)
+
+//! > ==========================================================================
+
+//! > Test loop with break
+
+//! > test_runner_name
+test_def_site_analysis
+
+//! > function_code
+fn foo(n: felt252) -> felt252 {
+    let mut i = n;
+    loop {
+        if i == 0 {
+            break i;
+        }
+        i = i - 1;
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+  (v1: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[51-138](v0)
+End:
+  Match(match_enum(v1) {
+    PanicResult::Ok(v2) => blk1,
+    PanicResult::Err(v3) => blk2,
+  })
+
+blk1:
+Statements:
+  (v4: core::felt252, v5: core::felt252) <- struct_destructure(v2)
+  (v6: (core::felt252,)) <- struct_construct(v5)
+  (v7: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Ok(v6)
+End:
+  Return(v7)
+
+blk2:
+Statements:
+  (v8: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v3)
+End:
+  Return(v8)
+
+//! > result
+DefSites(
+    [
+        entry(blk0),
+        stmt(blk0, 0),
+        entry(blk1),
+        entry(blk2),
+        stmt(blk1, 0),
+        stmt(blk1, 0),
+        stmt(blk1, 1),
+        stmt(blk1, 2),
+        stmt(blk2, 0),
+    ],
+)
+
+//! > ==========================================================================
+
+//! > Test multi-output statement (snapshot)
+
+//! > test_runner_name
+test_def_site_analysis
+
+//! > function_code
+fn foo(x: Array<felt252>) -> @Array<felt252> {
+    let snap = @x;
+    snap
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::array::Array::<core::felt252>
+blk0 (root):
+Statements:
+  (v1: core::array::Array::<core::felt252>, v2: @core::array::Array::<core::felt252>) <- snapshot(v0)
+End:
+  Return(v2)
+
+//! > result
+DefSites(
+    [
+        entry(blk0),
+        stmt(blk0, 0),
+        stmt(blk0, 0),
+    ],
+)


### PR DESCRIPTION
## Summary

Adds a `DefLocation` enum and a `DefSiteAnalysis` pass to the lowering analysis framework. `DefLocation` distinguishes between variables defined at block entry (function parameters, goto remapping destinations, match arm bindings) and variables defined as outputs of a statement. `DefSiteAnalysis` implements the `DataflowAnalyzer` trait using the existing forward dataflow framework and produces a `DefSites` result mapping each variable (by arena index) to its `DefLocation`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Downstream optimization passes and semantic checks need to know where each variable in the lowered IR is first defined. Previously there was no dedicated analysis for this; callers had to reconstruct def-site information ad hoc. A shared, tested analysis avoids duplicated logic and provides a consistent representation.

---

## What was the behavior or documentation before?

There was no `DefLocation` type and no `DefSiteAnalysis` pass. Consumers of the lowered IR had no standard way to query where a variable was defined.

---

## What is the behavior or documentation after?

Calling `DefSiteAnalysis::analyze(lowered)` returns a `DefSites` value (a `Vec<DefLocation>` indexed by variable arena index). Each entry is either:

- `DefLocation::BlockEntry(block)` — the variable is a function parameter, a goto remapping destination, or a match arm binding introduced at the entry of `block`.
- `DefLocation::Statement((block, stmt_idx))` — the variable is produced as an output of statement `stmt_idx` in `block`.

File-based tests covering linear functions, match arms, and goto remappings are included under `src/analysis/test_data/def_site`.

---

## Related issue or discussion (if any)

---

## Additional context

The `DefSiteAnalysis` state is accumulated globally (not per-block) because each variable has exactly one definition site in SSA-form lowered IR, so no per-block lattice state is needed. The `Info` type is `()` and `merge` is a no-op.