### PR TITLE
fix(lowering): emit RefutablePattern diagnostic instead of ICE on Span fixed-array let (#9966)

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -798,8 +798,14 @@ fn lower_single_pattern<'db>(
             ty,
             ..
         }) => {
-            let patterns = patterns.clone();
-            lower_tuple_like_pattern_helper(ctx, builder, lowered_expr, &patterns, *ty)?;
+            lower_tuple_like_pattern_helper(
+                ctx,
+                builder,
+                lowered_expr,
+                patterns,
+                *ty,
+                pattern.stable_ptr().untyped(),
+            )?;
         }
         semantic::Pattern::Otherwise(pattern) => {
             let stable_ptr = pattern.stable_ptr.untyped();
@@ -818,6 +824,7 @@ fn lower_tuple_like_pattern_helper<'db>(
     lowered_expr: LoweredExpr<'db>,
     patterns: &[semantic::PatternId],
     ty: semantic::TypeId<'db>,
+    stable_ptr: SyntaxStablePtrId<'db>,
 ) -> LoweringResult<'db, ()> {
     let outputs = match lowered_expr {
         LoweredExpr::Tuple { exprs, .. } => exprs,
@@ -833,6 +840,13 @@ fn lower_tuple_like_pattern_helper<'db>(
                         .to_usize()
                         .unwrap();
                     vec![type_id; size]
+                }
+                // `Span<T>` matched against `[..]` is synthesized as a fixed-size array, but
+                // stays refutable.
+                TypeLongId::Concrete(_) => {
+                    return Err(LoweringFlowError::Failed(
+                        ctx.diagnostics.report(stable_ptr, RefutablePattern),
+                    ));
                 }
                 _ => unreachable!("Tuple-like pattern must be a tuple or fixed size array."),
             };

--- a/crates/cairo-lang-lowering/src/test_data/refutable_pattern
+++ b/crates/cairo-lang-lowering/src/test_data/refutable_pattern
@@ -107,3 +107,31 @@ error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are o
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
+
+//! > ==========================================================================
+
+//! > Refutable fixed-size-array pattern on a Span value in `let`.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let arr: Array<u32> = array![100, 200, 300];
+    let s: Span<u32> = arr.span();
+    let [_a, _b, _c] = s;
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
+ --> lib.cairo:4:9
+    let [_a, _b, _c] = s;
+        ^^^^^^^^^^^^
+
+//! > lowering_flat
+<Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>


### PR DESCRIPTION
## Summary

Adds a diagnostic error when a fixed-size array or tuple pattern is used in a `let` binding against a `Span` value. Previously, this case fell through to an `unreachable!()` panic. Now, when the underlying type resolves to a `TypeLongId::Concrete` (i.e., a `Span`), a `RefutablePattern` diagnostic is emitted instead, surfacing a proper compiler error to the user.

The `stable_ptr` is now threaded through `lower_tuple_like_pattern_helper` so the diagnostic can be reported at the correct source location.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Using a fixed-size array pattern like `let [_a, _b, _c] = s;` where `s` is a `Span<T>` previously caused an internal `unreachable!()` panic during lowering. This is a refutable pattern (the length of the span is not statically known), so it should be rejected with a clear diagnostic rather than causing a compiler crash.

---

## What was the behavior or documentation before?

The compiler would hit an `unreachable!()` branch during lowering when a tuple-like pattern was matched against a `Span` type, resulting in a panic or opaque failure.

---

## What is the behavior or documentation after?

The compiler now emits:

```
error[E3010]: Refutable pattern in local binding. Add an `else` clause to handle the unmatched case.
 --> lib.cairo:4:9
    let [_a, _b, _c] = s;
        ^^^^^^^^^^^^
```

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A test case covering the `Span` pattern scenario has been added to the `fixed_size_array` lowering test data file.