### PR TITLE
(feat): Added an optimization dump for each phase under a special log target

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -1,3 +1,4 @@
+use cairo_lang_debug::DebugWithDb;
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_proc_macros::HeapSize;
 use cairo_lang_utils::{Intern, define_short_id};
@@ -139,8 +140,23 @@ impl<'db> ApplyOptimization<'db> for [OptimizationPhase<'db>] {
         function: ConcreteFunctionWithBodyId<'db>,
         lowered: &mut Lowered<'db>,
     ) -> Maybe<()> {
+        let fmt = crate::fmt::LoweredFormatter::new(db, &lowered.variables);
+        tracing::trace!(
+            target: "optimization_dump",
+            "({})\nInitial:\n{:?}",
+            function.full_path(db),
+            lowered.debug(&fmt)
+        );
+
         for phase in self {
             phase.apply(db, function, lowered)?;
+            let fmt = crate::fmt::LoweredFormatter::new(db, &lowered.variables);
+            tracing::trace!(
+                target: "optimization_dump",
+                "({})\nAfter {phase:?}:\n{:?}",
+                function.full_path(db),
+                lowered.debug(&fmt)
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Adds tracing instrumentation to the optimization pipeline that logs the lowered IR before any optimization phases run and after each individual phase completes. Logs are emitted at the `info` level under the `optimization_dump` target, including the function's full path and the formatted lowered representation.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

Without visibility into the intermediate lowered IR states between optimization phases, it is difficult to debug incorrect or unexpected transformations introduced by a specific phase. This change makes it possible to trace exactly how the lowered IR evolves through each optimization step.

---

## What was the behavior or documentation before?

The optimization pipeline applied each phase sequentially with no observable output about the intermediate IR states.

---

## What is the behavior or documentation after?

When tracing is enabled at the `info` level for the `optimization_dump` target, the lowered IR is logged before any phases run and after each phase completes, labeled with the function's full path and the phase name.

---

## Related issue or discussion (if any)

---

## Additional context

The logs can be selectively enabled using a tracing subscriber filtered to the `optimization_dump` target, making this a low-overhead addition when tracing is not active.