### PR TITLE
fix: point implicit unit return mismatch at tail expr

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1734,25 +1734,48 @@ pub fn compute_root_expr<'db>(
         ctx.db.generic_params_type_constraints(ctx.resolver.data.generic_params.clone());
     inference.conform_generic_params_type_constraints(constrains);
 
+    let db = ctx.db;
     let return_type = ctx.reduce_ty(return_type);
     let res = compute_expr_block_semantic(ctx, syntax)?;
     let res_ty = ctx.reduce_ty(res.ty());
     let res = ctx.arenas.exprs.alloc(res);
+    let implicit_unit_return = ctx
+        .signature
+        .map(|s| matches!(s.stable_ptr.lookup(db).ret_ty(db), OptionReturnTypeClause::Empty(_)))
+        .unwrap_or(false)
+        && return_type.is_unit(db);
+    let tail_expr_stable_ptr = if implicit_unit_return {
+        let (_, tail) = statements_and_tail(db, syntax.statements(db));
+        tail.map(|tail| tail.expr(db).stable_ptr(db).untyped())
+    } else {
+        None
+    };
+    let prefer_tail_return_diagnostic = tail_expr_stable_ptr.is_some() && !res_ty.is_var_free(db);
     let inference = &mut ctx.resolver.inference();
-    let db = ctx.db;
+    if prefer_tail_return_diagnostic {
+        let _ = inference.finalize_numeric_literals();
+    }
+    let res_ty = inference.rewrite(res_ty).no_err();
+    let tail_return_diag_stable_ptr = if prefer_tail_return_diagnostic && res_ty.is_var_free(db) {
+        tail_expr_stable_ptr
+    } else {
+        None
+    };
     let _ = inference.conform_ty_for_diag(
         res_ty,
         return_type,
         ctx.diagnostics,
         || {
-            ctx.signature
-                .map(|s| match s.stable_ptr.lookup(db).ret_ty(db) {
-                    OptionReturnTypeClause::Empty(_) => syntax.stable_ptr(db).untyped(),
-                    OptionReturnTypeClause::ReturnTypeClause(return_type_clause) => {
-                        return_type_clause.ty(db).stable_ptr(db).untyped()
-                    }
-                })
-                .unwrap_or_else(|| syntax.stable_ptr(db).untyped())
+            tail_return_diag_stable_ptr.unwrap_or_else(|| {
+                ctx.signature
+                    .map(|s| match s.stable_ptr.lookup(db).ret_ty(db) {
+                        OptionReturnTypeClause::Empty(_) => syntax.stable_ptr(db).untyped(),
+                        OptionReturnTypeClause::ReturnTypeClause(return_type_clause) => {
+                            return_type_clause.ty(db).stable_ptr(db).untyped()
+                        }
+                    })
+                    .unwrap_or_else(|| syntax.stable_ptr(db).untyped())
+            })
         },
         |actual_ty, expected_ty| WrongReturnType { expected_ty, actual_ty },
     );

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1754,29 +1754,34 @@ pub fn compute_root_expr<'db>(
             }
         })
         .unwrap_or((block_stable_ptr, false));
-    if !is_implicit_return_with_tail
-        || !report_return_type_diag_without_backpropagating(
-            db,
-            &ctx.resolver.data.inference_data,
-            ctx.diagnostics,
-            res_ty,
-            return_type,
-            return_diag_stable_ptr,
-        )
-    {
-        let inference = &mut ctx.resolver.inference();
-        let _ = inference.conform_ty_for_diag(
-            res_ty,
-            return_type,
-            ctx.diagnostics,
-            || return_diag_stable_ptr,
-            |actual_ty, expected_ty| WrongReturnType { expected_ty, actual_ty },
-        );
-    }
+    let inference = &mut ctx.resolver.inference();
+    let _ = inference.conform_ty_for_diag(
+        res_ty,
+        return_type,
+        ctx.diagnostics,
+        || return_diag_stable_ptr,
+        |actual_ty, expected_ty| WrongReturnType { expected_ty, actual_ty },
+    );
 
     // Check fully resolved.
     let inference = &mut ctx.resolver.inference();
