### PR TITLE
docs(corelib): use public integer trait paths

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -25,16 +25,16 @@
 //! [`Mul`]: crate::traits::Mul
 //! [`Div`]: crate::traits::Div
 //! [`Rem`]: crate::traits::Rem
-//! [`DivRem`]: crate::traits::DivRem
-//! [`CheckedAdd`]: crate::num::traits::ops::checked::CheckedAdd
-//! [`CheckedSub`]: crate::num::traits::ops::checked::CheckedSub
-//! [`CheckedMul`]: crate::num::traits::ops::checked::CheckedMul
-//! [`WrappingAdd`]: crate::num::traits::ops::wrapping::WrappingAdd
-//! [`WrappingSub`]: crate::num::traits::ops::wrapping::WrappingSub
-//! [`WrappingMul`]: crate::num::traits::ops::wrapping::WrappingMul
-//! [`OverflowingAdd`]: crate::num::traits::ops::overflowing::OverflowingAdd
-//! [`OverflowingSub`]: crate::num::traits::ops::overflowing::OverflowingSub
-//! [`OverflowingMul`]: crate::num::traits::ops::overflowing::OverflowingMul
+//! [`DivRem`]: crate::num::traits::DivRem
+//! [`CheckedAdd`]: crate::num::traits::CheckedAdd
+//! [`CheckedSub`]: crate::num::traits::CheckedSub
+//! [`CheckedMul`]: crate::num::traits::CheckedMul
+//! [`WrappingAdd`]: crate::num::traits::WrappingAdd
+//! [`WrappingSub`]: crate::num::traits::WrappingSub
+//! [`WrappingMul`]: crate::num::traits::WrappingMul
+//! [`OverflowingAdd`]: crate::num::traits::OverflowingAdd
+//! [`OverflowingSub`]: crate::num::traits::OverflowingSub
+//! [`OverflowingMul`]: crate::num::traits::OverflowingMul
 //!
 //! # Examples
 //!


### PR DESCRIPTION
## Summary

Updates the integer corelib module docs to link arithmetic helper traits through their public `crate::num::traits` re-export paths.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The integer module docs referenced implementation-module paths such as `crate::num::traits::ops::checked::CheckedAdd`. These traits are re-exported from `crate::num::traits`, which is the public path used elsewhere in corelib docs and examples.

---

## What was the behavior or documentation before?

The affected references pointed to deeper `ops::*` modules or to the legacy `crate::traits::DivRem` path.

---

## What is the behavior or documentation after?

The references now point to the public `crate::num::traits::*` paths for `DivRem`, checked arithmetic, wrapping arithmetic, and overflowing arithmetic traits.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

This follows recent corelib documentation fixes that align examples and notes with public import paths.