### PR TITLE
bugfix(semantic): const-eval no longer ICEs on free-function const fn…

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -850,3 +850,62 @@ error[E2127]: This expression is not supported as constant.
  --> lib.cairo:5:26
     const VALUE: bool = !F::VALUE;
                          ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Const fn whose body desugars to a free-function call (issue #9908).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+// `panic!("string")` desugars to a call to `core::panics::panic_with_byte_array`,
+// a free function. Const-eval used to panic at `evaluate_function_call` when the
+// trait-impl extraction of `GenericFunctionId` met a `Free(_)` variant; it must
+// now produce a regular const-evaluation diagnostic instead.
+const fn panic_string_body() -> felt252 {
+    panic!("nope")
+}
+
+const PANIC_STRING_CALLED: felt252 = panic_string_body();
+
+const fn panic_no_arg_body() -> felt252 {
+    panic!()
+}
+
+const PANIC_NO_ARG_CALLED: felt252 = panic_no_arg_body();
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:6:5
+    panic!("nope")
+    ^^^^^^^^^^^^^^
+
+error[E2130]: Failed to calculate constant.
+ --> lib.cairo:9:38
+const PANIC_STRING_CALLED: felt252 = panic_string_body();
+                                     ^^^^^^^^^^^^^^^^^^^
+note: In `test::panic_string_body`:
+  --> lib.cairo:6:5
+    panic!("nope")
+    ^^^^^^^^^^^^^^
+
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:12:5
+    panic!()
+    ^^^^^^^^
+
+error[E2130]: Failed to calculate constant.
+ --> lib.cairo:15:38
+const PANIC_NO_ARG_CALLED: felt252 = panic_no_arg_body();
+                                     ^^^^^^^^^^^^^^^^^^^
+note: In `test::panic_no_arg_body`:
+  --> lib.cairo:12:5
+    panic!()
+    ^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -898,7 +898,17 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             return calc_result;
         }
 
-        let imp = extract_matches!(concrete_function.generic_function, GenericFunctionId::Impl);
+        let GenericFunctionId::Impl(imp) = concrete_function.generic_function else {
+            // The const-eval pipeline only knows how to evaluate trait-impl operator calls past
+            // this point. A free function (e.g. the desugaring of `panic!("...")` into
+            // `core::panics::panic_with_byte_array`) reaches here when it is not handled by
+            // `evaluate_const_function_call`; rather than panic, surface it as a regular
+            // const-evaluation failure.
+            return to_missing(self.diagnostics.report(
+                expr.stable_ptr.untyped(),
+                SemanticDiagnosticKind::FailedConstantCalculation,
+            ));
+        };
         let bool_value = |condition: bool| {
             if condition { self.true_const } else { self.false_const }
         };


### PR DESCRIPTION
… body

Fixes #9908 

A `const fn` whose body is `panic!("...")` (string-literal arg) crashes the
compiler with a Rust `extract_matches!` assertion failure in
`cairo-lang-semantic/src/items/constant.rs`. This PR replaces the unconditional
`extract_matches!(GenericFunctionId::Impl)` in the const-eval call path with a
graceful `let-else`, so the compiler now emits a regular
`error[E2130]: Failed to calculate constant.` diagnostic instead of a Rust
backtrace.

---

## Type of change

- [x] Bug fix (fixes incorrect behavior)

---

## Why is this change needed?

`scarb build` produces a Rust backtrace on a 4-line program:

```cairo
const fn f() -> felt252 { panic!("nope") }
const X: felt252 = f();

#[executable]
fn main() -> felt252 { X }
```

This exposes a compiler `panic` to users, indistinguishable from a true
compiler crash. The `const fn` body of `panic!(...)` is a natural Rust-port
idiom for "unreachable const stub", so the surface is a real one, not contrived.

---

## What was the behavior before?

Compiler panic:

```
thread '<unnamed>' panicked at .../cairo-lang-semantic/src/items/constant.rs:891:19:
Variant extract failed: `Free(FreeFunctionId(...))` is not of variant `GenericFunctionId::Impl`

thread 'main' panicked at scarb/src/ops/compile.rs:238:14:
Compiler thread has panicked.: Any { .. }
```

Notably, sister "compile-time-unreachable" const-fn bodies were already handled
gracefully:

```cairo
const fn f() -> felt252 { Option::<felt252>::None.unwrap() }   // → error[E2130] graceful
const fn f() -> u32 { 1 / 0 }                                  // → error[E2130] graceful
```

Only the `panic!("string")` shape (and `panic!()` with no arg) ICEd, because
those macros desugar into a free-function call to
`core::panics::panic_with_byte_array` rather than into the operator/extern
paths the const-eval pipeline already covered.

---



Regression test: A new case in crates/cairo-lang-semantic/src/expr/test_data/constant covers both panic!("nope") (string-arg) and panic!() (no-arg) const-fn bodies, asserting the wrapped E2130 diagnostic with a note: In <fn>: chain — the same shape assert(false) and my_unwrap(...) already produce in that file. It runs under the existing expr_diagnostics::constant suite (no new harness needed). The test was confirmed to be a genuine regression test by reverting the fix and observing the original ICE signature reproduce verbatim.
