### PR TITLE
(bug fix): correct diagnostic span for write! named placeholders after escapes

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -426,6 +426,78 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 
 //! > ==========================================================================
 
+//! > Test write! named placeholder span is correct after escape sequences
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let mut f: core::fmt::Formatter = Default::default();
+    write!(f, "prefix\n{name}").unwrap();
+    write!(f, "\x41{hex_name}").unwrap();
+    write!(f, "\101{oct_name}").unwrap();
+    write!(f, "\u{41}{uni_name}").unwrap();
+    write!(f, "\u0041{uni4_name}").unwrap();
+    write!(f, "\\u{esc_bs_name}").unwrap();
+    write!(f, "{double_quotes}\"").unwrap();
+    write!(f, "\u{7B}uni_brace}").unwrap();
+    write!(f, "\u007Buni4_brace}").unwrap();
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error[E0006]: Identifier not found.
+ --> lib.cairo:3:25
+    write!(f, "prefix\n{name}").unwrap();
+                        ^^^^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:4:21
+    write!(f, "\x41{hex_name}").unwrap();
+                    ^^^^^^^^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:5:21
+    write!(f, "\101{oct_name}").unwrap();
+                    ^^^^^^^^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:6:23
+    write!(f, "\u{41}{uni_name}").unwrap();
+                      ^^^^^^^^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:7:23
+    write!(f, "\u0041{uni4_name}").unwrap();
+                      ^^^^^^^^^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:8:20
+    write!(f, "\\u{esc_bs_name}").unwrap();
+                   ^^^^^^^^^^^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:9:17
+    write!(f, "{double_quotes}\"").unwrap();
+                ^^^^^^^^^^^^^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:10:32
+    write!(f, "\u{7B}uni_brace}").unwrap();
+                               ^^^^^^^^^
+
+error[E0006]: Identifier not found.
+ --> lib.cairo:11:33
+    write!(f, "\u007Buni4_brace}").unwrap();
+                                ^^^^^^^^^^
+
+//! > ==========================================================================
+
 //! > Test bad writeln! macros
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/inline_macros/write.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/write.rs
@@ -10,7 +10,7 @@ use cairo_lang_defs::plugin_utils::{
 };
 use cairo_lang_filesystem::span::{TextSpan, TextWidth};
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
-use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode, ast};
 use cairo_lang_utils::{OptionHelper, try_extract_matches};
 use indoc::indoc;
 use num_bigint::{BigInt, Sign};
@@ -148,8 +148,12 @@ struct FormattingInfo<'db> {
     formatter_arg_node: RewriteNode<'db>,
     /// The format string argument.
     format_string_arg: ast::Arg<'db>,
-    /// The format string content.
+    /// The decoded format string content.
     format_string: String,
+    /// The raw source text of the format string (the body between the surrounding `"` quotes).
+    /// Needed so that placeholder spans account for escape sequences that occupy more source
+    /// bytes than their decoded counterpart.
+    format_string_source: &'db str,
     /// The positional arguments for the format string.
     args: Vec<ast::Expr<'db>>,
     macro_ast: ast::ExprInlineMacro<'db>,
@@ -213,14 +217,26 @@ impl<'db> FormattingInfo<'db> {
                 "Format string argument must be unnamed.",
             )]);
         };
-        let Some(format_string) = try_extract_matches!(format_string_expr, ast::Expr::String)
-            .and_then(|arg| arg.string_value(db))
+        let Some(format_string_terminal) =
+            try_extract_matches!(format_string_expr, ast::Expr::String)
         else {
             return Err(vec![error_with_inner_span(
                 format_string_arg.as_syntax_node(),
                 "Format string argument must be a string literal.",
             )]);
         };
