### PR TITLE
refactor(runner): migrate HashMap to {Unordered,Ordered} wrappers

### DIFF
--- a/crates/cairo-lang-execute-utils/src/lib.rs
+++ b/crates/cairo-lang-execute-utils/src/lib.rs
@@ -1,5 +1,3 @@
-#[expect(clippy::disallowed_types)]
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::Context;
@@ -7,6 +5,7 @@ use cairo_lang_casm::hints::Hint;
 use cairo_lang_executable::executable::{EntryPointKind, Executable, ExecutableEntryPoint};
 use cairo_lang_runner::{Arg, build_hints_dict};
 use cairo_lang_utils::bigint::BigUintAsHex;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_vm::Felt252;
 use cairo_vm::types::program::Program;
 use cairo_vm::types::relocatable::MaybeRelocatable;
@@ -17,11 +16,10 @@ use num_bigint::BigInt;
 /// 2. The hint by string mapping.
 ///
 /// This is required for running an executable in the Cairo-VM.
-#[expect(clippy::disallowed_types)]
 pub fn program_and_hints_from_executable(
     executable: &Executable,
     entrypoint: &ExecutableEntryPoint,
-) -> anyhow::Result<(Program, HashMap<String, Hint>)> {
+) -> anyhow::Result<(Program, UnorderedHashMap<String, Hint>)> {
     let data: Vec<MaybeRelocatable> =
         executable.program.bytecode.iter().map(Felt252::from).map(MaybeRelocatable::from).collect();
     let (hints, string_to_hint) = build_hints_dict(&executable.program.hints);

--- a/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
+++ b/crates/cairo-lang-runner/src/casm_run/dict_manager.rs
@@ -1,32 +1,28 @@
-#[expect(clippy::disallowed_types)]
-use std::collections::HashMap;
-
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::vm_core::VirtualMachine;
 use starknet_types_core::felt::Felt as Felt252;
 
 /// Stores the data of a specific dictionary.
-#[expect(clippy::disallowed_types)]
 pub struct DictTrackerExecScope {
     /// The data of the dictionary.
-    data: HashMap<Felt252, MaybeRelocatable>,
+    data: UnorderedHashMap<Felt252, MaybeRelocatable>,
     /// The index of the dictionary in the dict_infos segment.
     idx: usize,
 }
 
 /// Helper object to allocate, track and destruct all dictionaries in the run.
 #[derive(Default)]
-#[expect(clippy::disallowed_types)]
 pub struct DictManagerExecScope {
     /// Maps between a segment index and the DictTrackerExecScope associated with it.
-    trackers: HashMap<isize, DictTrackerExecScope>,
+    trackers: UnorderedHashMap<isize, DictTrackerExecScope>,
 }
 
 impl DictTrackerExecScope {
     /// Creates a new tracker placed in index `idx` in the dict_infos segment.
-    #[expect(clippy::disallowed_types)]
     pub fn new(idx: usize) -> Self {
-        Self { data: HashMap::default(), idx }
+        Self { data: Default::default(), idx }
     }
 }
 
@@ -98,10 +94,9 @@ impl DictManagerExecScope {
 
 /// Helper object for the management of dict_squash hints.
 #[derive(Default, Debug)]
-#[expect(clippy::disallowed_types)]
 pub struct DictSquashExecScope {
     /// A map from key to the list of indices accessing it, each list in reverse order.
-    pub access_indices: HashMap<Felt252, Vec<Felt252>>,
+    pub access_indices: OrderedHashMap<Felt252, Vec<Felt252>>,
     /// Descending list of keys.
     pub keys: Vec<Felt252>,
 }
@@ -115,7 +110,8 @@ impl DictSquashExecScope {
     /// Returns and removes the current key, and its access indices. Should be called when only the
     /// last key access is in the corresponding indices list.
     pub fn pop_current_key(&mut self) -> Option<Felt252> {
-        let key_accesses = self.access_indices.remove(&self.current_key().unwrap());
+        let key = self.current_key().unwrap();
+        let key_accesses = self.access_indices.swap_remove(&key);
         assert!(
             key_accesses.unwrap().len() == 1,
             "Key popped but not all accesses were processed."

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -1,7 +1,6 @@
 use std::any::Any;
 use std::borrow::Cow;
-#[expect(clippy::disallowed_types)]
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::ops::{Shl, Sub};
 use std::sync::Arc;
 use std::vec::IntoIter;
@@ -18,6 +17,7 @@ use cairo_lang_sierra::ids::FunctionId;
 use cairo_lang_utils::bigint::BigIntAsHex;
 use cairo_lang_utils::byte_array::{BYTE_ARRAY_MAGIC, BYTES_IN_WORD};
 use cairo_lang_utils::extract_matches;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_vm::hint_processor::hint_processor_definition::{
     HintProcessor, HintProcessorLogic, HintReference,
 };
@@ -59,14 +59,13 @@ mod contract_address;
 mod dict_manager;
 
 /// Converts a hint to the Cairo VM class `HintParams` by canonically serializing it to a string.
-#[expect(clippy::disallowed_types)]
 pub fn hint_to_hint_params(hint: &Hint) -> HintParams {
     HintParams {
         code: hint.representing_string(),
         accessible_scopes: vec![],
         flow_tracking_data: FlowTrackingData {
             ap_tracking: ApTracking::new(),
-            reference_ids: HashMap::new(),
+            reference_ids: Default::default(),
         },
     }
 }
@@ -88,7 +87,6 @@ struct Secp256r1ExecutionScope {
 }
 
 /// HintProcessor for Cairo compiler hints.
-#[expect(clippy::disallowed_types)]
 pub struct CairoHintProcessor<'a> {
     /// The Cairo runner.
     pub runner: Option<&'a SierraCasmRunner>,
@@ -98,7 +96,7 @@ pub struct CairoHintProcessor<'a> {
     /// several user args.
     pub user_args: Vec<Vec<Arg>>,
     /// A mapping from a string that represents a hint to the hint object.
-    pub string_to_hint: HashMap<String, Hint>,
+    pub string_to_hint: UnorderedHashMap<String, Hint>,
     /// The Starknet state.
     pub starknet_state: StarknetState,
     /// Maintains the resources of the run.
@@ -139,18 +137,17 @@ type L2ToL1Message = (Felt252, Vec<Felt252>);
 /// Execution scope for Starknet-related data.
 /// All values will be 0 by default if not set up by the test.
 #[derive(Clone, Default)]
-#[expect(clippy::disallowed_types)]
 pub struct StarknetState {
     /// The values of addresses in the simulated storage per contract.
-    storage: HashMap<Felt252, HashMap<Felt252, Felt252>>,
+    storage: UnorderedHashMap<Felt252, UnorderedHashMap<Felt252, Felt252>>,
     /// A mapping from contract address to class hash.
-    deployed_contracts: HashMap<Felt252, Felt252>,
+    deployed_contracts: UnorderedHashMap<Felt252, Felt252>,
     /// A mapping from contract address to logs.
-    logs: HashMap<Felt252, ContractLogs>,
+    logs: UnorderedHashMap<Felt252, ContractLogs>,
     /// The simulated execution info.
     exec_info: ExecutionInfo,
     /// A mock history, mapping block number to the block hash.
-    block_hash: HashMap<u64, Felt252>,
+    block_hash: UnorderedHashMap<u64, Felt252>,
 }
 impl StarknetState {
     /// Replaces the addresses in the context.
@@ -474,10 +471,10 @@ impl HintProcessorLogic for CairoHintProcessor<'_> {
         &self,
         hint_code: &str,
         _ap_tracking_data: &ApTracking,
-        _reference_ids: &HashMap<String, usize>,
+        _reference_ids: &std::collections::HashMap<String, usize>,
         _references: &[HintReference],
         _accessible_scopes: &[String],
-        _constants: Arc<HashMap<String, Felt252>>,
+        _constants: Arc<std::collections::HashMap<String, Felt252>>,
     ) -> Result<Box<dyn Any>, VirtualMachineError> {
         Ok(Box::new(self.string_to_hint[hint_code].clone()))
     }
@@ -2345,12 +2342,14 @@ pub fn run_function_with_runner(
     Ok(())
 }
 
-/// Creates CairoRunner for `program`.
 #[expect(clippy::disallowed_types)]
+pub type HintsDict = std::collections::HashMap<usize, Vec<HintParams>>;
+
+/// Creates CairoRunner for `program`.
 pub fn build_cairo_runner(
     data: Vec<MaybeRelocatable>,
     builtins: Vec<BuiltinName>,
-    hints_dict: HashMap<usize, Vec<HintParams>>,
+    hints_dict: HintsDict,
 ) -> Result<CairoRunner, Box<CairoRunError>> {
     let program = Program::new(
         builtins,
@@ -2358,7 +2357,7 @@ pub fn build_cairo_runner(
         Some(0),
         hints_dict,
         ReferenceManager { references: Vec::new() },
-        HashMap::new(),
+        Default::default(),
         vec![],
         None,
     )
@@ -2393,13 +2392,12 @@ pub struct RunFunctionResult {
 
 /// Runs `bytecode` on layout with prime, and returns the matching [RunFunctionResult].
 /// Allows injecting custom HintProcessor.
-#[expect(clippy::disallowed_types)]
 pub fn run_function<'a, 'b: 'a>(
     bytecode: impl Iterator<Item = &'a BigInt> + Clone,
     builtins: Vec<BuiltinName>,
     additional_initialization: impl FnOnce(&mut VirtualMachine) -> Result<(), Box<CairoRunError>>,
     hint_processor: &mut dyn HintProcessor,
-    hints_dict: HashMap<usize, Vec<HintParams>>,
+    hints_dict: HintsDict,
 ) -> Result<RunFunctionResult, Box<CairoRunError>> {
     let data: Vec<MaybeRelocatable> =
         bytecode.map(Felt252::from).map(MaybeRelocatable::from).collect();

--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -1,9 +1,5 @@
 //! Basic runner for running a Sierra program on the VM.
 
-#![expect(clippy::disallowed_types)]
-
-use std::collections::HashMap;
-
 use cairo_lang_casm::hints::Hint;
 use cairo_lang_runnable_utils::builder::{BuildError, EntryCodeConfig, RunnableBuilder};
 use cairo_lang_sierra::extensions::NamedType;
@@ -15,9 +11,9 @@ use cairo_lang_sierra_to_casm::metadata::MetadataComputationConfig;
 use cairo_lang_starknet::contract::ContractInfo;
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::{extract_matches, require};
 use cairo_vm::hint_processor::hint_processor_definition::HintProcessor;
-use cairo_vm::serde::deserialize_program::HintParams;
 use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use cairo_vm::vm::runners::cairo_runner::{ExecutionResources, RunResources};
@@ -30,7 +26,7 @@ use profiling::ProfilingInfo;
 use starknet_types_core::felt::Felt as Felt252;
 use thiserror::Error;
 
-use crate::casm_run::{RunFunctionResult, StarknetHintProcessor};
+use crate::casm_run::{HintsDict, RunFunctionResult, StarknetHintProcessor};
 use crate::profiling::ProfilerConfig;
 
 pub mod casm_run;
@@ -79,12 +75,11 @@ pub struct RunResult {
 /// The execution resources in a run.
 /// Extends [ExecutionResources] by including the used syscalls for Starknet.
 #[derive(Debug, Eq, PartialEq, Clone, Default)]
-#[expect(clippy::disallowed_types)]
 pub struct StarknetExecutionResources {
     /// The basic execution resources.
     pub basic_resources: ExecutionResources,
     /// The used syscalls.
-    pub syscalls: HashMap<String, usize>,
+    pub syscalls: OrderedHashMap<String, usize>,
 }
 
 impl std::ops::AddAssign<StarknetExecutionResources> for StarknetExecutionResources {
@@ -148,12 +143,11 @@ impl From<Felt252> for Arg {
 }
 
 /// Builds `hints_dict` required in `cairo_vm::types::program::Program` from instructions.
-#[expect(clippy::disallowed_types)]
 pub fn build_hints_dict(
     hints: &[(usize, Vec<Hint>)],
-) -> (HashMap<usize, Vec<HintParams>>, HashMap<String, Hint>) {
-    let mut hints_dict: HashMap<usize, Vec<HintParams>> = HashMap::new();
-    let mut string_to_hint: HashMap<String, Hint> = HashMap::new();
+) -> (HintsDict, UnorderedHashMap<String, Hint>) {
+    let mut hints_dict = HintsDict::new();
+    let mut string_to_hint = UnorderedHashMap::<String, Hint>::default();
 
     for (offset, offset_hints) in hints {
         // Register hint with string for the hint processor.
@@ -173,9 +167,8 @@ pub fn build_hints_dict(
 /// [`SierraCasmRunner::run_function_with_prepared_starknet_context`] to run the function.
 /// For typical use-cases you should use [`SierraCasmRunner::run_function_with_starknet_context`],
 /// which does all the preparation, running, and result composition for you.
-#[expect(clippy::disallowed_types)]
 pub struct PreparedStarknetContext {
-    pub hints_dict: HashMap<usize, Vec<HintParams>>,
+    pub hints_dict: HintsDict,
     pub bytecode: Vec<BigInt>,
     pub builtins: Vec<BuiltinName>,
 }
@@ -267,12 +260,11 @@ impl SierraCasmRunner {
     /// Runs the VM starting from a function with a custom hint processor. The function may have
     /// implicits, but no other ref params. The cost of the function is deducted from
     /// `available_gas` before the execution begins.
-    #[expect(clippy::disallowed_types)]
     pub fn run_function<'a, Bytecode>(
         &self,
         func: &Function,
         hint_processor: &mut dyn HintProcessor,
-        hints_dict: HashMap<usize, Vec<HintParams>>,
+        hints_dict: HintsDict,
         bytecode: Bytecode,
         builtins: Vec<BuiltinName>,
     ) -> Result<RunResult, RunnerError>


### PR DESCRIPTION
## Summary

Replaces usages of `std::collections::HashMap` in the runner crates with `UnorderedHashMap` (and `OrderedHashMap` where ordering matters), removing the associated `#[expect(clippy::disallowed_types)]` suppressions. Introduces a `HintsDict` type alias (keeping `std::collections::HashMap` where required by the Cairo VM API) to isolate the remaining allowed usage.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`std::collections::HashMap` is a disallowed type in this codebase (enforced via Clippy), but several locations in `cairo-lang-runner` and `cairo-lang-execute-utils` were suppressing the lint with `#[expect(clippy::disallowed_types)]` instead of using the project-standard `UnorderedHashMap`/`OrderedHashMap` wrappers. This change brings those locations into compliance with the project's conventions and removes the suppressions.

---

## What was the behavior or documentation before?

`std::collections::HashMap` was used directly in `DictTrackerExecScope`, `DictManagerExecScope`, `DictSquashExecScope`, `StarknetState`, `CairoHintProcessor`, `StarknetExecutionResources`, and related functions, with lint suppression attributes scattered throughout.

---

## What is the behavior or documentation after?

All internal uses of `HashMap` are replaced with `UnorderedHashMap` or `OrderedHashMap`. The only remaining `std::collections::HashMap` usage is in the `HintsDict` type alias, which is required by the Cairo VM external API and is explicitly annotated with a single `#[expect(clippy::disallowed_types)]` in one place.

---

## Related issue or discussion (if any)

---

## Additional context

The `DictSquashExecScope::pop_current_key` method was also updated to use `swap_remove` instead of `remove`, which is the correct removal method for `OrderedHashMap`.