### PR TITLE
bugfix(corelib): Maded bounde-int type pub.

### DIFF
--- a/corelib/src/internal/bounded_int.cairo
+++ b/corelib/src/internal/bounded_int.cairo
@@ -1,6 +1,6 @@
 use crate::RangeCheck;
 
-pub(crate) extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+pub extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 pub(crate) extern type BoundedIntGuarantee<const MIN: felt252, const MAX: felt252>;
 
 impl BoundedIntCopy<const MIN: felt252, const MAX: felt252> of Copy<BoundedInt<MIN, MAX>>;


### PR DESCRIPTION
## Summary

`BoundedInt` is changed from `pub(crate)` visibility to fully `pub`, making it part of the public API.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

`BoundedInt` was previously restricted to crate-internal use only, preventing external consumers from referencing or using this type directly. Exposing it publicly allows downstream users and libraries to leverage bounded integer types in their own code.

---

## What was the behavior or documentation before?

`BoundedInt<MIN, MAX>` was declared `pub(crate)`, meaning it could only be used within the `corelib` crate itself.

---

## What is the behavior or documentation after?

`BoundedInt<MIN, MAX>` is now declared `pub`, making it accessible to any external crate or user code that imports it from `corelib::internal::bounded_int`.

---

## Related issue or discussion (if any)

---

## Additional context

Note that `BoundedIntGuarantee` remains `pub(crate)` and is not affected by this change.