### PR TITLE
docs: simplify DivRem NonZero example

### DIFF
--- a/corelib/src/num/traits/ops/divrem.cairo
+++ b/corelib/src/num/traits/ops/divrem.cairo
@@ -20,7 +20,7 @@ use crate::zeroable::NonZero;
 /// use core::zeroable::NonZero;
 ///
 /// let lhs: u32 = 7;
-/// let rhs: NonZero<u32> = 3.try_into().unwrap();
+/// let rhs: NonZero<u32> = 3;
 /// assert!(DivRem::<u32, u32>::div_rem(lhs, rhs) == (2, 1));
 /// ```
 ///


### PR DESCRIPTION
This updates the DivRem homogeneous example to initialize NonZero directly, aligning with the reviewer-approved pattern already used in the adjacent u256/u128 example.