### PR TITLE
Add source links for visibility examples

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/visibility.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/visibility.adoc
@@ -37,6 +37,7 @@ See also:
 == Examples
 
 === Public module and re-exports
+Source: link:{cairo-repo}/corelib/src/starknet.cairo[corelib/src/starknet.cairo]
 
 [source,cairo]
 ----
@@ -46,6 +47,7 @@ pub use storage_access::{StorageAddress, Store};
 ----
 
 === Crate-visible items
+Source: link:{cairo-repo}/corelib/src/zeroable.cairo[corelib/src/zeroable.cairo]
 
 [source,cairo]
 ----
@@ -56,6 +58,7 @@ pub(crate) trait Zeroable<T> {
 ----
 
 === Public struct with a public field
+Source: link:{cairo-repo}/corelib/src/pedersen.cairo[corelib/src/pedersen.cairo]
 
 [source,cairo]
 ----
@@ -67,6 +70,7 @@ pub struct HashState {
 ----
 
 === Public implementations
+Source: link:{cairo-repo}/corelib/src/integer.cairo[corelib/src/integer.cairo] (representative pattern)
 
 [source,cairo]
 ----

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/visibility.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/visibility.adoc
@@ -1,3 +1,5 @@
+:cairo-repo: https://github.com/starkware-libs/cairo/blob/main
+
 = Visibility
 
 Visibility controls whether items can be accessed from other modules and crates.
@@ -41,7 +43,6 @@ Source: link:{cairo-repo}/corelib/src/starknet.cairo[corelib/src/starknet.cairo]
 
 [source,cairo]
 ----
-// corelib/src/starknet.cairo
 pub mod storage_access;
 pub use storage_access::{StorageAddress, Store};
 ----
@@ -51,7 +52,6 @@ Source: link:{cairo-repo}/corelib/src/zeroable.cairo[corelib/src/zeroable.cairo]
 
 [source,cairo]
 ----
-// corelib/src/zeroable.cairo
 pub(crate) trait Zeroable<T> {
     fn zero() -> T;
 }
@@ -62,7 +62,6 @@ Source: link:{cairo-repo}/corelib/src/pedersen.cairo[corelib/src/pedersen.cairo]
 
 [source,cairo]
 ----
-// corelib/src/pedersen.cairo
 #[derive(Copy, Drop, Debug)]
 pub struct HashState {
     pub state: felt252,
@@ -70,11 +69,10 @@ pub struct HashState {
 ----
 
 === Public implementations
-Source: link:{cairo-repo}/corelib/src/integer.cairo[corelib/src/integer.cairo] (representative pattern)
+Source: link:{cairo-repo}/corelib/src/integer.cairo[corelib/src/integer.cairo]
 
 [source,cairo]
 ----
-// corelib/src/integer.cairo (representative pattern)
 pub impl U128Add of Add<u128> {
     fn add(lhs: u128, rhs: u128) -> u128 { /* ... */ }
 }


### PR DESCRIPTION
This adds clickable source links for each visibility example, making reference verification faster while keeping the original examples unchanged.