### PR TITLE
Avoid ICE for generic numeric literal suffixes

### DIFF
--- a/crates/cairo-lang-semantic/src/corelib.rs
+++ b/crates/cairo-lang-semantic/src/corelib.rs
@@ -813,6 +813,7 @@ pub fn numeric_upcastable_to_felt252(db: &dyn Database, ty: TypeId<'_>) -> bool 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update)]
 pub enum LiteralError<'db> {
     InvalidTypeForLiteral(TypeId<'db>),
+    InvalidGenericTypeForLiteral(GenericTypeId<'db>),
     OutOfRange(TypeId<'db>),
 }
 impl<'db> LiteralError<'db> {
@@ -822,6 +823,9 @@ impl<'db> LiteralError<'db> {
                 format!("The value does not fit within the range of type {}.", ty.format(db))
             }
             Self::InvalidTypeForLiteral(ty) => {
+                format!("A numeric literal of type {} cannot be created.", ty.format(db))
+            }
+            Self::InvalidGenericTypeForLiteral(ty) => {
                 format!("A numeric literal of type {} cannot be created.", ty.format(db))
             }
         }

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -55,7 +55,7 @@ use super::pattern::{
     PatternOtherwise, PatternTuple, PatternVariable, PatternWrappingInfo,
 };
 use crate::corelib::{
-    self, CorelibSemantic, core_binary_operator, core_bool_ty, core_unary_operator,
+    self, CorelibSemantic, LiteralError, core_binary_operator, core_bool_ty, core_unary_operator,
     false_literal_expr, get_usize_ty, never_ty, true_literal_expr, try_extract_box_inner_type,
     try_get_core_ty_by_name, unit_expr, unit_ty, unwrap_error_propagation_type, validate_literal,
 };
@@ -93,9 +93,9 @@ use crate::resolve::{
 use crate::semantic::{self, Binding, FunctionId, LocalVariable, TypeId, TypeLongId};
 use crate::substitution::SemanticRewriter;
 use crate::types::{
-    ClosureTypeLongId, ConcreteTypeId, add_type_based_diagnostics, are_coupons_enabled,
-    extract_fixed_size_array_size, peel_snapshots, peel_snapshots_ex, resolve_type_ex,
-    verify_fixed_size_array_size, wrap_in_snapshots,
+    ClosureTypeLongId, ConcreteTypeId, TypesSemantic, add_type_based_diagnostics,
+    are_coupons_enabled, extract_fixed_size_array_size, peel_snapshots, peel_snapshots_ex,
+    resolve_type_ex, verify_fixed_size_array_size, wrap_in_snapshots,
 };
 use crate::usage::Usages;
 use crate::{
@@ -3681,6 +3681,21 @@ fn new_literal_expr<'db>(
         }
         let ty = try_get_core_ty_by_name(ctx.db, ty_str, vec![])
             .map_err(|err| ctx.diagnostics.report(stable_ptr.untyped(), err))?;
+        // Numeric suffixes cannot provide generic arguments, so reject generic core types before
+        // later semantic phases try to substitute their missing arguments.
+        if let TypeLongId::Concrete(concrete_ty) = ty.long(ctx.db) {
+            let generic_ty = concrete_ty.generic_type(ctx.db);
+            if ctx.db.generic_type_generic_params(generic_ty)?.len()
+                != concrete_ty.generic_args(ctx.db).len()
+            {
+                return Err(ctx.diagnostics.report(
+                    stable_ptr,
+                    SemanticDiagnosticKind::LiteralError(
+                        LiteralError::InvalidGenericTypeForLiteral(generic_ty),
+                    ),
+                ));
+            }
+        }
         if let Err(err) = validate_literal(ctx.db, ty, &value) {
             ctx.diagnostics.report(stable_ptr, SemanticDiagnosticKind::LiteralError(err));
         }

--- a/crates/cairo-lang-semantic/src/expr/test_data/literal
+++ b/crates/cairo-lang-semantic/src/expr/test_data/literal
@@ -19,6 +19,27 @@ error[E2008]: A numeric literal of type core::pedersen::Pedersen cannot be creat
 
 //! > ==========================================================================
 
+//! > Numeric literal with a generic core type suffix.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _x = 42_Span;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2008]: A numeric literal of type core::array::Span cannot be created.
+ --> lib.cairo:2:14
+    let _x = 42_Span;
+             ^^^^^^^
+
+//! > ==========================================================================
+
 //! > Numeric literal with a non-type suffix.
 
 //! > test_runner_name


### PR DESCRIPTION
## Summary

Reject generic core types used as numeric literal suffixes before carrying a malformed concrete type into later semantic phases.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Numeric literal suffix syntax can name a type, but it cannot provide generic arguments. For a suffix like `42_Span`, semantic analysis resolved `Span` with an empty generic argument list. That malformed concrete type could later reach substitution/formatting and panic in `zip_eq`.

This should be reported as a normal invalid numeric literal type diagnostic instead of an internal compiler error.

---

## What was the behavior or documentation before?

Compiling this code could panic:

```cairo
fn main() {
    let _x = 42_Span;
}
```

---

## What is the behavior or documentation after?

The compiler reports an E2008-style diagnostic and does not carry the malformed generic type forward:

```text
error[E2008]: A numeric literal of type core::array::Span cannot be created.
```

---

## Related issue or discussion (if any)

Fixes #9975.

---

## Additional context

Validation performed locally:

- reproduced the original `42_Span` panic
- verified `42_Span` and `42_Option` now emit E2008 instead of panicking
- `cargo test -p cairo-lang-semantic expr_diagnostics::literal --profile dev`
- `scripts/rust_fmt.sh`
- clippy equivalent for `cairo-lang-semantic` with the repo's pinned nightly and warning flags