### PR TITLE
(refactor): extract compile bench scenarios into common module

### DIFF
--- a/tests/benches/common.rs
+++ b/tests/benches/common.rs
@@ -1,0 +1,190 @@
+//! Shared scenarios for compile benchmarks.
+//!
+//! Each phase is exposed as a one-shot `run_*` function so the criterion timing harness in
+//! `compile.rs` can drive it without duplicating the setup boilerplate. Future bench binaries
+//! (e.g. a heap-profiling counterpart) can reuse the same helpers.
+
+use std::path::PathBuf;
+
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
+use cairo_lang_compiler::project::setup_project;
+use cairo_lang_compiler::{CompilerConfig, compile_prepared_db_program, ensure_diagnostics};
+use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
+use cairo_lang_filesystem::db::{files_group_input, set_crate_configs_input};
+use cairo_lang_filesystem::ids::{BlobLongId, CrateInput};
+use cairo_lang_lowering::cache::generate_crate_cache;
+use cairo_lang_lowering::optimizations::config::Optimizations;
+use cairo_lang_lowering::utils::InliningStrategy;
+use cairo_lang_sierra::program::Program;
+use cairo_lang_starknet::starknet_plugin_suite;
+use cairo_lang_test_plugin::{TestsCompilationConfig, compile_test_prepared_db, test_plugin_suite};
+use cairo_lang_test_runner::{TestRunConfig, TestRunner, run_tests};
+
+/// Configuration for a benchmarked project.
+pub struct BenchConfig {
+    pub name: &'static str,
+    pub path: PathBuf,
+    /// Whether to include the Starknet plugin (required for contract code).
+    pub starknet: bool,
+    /// Whether to run cairo-to-sierra and cache-to-sierra phases.
+    /// Set to false when source files use bare `#[test]` attributes (not guarded by
+    /// `#[cfg(test)]`), which are unrecognized without the test plugin, or when the project
+    /// contains only contract code with no program entry point.
+    pub sierra_phases: bool,
+}
+
+/// Returns the list of projects to benchmark across all phases.
+pub fn bench_configs() -> Vec<BenchConfig> {
+    let tests = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root = tests.parent().unwrap().to_path_buf();
+    let examples = tests.join("benches").join("examples");
+    vec![
+        BenchConfig {
+            name: "fib",
+            path: examples.join("fib.cairo"),
+            starknet: false,
+            sierra_phases: true,
+        },
+        BenchConfig {
+            name: "corelib",
+            path: root.join("corelib"),
+            starknet: false,
+            sierra_phases: true,
+        },
+        BenchConfig {
+            name: "bug_samples",
+            path: tests.join("bug_samples"),
+            starknet: true,
+            sierra_phases: false,
+        },
+        BenchConfig {
+            name: "cairo_level_tests",
+            path: root.join("crates").join("cairo-lang-starknet").join("cairo_level_tests"),
+            starknet: true,
+            sierra_phases: true,
+        },
+    ]
+}
+
+/// Builds a database for benchmarking with optimizations and corelib detection.
+/// `testing` enables the test plugin and `cfg(test)` for phases that compile test code.
+pub fn build_db(config: &BenchConfig, testing: bool) -> RootDatabase {
+    let mut builder = RootDatabase::builder();
+    builder
+        .with_optimizations(Optimizations::enabled_with_default_movable_functions(
+            InliningStrategy::Default,
+        ))
+        .detect_corelib();
+    if config.starknet {
+        builder.with_default_plugin_suite(starknet_plugin_suite());
+    }
+    if testing {
+        builder
+            .with_cfg(CfgSet::from_iter([Cfg::name("test"), Cfg::kv("target", "test")]))
+            .with_default_plugin_suite(test_plugin_suite());
+    }
+    builder.build().unwrap()
+}
+
+/// Returns the default test run config for use in benchmark phases.
+fn test_run_config() -> TestRunConfig {
+    TestRunConfig {
+        filter: String::new(),
+        include_ignored: false,
+        ignored: false,
+        profiler_config: None,
+        gas_enabled: true,
+        print_resource_usage: false,
+    }
+}
+
+/// Phase: source → Sierra (full IR generation). Returns the program so callers can hand it to a
+/// downstream phase outside the timed section.
+pub fn run_cairo_to_sierra(config: &BenchConfig) -> Program {
+    let mut db = build_db(config, false);
+    let inputs = setup_project(&mut db, &config.path).unwrap();
+    let diagnostics_reporter = DiagnosticsReporter::ignoring().with_crates(&inputs);
+    let crate_ids = CrateInput::into_crate_ids(&db, inputs);
+    compile_prepared_db_program(
+        &db,
+        crate_ids,
+        CompilerConfig { diagnostics_reporter, ..Default::default() },
+    )
+    .unwrap()
+}
+
+/// Phase: source → diagnostics (no Sierra generation).
+pub fn run_cairo_to_diagnostics(config: &BenchConfig) {
+    let mut db = build_db(config, true);
+    let inputs = setup_project(&mut db, &config.path).unwrap();
+    ensure_diagnostics(&db, &mut DiagnosticsReporter::ignoring().with_crates(&inputs)).unwrap();
+}
+
+/// Phase: source → test results (compile + execute all #[test] functions).
+pub fn run_cairo_to_testing(config: &BenchConfig) {
+    TestRunner::new(&config.path, config.starknet, false, test_run_config())
+        .unwrap()
+        .run()
+        .unwrap();
+}
+
+/// Phase: source → cache (compile + serialize lowering to bytes, no Sierra generation).
+pub fn run_cairo_to_cache(config: &BenchConfig) {
+    generate_cache(config, true);
+}
+
+/// Generates a lowering cache for use as input to cache-* phases.
+/// `testing` must match the database configuration of the consumer phase.
+pub fn generate_cache(config: &BenchConfig, testing: bool) -> Vec<u8> {
+    let mut db = build_db(config, testing);
+    let inputs = setup_project(&mut db, &config.path).unwrap();
+    let crate_ids = CrateInput::into_crate_ids(&db, inputs);
+    generate_crate_cache(&db, crate_ids[0]).unwrap()
+}
+
+/// Phase: cached lowering → Sierra (Sierra generation with pre-compiled lowering cache).
+pub fn run_cache_to_sierra(config: &BenchConfig, cache_bytes: &[u8]) {
+    let mut db = build_db(config, false);
+    let inputs = setup_project(&mut db, &config.path).unwrap();
+    let diagnostics_reporter = DiagnosticsReporter::ignoring().with_crates(&inputs);
+    let mut crate_configs = files_group_input(&db).crate_configs(&db).clone().unwrap();
+    crate_configs.get_mut(&inputs[0]).unwrap().cache_file =
+        Some(BlobLongId::Virtual(cache_bytes.to_vec()));
+    set_crate_configs_input(&mut db, Some(crate_configs));
+    let crate_ids = CrateInput::into_crate_ids(&db, inputs);
+    compile_prepared_db_program(
+        &db,
+        crate_ids,
+        CompilerConfig { diagnostics_reporter, ..Default::default() },
+    )
+    .unwrap();
+}
+
+/// Phase: cached lowering → test results (compile tests + execute with pre-compiled lowering).
+pub fn run_cache_to_testing(config: &BenchConfig, cache_bytes: &[u8]) {
+    let mut db = build_db(config, true);
+    let main_crate_inputs = setup_project(&mut db, &config.path).unwrap();
+    let mut crate_configs = files_group_input(&db).crate_configs(&db).clone().unwrap();
+    crate_configs.get_mut(&main_crate_inputs[0]).unwrap().cache_file =
+        Some(BlobLongId::Virtual(cache_bytes.to_vec()));
+    set_crate_configs_input(&mut db, Some(crate_configs));
+    let compiled = compile_test_prepared_db(
+        &db,
+        TestsCompilationConfig {
+            starknet: config.starknet,
+            contract_declarations: None,
+            contract_crate_ids: None,
+            executable_crate_ids: None,
+            add_statements_functions: false,
+            add_statements_code_locations: false,
+            add_functions_debug_info: false,
+            add_type_names: false,
+            replace_ids: false,
+        },
+        main_crate_inputs.clone(),
+        DiagnosticsReporter::stderr().with_crates(&main_crate_inputs),
+    )
+    .unwrap();
+    run_tests(None, compiled, &test_run_config(), None).unwrap();
+}

