### PR TITLE
docs: clarify mixed comparison/equality in operator expressions

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/operator-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/operator-expressions.adoc
@@ -71,13 +71,11 @@ Use parentheses to override the default precedence: `(2 + 3) * 4`.
 See xref:operator-precedence.adoc[Operator precedence] for the complete
 precedence table and associativity rules.
 
-Chained comparisons such as `a < b < c` are not supported.
-Write them as separate comparisons combined with `&&`, for example:
-`a < b && b < c`.
-
-Chained equality such as `a == b == c` is also not supported.
-Write it as separate equality comparisons combined with `&&`, for example:
-`a == b && b == c`.
+Consecutive comparison/equality operators are not supported, including
+`a < b < c`, `a == b == c`, and mixed forms such as `a < b == c` and `a == b < c`.
+Write them as explicit conjunctions or parenthesized boolean comparisons, for example:
+`a < b && b < c`, `a == b && b == c`, or `(a < b) == expected`.
+The parser reports this as `E1028` (consecutive comparison operators).
 
 Mixed consecutive comparison/equality operators are also not supported, for example
 `a < b == c` or `a == b < c`.


### PR DESCRIPTION
## Summary

Update the operator expressions overview to state that consecutive comparison/equality operators also reject mixed forms such as `a < b == c` and `a == b < c`, and show the supported explicit conjunction or parenthesized boolean alternatives.

---

## Type of change

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The operator expressions page is the overview page for operator syntax, but it currently only mentions unsupported homogeneous chains such as `a < b < c` and `a == b == c`. That leaves a real ambiguity for mixed forms like `a < b == c` and `a == b < c`, especially because readers are directed from this page to the precedence rules and can reasonably expect such expressions to be parsed by precedence alone. The parser rejects these forms with `E1028`.

---

## What was the behavior or documentation before?

The page did not explain that mixed consecutive comparison/equality operators are rejected.

---

## What is the behavior or documentation after?

The page explicitly covers both homogeneous and mixed consecutive comparison/equality operators, and gives explicit conjunction and parenthesized boolean examples for supported rewrites.

---

## Related issue or discussion (if any)

N/A

---

## Additional context