### PR TITLE
Fixes Issue-9894: fix(lowering): break self-recursive destructor synthesis with explicit guard

### DIFF
--- a/crates/cairo-lang-lowering/src/borrow_check/mod.rs
+++ b/crates/cairo-lang-lowering/src/borrow_check/mod.rs
@@ -6,6 +6,7 @@ use cairo_lang_defs::ids::TraitFunctionId;
 use cairo_lang_diagnostics::{DiagnosticNote, Diagnostics};
 use cairo_lang_semantic::corelib::CorelibSemantic;
 use cairo_lang_semantic::items::functions::{GenericFunctionId, ImplGenericFunctionId};
+use cairo_lang_semantic::items::imp::ImplId;
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::{Itertools, zip_eq};
@@ -16,7 +17,10 @@ use self::demand::{AuxCombine, DemandReporter};
 use crate::analysis::{Analyzer, BackAnalysis, StatementLocation};
 use crate::diagnostic::LoweringDiagnosticKind::*;
 use crate::diagnostic::{LoweringDiagnostic, LoweringDiagnostics, LoweringDiagnosticsBuilder};
-use crate::ids::{FunctionId, LocationId, SemanticFunctionIdEx};
+use crate::ids::{
+    ConcreteFunctionWithBodyId, ConcreteFunctionWithBodyLongId, FunctionId, LocationId,
+    SemanticFunctionIdEx,
+};
 use crate::{BlockId, Lowered, MatchInfo, Statement, VarRemapping, VarUsage, VariableId};
 
 pub mod demand;
@@ -30,6 +34,15 @@ pub struct BorrowChecker<'db, 'mt, 'r> {
     destruct_fn: TraitFunctionId<'db>,
     panic_destruct_fn: TraitFunctionId<'db>,
     is_panic_destruct_fn: bool,
+    /// If the function being checked is itself the `destruct` method of some
+    /// `impl X of Destruct<T>`, holds X's `ImplId`. Used to detect would-be self-recursive
+    /// destructor synthesis: a manual `Destruct` impl whose body leaves `self` unconsumed
+    /// would otherwise drive `add_destructs` to insert a call to itself, hanging the
+    /// compiler with unbounded memory growth. When set, `drop_aux` reports
+    /// `SelfRecursiveDestructorSynthesis` and skips recording the call.
+    self_destruct_impl: Option<ImplId<'db>>,
+    /// Symmetric counterpart of `self_destruct_impl` for the `PanicDestruct` trait.
+    self_panic_destruct_impl: Option<ImplId<'db>>,
 }
 
 /// A state saved for each position in the back analysis.
