### PR TITLE
clippy: disallow std HashMap/HashSet via disallowed-types

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,6 @@
 enum-variant-name-threshold = 1
+
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "use UnorderedHashMap or OrderedHashMap from cairo-lang-utils" },
+    { path = "std::collections::HashSet", reason = "use UnorderedHashSet or OrderedHashSet from cairo-lang-utils" },
+]

--- a/crates/cairo-lang-debug/src/debug.rs
+++ b/crates/cairo-lang-debug/src/debug.rs
@@ -3,6 +3,7 @@
 mod test;
 
 // Mostly taken from https://github.com/salsa-rs/salsa/blob/fd715619813f634fa07952f0d1b3d3a18b68fd65/components/salsa-2022/src/debug.rs
+#[expect(clippy::disallowed_types)]
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -147,6 +148,7 @@ where
     }
 }
 
+#[expect(clippy::disallowed_types)]
 impl<'db, K, V, S> DebugWithDb<'db> for HashMap<K, V, S>
 where
     K: DebugWithDb<'db>,
@@ -228,6 +230,7 @@ where
     }
 }
 
+#[expect(clippy::disallowed_types)]
 impl<'db, V, S> DebugWithDb<'db> for HashSet<V, S>
 where
     V: DebugWithDb<'db>,

--- a/crates/cairo-lang-doc/src/signature_data.rs
+++ b/crates/cairo-lang-doc/src/signature_data.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashSet;
 
 use cairo_lang_defs::ids::TraitItemId::Function;
@@ -244,6 +245,7 @@ fn get_free_function_signature_data<'db>(
 }
 
 /// Retrieves data for trait function signature formatting.
+#[expect(clippy::disallowed_types)]
 fn get_trait_function_signature_data<'db>(
     db: &'db dyn Database,
     item_id: TraitFunctionId<'db>,

--- a/crates/cairo-lang-execute-utils/src/lib.rs
+++ b/crates/cairo-lang-execute-utils/src/lib.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -16,6 +17,7 @@ use num_bigint::BigInt;
 /// 2. The hint by string mapping.
 ///
 /// This is required for running an executable in the Cairo-VM.
