### PR TITLE
(feat): dominator analysis using forward dataflow

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/dominator.rs
+++ b/crates/cairo-lang-lowering/src/analysis/dominator.rs
@@ -1,0 +1,71 @@
+//! Block dominator analysis for lowered IR.
+//!
+//! Computes the set of blocks that dominate each block using the forward
+//! dataflow framework. A block A dominates block B if every path from the
+//! entry block to B passes through A.
+
+use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
+
+use crate::analysis::core::{DataflowAnalyzer, Direction, StatementLocation};
+use crate::analysis::forward::ForwardDataflowAnalysis;
+use crate::{Block, BlockEnd, BlockId, Lowered};
+
+/// Result of dominator analysis, providing efficient dominator queries.
+pub struct Dominators {
+    /// Set of blocks that dominate `block_id` indexed by block ID.
+    per_block: Vec<OrderedHashSet<BlockId>>,
+}
+
+impl Dominators {
+    /// Runs dominator analysis on a lowered function.
+    pub fn analyze(lowered: &Lowered<'_>) -> Self {
+        let mut fwd = ForwardDataflowAnalysis::new(lowered, DominatorAnalyzer);
+        let per_block = fwd.run().into_iter().map(|opt| opt.unwrap_or_default()).collect();
+        Dominators { per_block }
+    }
+
+    /// Returns true if block `a` dominates block `b`.
+    pub fn dominates(&self, a: BlockId, b: BlockId) -> bool {
+        self.per_block[b.0].contains(&a)
+    }
+
+    /// Returns the set of dominators for the given block.
+    pub fn dominators_of(&self, block: BlockId) -> &OrderedHashSet<BlockId> {
+        &self.per_block[block.0]
+    }
+}
+
+/// Internal forward analyzer that computes dominator sets.
+struct DominatorAnalyzer;
+
+impl<'db, 'a> DataflowAnalyzer<'db, 'a> for DominatorAnalyzer {
+    type Info = OrderedHashSet<BlockId>;
+    const DIRECTION: Direction = Direction::Forward;
+
+    fn initial_info(&mut self, _block_id: BlockId, _block_end: &'a BlockEnd<'db>) -> Self::Info {
+        OrderedHashSet::default()
+    }
+
+    fn merge(
+        &mut self,
+        _lowered: &Lowered<'db>,
+        _statement_location: StatementLocation,
+        info1: Self::Info,
+        info2: Self::Info,
+    ) -> Self::Info {
+        // Dominator merge is set intersection:
+        // a block dominates B only if it dominates ALL predecessors of B.
+        let mut info1 = info1;
+        info1.retain(|id| info2.contains(id));
+        info1
+    }
+
+    fn transfer_block(&mut self, info: &mut Self::Info, block_id: BlockId, _block: &'a Block<'db>) {
+        // Every block dominates itself.
+        info.insert(block_id);
+    }
+}
+
+#[cfg(test)]
+#[path = "dominator_test.rs"]
+mod dominator_test;

