### PR TITLE
refactor(lowering): Made function not return Maybe and possibly hide diags.

### DIFF
--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -136,7 +136,7 @@ pub trait LoweringGroup: Database {
     fn function_with_body_lowering_diagnostics<'db>(
         &'db self,
         function_id: ids::FunctionWithBodyId<'db>,
-    ) -> Maybe<Diagnostics<'db, LoweringDiagnostic<'db>>> {
+    ) -> Diagnostics<'db, LoweringDiagnostic<'db>> {
         function_with_body_lowering_diagnostics(self.as_dyn_database(), function_id)
     }
     /// Aggregates semantic function level lowering diagnostics - along with all its generated
@@ -467,7 +467,7 @@ fn lowered_body<'db>(
     Ok(match stage {
         LoweringStage::Monomorphized => match function.generic_or_specialized(db) {
             GenericOrSpecialized::Generic(generic_function_id) => {
-                db.function_with_body_lowering_diagnostics(generic_function_id)?
+                db.function_with_body_lowering_diagnostics(generic_function_id)
                     .check_error_free()?;
                 let mut lowered = db.function_with_body_lowering(generic_function_id)?.clone();
                 concretize_lowered(db, &mut lowered, &function.substitution(db)?)?;
@@ -653,7 +653,7 @@ fn lowered_direct_callees_with_body<'db>(
 fn function_with_body_lowering_diagnostics<'db>(
     db: &'db dyn Database,
     function_id: ids::FunctionWithBodyId<'db>,
-) -> Maybe<Diagnostics<'db, LoweringDiagnostic<'db>>> {
+) -> Diagnostics<'db, LoweringDiagnostic<'db>> {
     let mut diagnostics = DiagnosticsBuilder::default();
 
     if let Ok(lowered) = db.function_with_body_lowering(function_id) {
@@ -661,7 +661,9 @@ fn function_with_body_lowering_diagnostics<'db>(
         if let Ok(bc) = db.borrow_check(function_id) {
             diagnostics.extend(bc.diagnostics.clone());
         }
-        if db.flag_add_withdraw_gas() && db.in_cycle(function_id, DependencyType::Cost)? {
+        if db.flag_add_withdraw_gas()
+            && matches!(db.in_cycle(function_id, DependencyType::Cost), Ok(true))
+        {
             let location =
                 Location::new(function_id.base_semantic_function(db).stable_location(db));
             if !lowered.signature.panicable {
@@ -678,7 +680,7 @@ fn function_with_body_lowering_diagnostics<'db>(
         diagnostics.extend(diag);
     }
 
-    Ok(diagnostics.build())
+    diagnostics.build()
 }
 
 #[salsa::tracked]
@@ -691,15 +693,12 @@ fn semantic_function_with_body_lowering_diagnostics<'db>(
 
     if let Ok(multi_lowering) = db.priv_function_with_body_multi_lowering(semantic_function_id) {
         let function_id = ids::FunctionWithBodyLongId::Semantic(semantic_function_id).intern(db);
-        diagnostics
-            .extend(db.function_with_body_lowering_diagnostics(function_id).unwrap_or_default());
+        diagnostics.extend(db.function_with_body_lowering_diagnostics(function_id));
         for (key, _) in multi_lowering.generated_lowerings.iter() {
             let function_id =
                 ids::FunctionWithBodyLongId::Generated { parent: semantic_function_id, key: *key }
                     .intern(db);
-            diagnostics.extend(
-                db.function_with_body_lowering_diagnostics(function_id).unwrap_or_default(),
-            );
+            diagnostics.extend(db.function_with_body_lowering_diagnostics(function_id));
         }
     }
 

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test.rs
@@ -49,11 +49,9 @@ fn block_generator_test(
     // Lower code.
     let function_id =
         ConcreteFunctionWithBodyId::from_semantic(db, test_function.concrete_function_id);
-    let lowering_diagnostics = db
-        .function_with_body_lowering_diagnostics(
-            ids::FunctionWithBodyLongId::Semantic(test_function.function_id).intern(db),
-        )
-        .unwrap();
+    let lowering_diagnostics = db.function_with_body_lowering_diagnostics(
+        ids::FunctionWithBodyLongId::Semantic(test_function.function_id).intern(db),
+    );
 
     let lowered = match db.lowered_body(function_id, LoweringStage::Final) {
         Ok(lowered) if !lowered.blocks.is_empty() => lowered,


### PR DESCRIPTION
## Summary

`function_with_body_lowering_diagnostics` now returns `Diagnostics` directly instead of `Maybe<Diagnostics>`. The `in_cycle` error case is handled inline using `matches!(..., Ok(true))` rather than propagating via `?`, allowing the function to be infallible. All call sites are updated to remove `.unwrap_or_default()` and `?` unwrapping accordingly.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`function_with_body_lowering_diagnostics` was returning `Maybe<Diagnostics>` despite having no meaningful failure path — the only `?` usage was on `db.in_cycle(...)`, which on error would silently swallow all diagnostics collected up to that point. This meant a query failure could cause legitimate diagnostics to be lost rather than reported.

---

## What was the behavior or documentation before?

If `db.in_cycle(function_id, DependencyType::Cost)` returned an `Err`, the function would early-return `Err`, discarding any diagnostics already accumulated in the builder. Call sites used `.unwrap_or_default()` to recover, silently dropping those diagnostics.

---

## What is the behavior or documentation after?

The function is now infallible and always returns a `Diagnostics` value. The `in_cycle` result is checked with `matches!(..., Ok(true))`, so errors are treated as "not in cycle" without aborting diagnostic collection. All diagnostics gathered before the cycle check are preserved and returned regardless of whether `in_cycle` succeeds.

---

## Related issue or discussion (if any)

---

## Additional context

The test helper in `block_generator_test.rs` is also updated to remove the now-unnecessary `.unwrap()` call.