### PR TITLE
docs: align DivRem examples with current import paths

### DIFF
--- a/corelib/src/num/traits/ops/divrem.cairo
+++ b/corelib/src/num/traits/ops/divrem.cairo
@@ -27,10 +27,9 @@ use crate::zeroable::NonZero;
 /// Heterogeneous division (`u256` by `u128`):
 /// ```cairo
 /// use core::num::traits::DivRem;
-/// use integer::u128_as_non_zero;
 ///
 /// let big: u256 = 1_000_000;                    // dividend
-/// let nz10: NonZero<u128> = u128_as_non_zero(10_u128);  // divisor
+/// let nz10: NonZero<u128> = 10;  // divisor
 ///
 /// let (q, r) = DivRem::<u256, u128>::div_rem(big, nz10);
 /// // q : u256, r : u128

--- a/corelib/src/num/traits/ops/divrem.cairo
+++ b/corelib/src/num/traits/ops/divrem.cairo
@@ -27,10 +27,10 @@ use crate::zeroable::NonZero;
 /// Heterogeneous division (`u256` by `u128`):
 /// ```cairo
 /// use core::num::traits::DivRem;
-/// use integer::u256_as_non_zero;
+/// use integer::u128_as_non_zero;
 ///
 /// let big: u256 = 1_000_000;                    // dividend
-/// let nz10: NonZero<u128> = u256_as_non_zero(10_u128.into());  // divisor
+/// let nz10: NonZero<u128> = u128_as_non_zero(10_u128);  // divisor
 ///
 /// let (q, r) = DivRem::<u256, u128>::div_rem(big, nz10);
 /// // q : u256, r : u128

--- a/corelib/src/num/traits/ops/divrem.cairo
+++ b/corelib/src/num/traits/ops/divrem.cairo
@@ -28,7 +28,7 @@ use crate::zeroable::NonZero;
 /// ```cairo
 /// use core::num::traits::DivRem;
 ///
-/// let big: u256 = 1_000_000;                    // dividend
+/// let big: u256 = 1_000_000;     // dividend
 /// let nz10: NonZero<u128> = 10;  // divisor
 ///
 /// let (q, r) = DivRem::<u256, u128>::div_rem(big, nz10);

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
@@ -118,11 +118,9 @@ Cairo provides `DivRem` trait for efficient combined division and remainder:
 [source,cairo]
 ----
 use core::num::traits::DivRem;
-use core::zeroable::NonZero;
 
 fn main() {
-    let divisor: NonZero<u32> = 5_u32.try_into().unwrap();
-    let (quotient, remainder) = DivRem::div_rem(17_u32, divisor);
+    let (quotient, remainder) = DivRem::div_rem(17_u32, 5);
     assert!(quotient == 3);
     assert!(remainder == 2);
 }

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
@@ -117,7 +117,8 @@ Cairo provides `DivRem` trait for efficient combined division and remainder:
 
 [source,cairo]
 ----
-use core::traits::DivRem;
+use core::num::traits::DivRem;
+use core::zeroable::NonZero;
 
 fn main() {
     let divisor: NonZero<u32> = 5_u32.try_into().unwrap();


### PR DESCRIPTION
Fix remaining DivRem example imports and NonZero constructor usage, aligning docs with current corelib public paths.