### PR TITLE
Fix DivRem docs reference

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/arithmetic-and-logical-operators.adoc
@@ -145,5 +145,6 @@ supported; see xref:bitwise-operators.adoc[Bitwise operators].
 == References (source)
 
 - link:{cairo-repo}/crates/cairo-lang-parser/src/operators.rs#L21-L22[Operator precedence]
-- link:{cairo-repo}/corelib/src/traits.cairo[Traits] (`Add`, `Sub`, `Mul`, `Div`, `Rem`, `DivRem`)
+- link:{cairo-repo}/corelib/src/traits.cairo[Traits] (`Add`, `Sub`, `Mul`, `Div`, `Rem`)
+- link:{cairo-repo}/corelib/src/num/traits/ops/divrem.cairo[`DivRem` trait]
 - link:{cairo-repo}/corelib/src/ops/arith.cairo[`Assignment operators`]


### PR DESCRIPTION
  This change points the `DivRem` reference in `arithmetic-and-logical-operators.adoc` to `corelib/src/num/traits/ops/divrem.cairo` and removes it from the generic `traits.cairo` list.         
  The same page already uses `core::num::traits::DivRem` and `DivRem::div_rem`, so this aligns the source link with the actual API location and makes the documentation consistent and trustworthy. 