### PR TITLE
(optimization): Using equality analysis to improve match optimization

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/def_site.rs
+++ b/crates/cairo-lang-lowering/src/analysis/def_site.rs
@@ -13,10 +13,13 @@ use crate::analysis::forward::ForwardDataflowAnalysis;
 use crate::{BlockEnd, BlockId, Lowered, Statement};
 
 /// Result of def-site analysis: the def location for each variable, indexed by arena index.
-pub struct DefSites(pub Vec<DefLocation>);
+///
+/// Each entry is `Some(loc)` when the variable's defining block is reachable from the function
+/// entry, and `None` when it is unreachable (and therefore never visited by the analysis).
+pub struct DefSites(pub Vec<Option<DefLocation>>);
 
 impl std::ops::Deref for DefSites {
-    type Target = [DefLocation];
+    type Target = [Option<DefLocation>];
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -26,7 +29,10 @@ impl fmt::Debug for DefSites {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut list = f.debug_list();
         for (idx, def) in self.0.iter().enumerate() {
-            list.entry(&format_args!("v{idx}: {def:?}"));
+            match def {
+                Some(loc) => list.entry(&format_args!("v{idx}: {loc:?}")),
+                None => list.entry(&format_args!("v{idx}: undefined")),
+            };
         }
         list.finish()
     }
@@ -36,14 +42,10 @@ impl fmt::Debug for DefSites {
 pub struct DefSiteAnalysis<'db, 'a> {
     lowered: &'a Lowered<'db>,
     /// First-available location for each variable, indexed by variable arena index.
-    /// Slots hold [`UNRESOLVED`] until the traversal reaches them; `analyze` asserts the
-    /// placeholder is gone before returning.
-    def_sites: Vec<DefLocation>,
+    /// Slots stay `None` until the traversal reaches them; slots that remain `None` correspond
+    /// to variables in unreachable blocks.
+    def_sites: Vec<Option<DefLocation>>,
 }
-
-/// Sentinel placeholder for `def_sites` slots before the traversal reaches them. Uses an
-/// out-of-range `BlockId` so it cannot collide with any real def location.
-const UNRESOLVED: DefLocation = DefLocation::Statement((BlockId(usize::MAX), usize::MAX));
 
 impl DefSiteAnalysis<'_, '_> {
     /// Runs def-site analysis on a lowered function.
@@ -53,15 +55,11 @@ impl DefSiteAnalysis<'_, '_> {
     /// - `BlockEntry(block)`: available at block entry (parameters, goto remappings, match arm
     ///   bindings).
     /// - `Statement((block, i))`: available after statement `i` in `block`.
+    /// - `None`: the variable's defining block is unreachable from the function entry.
     pub fn analyze(lowered: &Lowered<'_>) -> DefSites {
-        let analyzer =
-            DefSiteAnalysis { lowered, def_sites: vec![UNRESOLVED; lowered.variables.len()] };
+        let analyzer = DefSiteAnalysis { lowered, def_sites: vec![None; lowered.variables.len()] };
         let mut fwd = ForwardDataflowAnalysis::new(lowered, analyzer);
         fwd.run();
-        assert!(
-            fwd.analyzer.def_sites.iter().all(|d| *d != UNRESOLVED),
-            "DefSiteAnalysis left variables unresolved"
-        );
         DefSites(fwd.analyzer.def_sites)
     }
 }
@@ -72,7 +70,7 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for DefSiteAnalysis<'db, 'a> {
 
     fn initial_info(&mut self, _block_id: BlockId, _block_end: &'a BlockEnd<'db>) -> Self::Info {
         for &param in &self.lowered.parameters {
-            self.def_sites[param.index()] = DefLocation::BlockEntry(BlockId::root());
+            self.def_sites[param.index()] = Some(DefLocation::BlockEntry(BlockId::root()));
         }
     }
 
@@ -92,7 +90,7 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for DefSiteAnalysis<'db, 'a> {
         stmt: &'a Statement<'db>,
     ) {
         for &output in stmt.outputs() {
-            self.def_sites[output.index()] = DefLocation::Statement(statement_location);
+            self.def_sites[output.index()] = Some(DefLocation::Statement(statement_location));
         }
     }
 
@@ -100,12 +98,12 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for DefSiteAnalysis<'db, 'a> {
         match edge {
             Edge::Goto { target, remapping } => {
                 for (&dst, _) in remapping.iter() {
-                    self.def_sites[dst.index()] = DefLocation::BlockEntry(*target);
+                    self.def_sites[dst.index()] = Some(DefLocation::BlockEntry(*target));
                 }
             }
             Edge::MatchArm { arm, .. } => {
                 for &var in &arm.var_ids {
-                    self.def_sites[var.index()] = DefLocation::BlockEntry(arm.block_id);
+                    self.def_sites[var.index()] = Some(DefLocation::BlockEntry(arm.block_id));
                 }
             }
             Edge::Return { .. } | Edge::Panic { .. } => {}

--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
@@ -186,6 +186,15 @@ impl<'db> EqualityState<'db> {
         self.get_struct_construct_immut(rep)
     }
 
+    /// Looks up the enum construct info for a variable (mutable, uses find for path compression).
+    pub(crate) fn get_enum_construct(
+        &mut self,
+        var: VariableId,
+    ) -> Option<(ConcreteVariant<'db>, VariableId)> {
+        let rep = self.find(var);
+        self.get_enum_construct_immut(rep)
+    }
+
     /// Looks up the enum construct info for a representative (immutable).
     fn get_enum_construct_immut(
         &self,

--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
@@ -82,44 +82,6 @@ impl<'db> Relation<'db> {
             ),
         }
     }
-
-    /// Merges two reverse relationships (self and other are proven equal).
-    /// When both exist with the same kind, propagates equality through inputs.
-    /// Always returns a valid relation (self if no merge needed).
-    fn union_equal_relations(self, other: Option<Self>, uf: &mut EqualityState<'_>) -> Self {
-        let Some(other_rel) = other else { return self };
-        match (&self, &other_rel) {
-            (Relation::Box(a), Relation::Box(b)) if a != b => Relation::Box(uf.union(*a, *b)),
-            (Relation::Snapshot(a), Relation::Snapshot(b)) if a != b => {
-                Relation::Snapshot(uf.union(*a, *b))
-            }
-            (Relation::EnumConstruct(v1, a), Relation::EnumConstruct(v2, b))
-                if v1 == v2 && a != b =>
-            {
-                Relation::EnumConstruct(*v1, uf.union(*a, *b))
-            }
-            (Relation::StructConstruct(t1, a), Relation::StructConstruct(t2, b))
-                if t1 == t2 && a.len() == b.len() =>
-            {
-                Relation::StructConstruct(
-                    *t1,
-                    a.iter()
-                        .zip(b)
-                        .map(|(sf, of)| match (sf, of) {
-                            (FieldVar::Var(a), FieldVar::Var(b)) if a != b => {
-                                FieldVar::Var(uf.union(*a, *b))
-                            }
-                            (FieldVar::Var(_), _) => *sf,
-                            (_, FieldVar::Var(_)) => *of,
-                            (FieldVar::Placeholder(_), FieldVar::Placeholder(_)) => *sf,
-                        })
-                        .collect(),
-                )
-            }
-            // Same values or different kinds: keep self.
-            _ => self,
-        }
-    }
 }
 
 /// State for the equality analysis, tracking variable equivalences.
@@ -177,87 +139,37 @@ impl<'db> EqualityState<'db> {
         var
     }
 
-    /// Unions two variables into the same equivalence class.
+    /// Unions the two variables into the same equivalence class.
+    /// `old_var`'s root is kept as the representative; `union_var`'s root joins it.
+    /// `union_var` must be a root, unless already in `old_var`'s class (no-op).
     /// Returns the representative of the merged class.
-    /// Always chooses the lower ID as the representative to maintain canonical form.
-    fn union(&mut self, a: VariableId, b: VariableId) -> VariableId {
-        let root_a = self.find(a);
-        let root_b = self.find(b);
-
-        if root_a == root_b {
-            return root_a;
+    fn add_equality(&mut self, old_var: VariableId, union_var: VariableId) -> VariableId {
+        let old_var = self.find(old_var);
+        let new_var = self.find(union_var);
+        if new_var == old_var {
+            return old_var;
         }
-
-        // Always choose the lower ID as the new root to maintain canonical form.
-        // This ensures forward map keys remain valid since lower IDs are defined earlier.
-        let (new_root, old_root) =
-            if root_a.index() < root_b.index() { (root_a, root_b) } else { (root_b, root_a) };
-
-        // Ensure new_root is in the map (as its own parent).
-        self.union_find.entry(new_root).or_insert(new_root);
-        // Update old_root to point to new_root.
-        self.union_find.insert(old_root, new_root);
-
-        // Merge reverse entries for both roots.
-        let old_reverse = self.reverse.swap_remove(&old_root);
-        let new_reverse = self.reverse.swap_remove(&new_root);
-        let merged_reverse = match (new_reverse, old_reverse) {
-            (Some(new_rev), old) => Some(new_rev.union_equal_relations(old, self)),
-            (None, old) => old,
-        };
-
-        // TODO(eytan-starkware): Forward Struct/Enum entries aren't re-keyed during union.
-        //    Doing so would require congruence closure (updating all entries whose inputs
-        //    changed). The consequence is missed hashcons hits — conservative, not unsound.
-        //    We also don't invalidate forward entries that become inconsistent (e.g., two
-        //    different enum variants mapping to the now-merged class). These stale entries
-        //    are harmless as this code should be unreachable.
-        // Merge forward Box/Snapshot entries for both roots.
-        let constructors = [Relation::Box, Relation::Snapshot];
-        for ctor in constructors {
-            let old_fwd = self.forward.swap_remove(&ctor(old_root));
-            let new_fwd = self.forward.swap_remove(&ctor(new_root));
-            let merged = match (new_fwd, old_fwd) {
-                (Some(t1), Some(t2)) => Some(self.union(t1, t2)),
-                (Some(t), None) | (None, Some(t)) => Some(t),
-                (None, None) => None,
-            };
-            if let Some(target) = merged {
-                let final_root = self.find(new_root);
-                let target_rep = self.find(target);
-                self.forward.insert(ctor(final_root), target_rep);
-            }
-        }
-
-        let final_root = self.find(new_root);
-        if let Some(merged_reverse) = merged_reverse {
-            self.reverse.insert(final_root, merged_reverse);
-        }
-
-        self.find(new_root)
+        assert!(union_var == new_var, "Expected variables to always be 'new' or equal to old");
+        self.union_find.insert(new_var, old_var);
+        old_var
     }
 
     /// Records a relation: forward maps `relation -> output`, reverse maps `output -> relation`.
     /// If the same relation already maps to an existing output, unions them.
-    /// If the output already has a reverse, merges inputs via `union_equal_relations`.
     fn set_relation(&mut self, relation: Relation<'db>, output: VariableId) {
         // Refresh reps — callers may pass stale IDs, and this maximizes forward hits.
         let relation = relation.with_fresh_reps(self);
 
         // Forward dedup: if this exact relation already maps to an output, union them.
-        if let Some(&existing_output) = self.forward.get(&relation) {
-            self.union(existing_output, output);
-        }
+        let existing_output = if let Some(&existing_output) = self.forward.get(&relation) {
+            self.add_equality(existing_output, output)
+        } else {
+            output
+        };
 
-        // Reverse merge: if output already has a reverse, merge inputs and use the result.
-        let output_rep = self.find(output);
-        let existing = self.reverse.swap_remove(&output_rep);
-        let relation = relation.union_equal_relations(existing, self);
-
-        // Insert with current reps (may be slightly stale after unions above).
-        let output_rep = self.find(output);
-        self.forward.insert(relation.clone(), output_rep);
-        self.reverse.insert(output_rep, relation);
+        // Insert with current reps (may be slightly stale after the union above).
+        self.forward.insert(relation.clone(), existing_output);
+        self.reverse.insert(existing_output, relation);
     }
 
     /// Looks up the struct construct info for a representative (immutable).
@@ -332,12 +244,15 @@ impl<'db> DebugWithDb<'db> for EqualityState<'db> {
 /// Variable equality analysis.
 ///
 /// This analyzer tracks snapshot/desnap, box/unbox, and array construct relationships as data
-/// flows through the program. At merge points (after match arms converge), we conservatively
-/// intersect the equivalence classes, keeping only equalities that hold on all paths.
+/// flows through the program. At merge points (after match arms converge), we union-find variables
+/// that share the same equivalence classes in **both** branches (`(rep1, rep2)` meet), rebuild
+/// `forward` / `reverse`, and intersect relations **without** mapping variables across differing
+/// branch-local equivalence roots (structure fields fall back to placeholders).
 pub struct EqualityAnalysis<'a, 'db> {
     db: &'db dyn Database,
     lowered: &'a Lowered<'db>,
-    /// Counter for allocating globally unique placeholder IDs.
+    /// Counter for allocating globally unique `Placeholder` IDs for unknown struct fields after
+    /// merge.
     next_placeholder: usize,
     /// The `array_new` extern function id.
     array_new: ExternFunctionId<'db>,
@@ -388,6 +303,9 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
     /// - `array_snapshot_pop_front`: Same as above but through snapshot/box-of-snapshot wrappers.
     /// - `array_snapshot_pop_back`: Like pop_front but pops from the back: element is `Box(eN)`,
     ///   remaining is `[e0, ..., eN-1]`.
+    ///
+    /// The `None` arms are intentionally ignored: recording empty-array relations or unions there
+    /// would backedge-merge older SSA equivalence classes based on branch discrimination.
     fn transfer_extern_match_arm(
         &self,
         info: &mut EqualityState<'db>,
@@ -426,108 +344,81 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
         id: ExternFunctionId<'db>,
         is_some: bool,
     ) {
-        if id == self.array_pop_front || id == self.array_pop_front_consume {
-            if is_some {
-                // Some arm: var_ids = [remaining_arr, boxed_elem]
-                let input_arr = extern_info.inputs[0].var_id;
-                let remaining_arr = arm.var_ids[0];
-                let boxed_elem = arm.var_ids[1];
-                if let Some((ty, elems)) = info.get_struct_construct(input_arr)
-                    && let Some((first, rest)) = elems.split_first()
-                {
-                    // TODO(eytan-starkware): Add support for placeholders in boxes and reverse box
-                    // relation to unify placeholder.
-                    if let FieldVar::Var(first_var) = first {
-                        info.set_relation(Relation::Box(*first_var), boxed_elem);
-                    }
-                    let rest_fields: Vec<FieldVar> =
-                        rest.iter().map(|f| f.find_rep(info)).collect();
-                    info.set_relation(Relation::StructConstruct(ty, rest_fields), remaining_arr);
+        if (id == self.array_pop_front || id == self.array_pop_front_consume) && is_some {
+            // Some arm: var_ids = [remaining_arr, boxed_elem]
+            let input_arr = extern_info.inputs[0].var_id;
+            let remaining_arr = arm.var_ids[0];
+            let boxed_elem = arm.var_ids[1];
+            if let Some((ty, elems)) = info.get_struct_construct(input_arr)
+                && let Some((first, rest)) = elems.split_first()
+            {
+                // TODO(eytan-starkware): Add support for placeholders in boxes and reverse box
+                // relation to unify placeholder.
+                if let FieldVar::Var(first_var) = first {
+                    info.set_relation(Relation::Box(*first_var), boxed_elem);
                 }
-            } else {
-                // None arm for array_pop_front: var_ids = [original_arr]. Union with input.
-                // None arm for array_pop_front_consume: var_ids = [].
-                let old_array_var = extern_info.inputs[0].var_id;
-                let ty = self.lowered.variables[old_array_var].ty;
-                // TODO(eytan-starkware): This introduces a backedge to our forward map updates,
-                //    so we might need to support updating the structures accordingly.
-                //    For example, if this is empty after a pop, then we know previous array
-                //    was a singleton.
-                info.set_relation(Relation::StructConstruct(ty, vec![]), old_array_var);
-                if let [original_arr] = arm.var_ids[..] {
-                    info.union(original_arr, old_array_var);
-                }
+                let rest_fields: Vec<FieldVar> = rest.iter().map(|f| f.find_rep(info)).collect();
+                info.set_relation(Relation::StructConstruct(ty, rest_fields), remaining_arr);
             }
-        } else if id == self.array_snapshot_pop_front || id == self.array_snapshot_pop_back {
-            if is_some {
-                // Some arm: var_ids = [remaining_snap_arr, boxed_snap_elem]
-                let input_snap_arr = extern_info.inputs[0].var_id;
-                let remaining_snap_arr = arm.var_ids[0];
-                let boxed_snap_elem = arm.var_ids[1];
+        } else if (id == self.array_snapshot_pop_front || id == self.array_snapshot_pop_back)
+            && is_some
+        {
+            // Some arm: var_ids = [remaining_snap_arr, boxed_snap_elem]
+            let input_snap_arr = extern_info.inputs[0].var_id;
+            let remaining_snap_arr = arm.var_ids[0];
+            let boxed_snap_elem = arm.var_ids[1];
 
-                // Look up tracked elements via snapshot reverse relationship or direct lookup.
-                let snap_rep = info.find(input_snap_arr);
-                let original_rep = match info.reverse.get(&snap_rep) {
-                    Some(Relation::Snapshot(v)) => Some(*v),
-                    _ => None,
-                };
-                let elems_opt = original_rep
-                    .and_then(|orig| {
-                        let orig = info.find_immut(orig);
-                        info.get_struct_construct_immut(orig)
-                    })
-                    .or_else(|| info.get_struct_construct_immut(snap_rep));
+            // Look up tracked elements via snapshot reverse relationship or direct lookup.
+            let snap_rep = info.find(input_snap_arr);
+            let original_rep = match info.reverse.get(&snap_rep) {
+                Some(Relation::Snapshot(v)) => Some(*v),
+                _ => None,
+            };
+            let elems_opt = original_rep
+                .and_then(|orig| {
+                    let orig = info.find_immut(orig);
+                    info.get_struct_construct_immut(orig)
+                })
+                .or_else(|| info.get_struct_construct_immut(snap_rep));
 
-                let snap_ty = self.lowered.variables[remaining_snap_arr].ty;
-                let Some((_orig_ty, elems)) = elems_opt else {
+            let snap_ty = self.lowered.variables[remaining_snap_arr].ty;
+            let Some((_orig_ty, elems)) = elems_opt else {
+                return;
+            };
+            let pop_front = id == self.array_snapshot_pop_front;
+            let (elem, rest) = if pop_front {
+                let Some((first, tail)) = elems.split_first() else {
+                    info.set_relation(
+                        Relation::StructConstruct(snap_ty, vec![]),
+                        remaining_snap_arr,
+                    );
                     return;
                 };
-                let pop_front = id == self.array_snapshot_pop_front;
-                let (elem, rest) = if pop_front {
-                    let Some((first, tail)) = elems.split_first() else {
-                        info.set_relation(
-                            Relation::StructConstruct(snap_ty, vec![]),
-                            remaining_snap_arr,
-                        );
-                        return;
-                    };
-                    (*first, tail)
-                } else {
-                    let Some((last, init)) = elems.split_last() else {
-                        info.set_relation(
-                            Relation::StructConstruct(snap_ty, vec![]),
-                            remaining_snap_arr,
-                        );
-                        return;
-                    };
-                    (*last, init)
-                };
-
-                // The popped element is `Box<@T>`. Record the box relationship against
-                // the snapshot class of `elem` if it exists.
-                // TODO(eytan-starkware): Support relationships even when no variable
-                // represents `@elem` yet (elem is a Placeholder).
-                if let FieldVar::Var(elem_var) = elem {
-                    let elem_rep = info.find(elem_var);
-                    if let Some(&snap_of_elem) = info.forward.get(&Relation::Snapshot(elem_rep)) {
-                        info.set_relation(Relation::Box(snap_of_elem), boxed_snap_elem);
-                    }
-                }
-
-                let rest_fields: Vec<FieldVar> = rest.iter().map(|f| f.find_rep(info)).collect();
-                info.set_relation(
-                    Relation::StructConstruct(snap_ty, rest_fields),
-                    remaining_snap_arr,
-                );
+                (*first, tail)
             } else {
-                // None arm: record empty snapshot array and union output with input.
-                let old_snap_arr = extern_info.inputs[0].var_id;
-                let snap_ty = self.lowered.variables[old_snap_arr].ty;
-                info.set_relation(Relation::StructConstruct(snap_ty, vec![]), old_snap_arr);
-                if let [original_snap_arr] = arm.var_ids[..] {
-                    info.union(original_snap_arr, old_snap_arr);
+                let Some((last, init)) = elems.split_last() else {
+                    info.set_relation(
+                        Relation::StructConstruct(snap_ty, vec![]),
+                        remaining_snap_arr,
+                    );
+                    return;
+                };
+                (*last, init)
+            };
+
+            // The popped element is `Box<@T>`. Record the box relationship against
+            // the snapshot class of `elem` if it exists.
+            // TODO(eytan-starkware): Support relationships even when no variable
+            // represents `@elem` yet (elem is a Placeholder).
+            if let FieldVar::Var(elem_var) = elem {
+                let elem_rep = info.find(elem_var);
+                if let Some(&snap_of_elem) = info.forward.get(&Relation::Snapshot(elem_rep)) {
+                    info.set_relation(Relation::Box(snap_of_elem), boxed_snap_elem);
                 }
             }
+
+            let rest_fields: Vec<FieldVar> = rest.iter().map(|f| f.find_rep(info)).collect();
+            info.set_relation(Relation::StructConstruct(snap_ty, rest_fields), remaining_snap_arr);
         }
     }
 }
@@ -554,20 +445,9 @@ fn merge_referenced_vars<'db, 'a>(
     union_find_vars.chain(forward_vars).chain(reverse_vars)
 }
 
-/// Finds an intersection representative: given a rep in info1 and a rep in info2,
-/// returns the intersection representative in the result if one exists.
-fn find_intersection_rep(
-    intersections: &OrderedHashMap<VariableId, Vec<(VariableId, VariableId)>>,
-    rep1: VariableId,
-    rep2: VariableId,
-) -> Option<VariableId> {
-    intersections.get(&rep1)?.iter().find_map(|(intersection_r2, intersection_rep)| {
-        (*intersection_r2 == rep2).then_some(*intersection_rep)
-    })
-}
-
-/// Preserves relations that exist in both branches.
-/// All relation types are looked up via the forward map, which retains all entries.
+/// Keeps relational edges that survive the join **without** mapping variables across mismatched
+/// branch equivalence roots: struct fields become placeholders unless both sides cite the same SSA
+/// `VariableId`. Box/Snapshot/Enum reuse an edge only when merged outputs coincide in `result`.
 fn merge_relations<'db>(
     info1: &EqualityState<'db>,
     info2: &EqualityState<'db>,
@@ -576,6 +456,7 @@ fn merge_relations<'db>(
     next_placeholder: &mut usize,
 ) {
     // Index info2's StructConstruct entries by output representative for lookup in the merge loop.
+    // Forward entries are completely authoritative, so we use them to build the index.
     let info2_structs_by_output: OrderedHashMap<VariableId, (TypeId<'db>, Vec<FieldVar>)> = info2
         .forward
         .iter()
@@ -586,81 +467,72 @@ fn merge_relations<'db>(
         .collect();
 
     // Iterate all forward entries from info1 and find matching entries in info2.
-    // We use forward (not reverse) because reverse holds only the latest relation per output,
-    // while forward retains all entries and is the authoritative source.
     for (relation, &output1) in info1.forward.iter() {
         match relation {
             Relation::Box(source1) | Relation::Snapshot(source1) => {
-                for &(source2, intersection_var) in intersections.get(source1).unwrap_or(&vec![]) {
+                for &(source2, intersection_var) in intersections.get(source1).into_iter().flatten()
+                {
                     let relation2 = match relation {
                         Relation::Box(_) => Relation::Box(source2),
                         Relation::Snapshot(_) => Relation::Snapshot(source2),
                         _ => unreachable!(),
                     };
                     let Some(&output2) = info2.forward.get(&relation2) else { continue };
-                    if let Some(output_intersection) = find_intersection_rep(
-                        intersections,
-                        info1.find_immut(output1),
-                        info2.find_immut(output2),
-                    ) {
-                        let result_relation = match relation {
-                            Relation::Box(_) => Relation::Box(result.find(intersection_var)),
-                            Relation::Snapshot(_) => {
-                                Relation::Snapshot(result.find(intersection_var))
-                            }
-                            _ => unreachable!(),
-                        };
-                        result.set_relation(result_relation, output_intersection);
+                    // Require the same unified output (join meet); avoid mapping via rep pair
+                    // lookup.
+                    // TODO(eytan-starkware): We want to check that the intersection is not empty
+                    // and use that for the output rep, not that the leaders are there.
+                    let output_rep = result.find(output1);
+                    if output_rep != result.find_immut(output2) {
+                        continue;
                     }
+                    let result_relation = match relation {
+                        Relation::Box(_) => Relation::Box(result.find(intersection_var)),
+                        Relation::Snapshot(_) => Relation::Snapshot(result.find(intersection_var)),
+                        _ => unreachable!(),
+                    };
+                    result.set_relation(result_relation, output_rep);
                 }
             }
             Relation::EnumConstruct(variant, input1) => {
                 for &(input2, input_intersection) in
-                    intersections.get(&info1.find_immut(*input1)).unwrap_or(&vec![])
+                    intersections.get(&info1.find_immut(*input1)).into_iter().flatten()
                 {
                     let relation2 = Relation::EnumConstruct(*variant, input2);
                     let Some(&output2) = info2.forward.get(&relation2) else { continue };
-                    if let Some(output_intersection) = find_intersection_rep(
-                        intersections,
-                        info1.find_immut(output1),
-                        info2.find_immut(output2),
-                    ) {
-                        result.set_relation(
-                            Relation::EnumConstruct(*variant, input_intersection),
-                            output_intersection,
-                        );
+                    let output_rep = result.find(output1);
+                    if output_rep != result.find_immut(output2) {
+                        continue;
                     }
+                    result.set_relation(
+                        Relation::EnumConstruct(*variant, input_intersection),
+                        output_rep,
+                    );
                 }
             }
             Relation::StructConstruct(ty, fields1) => {
                 let output1_rep = info1.find_immut(output1);
-                let Some(output_pairs) = intersections.get(&output1_rep) else {
-                    continue;
-                };
-                for &(output2_rep, output_intersection) in output_pairs {
+                for &(output2_rep, output_intersection) in
+                    intersections.get(&output1_rep).into_iter().flatten()
+                {
                     let Some((ty2, fields2)) = info2_structs_by_output.get(&output2_rep) else {
                         continue;
                     };
                     if ty2 != ty || fields2.len() != fields1.len() {
                         continue;
                     }
-                    // Intersect fields pairwise; use placeholders for unresolvable fields.
                     let mut any_data = false;
                     let result_fields: Vec<FieldVar> = fields1
                         .iter()
                         .zip(fields2)
-                        .map(|(f1, f2)| {
-                            if let Some(v1) = f1.as_var()
-                                && let Some(v2) = f2.as_var()
-                                && let Some(v) = find_intersection_rep(
-                                    intersections,
-                                    info1.find_immut(v1),
-                                    info2.find_immut(v2),
-                                )
+                        .map(|(f1, f2)| match (f1, f2) {
+                            (FieldVar::Var(v), FieldVar::Var(w))
+                                if result.find(*v) == result.find(*w) =>
                             {
                                 any_data = true;
-                                FieldVar::Var(v)
-                            } else {
+                                FieldVar::Var(result.find(*v))
+                            }
+                            (_, _) => {
                                 *next_placeholder += 1;
                                 FieldVar::Placeholder(*next_placeholder - 1)
                             }
@@ -694,7 +566,9 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
         info1: Self::Info,
         info2: Self::Info,
     ) -> Self::Info {
-        // Intersection-based merge: keep only equalities that hold in BOTH branches.
+        // Meet of union-finds, then intersect relations (`merge_relations`) without bridging
+        // mismatched equiv-class reps across branches (struct fields → placeholders unless same SSA
+        // id).
         let mut result = EqualityState::default();
 
         // Group variables by (rep1, rep2) - for variables present in either state.
@@ -707,23 +581,19 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
             groups.entry(key).or_default().push(var);
         }
 
-        // Union all variables within each group
+        // Union all variables within each group. Members are fresh in `result`
+        // (which was just constructed), so any choice of `keep` is flat-preserving;
+        // the lowest-ID is chosen so the rep is stable/deterministic.
         for members in groups.values() {
-            if members.len() > 1 {
-                let first = members[0];
-                for &var in &members[1..] {
-                    result.union(first, var);
+            let Some(&keep) = members.iter().min_by_key(|v| v.index()) else { continue };
+            for &var in members {
+                if var != keep {
+                    result.add_equality(keep, var);
                 }
             }
         }
 
-        // An important point in this merge is to retain relationships.
-        // Consider:
-        //  info1 [equality class[1] = 1, 2, 4] and 6 is Box(1).
-        //  info2 [equality class[2] = 3, 5, 4] and 6 is Box(3).
-        // To detect we can keep 6 is Box(4), as it is true in all branches, we need intersection of
-        // eclasses (a single eclass can split in the result into multiple eclasses).
-        // Build secondary index: rep1 -> Vec<(rep2, intersection_rep)>.
+        // Secondary index: rep₁ -> `(rep₂, representative in result)` for relation intersection.
         let mut intersections: OrderedHashMap<VariableId, Vec<(VariableId, VariableId)>> =
             OrderedHashMap::default();
         for (&(rep1, rep2), vars) in groups.iter() {
@@ -743,7 +613,7 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
     ) {
         match stmt {
             Statement::Snapshot(snapshot_stmt) => {
-                info.union(snapshot_stmt.original(), snapshot_stmt.input.var_id);
+                info.add_equality(snapshot_stmt.input.var_id, snapshot_stmt.original());
                 info.set_relation(
                     Relation::Snapshot(snapshot_stmt.input.var_id),
                     snapshot_stmt.snapshot(),
@@ -751,7 +621,15 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
             }
 
             Statement::Desnap(desnap_stmt) => {
-                info.set_relation(Relation::Snapshot(desnap_stmt.output), desnap_stmt.input.var_id);
+                let input_rep = info.find(desnap_stmt.input.var_id);
+                if let Some(Relation::Snapshot(old_inner)) = info.reverse.get(&input_rep) {
+                    info.add_equality(*old_inner, desnap_stmt.output);
+                } else {
+                    info.set_relation(
+                        Relation::Snapshot(desnap_stmt.output),
+                        desnap_stmt.input.var_id,
+                    );
+                }
             }
 
             Statement::IntoBox(into_box_stmt) => {
@@ -759,7 +637,12 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
             }
 
             Statement::Unbox(unbox_stmt) => {
-                info.set_relation(Relation::Box(unbox_stmt.output), unbox_stmt.input.var_id);
+                let input_rep = info.find(unbox_stmt.input.var_id);
+                if let Some(Relation::Box(old_inner)) = info.reverse.get(&input_rep) {
+                    info.add_equality(*old_inner, unbox_stmt.output);
+                } else {
+                    info.set_relation(Relation::Box(unbox_stmt.output), unbox_stmt.input.var_id);
+                }
             }
 
             Statement::EnumConstruct(enum_stmt) => {
@@ -784,20 +667,21 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
 
             Statement::StructDestructure(struct_stmt) => {
                 // (outputs...) = struct_destructure(input)
+                let struct_var = info.find(struct_stmt.input.var_id);
                 // 1. If input was previously constructed, union outputs with original fields. Skip
                 //    placeholder fields (unknown after merge).
-                if let Some((_, field_reps)) = info.get_struct_construct(struct_stmt.input.var_id) {
+                if let Some((_, field_reps)) = info.get_struct_construct(struct_var) {
                     for (&output, field) in struct_stmt.outputs.iter().zip(field_reps.iter()) {
                         if let FieldVar::Var(field_rep) = field {
-                            info.union(output, *field_rep);
+                            info.add_equality(*field_rep, output);
                         }
                     }
                 }
                 // 2. Record: struct_construct(outputs) == input (for future constructs).
-                let ty = self.lowered.variables[struct_stmt.input.var_id].ty;
+                let ty = self.lowered.variables[struct_var].ty;
                 let fields =
                     struct_stmt.outputs.iter().map(|&v| FieldVar::Var(info.find(v))).collect();
-                info.set_relation(Relation::StructConstruct(ty, fields), struct_stmt.input.var_id);
+                info.set_relation(Relation::StructConstruct(ty, fields), struct_var);
             }
 
             Statement::Call(call_stmt) => {
@@ -829,7 +713,7 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
             Edge::Goto { remapping, .. } => {
                 // Union remapped variables: dst and src should be in the same equivalence class
                 for (dst, src_usage) in remapping.iter() {
-                    new_info.union(*dst, src_usage.var_id);
+                    new_info.add_equality(src_usage.var_id, *dst);
                 }
             }
             Edge::MatchArm { arm, match_info } => {
@@ -843,12 +727,12 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
                     // If we previously saw this enum constructed with the same variant,
                     // union with the original input. Skip if variants differ — this can
                     // happen after optimizations merge states from different branches.
-                    let output_rep = new_info.find(matched_var);
+                    let matched_rep = new_info.find(matched_var);
                     if let Some((old_variant, input)) =
-                        new_info.get_enum_construct_immut(output_rep)
+                        new_info.get_enum_construct_immut(matched_rep)
                         && variant == old_variant
                     {
-                        new_info.union(arm_var, input);
+                        new_info.add_equality(input, arm_var);
                     }
 
                     // Record the relationship: matched_var = Variant(arm_var)

--- a/crates/cairo-lang-lowering/src/analysis/test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/test.rs
@@ -241,24 +241,3 @@ fn test_forward_with_branching() {
         assert!(exit_info[block_id.0].is_some(), "Block {:?} should have exit info", block_id);
     }
 }
-
-/// Verifies the `UNRESOLVED` assert fires when an arena slot is left unreached by the traversal
-/// (a regression guard for future passes that drop defs without compacting `lowered.variables`).
-#[test]
-#[should_panic(expected = "DefSiteAnalysis left variables unresolved")]
-fn unresolved_assert_fires() {
-    let db = &mut LoweringDatabaseForTesting::default();
-    let inputs = OrderedHashMap::from([
-        ("function_code".to_string(), "fn foo(x: felt252) -> felt252 { x }".to_string()),
-        ("function_name".to_string(), "foo".to_string()),
-    ]);
-    let test_function = setup_test_function(db, &inputs).split().0;
-    let function_id =
-        ConcreteFunctionWithBodyId::from_semantic(db, test_function.concrete_function_id);
-    let mut lowered = db.lowered_body(function_id, LoweringStage::PostBaseline).cloned().unwrap();
-    // Here we allocate an extra variable to test that `UNRESOLVED` slots are detected. Causes
-    // panic.
-    let extra = lowered.variables.iter().next().unwrap().1.clone();
-    lowered.variables.alloc(extra);
-    DefSiteAnalysis::analyze(&lowered);
-}

--- a/crates/cairo-lang-lowering/src/analysis/test_data/equality
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/equality
@@ -581,7 +581,7 @@ Block 2:
 A(v1) = v6, True(v3) = v0
 
 Block 3:
-A(v1) = v5
+(empty)
 
 //! > ==========================================================================
 
@@ -1065,16 +1065,16 @@ Block 1:
 Box(v0) = v6, core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v4, core::array::Array::<core::felt252>(v1) = v5, v0 = v8
 
 Block 2:
-()() = v10, None(v10) = v11, core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v2, v2 = v4, v2 = v7
+()() = v10, None(v10) = v11, core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v4
 
 Block 3:
-()() = v10, None(v10) = v11, Some(v12) = v11, core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v2, v2 = v4, v2 = v7
+()() = v10, None(v10) = v11, Some(v12) = v11, core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v4
 
 Block 4:
 core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v4, core::array::Array::<core::felt252>(v9) = v15, v2 = v14
 
 Block 5:
-()() = v10, None(v10) = v11, core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v2, v10 = v13, v2 = v4, v2 = v7
+()() = v10, None(v10) = v11, core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v4, v10 = v13
 
 Block 6:
 @v16 = v18, core::array::Array::<core::felt252>() = v2, core::array::Array::<core::felt252>(v0) = v3, core::array::Array::<core::felt252>(v0, v1) = v4, v16 = v17
@@ -1181,10 +1181,10 @@ Block 2:
 @core::array::Array::<core::felt252>() = v19, @core::array::Array::<core::felt252>(v1) = v13, @v0 = v3, @v1 = v5, @v8 = v10, Box(v3) = v14, Box(v5) = v20, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, core::array::Span::<core::felt252>(v13) = v17, v0 = v2, v1 = v4, v10 = v12, v13 = v18, v3 = v16, v5 = v22, v8 = v9
 
 Block 3:
-()() = v23, @core::array::Array::<core::felt252>() = v13, @core::array::Array::<core::felt252>(v1) = v13, @v0 = v3, @v1 = v5, @v8 = v10, Box(v3) = v14, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, core::array::Span::<core::felt252>(v13) = v17, v0 = v2, v1 = v4, v10 = v12, v13 = v18, v13 = v21, v3 = v16, v8 = v9
+()() = v23, @core::array::Array::<core::felt252>(v1) = v13, @v0 = v3, @v1 = v5, @v8 = v10, Box(v3) = v14, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, core::array::Span::<core::felt252>(v13) = v17, v0 = v2, v1 = v4, v10 = v12, v13 = v18, v3 = v16, v8 = v9
 
 Block 4:
-()() = v24, @core::array::Array::<core::felt252>() = v10, @v0 = v3, @v1 = v5, @v8 = v10, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, v0 = v2, v1 = v4, v10 = v12, v10 = v15, v11 = v25, v8 = v9
+()() = v24, @v0 = v3, @v1 = v5, @v8 = v10, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, core::array::Span::<core::felt252>(v15) = v25, v0 = v2, v1 = v4, v10 = v12, v8 = v9
 
 //! > ==========================================================================
 
@@ -1288,10 +1288,10 @@ Block 2:
 @core::array::Array::<core::felt252>() = v19, @core::array::Array::<core::felt252>(v0) = v13, @v0 = v3, @v1 = v5, @v8 = v10, Box(v3) = v20, Box(v5) = v14, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, core::array::Span::<core::felt252>(v13) = v17, v0 = v2, v1 = v4, v10 = v12, v13 = v18, v3 = v22, v5 = v16, v8 = v9
 
 Block 3:
-()() = v23, @core::array::Array::<core::felt252>() = v13, @core::array::Array::<core::felt252>(v0) = v13, @v0 = v3, @v1 = v5, @v8 = v10, Box(v5) = v14, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, core::array::Span::<core::felt252>(v13) = v17, v0 = v2, v1 = v4, v10 = v12, v13 = v18, v13 = v21, v5 = v16, v8 = v9
+()() = v23, @core::array::Array::<core::felt252>(v0) = v13, @v0 = v3, @v1 = v5, @v8 = v10, Box(v5) = v14, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, core::array::Span::<core::felt252>(v13) = v17, v0 = v2, v1 = v4, v10 = v12, v13 = v18, v5 = v16, v8 = v9
 
 Block 4:
-()() = v24, @core::array::Array::<core::felt252>() = v10, @v0 = v3, @v1 = v5, @v8 = v10, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, v0 = v2, v1 = v4, v10 = v12, v10 = v15, v11 = v25, v8 = v9
+()() = v24, @v0 = v3, @v1 = v5, @v8 = v10, core::array::Array::<core::felt252>() = v6, core::array::Array::<core::felt252>(v0) = v7, core::array::Array::<core::felt252>(v0, v1) = v8, core::array::Span::<core::felt252>(v10) = v11, core::array::Span::<core::felt252>(v15) = v25, v0 = v2, v1 = v4, v10 = v12, v8 = v9
 
 //! > ==========================================================================
 
@@ -1356,11 +1356,11 @@ Block 1:
 @v2 = v4, Box(v10) = v8, core::array::Span::<core::felt252>(v4) = v5, v2 = v3, v4 = v6
 
 Block 2:
-()() = v11, @core::array::Array::<core::felt252>() = v4, @v2 = v4, core::array::Span::<core::felt252>(v4) = v5, v2 = v3, v4 = v6, v4 = v9
+()() = v11, @v2 = v4, core::array::Span::<core::felt252>(v4) = v5, v2 = v3, v4 = v6
 
 //! > ==========================================================================
 
-//! > Test pop_front None arm records array as empty
+//! > Test pop_front None arm does not backedge-merge or record empty on match input
 
 //! > test_runner_name
 test_equality_analysis
@@ -1414,7 +1414,7 @@ Block 1:
 Box(v4) = v2
 
 Block 2:
-()() = v5, core::array::Array::<core::felt252>() = v0, v0 = v3, v0 = v6
+()() = v5, core::array::Array::<core::felt252>() = v6
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-lowering/src/optimizations/match_optimizer.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/match_optimizer.rs
@@ -2,20 +2,25 @@
 #[path = "match_optimizer_test.rs"]
 mod test;
 
-use cairo_lang_semantic::MatchArmSelector;
+use cairo_lang_semantic::{ConcreteVariant, MatchArmSelector};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::{Itertools, zip_eq};
+use salsa::Database;
 
 use super::var_renamer::VarRenamer;
-use crate::analysis::{Analyzer, BackAnalysis, StatementLocation};
+use crate::analysis::def_site::{DefSiteAnalysis, DefSites};
+use crate::analysis::dominator::Dominators;
+use crate::analysis::equality_analysis::{EqualityAnalysis, EqualityState};
+use crate::analysis::{Analyzer, BackAnalysis, DefLocation, StatementLocation};
 use crate::borrow_check::Demand;
 use crate::borrow_check::demand::EmptyDemandReporter;
+use crate::ids::LocationId;
 use crate::utils::RebuilderEx;
 use crate::{
-    Block, BlockEnd, BlockId, Lowered, MatchArm, MatchEnumInfo, MatchInfo, Statement,
-    StatementEnumConstruct, VarRemapping, VarUsage, VariableArena, VariableId,
+    Block, BlockEnd, BlockId, Lowered, MatchArm, MatchEnumInfo, MatchInfo, Statement, VarRemapping,
+    VarUsage, VariableArena, VariableId,
 };
 
 pub type MatchOptimizerDemand<'db> = Demand<VariableId, (), ()>;
@@ -52,14 +57,13 @@ impl<'db> MatchOptimizerDemand<'db> {
 /// ```
 ///
 /// Change `blk0` to jump directly to `blk4`.
-pub fn optimize_matches<'db>(lowered: &mut Lowered<'db>) {
+pub fn optimize_matches<'db>(db: &'db dyn Database, lowered: &mut Lowered<'db>) {
     if lowered.blocks.is_empty() {
         return;
     }
-    let ctx = MatchOptimizerContext { fixes: vec![] };
-    let mut analysis = BackAnalysis::new(lowered, ctx);
+    let ctx = MatchOptimizerContext::new(db, lowered);
+    let mut analysis = BackAnalysis::new(&*lowered, ctx);
     analysis.get_root_info();
-    let ctx = analysis.analyzer;
 
     let mut new_blocks = vec![];
     let mut next_block_id = BlockId(lowered.blocks.len());
@@ -91,7 +95,7 @@ pub fn optimize_matches<'db>(lowered: &mut Lowered<'db>) {
     // Fixes were added in reverse order and need to be applied in that order.
     // This is because `additional_remappings` in later blocks may need to be renamed by fixes from
     // earlier blocks.
-    for fix in ctx.fixes {
+    for fix in analysis.analyzer.fixes {
         // Choose new variables for each destination of the additional remappings (see comment
         // above).
         let mut new_remapping = fix.remapping.clone();
@@ -105,15 +109,18 @@ pub fn optimize_matches<'db>(lowered: &mut Lowered<'db>) {
             renamed_vars.insert(*var, new_var);
         }
 
-        let block = &mut lowered.blocks[fix.statement_location.0];
-        assert_eq!(
-            block.statements.len() - 1,
-            fix.statement_location.1 + fix.n_same_block_statement,
-            "Unexpected number of statements in block."
-        );
-
-        if fix.remove_enum_construct {
-            block.statements.remove(fix.statement_location.1);
+        let block = &mut lowered.blocks[fix.fix_block];
+        if let Some(UpstreamEnumConstruct { stmt_idx, n_same_block_statement, remove }) =
+            &fix.enum_construct
+        {
+            assert_eq!(
+                block.statements.len() - 1,
+                stmt_idx + n_same_block_statement,
+                "Unexpected number of statements in block."
+            );
+            if *remove {
+                block.statements.remove(*stmt_idx);
+            }
         }
 
         handle_additional_statements(
@@ -126,7 +133,7 @@ pub fn optimize_matches<'db>(lowered: &mut Lowered<'db>) {
         );
 
         block.end = BlockEnd::Goto(fix.target_block, new_remapping);
-        if fix.statement_location.0 == fix.match_block {
+        if fix.fix_block == fix.match_block {
             // The match was removed (by the assignment of `block.end` above), no need to fix it.
             // Sanity check: there should be no additional remapping in this case.
             assert!(fix.additional_remappings.remapping.is_empty());
@@ -229,14 +236,22 @@ fn handle_additional_statements<'db>(
     }
 }
 
-/// Try to apply the optimization at the given statement.
-/// If the optimization can be applied, return the fix information and updates the analysis info
-/// accordingly.
+/// Try to apply the optimization for the given variant.
+///
+/// `inner` is the value to feed into the matched arm. `fix_block` is the block whose `end`
+/// will be replaced with a goto. `enum_construct`, when present, gives `(stmt_idx,
+/// output_var)` of the upstream `Statement::EnumConstruct` in `fix_block` — `output_var` is
+/// used to decide whether the construct can be removed. `None` for equality-anchored folds.
+///
+/// The candidate is consumed: on success its arm-specific state is folded into the returned
+/// `FixInfo`; on failure it is dropped. Either way the caller cannot reuse it.
 fn try_get_fix_info<'db>(
-    StatementEnumConstruct { variant, input, output }: &StatementEnumConstruct<'db>,
+    variant: &ConcreteVariant<'db>,
+    inner: VarUsage<'db>,
+    enum_construct: Option<(usize, VariableId)>,
+    fix_block: BlockId,
     info: &mut AnalysisInfo<'db, '_>,
-    candidate: &mut OptimizationCandidate<'db, '_>,
-    statement_location: (BlockId, usize),
+    mut candidate: OptimizationCandidate<'db, '_>,
 ) -> Option<FixInfo<'db>> {
     let (arm_idx, arm) = candidate
         .match_arms
@@ -253,7 +268,7 @@ fn try_get_fix_info<'db>(
     // Prepare a remapping object for the input of the EnumConstruct, which will be used as `var_id`
     // in `arm.block_id`.
     let mut remapping = VarRemapping::default();
-    remapping.insert(*var_id, *input);
+    remapping.insert(*var_id, inner);
 
     // Compute the demand based on the demand of the specific arm, rather than the current demand
     // (which contains the union of the demands from all the arms).
@@ -273,7 +288,7 @@ fn try_get_fix_info<'db>(
     }
 
     demand
-        .apply_remapping(&mut EmptyDemandReporter {}, [(var_id, (&input.var_id, ()))].into_iter());
+        .apply_remapping(&mut EmptyDemandReporter {}, [(var_id, (&inner.var_id, ()))].into_iter());
 
     let additional_remappings = match candidate.remapping {
         Some(remappings) => {
@@ -288,7 +303,7 @@ fn try_get_fix_info<'db>(
     };
 
     if !additional_remappings.is_empty() && candidate.future_merge {
-        // If there are additional_remappings and a future merge we cannot apply the optimization.
+        // additional_remappings with a future merge cannot be folded.
         return None;
     }
 
@@ -303,23 +318,28 @@ fn try_get_fix_info<'db>(
     info.demand = demand;
     info.reachable_blocks = std::mem::take(&mut candidate.arm_reachable_blocks[arm_idx]);
 
+    let enum_construct = enum_construct.map(|(stmt_idx, output)| UpstreamEnumConstruct {
+        stmt_idx,
+        n_same_block_statement: candidate.n_same_block_statement,
+        remove: !info.demand.vars.contains_key(&output),
+    });
+
     Some(FixInfo {
-        statement_location,
+        fix_block,
         match_block: candidate.match_block,
         arm_idx,
         target_block: arm.block_id,
         remapping,
         reachable_blocks: info.reachable_blocks.clone(),
         additional_remappings,
-        n_same_block_statement: candidate.n_same_block_statement,
-        remove_enum_construct: !info.demand.vars.contains_key(output),
+        enum_construct,
         additional_stmts,
     })
 }
 
 pub struct FixInfo<'db> {
-    /// The location that needs to be fixed.
-    statement_location: (BlockId, usize),
+    /// The block whose `end` will be replaced with a goto to the chosen arm.
+    fix_block: BlockId,
     /// The block with the match statement that we want to jump over.
     match_block: BlockId,
     /// The index of the arm that we want to jump to.
@@ -332,13 +352,25 @@ pub struct FixInfo<'db> {
     reachable_blocks: OrderedHashSet<BlockId>,
     /// Additional remappings that appeared in a `Goto` leading to the match.
     additional_remappings: VarRemapping<'db>,
-    /// The number of statement in the in the same block as the enum construct.
-    n_same_block_statement: usize,
-    /// Indicated that the enum construct statement can be removed.
-    remove_enum_construct: bool,
+    /// When `Some`, an upstream `EnumConstruct` sits at `(fix_block, stmt_idx)`; it is
+    /// removed iff `remove`. `None` for equality-anchored folds (no local construct).
+    enum_construct: Option<UpstreamEnumConstruct>,
     /// Additional statement that appear before the match but not in the same block as the enum
     /// construct.
     additional_stmts: Vec<Statement<'db>>,
+}
+
+/// Describes the upstream `EnumConstruct` in `fix_block` anchoring a construct-anchored fold.
+struct UpstreamEnumConstruct {
+    /// Index of the `EnumConstruct` statement in `fix_block`.
+    stmt_idx: usize,
+    /// Number of statements after the construct in the same block, used for an integrity
+    /// assertion.
+    n_same_block_statement: usize,
+    /// When true, the `EnumConstruct` is removed (input not demanded after the match).
+    /// When false, the construct stays (input is demanded elsewhere, only legal if droppable
+    /// because the fold may drop one use).
+    remove: bool,
 }
 
 #[derive(Clone)]
@@ -351,6 +383,9 @@ struct OptimizationCandidate<'db, 'a> {
 
     /// The block that the match is in.
     match_block: BlockId,
+
+    /// The source location of the match (used to synthesize `VarUsage`s for equality-based fixes).
+    match_location: LocationId<'db>,
 
     /// The demands at the arms.
     arm_demands: Vec<MatchOptimizerDemand<'db>>,
@@ -374,8 +409,44 @@ struct OptimizationCandidate<'db, 'a> {
     n_same_block_statement: usize,
 }
 
-pub struct MatchOptimizerContext<'db> {
+pub struct MatchOptimizerContext<'db, 'a> {
     fixes: Vec<FixInfo<'db>>,
+    equalities: Vec<Option<EqualityState<'db>>>,
+    dominators: Dominators,
+    def_sites: DefSites,
+    /// Borrow of `lowered.variables`, used by the equality-fold gate to check
+    /// droppable/copyable.
+    variables: &'a VariableArena<'db>,
+}
+
+impl<'db, 'a> MatchOptimizerContext<'db, 'a> {
+    fn new(db: &'db dyn Database, lowered: &'a Lowered<'db>) -> Self {
+        Self {
+            fixes: vec![],
+            equalities: EqualityAnalysis::analyze(db, lowered),
+            dominators: Dominators::analyze(lowered),
+            def_sites: DefSiteAnalysis::analyze(lowered),
+            variables: &lowered.variables,
+        }
+    }
+
+    /// Looks up the known variant of `var` at `block_id`'s exit via equality analysis.
+    fn get_enum_variant(
+        &mut self,
+        block_id: BlockId,
+        var: VariableId,
+    ) -> Option<(ConcreteVariant<'db>, VariableId)> {
+        self.equalities[block_id.0].as_mut()?.get_enum_construct(var)
+    }
+
+    /// Returns true if `var`'s definition is in scope at the end of `block_id`.
+    fn is_visible_at_block_end(&self, var_id: VariableId, at: BlockId) -> bool {
+        let Some(loc) = self.def_sites[var_id.index()] else { return false };
+        let block_id = match loc {
+            DefLocation::Statement((b, _)) | DefLocation::BlockEntry(b) => b,
+        };
+        self.dominators.dominates(block_id, at)
+    }
 }
 
 #[derive(Clone)]
@@ -386,7 +457,7 @@ pub struct AnalysisInfo<'db, 'a> {
     reachable_blocks: OrderedHashSet<BlockId>,
 }
 
-impl<'db: 'a, 'a> Analyzer<'db, 'a> for MatchOptimizerContext<'db> {
+impl<'db: 'a, 'a> Analyzer<'db, 'a> for MatchOptimizerContext<'db, 'a> {
     type Info = AnalysisInfo<'db, 'a>;
 
     fn visit_block_start(&mut self, info: &mut Self::Info, block_id: BlockId, _block: &Block<'db>) {
@@ -405,18 +476,16 @@ impl<'db: 'a, 'a> Analyzer<'db, 'a> for MatchOptimizerContext<'db> {
                     if enum_construct_stmt.output == candidate.match_variable =>
                 {
                     if let Some(fix_info) = try_get_fix_info(
-                        enum_construct_stmt,
+                        &enum_construct_stmt.variant,
+                        enum_construct_stmt.input,
+                        Some((statement_location.1, enum_construct_stmt.output)),
+                        statement_location.0,
                         info,
-                        &mut candidate,
-                        statement_location,
+                        candidate,
                     ) {
                         self.fixes.push(fix_info);
                         return;
                     }
-
-                    // Since `candidate.match_variable` was introduced, the candidate is no longer
-                    // applicable.
-                    info.candidate = None;
                 }
                 _ => {
                     candidate.statement_rev.push(stmt);
@@ -508,23 +577,65 @@ impl<'db: 'a, 'a> Analyzer<'db, 'a> for MatchOptimizerContext<'db> {
         // `arm_reachable_blocks`, then there was a collision.
         let found_collision = reachable_blocks.len() < max_possible_size;
 
+        // A match on an Enum is a fold candidate under one of the following cases:
+        // (a) Input not demanded after the match — the construct-anchored fold (`visit_stmt`)
+        //     may also remove the upstream construct.
+        // (b) Input demanded but droppable — the matched value is also consumed elsewhere
+        //     (must be Copy, else SSA would already be invalid). The construct-anchored fold
+        //     still applies, but the construct stays for the other consumers.
         let candidate = match match_info {
-            // A match is a candidate for the optimization if it is a match on an Enum
-            // and its input is unused after the match.
-            MatchInfo::Enum(MatchEnumInfo { input, arms, .. })
-                if !demand.vars.contains_key(&input.var_id) =>
+            MatchInfo::Enum(MatchEnumInfo { input, arms, location, .. })
+                if !demand.vars.contains_key(&input.var_id)
+                    || self.variables[input.var_id].info.droppable.is_ok() =>
             {
-                Some(OptimizationCandidate {
+                let candidate = OptimizationCandidate {
                     match_variable: input.var_id,
                     match_arms: arms,
                     match_block: block_id,
+                    match_location: *location,
                     arm_demands,
                     future_merge: found_collision,
                     arm_reachable_blocks,
                     remapping: None,
                     statement_rev: vec![],
                     n_same_block_statement: 0,
-                })
+                };
+                // If equality analysis already knows the variant at this block's exit, fold the
+                // match into a direct goto here. The matched-arm payload comes from equality
+                // analysis, not from a local construct; any newly-dead EnumConstruct upstream
+                // will be cleaned up by later passes.
+                if let Some((variant, payload_var)) =
+                    self.get_enum_variant(block_id, candidate.match_variable)
+                    // Without a construct to remove upstream, a non-droppable matched value
+                    // would leak (the match was its only consumer on this path).
+                    && self.variables[candidate.match_variable].info.droppable.is_ok()
+                    // Needs to be copy if we are introducing a new use.
+                    && self.variables[payload_var].info.copyable.is_ok()
+                {
+                    // Equality analysis only records an enum construct at blocks where the
+                    // payload definition dominates, so this must hold.
+                    assert!(self.is_visible_at_block_end(payload_var, block_id));
+                    let mut info = Self::Info {
+                        candidate: None,
+                        demand: MatchOptimizerDemand::default(),
+                        reachable_blocks: reachable_blocks.clone(),
+                    };
+                    // `try_get_fix_info` only fails when there are additional remappings, which
+                    // never exist for an equality-anchored fold (no goto observed yet on the
+                    // freshly-built candidate).
+                    let fix_info = try_get_fix_info(
+                        &variant,
+                        VarUsage { var_id: payload_var, location: candidate.match_location },
+                        None,
+                        block_id,
+                        &mut info,
+                        candidate,
+                    )
+                    .expect("equality-fold has no additional remappings, cannot fail");
+                    self.fixes.push(fix_info);
+                    return info;
+                }
+                Some(candidate)
             }
             _ => None,
         };

--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -95,7 +95,7 @@ impl<'db> ApplyOptimization<'db> for OptimizationPhase<'db> {
             OptimizationPhase::Cse => cse(lowered),
             OptimizationPhase::EarlyUnsafePanic => early_unsafe_panic(db, lowered),
             OptimizationPhase::DedupBlocks => dedup_blocks(lowered),
-            OptimizationPhase::OptimizeMatches => optimize_matches(lowered),
+            OptimizationPhase::OptimizeMatches => optimize_matches(db, lowered),
             OptimizationPhase::OptimizeRemappings => optimize_remappings(lowered),
             OptimizationPhase::Reboxing => apply_reboxing(db, lowered)?,
             OptimizationPhase::ReorderStatements => reorder_statements(db, lowered),

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/match_optimization
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/match_optimization
@@ -263,8 +263,8 @@ Statements:
   () <- core::internal::revoke_ap_tracking()
 End:
   Match(match_enum(v3) {
-    Option::Some(v19) => blk11,
-    Option::None(v18) => blk10,
+    Option::Some(v20) => blk12,
+    Option::None(v19) => blk11,
   })
 
 blk4:
@@ -277,16 +277,15 @@ End:
 blk5:
 Statements:
   (v11: ()) <- struct_construct()
-  (v12: core::option::Option::<core::integer::u16>) <- Option::None(v11)
 End:
-  Goto(blk6, {v12 -> v10})
+  Goto(blk8, {v11 -> v14})
 
 blk6:
 Statements:
 End:
   Match(match_enum(v10) {
     Option::Some(v13) => blk7,
-    Option::None(v14) => blk8,
+    Option::None(v18) => blk10,
   })
 
 blk7:
@@ -309,12 +308,17 @@ End:
 blk10:
 Statements:
 End:
-  Goto(blk5, {v18 -> v7})
+  Goto(blk8, {v18 -> v14})
 
 blk11:
 Statements:
 End:
-  Goto(blk4, {v19 -> v6})
+  Goto(blk5, {v19 -> v7})
+
+blk12:
+Statements:
+End:
+  Goto(blk4, {v20 -> v6})
 
 //! > ==========================================================================
 
@@ -2105,5 +2109,251 @@ blk6:
 Statements:
 End:
   Return(v12)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Test nested if on the same condition and its negation.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > TODO(eytan-starkware):
+optimization is not applicable: the inner match is on the result of `bool_not_impl`,
+which is opaque to the equality analysis, so the inner match cannot be folded even
+though the outer arm pins `c` to `true`.
+
+//! > function_code
+fn foo(c: bool) -> felt252 {
+    if c {
+        if !c {
+            1
+        } else {
+            2
+        }
+    } else {
+        3
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 3
+End:
+  Goto(blk6, {v3 -> v4})
+
+blk2:
+Statements:
+  (v5: core::bool) <- core::bool_not_impl(v0)
+End:
+  Match(match_enum(v5) {
+    bool::False(v6) => blk3,
+    bool::True(v7) => blk4,
+  })
+
+blk3:
+Statements:
+  (v8: core::felt252) <- 2
+End:
+  Goto(blk5, {v8 -> v9})
+
+blk4:
+Statements:
+  (v10: core::felt252) <- 1
+End:
+  Goto(blk5, {v10 -> v9})
+
+blk5:
+Statements:
+End:
+  Goto(blk6, {v9 -> v4})
+
+blk6:
+Statements:
+End:
+  Return(v4)
+
+//! > after
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 3
+End:
+  Goto(blk6, {v3 -> v4})
+
+blk2:
+Statements:
+  (v5: core::bool) <- core::bool_not_impl(v0)
+End:
+  Match(match_enum(v5) {
+    bool::False(v6) => blk3,
+    bool::True(v7) => blk4,
+  })
+
+blk3:
+Statements:
+  (v8: core::felt252) <- 2
+End:
+  Goto(blk5, {v8 -> v9})
+
+blk4:
+Statements:
+  (v10: core::felt252) <- 1
+End:
+  Goto(blk5, {v10 -> v9})
+
+blk5:
+Statements:
+End:
+  Goto(blk6, {v9 -> v4})
+
+blk6:
+Statements:
+End:
+  Return(v4)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
+//! > Test nested if on the same condition.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function_code
+fn foo(c: bool) -> felt252 {
+    if c {
+        if c {
+            1
+        } else {
+            2
+        }
+    } else {
+        3
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 3
+End:
+  Goto(blk6, {v3 -> v4})
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v5) => blk3,
+    bool::True(v6) => blk4,
+  })
+
+blk3:
+Statements:
+  (v7: core::felt252) <- 2
+End:
+  Goto(blk5, {v7 -> v8})
+
+blk4:
+Statements:
+  (v9: core::felt252) <- 1
+End:
+  Goto(blk5, {v9 -> v8})
+
+blk5:
+Statements:
+End:
+  Goto(blk6, {v8 -> v4})
+
+blk6:
+Statements:
+End:
+  Return(v4)
+
+//! > after
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 3
+End:
+  Goto(blk6, {v3 -> v4})
+
+blk2:
+Statements:
+End:
+  Goto(blk4, {v2 -> v6})
+
+blk3:
+Statements:
+  (v7: core::felt252) <- 2
+End:
+  Goto(blk5, {v7 -> v8})
+
+blk4:
+Statements:
+  (v9: core::felt252) <- 1
+End:
+  Goto(blk5, {v9 -> v8})
+
+blk5:
+Statements:
+End:
+  Goto(blk6, {v8 -> v4})
+
+blk6:
+Statements:
+End:
+  Return(v4)
 
 //! > lowering_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/match
+++ b/crates/cairo-lang-lowering/src/test_data/match
@@ -1372,86 +1372,35 @@ End:
   Match(match_enum(v0) {
     A::One(v2) => blk1,
     A::Two(v3) => blk2,
-    A::Three(v4) => blk11,
-    A::Four(v5) => blk12,
+    A::Three(v4) => blk3,
+    A::Four(v5) => blk4,
   })
 
 blk1:
 Statements:
 End:
-  Goto(blk13, {})
+  Goto(blk5, {})
 
 blk2:
 Statements:
 End:
-  Match(match_enum(v0) {
-    A::One(v6) => blk3,
-    A::Two(v7) => blk8,
-    A::Three(v8) => blk9,
-    A::Four(v9) => blk10,
-  })
+  Goto(blk5, {})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v1) {
-    A::One(v10) => blk4,
-    A::Two(v11) => blk5,
-    A::Three(v12) => blk6,
-    A::Four(v13) => blk7,
-  })
+  Goto(blk5, {})
 
 blk4:
 Statements:
-  (v14: core::felt252) <- 8
 End:
-  Return(v14)
+  Goto(blk5, {})
 
 blk5:
 Statements:
+  (v6: core::felt252) <- 4
 End:
-  Goto(blk13, {})
-
-blk6:
-Statements:
-End:
-  Goto(blk13, {})
-
-blk7:
-Statements:
-End:
-  Goto(blk13, {})
-
-blk8:
-Statements:
-End:
-  Goto(blk13, {})
-
-blk9:
-Statements:
-End:
-  Goto(blk13, {})
-
-blk10:
-Statements:
-End:
-  Goto(blk13, {})
-
-blk11:
-Statements:
-End:
-  Goto(blk13, {})
-
-blk12:
-Statements:
-End:
-  Goto(blk13, {})
-
-blk13:
-Statements:
-  (v15: core::felt252) <- 4
-End:
-  Return(v15)
+  Return(v6)
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-sierra-generator/src/local_variables_test_data/match_enum
+++ b/crates/cairo-lang-sierra-generator/src/local_variables_test_data/match_enum
@@ -158,28 +158,10 @@ Statements:
   (v7: core::felt252) <- core::felt252_add(v4, v4)
   (v8: core::felt252) <- core::felt252_add(v7, v4)
   (v9: core::felt252) <- core::felt252_add(v2, v1)
+  (v10: core::felt252) <- core::felt252_add(v4, v4)
+  (v11: core::felt252) <- core::felt252_add(v10, v4)
+  (v12: core::felt252) <- core::felt252_add(v9, v1)
 End:
-  Match(match_enum(v0) {
-    MyEnum::A(v10) => blk3,
-    MyEnum::B(v11) => blk4,
-  })
-
-blk3:
-Statements:
-End:
-  Goto(blk5, {})
-
-blk4:
-Statements:
-  (v12: core::felt252) <- core::felt252_add(v11, v11)
-  (v13: core::felt252) <- core::felt252_add(v12, v11)
-End:
-  Goto(blk5, {})
-
-blk5:
-Statements:
-  (v14: core::felt252) <- core::felt252_add(v9, v1)
-End:
-  Return(v14)
+  Return(v12)
 
 //! > local_variables

--- a/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/abi_dispatchers_tests.cairo
@@ -112,7 +112,7 @@ fn test_validate_gas_cost() {
     assert!(
         call_building_gas_usage == 3930
             && serialization_gas_usage == 27470
-            && entry_point_gas_usage == 99960,
+            && entry_point_gas_usage == 99760,
         "Unexpected gas_usage:
      call_building: `{call_building_gas_usage}`.
      serialization: `{serialization_gas_usage}`.


### PR DESCRIPTION
## Summary

Extends the match optimizer to fold matches whose variant is already known via equality analysis, not just when a local `EnumConstruct` statement is present in the same block. When equality analysis can determine the variant of a matched variable at a block's exit, the match is replaced with a direct goto to the corresponding arm, provided the matched value is droppable and the payload variable is copyable and in scope.

To support this:
- `DefSites` now stores `Option<DefLocation>` instead of `DefLocation`, replacing the `UNRESOLVED` sentinel with `None` for variables in unreachable blocks. The assertion that all slots are resolved is removed.
- `EqualityState` gains a mutable `get_enum_construct` method that performs path compression via `find`.
- `MatchOptimizerContext` now holds equality analysis results, dominator information, and def-site information, and exposes `get_enum_variant` and `is_visible_at_block_end` helpers.
- `try_get_fix_info` is generalized to accept a variant, an inner `VarUsage`, an optional `(stmt_idx, output_var)` for construct removal, and a `fix_block`, decoupling it from the `StatementEnumConstruct` type.
- `FixInfo` replaces `statement_location` + `remove_enum_construct` + `n_same_block_statement` with `fix_block` and `enum_construct_removal: Option<(usize, usize)>`, which is `None` for equality-anchored folds.
- `optimize_matches` now takes a `db` parameter, threaded through from `OptimizationPhase`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous match optimizer only eliminated a match when the matched enum value was constructed by a `StatementEnumConstruct` immediately upstream. Cases where the variant was already known through equality analysis (e.g., after a prior match on the same variable) were not folded, leaving redundant multi-arm matches in the lowered IR.

---

## What was the behavior or documentation before?

A match on a variable whose variant was already known via equality analysis was left as-is, producing multiple blocks and redundant match arms in the lowered output.

---

## What is the behavior or documentation after?

When equality analysis knows the variant of a matched variable at a block's exit and the payload is visible and copyable, the match is folded into a direct goto to the correct arm at that point, collapsing the redundant blocks. Test data reflects the reduced block count in the optimized output.

---

## Related issue or discussion (if any)

None.

---

## Additional context

The regression test `unresolved_assert_fires` is removed because the `UNRESOLVED` sentinel and its associated assertion no longer exist; unreachable-block variables are now represented as `None` in `DefSites`.