--- a/crates/cairo-lang-lowering/src/analysis/dominator_test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/dominator_test.rs
@@ -1,0 +1,108 @@
+//! File-based tests for the dominator analysis.
+
+use cairo_lang_semantic::test_utils::setup_test_function;
+use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
+use itertools::Itertools;
+
+use super::Dominators;
+use crate::db::LoweringGroup;
+use crate::ids::ConcreteFunctionWithBodyId;
+use crate::test_utils::{LoweringDatabaseForTesting, formatted_lowered};
+use crate::{BlockId, LoweringStage};
+
+cairo_lang_test_utils::test_file_test!(
+    dominator,
+    "src/analysis/test_data",
+    {
+        dominator: "dominator",
+    },
+    test_dominator_analysis
+);
+
+fn test_dominator_analysis(
+    inputs: &OrderedHashMap<String, String>,
+    _args: &OrderedHashMap<String, String>,
+) -> TestRunnerResult {
+    let db = &mut LoweringDatabaseForTesting::default();
+    let (test_function, semantic_diagnostics) = setup_test_function(db, inputs).split();
+
+    let function_id =
+        ConcreteFunctionWithBodyId::from_semantic(db, test_function.concrete_function_id);
+
+    let lowered = db.lowered_body(function_id, LoweringStage::PostBaseline);
+
+    let (lowering_str, dominators_str) = if let Ok(lowered) = lowered.cloned() {
+        let lowering_str = formatted_lowered(db, Some(&lowered));
+        let dominators = Dominators::analyze(&lowered);
+
+        let dominators_str = lowered
+            .blocks
+            .iter()
+            .map(|(block_id, _)| {
+                let doms = dominators.dominators_of(block_id);
+                let mut dom_strs = doms.iter().map(|d| d.0).sorted().map(|d| format!("blk{d}"));
+                format!("blk{}: {{{}}}", block_id.0, dom_strs.join(", "))
+            })
+            .join("\n");
+
+        (lowering_str, dominators_str)
+    } else {
+        ("Lowering failed.".to_string(), "".to_string())
+    };
+
+    TestRunnerResult::success(OrderedHashMap::from([
+        ("semantic_diagnostics".into(), semantic_diagnostics),
+        ("lowering".into(), lowering_str),
+        ("dominators".into(), dominators_str),
+    ]))
+}
+
+#[test]
+fn test_dominates() {
+    // Double diamond CFG dominator sets:
+    //   blk0:        {blk0}
+    //   blk1, blk2:  {blk0, self}     (arms)
+    //   blk3:        {blk0, blk3}     (merge)
+    //   blk4, blk5:  {blk3, self, blk0}     (arms)
+    //   blk6:        {blk3, blk0, blk6}          (merge)
+    let dominators = Dominators {
+        per_block: vec![
+            OrderedHashSet::from_iter([BlockId(0)]),
+            OrderedHashSet::from_iter([BlockId(0), BlockId(1)]),
+            OrderedHashSet::from_iter([BlockId(0), BlockId(2)]),
+            OrderedHashSet::from_iter([BlockId(0), BlockId(3)]),
+            OrderedHashSet::from_iter([BlockId(0), BlockId(3), BlockId(4)]),
+            OrderedHashSet::from_iter([BlockId(0), BlockId(3), BlockId(5)]),
+            OrderedHashSet::from_iter([BlockId(0), BlockId(3), BlockId(6)]),
+        ],
+    };
+
+    // Reflexivity: every block dominates itself.
+    for i in 0..dominators.per_block.len() {
+        assert!(dominators.dominates(BlockId(i), BlockId(i)));
+    }
+
+    // Root dominates every block.
+    for i in 0..dominators.per_block.len() {
+        assert!(dominators.dominates(BlockId(0), BlockId(i)));
+    }
+
+    // Merge block dominates its arms and final merge block.
+    assert!(dominators.dominates(BlockId(3), BlockId(4)));
+    assert!(dominators.dominates(BlockId(3), BlockId(5)));
+    assert!(dominators.dominates(BlockId(3), BlockId(6)));
+
+    // Diamond arms do not dominate each other.
+    assert!(!dominators.dominates(BlockId(1), BlockId(2)));
+    assert!(!dominators.dominates(BlockId(2), BlockId(1)));
+
+    // Arms do not dominate the merge block.
+    assert!(!dominators.dominates(BlockId(1), BlockId(3)));
+    assert!(!dominators.dominates(BlockId(2), BlockId(3)));
+
+    // Merge block does not dominate the arms.
+    assert!(!dominators.dominates(BlockId(3), BlockId(1)));
+    assert!(!dominators.dominates(BlockId(3), BlockId(2)));
+}

--- a/crates/cairo-lang-lowering/src/analysis/mod.rs
+++ b/crates/cairo-lang-lowering/src/analysis/mod.rs
@@ -10,6 +10,7 @@ pub use backward::{BackAnalysis, DataflowBackAnalysis};
 pub mod core;
 pub use core::{DataflowAnalyzer, Direction, Edge, StatementLocation};
 
+pub mod dominator;
 pub mod equality_analysis;
 pub mod forward;
 pub use forward::ForwardDataflowAnalysis;

