### PR TITLE
bugfix(semantic): fix ICE on nested const fn in const fn.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -967,3 +967,61 @@ error[E2127]: This expression is not supported as constant.
  --> lib.cairo:5:26
     const VALUE: bool = !F::VALUE;
                          ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test nested const fn inside const fn emits parser diagnostics without ICE.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > module_code
+const fn outer() -> felt252 {
+    const fn inner() -> felt252 { 7 }
+    inner()
+}
+const X: felt252 = outer();
+
+//! > function_code
+fn foo() -> felt252 {
+    X
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E1004]: Unexpected token, expected ':' followed by a type.
+ --> lib.cairo:2:13
+    const fn inner() -> felt252 { 7 }
+            ^
+
+error[E1001]: Missing token '='.
+ --> lib.cairo:4:2
+}
+ ^
+
+error[E1002]: Missing tokens. Expected an expression.
+ --> lib.cairo:4:2
+}
+ ^
+
+error[E1001]: Missing token ';'.
+ --> lib.cairo:4:2
+}
+ ^
+
+error[E1013]: 'fn' is a reserved identifier.
+ --> lib.cairo:2:11
+    const fn inner() -> felt252 { 7 }
+          ^^
+
+error[E1001]: Missing token '}'.
+ --> lib.cairo:5:28
+const X: felt252 = outer();
+                           ^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:7:5
+    X
+    ^

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -885,7 +885,9 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             return calc_result;
         }
 
-        let imp = extract_matches!(concrete_function.generic_function, GenericFunctionId::Impl);
+        let GenericFunctionId::Impl(imp) = concrete_function.generic_function else {
+            return to_missing(skip_diagnostic());
+        };
         let bool_value = |condition: bool| {
             if condition { self.true_const } else { self.false_const }
         };
@@ -938,12 +940,7 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                 )
                 .intern(db);
             }
-            _ => {
-                unreachable!(
-                    "Unexpected function call in constant lowering: `{:?}`",
-                    expr.function.debug(db)
-                )
-            }
+            _ => return to_missing(skip_diagnostic()),
         };
         if expr.ty == self.felt252 {
             ConstValue::Int(canonical_felt252(&value), expr.ty).intern(db)

--- a/crates/cairo-lang-semantic/src/items/free_function.rs
+++ b/crates/cairo-lang-semantic/src/items/free_function.rs
@@ -4,7 +4,7 @@ use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{
     FreeFunctionId, FunctionTitleId, LanguageElementId, LookupItemId, ModuleItemId,
 };
-use cairo_lang_diagnostics::{Diagnostics, Maybe, MaybeAsRef};
+use cairo_lang_diagnostics::{Diagnostics, Maybe, MaybeAsRef, skip_diagnostic};
 use cairo_lang_syntax::attribute::structured::{Attribute, AttributeListStructurize};
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::Intern;
@@ -124,7 +124,7 @@ fn free_function_declaration_data<'db>(
 }
 
 /// Query implementation of [FreeFunctionSemantic::priv_free_function_body_data].
-#[salsa::tracked(returns(ref))]
+#[salsa::tracked(returns(ref), cycle_fn=priv_free_function_body_data_cycle, cycle_initial=priv_free_function_body_data_initial)]
 fn priv_free_function_body_data<'db>(
     db: &'db dyn Database,
     free_function_id: FreeFunctionId<'db>,
@@ -174,6 +174,26 @@ fn priv_free_function_body_data<'db>(
         resolver_data,
         body: FunctionBody { arenas, body_expr },
     })
+}
+
+/// Cycle handling for [FreeFunctionSemantic::priv_free_function_body_data].
+fn priv_free_function_body_data_cycle<'db>(
+    _db: &'db dyn Database,
+    _cycle: &salsa::Cycle<'_>,
+    last_provisional_value: &Maybe<FunctionBodyData<'db>>,
+    _value: Maybe<FunctionBodyData<'db>>,
+    _free_function_id: FreeFunctionId<'db>,
+) -> Maybe<FunctionBodyData<'db>> {
+    last_provisional_value.clone()
+}
+
+/// Cycle handling for [FreeFunctionSemantic::priv_free_function_body_data].
+fn priv_free_function_body_data_initial<'db>(
+    _db: &'db dyn Database,
+    _id: salsa::Id,
+    _free_function_id: FreeFunctionId<'db>,
+) -> Maybe<FunctionBodyData<'db>> {
+    Err(skip_diagnostic())
 }
 
 /// Trait for free function-related semantic queries.


### PR DESCRIPTION
## Summary

Fixes an ICE (Internal Compiler Error) that occurred when a `const fn` was nested inside another `const fn`. The fix adds cycle recovery to `priv_free_function_body_data` and replaces a panicking `extract_matches!` call with a graceful fallback that returns a missing value when the generic function is not an `Impl` variant.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a `const fn` was nested inside another `const fn`, the compiler would ICE instead of emitting proper parser diagnostics. Two root causes were addressed:

1. `priv_free_function_body_data` had no cycle recovery, causing a panic when a cyclic dependency was encountered during evaluation of nested `const fn` bodies.
2. In `ConstantEvaluateContext`, `extract_matches!` would panic if `concrete_function.generic_function` was not a `GenericFunctionId::Impl`, which could happen in the presence of malformed or unsupported constructs.

---

## What was the behavior or documentation before?

Writing a nested `const fn` inside a `const fn` caused an ICE rather than emitting parser diagnostics and continuing gracefully.

---

## What is the behavior or documentation after?

The compiler now emits the expected parser diagnostics (e.g., unexpected token, missing `=`, reserved identifier `fn`, etc.) without crashing. A new test case documents the expected diagnostic output for this pattern.

---

## Related issue or discussion (if any)

Fixes https://github.com/starkware-libs/cairo/issues/9889

---

## Additional context

The cycle recovery functions (`priv_free_function_body_data_cycle` and `priv_free_function_body_data_initial`) follow the Salsa cycle-handling pattern: the initial value is `Err(skip_diagnostic())` and the cycle function propagates the last provisional value.