--- a/tests/benches/compile.rs
+++ b/tests/benches/compile.rs
@@ -1,105 +1,18 @@
-use std::path::PathBuf;
-
-use cairo_lang_compiler::db::RootDatabase;
-use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
-use cairo_lang_compiler::project::setup_project;
-use cairo_lang_compiler::{CompilerConfig, compile_prepared_db_program, ensure_diagnostics};
-use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
-use cairo_lang_filesystem::db::{files_group_input, set_crate_configs_input};
-use cairo_lang_filesystem::ids::{BlobLongId, CrateInput};
-use cairo_lang_lowering::cache::generate_crate_cache;
-use cairo_lang_lowering::optimizations::config::Optimizations;
-use cairo_lang_lowering::utils::InliningStrategy;
-use cairo_lang_starknet::starknet_plugin_suite;
-use cairo_lang_test_plugin::{TestsCompilationConfig, compile_test_prepared_db, test_plugin_suite};
-use cairo_lang_test_runner::{TestRunConfig, TestRunner, run_tests};
 use criterion::{Criterion, criterion_group, criterion_main};
 
-/// Configuration for a benchmarked project.
-struct BenchConfig {
-    name: &'static str,
-    path: PathBuf,
-    /// Whether to include the Starknet plugin (required for contract code).
-    starknet: bool,
-    /// Whether to run cairo-to-sierra and cache-to-sierra phases.
-    /// Set to false when source files use bare `#[test]` attributes (not guarded by
-    /// `#[cfg(test)]`), which are unrecognized without the test plugin, or when the project
-    /// contains only contract code with no program entry point.
-    sierra_phases: bool,
-}
+mod common;
 
