### PR TITLE
docs: use public Zero trait path in zeroable module

### DIFF
--- a/corelib/src/zeroable.cairo
+++ b/corelib/src/zeroable.cairo
@@ -5,7 +5,7 @@
 //! The [`Zeroable`] trait is meant for internal use only. The public-facing equivalent is the
 //! [`Zero`] trait.
 //!
-//! [`Zero`]: core::num::traits::zero::Zero
+//! [`Zero`]: core::num::traits::Zero
 
 /// A trait for types that have a concept of zero and can be compared to zero.
 ///


### PR DESCRIPTION
Update the Zero reference in zeroable docs to the public core::num::traits::Zero path, keeping the module documentation aligned with exported API naming.