### PR TITLE
fix(semantic): introduce `NumericLiteral` type variant for numeric literals.

### DIFF
--- a/crates/cairo-lang-doc/src/helpers.rs
+++ b/crates/cairo-lang-doc/src/helpers.rs
@@ -287,6 +287,7 @@ pub fn resolve_type<'db>(
             let item = generic_param_id.generic_item(db);
             resolve_generic_item(item, db)
         }
+        TypeLongId::NumericLiteral(_) => None,
         TypeLongId::Var(type_var) => match type_var.inference_id {
             InferenceId::LookupItemDeclaration(lookup_item_id)
             | InferenceId::LookupItemGenerics(lookup_item_id)

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -812,6 +812,7 @@ fn type_size<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> usize {
         TypeLongId::Coupon(_) => 0,
         TypeLongId::GenericParameter(_)
         | TypeLongId::Var(_)
+        | TypeLongId::NumericLiteral(_)
         | TypeLongId::ImplType(_)
         | TypeLongId::Missing(_) => {
             panic!("Function should only be called with fully concrete types")

--- a/crates/cairo-lang-semantic/src/cache/mod.rs
+++ b/crates/cairo-lang-semantic/src/cache/mod.rs
@@ -1177,7 +1177,7 @@ impl TypeCached {
             TypeLongId::Coupon(func_id) => {
                 TypeCached::Coupon(SemanticFunctionIdCached::new(func_id, ctx))
             }
-            TypeLongId::Var(_) | TypeLongId::Missing(_) => {
+            TypeLongId::Var(_) | TypeLongId::NumericLiteral(_) | TypeLongId::Missing(_) => {
                 unreachable!("type {:?} is not supported for caching", type_id.debug(ctx.db))
             }
         }

--- a/crates/cairo-lang-semantic/src/corelib.rs
+++ b/crates/cairo-lang-semantic/src/corelib.rs
@@ -518,6 +518,7 @@ pub fn unwrap_error_propagation_type<'db>(
         | TypeLongId::Tuple(_)
         | TypeLongId::Snapshot(_)
         | TypeLongId::Var(_)
+        | TypeLongId::NumericLiteral(_)
         | TypeLongId::Coupon(_)
         | TypeLongId::ImplType(_)
         | TypeLongId::Missing(_)
@@ -825,6 +826,29 @@ impl<'db> LiteralError<'db> {
             }
         }
     }
+}
+
+/// Returns whether `ty` is a valid target type for a numeric literal (regardless of the literal's
+/// value). I.e. `validate_literal` would not return [`LiteralError::InvalidTypeForLiteral`].
+pub fn is_valid_literal_type<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> bool {
+    NumericLiteralType::new(db, ty).is_some_and(|ty| match ty {
+        NumericLiteralType::U8
+        | NumericLiteralType::U16
+        | NumericLiteralType::U32
+        | NumericLiteralType::U64
+        | NumericLiteralType::U128
+        | NumericLiteralType::U256
+        | NumericLiteralType::I8
+        | NumericLiteralType::I16
+        | NumericLiteralType::I32
+        | NumericLiteralType::I64
+        | NumericLiteralType::I128
+        | NumericLiteralType::Felt252
+        | NumericLiteralType::ClassHash
+        | NumericLiteralType::ContractAddress
+        | NumericLiteralType::BoundedInt { .. } => true,
+        NumericLiteralType::NonZero(inner) => is_valid_literal_type(db, inner),
+    })
 }
 
 /// Validates that a given type is valid for a literal and that the value fits the range of the

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1488,6 +1488,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     InferenceError::NoNegativeImplsFound(_) => error_code!(E2312),
                     InferenceError::Ambiguity(_) => error_code!(E2313),
                     InferenceError::TypeNotInferred(_) => error_code!(E2314),
+                    InferenceError::InvalidLiteralType(_) => error_code!(E2315),
                 }
             }
         })

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -308,7 +308,7 @@ error[E0006]: Function not found.
   func_call(x);
   ^^^^^^^^^
 
-error[E0002]: Method `member_call` not found on type `?2`. Did you import the correct trait and impl?
+error[E0002]: Method `member_call` not found on type `{numeric}`. Did you import the correct trait and impl?
  --> lib.cairo:7:5
   z.member_call(y);
     ^^^^^^^^^^^
@@ -1526,7 +1526,7 @@ struct S {
 //! > function_body
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::integer::u8", found: "@?0".
+error[E2041]: Unexpected argument type. Expected: "core::integer::u8", found: "@{numeric}".
 It is possible that the type inference failed because the types differ in the number of snapshots.
 Consider adding or removing snapshots.
  --> lib.cairo:6:12

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -3662,15 +3662,12 @@ fn new_literal_expr<'db>(
         }
         return Ok(ExprNumericLiteral { value, ty, stable_ptr });
     };
-    let ty = ctx.resolver.inference().new_type_var(Some(stable_ptr.untyped()));
-
-    // Numeric trait.
-    let trait_id = ctx.db.core_info().numeric_literal_trt;
-    let generic_args = vec![GenericArgumentId::Type(ty)];
-    let concrete_trait_id = semantic::ConcreteTraitLongId { trait_id, generic_args }.intern(ctx.db);
-    let lookup_context = ctx.resolver.impl_lookup_context();
+    // Use a deferred `NumericLiteral` placeholder type. It synthetically satisfies the standard
+    // memory traits (so its `Destruct`/`Drop` can be proven inside trait-solver sandboxes) and
+    // unifies with whatever concrete type later constraints pin it to; if no constraint pins it,
+    // finalization defaults it to `felt252`.
     let inference = &mut ctx.resolver.inference();
-    inference.new_impl_var(concrete_trait_id, Some(stable_ptr.untyped()), lookup_context);
+    let ty = inference.new_integer_literal_type(Some(stable_ptr.untyped()));
 
     Ok(ExprNumericLiteral { value, ty, stable_ptr })
 }
@@ -4028,7 +4025,7 @@ fn member_access_expr<'db>(
         TypeLongId::Closure(_) => {
             Err(ctx.diagnostics.report(rhs_syntax.stable_ptr(db), Unsupported))
         }