+#[expect(clippy::disallowed_types)]
 pub fn program_and_hints_from_executable(
     executable: &Executable,
     entrypoint: &ExecutableEntryPoint,

--- a/crates/cairo-lang-lowering/src/analysis/backward.rs
+++ b/crates/cairo-lang-lowering/src/analysis/backward.rs
@@ -1,12 +1,14 @@
 //! This module introduces the BackAnalysis utility that allows writing analyzers that go backwards
 //! in the flow of the program, on a Lowered representation.
 
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 
 use crate::analysis::{Analyzer, DataflowAnalyzer, Direction, Edge, StatementLocation};
 use crate::{Block, BlockEnd, BlockId, Lowered, MatchInfo, Statement, VarRemapping, VarUsage};
 
 /// Main analysis type that allows traversing the flow backwards.
+#[expect(clippy::disallowed_types)]
 pub struct BackAnalysis<'db, 'a, TAnalyzer: Analyzer<'db, 'a>> {
     lowered: &'a Lowered<'db>,
     pub analyzer: TAnalyzer,

--- a/crates/cairo-lang-lowering/src/analysis/test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/test.rs
@@ -1,5 +1,6 @@
 //! Tests for the dataflow analysis framework.
 
+#[expect(clippy::disallowed_types)]
 use std::collections::HashSet;
 
 use cairo_lang_semantic::test_utils::setup_test_function;
@@ -115,10 +116,12 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for BlockCounter {
 /// A simple forward analyzer that tracks which blocks are reachable.
 /// Demonstrates using default transfer_block with statement-level transfer_stmt.
 #[derive(Default)]
+#[expect(clippy::disallowed_types)]
 struct ReachabilityAnalyzer {
     reachable_blocks: HashSet<BlockId>,
 }
 
+#[expect(clippy::disallowed_types)]
 impl<'db, 'a> DataflowAnalyzer<'db, 'a> for ReachabilityAnalyzer {
     type Info = HashSet<BlockId>; // Set of blocks visited to reach this point
 

--- a/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic.rs
@@ -2,6 +2,7 @@
 #[path = "early_unsafe_panic_test.rs"]
 mod test;
 
+#[expect(clippy::disallowed_types)]
 use std::collections::HashSet;
 
 use cairo_lang_defs::ids::ExternFunctionId;
@@ -21,6 +22,7 @@ use crate::{
 ///
 /// This step might replace a match on an empty enum with a call to unsafe_panic and we rely on the
 /// 'trim_unreachable' optimization to clean that up.
+#[expect(clippy::disallowed_types)]
 pub fn early_unsafe_panic<'db>(db: &'db dyn Database, lowered: &mut Lowered<'db>) {
     if !db.flag_unsafe_panic() || lowered.blocks.is_empty() {
         return;
@@ -59,6 +61,7 @@ pub fn early_unsafe_panic<'db>(db: &'db dyn Database, lowered: &mut Lowered<'db>
     }
 }
 
+#[expect(clippy::disallowed_types)]
 pub struct UnsafePanicContext<'db> {
     db: &'db dyn Database,
 

--- a/crates/cairo-lang-lowering/src/reorganize_blocks.rs
+++ b/crates/cairo-lang-lowering/src/reorganize_blocks.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 
 use itertools::Itertools;
@@ -16,6 +17,7 @@ use crate::{
 /// Removes unreachable blocks.
 /// Blocks that are reachable only through goto are combined with the block that does the goto.
 /// The order of the blocks is changed to be a topologically sorted.
+#[expect(clippy::disallowed_types)]
 pub fn reorganize_blocks<'db>(lowered: &mut Lowered<'db>) {
     if lowered.blocks.is_empty() {
         return;
@@ -181,6 +183,7 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for TopSortContext {
     }
 }
 
+#[expect(clippy::disallowed_types)]
 pub struct RebuildContext {
     block_remapping: HashMap<BlockId, BlockId>,
     remappings_ctx: remappings::Context,

--- a/crates/cairo-lang-lowering/src/test.rs
+++ b/crates/cairo-lang-lowering/src/test.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 
 use cairo_lang_debug::DebugWithDb;
@@ -167,6 +168,7 @@ a = a * 3
 }
 
 #[test]
+#[expect(clippy::disallowed_types)]
 fn test_sizes() {
     let db = &mut LoweringDatabaseForTesting::default();
     let type_to_size = [

--- a/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
+++ b/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
@@ -5,6 +6,7 @@ use cairo_vm::vm::vm_core::VirtualMachine;
 use starknet_types_core::felt::Felt as Felt252;
 
 /// Stores the data of a specific dictionary.
+#[expect(clippy::disallowed_types)]
 pub struct DictTrackerExecScope {
     /// The data of the dictionary.
     data: HashMap<Felt252, MaybeRelocatable>,
@@ -14,6 +16,7 @@ pub struct DictTrackerExecScope {
 
 /// Helper object to allocate, track and destruct all dictionaries in the run.
 #[derive(Default)]
+#[expect(clippy::disallowed_types)]
 pub struct DictManagerExecScope {
     /// Maps between a segment index and the DictTrackerExecScope associated with it.
     trackers: HashMap<isize, DictTrackerExecScope>,
@@ -21,6 +24,7 @@ pub struct DictManagerExecScope {
 
 impl DictTrackerExecScope {
     /// Creates a new tracker placed in index `idx` in the dict_infos segment.
+    #[expect(clippy::disallowed_types)]
     pub fn new(idx: usize) -> Self {
         Self { data: HashMap::default(), idx }
     }
@@ -94,6 +98,7 @@ impl DictManagerExecScope {
 
 /// Helper object for the management of dict_squash hints.
 #[derive(Default, Debug)]
+#[expect(clippy::disallowed_types)]
 pub struct DictSquashExecScope {
     /// A map from key to the list of indices accessing it, each list in reverse order.
     pub access_indices: HashMap<Felt252, Vec<Felt252>>,

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::borrow::Cow;
+#[expect(clippy::disallowed_types)]
 use std::collections::{HashMap, VecDeque};
 use std::ops::{Shl, Sub};
 use std::sync::Arc;
@@ -58,6 +59,7 @@ mod contract_address;
 mod dict_manager;
 
 /// Converts a hint to the Cairo VM class `HintParams` by canonically serializing it to a string.
+#[expect(clippy::disallowed_types)]
 pub fn hint_to_hint_params(hint: &Hint) -> HintParams {
     HintParams {
         code: hint.representing_string(),
@@ -86,6 +88,7 @@ struct Secp256r1ExecutionScope {
 }
 
 /// HintProcessor for Cairo compiler hints.
+#[expect(clippy::disallowed_types)]
 pub struct CairoHintProcessor<'a> {
     /// The Cairo runner.
     pub runner: Option<&'a SierraCasmRunner>,
@@ -136,6 +139,7 @@ type L2ToL1Message = (Felt252, Vec<Felt252>);
 /// Execution scope for Starknet-related data.
 /// All values will be 0 by default if not set up by the test.
 #[derive(Clone, Default)]
+#[expect(clippy::disallowed_types)]
 pub struct StarknetState {
     /// The values of addresses in the simulated storage per contract.
     storage: HashMap<Felt252, HashMap<Felt252, Felt252>>,
@@ -465,6 +469,7 @@ impl HintProcessorLogic for CairoHintProcessor<'_> {
     }
 
     /// Trait function to store hint in the hint processor by string.
+    #[expect(clippy::disallowed_types)]
     fn compile_hint(
         &self,
         hint_code: &str,
@@ -2341,6 +2346,7 @@ pub fn run_function_with_runner(
 }
 
 /// Creates CairoRunner for `program`.
+#[expect(clippy::disallowed_types)]
 pub fn build_cairo_runner(
     data: Vec<MaybeRelocatable>,
     builtins: Vec<BuiltinName>,
@@ -2387,6 +2393,7 @@ pub struct RunFunctionResult {
 
 /// Runs `bytecode` on layout with prime, and returns the matching [RunFunctionResult].
 /// Allows injecting custom HintProcessor.
+#[expect(clippy::disallowed_types)]
 pub fn run_function<'a, 'b: 'a>(
     bytecode: impl Iterator<Item = &'a BigInt> + Clone,
     builtins: Vec<BuiltinName>,

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -1,4 +1,7 @@
 //! Basic runner for running a Sierra program on the VM.
+
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashMap;
 
 use cairo_lang_casm::hints::Hint;
@@ -76,6 +79,7 @@ pub struct RunResult {
 /// The execution resources in a run.
 /// Extends [ExecutionResources] by including the used syscalls for Starknet.
 #[derive(Debug, Eq, PartialEq, Clone, Default)]
+#[expect(clippy::disallowed_types)]
 pub struct StarknetExecutionResources {
     /// The basic execution resources.
     pub basic_resources: ExecutionResources,
@@ -144,6 +148,7 @@ impl From<Felt252> for Arg {
 }
 
 /// Builds `hints_dict` required in `cairo_vm::types::program::Program` from instructions.
+#[expect(clippy::disallowed_types)]
 pub fn build_hints_dict(
     hints: &[(usize, Vec<Hint>)],
 ) -> (HashMap<usize, Vec<HintParams>>, HashMap<String, Hint>) {
@@ -168,6 +173,7 @@ pub fn build_hints_dict(
 /// [`SierraCasmRunner::run_function_with_prepared_starknet_context`] to run the function.
 /// For typical use-cases you should use [`SierraCasmRunner::run_function_with_starknet_context`],
 /// which does all the preparation, running, and result composition for you.
+#[expect(clippy::disallowed_types)]
 pub struct PreparedStarknetContext {
     pub hints_dict: HashMap<usize, Vec<HintParams>>,
     pub bytecode: Vec<BigInt>,
@@ -261,6 +267,7 @@ impl SierraCasmRunner {
     /// Runs the VM starting from a function with a custom hint processor. The function may have
     /// implicits, but no other ref params. The cost of the function is deducted from
     /// `available_gas` before the execution begins.
+    #[expect(clippy::disallowed_types)]
     pub fn run_function<'a, Bytecode>(
         &self,
         func: &Function,

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -1,5 +1,7 @@
 //! Bidirectional type inference.
 
+#![expect(clippy::disallowed_types)]
+
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};

--- a/crates/cairo-lang-sierra-gas/src/generate_equations_test.rs
+++ b/crates/cairo-lang-sierra-gas/src/generate_equations_test.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashMap;
 
 use cairo_lang_sierra::extensions::gas::CostTokenType;

--- a/crates/cairo-lang-sierra-generator/src/canonical_id_replacer.rs
+++ b/crates/cairo-lang-sierra-generator/src/canonical_id_replacer.rs
@@ -2,6 +2,7 @@
 #[path = "canonical_id_replacer_test.rs"]
 mod test;
 
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 
 use cairo_lang_sierra::ids::{ConcreteLibfuncId, ConcreteTypeId, FunctionId};
@@ -9,6 +10,7 @@ use cairo_lang_sierra::ids::{ConcreteLibfuncId, ConcreteTypeId, FunctionId};
 use crate::replace_ids::SierraIdReplacer;
 
 #[derive(Default)]
+#[expect(clippy::disallowed_types)]
 pub struct CanonicalReplacer {
     type_ids: HashMap<ConcreteTypeId, u64>,
     function_ids: HashMap<FunctionId, u64>,
@@ -18,6 +20,7 @@ pub struct CanonicalReplacer {
 /// A replacer that replace the Ids in the program with canonical ones.
 /// The canonical ids are defined by the order of the declaration in the program.
 /// The first type_id is 0, the second type id is 1, etc.
+#[expect(clippy::disallowed_types)]
 impl CanonicalReplacer {
     /// Builds a replacer from a program.
     pub fn from_program(program: &cairo_lang_sierra::program::Program) -> Self {

--- a/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info.rs
+++ b/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 
 use cairo_lang_defs::db::get_all_path_leaves;
@@ -99,6 +100,7 @@ impl<'db> FunctionDebugInfo<'db> {
     /// Extracts mapping from a sierra variable to a cairo variable (its name and definition span).
     /// The sierra variable value corresponds to the cairo variable value at some point during
     /// execution of the function code.
+    #[expect(clippy::disallowed_types)]
     fn extract_variables_mapping(
         &self,
         db: &'db dyn Database,

--- a/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info/serializable.rs
+++ b/crates/cairo-lang-sierra-generator/src/debug_info/function_debug_info/serializable.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashMap;
 
 use cairo_lang_sierra::debug_info::Annotations;

--- a/crates/cairo-lang-sierra-generator/src/debug_info/statements_locations/statements_code_locations.rs
+++ b/crates/cairo-lang-sierra-generator/src/debug_info/statements_locations/statements_code_locations.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashMap;
 
 use cairo_lang_sierra::debug_info::Annotations;

--- a/crates/cairo-lang-sierra-generator/src/debug_info/statements_locations/statements_functions.rs
+++ b/crates/cairo-lang-sierra-generator/src/debug_info/statements_locations/statements_functions.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashMap;
 use std::ops::Add;
 

--- a/crates/cairo-lang-sierra/src/program_registry.rs
+++ b/crates/cairo-lang-sierra/src/program_registry.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
@@ -72,11 +73,15 @@ pub enum ProgramRegistryError {
     TypeSizeOverflow(ConcreteTypeId),
 }
 
+#[expect(clippy::disallowed_types)]
 type TypeMap<TType> = HashMap<ConcreteTypeId, TType>;
+#[expect(clippy::disallowed_types)]
 type LibfuncMap<TLibfunc> = HashMap<ConcreteLibfuncId, TLibfunc>;
+#[expect(clippy::disallowed_types)]
 type FunctionMap = HashMap<FunctionId, Function>;
 /// Mapping from the arguments for generating a concrete type (the generic-id and the arguments) to
 /// the concrete-id that points to it.
+#[expect(clippy::disallowed_types)]
 type ConcreteTypeIdMap<'a> = HashMap<(GenericTypeId, &'a [GenericArg]), ConcreteTypeId>;
 
 /// Registry for the data of the compiler, for all program specific data.
@@ -88,6 +93,7 @@ pub struct ProgramRegistry<TType: GenericType, TLibfunc: GenericLibfunc> {
     /// Mapping ids to the concrete libfuncs represented by them.
     concrete_libfuncs: LibfuncMap<TLibfunc::Concrete>,
 }
+#[expect(clippy::disallowed_types)]
 impl<TType: GenericType, TLibfunc: GenericLibfunc> ProgramRegistry<TType, TLibfunc> {
     /// Create a registry for the program.
     pub fn new(
@@ -273,6 +279,7 @@ impl<TType: GenericType> TypeSpecializationContext
 
 /// Creates the type-id to concrete type map, and the reverse map from generic-id and arguments to
 /// concrete-id.
+#[expect(clippy::disallowed_types)]
 fn get_concrete_types_maps<TType: GenericType>(
     program: &Program,
 ) -> Result<(TypeMap<TType::Concrete>, ConcreteTypeIdMap<'_>), Box<ProgramRegistryError>> {
@@ -372,6 +379,7 @@ impl<TType: GenericType> SpecializationContext for SpecializationContextForRegis
 }
 
 /// Creates the libfuncs map.
+#[expect(clippy::disallowed_types)]
 fn get_concrete_libfuncs<TType: GenericType, TLibfunc: GenericLibfunc>(
     program: &Program,
     context: &SpecializationContextForRegistry<'_, TType>,

--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 
 use cairo_lang_utils::extract_matches;
@@ -48,6 +49,7 @@ macro_rules! take_inputs {
 ///
 /// `simulate_function` is a function that simulates running of a user function. It is provided here
 /// for the case where the extensions need to use it.
+#[expect(clippy::disallowed_types)]
 pub fn simulate<
     GetStatementGasInfo: Fn() -> Option<i64>,
     SimulateFunction: Fn(&FunctionId, Vec<CoreValue>) -> Result<Vec<CoreValue>, LibfuncSimulationError>,

--- a/crates/cairo-lang-sierra/src/simulation/mod.rs
+++ b/crates/cairo-lang-sierra/src/simulation/mod.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::HashMap;
 
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -47,6 +48,7 @@ pub enum SimulationError {
 }
 
 /// Runs a function from the program with the given inputs.
+#[expect(clippy::disallowed_types)]
 pub fn run(
     program: &Program,
     statement_gas_info: &HashMap<StatementIdx, i64>,
@@ -62,6 +64,7 @@ pub fn run(
 }
 
 /// Helper class for running the simulation.
+#[expect(clippy::disallowed_types)]
 struct SimulationContext<'a> {
     pub program: &'a Program,
     pub statement_gas_info: &'a HashMap<StatementIdx, i64>,

--- a/crates/cairo-lang-sierra/src/simulation/value.rs
+++ b/crates/cairo-lang-sierra/src/simulation/value.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashMap;
 
 use starknet_types_core::felt::Felt as Felt252;

--- a/crates/cairo-lang-sierra/tests/examples_test.rs
+++ b/crates/cairo-lang-sierra/tests/examples_test.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs.rs
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::fs;

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_test.rs
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_test.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::{BTreeSet, HashSet};
 
 use cairo_lang_sierra::extensions::GenericLibfunc;
@@ -28,6 +29,7 @@ fn all_list_includes_all_supported() {
 }
 
 #[test]
+#[expect(clippy::disallowed_types)]
 fn libfunc_lists_include_only_supported_libfuncs() {
     let supported_ids = CoreLibfunc::supported_ids().into_iter().collect::<HashSet<_>>();
     for list_name in [

--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashSet;
 use std::fs;
 use std::io::BufReader;

--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::disallowed_types)]
 use std::collections::{HashMap, HashSet};
 
 use cairo_lang_defs::ids::{
@@ -49,6 +50,7 @@ use crate::plugin::events::EventData;
 mod test;
 
 /// Event information.
+#[expect(clippy::disallowed_types)]
 enum EventInfo {
     /// The event is a struct.
     Struct,
@@ -71,6 +73,7 @@ pub struct BuilderConfig {
     pub account_contract_validations: bool,
 }
 
+#[expect(clippy::disallowed_types)]
 pub struct AbiBuilder<'db> {
     /// The db.
     db: &'db dyn Database,
@@ -101,6 +104,7 @@ pub struct AbiBuilder<'db> {
 }
 impl<'db> AbiBuilder<'db> {
     /// Creates an `AbiBuilder` from a Starknet contract module.
+    #[expect(clippy::disallowed_types)]
     pub fn from_submodule(
         db: &'db dyn Database,
         submodule_id: SubmoduleId<'db>,
@@ -559,6 +563,7 @@ impl<'db> AbiBuilder<'db> {
     }
 
     /// Adds an event to the ABI from a type with an Event derive.
+    #[expect(clippy::disallowed_types)]
     fn add_event(
         &mut self,
         type_id: TypeId<'db>,

--- a/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
+++ b/crates/cairo-lang-utils/src/graph_algos/strongly_connected_components_test.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::disallowed_types)]
+
 use std::collections::HashSet;
 
 use cairo_lang_test_utils::test;

--- a/crates/cairo-lang-utils/src/heap_size.rs
+++ b/crates/cairo-lang-utils/src/heap_size.rs
@@ -158,6 +158,7 @@ impl HeapSize for std::path::PathBuf {
     }
 }
 
+#[expect(clippy::disallowed_types)]
 impl<K: HeapSize, V: HeapSize> HeapSize for std::collections::HashMap<K, V> {
     fn heap_size(&self) -> usize {
         // Approximate: capacity * size_of key/value + heap of keys/values
@@ -166,6 +167,7 @@ impl<K: HeapSize, V: HeapSize> HeapSize for std::collections::HashMap<K, V> {
     }
 }
 
+#[expect(clippy::disallowed_types)]
 impl<T: HeapSize> HeapSize for std::collections::HashSet<T> {
     fn heap_size(&self) -> usize {
         self.capacity() * std::mem::size_of::<T>()

--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    feature = "std",
+    expect(
+        clippy::disallowed_types,
+        reason = "this module is the UnorderedHashMap wrapper over std::collections::HashMap"
+    )
+)]
+
 #[cfg(test)]
 #[path = "unordered_hash_map_test.rs"]
 mod test;

--- a/crates/cairo-lang-utils/src/unordered_hash_set.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_set.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    feature = "std",
+    expect(
+        clippy::disallowed_types,
+        reason = "this module is the UnorderedHashSet wrapper over std::collections::HashSet"
+    )
+)]
+
 use core::borrow::Borrow;
 use core::hash::{BuildHasher, Hash};
 use core::ops::Sub;


### PR DESCRIPTION
## Summary

Adds a Clippy `disallowed-types` rule to `clippy.toml` that forbids direct use of `std::collections::HashMap` and `std::collections::HashSet`, directing users to use `UnorderedHashMap`/`OrderedHashMap` and `UnorderedHashSet`/`OrderedHashSet` from `cairo-lang-utils` instead. All existing legitimate uses of the standard library types are annotated with `#[expect(clippy::disallowed_types)]` to suppress the lint, including the wrapper modules themselves (`unordered_hash_map.rs` and `unordered_hash_set.rs`) which use `cfg_attr` to apply the suppression only when the `std` feature is enabled.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

New code could accidentally introduce `std::collections::HashMap` or `std::collections::HashSet` directly instead of using the project-specific wrappers, which provide consistent hashing behavior and ordering guarantees. Enforcing this at the lint level prevents such regressions from being introduced silently.

---

## What was the behavior or documentation before?

There was no enforcement preventing direct use of `std::collections::HashMap` or `std::collections::HashSet`. Developers had to rely on convention or code review to ensure the project-specific types were used.

---

## What is the behavior or documentation after?

Clippy will emit an error when `std::collections::HashMap` or `std::collections::HashSet` are used directly, with a message pointing to the preferred `UnorderedHashMap`/`OrderedHashMap` or `UnorderedHashSet`/`OrderedHashSet` alternatives. Existing legitimate uses are suppressed with `#[expect(clippy::disallowed_types)]`.

---

## Related issue or discussion (if any)

---

## Additional context

The `unordered_hash_map.rs` and `unordered_hash_set.rs` modules use `#![cfg_attr(feature = "std", expect(...))]` rather than an unconditional `#![expect(...)]` to avoid a warning about an unused `expect` attribute in `no_std` builds where the standard library types are not imported.