### PR TITLE
refactor: migrate HashMap/HashSet to Unordered/Ordered wrappers

### DIFF
--- a/crates/cairo-lang-debug/src/debug.rs
+++ b/crates/cairo-lang-debug/src/debug.rs
@@ -3,8 +3,6 @@
 mod test;
 
 // Mostly taken from https://github.com/salsa-rs/salsa/blob/fd715619813f634fa07952f0d1b3d3a18b68fd65/components/salsa-2022/src/debug.rs
-#[expect(clippy::disallowed_types)]
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -149,7 +147,7 @@ where
 }
 
 #[expect(clippy::disallowed_types)]
-impl<'db, K, V, S> DebugWithDb<'db> for HashMap<K, V, S>
+impl<'db, K, V, S> DebugWithDb<'db> for std::collections::HashMap<K, V, S>
 where
     K: DebugWithDb<'db>,
     V: DebugWithDb<'db, Db = K::Db>,
@@ -162,7 +160,7 @@ where
     }
 }
 
-impl<'db, K, V> DebugWithDb<'db> for BTreeMap<K, V>
+impl<'db, K, V> DebugWithDb<'db> for std::collections::BTreeMap<K, V>
 where
     K: DebugWithDb<'db>,
     V: DebugWithDb<'db, Db = K::Db>,
@@ -231,7 +229,7 @@ where
 }
 
 #[expect(clippy::disallowed_types)]
-impl<'db, V, S> DebugWithDb<'db> for HashSet<V, S>
+impl<'db, V, S> DebugWithDb<'db> for std::collections::HashSet<V, S>
 where
     V: DebugWithDb<'db>,
 {
@@ -242,7 +240,7 @@ where
     }
 }
 
