### PR TITLE
fix(semantic): point const-decl literal errors at the value expression

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/closure
@@ -120,12 +120,12 @@ error[E2182]: Closures are not allowed in this context.
 |_^
 
 error[E2302]: Type mismatch: `{closure@lib.cairo:1:17: 1:19}` and `core::integer::i32`.
- --> lib.cairo:1:1-4:2
+ --> lib.cairo:1:17-4:1
   const _x: i32 = || {
- _^
+ _________________^
 | ...
 | };
-|__^
+|_^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -248,9 +248,9 @@ error[E2125]: The '?' operator is not supported outside of functions.
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
- --> lib.cairo:6:1
+ --> lib.cairo:6:42
 const WRONG_TYPE_AND_NOT_LITERAL: bool = 1 + 2;
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                         ^^^^^
 
 error[E2127]: This expression is not supported as constant.
  --> lib.cairo:14:47
@@ -308,9 +308,9 @@ const DEFAULT_VAR: bool = 1;
 
 //! > expected_diagnostics
 error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
- --> lib.cairo:1:1
+ --> lib.cairo:1:27
 const DEFAULT_VAR: bool = 1;
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                          ^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -469,7 +469,7 @@ pub fn resolve_const_expr_and_evaluate<'db, 'mt>(
     let mut_ref = &mut ctx.resolver;
     let mut inference: crate::expr::inference::Inference<'db, '_> = mut_ref.inference();
     if let Err(err_set) = inference.conform_ty(value.ty(), target_type) {
-        inference.report_on_pending_error(err_set, ctx.diagnostics, const_stable_ptr);
+        inference.report_on_pending_error(err_set, ctx.diagnostics, value.stable_ptr().untyped());
     }
 
     if finalize {

--- a/crates/cairo-lang-semantic/src/items/tests/trait_const
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_const
@@ -645,9 +645,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2302]: Type mismatch: `core::integer::u32` and `core::integer::u16`.
- --> lib.cairo:6:5
+ --> lib.cairo:6:20
     const X: u16 = Self::Y;
-    ^^^^^^^^^^^^^^^^^^^^^^^
+                   ^^^^^^^
 
 //! > ==========================================================================
 


### PR DESCRIPTION
## Summary

Type mismatch diagnostics for constants and closures now point to the value expression rather than the entire constant declaration. For example, in `const X: bool = 1;`, the error now highlights `1` instead of the full `const X: bool = 1;` line. This is achieved by passing `value.stable_ptr().untyped()` instead of `const_stable_ptr` when reporting type conformance errors in `resolve_const_expr_and_evaluate`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Diagnostic spans for type mismatch errors in constant declarations were pointing to the entire `const` statement rather than the offending value expression. This made it harder to identify exactly which part of the code caused the error, especially in longer or more complex constant definitions.

---

## What was the behavior or documentation before?

A type mismatch error such as `const DEFAULT_VAR: bool = 1;` would underline the entire declaration starting from column 1, including the `const` keyword, name, and type annotation.

---

## What is the behavior or documentation after?

The same error now underlines only the value expression (e.g., `1` or `Self::Y`), pointing directly to the source of the mismatch.

---

## Related issue or discussion (if any)

---

## Additional context

The fix also corrects the diagnostic span for closure type mismatches in constant contexts, where the highlighted range now starts at the closure expression rather than the beginning of the `const` statement.