### PR TITLE
Skip macro rules with parser-rejected patterns instead of expanding them

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -2698,3 +2698,35 @@ error[E2200]: Plugin diagnostic: Literals with suffix are not supported in const
  --> lib.cairo:1:35
 const a: felt252 = consteval_int!(1_u32 + 2);
                                   ^^^^^^
+
+//! > ==========================================================================
+
+//! > Regression for #9936: unsupported macro param kind emits a diagnostic, not an ICE.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() -> u32 {
+    mymac!(0)
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro mymac {
+    ($x:literal) => { 5_u32 };
+}
+
+//! > expected_diagnostics
+error[E1008]: Missing tokens. Expected a macro rule parameter kind.
+ --> lib.cairo:3:9
+    ($x:literal) => { 5_u32 };
+        ^
+
+error[E2158]: No matching rule found in inline macro `mymac`.
+ --> lib.cairo:6:5
+    mymac!(0)
+    ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -156,6 +156,10 @@ fn priv_macro_declaration_data<'db>(
             rule_err: Ok(()),
         };
         ctx.check_node(expansion.as_syntax_node());
+        // Skipping expanding an inline macro if it had a parser error.
+        if pattern.as_syntax_node().descendants(db).any(|node| node.kind(db).is_missing()) {
+            continue;
+        }
         rules.push(MacroRuleData { pattern, expansion, err: ctx.rule_err });
     }
     let resolver_data = Arc::new(resolver.data);
@@ -376,12 +380,10 @@ fn is_macro_rule_match_ex<'db>(
             }
             ast::MacroElement::Param(param) => {
                 advanced = true;
-                let placeholder_kind: PlaceholderKind =
-                    if let ast::OptionParamKind::ParamKind(param_kind) = param.kind(db) {
-                        param_kind.kind(db).into()
-                    } else {
-                        return None;
-                    };
+                let ast::OptionParamKind::ParamKind(param_kind) = param.kind(db) else {
+                    return None;
+                };
+                let placeholder_kind: PlaceholderKind = param_kind.kind(db).into();
                 let placeholder_name = param.name(db).as_syntax_node().get_text_without_trivia(db);
                 match placeholder_kind {
                     PlaceholderKind::Identifier => {


### PR DESCRIPTION
## Summary

When a user-defined inline macro rule contains an unsupported/missing parameter kind (e.g., `$x:literal`), the compiler now emits a proper diagnostic instead of panicking with an internal compiler error (ICE). Rules whose pattern contains missing syntax nodes are skipped during macro rule registration, and the matching logic uses a `let...else` guard to return `None` cleanly when no valid `ParamKind` is present.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Using an unsupported macro parameter kind (such as `literal`) in a `#[feature("user_defined_inline_macros")]` macro rule caused an ICE rather than a user-facing diagnostic. This is a regression tracked in issue #9936.

---

## What was the behavior or documentation before?

A macro rule like:

```cairo
macro mymac {
    ($x:literal) => { 5_u32 };
}
```

would trigger an internal compiler error when the macro was invoked, because the unsupported parameter kind was not handled gracefully during rule matching.

---

## What is the behavior or documentation after?

The compiler now emits two clear diagnostics:

- `E1008`: Missing tokens — expected a macro rule parameter kind (pointing at the unsupported kind in the rule definition).
- `E2158`: No matching rule found in inline macro `mymac` (pointing at the call site).

No ICE occurs.

---

## Related issue or discussion (if any)

Fixes #9936.

---

## Additional context

A regression test has been added to `inline_macros` test data to cover this case going forward.