### PR TITLE
fix: skip semantic cache when crate has semantic errors

### DIFF
--- a/crates/cairo-lang-semantic/src/cache/mod.rs
+++ b/crates/cairo-lang-semantic/src/cache/mod.rs
@@ -33,7 +33,7 @@ use num_bigint::BigInt;
 use salsa::Database;
 use serde::{Deserialize, Serialize};
 
-use crate::db::ModuleSemanticDataCacheAndLoadingData;
+use crate::db::{ModuleSemanticDataCacheAndLoadingData, SemanticGroup};
 use crate::items::constant::{ConstValue, ConstValueId, ImplConstantId};
 use crate::items::feature_kind::FeatureKind;
 use crate::items::functions::{
@@ -152,6 +152,13 @@ pub fn generate_crate_semantic_cache<'db>(
     ctx: &mut SemanticCacheSavingContext<'db>,
 ) -> Maybe<CrateSemanticCache> {
     let all_modules = all_crate_modules_for_cache(ctx.db, crate_id);
+
+    // Bail out before encoding if any module has semantic errors. Otherwise unresolved
+    // (`Missing`/`Var`) types or const values can reach the cache encoder and ICE on the
+    // `unreachable!` arms in `TypeCached::new` / `ConstValueCached::new`.
+    for module_id in &all_modules {
+        ctx.db.module_semantic_diagnostics(*module_id)?.check_error_free()?;
+    }
 
     let modules_data = all_modules
         .iter()


### PR DESCRIPTION
## Description

Fixes #9888.

`scarb build` of a crate with `[[target.starknet-contract]]` triggers semantic cache generation. When the crate contains a semantic error (e.g. a `match` in a `const` initializer that yields a `Missing` type), the cache encoder reaches `TypeCached::new` / `ConstValueCached::new` with unresolved `Var` / `Missing` variants and ICEs on the `unreachable!` arm at `crates/cairo-lang-semantic/src/cache/mod.rs:1180`.

This change bails out at the start of `generate_crate_semantic_cache` if any module in the crate has unresolved semantic diagnostics. The compilation then surfaces the original semantic error normally instead of panicking the compiler thread.

## Repro from the issue

```cairo
fn helper() -> felt252 {
    const X: felt252 = match 1_u8 { _ => 1 };
    X
}
```

with `[[target.starknet-contract]]` in `Scarb.toml`.