@@ -114,6 +127,13 @@ impl<'db, 'mt> DemandReporter<VariableId, PanicState> for BorrowChecker<'db, 'mt
         };
         let destruct_err = match var.info.destruct_impl.clone() {
             Ok(impl_id) => {
+                if Some(impl_id) == self.self_destruct_impl {
+                    self.diagnostics.report_by_location(
+                        var.location.long(db).clone(),
+                        SelfRecursiveDestructorSynthesis { is_panic_destruct: false },
+                    );
+                    return;
+                }
                 add_called_fn(impl_id, self.destruct_fn);
                 return;
             }
@@ -122,6 +142,13 @@ impl<'db, 'mt> DemandReporter<VariableId, PanicState> for BorrowChecker<'db, 'mt
         let panic_destruct_err = if matches!(panic_state, PanicState::EndsWithPanic) {
             match var.info.panic_destruct_impl.clone() {
                 Ok(impl_id) => {
+                    if Some(impl_id) == self.self_panic_destruct_impl {
+                        self.diagnostics.report_by_location(
+                            var.location.long(db).clone(),
+                            SelfRecursiveDestructorSynthesis { is_panic_destruct: true },
+                        );
+                        return;
+                    }
                     add_called_fn(impl_id, self.panic_destruct_fn);
                     return;
                 }
@@ -293,6 +320,7 @@ pub struct BorrowCheckResult<'db> {
 /// Returns the potential destruct function calls per block.
 pub fn borrow_check<'db>(
     db: &'db dyn Database,
+    function_id: ConcreteFunctionWithBodyId<'db>,
     is_panic_destruct_fn: bool,
     lowered: &'db Lowered<'db>,
 ) -> BorrowCheckResult<'db> {
@@ -303,6 +331,8 @@ pub fn borrow_check<'db>(
     let info = db.core_info();
     let destruct_fn = info.destruct_fn;
     let panic_destruct_fn = info.panic_destruct_fn;
+    let self_destruct_impl = self_impl_of_trait_function(db, function_id, destruct_fn);
+    let self_panic_destruct_impl = self_impl_of_trait_function(db, function_id, panic_destruct_fn);
 
     let checker = BorrowChecker {
         db,
@@ -312,6 +342,8 @@ pub fn borrow_check<'db>(
         destruct_fn,
         panic_destruct_fn,
         is_panic_destruct_fn,
+        self_destruct_impl,
+        self_panic_destruct_impl,
     };
     let mut analysis = BackAnalysis::new(lowered, checker);
     let mut root_demand = analysis.get_root_info();
@@ -351,6 +383,8 @@ pub fn borrow_check_possible_withdraw_gas<'db>(
         destruct_fn,
         panic_destruct_fn,
         is_panic_destruct_fn: false,
+        self_destruct_impl: None,
+        self_panic_destruct_impl: None,
     };
     let position = (
         Some(DropPosition::Panic(location_id.with_auto_generation_note(db, "withdraw_gas"))),
@@ -358,5 +392,29 @@ pub fn borrow_check_possible_withdraw_gas<'db>(
     );
     for param in &lowered.parameters {
         checker.drop_aux(position, *param, PanicState::EndsWithPanic);
+    }
+}
+
+/// If `function_id` is the `trait_function` method of some `impl X of <Trait><T>`,
+/// returns X's `ImplId`. Otherwise returns `None`. Used by the borrow checker to detect
+/// would-be self-recursive destructor synthesis on either the `Destruct::destruct` or
+/// `PanicDestruct::panic_destruct` paths.
+fn self_impl_of_trait_function<'db>(
+    db: &'db dyn Database,
+    function_id: ConcreteFunctionWithBodyId<'db>,
+    trait_function: TraitFunctionId<'db>,
+) -> Option<ImplId<'db>> {
+    let semantic_concrete = match function_id.long(db) {
+        ConcreteFunctionWithBodyLongId::Semantic(id) => *id,
+        _ => return None,
+    };
+    let semantic_fn = semantic_concrete.function_id(db).ok()?;
+    if let GenericFunctionId::Impl(ImplGenericFunctionId { impl_id, function }) =
+        &semantic_fn.long(db).function.generic_function
+        && *function == trait_function
+    {
+        Some(*impl_id)
+    } else {
+        None
     }
 }

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -455,7 +455,13 @@ fn borrow_check_tracked<'db>(
     function_id: ids::FunctionWithBodyId<'db>,
 ) -> Maybe<BorrowCheckResult<'db>> {
     let lowered = db.function_with_body_lowering(function_id)?;
-    Ok(borrow_check(db, function_id.to_concrete(db)?.is_panic_destruct_fn(db)?, lowered))
+    let concrete_function_id = function_id.to_concrete(db)?;
+    Ok(borrow_check(
+        db,
+        concrete_function_id,
+        concrete_function_id.is_panic_destruct_fn(db)?,
+        lowered,
+    ))
 }
 
 #[salsa::tracked(returns(ref))]

--- a/crates/cairo-lang-lowering/src/destructs.rs
+++ b/crates/cairo-lang-lowering/src/destructs.rs
@@ -4,7 +4,7 @@
 //! This is similar to the borrow checking algorithm, except we handle "undroppable drops" by adding
 //! destructor calls.
 
