### PR TITLE
fix(semantic): graceful diagnostic for impl-method calls in const fn …

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -850,3 +850,64 @@ error[E2127]: This expression is not supported as constant.
  --> lib.cairo:5:26
     const VALUE: bool = !F::VALUE;
                          ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Regression: user-defined const fn returning a heap type - graceful diagnostic, not ICE.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+const fn f() -> Array<felt252> {
+    array![1, 2, 3]
+}
+const X: Array<felt252> = f();
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:2:5
+    array![1, 2, 3]
+    ^^^^^^^^^^^^^^^
+
+error[E2130]: This expression is not supported as constant.
+ --> lib.cairo:4:27
+const X: Array<felt252> = f();
+                          ^^^
+note: In `test::f`:
+  --> lib.cairo:2:5
+    array![1, 2, 3]
+    ^^^^^^^^^^^^^^^
+
+error[E2130]: This expression is not supported as constant.
+ --> lib.cairo:4:27
+const X: Array<felt252> = f();
+                          ^^^
+note: In `test::f`:
+  --> lib.cairo:2:5
+    array![1, 2, 3]
+    ^^^^^^^^^^^^^^^
+
+error[E2130]: This expression is not supported as constant.
+ --> lib.cairo:4:27
+const X: Array<felt252> = f();
+                          ^^^
+note: In `test::f`:
+  --> lib.cairo:2:5
+    array![1, 2, 3]
+    ^^^^^^^^^^^^^^^
+
+error[E2130]: This expression is not supported as constant.
+ --> lib.cairo:4:27
+const X: Array<felt252> = f();
+                          ^^^
+note: In `test::f`:
+  --> lib.cairo:2:5
+    array![1, 2, 3]
+    ^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -952,10 +952,12 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                 .intern(db);
             }
             _ => {
-                unreachable!(
-                    "Unexpected function call in constant lowering: `{:?}`",
-                    expr.function.debug(db)
-                )
+                // Reachable via impl methods we don't lower (e.g. `ArrayTrait::new`
+                // from `array![...]` in a `const fn` body). Mirror the extern fallback.
+                return to_missing(self.diagnostics.report(
+                    expr.stable_ptr.untyped(),
+                    SemanticDiagnosticKind::UnsupportedConstant,
+                ));
             }
         };
         if expr.ty == self.felt252 {


### PR DESCRIPTION
Fixes #9906 

Replaces the `unreachable!()` in `evaluate_function_call`
(`crates/cairo-lang-semantic/src/items/constant.rs`) with a graceful
`UnsupportedConstant` (E2127) diagnostic, mirroring the existing extern
fallback in the same function. The arm is reachable when the inner const
evaluator encounters an impl-method call it has no lowering rule for —
e.g. `ArrayTrait::new` reached via `array![...]` desugared inside a
user-defined `const fn` body — and currently produces a Rust backtrace
instead of a compiler error. Adds a regression fixture in
`expr/test_data/constant`.



## Why is this change needed?

The arm at the bottom of `evaluate_function_call`'s `match imp.function`
was annotated `unreachable!("Unexpected function call in constant
lowering: ...")`, but it is in fact reachable: when a user-defined
`const fn` body uses `array![...]`, the desugared `ArrayTrait::new()`
call has no const-evaluation handler and falls through to this arm. The
result on `scarb 2.18.0` is a Rust panic with the user-facing message
"Compiler thread has panicked" — not a compiler diagnostic — for code
that should produce the same `error[E2127]` Cairo already emits when
`const X = ArrayTrait::new()` is written directly (without the
`const fn` indirection).