-    inference.finalize(ctx.diagnostics, syntax.stable_ptr(db).untyped());
+    inference.finalize_with_error_reporter(
+        ctx.diagnostics,
+        syntax.stable_ptr(db).untyped(),
+        |err, _stable_ptr, diagnostics| {
+            if is_implicit_return_with_tail {
+                report_implicit_unit_return_type_diag(
+                    db,
+                    err,
+                    diagnostics,
+                    return_type,
+                    return_diag_stable_ptr,
+                )
+            } else {
+                None
+            }
+        },
+    );
 
     ctx.apply_inference_rewriter();
     if ctx.signature.map(|s| s.is_const) == Some(true) {
@@ -1785,29 +1790,42 @@ pub fn compute_root_expr<'db>(
     Ok(res)
 }
 
-fn report_return_type_diag_without_backpropagating<'db>(
+fn report_implicit_unit_return_type_diag<'db>(
     db: &'db dyn Database,
-    inference_data: &InferenceData<'db>,
+    err: &InferenceError<'db>,
     diagnostics: &mut SemanticDiagnostics<'db>,
-    res_ty: TypeId<'db>,
-    return_type: TypeId<'db>,
+    expected_ty: TypeId<'db>,
     stable_ptr: SyntaxStablePtrId<'db>,
