### PR TITLE
Avoid panic when an item-scope inline macro lacks an arg-list bracket

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -2730,3 +2730,39 @@ error[E2158]: No matching rule found in inline macro `mymac`.
  --> lib.cairo:6:5
     mymac!(0)
     ^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Regression for #9938: item-scope macro invocation without arg brackets does not ICE.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro m {
+    ($x:ident) => { 1 };
+}
+m!
+
+//! > expected_diagnostics
+error[E1006]: Missing tokens. Expected an argument list wrapped in either parentheses, brackets, or braces.
+ --> lib.cairo:5:3
+m!
+  ^
+
+error[E1001]: Missing token ';'.
+ --> lib.cairo:5:3
+m!
+  ^
+
+error[E2158]: No matching rule found in inline macro `m`.
+ --> lib.cairo:5:1
+m!
+^^

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -331,7 +331,7 @@ pub fn is_macro_rule_match<'db>(
         ast::WrappedTokenTree::Parenthesized(tt) => tt.tokens(db),
         ast::WrappedTokenTree::Braced(tt) => tt.tokens(db),
         ast::WrappedTokenTree::Bracketed(tt) => tt.tokens(db),
-        ast::WrappedTokenTree::Missing(_) => unreachable!(),
+        ast::WrappedTokenTree::Missing(_) => return None,
     }
     .elements(db)
     .peekable();


### PR DESCRIPTION
## Summary

Fixes an ICE (Internal Compiler Error) that occurred when a user-defined inline macro was invoked at item scope without argument brackets (e.g., `m!` with no following `(...)`, `[...]`, or `{...}`). The `Missing` variant of `WrappedTokenTree` was previously marked `unreachable!()`, causing a panic. It now returns `None` from `is_macro_rule_match`, allowing the compiler to emit proper diagnostics instead of crashing.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a user-defined inline macro was invoked without an argument list at item scope, the `WrappedTokenTree::Missing` variant was hit inside `is_macro_rule_match`, which contained an `unreachable!()` assertion. This caused the compiler to panic (ICE) rather than report a diagnostic.

---

## What was the behavior or documentation before?

The compiler would ICE when encountering a macro invocation like `m!` (missing argument brackets) at item scope.

---

## What is the behavior or documentation after?

The compiler now gracefully handles the missing argument list by returning `None` from `is_macro_rule_match`, resulting in proper diagnostics:

- `E1006`: Missing tokens — expected an argument list wrapped in parentheses, brackets, or braces.
- `E1001`: Missing token `;`.
- `E2158`: No matching rule found in inline macro `m`.

---

## Related issue or discussion (if any)

Regression fix for #9938.

---

## Additional context

A test case covering this regression has been added to the inline macros test data.