### PR TITLE
Bumped nightly version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-09
+          toolchain: nightly-2026-04-26
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - run: |
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2026-04-09
+          toolchain: nightly-2026-04-26
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --profile=ci-dev -p cairo-lang-syntax-codegen
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2026-04-09
+          toolchain: nightly-2026-04-26
       - uses: Swatinem/rust-cache@v2
       - run: scripts/rust_fmt.sh --check
 
@@ -169,7 +169,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
-          toolchain: nightly-2026-04-09
+          toolchain: nightly-2026-04-26
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/clippy.sh
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-09
+          toolchain: nightly-2026-04-26
       - uses: Swatinem/rust-cache@v2
       - run: >
           scripts/docs.sh

--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -49,7 +49,7 @@ pub fn reformat_rust_code(text: String) -> String {
 }
 pub fn reformat_rust_code_inner(text: String) -> String {
     let sh = Shell::new().unwrap();
-    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-04-09");
+    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-04-26");
     let cmd_with_args = cmd.arg("--config-path").arg(project_root().join("rustfmt.toml"));
     let mut stdout = cmd_with_args.stdin(text).read().unwrap();
     if !stdout.ends_with('\n') {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The `rustfmt` configuration used by Cairo requires a nightly version of Rust.
 You can install the nightly version by running:
 
 ```sh
-rustup install nightly-2026-04-09
+rustup install nightly-2026-04-26
 ```
 
 ## Running Tests

--- a/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
@@ -35,5 +35,5 @@ You can install the nightly version by running:
 
 [source,bash]
 ----
-rustup install nightly-2026-04-09
+rustup install nightly-2026-04-26
 ----

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,11 +23,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2026-04-09",
+#         "nightly-2026-04-26",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2024",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2026-04-09".
+# and run "rustup toolchain install nightly-2026-04-26".

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-09}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-26}"
 
 cargo clippy "$@" --all-targets --all-features -- -D warnings -D future-incompatible \
     -D nonstandard-style -D rust-2018-idioms -D unused

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-09}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-26}"
 
 RUSTDOCFLAGS="-Dwarnings" cargo doc --document-private-items --no-deps --all-features

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-09}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-04-26}"
 
 cargo fmt --all -- "$@"


### PR DESCRIPTION
## Summary

Bumps the Rust nightly toolchain from `nightly-2026-04-09` to `nightly-2026-04-26` across CI workflows, scripts, code generation, and documentation.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The project pins a specific nightly Rust toolchain for formatting, linting, doc generation, and WASM builds. This updates the pin to a newer nightly release to pick up the latest compiler fixes and ensure toolchain consistency across all environments.

---

## What was the behavior or documentation before?

All CI jobs, scripts (`rust_fmt.sh`, `clippy.sh`, `docs.sh`), the syntax codegen tool, and contributor documentation referenced `nightly-2026-04-09`.

---

## What is the behavior or documentation after?

All references now point to `nightly-2026-04-26`, including the CI workflow toolchain installs, the `RUSTUP_TOOLCHAIN` defaults in scripts, the `rustfmt` invocation in the code generator, and the `rustup install` commands in `CONTRIBUTING.md` and the prerequisites documentation.

---

## Related issue or discussion (if any)

---

## Additional context

The `rustfmt.toml` comment block, which provides guidance for configuring rust-analyzer's override command, has also been updated to reflect the new toolchain version.