### PR TITLE
bugfix(consteval_int): emit diagnostic on division/modulo by zero

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -104,6 +104,112 @@ const out_of_range: u8 = consteval_int!(120 + 160);
 
 //! > ==========================================================================
 
+//! > Test consteval_int! division/modulo by zero
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+const div_lit: felt252 = consteval_int!(1 / 0);
+
+const mod_lit: felt252 = consteval_int!(1 % 0);
+
+const div_computed: felt252 = consteval_int!(5 / (3 - 3));
+
+const mod_computed: felt252 = consteval_int!(5 % (7 * 0));
+
+//! > expected_diagnostics
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:1:26
+const div_lit: felt252 = consteval_int!(1 / 0);
+                         ^^^^^^^^^^^^^^^^^^^^^
+
+error[E2200]: Plugin diagnostic: Division by zero in consteval_int macro
+ --> lib.cairo:1:41
+const div_lit: felt252 = consteval_int!(1 / 0);
+                                        ^^^^^
+
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:3:26
+const mod_lit: felt252 = consteval_int!(1 % 0);
+                         ^^^^^^^^^^^^^^^^^^^^^
+
+error[E2200]: Plugin diagnostic: Modulo by zero in consteval_int macro
+ --> lib.cairo:3:41
+const mod_lit: felt252 = consteval_int!(1 % 0);
+                                        ^^^^^
+
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:5:31
+const div_computed: felt252 = consteval_int!(5 / (3 - 3));
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2200]: Plugin diagnostic: Division by zero in consteval_int macro
+ --> lib.cairo:5:46
+const div_computed: felt252 = consteval_int!(5 / (3 - 3));
+                                             ^^^^^^^^^^^
+
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:7:31
+const mod_computed: felt252 = consteval_int!(5 % (7 * 0));
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2200]: Plugin diagnostic: Modulo by zero in consteval_int macro
+ --> lib.cairo:7:46
+const mod_computed: felt252 = consteval_int!(5 % (7 * 0));
+                                             ^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test consteval_int! division/modulo with non-zero divisor (happy path)
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+const div_ok: felt252 = consteval_int!(10 / 2);
+
+const mod_ok: felt252 = consteval_int!(10 % 3);
+
+const div_negative: felt252 = consteval_int!(-7 / 2);
+
+const mod_negative: felt252 = consteval_int!(-7 % 3);
+
+//! > expected_diagnostics
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:1:25
+const div_ok: felt252 = consteval_int!(10 / 2);
+                        ^^^^^^^^^^^^^^^^^^^^^^
+
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:3:25
+const mod_ok: felt252 = consteval_int!(10 % 3);
+                        ^^^^^^^^^^^^^^^^^^^^^^
+
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:5:31
+const div_negative: felt252 = consteval_int!(-7 / 2);
+                              ^^^^^^^^^^^^^^^^^^^^^^
+
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:7:31
+const mod_negative: felt252 = consteval_int!(-7 % 3);
+                              ^^^^^^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
 //! > Test bad array! macros
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
@@ -10,6 +10,7 @@ use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use indoc::indoc;
 use num_bigint::BigInt;
+use num_traits::Zero;
 use salsa::Database;
 
 #[derive(Debug, Default)]
@@ -119,14 +120,34 @@ pub fn compute_constant_expr<'db>(
                 compute_constant_expr(db, &bin_expr.lhs(db), diagnostics, macro_ast)?
                     - compute_constant_expr(db, &bin_expr.rhs(db), diagnostics, macro_ast)?,
             ),
