### PR TITLE
Fix function debug info when file content is missing

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info.rs
+++ b/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info.rs
@@ -10,6 +10,7 @@ use cairo_lang_defs::ids::{
     TraitItemId, TraitLongId, TraitTypeLongId, UseLongId,
 };
 use cairo_lang_filesystem::db::FilesGroup;
+use cairo_lang_filesystem::ids::SpanInFile;
 use cairo_lang_lowering::Location;
 use cairo_lang_lowering::ids::LocationId;
 use cairo_lang_semantic::Expr;
@@ -143,10 +144,7 @@ impl<'db> FunctionDebugInfo<'db> {
                 };
                 let user_location = location.span_in_file(db).user_location(db);
 
-                let var_name = user_location
-                    .span
-                    .take(db.file_content(user_location.file_id).unwrap())
-                    .to_string();
+                let var_name = variable_name_from_user_location(db, user_location)?;
 
                 let position = user_location.span.position_in_file(db, user_location.file_id)?;
                 let source_location = SourceCodeSpan {
@@ -179,6 +177,13 @@ impl<'db> FunctionDebugInfo<'db> {
 
         Some((function_file_path, function_code_span))
     }
+}
+
+fn variable_name_from_user_location<'db>(
+    db: &'db dyn Database,
+    user_location: SpanInFile<'db>,
+) -> Option<String> {
+    Some(user_location.span.take(db.file_content(user_location.file_id)?).to_string())
 }
 
 /// This function gets a node that a sierra variable was mapped to.
@@ -521,4 +526,23 @@ fn lookup_variable_in_resolved_items<'db>(
     }
 
     None
+}
+
+#[cfg(test)]
+mod test {
+    use cairo_lang_filesystem::ids::{FileLongId, SpanInFile};
+    use cairo_lang_filesystem::span::{TextOffset, TextSpan};
+    use cairo_lang_utils::Intern;
+
+    use super::variable_name_from_user_location;
+    use crate::test_utils::SierraGenDatabaseForTesting;
+
+    #[test]
+    fn variable_name_from_user_location_returns_none_when_file_content_is_missing() {
+        let db = SierraGenDatabaseForTesting::new_empty();
+        let file_id = FileLongId::OnDisk("missing.cairo".into()).intern(&db);
+        let user_location = SpanInFile { file_id, span: TextSpan::cursor(TextOffset::START) };
+
+        assert_eq!(variable_name_from_user_location(&db, user_location), None);
+    }
 }


### PR DESCRIPTION
## Summary

Avoid panicking during function debug info extraction when the source file content is unavailable. Return `None` for the affected variable mapping and add a unit test that covers the missing-file path.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Debug info extraction already models missing source locations as `Option`, but variable name extraction still used `db.file_content(...).unwrap()`. When file content is unavailable this can panic instead of degrading gracefully.

---

## What was the behavior or documentation before?

If the user-location file content could not be loaded, debug info extraction could panic while trying to build the variable name, even though the surrounding code path otherwise uses optional fallbacks.

---

## What is the behavior or documentation after?

Variable name extraction now returns `None` when file content is missing, so the mapper skips that entry instead of panicking. The new unit test exercises this behavior with an empty testing database and a missing on-disk file.

---

## Related issue or discussion (if any)

---

## Additional context

This keeps the change aligned with the existing `maybe_code_location` semantics and limits the fix to the local debug-info extraction path.