### PR TITLE
docs: document E1028 in operator pages

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/comparison-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/comparison-operators.adoc
@@ -58,6 +58,8 @@ let in_range_and_equal = a < b && b == c;
 let bool_comparison = (a < b) == expected;
 ----
 
+The parser reports these forms as `E1028` (consecutive comparison operators).
+
 == Examples
 
 === Primitives

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/equality-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/equality-operators.adoc
@@ -54,6 +54,8 @@ Make the intent explicit with conjunctions or parentheses:
 let in_range_and_equal = a < b && b == c;
 let bool_comparison = (a < b) == expected;
 ----
+
+The parser reports these forms as `E1028` (consecutive comparison operators).
  
  == Examples
  


### PR DESCRIPTION
## Summary

Document the `E1028` parser diagnostic on the comparison and equality operator pages when mixed consecutive comparison/equality forms are rejected.

---

## Type of change

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Both pages already explain that mixed forms such as `a < b == c` and `a == b < c` are unsupported and show supported rewrites. They did not name the diagnostic users see from the parser, while the operator precedence and operator expressions pages already connect the same rejected forms to `E1028`.

---

## What was the behavior or documentation before?

The comparison and equality operator pages documented the unsupported mixed forms without identifying the parser diagnostic.

---

## What is the behavior or documentation after?

Both pages state that the parser reports these forms as `E1028` (consecutive comparison operators), matching the existing operator overview and precedence documentation.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The diagnostic is defined in the parser and appears in parser/semantic test data for consecutive comparison operators.