-            ast::BinaryOperator::Div(_) => Some(
-                compute_constant_expr(db, &bin_expr.lhs(db), diagnostics, macro_ast)?
-                    / compute_constant_expr(db, &bin_expr.rhs(db), diagnostics, macro_ast)?,
-            ),
-            ast::BinaryOperator::Mod(_) => Some(
-                compute_constant_expr(db, &bin_expr.lhs(db), diagnostics, macro_ast)?
-                    % compute_constant_expr(db, &bin_expr.rhs(db), diagnostics, macro_ast)?,
-            ),
+            ast::BinaryOperator::Div(_) => {
+                let lhs = compute_constant_expr(db, &bin_expr.lhs(db), diagnostics, macro_ast)?;
+                let rhs = compute_constant_expr(db, &bin_expr.rhs(db), diagnostics, macro_ast)?;
+                if rhs.is_zero() {
+                    diagnostics.push(PluginDiagnostic::error_with_inner_span(
+                        db,
+                        macro_ast.stable_ptr(db),
+                        bin_expr.as_syntax_node(),
+                        "Division by zero in consteval_int macro".to_string(),
+                    ));
+                    return None;
+                }
+                Some(lhs / rhs)
+            }
+            ast::BinaryOperator::Mod(_) => {
+                let lhs = compute_constant_expr(db, &bin_expr.lhs(db), diagnostics, macro_ast)?;
+                let rhs = compute_constant_expr(db, &bin_expr.rhs(db), diagnostics, macro_ast)?;
+                if rhs.is_zero() {
+                    diagnostics.push(PluginDiagnostic::error_with_inner_span(
+                        db,
+                        macro_ast.stable_ptr(db),
+                        bin_expr.as_syntax_node(),
+                        "Modulo by zero in consteval_int macro".to_string(),
+                    ));
+                    return None;
+                }
+                Some(lhs % rhs)
+            }
             ast::BinaryOperator::And(_) => Some(
                 compute_constant_expr(db, &bin_expr.lhs(db), diagnostics, macro_ast)?
                     & compute_constant_expr(db, &bin_expr.rhs(db), diagnostics, macro_ast)?,


### PR DESCRIPTION
Fixes #9902 


## Summary

Fixes #9902.

The `Div`/`Mod` arms of `compute_constant_expr` in
`crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs` evaluated
both operands to `BigInt` and applied `/` or `%` directly, with no check
that the divisor was non-zero. `BigInt`'s `Div`/`Rem` panic on zero per
Rust standard semantics, so any program containing a `consteval_int!(... / 0)`
or `consteval_int!(... % 0)` (literal or computed zero on the RHS) caused
the compiler thread to panic with a `num-bigint` backtrace instead of
emitting a Cairo diagnostic.

This patch guards both arms with `BigInt::is_zero()` and emits a
localized `PluginDiagnostic` (`"Division by zero in consteval_int macro"`
/ `"Modulo by zero in consteval_int macro"`) pointing at the offending
binary expression. The `+ - *` arms are unaffected (BigInt arithmetic is
total for these), and the bitwise `& | ^` arms are also unaffected.

The macro is already deprecated in favor of plain `const X: felt252 = a / b;`,
but it remains reachable today and the panic is a poor user experience,
so a defensive fix seemed warranted on the deprecation timeline.

## Changes

- `crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs`
  — guard `Div` and `Mod` arms against zero divisor, emit
    `PluginDiagnostic::error_with_inner_span` instead of panicking.
  — add `use num_traits::Zero;` (already a workspace dep, used elsewhere
    in this crate at `types.rs`).
- `crates/cairo-lang-semantic/src/expr/test_data/inline_macros`
  — add a regression block covering literal-zero RHS (`1 / 0`, `1 % 0`)
    and computed-zero RHS (`5 / (3 - 3)`, `5 % (7 * 0)`).
  — add a happy-path block covering `10 / 2`, `10 % 3`, `-7 / 2`, `-7 % 3`
    to confirm non-zero divisors (including negatives) remain unaffected.

## Test plan

- [x] `cargo test -p cairo-lang-semantic --lib inline_macros` — all 3
      runners pass (`expr_diagnostics`, `expr_semantics`, `expand_inline_macros`).
- [x] `./scripts/rust_fmt.sh` — clean.
- [x] `./scripts/clippy.sh` — clean.
- [x] Manual repro from #9902 (`const X: felt252 = consteval_int!(1 / 0);`)
      now produces the new diagnostic instead of a `num-bigint` panic.