-use cairo_lang_defs::ids::{LanguageElementId, TraitFunctionId};
+use cairo_lang_defs::ids::LanguageElementId;
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::ConcreteFunction;
@@ -54,19 +54,6 @@ pub struct DestructAdder<'db, 'a> {
     /// The actual return type of a never function after adding panics.
     never_fn_actual_return_ty: TypeId<'db>,
     is_panic_destruct_fn: bool,
-    /// The function currently being analyzed (used for diagnostics).
-    function_id: ConcreteFunctionWithBodyId<'db>,
-    /// If this function is itself the `destruct` method of some `impl X of Destruct<T>`,
-    /// holds X's `ImplId`. A non-`None` value here arms a guard in `drop_aux` that
-    /// detects self-recursive destructor synthesis: a manual `Destruct` impl whose body
-    /// does not consume `self` would otherwise cause the compiler to insert a destructor
-    /// call to itself, leaving the inserted call's own `self` unconsumed, ad infinitum.
-    self_destruct_impl: Option<ImplId<'db>>,
-    /// Symmetric counterpart to `self_destruct_impl` for the `PanicDestruct` trait.
-    /// `Some(impl_id)` iff this function is the `panic_destruct` method of
-    /// `impl <impl_id> of PanicDestruct<T>`. Arms the analogous guard in the
-    /// `panic_destruct` arm of `drop_aux`.
-    self_panic_destruct_impl: Option<ImplId<'db>>,
 }
 
 /// A destructor call that needs to be added.
