### PR TITLE
fix: report UnsupportedConstant for non-concrete args in eq/ne/not const eval

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -679,7 +679,7 @@ impl AnotherFoo<impl F: Foo> of Foo {
 error[E2127]: This expression is not supported as constant.
  --> lib.cairo:8:28
     const VALUE: felt252 = F::VALUE + 1;
-                           ^^^^^^^^^^^^
+                           ^^^^^^^^
 
 //! > ==========================================================================
 
@@ -761,3 +761,92 @@ warning[E2070]: Unused constant. Consider ignoring by prefixing with `_`.
  --> lib.cairo:6:11
     const X: S = S { a: 1 };
           ^
+
+//! > ==========================================================================
+
+//! > Equality comparison with non-concrete impl const arg is unsupported.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait Foo {
+    const VALUE: felt252;
+}
+impl AnotherFoo<impl F: Foo> of Foo {
+    const VALUE: felt252 = if F::VALUE == 42 {
+        1
+    } else {
+        0
+    };
+}
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:5:31
+    const VALUE: felt252 = if F::VALUE == 42 {
+                              ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Non-equality comparison with non-concrete impl const arg is unsupported.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait Foo {
+    const VALUE: felt252;
+}
+impl AnotherFoo<impl F: Foo> of Foo {
+    const VALUE: felt252 = if F::VALUE != 42 {
+        1
+    } else {
+        0
+    };
+}
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:5:31
+    const VALUE: felt252 = if F::VALUE != 42 {
+                              ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Boolean not with non-concrete impl const arg is unsupported.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait BoolConst {
+    const VALUE: bool;
+}
+impl AnotherBoolConst<impl F: BoolConst> of BoolConst {
+    const VALUE: bool = !F::VALUE;
+}
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:5:26
+    const VALUE: bool = !F::VALUE;
+                         ^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -869,7 +869,17 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             .args
             .iter()
             .filter_map(|arg| try_extract_matches!(arg, ExprFunctionCallArg::Value))
-            .map(|arg| self.evaluate(*arg))
+            .map(|arg| {
+                let value = self.evaluate(*arg);
+                if value.is_fully_concrete(db) || matches!(value.long(db), ConstValue::Missing(_)) {
+                    value
+                } else {
+                    to_missing(self.diagnostics.report(
+                        self.arenas.exprs[*arg].stable_ptr(),
+                        SemanticDiagnosticKind::UnsupportedConstant,
+                    ))
+                }
+            })
             .collect_vec();
         if expr.function == self.panic_with_felt252 {
             return to_missing(self.diagnostics.report(
@@ -901,32 +911,13 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             return bool_value(args[0] == self.false_const);
         }
 
-        let mut all_args_concrete = true;
         let args = match args
             .into_iter()
-            .map(|arg| {
-                // Track if any argument is not fully concrete (e.g., ImplConstant with a generic
-                // impl parameter) so we can report a diagnostic if NumericArg conversion fails.
-                if !arg.is_fully_concrete(db) && !matches!(arg.long(db), ConstValue::Missing(_)) {
-                    all_args_concrete = false;
-                }
-                NumericArg::try_new(db, arg)
-            })
+            .map(|arg| NumericArg::try_new(db, arg))
             .collect::<Option<Vec<_>>>()
         {
             Some(args) => args,
-            None => {
-                return to_missing(if all_args_concrete {
-                    // Diagnostic can be skipped as there would be a semantic error for a bad arg,
-                    // or the arg itself is Missing.
-                    skip_diagnostic()
-                } else {
-                    self.diagnostics.report(
-                        expr.stable_ptr.untyped(),
-                        SemanticDiagnosticKind::UnsupportedConstant,
-                    )
-                });
-            }
+            None => return to_missing(skip_diagnostic()),
         };
         let value = match imp.function {
             id if id == self.neg_fn => -&args[0].v,
@@ -961,7 +952,10 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                 .intern(db);
             }
             _ => {
-                unreachable!("Unexpected function call in constant lowering: {:?}", expr)
+                unreachable!(
+                    "Unexpected function call in constant lowering: `{:?}`",
+                    expr.function.debug(db)
+                )
             }
         };
         if expr.ty == self.felt252 {


### PR DESCRIPTION
## Summary

Moves the non-concrete impl argument check for boolean operations (`==`, `!=`, `!`) earlier in the constant evaluation pipeline, before the `NumericArg` conversion attempt. This ensures that when a constant expression involves a non-concrete impl constant (e.g., `F::VALUE` where `F` is a generic impl parameter), an `UnsupportedConstant` diagnostic is emitted immediately and consistently, rather than relying on the downstream `NumericArg` conversion failure to trigger the diagnostic.

The `all_args_concrete` tracking logic inside the `NumericArg` mapping has been removed, and the `None` branch of that conversion now unconditionally calls `skip_diagnostic()`, since any non-concrete case is already handled upfront.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, equality (`==`), inequality (`!=`), and boolean not (`!`) operations on non-concrete impl constants could silently pass through the `NumericArg` conversion check without emitting a diagnostic, depending on the order of evaluation. The diagnostic was only reported if `NumericArg::try_new` returned `None` and `all_args_concrete` was `false`, which was fragile and could miss cases.

---

## What was the behavior or documentation before?

Comparisons and boolean negation involving non-concrete impl const arguments (e.g., `F::VALUE == 42`, `F::VALUE != 42`, `!F::VALUE`) could fail to produce a clear `UnsupportedConstant` diagnostic in some code paths.

---

## What is the behavior or documentation after?

All three operations now consistently emit `error[E2127]: This expression is not supported as constant.` when any argument is not fully concrete, as verified by the three new test cases added to the constant test data.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The unreachable panic message in the unexpected function call branch was also improved to include the function's debug name for easier diagnosis.