### PR TITLE
bugfix(syntax): fix numeric_value_and_suffix to handle compound suffixes; error on typed literals in consteval_int and test attrs.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1028,7 +1028,7 @@ fn compute_expr_unary_semantic<'db>(
     match (&unary_op, &inner) {
         // If this is not an actual function call, but actually a minus literal (e.g. -1).
         (UnaryOperator::Minus(_), ast::Expr::Literal(literal)) => {
-            let (value, ty) = literal.numeric_value_and_suffix(db).unwrap_or_default();
+            let (value, ty) = literal.numeric_value_and_suffix(db);
 
             Ok(Expr::Literal(new_literal_expr(ctx, ty, -value, syntax.stable_ptr(db).into())?))
         }
@@ -3683,7 +3683,7 @@ fn literal_to_semantic<'db>(
 ) -> Maybe<ExprNumericLiteral<'db>> {
     let db = ctx.db;
 
-    let (value, ty) = literal_syntax.numeric_value_and_suffix(db).unwrap_or_default();
+    let (value, ty) = literal_syntax.numeric_value_and_suffix(db);
 
     new_literal_expr(ctx, ty, value, literal_syntax.stable_ptr(db).into())
 }

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -2644,3 +2644,57 @@ error[E2199]: Macro placeholder 'y' is from a different repetition than the one 
  --> lib.cairo:2:54
     ($($x:expr),* ; $($($y:expr),*),*) => { $($($x + $y),*),* };
                                                      ^^
+
+//! > ==========================================================================
+
+//! > Test consteval_int with typed literal.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+const a: felt252 = consteval_int!(1_u32);
+
+//! > expected_diagnostics
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:1:20
+const a: felt252 = consteval_int!(1_u32);
+                   ^^^^^^^^^^^^^^^^^^^^^
+
+error[E2200]: Plugin diagnostic: Literals with suffix are not supported in consteval_int macro
+ --> lib.cairo:1:35
+const a: felt252 = consteval_int!(1_u32);
+                                  ^^^^^
+
+//! > ==========================================================================
+
+//! > Test consteval_int with typed literal in subexpression.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+const a: felt252 = consteval_int!(1_u32 + 2);
+
+//! > expected_diagnostics
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:1:20
+const a: felt252 = consteval_int!(1_u32 + 2);
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2200]: Plugin diagnostic: Literals with suffix are not supported in consteval_int macro
+ --> lib.cairo:1:35
+const a: felt252 = consteval_int!(1_u32 + 2);
+                                  ^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/literal
+++ b/crates/cairo-lang-semantic/src/expr/test_data/literal
@@ -37,3 +37,45 @@ error[E2011]: Not a type.
  --> lib.cairo:2:14
     let _x = 1_boolean;
              ^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Numeric literal with a compound suffix (multiple underscore segments).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _x = 1_u32_u8;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2006]: Unknown type.