+        let Some(format_string) = format_string_terminal.string_value(db) else {
+            return Err(vec![error_with_inner_span(
+                format_string_arg.as_syntax_node(),
+                "Format string argument must be a string literal.",
+            )]);
+        };
+        let format_string_source = format_string_terminal
+            .text(db)
+            .long(db)
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .unwrap_or("");
         let mut diagnostics = vec![];
         let args: Vec<_> = args_iter
             .filter_map(|arg| {
@@ -238,8 +254,8 @@ impl<'db> FormattingInfo<'db> {
         Ok(FormattingInfo {
             formatter_arg_node: RewriteNode::from_ast_trimmed(&formatter_arg),
             format_string_arg: format_string_arg.clone(),
-            // `unwrap` is ok because the above `on_none` ensures it's not None.
             format_string,
+            format_string_source,
             args,
             macro_ast: syntax.clone(),
         })
@@ -254,10 +270,13 @@ impl<'db> FormattingInfo<'db> {
     ) {
         let mut next_arg_index = 0..self.args.len();
         let mut arg_used = vec![false; self.args.len()];
-        let mut format_iter = self.format_string.chars().enumerate().peekable();
+        let mut format_iter = self.format_string.chars().peekable();
         let mut pending_chars = String::new();
         let mut ident_count = 1;
         let mut missing_args = 0;
+        // Cursor over source-byte positions of `{` in the raw format string, advanced in lockstep
+        // with the decoded format string so named-placeholder spans land on the correct byte.
+        let mut source_braces = source_brace_positions(self.format_string_source).into_iter();
         let format_string_base = self
             .format_string_arg
             .as_syntax_node()
@@ -271,13 +290,17 @@ impl<'db> FormattingInfo<'db> {
                 &[("arg".to_string(), RewriteNode::from_ast_trimmed(arg))].into(),
             ));
         }
-        while let Some((idx, c)) = format_iter.next() {
+        while let Some(c) = format_iter.next() {
             if c == '{' {
-                if matches!(format_iter.peek(), Some(&(_, '{'))) {
+                if matches!(format_iter.peek(), Some(&'{')) {
                     pending_chars.push('{');
                     format_iter.next();
+                    // Step past both `{`s of the `{{` escape in the source cursor.
+                    source_braces.next();
+                    source_braces.next();
                     continue;
                 }
+                let brace_source_pos = source_braces.next();
                 let argument_info = match extract_placeholder_argument(&mut format_iter) {
                     Ok(argument_info) => argument_info,
                     Err(error_message) => {
@@ -337,8 +360,10 @@ impl<'db> FormattingInfo<'db> {
                         }
                     }
                     PlaceholderArgumentSource::Named(argument) => {
-                        let start = format_string_base
-                            .add_width(TextWidth::from_str(&self.format_string[..(idx + 1)]));
+                        let start = format_string_base.add_width(TextWidth::from_str(
+                            &self.format_string_source[..brace_source_pos
+                                .map_or(self.format_string_source.len(), |pos| pos + 1)],
+                        ));
                         let origin =
                             TextSpan::new_with_width(start, TextWidth::from_str(&argument));
                         self.append_formatted_arg(
@@ -357,7 +382,7 @@ impl<'db> FormattingInfo<'db> {
                     }
                 }
             } else if c == '}' {
-                if matches!(format_iter.peek(), Some(&(_, '}'))) {
+                if matches!(format_iter.peek(), Some(&'}')) {
                     pending_chars.push('}');
                     format_iter.next();
                 } else {
@@ -503,23 +528,50 @@ impl fmt::Display for FormattingTrait {
     }
 }
 
+/// Returns the byte positions of literal `{` characters in the raw source of a format string.
+/// `{` characters inside `\u{...}` unicode escapes are skipped, since they don't appear in the
+/// decoded string. The `\uNNNN` form (4 hex digits, no braces) is also recognized so the helper
+/// doesn't misread the following text.
+fn source_brace_positions(source: &str) -> Vec<usize> {
+    let mut positions = vec![];
+    let mut chars = source.char_indices();
+    while let Some((idx, c)) = chars.next() {
+        match c {
+            '\\' => {
+                if matches!(chars.next(), Some((_, 'u'))) {
+                    if matches!(chars.next(), Some((_, '{'))) {
+                        // `\u{...}`: consume the embedded `{...}`.
+                        chars.by_ref().take_while(|&(_, c)| c != '}').for_each(drop);
+                    } else {
+                        // `\uNNNN`: 4 hex digits, the first already consumed above.
+                        chars.by_ref().take(3).for_each(drop);
+                    }
+                }
+            }
+            '{' => positions.push(idx),
+            _ => {}
+        }
+    }
+    positions
+}
+
 /// Extracts a placeholder argument from a format string. On error, returns Err with a relevant
 /// error string.
 fn extract_placeholder_argument(
-    format_iter: &mut std::iter::Peekable<std::iter::Enumerate<std::str::Chars<'_>>>,
+    format_iter: &mut std::iter::Peekable<std::str::Chars<'_>>,
 ) -> Result<PlaceholderArgumentInfo, &'static str> {
     // The part before the ':' (if any), indicating the name of the parameter.
     let mut parameter_name = String::new();
     // The part after the ':' (if any), indicating the formatting specification.
     let mut formatting_spec = String::new();
     let mut placeholder_terminated = false;
-    for (_, c) in format_iter.by_ref() {
+    for c in format_iter.by_ref() {
         if c == '}' {
             placeholder_terminated = true;
             break;
         }
         if c == ':' {
-            for (_, c) in format_iter.by_ref() {
+            for c in format_iter.by_ref() {
                 if c == '}' {
                     placeholder_terminated = true;
                     break;


### PR DESCRIPTION
## Summary

Fixes incorrect source span computation for named placeholders in `write!`/`writeln!` macros when the format string contains escape sequences (e.g., `\n`, `\x41`, `\101`). The fix tracks a separate raw source string (`format_string_source`) alongside the decoded string, and uses brace positions from the raw source when computing `TextSpan` offsets for named placeholder diagnostics.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a format string contained escape sequences before a named placeholder (e.g., `"prefix\n{name}"`), the span for the placeholder was computed using byte offsets into the *decoded* string. Escape sequences like `\n` decode to a single byte but occupy two bytes in the source, causing the reported span to point to the wrong location in the source file.

---

## What was the behavior or documentation before?

Diagnostic error spans for named placeholders in `write!` were offset incorrectly when escape sequences appeared earlier in the format string. For example, `write!(f, "prefix\n{name}")` would report the error span for `name` at the wrong column.

---

## What is the behavior or documentation after?

Diagnostic spans for named placeholders now correctly point to the placeholder's actual position in the source, even when escape sequences like `\n`, `\x41`, or `\101` appear earlier in the format string. A new test case verifies the correct span positions for all three escape sequence forms.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The fix introduces `format_string_source`, which holds the raw (un-decoded) body of the format string literal (stripped of surrounding quotes). A `source_braces` iterator over `{` positions in the raw source is advanced in lockstep with the main format string parsing loop, so that `brace_source_pos` always reflects the true byte offset in the source text rather than the decoded string.