### PR TITLE
fix(semantic): narrow return-type mismatch span to the value-producing   expression

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/test_data/equality
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/equality
@@ -1532,4 +1532,3 @@ True(v3) = v1, test::MyStruct(v0, v7) = v8
 
 Block 3:
 @v6 = v10, test::MyStruct(v0, ?) = v6, v6 = v9
-

--- a/crates/cairo-lang-lowering/src/test_data/tests
+++ b/crates/cairo-lang-lowering/src/test_data/tests
@@ -396,9 +396,9 @@ foo
 
 //! > semantic_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "core::option::Option::<core::integer::u128>".
- --> lib.cairo:1:36
-fn foo(mut data: Span<felt252>) -> u128 {
-                                   ^^^^
+ --> lib.cairo:2:5
+    serde::Serde::<u128>::deserialize(ref data)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > lowering_diagnostics
 

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -1711,6 +1711,39 @@ fn handle_possible_closure_expr<'db>(
     }
 }
 
+/// Returns the stable_ptr of the value-producing sub-expression of `expr_id`: drills through
+/// blocks to the tail, through matches to the first non-`never` arm, through ifs to the first
+/// non-`never` branch. Falls back to the expression's own stable_ptr.
+fn value_producer_stable_ptr<'db>(
+    db: &'db dyn Database,
+    arenas: &Arenas<'db>,
+    expr_id: ExprId,
+) -> SyntaxStablePtrId<'db> {
+    let never = never_ty(db);
+    match &arenas.exprs[expr_id] {
+        Expr::Block(ExprBlock { tail: Some(tail), .. }) => {
+            value_producer_stable_ptr(db, arenas, *tail)
+        }
+        Expr::Match(ExprMatch { arms, stable_ptr, .. }) => arms
+            .iter()
+            .find(|arm| arenas.exprs[arm.expression].ty() != never)
+            .map(|arm| value_producer_stable_ptr(db, arenas, arm.expression))
+            .unwrap_or_else(|| stable_ptr.untyped()),
+        Expr::If(ExprIf { if_block, else_block, stable_ptr, .. }) => {
+            if arenas.exprs[*if_block].ty() != never {
+                value_producer_stable_ptr(db, arenas, *if_block)
+            } else if let Some(else_block) = else_block
+                && arenas.exprs[*else_block].ty() != never
+            {
+                value_producer_stable_ptr(db, arenas, *else_block)
+            } else {
+                stable_ptr.untyped()
+            }
+        }
+        other => other.stable_ptr().untyped(),
+    }
+}
+
 pub fn compute_root_expr<'db>(
     ctx: &mut ComputationContext<'db, '_>,
     syntax: &ast::ExprBlock<'db>,
@@ -1743,16 +1776,7 @@ pub fn compute_root_expr<'db>(
         res_ty,
         return_type,
         ctx.diagnostics,
-        || {
-            ctx.signature
-                .map(|s| match s.stable_ptr.lookup(db).ret_ty(db) {
-                    OptionReturnTypeClause::Empty(_) => syntax.stable_ptr(db).untyped(),
-                    OptionReturnTypeClause::ReturnTypeClause(return_type_clause) => {
-                        return_type_clause.ty(db).stable_ptr(db).untyped()
-                    }
-                })
-                .unwrap_or_else(|| syntax.stable_ptr(db).untyped())
-        },
+        || value_producer_stable_ptr(db, &ctx.arenas, res),
         |actual_ty, expected_ty| WrongReturnType { expected_ty, actual_ty },
     );
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/coupon
+++ b/crates/cairo-lang-semantic/src/expr/test_data/coupon
@@ -89,19 +89,19 @@ foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "test::bar::<S, T>::Coupon", found: "()".
- --> lib.cairo:8:26
+ --> lib.cairo:8:46
 fn get_coupon<S, T>() -> bar::<S, T>::Coupon {}
-                         ^^^^^^^^^^^^^^^^^^^
+                                             ^^
 
 error[E2042]: Unexpected return type. Expected: "test::bar2::<S, T>::Coupon", found: "()".
