### PR TITLE
Preventing infinite inlining of cycle functions.

### DIFF
--- a/crates/cairo-lang-lowering/src/inline/mod.rs
+++ b/crates/cairo-lang-lowering/src/inline/mod.rs
@@ -72,7 +72,7 @@ pub fn priv_should_inline<'db>(
         | ConcreteFunctionWithBodyLongId::Generated(_) => function_id,
         ConcreteFunctionWithBodyLongId::Specialized(specialized) => specialized.long(db).base,
     };
-    if db.concrete_in_cycle(base, DependencyType::Call, LoweringStage::Monomorphized)? {
+    if db.concrete_in_cycle(base, DependencyType::Call, LoweringStage::PreOptimizations)? {
         return Ok(false);
     }
 
@@ -357,8 +357,6 @@ where
                 return Ok(Some((stmt, called_func)));
             }
 
-            // TODO: Implement better logic to avoid inlining of destructors that call
-            // themselves.
             if called_func != calling_function_id && db.priv_should_inline(called_func)? {
                 return Ok(Some((stmt, called_func)));
             }

--- a/crates/cairo-lang-lowering/src/test.rs
+++ b/crates/cairo-lang-lowering/src/test.rs
@@ -60,14 +60,18 @@ cairo_lang_test_utils::test_file_test!(
         for_: "for",
     },
     test_function_lowering,
-    ["expect_diagnostics"]
+    ["expect_diagnostics", "no_gas"]
 );
 
 fn test_function_lowering(
     inputs: &OrderedHashMap<String, String>,
     args: &OrderedHashMap<String, String>,
 ) -> TestRunnerResult {
-    let db = &mut LoweringDatabaseForTesting::default();
+    let db = &mut if args.get("no_gas").map(|s| s.trim()) == Some("true") {
+        LoweringDatabaseForTesting::with_no_gas()
+    } else {
+        LoweringDatabaseForTesting::default()
+    };
     let (test_function, semantic_diagnostics) = setup_test_function(db, inputs).split();
     let function_id =
         ConcreteFunctionWithBodyId::from_semantic(db, test_function.concrete_function_id);

--- a/crates/cairo-lang-lowering/src/test_data/cycles
+++ b/crates/cairo-lang-lowering/src/test_data/cycles
@@ -170,3 +170,37 @@ blk0 (root):
 Statements:
 End:
   Return()
+
+//! > ==========================================================================
+
+//! > Test self-referential Destruct impl in no-gas mode does not hang (issue #9894).
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false, no_gas: true)
+
+//! > function_code
+fn foo() {
+    let _ = D {};
+}
+
+//! > function_name
+foo
+
+//! > module_code
+struct D {}
+impl DDestruct of Destruct<D> {
+    fn destruct(self: D) nopanic {}
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+  (v0: test::D) <- struct_construct()
+  () <- test::DDestruct::destruct(v0)
+End:
+  Return()

--- a/crates/cairo-lang-lowering/src/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/test_utils.rs
@@ -50,17 +50,24 @@ impl LoweringDatabaseForTesting {
     }
 }
 
-pub static SHARED_DB: LazyLock<Mutex<LoweringDatabaseForTesting>> =
+static SHARED_DB: LazyLock<Mutex<LoweringDatabaseForTesting>> =
     LazyLock::new(|| Mutex::new(LoweringDatabaseForTesting::new()));
-pub static SHARED_DB_FUTURE_SIERRA: LazyLock<Mutex<LoweringDatabaseForTesting>> =
-    LazyLock::new(|| {
-        let mut db = LoweringDatabaseForTesting::new();
-        db.set_flag(FlagLongId(Flag::FUTURE_SIERRA.into()), Some(Flag::FutureSierra(true)));
-        Mutex::new(db)
-    });
+static SHARED_DB_NO_GAS: LazyLock<Mutex<LoweringDatabaseForTesting>> = LazyLock::new(|| {
+    let mut db = LoweringDatabaseForTesting::new();
+    db.set_flag(FlagLongId(Flag::ADD_WITHDRAW_GAS.into()), Some(Flag::AddWithdrawGas(false)));
+    Mutex::new(db)
+});
+static SHARED_DB_FUTURE_SIERRA: LazyLock<Mutex<LoweringDatabaseForTesting>> = LazyLock::new(|| {
+    let mut db = LoweringDatabaseForTesting::new();
+    db.set_flag(FlagLongId(Flag::FUTURE_SIERRA.into()), Some(Flag::FutureSierra(true)));
+    Mutex::new(db)
+});
 impl LoweringDatabaseForTesting {
     pub fn with_future_sierra() -> Self {
         SHARED_DB_FUTURE_SIERRA.lock().unwrap().snapshot()
+    }
+    pub fn with_no_gas() -> Self {
+        SHARED_DB_NO_GAS.lock().unwrap().snapshot()
     }
 }
 impl Default for LoweringDatabaseForTesting {


### PR DESCRIPTION
## Summary

Fixes a hang that occurred when lowering self-referential `Destruct` implementations in no-gas mode (issue #9894). The cycle detection for inlining now uses `LoweringStage::PreOptimizations` instead of `LoweringStage::Monomorphized`, which correctly identifies recursive destructors as cyclic and prevents infinite inlining. The TODO comment about needing better logic to avoid inlining destructors that call themselves has been removed, as this fix addresses that concern.

A `no_gas` test flag and corresponding `LoweringDatabaseForTesting::with_no_gas()` snapshot are introduced to enable lowering tests that disable `withdraw_gas` insertion, along with a regression test covering the self-referential `Destruct` case.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

In no-gas mode, a struct with a `Destruct` impl that calls itself (directly or indirectly) caused the compiler to hang indefinitely during inlining. The cycle check was running against `LoweringStage::Monomorphized`, which did not detect the cycle at the point where inlining decisions are made, allowing unbounded recursive inlining attempts.

---

## What was the behavior or documentation before?

Compiling a self-referential `Destruct` impl with gas disabled would cause the compiler to hang without producing diagnostics or output.

---

## What is the behavior or documentation after?

The compiler correctly detects the cycle, skips inlining for the recursive destructor, and produces valid lowered output without hanging.

---

## Related issue or discussion (if any)

Fixes #9894

---

## Additional context

The `SHARED_DB` static in `test_utils.rs` was also changed from `pub` to private, as it was not intended to be part of the public API.