### PR TITLE
fix(semantic): emit E2008 for generic-type numeric literal suffixes instead of ICE

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -55,7 +55,7 @@ use super::pattern::{
     PatternOtherwise, PatternTuple, PatternVariable, PatternWrappingInfo,
 };
 use crate::corelib::{
-    self, CorelibSemantic, core_binary_operator, core_bool_ty, core_unary_operator,
+    self, CorelibSemantic, LiteralError, core_binary_operator, core_bool_ty, core_unary_operator,
     false_literal_expr, get_usize_ty, never_ty, true_literal_expr, try_extract_box_inner_type,
     try_get_core_ty_by_name, unit_expr, unit_ty, unwrap_error_propagation_type, validate_literal,
 };
@@ -3682,7 +3682,14 @@ fn new_literal_expr<'db>(
         let ty = try_get_core_ty_by_name(ctx.db, ty_str, vec![])
             .map_err(|err| ctx.diagnostics.report(stable_ptr.untyped(), err))?;
         if let Err(err) = validate_literal(ctx.db, ty, &value) {
-            ctx.diagnostics.report(stable_ptr, SemanticDiagnosticKind::LiteralError(err));
+            let is_invalid_type = matches!(err, LiteralError::InvalidTypeForLiteral(_));
+            let diag =
+                ctx.diagnostics.report(stable_ptr, SemanticDiagnosticKind::LiteralError(err));
+            // The type is malformed (generic type with zero args); returning Ok would ICE
+            // downstream queries via GenericSubstitution::new zip_eq mismatch.
+            if is_invalid_type {
+                return Err(diag);
+            }
         }
         return Ok(ExprNumericLiteral { value, ty, stable_ptr });
     };

--- a/crates/cairo-lang-semantic/src/expr/test_data/literal
+++ b/crates/cairo-lang-semantic/src/expr/test_data/literal
@@ -218,3 +218,42 @@ error[E2315]: Mismatched types. The type `()` cannot be created from a numeric l
  --> lib.cairo:3:5
     x
     ^
+
+//! > ==========================================================================
+
+//! > Numeric literal suffix with generic type emits E2008 instead of ICE (#9975).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _a = 42_Option;
+    let _b = 42_Result;
+    let _c = 42_PanicResult;
+    let _d = 42_Span;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2008]: A numeric literal of type core::option::Option cannot be created.
+ --> lib.cairo:2:14
+    let _a = 42_Option;
+             ^^^^^^^^^
+
+error[E2008]: A numeric literal of type core::result::Result cannot be created.
+ --> lib.cairo:3:14
+    let _b = 42_Result;
+             ^^^^^^^^^
+
+error[E2008]: A numeric literal of type core::panics::PanicResult cannot be created.
+ --> lib.cairo:4:14
+    let _c = 42_PanicResult;
+             ^^^^^^^^^^^^^^
+
+error[E2008]: A numeric literal of type core::array::Span cannot be created.
+ --> lib.cairo:5:14
+    let _d = 42_Span;
+             ^^^^^^^


### PR DESCRIPTION
## Summary

When a numeric literal uses a generic type as its suffix (e.g., `42_Option`, `42_Result`), the compiler now emits a proper `E2008` diagnostic instead of panicking with an internal compiler error (ICE).

The fix detects when `validate_literal` returns a `LiteralError::InvalidTypeForLiteral` error and propagates it as an `Err` rather than continuing to build the expression. Previously, returning `Ok` with a malformed generic type caused a downstream `GenericSubstitution::new` `zip_eq` mismatch panic.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Using a generic type name as a numeric literal suffix (e.g., `42_Option`) triggered an ICE instead of a user-facing diagnostic. The compiler would proceed past the error, attempt to construct a `GenericSubstitution` with a type that had no generic arguments, and crash with a `zip_eq` mismatch.

---

## What was the behavior or documentation before?

Writing `42_Option`, `42_Result`, `42_Span`, or similar caused an internal compiler error (ICE) rather than a clean diagnostic.

---

## What is the behavior or documentation after?

The compiler emits a proper `E2008` error — "A numeric literal of type `core::option::Option` cannot be created" — and compilation continues cleanly without crashing.

---

## Related issue or discussion (if any)

Fixes #9975.

---

## Additional context

Test cases for `42_Option`, `42_Result`, `42_PanicResult`, and `42_Span` have been added to the literal test data to cover this scenario.