- --> lib.cairo:9:27
+ --> lib.cairo:9:48
 fn get_coupon2<S, T>() -> bar2::<S, T>::Coupon {}
-                          ^^^^^^^^^^^^^^^^^^^^
+                                               ^^
 
 error[E2042]: Unexpected return type. Expected: "test::MyStruct::<S>", found: "()".
- --> lib.cairo:10:23
+ --> lib.cairo:10:35
 fn get_struct<S>() -> MyStruct<S> {}
-                      ^^^^^^^^^^^
+                                  ^^
 
 error[E2057]: Type "test::bar::<core::integer::u8, core::integer::u16>::Coupon" has no members.
  --> lib.cairo:15:7

--- a/crates/cairo-lang-semantic/src/expr/test_data/error_propagate
+++ b/crates/cairo-lang-semantic/src/expr/test_data/error_propagate
@@ -128,9 +128,9 @@ error[E2062]: Return type "core::result::Result::<core::felt252, core::integer::
     ^^^^^^^^^^^^^^^^^
 
 error[E2042]: Unexpected return type. Expected: "core::result::Result::<core::felt252, core::integer::u128>", found: "core::result::Result::<core::felt252, core::felt252>".
- --> lib.cairo:4:13
-fn foo() -> Result<felt252, u128> {
-            ^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:6:5
+    Result::<felt252, felt252>::Ok((0))
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/function_call
+++ b/crates/cairo-lang-semantic/src/expr/test_data/function_call
@@ -199,9 +199,9 @@ foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u8".
- --> lib.cairo:1:13
-fn foo() -> () {
-            ^^
+ --> lib.cairo:2:5
+    4_u8
+    ^^^^
 
 //! > ==========================================================================
 
@@ -218,9 +218,9 @@ foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "()".
- --> lib.cairo:1:13
+ --> lib.cairo:1:16
 fn foo() -> u8 {}
-            ^^
+               ^^
 
 //! > ==========================================================================
 
@@ -244,9 +244,9 @@ trait MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u16".
- --> lib.cairo:2:17
-    fn bar() -> u8 {
-                ^^
+ --> lib.cairo:3:9
+        1_u16
+        ^^^^^
 
 //! > ==========================================================================
 
@@ -274,9 +274,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u16".
- --> lib.cairo:6:17
-    fn bar() -> u8 {
-                ^^
+ --> lib.cairo:7:9
+        1_u16
+        ^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/generics
+++ b/crates/cairo-lang-semantic/src/expr/test_data/generics
@@ -674,9 +674,9 @@ struct S<const N: felt252> {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "test::S::<1>", found: "test::S::<N>".
- --> lib.cairo:1:31
-fn bar<const N: felt252>() -> S<{ 3 - 2 }> {
-                              ^^^^^^^^^^^^
+ --> lib.cairo:2:5
+    S::<N> { field: 1 }
+    ^^^^^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/if
+++ b/crates/cairo-lang-semantic/src/expr/test_data/if
@@ -31,12 +31,9 @@ error[E2056]: If blocks have incompatible types: "core::bool" and "{numeric}"
 |_____^
 
 error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
- --> lib.cairo:1:10-8:1
-  fn foo() {
- __________^
-| ...
-| }
-|_^
+ --> lib.cairo:4:9
+        true
+        ^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/inference
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inference
@@ -140,9 +140,9 @@ foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::never", found: "core::felt252".
- --> lib.cairo:1:13
-fn foo() -> never {
-            ^^^^^
+ --> lib.cairo:2:5
+    5_felt252
+    ^^^^^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/literal
+++ b/crates/cairo-lang-semantic/src/expr/test_data/literal
@@ -215,9 +215,6 @@ incorrect_return_type
 
 //! > expected_diagnostics
 error[E2315]: Mismatched types. The type `()` cannot be created from a numeric literal.
- --> lib.cairo:1:28-4:1
-  fn incorrect_return_type() {
- ____________________________^
-| ...
-| }
-|_^
+ --> lib.cairo:3:5
+    x
+    ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/loop
+++ b/crates/cairo-lang-semantic/src/expr/test_data/loop
@@ -51,12 +51,12 @@ error[E2056]: Loop has incompatible return types: "core::bool" and "{numeric}"
                   ^
 
 error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
- --> lib.cairo:1:23-9:1
-  fn foo(x: Option<()>) {
- _______________________^
+ --> lib.cairo:2:5-8:5
+      loop {
+ _____^
 | ...
-| }
-|_^
+|     }
+|_____^
 
 //! > ==========================================================================
 
@@ -199,9 +199,12 @@ foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
- --> lib.cairo:1:13
-fn foo() -> bool {
-            ^^^^
+ --> lib.cairo:2:5-4:5
+      loop {
+ _____^
+|         break;
+|     }
+|_____^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/match
+++ b/crates/cairo-lang-semantic/src/expr/test_data/match
@@ -176,12 +176,9 @@ error[E2056]: Match arms have incompatible types: "core::bool" and "{numeric}"
                 ^
 
 error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
- --> lib.cairo:1:23-6:1
-  fn foo(x: Option<()>) {
- _______________________^
-| ...
-| }
-|_^
+ --> lib.cairo:3:20
+        Some(_) => true,
+                   ^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/operators
+++ b/crates/cairo-lang-semantic/src/expr/test_data/operators
@@ -57,12 +57,9 @@ error[E2041]: Unexpected argument type. Expected: "core::integer::u128", found: 
         ^
 
 error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u128".
- --> lib.cairo:1:48-8:1
-  fn foo(a: u128, b: bool) implicits(RangeCheck) {
- ________________________________________________^
-| ...
-| }
-|_^
+ --> lib.cairo:7:5
+    a - b
+    ^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/return
+++ b/crates/cairo-lang-semantic/src/expr/test_data/return
@@ -67,6 +67,6 @@ foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::felt252", found: "()".
- --> lib.cairo:1:13
+ --> lib.cairo:1:21
 fn foo() -> felt252 {}
-            ^^^^^^^
+                    ^^

--- a/crates/cairo-lang-semantic/src/items/tests/trait
+++ b/crates/cairo-lang-semantic/src/items/tests/trait
@@ -141,9 +141,12 @@ error[E2113]: The signature of function `param_test` is incompatible with trait 
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "()".
- --> lib.cairo:26:58
-    fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
-                                                         ^^^^
+ --> lib.cairo:26:63-28:5
+      fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
+ _______________________________________________________________^
+| 
+|     }
+|_____^
 
 error[E2035]: Parameter of impl function MyImpl2::no_ret_ty is incompatible with MyTrait::no_ret_ty. It should not be a reference.
  --> lib.cairo:30:18
@@ -1005,9 +1008,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
- --> lib.cairo:6:18
-    fn foo1() -> u32 {
-                 ^^^
+ --> lib.cairo:7:9
+        Self::foo2()
+        ^^^^^^^^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/items/tests/trait_const
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_const
@@ -330,9 +330,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "core::integer::u32".
- --> lib.cairo:11:17
-    fn foo() -> u16 {
-                ^^^
+ --> lib.cairo:12:9
+        AnotherTrait::X
+        ^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/items/tests/trait_impl
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_impl
@@ -391,9 +391,9 @@ error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "core::integer::u32".
- --> lib.cairo:18:18
-    fn foo1() -> AnotherTrait::Impl::InputType {
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:19:9
+        3_u32
+        ^^^^^
 
 error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `core::integer::u32`, actual: `core::integer::u16`.
  --> lib.cairo:21:16
@@ -516,9 +516,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "core::integer::u32".
- --> lib.cairo:14:18
-    fn foo1() -> Self::Impl::InputType {
-                 ^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:15:9
+        3_u32
+        ^^^^^
 
 //! > ==========================================================================
 
@@ -646,9 +646,9 @@ fn complex(
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "@(core::integer::u32, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)", found: "@(core::integer::u16, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u16>; 3], (@core::integer::u16, core::integer::u16)>>)".
- --> lib.cairo:44:6
-) -> @(u32, Option<@Result<[Option<u32>; 3], (@u32, u32)>>) {
-     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:45:5
+    x
+    ^
 
 //! > ==========================================================================
 
@@ -720,9 +720,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
- --> lib.cairo:15:42
-    fn bar(x: Self::Impl1::InputType) -> u32 {
-                                         ^^^
+ --> lib.cairo:16:9
+        x
+        ^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/items/tests/trait_type
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_type
@@ -1140,9 +1140,9 @@ error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible wit
                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "core::integer::u32".
- --> lib.cairo:19:14
-fn bar1() -> MyTrait::MyType {
-             ^^^^^^^^^^^^^^^
+ --> lib.cairo:20:5
+    3_u32
+    ^^^^^
 
 error[E2041]: Unexpected argument type. Expected: "core::integer::u32", found: "core::integer::u16".
  --> lib.cairo:23:18
@@ -1385,9 +1385,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
- --> lib.cairo:8:18
-    fn foo1() -> Self::MyType {
-                 ^^^^^^^^^^^^
+ --> lib.cairo:9:9
+        3_u16
+        ^^^^^
 
 //! > ==========================================================================
 
@@ -1520,9 +1520,9 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "co
            ^
 
 error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
- --> lib.cairo:12:37
-fn ret_expr(x: MyTrait::MyType1) -> MyTrait::MyType2 {
-                                    ^^^^^^^^^^^^^^^^
+ --> lib.cairo:13:5
+    x
+    ^
 
 error[E2308]: `test::MyImpl::MyType1` type mismatch: `core::integer::u32` and `core::integer::u16`.
  --> lib.cairo:16:21
@@ -1548,9 +1548,9 @@ error[E2056]: If blocks have incompatible types: "core::integer::u16" and "core:
 |_____^
 
 error[E2042]: Unexpected return type. Expected: "core::option::Option::<core::integer::u32>", found: "core::option::Option::<core::integer::u16>".
- --> lib.cairo:44:54
-fn error_propagation(x: Option<MyTrait::MyType1>) -> Option<MyTrait::MyType2> {
-                                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:45:5
+    Some(x?)
+    ^^^^^^^^
 
 //! > ==========================================================================
 
@@ -1672,42 +1672,39 @@ fn complex2(
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::option::Option::<core::integer::u32>", found: "core::option::Option::<core::integer::u16>".
- --> lib.cairo:13:49
-fn generic_args(x: Option<MyTrait::MyType1>) -> Option<MyTrait::MyType2> {
-                                                ^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:14:5
+    Some(x?)
+    ^^^^^^^^
 
 error[E2042]: Unexpected return type. Expected: "(core::integer::u32, core::integer::u16)", found: "(core::integer::u16, core::integer::u32)".
- --> lib.cairo:16:55
-fn tuple(x: MyTrait::MyType1, y: MyTrait::MyType2) -> (MyTrait::MyType2, MyTrait::MyType1) {
-                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:17:5
+    (x, y)
+    ^^^^^^
 
 error[E2042]: Unexpected return type. Expected: "[core::integer::u32; 3]", found: "[core::integer::u16; 3]".
- --> lib.cairo:19:49
-fn fix_sized_array(x: [MyTrait::MyType1; 3]) -> [MyTrait::MyType2; 3] {
-                                                ^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:20:5
+    x
+    ^
 
 error[E2042]: Unexpected return type. Expected: "@@core::integer::u32", found: "@@core::integer::u16".
- --> lib.cairo:22:39
-fn snapshot(x: @@MyTrait::MyType1) -> @@MyTrait::MyType2 {
-                                      ^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:23:5
+    x
+    ^
 
 error[E2042]: Unexpected return type. Expected: "@@core::integer::u32", found: "@@core::integer::u16".
- --> lib.cairo:25:39
-fn snapshot2(x: @MyTrait::MyType1) -> @@MyTrait::MyType2 {
-                                      ^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:26:5
+    @x
+    ^^
 
 error[E2042]: Unexpected return type. Expected: "@(core::integer::u32, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)", found: "@(core::integer::u16, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)".
- --> lib.cairo:33:6
-) -> @(u32, Option<@Result<[Option<u32>; 3], (@u32, u32)>>) {
-     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:34:5
+    x
+    ^
 
 error[E2042]: Unexpected return type. Expected: "@(core::integer::u16, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)", found: "@(core::integer::u32, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)".
- --> lib.cairo:38:6-41:1
-  ) -> @(
- ______^
-| ...
-| ) {
-|_^
+ --> lib.cairo:42:5
+    x
+    ^
 
 //! > ==========================================================================
 
@@ -1805,9 +1802,9 @@ impl MyImpl of MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
- --> lib.cairo:9:33
-    fn bar(x: Self::MyType1) -> u32 {
-                                ^^^
+ --> lib.cairo:10:9
+        x
+        ^
 
 //! > ==========================================================================
 
@@ -2328,9 +2325,9 @@ trait MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::felt252", found: "core::integer::u32".
- --> lib.cairo:9:8
->() -> I2::ty {
-       ^^^^^^
+ --> lib.cairo:10:5
+    3_u32
+    ^^^^^
 
 //! > ==========================================================================
 
@@ -2682,9 +2679,9 @@ trait MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u8".
- --> lib.cairo:4:70
-fn bar<impl I1: MyTrait[ty: u32], impl I2: MyTrait[ty: I1::ty]>() -> I2::ty {
-                                                                     ^^^^^^
+ --> lib.cairo:5:5
+    3_u8
+    ^^^^
 
 //! > ==========================================================================
 
@@ -2826,9 +2823,9 @@ trait MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "J1::ty", found: "core::felt252".
- --> lib.cairo:8:32
-fn bar2<impl J1: MyTrait>() -> J1::ty {
-                               ^^^^^^
+ --> lib.cairo:9:5
+    bar()
+    ^^^^^
 
 //! > ==========================================================================
 
@@ -2885,9 +2882,9 @@ trait MyTrait {
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u32".
- --> lib.cairo:8:40
-fn bar2<impl I1: MyTrait[ty: u8]>() -> I1::ty {
-                                       ^^^^^^
+ --> lib.cairo:9:5
+    bar()
+    ^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -1136,9 +1136,9 @@ impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "(core::felt252, core::felt252)", found: "()".
- --> lib.cairo:6:40
+ --> lib.cairo:6:59
     fn foo(ref self: ContractState) -> (felt252, felt252) {}
-                                       ^^^^^^^^^^^^^^^^^^
+                                                          ^^
 
 //! > ==========================================================================
 
@@ -1593,9 +1593,9 @@ impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "(core::felt252, core::felt252)", found: "()".
- --> lib.cairo:8:10
+ --> lib.cairo:8:29
     ) -> (felt252, felt252) {}
-         ^^^^^^^^^^^^^^^^^^
+                            ^^
 
 //! > ==========================================================================
 


### PR DESCRIPTION
## Summary

The `WrongReturnType` diagnostic now points to the actual value-producing expression instead of the return type annotation in the function signature.

A new helper function `value_producer_stable_ptr` is introduced in `compute.rs` that drills through blocks (to their tail), match expressions (to the first non-`never` arm), and if expressions (to the first non-`never` branch) to locate the concrete sub-expression responsible for producing the returned value. This pointer is used as the diagnostic span instead of the return type clause in the signature.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)

---

## Why is this change needed?

Previously, when a function returned a value of the wrong type, the error diagnostic highlighted the return type annotation in the function signature (e.g., `-> u8`). This was often unhelpful because the annotation itself is correct — the problem is the expression that actually produces the value. Pointing at the return type annotation forced developers to manually trace which expression was at fault.

---

## What was the behavior or documentation before?

The `E2042: Unexpected return type` diagnostic pointed to the return type clause in the function signature, for example:

```
error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u8".
 --> lib.cairo:1:13
fn foo() -> () {
            ^^
```

---

## What is the behavior or documentation after?

The diagnostic now points directly to the offending value-producing expression:

```
error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u8".
 --> lib.cairo:2:5
    4_u8
    ^^^^
```

For compound expressions like blocks, matches, and ifs, the diagnostic drills into the relevant sub-expression rather than spanning the entire function body.

---

Related issue or discussion (if any)  
  
Fixes #6486

---

## Additional context

For empty function bodies (no tail expression), the diagnostic falls back to pointing at the closing `}` of the block, which correctly indicates that a value is missing.