-/// Returns the list of projects to benchmark across all phases.
-fn bench_configs() -> Vec<BenchConfig> {
-    let tests = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let root = tests.parent().unwrap().to_path_buf();
-    let examples = tests.join("benches").join("examples");
-    vec![
-        BenchConfig {
-            name: "fib",
-            path: examples.join("fib.cairo"),
-            starknet: false,
-            sierra_phases: true,
-        },
-        BenchConfig {
-            name: "corelib",
-            path: root.join("corelib"),
-            starknet: false,
-            sierra_phases: true,
-        },
-        BenchConfig {
-            name: "bug_samples",
-            path: tests.join("bug_samples"),
-            starknet: true,
-            sierra_phases: false,
-        },
-        BenchConfig {
-            name: "cairo_level_tests",
-            path: root.join("crates").join("cairo-lang-starknet").join("cairo_level_tests"),
-            starknet: true,
-            sierra_phases: true,
-        },
-    ]
-}
-
-/// Builds a database for benchmarking with optimizations and corelib detection.
-/// `testing` enables the test plugin and `cfg(test)` for phases that compile test code.
-fn build_db(config: &BenchConfig, testing: bool) -> RootDatabase {
-    let mut builder = RootDatabase::builder();
-    builder
-        .with_optimizations(Optimizations::enabled_with_default_movable_functions(
-            InliningStrategy::Default,
-        ))
-        .detect_corelib();
-    if config.starknet {
-        builder.with_default_plugin_suite(starknet_plugin_suite());
-    }
-    if testing {
-        builder
-            .with_cfg(CfgSet::from_iter([Cfg::name("test"), Cfg::kv("target", "test")]))
-            .with_default_plugin_suite(test_plugin_suite());
-    }
-    builder.build().unwrap()
-}
+use common::{
+    bench_configs, generate_cache, run_cache_to_sierra, run_cache_to_testing, run_cairo_to_cache,
+    run_cairo_to_diagnostics, run_cairo_to_sierra, run_cairo_to_testing,
+};
 
 /// Phase: source → Sierra (full IR generation).
 fn bench_cairo_to_sierra(c: &mut Criterion) {
     let mut group = c.benchmark_group("cairo-to-sierra");
     group.sample_size(10);
     for config in bench_configs().into_iter().filter(|c| c.sierra_phases) {
-        group.bench_function(config.name, |b| {
-            b.iter(|| {
-                let mut db = build_db(&config, false);
-                let inputs = setup_project(&mut db, &config.path).unwrap();
-                let diagnostics_reporter = DiagnosticsReporter::ignoring().with_crates(&inputs);
-                let crate_ids = CrateInput::into_crate_ids(&db, inputs);
-                compile_prepared_db_program(
-                    &db,
-                    crate_ids,
-                    CompilerConfig { diagnostics_reporter, ..Default::default() },
-                )
-                .unwrap()
-            });
-        });
+        group.bench_function(config.name, |b| b.iter(|| run_cairo_to_sierra(&config)));
     }
     group.finish();
 }
