### PR TITLE
Canonicalize felt252 const-eval values to a unique field-element representative

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -177,6 +177,15 @@ const FUNC_CALC_SUCCESS: () = assert(true);
 const FUNC_CALC_FAILURE: () = assert(false);
 const VALID_EQ: () = assert(1 == 1);
 const VALID_NE: () = assert(1 != 2);
+const VALID_EQ_FELT_CROSS_FORM: () = assert(
+    -1_felt252 == 0x800000000000011000000000000000000000000000000000000000000000000,
+);
+const VALID_MATCH_FELT_CROSS_FORM: () = assert(
+    match -1_felt252 {
+        0x800000000000011000000000000000000000000000000000000000000000000 => true,
+        _ => false,
+    },
+);
 const VALID_LT: () = assert(1_usize < 2);
 const VALID_LE: () = assert(1_usize <= 1);
 const VALID_GT: () = assert(2_usize > 1);
@@ -272,21 +281,21 @@ note: In `test::assert`:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2129]: Constant calculation depth exceeded.
- --> lib.cairo:63:43
+ --> lib.cairo:72:43
 const FUNC_CALC_STACK_EXCEEDED: felt252 = call_myself();
                                           ^^^^^^^^^^^^^
 
 error[E2130]: Failed to calculate constant.
- --> lib.cairo:70:37
+ --> lib.cairo:79:37
 const NON_ZERO_ZERO: NonZero<u64> = my_unwrap(ZERO.try_into());
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: In `test::my_unwrap::<core::zeroable::NonZero::<core::integer::u64>>`:
-  --> lib.cairo:76:17
+  --> lib.cairo:85:17
         None => core::panic_with_felt252('bad value'),
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2128]: Failed to calculate constant.
- --> lib.cairo:82:9
+ --> lib.cairo:91:9
         core::panic_with_felt252('should fail')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/inference
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inference
@@ -256,6 +256,40 @@ error[E2313]: Trait `test::MyTrait::<core::felt252>` has multiple implementation
 
 //! > ==========================================================================
 
+//! > Test felt252 const-generic impls with field-equal but syntactically distinct literals are distinct.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() -> felt252 {
+    Marker::<-1>::tag()
+}
+
+//! > function_name
+foo
+
+//! > module_code
+trait Marker<const K: felt252> {
+    fn tag() -> felt252;
+}
+impl MarkerMinus1 of Marker<-1> {
+    fn tag() -> felt252 {
+        100
+    }
+}
+impl MarkerPrimeMinus1 of Marker<
+    0x800000000000011000000000000000000000000000000000000000000000000,
+> {
+    fn tag() -> felt252 {
+        200
+    }
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
 //! > Test trait inference unresolved type for impl.
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -903,9 +903,9 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
         };
 
         if imp.function == self.eq_fn {
-            return bool_value(args[0] == args[1]);
+            return bool_value(self.const_values_eq(args[0], args[1]));
         } else if imp.function == self.ne_fn {
-            return bool_value(args[0] != args[1]);
+            return bool_value(!self.const_values_eq(args[0], args[1]));
         } else if imp.function == self.not_fn {
             return bool_value(args[0] == self.false_const);
         }
@@ -987,7 +987,7 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                 };
                 let (narrow, wide) =
                     db.concrete_enum_variants(*enm).ok()?.into_iter().collect_tuple()?;
-                let value = felt252_for_downcast(arg.to_int(db)?, &BigInt::ZERO);
+                let value = Felt252::from(arg.to_int(db)?).to_bigint();
                 let mask128 = BigInt::from(u128::MAX);
                 let low = (&value) & mask128;
                 let high: BigInt = (&value) >> 128;
@@ -1171,7 +1171,11 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
         match pattern {
             Pattern::Missing(_) | Pattern::StringLiteral(_) => None,
             Pattern::Otherwise(_) => Some(()),
-            Pattern::Literal(v) => require(numeric_arg_value(db, value)? == v.literal.value),
+            Pattern::Literal(v) => require(self.eq_in_type(
+                &numeric_arg_value(db, value)?,
+                &v.literal.value,
+                value.ty(db).ok()?,
+            )),
             Pattern::Variable(pattern) => {
                 self.vars.insert(VarId::Local(pattern.var.id), value);
                 Some(())
@@ -1220,6 +1224,28 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                 }
             }
         }
