### PR TITLE
fix: reject non-concrete eq/ne/not in const evaluation

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -709,6 +709,36 @@ impl AnotherFoo<impl F: Foo> of Foo {
 
 //! > ==========================================================================
 
+//! > Const not with generic impl constants is unsupported.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait FlagTrait {
+    const FLAG: bool;
+}
+impl AFlag of FlagTrait {
+    const FLAG: bool = true;
+}
+impl AnotherFlag<impl F: FlagTrait> of FlagTrait {
+    const FLAG: bool = !F::FLAG;
+}
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:8:24
+    const FLAG: bool = !F::FLAG;
+                       ^^^^^^^^
+
+//! > ==========================================================================
+
 //! > User-defined extern const fn in constant expression.
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -893,6 +893,18 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             if condition { self.true_const } else { self.false_const }
         };
 
+        let has_non_concrete_arg = args.iter().any(|arg| {
+            !arg.is_fully_concrete(db) && !matches!(arg.long(db), ConstValue::Missing(_))
+        });
+        if (imp.function == self.eq_fn || imp.function == self.ne_fn || imp.function == self.not_fn)
+            && has_non_concrete_arg
+        {
+            return to_missing(
+                self.diagnostics
+                    .report(expr.stable_ptr.untyped(), SemanticDiagnosticKind::UnsupportedConstant),
+            );
+        }
+
         if imp.function == self.eq_fn {
             return bool_value(args[0] == args[1]);
         } else if imp.function == self.ne_fn {


### PR DESCRIPTION
## Summary

Reject non-concrete equality, inequality, and logical-not operations during constant evaluation. Add a regression test for `!F::FLAG` on generic impl constants and report E2127 instead of folding the expression.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Generic impl constants are not fully concrete during constant evaluation, so `==`, `!=`, and `!` should not be folded eagerly. Before this change these operators could bypass the existing non-concrete checks and produce an incorrect boolean result instead of a diagnostic.

---

## What was the behavior or documentation before?

Constant evaluation could accept equality, inequality, or logical-not expressions over generic impl constants and fold them as if the value were known. This could silently produce the wrong constant result instead of reporting E2127.

---

## What is the behavior or documentation after?

The evaluator now reports E2127 for `==`, `!=`, and `!` when any argument is a non-concrete impl constant. The regression test covers `!F::FLAG` and verifies that unsupported constant expressions are rejected.

---

## Related issue or discussion (if any)

---

## Additional context

This follows the same constant-evaluation policy already used for other unsupported operations on generic impl constants and keeps the fix scoped to the boolean operator fast path.