### PR TITLE
refactor(lowering): migrate HashMap/HashSet to {Unordered,Ordered} wrappers

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/backward.rs
+++ b/crates/cairo-lang-lowering/src/analysis/backward.rs
@@ -1,18 +1,16 @@
 //! This module introduces the BackAnalysis utility that allows writing analyzers that go backwards
 //! in the flow of the program, on a Lowered representation.
 
-#[expect(clippy::disallowed_types)]
-use std::collections::HashMap;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 
 use crate::analysis::{Analyzer, DataflowAnalyzer, Direction, Edge, StatementLocation};
 use crate::{Block, BlockEnd, BlockId, Lowered, MatchInfo, Statement, VarRemapping, VarUsage};
 
 /// Main analysis type that allows traversing the flow backwards.
-#[expect(clippy::disallowed_types)]
 pub struct BackAnalysis<'db, 'a, TAnalyzer: Analyzer<'db, 'a>> {
     lowered: &'a Lowered<'db>,
     pub analyzer: TAnalyzer,
-    block_info: HashMap<BlockId, TAnalyzer::Info>,
+    block_info: UnorderedHashMap<BlockId, TAnalyzer::Info>,
 }
 impl<'db, 'a, TAnalyzer: Analyzer<'db, 'a>> BackAnalysis<'db, 'a, TAnalyzer> {
     /// Creates a new BackAnalysis instance.

--- a/crates/cairo-lang-lowering/src/analysis/test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/test.rs
@@ -1,12 +1,10 @@
 //! Tests for the dataflow analysis framework.
 
-#[expect(clippy::disallowed_types)]
-use std::collections::HashSet;
-
 use cairo_lang_semantic::test_utils::setup_test_function;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 
 use super::core::{DataflowAnalyzer, Direction, StatementLocation};
 use super::def_site::DefSiteAnalysis;
@@ -116,19 +114,17 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for BlockCounter {
 /// A simple forward analyzer that tracks which blocks are reachable.
 /// Demonstrates using default transfer_block with statement-level transfer_stmt.
 #[derive(Default)]
-#[expect(clippy::disallowed_types)]
 struct ReachabilityAnalyzer {
-    reachable_blocks: HashSet<BlockId>,
+    reachable_blocks: OrderedHashSet<BlockId>,
 }
 
-#[expect(clippy::disallowed_types)]
 impl<'db, 'a> DataflowAnalyzer<'db, 'a> for ReachabilityAnalyzer {
-    type Info = HashSet<BlockId>; // Set of blocks visited to reach this point
+    type Info = OrderedHashSet<BlockId>; // Set of blocks visited to reach this point
 
     const DIRECTION: Direction = Direction::Forward;
 
     fn initial_info(&mut self, _block_id: BlockId, _block_end: &'a BlockEnd<'db>) -> Self::Info {
-        HashSet::new()
+        OrderedHashSet::default()
     }
 
     fn merge(

--- a/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic.rs
@@ -2,12 +2,10 @@
 #[path = "early_unsafe_panic_test.rs"]
 mod test;
 
-#[expect(clippy::disallowed_types)]
-use std::collections::HashSet;
-
 use cairo_lang_defs::ids::ExternFunctionId;
 use cairo_lang_filesystem::flag::FlagsGroup;
 use cairo_lang_semantic::helper::ModuleHelper;
+use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 use salsa::Database;
 
 use crate::analysis::core::StatementLocation;
@@ -22,14 +20,13 @@ use crate::{
 ///
 /// This step might replace a match on an empty enum with a call to unsafe_panic and we rely on the
 /// 'trim_unreachable' optimization to clean that up.
-#[expect(clippy::disallowed_types)]
 pub fn early_unsafe_panic<'db>(db: &'db dyn Database, lowered: &mut Lowered<'db>) {
     if !db.flag_unsafe_panic() || lowered.blocks.is_empty() {
         return;
     }
 
     let core = ModuleHelper::core(db);
-    let libfuncs_with_sideffect = HashSet::from_iter([
+    let libfuncs_with_sideffect = UnorderedHashSet::from_iter([
         core.submodule("debug").extern_function_id("print"),
         core.submodule("internal").extern_function_id("trace"),
     ]);
@@ -61,7 +58,6 @@ pub fn early_unsafe_panic<'db>(db: &'db dyn Database, lowered: &mut Lowered<'db>
     }
 }
 
-#[expect(clippy::disallowed_types)]
 pub struct UnsafePanicContext<'db> {
     db: &'db dyn Database,
 
@@ -69,7 +65,7 @@ pub struct UnsafePanicContext<'db> {
     fixes: Vec<(StatementLocation, LocationId<'db>)>,
 
     /// libfuncs with side effects that we need to ignore.
-    libfuncs_with_sideffect: HashSet<ExternFunctionId<'db>>,
+    libfuncs_with_sideffect: UnorderedHashSet<ExternFunctionId<'db>>,
 }
 
 impl<'db> UnsafePanicContext<'db> {

--- a/crates/cairo-lang-lowering/src/reorganize_blocks.rs
+++ b/crates/cairo-lang-lowering/src/reorganize_blocks.rs
@@ -1,6 +1,4 @@
-#[expect(clippy::disallowed_types)]
-use std::collections::HashMap;
-
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::Itertools;
 
 use crate::analysis::core::StatementLocation;
@@ -16,8 +14,6 @@ use crate::{
 ///
 /// Removes unreachable blocks.
 /// Blocks that are reachable only through goto are combined with the block that does the goto.
-/// The order of the blocks is changed to be a topologically sorted.
-#[expect(clippy::disallowed_types)]
 pub fn reorganize_blocks<'db>(lowered: &mut Lowered<'db>) {
     if lowered.blocks.is_empty() {
         return;
@@ -56,7 +52,7 @@ pub fn reorganize_blocks<'db>(lowered: &mut Lowered<'db>) {
     let n_visited_blocks = old_block_rev_order.len();
 
     let mut rebuilder = RebuildContext {
-        block_remapping: HashMap::from_iter(
+        block_remapping: UnorderedHashMap::from_iter(
             old_block_rev_order
                 .iter()
                 .enumerate()
@@ -183,9 +179,8 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for TopSortContext {
     }
 }
 
-#[expect(clippy::disallowed_types)]
 pub struct RebuildContext {
-    block_remapping: HashMap<BlockId, BlockId>,
+    block_remapping: UnorderedHashMap<BlockId, BlockId>,
     remappings_ctx: remappings::Context,
 }
 impl<'db> Rebuilder<'db> for RebuildContext {

--- a/crates/cairo-lang-lowering/src/test.rs
+++ b/crates/cairo-lang-lowering/src/test.rs
@@ -1,6 +1,3 @@
-#[expect(clippy::disallowed_types)]
-use std::collections::HashMap;
-
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::LanguageElementId;
@@ -14,6 +11,7 @@ use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_test_utils::verify_diagnostics_expectation;
 use cairo_lang_utils::extract_matches;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
 
@@ -168,7 +166,6 @@ a = a * 3
 }
 
 #[test]
-#[expect(clippy::disallowed_types)]
 fn test_sizes() {
     let db = &mut LoweringDatabaseForTesting::default();
     let type_to_size = [
@@ -208,7 +205,7 @@ fn test_sizes() {
     let db: &LoweringDatabaseForTesting = db;
     let type_aliases = test_module.module_id.module_data(db).unwrap().type_aliases(db);
     assert_eq!(type_aliases.len(), type_to_size.len());
-    let alias_expected_size = HashMap::<_, _>::from_iter(
+    let alias_expected_size = UnorderedHashMap::<_, _>::from_iter(
         type_to_size.iter().enumerate().map(|(i, (_, size))| (format!("T{i}"), *size)),
     );
     for (alias_id, alias) in type_aliases.iter() {


### PR DESCRIPTION
## Summary

Replaces usages of `std::collections::HashMap` and `std::collections::HashSet` with `UnorderedHashMap` and `UnorderedHashSet` from `cairo_lang_utils` across the lowering crate. This removes all associated `#[expect(clippy::disallowed_types)]` suppression attributes that were previously required to silence Clippy warnings about using the standard library hash collections directly.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The codebase enforces the use of project-specific hash collection types (`UnorderedHashMap`, `UnorderedHashSet`) via Clippy's `disallowed_types` lint. Several locations in the lowering crate were bypassing this rule using `#[expect(clippy::disallowed_types)]` instead of migrating to the approved types.

---

## What was the behavior or documentation before?

`std::collections::HashMap` and `std::collections::HashSet` were used directly in `backward.rs`, `test.rs`, `early_unsafe_panic.rs`, `reorganize_blocks.rs`, and `test.rs`, with lint suppression attributes to avoid Clippy errors.

---

## What is the behavior or documentation after?

All affected usages now use `cairo_lang_utils::unordered_hash_map::UnorderedHashMap` and `cairo_lang_utils::unordered_hash_set::UnorderedHashSet`, and the `#[expect(clippy::disallowed_types)]` suppressions have been removed.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A