+    }
+
+    /// Compares two const values for `felt252` field-element equality.
+    ///
+    /// Direct `felt252` literals are stored in their original signed form (`-1` vs `PRIME - 1` are
+    /// distinct `ConstValueId`s). The PartialEq operator must agree with the field, not with the
+    /// stored representation, so we canonicalize both sides before comparing for `felt252` ints.
+    /// Non-felt252 types keep id equality.
+    fn const_values_eq(&self, a: ConstValueId<'a>, b: ConstValueId<'a>) -> bool {
+        if a == b {
+            return true;
+        }
+        let (ConstValue::Int(va, ty), ConstValue::Int(vb, _)) = (a.long(self.db), b.long(self.db))
+        else {
+            return false;
+        };
+        self.eq_in_type(va, vb, *ty)
+    }
+
+    /// Compares two `BigInt`s of type `ty` for value equality, treating `felt252` as a field.
+    fn eq_in_type(&self, a: &BigInt, b: &BigInt, ty: TypeId<'a>) -> bool {
+        a == b || (ty == self.felt252 && Felt252::from(a) == Felt252::from(b))
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes `felt252` constant canonicalization so that structurally different representations of the same field element (e.g., `-1` and `0x800000000000011000000000000000000000000000000000000000000000000`, which is `PRIME - 1`) are treated as equal. Previously, `canonical_felt252` reduced values modulo `PRIME` but could produce both a positive and a negative representative for the same element, causing structural equality on `ConstValue::Int` to disagree with field equality. The fix, renamed `canonical_calculated_felt252`, maps every `felt252` to a unique balanced representative in the range `[2^251 - PRIME, 2^251)`: values `>= 2^251` are shifted down by `PRIME`, collapsing all aliases of the same field element to a single canonical form.

Equality comparisons for `felt252` constants (in `==`, `!=`, and match arms) now go through field-aware helpers (`const_values_eq` and `eq_in_type`) rather than relying on `ConstValueId` pointer equality, so `-1` and `PRIME - 1` are correctly recognized as the same element in those contexts. Const-generic impl deduplication (e.g. `Trait<-1>` vs `Trait<PRIME - 1>`) is intentionally out of scope: direct literal usages preserve their original form as distinct identities, which is necessary for types like `BoundedInt<-(P-1), 0>`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Structural equality on `ConstValue::Int` was used to compare `felt252` constants, but two values representing the same field element could have different `BigInt` representations after the old `canonical_felt252` (which only reduced modulo `PRIME` without normalizing the sign). This caused `-1` and `PRIME - 1` to be treated as distinct constants, breaking constant equality assertions and match arm resolution.

---

## What was the behavior or documentation before?

`canonical_felt252` returned `value % PRIME`, which could be negative for negative inputs. This meant `-1` and `PRIME - 1` had different canonical forms and were not recognized as the same field element in constant comparisons or match patterns.

---

## What is the behavior or documentation after?

`canonical_calculated_felt252` now returns a value in `[2^251 - PRIME, 2^251)`. Values are first reduced into `[0, PRIME)` via `Felt252::from`, then those `>= 2^251` are shifted down by `PRIME`. This produces a unique representative per field element, so `-1` and `PRIME - 1` both canonicalize to `-1`.

New semantic tests verify that `assert(NEG_ONE_FELT == P_MINUS_1_FELT)` passes at compile time and that a match on `-1_felt252` against the hex form of `PRIME - 1` resolves correctly. A separate inference test pins the intentional behavior that `Trait<-1>` and `Trait<PRIME - 1>` are distinct const-generic instantiations with no duplicate-impl diagnostic.

---

## Additional context

The `felt252_for_downcast` call in the `u256` split path is replaced with a direct `Felt252::from(...).to_bigint()` to ensure the value is always reduced into `[0, PRIME)` before extracting the low and high 128-bit limbs, avoiding incorrect results for negative `felt252\` inputs.

Fixes #9932, #9934.
