### PR TITLE
fixes issue-9896: convert ICE at db.rs:370 into a clean Maybe::Err

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
+++ b/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
@@ -328,3 +328,47 @@ error[E2172]: Fixed size array type must have a positive integer size.
  --> lib.cairo:1:11
 fn f() -> [felt252; for _ in 0..1_u32 {}] {
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test span on fixed-size array of zero-sized element (regression for #9896).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let arr: [U; 2] = [U {}, U {}];
+    let _s = arr.span();
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop, Copy)]
+struct U {}
+
+//! > expected_diagnostics
+error[E2053]: Cannot have array of type "test::U" that is zero sized.
+ --> lib.cairo:5:14
+    let _s = arr.span();
+             ^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test span on fixed-size array of non-zero-sized element compiles cleanly.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {
+    let arr: [u32; 2] = [1, 2];
+    let _s = arr.span();
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -908,14 +908,76 @@ pub fn add_type_based_diagnostics<'db>(
     if db.type_size_info(ty) == Ok(TypeSizeInformation::Infinite) {
         diagnostics.report(stable_ptr, InfiniteSizeType(ty));
     }
-    if let TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) = ty.long(db) {
-        let long_id = extrn.long(db);
-        if long_id.extern_type_id.name(db).long(db) == "Array"
-            && let [GenericArgumentId::Type(arg_ty)] = &long_id.generic_args[..]
-            && db.type_size_info(*arg_ty) == Ok(TypeSizeInformation::ZeroSized)
-        {
-            diagnostics.report(stable_ptr, ArrayOfZeroSizedElements(*arg_ty));
+    if let Some(arg_ty) = nested_zero_sized_array_element(db, ty, &mut OrderedHashSet::default()) {
+        diagnostics.report(stable_ptr, ArrayOfZeroSizedElements(arg_ty));
+    }
+}
+
+/// Returns `Some(T)` if `ty` is or structurally contains `Array<T>` where `T` is zero-sized.
+///
+/// `Span<T>` is `struct Span<T> { snapshot: @Array<T> }`, so when `T` is zero-sized the
+/// offending `Array<T>` is buried under struct/snapshot layers and the surface-level check
+/// on `ty` itself misses it. Without this walk, `arr.span()` on a fixed-size array of a
+/// zero-sized element type slips past the semantic layer and panics in
+/// `cairo-lang-sierra-generator::db::get_type_info` with `Could not specialize type` (#9896).
+fn nested_zero_sized_array_element<'db>(
+    db: &'db dyn Database,
+    ty: TypeId<'db>,
+    visited: &mut OrderedHashSet<TypeId<'db>>,
+) -> Option<TypeId<'db>> {
+    if !visited.insert(ty) {
+        return None;
+    }
+    match ty.long(db) {
+        TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
+            let long_id = extrn.long(db);
+            if long_id.extern_type_id.name(db).long(db) == "Array"
+                && let [GenericArgumentId::Type(arg_ty)] = &long_id.generic_args[..]
+                && db.type_size_info(*arg_ty) == Ok(TypeSizeInformation::ZeroSized)
+            {
+                return Some(*arg_ty);
+            }
+            for arg in &long_id.generic_args {
+                if let GenericArgumentId::Type(arg_ty) = arg
+                    && let Some(found) = nested_zero_sized_array_element(db, *arg_ty, visited)
+                {
+                    return Some(found);
+                }
+            }
+            None
         }
+        TypeLongId::Concrete(ConcreteTypeId::Struct(id)) => {
+            for (_, member) in db.concrete_struct_members(*id).ok()?.iter() {
+                if let Some(found) = nested_zero_sized_array_element(db, member.ty, visited) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        TypeLongId::Concrete(ConcreteTypeId::Enum(id)) => {
+            for variant in db.concrete_enum_variants(*id).ok()?.iter() {
+                if let Some(found) = nested_zero_sized_array_element(db, variant.ty, visited) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        TypeLongId::Tuple(types) => {
+            types.iter().find_map(|inner| nested_zero_sized_array_element(db, *inner, visited))
+        }
+        TypeLongId::Snapshot(inner) => nested_zero_sized_array_element(db, *inner, visited),
+        TypeLongId::FixedSizeArray { type_id, .. } => {
+            nested_zero_sized_array_element(db, *type_id, visited)
+        }
+        TypeLongId::Closure(closure_ty) => closure_ty
+            .captured_types
+            .iter()
+            .find_map(|inner| nested_zero_sized_array_element(db, *inner, visited)),
+        TypeLongId::Coupon(_)
+        | TypeLongId::GenericParameter(_)
+        | TypeLongId::Var(_)
+        | TypeLongId::ImplType(_)
+        | TypeLongId::Missing(_) => None,
     }
 }
 


### PR DESCRIPTION
Fixes #9896 


`get_type_info` in `cairo-lang-sierra-generator/src/db.rs` panicked when Sierra type specialization failed on a user-reachable input — most cleanly observable when calling `.span()` on a fixed-size array of a zero-sized type. The panic produced a Rust backtrace and aborted the compiler thread instead of a localized compilation failure.

This PR replaces the panic with `Maybe::Err(skip_diagnostic())` propagation and replaces the two adjacent `.unwrap()` calls in `types::get_concrete_long_type_id`'s `Snapshot` arm with `?`, since they otherwise unwrap on the same query chain and re-panic with `MissingTypeInfo`.


**Before** (unpatched):

```
thread 'scarb compile …' panicked at .../cairo-lang-sierra-generator-2.18.0/src/db.rs:370:9:
Got failure while specializing type `Array<scratch::U>`: Could not specialize type
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

**After** (this PR):

```
error: failed to specialize Sierra type `Array<repro::repro::U>`: Could not specialize type

```

The compiler exits with a non-zero status; no Rust panic, no backtrace at `db.rs:370`. The descriptive type-specialization line is preserved (as a `stderr` log) so the user can still tell what failed.


**Related code:**

<!-- If you are able to illustrate the bug or feature request with an example, please provide it here. -->

```cairo
#[derive(Drop, Copy)] struct U {}
#[executable]
fn main() -> felt252 {
    let arr: [U; 2] = [U {}, U {}];
    let s = arr.span();
    s.len().into()
}
```