-) -> bool {
-    if res_ty.is_var_free(db) {
-        return false;
+) -> Option<cairo_lang_diagnostics::DiagnosticAdded> {
+    if !expected_ty.is_unit(db) {
+        return None;
     }
-    let mut temp_inference_data = inference_data.temporary_clone();
-    let mut temp_inference = temp_inference_data.inference(db);
-    if temp_inference.finalize_without_reporting().is_err() {
-        return false;
-    }
-    let actual_ty = temp_inference.rewrite(res_ty).no_err();
-    let expected_ty = temp_inference.rewrite(return_type).no_err();
-    if actual_ty == expected_ty {
-        return false;
-    }
-    diagnostics.report(stable_ptr, WrongReturnType { expected_ty, actual_ty });
-    true
+    let actual_ty = match err {
+        InferenceError::NoImplsFound(concrete_trait_id) => {
+            let info = db.core_info();
+            if concrete_trait_id.trait_id(db) != info.numeric_literal_trt {
+                return None;
+            }
+            let GenericArgumentId::Type(ty) = concrete_trait_id.generic_args(db)[0] else {
+                return None;
+            };
+            if ty != expected_ty {
+                return None;
+            }
+            info.felt252
+        }
+        InferenceError::TypeKindMismatch { ty0, ty1 } => {
+            let felt_ty = db.core_info().felt252;
+            if (*ty0 == expected_ty && *ty1 == felt_ty) || (*ty1 == expected_ty && *ty0 == felt_ty)
+            {
+                felt_ty
+            } else {
+                return None;
+            }
+        }
+        _ => return None,
+    };
+    Some(diagnostics.report(stable_ptr, WrongReturnType { expected_ty, actual_ty }))
 }
 
 /// Computes the semantic model for a list of statements, flattening the result.

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1739,48 +1739,43 @@ pub fn compute_root_expr<'db>(
     let res = compute_expr_block_semantic(ctx, syntax)?;
     let res_ty = ctx.reduce_ty(res.ty());
     let res = ctx.arenas.exprs.alloc(res);
-    let implicit_unit_return = ctx
+    let block_stable_ptr = syntax.stable_ptr(db).untyped();
+    let (return_diag_stable_ptr, is_implicit_return_with_tail) = ctx
         .signature
-        .map(|s| matches!(s.stable_ptr.lookup(db).ret_ty(db), OptionReturnTypeClause::Empty(_)))
-        .unwrap_or(false)
-        && return_type.is_unit(db);
-    let tail_expr_stable_ptr = if implicit_unit_return {
-        let (_, tail) = statements_and_tail(db, syntax.statements(db));
-        tail.map(|tail| tail.expr(db).stable_ptr(db).untyped())
-    } else {
-        None
-    };
-    let prefer_tail_return_diagnostic = tail_expr_stable_ptr.is_some() && !res_ty.is_var_free(db);
-    let inference = &mut ctx.resolver.inference();
-    if prefer_tail_return_diagnostic {
-        let _ = inference.finalize_numeric_literals();
+        .map(|s| match s.stable_ptr.lookup(db).ret_ty(db) {
+            OptionReturnTypeClause::Empty(_) => {
+                let (_, tail) = statements_and_tail(db, syntax.statements(db));
+                let tail_stable_ptr = tail.map(|tail| tail.expr(db).stable_ptr(db).untyped());
+                let has_tail = tail_stable_ptr.is_some();
+                (tail_stable_ptr.unwrap_or(block_stable_ptr), has_tail)
+            }
+            OptionReturnTypeClause::ReturnTypeClause(return_type_clause) => {
+                (return_type_clause.ty(db).stable_ptr(db).untyped(), false)
+            }
+        })
+        .unwrap_or((block_stable_ptr, false));
+    if !is_implicit_return_with_tail
+        || !report_return_type_diag_without_backpropagating(
+            db,
+            &ctx.resolver.data.inference_data,
+            ctx.diagnostics,
+            res_ty,
+            return_type,
+            return_diag_stable_ptr,
+        )
+    {
+        let inference = &mut ctx.resolver.inference();
+        let _ = inference.conform_ty_for_diag(
+            res_ty,
+            return_type,
+            ctx.diagnostics,
+            || return_diag_stable_ptr,
+            |actual_ty, expected_ty| WrongReturnType { expected_ty, actual_ty },
+        );
     }
-    let res_ty = inference.rewrite(res_ty).no_err();
-    let tail_return_diag_stable_ptr = if prefer_tail_return_diagnostic && res_ty.is_var_free(db) {
-        tail_expr_stable_ptr
-    } else {
-        None
-    };
-    let _ = inference.conform_ty_for_diag(
-        res_ty,
-        return_type,
-        ctx.diagnostics,
-        || {
-            tail_return_diag_stable_ptr.unwrap_or_else(|| {
-                ctx.signature
-                    .map(|s| match s.stable_ptr.lookup(db).ret_ty(db) {
-                        OptionReturnTypeClause::Empty(_) => syntax.stable_ptr(db).untyped(),
-                        OptionReturnTypeClause::ReturnTypeClause(return_type_clause) => {
-                            return_type_clause.ty(db).stable_ptr(db).untyped()
-                        }
-                    })
-                    .unwrap_or_else(|| syntax.stable_ptr(db).untyped())
-            })
-        },
-        |actual_ty, expected_ty| WrongReturnType { expected_ty, actual_ty },
-    );
 
     // Check fully resolved.
+    let inference = &mut ctx.resolver.inference();
     inference.finalize(ctx.diagnostics, syntax.stable_ptr(db).untyped());
 
     ctx.apply_inference_rewriter();
@@ -1788,6 +1783,31 @@ pub fn compute_root_expr<'db>(
         validate_const_expr(ctx, res);
     }
     Ok(res)
+}
+
+fn report_return_type_diag_without_backpropagating<'db>(
+    db: &'db dyn Database,
+    inference_data: &InferenceData<'db>,
+    diagnostics: &mut SemanticDiagnostics<'db>,
+    res_ty: TypeId<'db>,
+    return_type: TypeId<'db>,
+    stable_ptr: SyntaxStablePtrId<'db>,
+) -> bool {
+    if res_ty.is_var_free(db) {
+        return false;
+    }
+    let mut temp_inference_data = inference_data.temporary_clone();
+    let mut temp_inference = temp_inference_data.inference(db);
+    if temp_inference.finalize_without_reporting().is_err() {
+        return false;
+    }
+    let actual_ty = temp_inference.rewrite(res_ty).no_err();
+    let expected_ty = temp_inference.rewrite(return_type).no_err();
+    if actual_ty == expected_ty {
+        return false;
+    }
+    diagnostics.report(stable_ptr, WrongReturnType { expected_ty, actual_ty });
+    true
 }
 
 /// Computes the semantic model for a list of statements, flattening the result.

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -849,9 +849,9 @@ impl<'db, 'id> Inference<'db, 'id> {
         Ok(SolutionSet::Unique(()))
     }
 
