### PR TITLE
refactor(semantic): cache Result/Option EnumIds in CoreInfo, use ID comparison.

### DIFF
--- a/crates/cairo-lang-semantic/src/corelib.rs
+++ b/crates/cairo-lang-semantic/src/corelib.rs
@@ -9,6 +9,7 @@ use cairo_lang_filesystem::ids::{CrateId, SmolStrId};
 use cairo_lang_syntax::node::ast::{self, BinaryOperator, UnaryOperator};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_utils::{Intern, OptionFrom, extract_matches, require, try_extract_matches};
+use itertools::Itertools;
 use num_bigint::BigInt;
 use num_traits::{Num, Signed, ToPrimitive, Zero};
 use salsa::Database;
@@ -110,21 +111,25 @@ pub fn core_result_ty<'db>(
     ok_type: TypeId<'db>,
     err_type: TypeId<'db>,
 ) -> TypeId<'db> {
-    get_ty_by_name(
-        db,
-        core_submodule(db, SmolStrId::from(db, "result")),
-        SmolStrId::from(db, "Result"),
-        vec![GenericArgumentId::Type(ok_type), GenericArgumentId::Type(err_type)],
-    )
+    TypeLongId::Concrete(ConcreteTypeId::Enum(
+        ConcreteEnumLongId {
+            enum_id: db.core_info().result,
+            generic_args: vec![GenericArgumentId::Type(ok_type), GenericArgumentId::Type(err_type)],
+        }
+        .intern(db),
+    ))
+    .intern(db)
 }
 
 pub fn core_option_ty<'db>(db: &'db dyn Database, some_type: TypeId<'db>) -> TypeId<'db> {
-    get_ty_by_name(
-        db,
-        core_submodule(db, SmolStrId::from(db, "option")),
-        SmolStrId::from(db, "Option"),
-        vec![GenericArgumentId::Type(some_type)],
-    )
+    TypeLongId::Concrete(ConcreteTypeId::Enum(
+        ConcreteEnumLongId {
+            enum_id: db.core_info().option,
+            generic_args: vec![GenericArgumentId::Type(some_type)],
+        }
+        .intern(db),
+    ))
+    .intern(db)
 }
 
 pub fn core_box_ty<'db>(db: &'db dyn Database, inner_type: TypeId<'db>) -> TypeId<'db> {
@@ -490,23 +495,16 @@ pub fn unwrap_error_propagation_type<'db>(
     match ty.long(db) {
         // Only enums may be `Result` and `Option` types.
         TypeLongId::Concrete(semantic::ConcreteTypeId::Enum(enm)) => {
-            if let [ok_variant, err_variant] =
-                db.concrete_enum_variants(*enm).to_option()?.as_slice()
-            {
-                let name = enm.enum_id(db).name(db);
-                if name.long(db) == "Option" {
-                    return Some(ErrorPropagationType::Option {
-                        some_variant: *ok_variant,
-                        none_variant: *err_variant,
-                    });
-                } else if name.long(db) == "Result" {
-                    return Some(ErrorPropagationType::Result {
-                        ok_variant: *ok_variant,
-                        err_variant: *err_variant,
-                    });
-                }
+            let [v0, v1] = db.concrete_enum_variants(*enm).ok()?.into_iter().collect_array()?;
+            let info = db.core_info();
+            let enum_id = enm.enum_id(db);
+            if enum_id == info.result {
+                Some(ErrorPropagationType::Result { ok_variant: v0, err_variant: v1 })
+            } else if enum_id == info.option {
+                Some(ErrorPropagationType::Option { some_variant: v0, none_variant: v1 })
+            } else {
+                None
             }
-            None
         }
         TypeLongId::GenericParameter(_) => todo!(
             "When generic types are supported, if type is of matching type, allow unwrapping it \
@@ -1025,6 +1023,9 @@ pub struct CoreInfo<'db> {
     pub i128: TypeId<'db>,
     pub class_hash: TypeId<'db>,
     pub contract_address: TypeId<'db>,
+    // Enums.
+    pub result: EnumId<'db>,
+    pub option: EnumId<'db>,
     // Traits.
     pub numeric_literal_trt: TraitId<'db>,
     pub string_literal_trt: TraitId<'db>,
@@ -1177,6 +1178,8 @@ impl<'db> CoreInfo<'db> {
             i128: integer.ty("i128", vec![]),
             class_hash: starknet.submodule("class_hash").ty("ClassHash", vec![]),
             contract_address: starknet.submodule("contract_address").ty("ContractAddress", vec![]),
+            result: core.submodule("result").enum_id("Result"),
+            option: core.submodule("option").enum_id("Option"),
             numeric_literal_trt: integer.trait_id("NumericLiteral"),
             string_literal_trt: core.submodule("string").trait_id("StringLiteral"),
             index_trt: index_module.trait_id("Index"),

--- a/crates/cairo-lang-semantic/src/helper.rs
+++ b/crates/cairo-lang-semantic/src/helper.rs
@@ -1,4 +1,6 @@
-use cairo_lang_defs::ids::{ExternFunctionId, FreeFunctionId, ModuleId, ModuleItemId, TraitId};
+use cairo_lang_defs::ids::{
+    EnumId, ExternFunctionId, FreeFunctionId, ModuleId, ModuleItemId, TraitId,
+};
 use cairo_lang_filesystem::ids::SmolStrId;
 use salsa::Database;
 
@@ -31,6 +33,15 @@ impl<'a> ModuleHelper<'a> {
             self.db.module_item_by_name(self.id, SmolStrId::from(self.db, name))
         else {
             panic!("`{}` not found in `{}`.", name, self.id.full_path(self.db));
+        };
+        id
+    }
+    /// Returns the id of an enum named `name` in the current module.
+    pub fn enum_id(&self, name: &str) -> EnumId<'a> {
+        let Ok(Some(ModuleItemId::Enum(id))) =
+            self.db.module_item_by_name(self.id, SmolStrId::from(self.db, name))
+        else {
+            panic!("`{name}` not found in `{}`.", self.id.full_path(self.db));
         };
         id
     }


### PR DESCRIPTION
## Summary

Adds `result` and `option` `EnumId` fields to `CoreInfo`, and refactors `core_result_ty`, `core_option_ty`, and `unwrap_error_propagation_type` to use these cached IDs directly instead of performing name-based module lookups at call time. Also adds a `ModuleHelper::enum_id` helper method to look up an enum by name within a module.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, `core_result_ty`, `core_option_ty`, and `unwrap_error_propagation_type` resolved `Result` and `Option` by performing string-based module and name lookups on every call. By caching the `EnumId`s for `Result` and `Option` in `CoreInfo`, these lookups are replaced with direct ID comparisons and direct construction of concrete types, avoiding repeated resolution overhead.

---

## What was the behavior or documentation before?

`core_result_ty` and `core_option_ty` called `get_ty_by_name` with string lookups into the `result` and `option` submodules on every invocation. `unwrap_error_propagation_type` identified `Option` and `Result` by comparing the enum's name string.

---

## What is the behavior or documentation after?

`CoreInfo` now holds pre-resolved `EnumId`s for `Result` and `Option`. Type construction uses `ConcreteEnumLongId` directly with these IDs, and `unwrap_error_propagation_type` identifies the enum by comparing `EnumId`s against the cached values rather than matching on name strings.

---

## Related issue or discussion (if any)

---

## Additional context

The `itertools::Itertools::collect_array` method is used in `unwrap_error_propagation_type` to cleanly destructure the two concrete enum variants into `[v0, v1]`, replacing the previous slice pattern match on a `to_option` result.