-        TypeLongId::Var(_) => Err(ctx.diagnostics.report(
+        TypeLongId::Var(_) | TypeLongId::NumericLiteral(_) => Err(ctx.diagnostics.report(
             rhs_syntax.stable_ptr(db),
             InternalInferenceError(InferenceError::TypeNotInferred(long_ty.intern(ctx.db))),
         )),

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -24,7 +24,7 @@ use salsa::Database;
 
 use self::canonic::{CanonicalImpl, CanonicalMapping, CanonicalTrait, NoError};
 use self::solver::{Ambiguity, SolutionSet, enrich_lookup_context};
-use crate::corelib::CorelibSemantic;
+use crate::corelib::{CorelibSemantic, is_valid_literal_type};
 use crate::diagnostic::{SemanticDiagnosticKind, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::inference::canonic::ResultNoErrEx;
 use crate::expr::inference::conform::InferenceConform;
@@ -42,7 +42,7 @@ use crate::items::generics::{
 };
 use crate::items::imp::{
     GeneratedImplId, GeneratedImplItems, GeneratedImplLongId, ImplId, ImplImplId, ImplLongId,
-    ImplLookupContextId, ImplSemantic, NegativeImplId, NegativeImplLongId,
+    ImplLookupContext, ImplLookupContextId, ImplSemantic, NegativeImplId, NegativeImplLongId,
     UninferredGeneratedImplId, UninferredGeneratedImplLongId, UninferredImpl,
 };
 use crate::items::trt::{
@@ -52,7 +52,7 @@ use crate::items::trt::{
 use crate::substitution::{GenericSubstitution, HasDb, RewriteResult, SemanticRewriter};
 use crate::types::{
     ClosureTypeLongId, ConcreteEnumLongId, ConcreteExternTypeLongId, ConcreteStructLongId,
-    ImplTypeById, ImplTypeId,
+    ImplTypeById, ImplTypeId, get_impl_at_context,
 };
 use crate::{
     ConcreteEnumId, ConcreteExternTypeId, ConcreteFunction, ConcreteImplId, ConcreteImplLongId,
@@ -232,6 +232,8 @@ pub enum InferenceError<'db> {
     NoNegativeImplsFound(ConcreteTraitId<'db>),
     Ambiguity(Ambiguity<'db>),
     TypeNotInferred(TypeId<'db>),
+    /// A numeric literal was bound to a type that does not accept numeric literals.
+    InvalidLiteralType(TypeId<'db>),
 }
 impl<'db> InferenceError<'db> {
     pub fn format(&self, db: &dyn Database) -> String {
@@ -266,19 +268,7 @@ impl<'db> InferenceError<'db> {
             }
             InferenceError::ConstNotInferred => "Failed to infer constant.".into(),
             InferenceError::NoImplsFound(concrete_trait_id) => {
-                let info = db.core_info();
-                let trait_id = concrete_trait_id.trait_id(db);
-                if trait_id == info.numeric_literal_trt {
-                    let generic_type = extract_matches!(
-                        concrete_trait_id.generic_args(db)[0],
-                        GenericArgumentId::Type
-                    );
-                    return format!(
-                        "Mismatched types. The type `{:?}` cannot be created from a numeric \
-                         literal.",
-                        generic_type.debug(db)
-                    );
-                } else if trait_id == info.string_literal_trt {
+                if concrete_trait_id.trait_id(db) == db.core_info().string_literal_trt {
                     let generic_type = extract_matches!(
                         concrete_trait_id.generic_args(db)[0],
                         GenericArgumentId::Type
@@ -313,6 +303,10 @@ impl<'db> InferenceError<'db> {
                     ty1.debug(db)
                 )
             }
+            InferenceError::InvalidLiteralType(ty) => format!(
+                "Mismatched types. The type `{:?}` cannot be created from a numeric literal.",
+                ty.debug(db),
+            ),
         }
     }
 }
@@ -393,6 +387,10 @@ pub struct InferenceData<'db> {
     pub impl_vars_trait_item_mappings: HashMap<LocalImplVarId, ImplVarTraitItemMappings<'db>>,
     /// Type variables.
     pub type_vars: Vec<TypeVar<'db>>,
+    /// Type variables that represent deferred concrete integer types from numeric literals
+    /// (`TypeLongId::NumericLiteral`). At finalization, any of these that remain unassigned are
+    /// defaulted to `felt252`.
+    pub integer_literal_vars: Vec<LocalTypeVarId>,
     /// Const variables.
     pub const_vars: Vec<ConstVar<'db>>,
     /// Impl variables.
@@ -431,6 +429,7 @@ impl<'db> InferenceData<'db> {
             negative_impl_assignment: OrderedHashMap::default(),
             impl_vars_trait_item_mappings: HashMap::new(),
             type_vars: Vec::new(),
+            integer_literal_vars: Vec::new(),
             impl_vars: Vec::new(),
             const_vars: Vec::new(),
             negative_impl_vars: Vec::new(),
@@ -505,6 +504,7 @@ impl<'db> InferenceData<'db> {
                 })
                 .collect(),
             type_vars: inference_id_replacer.rewrite(self.type_vars.clone()).no_err(),
+            integer_literal_vars: self.integer_literal_vars.clone(),
             const_vars: inference_id_replacer.rewrite(self.const_vars.clone()).no_err(),
             impl_vars: inference_id_replacer.rewrite(self.impl_vars.clone()).no_err(),
             negative_impl_vars: inference_id_replacer
@@ -535,6 +535,7 @@ impl<'db> InferenceData<'db> {
             negative_impl_assignment: self.negative_impl_assignment.clone(),
             impl_vars_trait_item_mappings: self.impl_vars_trait_item_mappings.clone(),
             type_vars: self.type_vars.clone(),
+            integer_literal_vars: self.integer_literal_vars.clone(),
             const_vars: self.const_vars.clone(),
             impl_vars: self.impl_vars.clone(),
             negative_impl_vars: self.negative_impl_vars.clone(),
@@ -619,6 +620,19 @@ impl<'db, 'id> Inference<'db, 'id> {
         TypeLongId::Var(var).intern(self.db)
     }
 
+    /// Allocates a new [TypeVar] wrapped in a [`TypeLongId::NumericLiteral`] placeholder for a
+    /// numeric literal whose type is not yet known. The synthetic-impl machinery treats this
+    /// placeholder as satisfying `Drop`/`Copy`/`Destruct`/`PanicDestruct`, and finalization
+    /// defaults any still-unbound variant to `felt252`.
+    pub fn new_integer_literal_type(
+        &mut self,
+        stable_ptr: Option<SyntaxStablePtrId<'db>>,
+    ) -> TypeId<'db> {
+        let var = self.new_type_var_raw(stable_ptr);
+        self.data.integer_literal_vars.push(var.id);
+        TypeLongId::NumericLiteral(var).intern(self.db)
+    }
+
     /// Allocates a new [TypeVar] for an unknown type that needs to be inferred.
     /// Returns the variable id.
     pub fn new_type_var_raw(&mut self, stable_ptr: Option<SyntaxStablePtrId<'db>>) -> TypeVar<'db> {
@@ -641,7 +655,7 @@ impl<'db, 'id> Inference<'db, 'id> {
             .iter()
             .filter_map(|(impl_type, ty)| {
                 let rewritten_type = self.rewrite(ty.long(self.db).clone()).no_err();
-                if !matches!(rewritten_type, TypeLongId::Var(_)) {
+                if !matches!(rewritten_type, TypeLongId::Var(_) | TypeLongId::NumericLiteral(_)) {
                     return Some(((*impl_type).into(), rewritten_type.intern(self.db)));
                 }
                 // conformed the var type to the original impl type to remove it from the pending
@@ -855,29 +869,28 @@ impl<'db, 'id> Inference<'db, 'id> {
         if self.error_status.is_err() {
             return Err(ErrorSet);
         }
-        let info = self.db.core_info();
-        let numeric_trait_id = info.numeric_literal_trt;
-        let felt_ty = info.felt252;
+        let felt_ty = self.db.core_info().felt252;
 
-        // Conform all uninferred numeric literals to felt252.
+        // Default any still-unbound `NumericLiteral` type variables to `felt252`. We do this one
+        // var at a time and re-solve between each, mirroring the old behavior for
+        // `NumericLiteral<Var>`: defaulting the first literal can constrain other literals
+        // through trait resolution (e.g., `0.pow(0)` — defaulting the receiver lets `Pow<T, Exp>`
+        // resolve, which then constrains the exponent to `usize`, avoiding a felt252 default for
+        // the second literal).
         loop {
-            let mut changed = false;
             self.solve()?;
-            for (var, _) in self.ambiguous.clone() {
-                let impl_var = self.impl_var(var).clone();
-                if impl_var.concrete_trait_id.trait_id(self.db) != numeric_trait_id {
+            let mut changed = false;
+            for var_id in self.data.integer_literal_vars.clone() {
+                if self.type_assignment.contains_key(&var_id) {
                     continue;
                 }
-                // Uninferred numeric trait. Resolve as felt252.
-                let ty = extract_matches!(
-                    impl_var.concrete_trait_id.generic_args(self.db)[0],
-                    GenericArgumentId::Type
-                );
-                if self.rewrite(ty).no_err() == felt_ty {
+                let var = self.type_vars[var_id.0];
+                let placeholder = TypeLongId::NumericLiteral(var).intern(self.db);
+                if self.rewrite(placeholder).no_err() == felt_ty {
                     continue;
                 }
-                self.conform_ty(ty, felt_ty).inspect_err(|_err_set| {
-                    self.add_error_stable_ptr(InferenceVar::Impl(impl_var.id));
+                self.conform_ty(placeholder, felt_ty).inspect_err(|_err_set| {
+                    self.add_error_stable_ptr(InferenceVar::Type(var_id));
                 })?;
                 changed = true;
                 break;
@@ -890,6 +903,31 @@ impl<'db, 'id> Inference<'db, 'id> {
             self.pending.is_empty(),
             "pending should all be solved by this point. Guaranteed by solve()."
         );
+
+        // Defensive backstop: every invalid `IntegerLiteral` binding should already have been
+        // caught at conform-time by `bind_integer_literal`.
+        for var_id in self.data.integer_literal_vars.clone() {
+            let Some(bound) = self.type_assignment.get(&var_id).copied() else {
+                continue;
+            };
+            let bound = self.rewrite(bound).no_err();
+            if !bound.is_var_free(self.db) || is_valid_literal_type(self.db, bound) {
+                continue;
+            }
+            let err = self.set_error(InferenceError::InvalidLiteralType(bound));
+            self.add_error_stable_ptr(InferenceVar::Type(var_id));
+            return Err(err);
+        }
+
+        // Persist rewriter substitutions of synthetic `NumericLiteral`-over-mem-trait
+        // `GeneratedImpl`s into `impl_assignment` so subsequent queries see the natural impl.
+        let assignments: Vec<_> = self.impl_assignment.iter().map(|(k, v)| (*k, *v)).collect();
+        for (var_id, impl_id) in assignments {
+            let rewritten = self.rewrite(impl_id).no_err();
+            if rewritten != impl_id {
+                self.impl_assignment.insert(var_id, rewritten);
+            }
+        }
 
         let Some((var, err)) = self.first_undetermined_variable() else {
             return Ok(());
@@ -1206,7 +1244,10 @@ impl<'db, 'id> Inference<'db, 'id> {
             matches!(
                 garg,
                 GenericArgumentId::Type(ty)
-                if !matches!(ty.long(self.db), TypeLongId::Closure(_))
+                if !matches!(
+                    ty.long(self.db),
+                    TypeLongId::Closure(_) | TypeLongId::NumericLiteral(_)
+                )
                 && !ty.is_var_free(self.db)
             )
         }) {
@@ -1268,7 +1309,8 @@ impl<'db, 'id> Inference<'db, 'id> {
                 let GenericArgumentId::Type(ty) = garg else {
                     panic!("Expected a type variable");
                 };
-                let TypeLongId::Var(var) = ty.long(self.db) else {
+                let (TypeLongId::Var(var) | TypeLongId::NumericLiteral(var)) = ty.long(self.db)
+                else {
                     panic!("Expected a type variable");
                 };
                 self.type_assignment
@@ -1534,7 +1576,7 @@ impl<'db, 'mt> SemanticRewriter<NegativeImplId<'db>, NoError> for Inference<'db,
 impl<'db, 'mt> SemanticRewriter<TypeLongId<'db>, NoError> for Inference<'db, 'mt> {
     fn internal_rewrite(&mut self, value: &mut TypeLongId<'db>) -> Result<RewriteResult, NoError> {
         match value {
-            TypeLongId::Var(var) => {
+            TypeLongId::Var(var) | TypeLongId::NumericLiteral(var) => {
                 if let Some(type_id) = self.type_assignment.get(&var.id) {
                     let mut long_type_id = type_id.long(self.db).clone();
                     if let RewriteResult::Modified = self.internal_rewrite(&mut long_type_id)? {
@@ -1659,6 +1701,39 @@ impl<'db, 'mt> SemanticRewriter<ImplLongId<'db>, NoError> for Inference<'db, 'mt
                     *value = long_impl_id;
                     return Ok(RewriteResult::Modified);
                 }
+            }
+            ImplLongId::GeneratedImpl(generated) => {
+                // Recurse into the generated impl's fields first so the inner type is rewritten.
+                let inner_result = generated.default_rewrite(self)?;
+                let concrete_trait = generated.concrete_trait(self.db);
+                if let Some(GenericArgumentId::Type(first_ty)) =
+                    concrete_trait.generic_args(self.db).first().copied()
+                    && !matches!(
+                        first_ty.long(self.db),
+                        TypeLongId::Closure(_)
+                            | TypeLongId::Var(_)
+                            | TypeLongId::NumericLiteral(_)
+                            | TypeLongId::ImplType(_)
+                    )
+                {
+                    let info = self.db.core_info();
+                    let trait_id = concrete_trait.trait_id(self.db);
+                    if [info.drop_trt, info.copy_trt, info.destruct_trt, info.panic_destruct_trt]
+                        .contains(&trait_id)
+                    {
+                        // The synthetic NumericLiteral candidate produced this GeneratedImpl;
+                        // now that the inner type is concrete, replace it with the natural impl.
+                        let lookup_context =
+                            ImplLookupContext::new_from_type(first_ty, self.db).intern(self.db);
+                        if let Ok(real_impl) =
+                            get_impl_at_context(self.db, lookup_context, concrete_trait, None)
+                        {
+                            *value = real_impl.long(self.db).clone();
+                            return Ok(RewriteResult::Modified);
+                        }
+                    }
+                }
+                return Ok(inner_result);
             }
             ImplLongId::ImplImpl(impl_impl_id) => {
                 let impl_impl_id_rewrite_result = self.internal_rewrite(impl_impl_id)?;

--- a/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
@@ -233,7 +233,9 @@ impl<'db> SemanticRewriter<TypeId<'db>, NoError> for Canonicalizer<'db> {
 }
 impl<'db> SemanticRewriter<TypeLongId<'db>, NoError> for Canonicalizer<'db> {
     fn internal_rewrite(&mut self, value: &mut TypeLongId<'db>) -> Result<RewriteResult, NoError> {
-        let TypeLongId::Var(var) = value else {
+        // Both `Var` and `NumericLiteral` wrap a `TypeVar` whose `LocalTypeVarId` must be remapped
+        // to canonical form. The variant tag itself is preserved.
+        let (TypeLongId::Var(var) | TypeLongId::NumericLiteral(var)) = value else {
             return value.default_rewrite(self);
         };
         if var.inference_id != self.to_canonic.source_inference_id {
@@ -381,17 +383,24 @@ impl<'db> SemanticRewriter<TypeId<'db>, NoError> for Embedder<'db, '_, '_> {
 }
 impl<'db> SemanticRewriter<TypeLongId<'db>, NoError> for Embedder<'db, '_, '_> {
     fn internal_rewrite(&mut self, value: &mut TypeLongId<'db>) -> Result<RewriteResult, NoError> {
-        let TypeLongId::Var(var) = value else {
+        // Both `Var` and `NumericLiteral` wrap a `TypeVar`; the embedded form preserves the
+        // outer variant while allocating a fresh local id in the target inference's type-var
+        // table.
+        let is_numeric_literal = matches!(value, TypeLongId::NumericLiteral(_));
+        let (TypeLongId::Var(var) | TypeLongId::NumericLiteral(var)) = value else {
             return value.default_rewrite(self);
         };
         if var.inference_id != InferenceId::Canonical {
             return value.default_rewrite(self);
         }
-        let new_id = self
-            .from_canonic
-            .type_var_mapping
-            .entry(var.id)
-            .or_insert_with(|| self.inference.new_type_var_raw(None).id);
+        let new_id = self.from_canonic.type_var_mapping.entry(var.id).or_insert_with(|| {
+            let new_id = self.inference.new_type_var_raw(None).id;
+            // Register the embedded NumericLiteral so finalization can default it to felt252.
+            if is_numeric_literal {
+                self.inference.data.integer_literal_vars.push(new_id);
+            }
+            new_id
+        });
         *var = self.inference.type_vars[new_id.0];
         Ok(RewriteResult::Modified)
     }
@@ -532,7 +541,9 @@ impl<'db> SemanticRewriter<TypeLongId<'db>, MapperError> for Mapper<'db, '_> {
         &mut self,
         value: &mut TypeLongId<'db>,
     ) -> Result<RewriteResult, MapperError> {
-        let TypeLongId::Var(var) = value else {
+        // Both `Var` and `NumericLiteral` wrap a `TypeVar` whose local id must be mapped through
+        // the variable mapping.
+        let (TypeLongId::Var(var) | TypeLongId::NumericLiteral(var)) = value else {
             return value.default_rewrite(self);
         };
         let id = self

--- a/crates/cairo-lang-semantic/src/expr/inference/conform.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/conform.rs
@@ -12,7 +12,7 @@ use super::{
     ErrorSet, ImplVarId, ImplVarTraitItemMappings, Inference, InferenceError, InferenceResult,
     InferenceVar, LocalTypeVarId, TypeVar,
 };
-use crate::corelib::never_ty;
+use crate::corelib::{is_valid_literal_type, never_ty};
 use crate::diagnostic::{SemanticDiagnosticKind, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::items::constant::{ConstValue, ConstValueId, ImplConstantId};
 use crate::items::functions::{GenericFunctionId, ImplGenericFunctionId};
@@ -119,15 +119,29 @@ impl<'db> InferenceConform<'db> for Inference<'db, '_> {
         let long_ty1 = ty1.long(self.db);
         match long_ty1 {
             TypeLongId::Var(var) => return Ok((self.assign_ty(*var, ty0)?, 0)),
+            // Conforming `ty0 -> NumericLiteral(var)`. If `ty0` is also an NumericLiteral or a
+            // Var, fall through so the `long_ty0` match below handles the unification.
+            TypeLongId::NumericLiteral(var)
+                if !matches!(
+                    ty0.long(self.db),
+                    TypeLongId::Var(_) | TypeLongId::NumericLiteral(_)
+                ) =>
+            {
+                return self.bind_integer_literal(*var, ty0);
+            }
             TypeLongId::Missing(_) => return Ok((ty1, 0)),
             TypeLongId::Snapshot(inner_ty) if ty0_is_self => {
                 if *inner_ty == ty0 {
                     return Ok((ty1, 1));
                 }
-                if !matches!(ty0.long(self.db), TypeLongId::Snapshot(_))
-                    && let TypeLongId::Var(var) = inner_ty.long(self.db)
-                {
-                    return Ok((self.assign_ty(*var, ty0)?, 1));
+                if !matches!(ty0.long(self.db), TypeLongId::Snapshot(_)) {
+                    if let TypeLongId::Var(var) = inner_ty.long(self.db) {
+                        return Ok((self.assign_ty(*var, ty0)?, 1));
+                    }
+                    if let TypeLongId::NumericLiteral(var) = ty0.long(self.db) {
+                        let (bound, n) = self.bind_integer_literal(*var, *inner_ty)?;
+                        return Ok((bound, n + 1));
+                    }
                 }
             }
             TypeLongId::ImplType(impl_type) => {
@@ -219,6 +233,20 @@ impl<'db> InferenceConform<'db> for Inference<'db, '_> {
                 Err(self.set_error(InferenceError::TypeKindMismatch { ty0, ty1 }))
             }
             TypeLongId::Var(var) => Ok((self.assign_ty(*var, ty1)?, 0)),
+            TypeLongId::NumericLiteral(var) => {
+                // Conforming `NumericLiteral(var) -> ty1`.
+                match long_ty1 {
+                    // Same kind: unify the two integer-literal placeholders by binding their
+                    // underlying type vars.
+                    TypeLongId::NumericLiteral(var2) => Ok((
+                        self.assign_ty(*var, TypeLongId::NumericLiteral(*var2).intern(self.db))?,
+                        0,
+                    )),
+                    // `ty1` is a bare Var: let it bind to the NumericLiteral.
+                    TypeLongId::Var(other) => Ok((self.assign_ty(*other, ty0)?, 0)),
+                    _ => self.bind_integer_literal(*var, ty1),
+                }
+            }
             TypeLongId::ImplType(impl_type) => {
                 if let Some(ty) = self.impl_type_bounds.get(&(*impl_type).into()) {
                     return self.conform_ty_ex(*ty, ty1, ty0_is_self);
@@ -597,6 +625,23 @@ impl<'db> InferenceConform<'db> for Inference<'db, '_> {
 }
 
 impl<'db> Inference<'db, '_> {
+    /// Binds an `IntegerLiteral`'s inner type variable to `ty`. If `ty` is not a type that
+    /// accepts numeric literals (felt252, primitive integers, `NonZero<…>`, bounded ints …),
+    /// raises `InvalidLiteralType` so the conform-site caller — not the literal site — reports
+    /// the diagnostic.
+    fn bind_integer_literal(
+        &mut self,
+        var: TypeVar<'db>,
+        ty: TypeId<'db>,
+    ) -> InferenceResult<(TypeId<'db>, usize)> {
+        let bound = self.assign_ty(var, ty)?;
+        let rewritten = self.rewrite(bound).no_err();
+        if !rewritten.is_var_free(self.db) || is_valid_literal_type(self.db, rewritten) {
+            return Ok((bound, 0));
+        }
+        Err(self.set_error(InferenceError::InvalidLiteralType(rewritten)))
+    }
+
     /// Reduces an impl type to a concrete type.
     pub fn reduce_impl_ty(
         &mut self,
@@ -800,7 +845,7 @@ impl<'db> Inference<'db, '_> {
             }
             TypeLongId::Tuple(tys) => tys.iter().any(|ty| self.internal_ty_contains_var(*ty, var)),
             TypeLongId::Snapshot(ty) => self.internal_ty_contains_var(*ty, var),
-            TypeLongId::Var(ty_var) => {
+            TypeLongId::Var(ty_var) | TypeLongId::NumericLiteral(ty_var) => {
                 if InferenceVar::Type(ty_var.id) == var {
                     return true;
                 }

--- a/crates/cairo-lang-semantic/src/expr/inference/solver.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/solver.rs
@@ -6,6 +6,7 @@ use cairo_lang_defs::ids::{GenericParamId, LanguageElementId};
 use cairo_lang_proc_macros::SemanticObject;
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::Entry;
+use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use itertools::{Itertools, chain, zip_eq};
 use salsa::Database;
 
@@ -20,7 +21,7 @@ use crate::items::constant::{ConstValue, ConstValueId, ImplConstantId};
 use crate::items::imp::{
     ImplId, ImplImplId, ImplLongId, ImplLookupContext, ImplLookupContextId, ImplSemantic,
     UninferredImpl, UninferredImplById, find_candidates_at_context,
-    find_closure_generated_candidate,
+    find_closure_generated_candidate, find_integer_literal_generated_candidate,
 };
 use crate::items::trt::TraitSemantic;
 use crate::substitution::{GenericSubstitution, SemanticRewriter};
@@ -205,9 +206,19 @@ fn solve_canonical_trait<'db>(
     impl_type_bounds: Arc<BTreeMap<ImplTypeById<'db>, TypeId<'db>>>,
 ) -> SolutionSet<'db, CanonicalImpl<'db>> {
     let filter = canonical_trait.id.filter(db);
-    let mut candidates = find_candidates_at_context(db, lookup_context, filter).unwrap_or_default();
-    find_closure_generated_candidate(db, canonical_trait.id)
-        .map(|candidate| candidates.insert(UninferredImplById(candidate)));
+    // For `NumericLiteral` target types with Drop/Copy/Destruct/PanicDestruct, only the
+    // synthetic candidate should match. Otherwise concrete-headed candidates like `felt252Drop`
+    // would "claim" the integer literal and default its type via trait resolution.
+    let candidates = if let Some(integer_literal_candidate) =
+        find_integer_literal_generated_candidate(db, canonical_trait.id)
+    {
+        OrderedHashSet::from_iter([UninferredImplById(integer_literal_candidate)])
+    } else {
+        let mut set = find_candidates_at_context(db, lookup_context, filter).unwrap_or_default();
+        find_closure_generated_candidate(db, canonical_trait.id)
+            .map(|candidate| set.insert(UninferredImplById(candidate)));
+        set
+    };
 
     let mut unique_solution: Option<CanonicalImpl<'_>> = None;
     for candidate in candidates.into_iter() {
@@ -562,7 +573,7 @@ impl<'db> LiteInference<'db> {
         }
         let target_long_ty = target_ty.long(self.db);
 
-        if let TypeLongId::Var(_) = target_long_ty {
+        if let TypeLongId::Var(_) | TypeLongId::NumericLiteral(_) = target_long_ty {
             return CanConformResult::InferenceRequired;
         }
 
@@ -692,6 +703,7 @@ impl<'db> LiteInference<'db> {
             }
             (
                 TypeLongId::Var(_)
+                | TypeLongId::NumericLiteral(_)
                 | TypeLongId::ImplType(_)
                 | TypeLongId::Missing(_)
                 | TypeLongId::Coupon(_),

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/if
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/if
@@ -223,7 +223,7 @@ If(
                     tail: Some(
                         FunctionCall(
                             ExprFunctionCall {
-                                function: ?2::add,
+                                function: ?1::add,
                                 args: [
                                     Value(
                                         Literal(

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/loop
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/loop
@@ -179,7 +179,7 @@ Loop(
                                                     expr_option: Some(
                                                         FunctionCall(
                                                             ExprFunctionCall {
-                                                                function: ?2::add,
+                                                                function: ?1::add,
                                                                 args: [
                                                                     Value(
                                                                         Literal(

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/match
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/match
@@ -543,7 +543,7 @@ Match(
                 ],
                 expression: FunctionCall(
                     ExprFunctionCall {
-                        function: ?2::add,
+                        function: ?1::add,
                         args: [
                             Value(
                                 Literal(
@@ -647,7 +647,7 @@ Match(
                 ],
                 expression: FunctionCall(
                     ExprFunctionCall {
-                        function: ?1::add,
+                        function: ?0::add,
                         args: [
                             Value(
                                 Var(
@@ -748,7 +748,7 @@ Match(
                 ],
                 expression: FunctionCall(
                     ExprFunctionCall {
-                        function: ?2::add,
+                        function: ?1::add,
                         args: [
                             Value(
                                 Var(

--- a/crates/cairo-lang-semantic/src/expr/test_data/assignment
+++ b/crates/cairo-lang-semantic/src/expr/test_data/assignment
@@ -116,7 +116,7 @@ fn foo() {
 foo
 
 //! > expected_diagnostics
-error[E2311]: Mismatched types. The type `core::byte_array::ByteArray` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `core::byte_array::ByteArray` cannot be created from a numeric literal.
  --> lib.cairo:2:25
     let _x: ByteArray = 252;
                         ^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -247,10 +247,10 @@ error[E2125]: The '?' operator is not supported outside of functions.
     Option::<felt252>::Some(0)?
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: core::traits::Add::<core::bool>.
- --> lib.cairo:6:42
+error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+ --> lib.cairo:6:1
 const WRONG_TYPE_AND_NOT_LITERAL: bool = 1 + 2;
-                                         ^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2127]: This expression is not supported as constant.
  --> lib.cairo:14:47
@@ -307,10 +307,10 @@ foo
 const DEFAULT_VAR: bool = 1;
 
 //! > expected_diagnostics
-error[E2311]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
- --> lib.cairo:1:27
+error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+ --> lib.cairo:1:1
 const DEFAULT_VAR: bool = 1;
-                          ^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
+++ b/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
@@ -54,12 +54,12 @@ fn foo() {
 foo
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[?1; 3]".
+error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[{numeric}; 3]".
  --> lib.cairo:2:24
     let _x: [u32; 2] = [1, 2, 3];
                        ^^^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[?6; 3]".
+error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[{numeric}; 3]".
  --> lib.cairo:3:24
     let _x: [u32; 2] = [1; 3];
                        ^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/function_call
+++ b/crates/cairo-lang-semantic/src/expr/test_data/function_call
@@ -166,6 +166,11 @@ error[E0006]: Function not found.
     bar(0);
     ^^^
 
+error[E2315]: Mismatched types. The type `test::MyStruct` cannot be created from a numeric literal.
+ --> lib.cairo:13:9
+    d + 0;
+        ^
+
 error[E0002]: Method `bar` not found on type `test::MyStruct`. Did you import the correct trait and impl?
  --> lib.cairo:15:7
     d.bar();
@@ -176,11 +181,6 @@ Candidate `test::MyTrait::baz` inference failed with: Trait has no implementatio
  --> lib.cairo:16:7
     d.baz();
       ^^^
-
-error[E2311]: Trait has no implementation in context: core::traits::Add::<test::MyStruct>.
- --> lib.cairo:13:5
-    d + 0;
-    ^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/if
+++ b/crates/cairo-lang-semantic/src/expr/test_data/if
@@ -22,6 +22,14 @@ error[E2055]: Condition has type "core::felt252", expected bool.
     if x {
        ^
 
+error[E2056]: If blocks have incompatible types: "core::bool" and "{numeric}"
+ --> lib.cairo:3:5-7:5
+      if x {
+ _____^
+| ...
+|     }
+|_____^
+
 error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
  --> lib.cairo:1:10-8:1
   fn foo() {

--- a/crates/cairo-lang-semantic/src/expr/test_data/literal
+++ b/crates/cairo-lang-semantic/src/expr/test_data/literal
@@ -79,3 +79,145 @@ error[E2006]: Unknown type.
  --> lib.cairo:2:14
     let _x = -1_u32_u8;
              ^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Unsuffixed numeric literal defaults to felt252.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {
+    let x = 5;
+    let _y: felt252 = x;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Unsuffixed numeric literal infers from explicit type ascription.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {
+    let x: u32 = 5;
+    let _y: u32 = x;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Array of unsuffixed literals unifies with one suffixed element.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {
+    let _arr: Array<u32> = array![0, 1, 2_u32];
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Unsuffixed literals support `Drop` and `Copy` without explicit suffix.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {
+    let mut total: u32 = 0;
+    for (k, v) in array![0, 1, 2].into_iter().enumerate() {
+        total = total + k + v;
+    };
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Numeric literal cannot be bound to a non-numeric type via let ascription.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _x: ByteArray = 252;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2315]: Mismatched types. The type `core::byte_array::ByteArray` cannot be created from a numeric literal.
+ --> lib.cairo:2:25
+    let _x: ByteArray = 252;
+                        ^^^
+
+//! > ==========================================================================
+
+//! > Numeric literal cannot be bound to `bool`.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _x: bool = 5;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+ --> lib.cairo:2:20
+    let _x: bool = 5;
+                   ^
+
+//! > ==========================================================================
+
+//! > Issue #6486: diagnostic for an integer-literal tail in a unit-returning function points at the
+
+//! > tail/function-body span, not at the literal's `let` binding.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn incorrect_return_type() {
+    let x = 5;
+    x
+}
+
+//! > function_name
+incorrect_return_type
+
+//! > expected_diagnostics
+error[E2315]: Mismatched types. The type `()` cannot be created from a numeric literal.
+ --> lib.cairo:1:28-4:1
+  fn incorrect_return_type() {
+ ____________________________^
+| ...
+| }
+|_^

--- a/crates/cairo-lang-semantic/src/expr/test_data/loop
+++ b/crates/cairo-lang-semantic/src/expr/test_data/loop
@@ -18,7 +18,7 @@ fn foo() {
 foo
 
 //! > expected_diagnostics
-error[E2311]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+error[E2056]: Loop has incompatible return types: "core::bool" and "{numeric}"
  --> lib.cairo:6:19
             break 0;
                   ^
@@ -45,6 +45,11 @@ fn foo(x: Option<()>) {
 foo
 
 //! > expected_diagnostics
+error[E2056]: Loop has incompatible return types: "core::bool" and "{numeric}"
+ --> lib.cairo:6:19
+            break 0;
+                  ^
+
 error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
  --> lib.cairo:1:23-9:1
   fn foo(x: Option<()>) {

--- a/crates/cairo-lang-semantic/src/expr/test_data/match
+++ b/crates/cairo-lang-semantic/src/expr/test_data/match
@@ -26,6 +26,11 @@ enum A {
 }
 
 //! > expected_diagnostics
+error[E2315]: Mismatched types. The type `test::A` cannot be created from a numeric literal.
+ --> lib.cairo:9:10
+        (7, 1) => { x },
+         ^
+
 error[E0006]: Identifier not found.
  --> lib.cairo:9:21
         (7, 1) => { x },
@@ -40,11 +45,6 @@ error[E0006]: Identifier not found.
  --> lib.cairo:10:30
         (A::b(x), 1, _) => { x },
                              ^
-
-error[E2311]: Mismatched types. The type `test::A` cannot be created from a numeric literal.
- --> lib.cairo:9:10
-        (7, 1) => { x },
-         ^
 
 //! > ==========================================================================
 
@@ -71,6 +71,11 @@ enum A {
 }
 
 //! > expected_diagnostics
+error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+ --> lib.cairo:6:15
+    match a + 1 {
+              ^
+
 error[E2109]: Wrong enum in pattern. Expected: "bool". Got: "A".
  --> lib.cairo:7:9
         A::a(_) => 0,
@@ -80,11 +85,6 @@ error[E2109]: Wrong enum in pattern. Expected: "bool". Got: "A".
  --> lib.cairo:8:9
         A::b(_) => 1,
         ^^^^^^^
-
-error[E2311]: Trait has no implementation in context: core::traits::Add::<core::bool>.
- --> lib.cairo:6:11
-    match a + 1 {
-          ^^^^^
 
 //! > ==========================================================================
 
@@ -170,6 +170,11 @@ fn foo(x: Option<()>) {
 foo
 
 //! > expected_diagnostics
+error[E2056]: Match arms have incompatible types: "core::bool" and "{numeric}"
+ --> lib.cairo:4:17
+        None => 0,
+                ^
+
 error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
  --> lib.cairo:1:23-6:1
   fn foo(x: Option<()>) {

--- a/crates/cairo-lang-semantic/src/expr/test_data/pattern
+++ b/crates/cairo-lang-semantic/src/expr/test_data/pattern
@@ -248,7 +248,7 @@ fn foo(s: [felt252; 3]) {
 foo
 
 //! > expected_diagnostics
-error[E2056]: If blocks have incompatible types: "()" and "(core::array::Array::<(?3, ?4, ?5)>,)"
+error[E2056]: If blocks have incompatible types: "()" and "(core::array::Array::<({numeric}, {numeric}, {numeric})>,)"
  --> lib.cairo:2:25-4:5
       let (unresolved,) = if true {} else {
  _________________________^
@@ -463,6 +463,11 @@ foo
 //! > module_code
 
 //! > expected_diagnostics
+error[E2315]: Mismatched types. The type `core::array::Span::<core::integer::u32>` cannot be created from a numeric literal.
+ --> lib.cairo:4:9
+        5 => 0,
+        ^
+
 error[E2103]: Mismatched types: pattern cannot match against type "core::array::Span::<core::integer::u32>".
  --> lib.cairo:5:9
         (a, b) => *a + *b,
@@ -492,8 +497,3 @@ error[E2135]: Type `<missing>` cannot be dereferenced
  --> lib.cairo:6:20
         Some(a) => *a,
                    ^
-
-error[E2311]: Mismatched types. The type `core::array::Span::<core::integer::u32>` cannot be created from a numeric literal.
- --> lib.cairo:4:9
-        5 => 0,
-        ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/snapshot
+++ b/crates/cairo-lang-semantic/src/expr/test_data/snapshot
@@ -37,7 +37,12 @@ fn foo() {
 foo
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "@?1".
+error[E2315]: Mismatched types. The type `@core::felt252` cannot be created from a numeric literal.
+ --> lib.cairo:2:24
+    let _x: @felt252 = 5;
+                       ^
+
+error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "@{numeric}".
 It is possible that the type inference failed because the types differ in the number of snapshots.
 Consider adding or removing snapshots.
  --> lib.cairo:3:23

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -1666,7 +1666,7 @@ fn get_inner_types<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> Maybe<Vec<Typ
         TypeLongId::GenericParameter(_) => {
             return Err(skip_diagnostic());
         }
-        TypeLongId::Var(_) | TypeLongId::ImplType(_) => {
+        TypeLongId::Var(_) | TypeLongId::NumericLiteral(_) | TypeLongId::ImplType(_) => {
             panic!("Types should be fully resolved at this point.")
         }
         TypeLongId::Coupon(_) => vec![],
@@ -2258,6 +2258,39 @@ pub fn find_closure_generated_candidate<'db>(
             concrete_trait,
             generic_params,
             impl_items: GeneratedImplItems(impl_items),
+        }
+        .intern(db),
+    ))
+}
+
+/// Finds the synthetic generated candidate for a numeric-literal placeholder type
+/// (`TypeLongId::NumericLiteral`). The placeholder always satisfies `Drop`, `Copy`, `Destruct`,
+/// and `PanicDestruct` (these are the memory traits which the trait solver must be able to
+/// discharge for the literal's containing expression to type-check while the literal's concrete
+/// type is still being inferred). All other traits — including `NumericLiteral<T>` — are left to
+/// the normal solver path once the placeholder is conformed to a concrete type.
+pub fn find_integer_literal_generated_candidate<'db>(
+    db: &'db dyn Database,
+    concrete_trait_id: ConcreteTraitId<'db>,
+) -> Option<UninferredImpl<'db>> {
+    let GenericArgumentId::Type(ty) = *concrete_trait_id.generic_args(db).first()? else {
+        return None;
+    };
+    if !matches!(ty.long(db), TypeLongId::NumericLiteral(_)) {
+        return None;
+    }
+    let info = db.core_info();
+    let trait_id = concrete_trait_id.trait_id(db);
+    if ![info.drop_trt, info.copy_trt, info.destruct_trt, info.panic_destruct_trt]
+        .contains(&trait_id)
+    {
+        return None;
+    }
+    Some(UninferredImpl::GeneratedImpl(
+        UninferredGeneratedImplLongId {
+            concrete_trait: concrete_trait_id,
+            generic_params: vec![],
+            impl_items: GeneratedImplItems(Default::default()),
         }
         .intern(db),
     ))

--- a/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
+++ b/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
@@ -12,7 +12,7 @@ fn foo() {
 foo
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "(?0, ?1)".
+error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "({numeric}, {numeric})".
  --> lib.cairo:2:22
     let _: felt252 = (3, 3);
                      ^^^^^^

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -50,6 +50,12 @@ pub enum TypeLongId<'db> {
     Snapshot(TypeId<'db>),
     GenericParameter(GenericParamId<'db>),
     Var(TypeVar<'db>),
+    /// A deferred concrete integer type. A placeholder produced by numeric literal expressions.
+    /// Always satisfies `Drop`, `Copy`, `Destruct`, `PanicDestruct` (via a synthetic generated
+    /// impl). Can be unified with any type that accepts numeric literals (felt252, primitive
+    /// integers, `NonZero<…>`, bounded ints), and defaults to `felt252` if still unbound at
+    /// inference finalization.
+    NumericLiteral(TypeVar<'db>),
     Coupon(FunctionId<'db>),
     FixedSizeArray {
         type_id: TypeId<'db>,
@@ -133,6 +139,7 @@ impl<'db> TypeLongId<'db> {
             TypeLongId::FixedSizeArray { .. } => TypeHead::FixedSizeArray,
             TypeLongId::GenericParameter(generic_param_id) => TypeHead::Generic(*generic_param_id),
             TypeLongId::Var(_)
+            | TypeLongId::NumericLiteral(_)
             | TypeLongId::Missing(_)
             | TypeLongId::ImplType(_)
             | TypeLongId::Closure(_) => {
@@ -175,6 +182,7 @@ impl<'db> TypeLongId<'db> {
             TypeLongId::Snapshot(_)
             | TypeLongId::GenericParameter(_)
             | TypeLongId::Var(_)
+            | TypeLongId::NumericLiteral(_)
             | TypeLongId::Coupon(_)
             | TypeLongId::ImplType(_)
             | TypeLongId::Missing(_)
@@ -192,6 +200,7 @@ impl<'db> TypeLongId<'db> {
             }
             TypeLongId::GenericParameter(_) => None,
             TypeLongId::Var(_) => None,
+            TypeLongId::NumericLiteral(_) => None,
             TypeLongId::Coupon(function_id) => {
                 function_id.get_concrete(db).generic_function.module_id(db)
             }
@@ -235,6 +244,7 @@ impl<'db> TypeLongId<'db> {
                 generic_parameters.insert(*generic_param);
             }
             TypeLongId::Var(_) => {}
+            TypeLongId::NumericLiteral(_) => {}
             TypeLongId::Coupon(_) => {}
             TypeLongId::FixedSizeArray { type_id, .. } => {
                 type_id.extract_generic_params(db, generic_parameters, visited)?
@@ -301,6 +311,7 @@ impl<'db> DebugWithDb<'db> for TypeLongId<'db> {
                 )
             }
             TypeLongId::Var(var) => write!(f, "?{}", var.id.0),
+            TypeLongId::NumericLiteral(_) => write!(f, "{{numeric}}"),
             TypeLongId::Coupon(function_id) => write!(f, "{}::Coupon", function_id.full_path(db)),
             TypeLongId::Missing(_) => write!(f, "<missing>"),
             TypeLongId::FixedSizeArray { type_id, size } => {
@@ -880,6 +891,7 @@ fn single_value_type(db: &dyn Database, ty: TypeId<'_>) -> Maybe<bool> {
         TypeLongId::Snapshot(ty) => db.single_value_type(*ty)?,
         TypeLongId::GenericParameter(_)
         | TypeLongId::Var(_)
+        | TypeLongId::NumericLiteral(_)
         | TypeLongId::Missing(_)
         | TypeLongId::Coupon(_)
         | TypeLongId::ImplType(_)
@@ -969,6 +981,7 @@ fn type_size_info(db: &dyn Database, ty: TypeId<'_>) -> Maybe<TypeSizeInformatio
         TypeLongId::Coupon(_) => return Ok(TypeSizeInformation::ZeroSized),
         TypeLongId::GenericParameter(_)
         | TypeLongId::Var(_)
+        | TypeLongId::NumericLiteral(_)
         | TypeLongId::Missing(_)
         | TypeLongId::ImplType(_) => {}
         TypeLongId::FixedSizeArray { type_id, size } => {
@@ -1113,6 +1126,7 @@ fn priv_type_is_fully_concrete(db: &dyn Database, ty: TypeId<'_>) -> bool {
         TypeLongId::Snapshot(ty) => ty.is_fully_concrete(db),
         TypeLongId::GenericParameter(_)
         | TypeLongId::Var(_)
+        | TypeLongId::NumericLiteral(_)
         | TypeLongId::Missing(_)
         | TypeLongId::ImplType(_) => false,
         TypeLongId::Coupon(function_id) => function_id.is_fully_concrete(db),
@@ -1139,6 +1153,7 @@ pub fn priv_type_is_var_free<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> boo
         TypeLongId::Tuple(types) => types.iter().all(|ty| ty.is_var_free(db)),
         TypeLongId::Snapshot(ty) => ty.is_var_free(db),
         TypeLongId::Var(_) => false,
+        TypeLongId::NumericLiteral(_) => false,
         TypeLongId::GenericParameter(_) | TypeLongId::Missing(_) => true,
         TypeLongId::Coupon(function_id) => function_id.is_var_free(db),
         TypeLongId::FixedSizeArray { type_id, size } => {
@@ -1196,6 +1211,7 @@ pub fn priv_type_short_name(db: &dyn Database, ty: TypeId<'_>) -> String {
         TypeLongId::FixedSizeArray { type_id, size } => {
             format!("[{}; {:?}", type_id.short_name(db), size.debug(db))
         }
+        TypeLongId::NumericLiteral(_) => "{numeric}".to_string(),
         other => other.format(db),
     }
 }

--- a/crates/cairo-lang-sierra-generator/src/types.rs
+++ b/crates/cairo-lang-sierra-generator/src/types.rs
@@ -160,6 +160,7 @@ pub fn get_concrete_long_type_id<'db>(
         .into(),
         semantic::TypeLongId::GenericParameter(_)
         | semantic::TypeLongId::Var(_)
+        | semantic::TypeLongId::NumericLiteral(_)
         | semantic::TypeLongId::ImplType(_)
         | semantic::TypeLongId::Missing(_) => {
             panic!("Types should be fully resolved at this point. Got: `{}`.", type_id.format(db))
@@ -212,6 +213,7 @@ pub fn type_dependencies<'db>(
         }
         semantic::TypeLongId::GenericParameter(_)
         | semantic::TypeLongId::Var(_)
+        | semantic::TypeLongId::NumericLiteral(_)
         | semantic::TypeLongId::ImplType(_)
         | semantic::TypeLongId::Missing(_) => {
             panic!("Types should be fully resolved at this point. Got: `{}`.", type_id.format(db))

--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -690,6 +690,7 @@ impl<'db> AbiBuilder<'db> {
             TypeLongId::Coupon(_)
             | TypeLongId::GenericParameter(_)
             | TypeLongId::Var(_)
+            | TypeLongId::NumericLiteral(_)
             | TypeLongId::ImplType(_)
             | TypeLongId::Missing(_)
             | TypeLongId::Closure(_) => Err(ABIError::UnexpectedType),

--- a/tests/bug_samples/issue7155.cairo
+++ b/tests/bug_samples/issue7155.cairo
@@ -1,8 +1,6 @@
 #[test]
 fn test_enumerate_type_resolution() {
-    // TODO(orizi): Remove "_usize" from the next line. Currently doesn't work without it, due to
-    // `NumericLiteral` not auto supplying `Destruct` to a type implementing it.
-    for (k, v) in array![0, 1, 2_usize].into_iter().enumerate() {
+    for (k, v) in array![0, 1, 2].into_iter().enumerate() {
         assert_eq!(k, v);
     }
 


### PR DESCRIPTION
## Summary

Introduces `TypeLongId::NumericLiteral` — a dedicated placeholder type for unsuffixed numeric literal expressions. Previously, numeric literals created a fresh type variable plus an impl variable for the `NumericLiteral<T>` trait, relying on trait resolution to constrain the type. The new approach allocates a `NumericLiteral(TypeVar)` placeholder that:

- Synthetically satisfies `Drop`, `Copy`, `Destruct`, and `PanicDestruct` via a generated impl, so the trait solver can discharge memory obligations while the literal's concrete type is still unknown.
- Unifies directly with any type that accepts numeric literals (felt252, primitive integers, `NonZero<…>`, bounded ints) at conform-time via `bind_integer_literal`, emitting `InferenceError::InvalidLiteralType` immediately when bound to an incompatible type.
- Defaults to `felt252` at inference finalization if no constraint has pinned it, with inter-literal defaulting done one variable at a time so that resolving one literal can constrain others through trait resolution (e.g., `0.pow(0)` correctly infers the exponent as `usize`).
- Displays as `{numeric}` in diagnostics instead of `?N`.

The `InferenceError::NoImplsFound` path for the old `NumericLiteral` trait is replaced by the new `InferenceError::InvalidLiteralType` variant (error code `E2311`). The `integer_literal_vars` list on `InferenceData` tracks which type vars are numeric-literal placeholders for finalization defaulting. The rewriter for `ImplLongId::GeneratedImpl` is extended to replace synthetic memory-trait impls with the real impl once the inner type becomes concrete.

Fixes the long-standing issue where unsuffixed literals in `enumerate`-style loops required an explicit `_usize` suffix, and adds regression tests covering unification, defaulting, `Drop`/`Copy` satisfaction, and invalid-type diagnostics.

---

## Type of change

Please check **one**:

- [x] New feature

---

## Why is this change needed?

The old `NumericLiteral<T>` trait-based approach had two problems:

1. The trait solver could not discharge `Drop`/`Copy`/`Destruct` for a literal whose type was still a bare type variable, causing spurious errors or requiring explicit suffixes (e.g., `array![0, 1, 2_usize]` instead of `array![0, 1, 2]`).
2. Concrete-headed candidates like `felt252Drop` could "claim" an integer literal during trait resolution and prematurely default its type, producing confusing diagnostics and incorrect inference in multi-literal expressions.

---

## What was the behavior or documentation before?

Unsuffixed numeric literals created a type variable and an impl variable for `NumericLiteral<T>`. Memory traits (`Drop`, `Copy`, etc.) could not be proven for the literal until the type was resolved, requiring workarounds like explicit suffixes. Diagnostics showed `?N` for unresolved literal types and reported errors as `Trait has no implementation in context: core::traits::Add::<T>` rather than pointing at the literal itself.

---

## What is the behavior or documentation after?

Unsuffixed numeric literals use a `NumericLiteral(TypeVar)` placeholder that inherently satisfies memory traits. Invalid bindings (e.g., `let _x: bool = 5`) are caught at conform-time with a clear `Mismatched types. The type \`T\` cannot be created from a numeric literal.` diagnostic pointing at the literal. Unresolved literal types display as `{numeric}` in error messages. The `array![0, 1, 2].into_iter().enumerate()` pattern now works without explicit suffixes.

---

## Related issue or discussion (if any)

Resolves the workaround noted in `issue7155.cairo` regarding `NumericLiteral` not auto-supplying `Destruct`.

---

## Additional context

The `integer_literal_vars` field is cloned (not rewritten) through `InferenceData::clone_with_inference_id` and `clone` because the local var IDs are stable across inference-id remapping. The rewriter for `GeneratedImpl` resolves synthetic memory-trait impls to real impls once the inner type is concrete, ensuring downstream queries (lowering, Sierra generation) see only natural impls.