+ --> lib.cairo:2:14
+    let _x = 1_u32_u8;
+             ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Negative numeric literal with a compound suffix (multiple underscore segments).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _x = -1_u32_u8;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2006]: Unknown type.
+ --> lib.cairo:2:14
+    let _x = -1_u32_u8;
+             ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
@@ -106,7 +106,19 @@ pub fn compute_constant_expr<'db>(
     macro_ast: &ast::ExprInlineMacro<'db>,
 ) -> Option<BigInt> {
     match value {
-        ast::Expr::Literal(lit) => lit.numeric_value(db),
+        ast::Expr::Literal(lit) => {
+            let (value, suffix) = lit.numeric_value_and_suffix(db);
+            if suffix.is_some() {
+                diagnostics.push(PluginDiagnostic::error_with_inner_span(
+                    db,
+                    macro_ast.stable_ptr(db),
+                    lit.as_syntax_node(),
+                    "Literals with suffix are not supported in consteval_int macro".to_string(),
+                ));
+                return None;
+            }
+            Some(value)
+        }
         ast::Expr::Binary(bin_expr) => match bin_expr.op(db) {
             ast::BinaryOperator::Plus(_) => Some(
                 compute_constant_expr(db, &bin_expr.lhs(db), diagnostics, macro_ast)?

--- a/crates/cairo-lang-syntax/src/node/ast_ext.rs
+++ b/crates/cairo-lang-syntax/src/node/ast_ext.rs
@@ -29,16 +29,22 @@ impl<'a> TerminalFalse<'a> {
 }
 
 impl<'a> TerminalLiteralNumber<'a> {
-    /// Interpret this terminal as a [`BigInt`] number.
-    pub fn numeric_value(&self, db: &'a dyn Database) -> Option<BigInt> {
-        self.numeric_value_and_suffix(db).map(|(value, _suffix)| value)
-    }
-
     /// Interpret this terminal as a [`BigInt`] number and get the suffix if this literal has one.
+    ///
+    /// Splits at `_` boundaries from right to left, returning the longest prefix that parses as a
+    /// valid number in the appropriate radix, with the remainder (after the `_`) as the suffix.
+    /// This handles ambiguity for radices where suffix chars are valid digits — e.g., `0x1_f32`
+    /// parses as hex `0x1F32` (no suffix) because `"1_f32"` is a valid hex number, while
+    /// `1_f32` in decimal returns value `1` with suffix `"f32"`. Also handles compound suffixes
+    /// like `1_u32_u8`: returns value `1` with suffix `"u32_u8"`.
+    ///
+    /// Returns `(BigInt::ZERO, Some(full_token_text))` as a sentinel for malformed literals where
+    /// no prefix parses (e.g., `0x_u32` where the hex body is empty). Callers treat `Some` suffix
+    /// as an error indicator.
     pub fn numeric_value_and_suffix(
         &self,
         db: &'a dyn Database,
-    ) -> Option<(BigInt, Option<SmolStrId<'a>>)> {
+    ) -> (BigInt, Option<SmolStrId<'a>>) {
         let text = self.text(db).long(db).as_str();
 
         let (text, radix) = if let Some(num_no_prefix) = text.strip_prefix("0x") {
@@ -51,24 +57,16 @@ impl<'a> TerminalLiteralNumber<'a> {
             (text, 10)
         };
 
-        // Catch an edge case, where literal seems to have a suffix that is valid numeric part
-        // according to the radix. Interpret this as an untyped number.
-        // Example: 0x1_f32 is interpreted as 0x1F32 without suffix.
-        if let Ok(value) = BigInt::from_str_radix(text, radix) {
-            Some((value, None))
-        } else {
-            let (text, suffix) = match text.rsplit_once('_') {
-                Some((text, suffix)) => {
-                    let suffix = if suffix.is_empty() { None } else { Some(suffix) };
-                    (text, suffix)
-                }
-                None => (text, None),
-            };
-            Some((
-                BigInt::from_str_radix(text, radix).ok()?,
-                suffix.map(|s| SmolStrId::from(db, s)),
-            ))
+        let mut index = text.len();
+        while index > 0 {
+            if let Ok(value) = BigInt::from_str_radix(&text[..index], radix) {
+                return (value, text.get((index + 1)..).map(|s| SmolStrId::from(db, s)));
+            }
+            index = text[..index].rfind('_').unwrap_or(0);
         }
+        // Malformed token (e.g., `0x_u32`): no numeric prefix found; return full text as suffix
+        // so callers that check `suffix.is_some()` correctly treat this as an error.
+        (BigInt::ZERO, Some(self.text(db)))
     }
 }
 

--- a/crates/cairo-lang-test-plugin/src/test_config.rs
+++ b/crates/cairo-lang-test-plugin/src/test_config.rs
@@ -141,7 +141,15 @@ fn extract_available_gas<'db>(
                 return None;
             }
             ast::Expr::Literal(literal) => {
-                literal.numeric_value(db).and_then(|v| v.to_i64()).and_then(|v| v.to_usize())
+                let (value, suffix) = literal.numeric_value_and_suffix(db);
+                if suffix.is_some() {
+                    diagnostics.push(PluginDiagnostic::error(
+                        literal.stable_ptr(db).untyped(),
+                        "Literals with suffix are not supported as gas values".to_string(),
+                    ));
+                    return None;
+                }
+                value.to_i64().and_then(|v| v.to_usize())
             }
             _ => None,
         },
@@ -174,7 +182,11 @@ fn extract_panic_bytes(db: &dyn Database, attr: &Attribute<'_>) -> Option<Vec<Fe
             for panic_expr in panic_exprs.expressions(db).elements(db) {
                 match panic_expr {
                     ast::Expr::Literal(panic_expr) => {
-                        panic_bytes.push(panic_expr.numeric_value(db).unwrap_or_default().into())
+                        let (value, suffix) = panic_expr.numeric_value_and_suffix(db);
+                        if suffix.is_some() {
+                            return None;
+                        }
+                        panic_bytes.push(value.into());
                     }
                     ast::Expr::ShortString(panic_expr) => {
                         panic_bytes.push(panic_expr.numeric_value(db).unwrap_or_default().into())
@@ -189,7 +201,11 @@ fn extract_panic_bytes(db: &dyn Database, attr: &Attribute<'_>) -> Option<Vec<Fe
         }
         ast::Expr::String(panic_string) => Some(extract_string_panic_bytes(panic_string, db)),
         ast::Expr::Literal(panic_expr) => {
-            Some(vec![panic_expr.numeric_value(db).unwrap_or_default().into()])
+            let (value, suffix) = panic_expr.numeric_value_and_suffix(db);
+            if suffix.is_some() {
+                return None;
+            }
+            Some(vec![value.into()])
         }
         ast::Expr::ShortString(panic_expr) => {
             Some(vec![panic_expr.numeric_value(db).unwrap_or_default().into()])


### PR DESCRIPTION
## Summary

Replaces `numeric_value_and_suffix` returning `Option<(BigInt, Option<SmolStrId>)>` with a direct `(BigInt, Option<SmolStrId>)` return type. The new implementation scans `_`\-separated segments from right to left, finding the longest valid numeric prefix and treating the remainder as the suffix. This correctly handles compound suffixes like `1_u32_u8` (returning value `1` with suffix `"u32_u8"`) and ambiguous radix cases like `0x1_f32` (parsed as hex `0x1F32` with no suffix). Malformed literals such as `0x_u32` return `(BigInt::ZERO, Some(full_token_text))` as a sentinel.

Callers that previously used `.unwrap_or_default()` now receive the value directly and check `suffix.is_some()` to detect errors. The `consteval_int` macro and `available_gas` test attribute now emit explicit diagnostics when a typed (suffixed) literal is used where only plain integers are valid.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous `rsplit_once('_')` approach only split at the last `_`, so compound suffixes like `1_u32_u8` were mishandled — `u32_u8` was not recognized as a suffix, and the numeric parse would silently fail or return a wrong value via `unwrap_or_default()`. Additionally, callers that used `unwrap_or_default()` would silently swallow parse failures rather than surfacing them as diagnostics.

---

## What was the behavior or documentation before?

`numeric_value_and_suffix` returned `Option<(BigInt, Option<SmolStrId>)>`, splitting only at the rightmost `_`. Compound suffixes like `1_u32_u8` were not correctly identified. Callers used `.unwrap_or_default()`, silently producing `0` on failure. The `consteval_int` macro and gas-value extraction did not emit diagnostics for typed literals.

---

## What is the behavior or documentation after?

`numeric_value_and_suffix` returns `(BigInt, Option<SmolStrId>)` directly, scanning from right to left across all `_` boundaries to find the longest valid numeric prefix. Compound suffixes are correctly extracted. The `consteval_int` macro emits `"Literals with suffix are not supported in consteval_int macro"` and `available_gas` emits `"Literals with suffix are not supported as gas values"` when a suffixed literal is encountered.

---

Related issue or discussion (if any)  
  
Fixes #9926

---

## Additional context

New test cases cover `1_u32_u8` and `-1_u32_u8` for compound suffixes in literal parsing, and `consteval_int!(1_u32)` / `consteval_int!(1_u32 + 2)` for typed literals inside the `consteval_int` macro.