### PR TITLE
Avoid panic on inline macro calls with missing arguments

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -1905,6 +1905,69 @@ macro_item_level!();
 
 //! > ==========================================================================
 
+//! > Test item-level macro invocation with missing argument list.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > crate_settings
+edition = "2024_07"
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = true
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($x:ident) => { 1 };
+}
+m!;
+
+//! > expected_diagnostics
+error[E1006]: Missing tokens. Expected an argument list wrapped in either parentheses, brackets, or braces.
+ --> lib.cairo:4:3
+m!;
+  ^
+
+//! > ==========================================================================
+
+//! > Test unresolved item-level macro invocation with missing argument list.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > crate_settings
+edition = "2024_07"
+[experimental_features]
+negative_impls = false
+associated_item_constraints = false
+coupons = false
+user_defined_inline_macros = true
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+m!;
+
+//! > expected_diagnostics
+error[E1006]: Missing tokens. Expected an argument list wrapped in either parentheses, brackets, or braces.
+ --> lib.cairo:1:3
+m!;
+  ^
+
+//! > ==========================================================================
+
 //! > Test macro with use-star resolution.
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -43,16 +43,29 @@ fn priv_macro_call_data<'db>(
     let module_id = macro_call_id.parent_module(db);
     let mut resolver = Resolver::new(db, module_id, inference_id);
     let macro_call_syntax = db.module_macro_call_by_id(macro_call_id)?;
+    let callsite_module_id = module_id;
+    let arguments = macro_call_syntax.arguments(db);
+    // The parser already reports the missing argument list. Avoid resolving or expanding a
+    // syntactically incomplete macro call, so semantic recovery does not add unrelated errors.
+    if matches!(arguments.subtree(db), ast::WrappedTokenTree::Missing(_)) {
+        return Ok(MacroCallData {
+            macro_call_module: Err(skip_diagnostic()),
+            diagnostics: Default::default(),
+            defsite_module_id: callsite_module_id,
+            callsite_module_id,
+            expansion_mappings: Arc::new([]),
+            parent_macro_call_data: resolver.macro_call_data,
+        });
+    }
     // Resolve the macro call path, and report diagnostics if it finds no match or
     // the resolved item is not a macro declaration.
     let macro_call_path = macro_call_syntax.path(db);
     let macro_name = macro_call_path.as_syntax_node().get_text_without_trivia(db);
-    let callsite_module_id = macro_call_id.parent_module(db);
-    // If the call is to `expose!` and no other `expose` item is locally declared - using expose.
+    // Treat `expose!` as the built-in macro when no local item named `expose` shadows it.
     if macro_name.long(db) == EXPOSE_MACRO_NAME
         && let Ok(None) = db.module_item_by_name(callsite_module_id, macro_name)
     {
-        let (content, mapping) = expose_content_and_mapping(db, macro_call_syntax.arguments(db))?;
+        let (content, mapping) = expose_content_and_mapping(db, arguments.clone())?;
         let code_mappings: Arc<[CodeMapping]> = [mapping].into();
         let generated_file_id = FileLongId::Virtual(VirtualFile {
             parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),
@@ -123,9 +136,10 @@ fn priv_macro_call_data<'db>(
             });
         }
     };
-    let Some((rule, (captures, placeholder_to_rep_id))) = macro_rules.iter().find_map(|rule| {
-        is_macro_rule_match(db, rule, &macro_call_syntax.arguments(db)).map(|res| (rule, res))
-    }) else {
+    let Some((rule, (captures, placeholder_to_rep_id))) = macro_rules
+        .iter()
+        .find_map(|rule| is_macro_rule_match(db, rule, &arguments).map(|res| (rule, res)))
+    else {
         let diag_added = diagnostics.report(
             macro_call_syntax.stable_ptr(db),
             SemanticDiagnosticKind::InlineMacroNoMatchingRule(macro_name),

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -327,7 +327,7 @@ pub fn is_macro_rule_match<'db>(
         ast::WrappedTokenTree::Parenthesized(tt) => tt.tokens(db),
         ast::WrappedTokenTree::Braced(tt) => tt.tokens(db),
         ast::WrappedTokenTree::Bracketed(tt) => tt.tokens(db),
-        ast::WrappedTokenTree::Missing(_) => unreachable!(),
+        ast::WrappedTokenTree::Missing(_) => return None,
     }
     .elements(db)
     .peekable();


### PR DESCRIPTION
Fixes #9938.

## Summary
This fixes a compiler panic for malformed item-level user-defined inline macro calls like `m!;`, where the parser recovers a missing argument list.

When the macro call has no parsed argument token tree, semantic analysis now stops before resolving or expanding the macro. The parser diagnostic is kept as the only user-facing error, and semantic recovery no longer reaches macro rule matching with a missing token tree.

The matcher also defensively treats a missing wrapped token tree as “no match” instead of panicking if that path is reached directly.

## Tests
Added regression coverage for:
- a declared item-level macro called as `m!;`
- an unresolved item-level macro called as `m!;`

Verified with:
- `cargo test -p cairo-lang-semantic inline_macros --lib`
- `./scripts/rust_fmt.sh`
- `./scripts/clippy.sh`
- `git diff --check`
