### PR TITLE
docs(corelib): use public ops paths in index deprecation notes

### DIFF
--- a/corelib/src/prelude/v2023_10.cairo
+++ b/corelib/src/prelude/v2023_10.cairo
@@ -33,9 +33,7 @@ pub use crate::traits::AddEq;
 )]
 #[feature("deprecated-op-assign-traits")]
 pub use crate::traits::DivEq;
-#[deprecated(
-    feature: "deprecated-index-traits", note: "Use `core::ops::Index`.", since: "2.7.0",
-)]
+#[deprecated(feature: "deprecated-index-traits", note: "Use `core::ops::Index`.", since: "2.7.0")]
 #[feature("deprecated-index-traits")]
 pub use crate::traits::Index;
 #[deprecated(

--- a/corelib/src/prelude/v2023_10.cairo
+++ b/corelib/src/prelude/v2023_10.cairo
@@ -34,12 +34,12 @@ pub use crate::traits::AddEq;
 #[feature("deprecated-op-assign-traits")]
 pub use crate::traits::DivEq;
 #[deprecated(
-    feature: "deprecated-index-traits", note: "Use `core::ops::index::Index`.", since: "2.7.0",
+    feature: "deprecated-index-traits", note: "Use `core::ops::Index`.", since: "2.7.0",
 )]
 #[feature("deprecated-index-traits")]
 pub use crate::traits::Index;
 #[deprecated(
-    feature: "deprecated-index-traits", note: "Use `core::ops::index::IndexView`.", since: "2.7.0",
+    feature: "deprecated-index-traits", note: "Use `core::ops::IndexView`.", since: "2.7.0",
 )]
 #[feature("deprecated-index-traits")]
 pub use crate::traits::IndexView;

--- a/corelib/src/traits.cairo
+++ b/corelib/src/traits.cairo
@@ -934,9 +934,7 @@ pub trait IndexView<C, I, V> {
     fn index(self: @C, index: I) -> V;
 }
 
-#[deprecated(
-    feature: "deprecated-index-traits", note: "Use `core::ops::Index`.", since: "2.7.0",
-)]
+#[deprecated(feature: "deprecated-index-traits", note: "Use `core::ops::Index`.", since: "2.7.0")]
 pub trait Index<C, I, V> {
     fn index(ref self: C, index: I) -> V;
 }

--- a/corelib/src/traits.cairo
+++ b/corelib/src/traits.cairo
@@ -928,14 +928,14 @@ pub trait Not<T> {
 // for each type. Both are not consuming of `self`, the first gets a snapshot of the object and
 // the second gets a reference.
 #[deprecated(
-    feature: "deprecated-index-traits", note: "Use `core::ops::index::IndexView`.", since: "2.7.0",
+    feature: "deprecated-index-traits", note: "Use `core::ops::IndexView`.", since: "2.7.0",
 )]
 pub trait IndexView<C, I, V> {
     fn index(self: @C, index: I) -> V;
 }
 
 #[deprecated(
-    feature: "deprecated-index-traits", note: "Use `core::ops::index::Index`.", since: "2.7.0",
+    feature: "deprecated-index-traits", note: "Use `core::ops::Index`.", since: "2.7.0",
 )]
 pub trait Index<C, I, V> {
     fn index(ref self: C, index: I) -> V;


### PR DESCRIPTION
This updates deprecated-index-traits notes to reference core::ops::Index and IndexView, keeping deprecation guidance aligned with the public trait paths.