-    /// Infers uninferred numeric literals as felt252.
+    /// Finalizes the inference by inferring uninferred numeric literals as felt252.
     /// Returns an error and does not report it.
-    pub fn finalize_numeric_literals(&mut self) -> Result<(), ErrorSet> {
+    pub fn finalize_without_reporting(&mut self) -> Result<(), ErrorSet> {
         if self.error_status.is_err() {
             return Err(ErrorSet);
         }
@@ -886,13 +886,6 @@ impl<'db, 'id> Inference<'db, 'id> {
                 break;
             }
         }
-        Ok(())
-    }
-
-    /// Finalizes the inference by inferring uninferred numeric literals as felt252.
-    /// Returns an error and does not report it.
-    pub fn finalize_without_reporting(&mut self) -> Result<(), ErrorSet> {
-        self.finalize_numeric_literals()?;
         assert!(
             self.pending.is_empty(),
             "pending should all be solved by this point. Guaranteed by solve()."

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -849,9 +849,9 @@ impl<'db, 'id> Inference<'db, 'id> {
         Ok(SolutionSet::Unique(()))
     }
 
-    /// Finalizes the inference by inferring uninferred numeric literals as felt252.
+    /// Infers uninferred numeric literals as felt252.
     /// Returns an error and does not report it.
-    pub fn finalize_without_reporting(&mut self) -> Result<(), ErrorSet> {
+    pub fn finalize_numeric_literals(&mut self) -> Result<(), ErrorSet> {
         if self.error_status.is_err() {
             return Err(ErrorSet);
         }
@@ -886,6 +886,13 @@ impl<'db, 'id> Inference<'db, 'id> {
                 break;
             }
         }
+        Ok(())
+    }
+
+    /// Finalizes the inference by inferring uninferred numeric literals as felt252.
+    /// Returns an error and does not report it.
+    pub fn finalize_without_reporting(&mut self) -> Result<(), ErrorSet> {
+        self.finalize_numeric_literals()?;
         assert!(
             self.pending.is_empty(),
             "pending should all be solved by this point. Guaranteed by solve()."

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -905,8 +905,23 @@ impl<'db, 'id> Inference<'db, 'id> {
         diagnostics: &mut SemanticDiagnostics<'db>,
         stable_ptr: SyntaxStablePtrId<'db>,
     ) {
+        self.finalize_with_error_reporter(diagnostics, stable_ptr, |_, _, _| None);
+    }
+
+    /// Finalizes the inference and allows replacing a pending inference error with a more specific
+    /// diagnostic.
+    pub fn finalize_with_error_reporter<'m>(
+        &'m mut self,
+        diagnostics: &mut SemanticDiagnostics<'db>,
+        stable_ptr: SyntaxStablePtrId<'db>,
+        report: impl FnOnce(
+            &InferenceError<'db>,
+            SyntaxStablePtrId<'db>,
+            &mut SemanticDiagnostics<'db>,
+        ) -> Option<DiagnosticAdded>,
+    ) {
         if let Err(err_set) = self.finalize_without_reporting() {
-            let diag = self.report_on_pending_error(err_set, diagnostics, stable_ptr);
+            let diag = self.report_on_pending_error_with(err_set, diagnostics, stable_ptr, report);
 
             let ty_missing = TypeId::missing(self.db, diag);
             for var in &self.data.type_vars {
@@ -1460,21 +1475,42 @@ impl<'db, 'id> Inference<'db, 'id> {
         diagnostics: &mut SemanticDiagnostics<'db>,
         stable_ptr: SyntaxStablePtrId<'db>,
     ) -> DiagnosticAdded {
+        self.report_on_pending_error_with(_err_set, diagnostics, stable_ptr, |_, _, _| None)
+    }
+
+    fn report_on_pending_error_with(
+        &mut self,
+        _err_set: ErrorSet,
+        diagnostics: &mut SemanticDiagnostics<'db>,
+        stable_ptr: SyntaxStablePtrId<'db>,
+        report: impl FnOnce(
+            &InferenceError<'db>,
+            SyntaxStablePtrId<'db>,
+            &mut SemanticDiagnostics<'db>,
+        ) -> Option<DiagnosticAdded>,
+    ) -> DiagnosticAdded {
         let Err(state_error) = &self.error_status else {
             panic!("report_on_pending_error should be called only on error");
         };
         match state_error {
             InferenceErrorStatus::Consumed(diag_added) => *diag_added,
             InferenceErrorStatus::Pending(pending) => {
-                let diag_added = match &pending.err {
-                    InferenceError::TypeNotInferred(_) if diagnostics.error_count > 0 => {
-                        // If we have other diagnostics, there is no need to TypeNotInferred.
+                let stable_ptr = pending.stable_ptr.unwrap_or(stable_ptr);
+                let diag_added = if let Some(diag_added) =
+                    report(&pending.err, stable_ptr, diagnostics)
+                {
+                    diag_added
+                } else {
+                    match &pending.err {
+                        InferenceError::TypeNotInferred(_) if diagnostics.error_count > 0 => {
+                            // If we have other diagnostics, there is no need to TypeNotInferred.
 
-                        // Note that `diagnostics` is not empty, so it is safe to return
-                        // 'DiagnosticAdded' here.
-                        skip_diagnostic()
+                            // Note that `diagnostics` is not empty, so it is safe to return
+                            // 'DiagnosticAdded' here.
+                            skip_diagnostic()
+                        }
+                        diag => diag.report(diagnostics, stable_ptr),
                     }
-                    diag => diag.report(diagnostics, pending.stable_ptr.unwrap_or(stable_ptr)),
                 };
                 self.error_status = Err(InferenceErrorStatus::Consumed(diag_added));
                 diag_added

--- a/crates/cairo-lang-semantic/src/expr/test_data/return
+++ b/crates/cairo-lang-semantic/src/expr/test_data/return
@@ -70,3 +70,25 @@ error[E2042]: Unexpected return type. Expected: "core::felt252", found: "()".
  --> lib.cairo:1:13
 fn foo() -> felt252 {}
             ^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test implicit unit return with inferred numeric tail.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let x = 5;
+    x
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2042]: Unexpected return type. Expected: "()", found: "core::felt252".
+ --> lib.cairo:3:5
+    x
+    ^


### PR DESCRIPTION
## Summary

Reports implicit unit-return mismatches on the inferred tail expression instead of forcing an unconstrained numeric literal to conform to `()`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

For a function without an explicit return type, a trailing expression should be diagnosed as the value that does not match the implicit `()` return type. When the tail expression was an inferred numeric local, the compiler instead reported that `()` could not be created from the numeric literal at the variable definition.

---

## What was the behavior or documentation before?

In code like:

```cairo
fn foo() {
    let x = 5;
    x
}
```

the diagnostic pointed at `5` in `let x = 5`.

---

## What is the behavior or documentation after?

The diagnostic reports `Unexpected return type. Expected: "()", found: "core::felt252".` on the tail expression `x`, matching the actual source of the return-type mismatch.

---

## Related issue or discussion (if any)

Fixes #6486

---

## Additional context

Adds semantic regression coverage for the implicit unit-return case while preserving the existing diagnostic locations for explicit return types and already concrete tail expressions.