### PR TITLE
Link corelib doc references

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/equality-operators.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/equality-operators.adoc
@@ -125,4 +125,4 @@ let bool_comparison = (a < b) == expected;
  
  - Lexer tokens: link:{cairo-repo}/crates/cairo-lang-parser/src/lexer.rs[crates/cairo-lang-parser/src/lexer.rs] (`EqEq`, `Neq`).
  - Operator precedence: link:{cairo-repo}/crates/cairo-lang-parser/src/operators.rs[crates/cairo-lang-parser/src/operators.rs].
- - Trait and behavior: `corelib/src/traits.cairo` (`PartialEq`).
+- Trait and behavior: link:{cairo-repo}/corelib/src/traits.cairo[corelib/src/traits.cairo] (`PartialEq`).

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/error-type.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/error-type.adoc
@@ -57,7 +57,7 @@ The error type `E` is often:
 - An enum describing a small, fixed set of error cases.
 
 For a detailed API overview of `Result`, see
-`corelib/src/result.cairo`.
+link:{cairo-repo}/corelib/src/result.cairo[corelib/src/result.cairo].
 
 == Optional values as errors: `Option`
 
@@ -80,7 +80,7 @@ fn first_even(values: Span<u32>) -> Option<u32> {
 
 When more information about the failure is needed, `Option<T>` can be
 converted into `Result<T, E>` using helpers like `ok_or` and
-`ok_or_else` from `corelib/src/option.cairo`.
+`ok_or_else` from link:{cairo-repo}/corelib/src/option.cairo[corelib/src/option.cairo].
 
 == Unrecoverable errors and `Panic`
 


### PR DESCRIPTION
This PR turns plain corelib path mentions into clickable repository links in `equality-operators.adoc` and `error-type.adoc`.                                                                  
                                                                                                                                                                                                 
  This is necessary because these references were previously non-clickable, which made source verification slower and inconsistent with nearby linked references in the same docs.               
                                                                                                                                                                                                 
  The change is low-risk and correct: it only updates link formatting (no behavioral or semantic doc changes) and uses the existing `link:{cairo-repo}/...` convention to point to the exact canonical files (`traits.cairo`, `result.cairo`, `option.cairo`).   