### PR TITLE
docs(corelib): use public path in WideMul deprecation notes

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -1990,7 +1990,7 @@ impl I8Neg of Neg<i8> {
     }
 }
 
-#[deprecated(feature: "corelib-internal-use", note: "Use `crate::num::traits::WideMul` instead")]
+#[deprecated(feature: "corelib-internal-use", note: "Use `core::num::traits::WideMul` instead")]
 pub extern fn i8_wide_mul(lhs: i8, rhs: i8) -> i16 implicits() nopanic;
 impl I8Mul of Mul<i8> {
     fn mul(lhs: i8, rhs: i8) -> i8 {
@@ -2080,7 +2080,7 @@ impl I16Neg of Neg<i16> {
     }
 }
 
-#[deprecated(feature: "corelib-internal-use", note: "Use `crate::num::traits::WideMul` instead")]
+#[deprecated(feature: "corelib-internal-use", note: "Use `core::num::traits::WideMul` instead")]
 pub extern fn i16_wide_mul(lhs: i16, rhs: i16) -> i32 implicits() nopanic;
 
 impl I16Mul of Mul<i16> {


### PR DESCRIPTION
This PR updates two deprecated notes (`i8_wide_mul` and `i16_wide_mul`) from `crate::num::traits::WideMul` to `core::num::traits::WideMul`.                                                    
  In the same file, all other `WideMul` deprecation notes already use the public `core::...` path, so these two were inconsistent outliers.                                                      
  The change is documentation-only, does not alter behavior, and makes user-facing migration guidance consistent and correct.