### PR TITLE
refactor(lowering): rename `UnsupportedPattern` → `RefutablePattern` and improve diagnostic

### DIFF
--- a/crates/cairo-lang-lowering/src/diagnostic.rs
+++ b/crates/cairo-lang-lowering/src/diagnostic.rs
@@ -68,9 +68,11 @@ impl<'db> DiagnosticEntry<'db> for LoweringDiagnostic<'db> {
                 "Call cycle of `nopanic` functions is not allowed.".into()
             }
             LoweringDiagnosticKind::LiteralError(literal_error) => literal_error.format(db),
-            LoweringDiagnosticKind::UnsupportedPattern => {
-                "Inner patterns are not allowed in this context.".into()
-            }
+            LoweringDiagnosticKind::RefutablePattern => "Refutable pattern in irrefutable \
+                                                          binding. Refutable patterns are only \
+                                                          supported in `match`, `if let`, \
+                                                          `while let`, and `let ... else`."
+                .into(),
             LoweringDiagnosticKind::Unsupported => "Unsupported feature.".into(),
             LoweringDiagnosticKind::FixedSizeArrayNonCopyableType => {
                 "Fixed size array inner type must implement the `Copy` trait when the array size \
@@ -117,7 +119,7 @@ impl<'db> DiagnosticEntry<'db> for LoweringDiagnostic<'db> {
             LoweringDiagnosticKind::UnexpectedError => error_code!(E3007),
             LoweringDiagnosticKind::NoPanicFunctionCycle => error_code!(E3008),
             LoweringDiagnosticKind::LiteralError(_) => error_code!(E3009),
-            LoweringDiagnosticKind::UnsupportedPattern => error_code!(E3010),
+            LoweringDiagnosticKind::RefutablePattern => error_code!(E3010),
             LoweringDiagnosticKind::Unsupported => error_code!(E3011),
             LoweringDiagnosticKind::FixedSizeArrayNonCopyableType => error_code!(E3012),
             LoweringDiagnosticKind::EmptyRepeatedElementFixedSizeArray => error_code!(E3013),
@@ -218,7 +220,7 @@ pub enum LoweringDiagnosticKind<'db> {
     LiteralError(LiteralError<'db>),
     FixedSizeArrayNonCopyableType,
     EmptyRepeatedElementFixedSizeArray,
-    UnsupportedPattern,
+    RefutablePattern,
     Unsupported,
 }
 

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -726,7 +726,7 @@ fn lower_single_pattern<'db>(
         | semantic::Pattern::StringLiteral(_)
         | semantic::Pattern::EnumVariant(_) => {
             return Err(LoweringFlowError::Failed(
-                ctx.diagnostics.report(pattern.stable_ptr(), UnsupportedPattern),
+                ctx.diagnostics.report(pattern.stable_ptr(), RefutablePattern),
             ));
         }
         semantic::Pattern::Variable(semantic::PatternVariable {

--- a/crates/cairo-lang-lowering/src/test.rs
+++ b/crates/cairo-lang-lowering/src/test.rs
@@ -49,6 +49,7 @@ cairo_lang_test_utils::test_file_test!(
         members: "members",
         panic: "panic",
         rebindings: "rebindings",
+        refutable_pattern: "refutable_pattern",
         repr_ptr: "repr_ptr",
         snapshot: "snapshot",
         struct_: "struct",

--- a/crates/cairo-lang-lowering/src/test_data/refutable_pattern
+++ b/crates/cairo-lang-lowering/src/test_data/refutable_pattern
@@ -1,0 +1,109 @@
+//! > Refutable enum-variant pattern in `let` (no `else`).
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function_code
+fn foo(opt: Option<u32>) -> u32 {
+    let Option::Some(x) = opt;
+    x
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
+ --> lib.cairo:2:9
+    let Option::Some(x) = opt;
+        ^^^^^^^^^^^^^^^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Refutable literal pattern in `let`.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function_code
+fn foo(x: u32) {
+    let 5 = x;
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
+ --> lib.cairo:2:9
+    let 5 = x;
+        ^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Refutable enum-variant pattern nested inside a struct destructure in `let`.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function_code
+fn foo(s: Wrapper) -> u32 {
+    let Wrapper { inner: Option::Some(x) } = s;
+    x
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+struct Wrapper {
+    inner: Option<u32>,
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
+ --> lib.cairo:6:26
+    let Wrapper { inner: Option::Some(x) } = s;
+                         ^^^^^^^^^^^^^^^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Refutable pattern in a `for` loop binding.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function_code
+fn foo(opts: Array<Option<u32>>) {
+    for Option::Some(_x) in opts {}
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
+ --> lib.cairo:2:9
+    for Option::Some(_x) in opts {}
+        ^^^^^^^^^^^^^^^^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>


### PR DESCRIPTION
## Summary

Renames the `UnsupportedPattern` diagnostic variant to `RefutablePattern` and updates its error message from `"Inner patterns are not allowed in this context."` to `"Refutable pattern in local binding. Add an 'else' clause to handle the unmatched case."` Adds a new test file (`refutable_pattern`) covering enum-variant patterns, literal patterns, and nested refutable patterns inside struct destructures in `let` bindings without an `else` clause.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous diagnostic name and message were inaccurate. `UnsupportedPattern` implied the pattern itself was unsupported, when the real issue is that the pattern is *refutable* — it can fail to match — and is being used in a context (a `let` binding without an `else`) that requires an irrefutable pattern. The old message gave no guidance on how to fix the problem.

---

## What was the behavior or documentation before?

Using a refutable pattern (e.g., `let Option::Some(x) = opt;`) in a `let` binding without an `else` clause produced:

```
error[E3010]: Inner patterns are not allowed in this context.
```

---

## What is the behavior or documentation after?

The same situation now produces:

```
error[E3010]: Refutable pattern in local binding. Add an `else` clause to handle the unmatched case.
```

This accurately names the problem and tells the user how to resolve it.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The error code `E3010` is preserved, so no downstream tooling that keys on error codes is affected.