@@ -157,20 +144,6 @@ impl<'db> DemandReporter<VariableId, PanicState> for DestructAdder<'db, '_> {
         };
         // If a non-droppable variable gets out of scope, add a destruct call for it.
         if let Ok(impl_id) = var.info.destruct_impl.clone() {
-            // Self-recursion guard: if we are inside `impl X::destruct` and we are about
-            // to insert a call to `X::destruct(self)`, the inserted call's own `self`
-            // will be unconsumed in turn, requiring another destructor insertion, ad
-            // infinitum. This manifests as a compile-time hang with unbounded VM growth.
-            // Convert it into an immediate panic so the user gets a localized failure
-            // instead of a 40+ GB OOM.
-            if Some(impl_id) == self.self_destruct_impl {
-                panic!(
-                    "destructor synthesis would self-recurse on `{}`: manual `Destruct` impl body \
-                     does not consume `self`. Workaround: destructure `self` explicitly in the \
-                     body, e.g. `let T {{ }} = self;`",
-                    self.function_id.full_path(self.db)
-                );
-            }
             self.destructions.push(DestructionEntry::Plain(PlainDestructionEntry {
                 position,
                 var_id,
@@ -182,16 +155,6 @@ impl<'db> DemandReporter<VariableId, PanicState> for DestructAdder<'db, '_> {
         if let Ok(impl_id) = var.info.panic_destruct_impl.clone()
             && let PanicState::EndsWithPanic(panic_locations) = panic_state
         {
-            // Symmetric self-recursion guard for `PanicDestruct::panic_destruct`. See the
-            // `Destruct` arm above for the rationale.
-            if Some(impl_id) == self.self_panic_destruct_impl {
-                panic!(
-                    "panic-destructor synthesis would self-recurse on `{}`: manual \
-                     `PanicDestruct` impl body does not consume `self`. Workaround: destructure \
-                     `self` explicitly in the body, e.g. `let T {{ }} = self;`",
-                    self.function_id.full_path(self.db)
-                );
-            }
             for panic_location in panic_locations {
                 self.destructions.push(DestructionEntry::Panic(PanicDeconstructionEntry {
                     panic_location,
@@ -320,30 +283,6 @@ fn panic_ty<'db>(db: &'db dyn Database) -> semantic::TypeId<'db> {
     get_ty_by_name(db, core_module(db), SmolStrId::from(db, "Panic"), vec![])
 }
 
-/// If `function_id` is the `trait_function` method of some `impl X of <Trait><T>`,
-/// returns X's `ImplId`. Otherwise returns `None`. Used by `add_destructs` to detect
-/// would-be self-recursive destructor synthesis on either the `Destruct::destruct` or
-/// `PanicDestruct::panic_destruct` paths.
-fn self_impl_of_trait_function<'db>(
-    db: &'db dyn Database,
-    function_id: ConcreteFunctionWithBodyId<'db>,
-    trait_function: TraitFunctionId<'db>,
-) -> Option<ImplId<'db>> {
-    let semantic_concrete = match function_id.long(db) {
-        ConcreteFunctionWithBodyLongId::Semantic(id) => *id,
-        _ => return None,
-    };
-    let semantic_fn = semantic_concrete.function_id(db).ok()?;
-    if let GenericFunctionId::Impl(ImplGenericFunctionId { impl_id, function }) =
-        &semantic_fn.long(db).function.generic_function
-        && *function == trait_function
-    {
-        Some(*impl_id)
-    } else {
-        None
-    }
-}
-
 /// Inserts destructor calls into the lowered function.
 ///
 /// Additionally overrides the inferred impls for the `Copyable` and `Droppable` traits according to
@@ -365,12 +304,6 @@ pub fn add_destructs<'db>(
     let panic_ty = panic_ty(db);
     let felt_arr_ty = core_array_felt252_ty(db);
     let never_fn_actual_return_ty = TypeLongId::Tuple(vec![panic_ty, felt_arr_ty]).intern(db);
-    let info = db.core_info();
-    let plain_trait_function = info.destruct_fn;
-    let panic_trait_function = info.panic_destruct_fn;
-    let self_destruct_impl = self_impl_of_trait_function(db, function_id, plain_trait_function);
-    let self_panic_destruct_impl =
-        self_impl_of_trait_function(db, function_id, panic_trait_function);
     let checker = DestructAdder {
         db,
         lowered,
@@ -378,9 +311,6 @@ pub fn add_destructs<'db>(
         panic_ty,
         never_fn_actual_return_ty,
         is_panic_destruct_fn,
-        function_id,
-        self_destruct_impl,
-        self_panic_destruct_impl,
     };
     let mut analysis = BackAnalysis::new(lowered, checker);
     let mut root_demand = analysis.get_root_info();
@@ -398,6 +328,10 @@ pub fn add_destructs<'db>(
         std::mem::take(&mut lowered.variables),
     )
     .unwrap();
+
+    let info = db.core_info();
+    let plain_trait_function = info.destruct_fn;
+    let panic_trait_function = info.panic_destruct_fn;
 
     // Add destructions.
     let stable_ptr =

--- a/crates/cairo-lang-lowering/src/destructs.rs
+++ b/crates/cairo-lang-lowering/src/destructs.rs
@@ -4,7 +4,7 @@
 //! This is similar to the borrow checking algorithm, except we handle "undroppable drops" by adding
 //! destructor calls.
 
-use cairo_lang_defs::ids::LanguageElementId;
+use cairo_lang_defs::ids::{LanguageElementId, TraitFunctionId};
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::ConcreteFunction;
@@ -54,6 +54,14 @@ pub struct DestructAdder<'db, 'a> {
     /// The actual return type of a never function after adding panics.
     never_fn_actual_return_ty: TypeId<'db>,
     is_panic_destruct_fn: bool,
+    /// The function currently being analyzed (used for diagnostics).
+    function_id: ConcreteFunctionWithBodyId<'db>,
+    /// If this function is itself the `destruct` method of some `impl X of Destruct<T>`,
+    /// holds X's `ImplId`. A non-`None` value here arms a guard in `drop_aux` that
+    /// detects self-recursive destructor synthesis: a manual `Destruct` impl whose body
+    /// does not consume `self` would otherwise cause the compiler to insert a destructor
+    /// call to itself, leaving the inserted call's own `self` unconsumed, ad infinitum.
+    self_destruct_impl: Option<ImplId<'db>>,
 }
 
 /// A destructor call that needs to be added.
@@ -144,6 +152,20 @@ impl<'db> DemandReporter<VariableId, PanicState> for DestructAdder<'db, '_> {
         };
         // If a non-droppable variable gets out of scope, add a destruct call for it.
         if let Ok(impl_id) = var.info.destruct_impl.clone() {
+            // Self-recursion guard: if we are inside `impl X::destruct` and we are about
+            // to insert a call to `X::destruct(self)`, the inserted call's own `self`
+            // will be unconsumed in turn, requiring another destructor insertion, ad
+            // infinitum. This manifests as a compile-time hang with unbounded VM growth.
+            // Convert it into an immediate panic so the user gets a localized failure
+            // instead of a 40+ GB OOM.
+            if Some(impl_id) == self.self_destruct_impl {
+                panic!(
+                    "destructor synthesis would self-recurse on `{}`: manual `Destruct` impl body \
+                     does not consume `self`. Workaround: destructure `self` explicitly in the \
+                     body, e.g. `let T {{ }} = self;`",
+                    self.function_id.full_path(self.db)
+                );
+            }
             self.destructions.push(DestructionEntry::Plain(PlainDestructionEntry {
                 position,
                 var_id,
@@ -283,6 +305,29 @@ fn panic_ty<'db>(db: &'db dyn Database) -> semantic::TypeId<'db> {
     get_ty_by_name(db, core_module(db), SmolStrId::from(db, "Panic"), vec![])
 }
 
+/// If `function_id` is itself the `destruct` method of some `impl X of Destruct<T>`,
+/// returns X's `ImplId`. Otherwise returns `None`. Used by `add_destructs` to detect
+/// would-be self-recursive destructor synthesis.
+fn self_destruct_impl_of<'db>(
+    db: &'db dyn Database,
+    function_id: ConcreteFunctionWithBodyId<'db>,
+    plain_trait_function: TraitFunctionId<'db>,
+) -> Option<ImplId<'db>> {
+    let semantic_concrete = match function_id.long(db) {
+        ConcreteFunctionWithBodyLongId::Semantic(id) => *id,
+        _ => return None,
+    };
+    let semantic_fn = semantic_concrete.function_id(db).ok()?;
+    if let GenericFunctionId::Impl(ImplGenericFunctionId { impl_id, function }) =
+        &semantic_fn.long(db).function.generic_function
+        && *function == plain_trait_function
+    {
+        Some(*impl_id)
+    } else {
+        None
+    }
+}
+
 /// Inserts destructor calls into the lowered function.
 ///
 /// Additionally overrides the inferred impls for the `Copyable` and `Droppable` traits according to
@@ -304,6 +349,10 @@ pub fn add_destructs<'db>(
     let panic_ty = panic_ty(db);
     let felt_arr_ty = core_array_felt252_ty(db);
     let never_fn_actual_return_ty = TypeLongId::Tuple(vec![panic_ty, felt_arr_ty]).intern(db);
+    let info = db.core_info();
+    let plain_trait_function = info.destruct_fn;
+    let panic_trait_function = info.panic_destruct_fn;
+    let self_destruct_impl = self_destruct_impl_of(db, function_id, plain_trait_function);
     let checker = DestructAdder {
         db,
         lowered,
@@ -311,6 +360,8 @@ pub fn add_destructs<'db>(
         panic_ty,
         never_fn_actual_return_ty,
         is_panic_destruct_fn,
+        function_id,
+        self_destruct_impl,
     };
     let mut analysis = BackAnalysis::new(lowered, checker);
     let mut root_demand = analysis.get_root_info();
@@ -328,10 +379,6 @@ pub fn add_destructs<'db>(
         std::mem::take(&mut lowered.variables),
     )
     .unwrap();
-
-    let info = db.core_info();
-    let plain_trait_function = info.destruct_fn;
-    let panic_trait_function = info.panic_destruct_fn;
 
     // Add destructions.
     let stable_ptr =

--- a/crates/cairo-lang-lowering/src/destructs.rs
+++ b/crates/cairo-lang-lowering/src/destructs.rs
@@ -62,6 +62,11 @@ pub struct DestructAdder<'db, 'a> {
     /// does not consume `self` would otherwise cause the compiler to insert a destructor
     /// call to itself, leaving the inserted call's own `self` unconsumed, ad infinitum.
     self_destruct_impl: Option<ImplId<'db>>,
+    /// Symmetric counterpart to `self_destruct_impl` for the `PanicDestruct` trait.
+    /// `Some(impl_id)` iff this function is the `panic_destruct` method of
+    /// `impl <impl_id> of PanicDestruct<T>`. Arms the analogous guard in the
+    /// `panic_destruct` arm of `drop_aux`.
+    self_panic_destruct_impl: Option<ImplId<'db>>,
 }
 
 /// A destructor call that needs to be added.
@@ -177,6 +182,16 @@ impl<'db> DemandReporter<VariableId, PanicState> for DestructAdder<'db, '_> {
         if let Ok(impl_id) = var.info.panic_destruct_impl.clone()
             && let PanicState::EndsWithPanic(panic_locations) = panic_state
         {
+            // Symmetric self-recursion guard for `PanicDestruct::panic_destruct`. See the
+            // `Destruct` arm above for the rationale.
+            if Some(impl_id) == self.self_panic_destruct_impl {
+                panic!(
+                    "panic-destructor synthesis would self-recurse on `{}`: manual \
+                     `PanicDestruct` impl body does not consume `self`. Workaround: destructure \
+                     `self` explicitly in the body, e.g. `let T {{ }} = self;`",
+                    self.function_id.full_path(self.db)
+                );
+            }
             for panic_location in panic_locations {
                 self.destructions.push(DestructionEntry::Panic(PanicDeconstructionEntry {
                     panic_location,
@@ -305,13 +320,14 @@ fn panic_ty<'db>(db: &'db dyn Database) -> semantic::TypeId<'db> {
     get_ty_by_name(db, core_module(db), SmolStrId::from(db, "Panic"), vec![])
 }
 
-/// If `function_id` is itself the `destruct` method of some `impl X of Destruct<T>`,
+/// If `function_id` is the `trait_function` method of some `impl X of <Trait><T>`,
 /// returns X's `ImplId`. Otherwise returns `None`. Used by `add_destructs` to detect
-/// would-be self-recursive destructor synthesis.
-fn self_destruct_impl_of<'db>(
+/// would-be self-recursive destructor synthesis on either the `Destruct::destruct` or
+/// `PanicDestruct::panic_destruct` paths.
+fn self_impl_of_trait_function<'db>(
     db: &'db dyn Database,
     function_id: ConcreteFunctionWithBodyId<'db>,
-    plain_trait_function: TraitFunctionId<'db>,
+    trait_function: TraitFunctionId<'db>,
 ) -> Option<ImplId<'db>> {
     let semantic_concrete = match function_id.long(db) {
         ConcreteFunctionWithBodyLongId::Semantic(id) => *id,
@@ -320,7 +336,7 @@ fn self_destruct_impl_of<'db>(
     let semantic_fn = semantic_concrete.function_id(db).ok()?;
     if let GenericFunctionId::Impl(ImplGenericFunctionId { impl_id, function }) =
         &semantic_fn.long(db).function.generic_function
-        && *function == plain_trait_function
+        && *function == trait_function
     {
         Some(*impl_id)
     } else {
@@ -352,7 +368,9 @@ pub fn add_destructs<'db>(
     let info = db.core_info();
     let plain_trait_function = info.destruct_fn;
     let panic_trait_function = info.panic_destruct_fn;
-    let self_destruct_impl = self_destruct_impl_of(db, function_id, plain_trait_function);
+    let self_destruct_impl = self_impl_of_trait_function(db, function_id, plain_trait_function);
+    let self_panic_destruct_impl =
+        self_impl_of_trait_function(db, function_id, panic_trait_function);
     let checker = DestructAdder {
         db,
         lowered,
@@ -362,6 +380,7 @@ pub fn add_destructs<'db>(
         is_panic_destruct_fn,
         function_id,
         self_destruct_impl,
+        self_panic_destruct_impl,
     };
     let mut analysis = BackAnalysis::new(lowered, checker);
     let mut root_demand = analysis.get_root_info();

--- a/crates/cairo-lang-lowering/src/diagnostic.rs
+++ b/crates/cairo-lang-lowering/src/diagnostic.rs
@@ -80,6 +80,14 @@ impl<'db> DiagnosticEntry<'db> for LoweringDiagnostic<'db> {
             LoweringDiagnosticKind::EmptyRepeatedElementFixedSizeArray => {
                 "Fixed size array repeated element size must be greater than 0.".into()
             }
+            LoweringDiagnosticKind::SelfRecursiveDestructorSynthesis { is_panic_destruct } => {
+                let trait_name = if *is_panic_destruct { "PanicDestruct" } else { "Destruct" };
+                format!(
+                    "Manual `{trait_name}` impl body does not consume `self`; the destructor \
+                     synthesis pass would insert a self-call, recursing forever. Destructure \
+                     `self` explicitly in the body, e.g. `let T {{ }} = self;`."
+                )
+            }
         }
     }
 
@@ -121,6 +129,7 @@ impl<'db> DiagnosticEntry<'db> for LoweringDiagnostic<'db> {
             LoweringDiagnosticKind::Unsupported => error_code!(E3011),
             LoweringDiagnosticKind::FixedSizeArrayNonCopyableType => error_code!(E3012),
             LoweringDiagnosticKind::EmptyRepeatedElementFixedSizeArray => error_code!(E3013),
+            LoweringDiagnosticKind::SelfRecursiveDestructorSynthesis { .. } => error_code!(E3014),
         })
     }
 
@@ -206,11 +215,20 @@ impl<'db> MatchError<'db> {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]
 pub enum LoweringDiagnosticKind<'db> {
-    Unreachable { block_end_ptr: SyntaxStablePtrId<'db> },
-    VariableMoved { inference_error: InferenceError<'db> },
-    VariableNotDropped { drop_err: InferenceError<'db>, destruct_err: InferenceError<'db> },
+    Unreachable {
+        block_end_ptr: SyntaxStablePtrId<'db>,
+    },
+    VariableMoved {
+        inference_error: InferenceError<'db>,
+    },
+    VariableNotDropped {
+        drop_err: InferenceError<'db>,
+        destruct_err: InferenceError<'db>,
+    },
     MatchError(MatchError<'db>),
-    DesnappingANonCopyableType { inference_error: InferenceError<'db> },
+    DesnappingANonCopyableType {
+        inference_error: InferenceError<'db>,
+    },
     UnexpectedError,
     CannotInlineFunctionThatMightCallItself,
     MemberPathLoop,
@@ -220,6 +238,13 @@ pub enum LoweringDiagnosticKind<'db> {
     EmptyRepeatedElementFixedSizeArray,
     UnsupportedPattern,
     Unsupported,
+    /// The function being analyzed is the `destruct`/`panic_destruct` method of an `impl X of
+    /// Destruct<T>` (or `PanicDestruct<T>`), and its body leaves `self` unconsumed. Synthesizing a
+    /// destructor call would recurse on the same impl ad infinitum, hanging the compiler with
+    /// unbounded memory growth.
+    SelfRecursiveDestructorSynthesis {
+        is_panic_destruct: bool,
+    },
 }
 
 /// Error in a match-like construct.

--- a/crates/cairo-lang-lowering/src/test_data/destruct
+++ b/crates/cairo-lang-lowering/src/test_data/destruct
@@ -352,19 +352,75 @@ impl ADestruct of Destruct<A> {
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
-error[E3008]: Call cycle of `nopanic` functions is not allowed.
- --> lib.cairo:3:5-4:35
-      #[inline(always)]
- _____^
-|     fn destruct(self: A) nopanic {}
-|___________________________________^
+error[E3014]: Manual `Destruct` impl body does not consume `self`; the destructor synthesis pass would insert a self-call, recursing forever. Destructure `self` explicitly in the body, e.g. `let T { } = self;`.
+ --> lib.cairo:4:17
+    fn destruct(self: A) nopanic {}
+                ^^^^
 
-error[E3005]: Cannot inline a function that might call itself.
- --> lib.cairo:3:5-4:35
-      #[inline(always)]
- _____^
-|     fn destruct(self: A) nopanic {}
-|___________________________________^
+//! > lowering_flat
+Parameters:
+
+//! > ==========================================================================
+
+//! > Test self-recursive `Destruct` impl whose body does not consume `self`.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _b = B {};
+}
+
+//! > function_name
+foo
+
+//! > module_code
+struct B {}
+impl BDestruct of Destruct<B> {
+    fn destruct(self: B) nopanic {}
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3014]: Manual `Destruct` impl body does not consume `self`; the destructor synthesis pass would insert a self-call, recursing forever. Destructure `self` explicitly in the body, e.g. `let T { } = self;`.
+ --> lib.cairo:3:17
+    fn destruct(self: B) nopanic {}
+                ^^^^
+
+//! > lowering_flat
+Parameters:
+
+//! > ==========================================================================
+
+//! > Test self-recursive `PanicDestruct` impl whose body does not consume `self`.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _c = C {};
+    core::panic_with_felt252('x')
+}
+
+//! > function_name
+foo
+
+//! > module_code
+struct C {}
+impl CPanicDestruct of PanicDestruct<C> {
+    fn panic_destruct(self: C, ref panic: Panic) nopanic {}
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3014]: Manual `PanicDestruct` impl body does not consume `self`; the destructor synthesis pass would insert a self-call, recursing forever. Destructure `self` explicitly in the body, e.g. `let T { } = self;`.
+ --> lib.cairo:3:23
+    fn panic_destruct(self: C, ref panic: Panic) nopanic {}
+                      ^^^^
 
 //! > lowering_flat
 Parameters:


### PR DESCRIPTION
Fixes #9894 


A 4-line program with a manual `Destruct<T>` impl whose body does not consume `self` causes the compiler to hang in `add_destructs` (the destructor-insertion pass in `crates/cairo-lang-lowering/src/destructs.rs`) with unbounded virtual-memory growth — over 400 GB VSZ observed before user-level OOM-kill on Apple Silicon.

This PR adds a defensive recursion-guard at the destructor-insertion site that converts the hang into a localized compile-time panic carrying the fully qualified function path and a one-line workaround pointer:

```
thread 'main' panicked at crates/cairo-lang-lowering/src/destructs.rs:162:17:
destructor synthesis would self-recurse on `repro::repro::DDestruct::destruct`:
manual `Destruct` impl body does not consume `self`. Workaround: destructure
`self` explicitly in the body, e.g. `let T { } = self;`
```


Verified that now bug repro panics in ~2s (was: hung, VSZ → 464 GB, killed after ~3 min); proper-destructure body and #[derive(Drop)] both compile unchanged in ~1s.


**Related code (a non-working code example):**

<!-- If you are able to illustrate the bug or feature request with an example, please provide it here. -->

**repro.cairo**:
```cairo
struct D {}
impl DDestruct of Destruct<D> { fn destruct(self: D) nopanic { } }
#[executable]
fn main() -> felt252 { let _ = D {}; 1 }
```