@@ -109,14 +22,7 @@ fn bench_cairo_to_diagnostics(c: &mut Criterion) {
     let mut group = c.benchmark_group("cairo-to-diagnostics");
     group.sample_size(10);
     for config in bench_configs() {
-        group.bench_function(config.name, |b| {
-            b.iter(|| {
-                let mut db = build_db(&config, true);
-                let inputs = setup_project(&mut db, &config.path).unwrap();
-                ensure_diagnostics(&db, &mut DiagnosticsReporter::ignoring().with_crates(&inputs))
-                    .unwrap()
-            })
-        });
+        group.bench_function(config.name, |b| b.iter(|| run_cairo_to_diagnostics(&config)));
     }
     group.finish();
 }
@@ -126,26 +32,7 @@ fn bench_cairo_to_testing(c: &mut Criterion) {
     let mut group = c.benchmark_group("cairo-to-testing");
     group.sample_size(10);
     for config in bench_configs() {
-        group.bench_function(config.name, |b| {
-            b.iter(|| {
-                TestRunner::new(
-                    &config.path,
-                    config.starknet,
-                    false,
-                    TestRunConfig {
-                        filter: String::new(),
-                        include_ignored: false,
-                        ignored: false,
-                        profiler_config: None,
-                        gas_enabled: true,
-                        print_resource_usage: false,
-                    },
-                )
-                .unwrap()
-                .run()
-                .unwrap()
-            })
-        });
+        group.bench_function(config.name, |b| b.iter(|| run_cairo_to_testing(&config)));
     }
     group.finish();
 }
@@ -155,14 +42,7 @@ fn bench_cairo_to_cache(c: &mut Criterion) {
     let mut group = c.benchmark_group("cairo-to-cache");
     group.sample_size(10);
     for config in bench_configs() {
-        group.bench_function(config.name, |b| {
-            b.iter(|| {
-                let mut db = build_db(&config, true);
-                let inputs = setup_project(&mut db, &config.path).unwrap();
-                let crate_ids = CrateInput::into_crate_ids(&db, inputs);
-                generate_crate_cache(&db, crate_ids[0]).unwrap()
-            })
-        });
+        group.bench_function(config.name, |b| b.iter(|| run_cairo_to_cache(&config)));
     }
     group.finish();
 }
@@ -172,30 +52,9 @@ fn bench_cache_to_sierra(c: &mut Criterion) {
     let mut group = c.benchmark_group("cache-to-sierra");
     group.sample_size(10);
     for config in bench_configs().into_iter().filter(|c| c.sierra_phases) {
-        group.bench_function(config.name, |b| {
-            let cache_bytes = {
-                let mut db = build_db(&config, false);
-                let inputs = setup_project(&mut db, &config.path).unwrap();
-                let crate_ids = CrateInput::into_crate_ids(&db, inputs);
-                generate_crate_cache(&db, crate_ids[0]).unwrap()
-            };
-            b.iter(|| {
-                let mut db = build_db(&config, false);
-                let inputs = setup_project(&mut db, &config.path).unwrap();
-                let diagnostics_reporter = DiagnosticsReporter::ignoring().with_crates(&inputs);
-                let mut crate_configs = files_group_input(&db).crate_configs(&db).clone().unwrap();
-                crate_configs.get_mut(&inputs[0]).unwrap().cache_file =
-                    Some(BlobLongId::Virtual(cache_bytes.clone()));
-                set_crate_configs_input(&mut db, Some(crate_configs));
-                let crate_ids = CrateInput::into_crate_ids(&db, inputs);
-                compile_prepared_db_program(
-                    &db,
-                    crate_ids,
-                    CompilerConfig { diagnostics_reporter, ..Default::default() },
-                )
-                .unwrap()
-            })
-        });
+        let cache_bytes = generate_cache(&config, false);
+        group
+            .bench_function(config.name, |b| b.iter(|| run_cache_to_sierra(&config, &cache_bytes)));
     }
     group.finish();
 }