--- a/crates/cairo-lang-lowering/src/analysis/test_data/dominator
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/dominator
@@ -1,0 +1,255 @@
+//! > Test simple linear function — root dominates itself
+
+//! > test_runner_name
+test_dominator_analysis
+
+//! > function_code
+fn foo(x: felt252, y: felt252) -> felt252 {
+    x + y
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252
+blk0 (root):
+Statements:
+  (v2: core::felt252) <- core::felt252_add(v0, v1)
+End:
+  Return(v2)
+
+//! > dominators
+blk0: {blk0}
+
+//! > ==========================================================================
+
+//! > Test if-else with no merge — root dominates both arms
+
+//! > test_runner_name
+test_dominator_analysis
+
+//! > function_code
+fn foo(x: bool) -> felt252 {
+    if x {
+        1
+    } else {
+        2
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 2
+End:
+  Return(v3)
+
+blk2:
+Statements:
+  (v4: core::felt252) <- 1
+End:
+  Return(v4)
+
+//! > dominators
+blk0: {blk0}
+blk1: {blk0, blk1}
+blk2: {blk0, blk2}
+
+//! > ==========================================================================
+
+//! > Test diamond CFG — if-else with merge block
+
+//! > test_runner_name
+test_dominator_analysis
+
+//! > function_code
+fn foo(x: bool) -> felt252 {
+    let y = if x {
+        1
+    } else {
+        2
+    };
+    y + 3
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 2
+End:
+  Goto(blk3, {v3 -> v4})
+
+blk2:
+Statements:
+  (v5: core::felt252) <- 1
+End:
+  Goto(blk3, {v5 -> v4})
+
+blk3:
+Statements:
+  (v6: core::felt252) <- 3
+  (v7: core::felt252) <- core::felt252_add(v4, v6)
+End:
+  Return(v7)
+
+//! > dominators
+blk0: {blk0}
+blk1: {blk0, blk1}
+blk2: {blk0, blk2}
+blk3: {blk0, blk3}
+
+//! > ==========================================================================
+
+//! > Test nested if-else — transitive dominance
+
+//! > test_runner_name
+test_dominator_analysis
+
+//! > function_code
+fn foo(x: bool, y: bool) -> felt252 {
+    if x {
+        if y {
+            1
+        } else {
+            2
+        }
+    } else {
+        3
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool, v1: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v2) => blk1,
+    bool::True(v3) => blk2,
+  })
+
+blk1:
+Statements:
+  (v4: core::felt252) <- 3
+End:
+  Return(v4)
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v1) {
+    bool::False(v5) => blk3,
+    bool::True(v6) => blk4,
+  })
+
+blk3:
+Statements:
+  (v7: core::felt252) <- 2
+End:
+  Return(v7)
+
+blk4:
+Statements:
+  (v8: core::felt252) <- 1
+End:
+  Return(v8)
+
+//! > dominators
+blk0: {blk0}
+blk1: {blk0, blk1}
+blk2: {blk0, blk2}
+blk3: {blk0, blk2, blk3}
+blk4: {blk0, blk2, blk4}
+
+//! > ==========================================================================
+
+//! > Test match with multiple arms
+
+//! > test_runner_name
+test_dominator_analysis
+
+//! > function_code
+fn foo(x: felt252) -> felt252 {
+    match x {
+        0 => 10,
+        _ => 20,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+End:
+  Match(match core::felt252_is_zero(v0) {
+    IsZeroResult::Zero => blk1,
+    IsZeroResult::NonZero(v1) => blk2,
+  })
+
+blk1:
+Statements:
+  (v2: core::felt252) <- 10
+End:
+  Return(v2)
+
+blk2:
+Statements:
+  (v3: core::felt252) <- 20
+End:
+  Return(v3)
+
+//! > dominators
+blk0: {blk0}
+blk1: {blk0, blk1}
+blk2: {blk0, blk2}


### PR DESCRIPTION
## Summary

Adds a block dominator analysis pass to the lowering IR. The analysis computes, for each block, the set of all blocks that dominate it (i.e., every path from the entry block to that block must pass through each dominator). The implementation uses the existing forward dataflow framework, with set intersection as the merge operation and self-insertion as the transfer function.

A `Dominators` struct is exposed with `dominates(a, b)` and `dominators_of(block)` query methods. File-based tests cover linear functions, if-else without a merge block, diamond CFGs, nested conditionals, and multi-arm matches.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Dominator information is a foundational building block for many compiler analyses and optimizations (e.g., loop detection, SSA construction, code motion). Without a dedicated dominator pass, downstream analyses must either recompute dominance ad hoc or forgo dominator-dependent optimizations entirely.

---

## What was the behavior or documentation before?

No dominator analysis existed in the lowering analysis crate.

---

## What is the behavior or documentation after?

Callers can run `Dominators::analyze(&lowered)` on a lowered function body and query whether one block dominates another, or retrieve the full dominator set for any block.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The implementation piggybacks on the existing `ForwardDataflowAnalysis` infrastructure. The merge step performs set intersection across predecessor dominator sets, and the transfer step adds the current block to its own dominator set, correctly encoding the standard dominator lattice.