### PR TITLE
fix(semantic): reject non-concrete const logical lhs

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -1025,3 +1025,57 @@ error[E0006]: Identifier not found.
  --> lib.cairo:7:5
     X
     ^
+
+//! > ==========================================================================
+
+//! > Boolean and with non-concrete impl const lhs is unsupported.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait BoolConst {
+    const VALUE: bool;
+}
+impl AnotherBoolConst<impl F: BoolConst> of BoolConst {
+    const VALUE: bool = F::VALUE && true;
+}
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:5:25
+    const VALUE: bool = F::VALUE && true;
+                        ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Boolean or with non-concrete impl const lhs is unsupported.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait BoolConst {
+    const VALUE: bool;
+}
+impl AnotherBoolConst<impl F: BoolConst> of BoolConst {
+    const VALUE: bool = F::VALUE || false;
+}
+
+//! > expected_diagnostics
+error[E2127]: This expression is not supported as constant.
+ --> lib.cairo:5:25
+    const VALUE: bool = F::VALUE || false;
+                        ^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -789,8 +789,13 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                         LogicalOperator::OrOr => true_variant(self.db),
                     };
                     if *v == early_return_variant { lhs } else { self.evaluate(expr.rhs) }
-                } else {
+                } else if matches!(lhs.long(db), ConstValue::Missing(_)) {
                     to_missing(skip_diagnostic())
+                } else {
+                    to_missing(self.diagnostics.report(
+                        self.arenas.exprs[expr.lhs].stable_ptr(),
+                        SemanticDiagnosticKind::UnsupportedConstant,
+                    ))
                 }
             }
             Expr::Match(expr) => {

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -789,8 +789,8 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                         LogicalOperator::OrOr => true_variant(self.db),
                     };
                     if *v == early_return_variant { lhs } else { self.evaluate(expr.rhs) }
-                } else if matches!(lhs.long(db), ConstValue::Missing(_)) {
-                    to_missing(skip_diagnostic())
+                } else if let ConstValue::Missing(diag_added) = lhs.long(db) {
+                    to_missing(*diag_added)
                 } else {
                     to_missing(self.diagnostics.report(
                         self.arenas.exprs[expr.lhs].stable_ptr(),


### PR DESCRIPTION
## Summary

Report `UnsupportedConstant` for non-concrete constant values used as the left-hand side of `&&` or `||` during const evaluation.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

#9879 made const evaluation report `UnsupportedConstant` for non-concrete values used by `==`, `!=`, and `!`. The `&&` and `||` path had the same unsupported input shape, but did not report the diagnostic itself when the left-hand side was non-concrete. This left users without the expected `E2127` diagnostic at the source expression.

---

## What was the behavior or documentation before?

In const contexts, expressions such as `F::VALUE && true` and `F::VALUE || false` could fail without reporting `UnsupportedConstant` on `F::VALUE`.

---

## What is the behavior or documentation after?

The evaluator now reports `error[E2127]: This expression is not supported as constant.` on the non-concrete left-hand side. Existing short-circuit behavior for concrete boolean operands is unchanged.

---

## Related issue or discussion (if any)

Follow-up to #9879.

---

## Additional context

Adds semantic regression coverage for non-concrete values used as the left-hand side of both logical operators.