### PR TITLE
Bound test result queue in test runner

### DIFF
--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -38,8 +38,6 @@ type ArcCustomHintProcessorFactory = Arc<
     dyn (for<'a> Fn(CairoHintProcessor<'a>) -> Box<dyn StarknetHintProcessor + 'a>) + Send + Sync,
 >;
 
-const TEST_RESULT_CHANNEL_CAPACITY_FACTOR: usize = 4;
-
 /// Compile and run tests.
 pub struct TestRunner<'db> {
     compiler: TestCompiler<'db>,
@@ -386,9 +384,8 @@ pub fn run_tests(
     let suffix = if named_tests.len() != 1 { "s" } else { "" };
     println!("running {} test{}", named_tests.len(), suffix);
 
-    let result_channel_capacity =
-        rayon::current_num_threads().max(1) * TEST_RESULT_CHANNEL_CAPACITY_FACTOR;
-    let (tx, rx) = sync_channel::<_>(result_channel_capacity);
+    const CAPACITY_FACTOR: usize = 4;
+    let (tx, rx) = sync_channel::<_>(rayon::current_num_threads().max(1) * CAPACITY_FACTOR);
     rayon::spawn(move || {
         named_tests.into_par_iter().for_each(|(name, test)| {
             let result =

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::mpsc::channel;
+use std::sync::mpsc::sync_channel;
 
 use anyhow::{Context, Result, bail};
 use cairo_lang_compiler::db::RootDatabase;
@@ -37,6 +37,8 @@ mod test;
 type ArcCustomHintProcessorFactory = Arc<
     dyn (for<'a> Fn(CairoHintProcessor<'a>) -> Box<dyn StarknetHintProcessor + 'a>) + Send + Sync,
 >;
+
+const TEST_RESULT_CHANNEL_CAPACITY_FACTOR: usize = 4;
 
 /// Compile and run tests.
 pub struct TestRunner<'db> {
@@ -384,7 +386,9 @@ pub fn run_tests(
     let suffix = if named_tests.len() != 1 { "s" } else { "" };
     println!("running {} test{}", named_tests.len(), suffix);
 
-    let (tx, rx) = channel::<_>();
+    let result_channel_capacity =
+        rayon::current_num_threads().max(1) * TEST_RESULT_CHANNEL_CAPACITY_FACTOR;
+    let (tx, rx) = sync_channel::<_>(result_channel_capacity);
     rayon::spawn(move || {
         named_tests.into_par_iter().for_each(|(name, test)| {
             let result =


### PR DESCRIPTION
This change replaces the unbounded test-result channel with a bounded queue, preventing unbounded result accumulation and stabilizing memory under heavy parallel and profiling runs.