@@ -205,49 +64,11 @@ fn bench_cache_to_testing(c: &mut Criterion) {
     let mut group = c.benchmark_group("cache-to-testing");
     group.sample_size(10);
     for config in bench_configs() {
+        // Cache must be generated with the same DB configuration as the test compiler uses
+        // (test plugin + cfg(test)), so that test functions are included in the cache.
+        let cache_bytes = generate_cache(&config, true);
         group.bench_function(config.name, |b| {
-            // Cache must be generated with the same DB configuration as the test compiler uses
-            // (test plugin + cfg(test)), so that test functions are included in the cache.
-            let cache_bytes = {
-                let mut db = build_db(&config, true);
-                let inputs = setup_project(&mut db, &config.path).unwrap();
-                let crate_ids = CrateInput::into_crate_ids(&db, inputs);
-                generate_crate_cache(&db, crate_ids[0]).unwrap()
-            };
-            let run_config = TestRunConfig {
-                filter: String::new(),
-                include_ignored: false,
-                ignored: false,
-                profiler_config: None,
-                gas_enabled: true,
-                print_resource_usage: false,
-            };
-            b.iter(|| {
-                let mut db = build_db(&config, true);
-                let main_crate_inputs = setup_project(&mut db, &config.path).unwrap();
-                let mut crate_configs = files_group_input(&db).crate_configs(&db).clone().unwrap();
-                crate_configs.get_mut(&main_crate_inputs[0]).unwrap().cache_file =
-                    Some(BlobLongId::Virtual(cache_bytes.clone()));
-                set_crate_configs_input(&mut db, Some(crate_configs));
-                let compiled = compile_test_prepared_db(
-                    &db,
-                    TestsCompilationConfig {
-                        starknet: config.starknet,
-                        contract_declarations: None,
-                        contract_crate_ids: None,
-                        executable_crate_ids: None,
-                        add_statements_functions: false,
-                        add_statements_code_locations: false,
-                        add_functions_debug_info: false,
-                        add_type_names: false,
-                        replace_ids: false,
-                    },
-                    main_crate_inputs.clone(),
-                    DiagnosticsReporter::stderr().with_crates(&main_crate_inputs),
-                )
-                .unwrap();
-                run_tests(None, compiled, &run_config, None).unwrap()
-            })
+            b.iter(|| run_cache_to_testing(&config, &cache_bytes))
         });
     }
     group.finish();


### PR DESCRIPTION
## Summary

Extracts all benchmark phase logic from `compile.rs` into a new `tests/benches/common.rs` module. Each compilation phase (`cairo-to-sierra`, `cairo-to-diagnostics`, `cairo-to-testing`, `cairo-to-cache`, `cache-to-sierra`, `cache-to-testing`) is now exposed as a standalone `run_*` function, with shared helpers `bench_configs`, `build_db`, and `generate_cache` also moved there. The `compile.rs` criterion harness is reduced to thin wrappers that call into `common`.

Additionally, cache generation for `bench_cache_to_sierra` and `bench_cache_to_testing` is moved outside the `b.iter(...)` loop, so it is no longer included in the timed measurement.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The benchmark logic was entirely self-contained in `compile.rs`, making it impossible for other bench binaries (e.g. a heap-profiling harness) to reuse the same phase implementations without duplicating the setup boilerplate. Extracting to `common.rs` enables future bench binaries to share the same scenarios.

---

## What was the behavior or documentation before?

All benchmark phase implementations lived inline inside `compile.rs`, including DB setup, cache generation, and test execution. Cache generation for `cache-to-*` benchmarks was performed inside the timed `b.iter` loop.

---

## What is the behavior or documentation after?

Each phase is a reusable `run_*` function in `common.rs`. The criterion harness in `compile.rs` calls these functions directly. Cache generation for `cache-to-*` benchmarks is performed once before the timed loop, so only the Sierra generation or test execution is measured.

---

## Related issue or discussion (if any)

---

## Additional context

The `common` module is declared with `mod common` inside `compile.rs` rather than as a separate binary entry point, keeping it scoped to the bench binary while still being shareable with future bench targets in the same directory.