-impl<'db, V> DebugWithDb<'db> for BTreeSet<V>
+impl<'db, V> DebugWithDb<'db> for std::collections::BTreeSet<V>
 where
     V: DebugWithDb<'db>,
 {

--- a/crates/cairo-lang-doc/src/signature_data.rs
+++ b/crates/cairo-lang-doc/src/signature_data.rs
@@ -1,6 +1,3 @@
-#[expect(clippy::disallowed_types)]
-use std::collections::HashSet;
-
 use cairo_lang_defs::ids::TraitItemId::Function;
 use cairo_lang_defs::ids::{
     ConstantId, EnumId, ExternFunctionId, ExternTypeId, FreeFunctionId, GenericParamId,
@@ -25,6 +22,7 @@ use cairo_lang_semantic::items::visibility::Visibility;
 use cairo_lang_semantic::lookup_item::HasResolverData;
 use cairo_lang_semantic::{Expr, GenericArgumentId, GenericParam, Parameter, TypeId};
 use cairo_lang_syntax::attribute::structured::Attribute;
+use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 use itertools::Itertools;
 use salsa::Database;
 
@@ -245,7 +243,6 @@ fn get_free_function_signature_data<'db>(
 }
 
 /// Retrieves data for trait function signature formatting.
-#[expect(clippy::disallowed_types)]
 fn get_trait_function_signature_data<'db>(
     db: &'db dyn Database,
     item_id: TraitFunctionId<'db>,
@@ -258,7 +255,7 @@ fn get_trait_function_signature_data<'db>(
     // to get a signature relevant subset, the trait ones need to be filtered out
     let trait_id = item_id.trait_id(db);
     let trait_resolver_data = trait_id.resolver_data(db)?;
-    let trait_params_set: HashSet<_> = trait_resolver_data.generic_params.iter().collect();
+    let trait_params_set: UnorderedHashSet<_> = trait_resolver_data.generic_params.iter().collect();
 
     let function_generic_params: Vec<GenericParamId<'_>> = resolver_data
         .generic_params

--- a/crates/cairo-lang-sierra-generator/src/canonical_id_replacer.rs
+++ b/crates/cairo-lang-sierra-generator/src/canonical_id_replacer.rs
@@ -2,40 +2,36 @@
 #[path = "canonical_id_replacer_test.rs"]
 mod test;
 
-#[expect(clippy::disallowed_types)]
-use std::collections::HashMap;
-
 use cairo_lang_sierra::ids::{ConcreteLibfuncId, ConcreteTypeId, FunctionId};
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 
 use crate::replace_ids::SierraIdReplacer;
 
 #[derive(Default)]
-#[expect(clippy::disallowed_types)]
 pub struct CanonicalReplacer {
-    type_ids: HashMap<ConcreteTypeId, u64>,
-    function_ids: HashMap<FunctionId, u64>,
-    libfunc_ids: HashMap<ConcreteLibfuncId, u64>,
+    type_ids: UnorderedHashMap<ConcreteTypeId, u64>,
+    function_ids: UnorderedHashMap<FunctionId, u64>,
+    libfunc_ids: UnorderedHashMap<ConcreteLibfuncId, u64>,
 }
 
 /// A replacer that replace the Ids in the program with canonical ones.
 /// The canonical ids are defined by the order of the declaration in the program.
 /// The first type_id is 0, the second type id is 1, etc.
-#[expect(clippy::disallowed_types)]
 impl CanonicalReplacer {
     /// Builds a replacer from a program.
     pub fn from_program(program: &cairo_lang_sierra::program::Program) -> Self {
-        let mut type_ids = HashMap::default();
+        let mut type_ids = UnorderedHashMap::default();
 
         for type_declaration in &program.type_declarations {
             type_ids.insert(type_declaration.id.clone(), type_ids.len() as u64);
         }
 
-        let mut function_ids = HashMap::default();
+        let mut function_ids = UnorderedHashMap::default();
         for function in &program.funcs {
             function_ids.insert(function.id.clone(), function_ids.len() as u64);
         }
 
-        let mut libfunc_ids = HashMap::default();
+        let mut libfunc_ids = UnorderedHashMap::default();
         for libfunc_declaration in &program.libfunc_declarations {
             libfunc_ids.insert(libfunc_declaration.id.clone(), libfunc_ids.len() as u64);
         }

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_test.rs
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_test.rs
@@ -1,8 +1,8 @@
-#[expect(clippy::disallowed_types)]
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 
 use cairo_lang_sierra::extensions::GenericLibfunc;
 use cairo_lang_sierra::extensions::core::CoreLibfunc;
+use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 
 use super::{
     BUILTIN_ALL_LIBFUNCS_LIST, BUILTIN_AUDITED_LIBFUNCS_LIST, BUILTIN_EXPERIMENTAL_LIBFUNCS_LIST,
@@ -29,9 +29,8 @@ fn all_list_includes_all_supported() {
 }
 
 #[test]
-#[expect(clippy::disallowed_types)]
 fn libfunc_lists_include_only_supported_libfuncs() {
-    let supported_ids = CoreLibfunc::supported_ids().into_iter().collect::<HashSet<_>>();
+    let supported_ids = CoreLibfunc::supported_ids().into_iter().collect::<UnorderedHashSet<_>>();
     for list_name in [
         BUILTIN_ALL_LIBFUNCS_LIST,
         BUILTIN_AUDITED_LIBFUNCS_LIST,

--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -1,6 +1,3 @@
-#[expect(clippy::disallowed_types)]
-use std::collections::{HashMap, HashSet};
-
 use cairo_lang_defs::ids::{
     FunctionWithBodyId, ImplAliasId, ImplDefId, LanguageElementId, ModuleId, ModuleItemId,
     NamedLanguageElementId, SubmoduleId, TopLevelLanguageElementId, TraitFunctionId, TraitId,
@@ -31,6 +28,8 @@ use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
+use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 use cairo_lang_utils::{Intern, require, try_extract_matches};
 use itertools::zip_eq;
 use salsa::Database;
@@ -50,12 +49,11 @@ use crate::plugin::events::EventData;
 mod test;
 
 /// Event information.
-#[expect(clippy::disallowed_types)]
 enum EventInfo {
     /// The event is a struct.
     Struct,
     /// The event is an enum, contains its set of selectors.
-    Enum(HashSet<String>),
+    Enum(OrderedHashSet<String>),
 }
 
 /// The information of an entrypoint.
@@ -73,7 +71,6 @@ pub struct BuilderConfig {
     pub account_contract_validations: bool,
 }
 
-#[expect(clippy::disallowed_types)]
 pub struct AbiBuilder<'db> {
     /// The db.
     db: &'db dyn Database,
@@ -86,15 +83,15 @@ pub struct AbiBuilder<'db> {
 
     /// List of types that were included in the abi.
     /// Used to avoid redundancy.
-    types: HashSet<TypeId<'db>>,
+    types: UnorderedHashSet<TypeId<'db>>,
 
     /// A map of events that were included in the abi to their info.
     /// Used to avoid redundancy, as well as preventing enum events from repeating selectors.
-    event_info: HashMap<TypeId<'db>, EventInfo>,
+    event_info: UnorderedHashMap<TypeId<'db>, EventInfo>,
 
     /// List of entry point names that were included in the abi.
     /// Used to avoid duplication.
-    entry_points: HashMap<String, EntryPointInfo<'db>>,
+    entry_points: UnorderedHashMap<String, EntryPointInfo<'db>>,
 
     /// The constructor for the contract.
     ctor: Option<EntryPointInfo<'db>>,
@@ -104,7 +101,6 @@ pub struct AbiBuilder<'db> {
 }
 impl<'db> AbiBuilder<'db> {
     /// Creates an `AbiBuilder` from a Starknet contract module.
-    #[expect(clippy::disallowed_types)]
     pub fn from_submodule(
         db: &'db dyn Database,
         submodule_id: SubmoduleId<'db>,
@@ -114,9 +110,9 @@ impl<'db> AbiBuilder<'db> {
             db,
             config,
             abi_items: Default::default(),
-            types: HashSet::new(),
-            event_info: HashMap::new(),
-            entry_points: HashMap::new(),
+            types: Default::default(),
+            event_info: Default::default(),
+            entry_points: Default::default(),
             ctor: None,
             errors: Vec::new(),
         };
@@ -563,7 +559,6 @@ impl<'db> AbiBuilder<'db> {
     }
 
     /// Adds an event to the ABI from a type with an Event derive.
-    #[expect(clippy::disallowed_types)]
     fn add_event(
         &mut self,
         type_id: TypeId<'db>,
@@ -599,7 +594,7 @@ impl<'db> AbiBuilder<'db> {
                 let ConcreteTypeId::Enum(concrete_enum_id) = concrete else {
                     unreachable!();
                 };
-                let mut selectors = HashSet::new();
+                let mut selectors = OrderedHashSet::default();
                 let mut add_selector = |selector: &str, source_ptr| {
                     if !selectors.insert(selector.to_string()) {
                         Err(ABIError::EventSelectorDuplication {


### PR DESCRIPTION
## Summary

Replaces usages of `std::collections::{HashMap, HashSet, BTreeMap, BTreeSet}` with their project-internal equivalents (`UnorderedHashMap`, `UnorderedHashSet`, `OrderedHashSet`) across several crates, and removes the associated `#[expect(clippy::disallowed_types)]` suppression attributes that were previously required to allow those standard library types.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The codebase enforces a lint (`clippy::disallowed_types`) that disallows direct use of `std::collections` hash and tree map/set types in favor of project-defined wrappers. Several locations were suppressing this lint with `#[expect(clippy::disallowed_types)]` instead of migrating to the correct types. This PR removes those suppressions by switching to the appropriate internal types.

---

## What was the behavior or documentation before?

`std::collections::HashMap`, `HashSet`, `BTreeMap`, and `BTreeSet` were used directly in several modules, with lint suppression attributes to silence the disallowed-types warning.

---

## What is the behavior or documentation after?

The same data structures are now represented using `UnorderedHashMap`, `UnorderedHashSet`, and `OrderedHashSet` from `cairo_lang_utils`, and the `#[expect(clippy::disallowed_types)]` suppressions are removed. In `debug.rs`, the standard library types are referenced via their full paths (`std::collections::HashMap`, etc.) rather than imported, which is sufficient for the trait `impl` blocks there.

---

## Related issue or discussion (if any)

---

## Additional context

The change in `abi.rs` also switches the `EventInfo::Enum` selector set from `HashSet<String>` to `OrderedHashSet<String>`, which provides deterministic ordering for event selectors in addition to satisfying the lint.