### PR TITLE
Removed non-safe variant of array-hash.

### DIFF
--- a/corelib/src/sha512.cairo
+++ b/corelib/src/sha512.cairo
@@ -20,7 +20,7 @@
 #[feature("byte-span")]
 use core::byte_array::ToByteSpanTrait;
 #[feature("bounded-int-utils")]
-use core::internal::bounded_int::{BoundedInt, downcast, upcast};
+use core::internal::bounded_int::{BoundedInt, upcast};
 use starknet::SyscallResultTrait;
 
 /// A handle to the state of a SHA-512 hash.
@@ -40,51 +40,6 @@ const SHA512_INITIAL_STATE: [u64; 8] = [
     0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
     0x510e527fade682d1, 0x9b05688c2b3e6c1f, 0x1f83d9abfb41bd6b, 0x5be0cd19137e2179,
 ];
-
-/// Computes the SHA-512 hash of an input provided as 64-bit words, with optional trailing bytes.
-///
-/// # Note
-///
-/// For better type safety, consider using `compute_sha512_u64_array_safe` when
-/// `last_input_num_bytes` is guaranteed to be in the range 0..=7.
-///
-/// # Arguments
-///
-/// * `input` - The main input, expressed as an array of `u64` words.
-/// * `last_input_word` - A partial final word containing any remaining bytes when the input is not
-/// word-aligned.
-/// * `last_input_num_bytes` - The number of valid bytes in `last_input_word`. Must be in the range
-/// 0..=7.
-///
-/// # Panics
-///
-/// * If `last_input_num_bytes` is greater than 7.
-///
-/// # Returns
-///
-/// * The SHA-512 hash of `input` followed by the `last_input_num_bytes` most significant bytes of
-/// `last_input_word`, interpreted in big-endian order.
-///
-/// # Examples
-///
-/// ```
-/// use core::sha512::compute_sha512_u64_array;
-///
-/// // SHA-512("Hello world")
-/// let hash = compute_sha512_u64_array(array![0x48656c6c6f20776f], 0x726c64, 3);
-/// assert!(
-///     hash == [
-///         0xb7f783baed8297f0, 0xdb917462184ff4f0, 0x8e69c2d5e5f79a94, 0x2600f9725f58ce1f,
-///         0x29c18139bf80b06c, 0x0fff2bdd34738452, 0xecf40c488c22a7e3, 0xd80cdf6f9c1c0d47,
-///     ],
-/// );
-/// ```
-pub fn compute_sha512_u64_array(
-    mut input: Array<u64>, last_input_word: u64, last_input_num_bytes: u32,
-) -> [u64; 8] {
-    let last_input_num_bytes = downcast(last_input_num_bytes).expect('`last_input_num_bytes` > 7');
-    compute_sha512_u64_array_safe(input, last_input_word, last_input_num_bytes)
-}
 
 /// A type representing a bounded integer in the range `0..=7`.
 pub type u3 = BoundedInt<0, 7>;
@@ -106,10 +61,10 @@ pub type u3 = BoundedInt<0, 7>;
 /// # Examples
 ///
 /// ```
-/// use core::sha512::compute_sha512_u64_array_safe;
+/// use core::sha512::compute_sha512_u64_array;
 ///
 /// // SHA-512("Hello world")
-/// let hash = compute_sha512_u64_array_safe(array![0x48656c6c6f20776f], 0x726c64, 3);
+/// let hash = compute_sha512_u64_array(array![0x48656c6c6f20776f], 0x726c64, 3);
 /// assert!(
 ///     hash == [
 ///         0xb7f783baed8297f0, 0xdb917462184ff4f0, 0x8e69c2d5e5f79a94, 0x2600f9725f58ce1f,
@@ -117,7 +72,7 @@ pub type u3 = BoundedInt<0, 7>;
 ///     ],
 /// );
 /// ```
-pub fn compute_sha512_u64_array_safe(
+pub fn compute_sha512_u64_array(
     mut input: Array<u64>, last_input_word: u64, last_input_num_bytes: u3,
 ) -> [u64; 8] {
     add_sha512_padding(ref input, last_input_word, last_input_num_bytes);
@@ -187,7 +142,7 @@ pub fn compute_sha512_byte_array(arr: @ByteArray) -> [u64; 8] {
         word_arr.append(upcast(conversions::shift_append_byte(b0_b1_b2_b3_b4_b5_b6, b7)));
     };
 
-    compute_sha512_u64_array_safe(word_arr, last_word, last_word_len)
+    compute_sha512_u64_array(word_arr, last_word, last_word_len)
 }
 
 /// Adds padding to the input array according to the SHA-512 specification.

--- a/corelib/src/test/sha512_test.cairo
+++ b/corelib/src/test/sha512_test.cairo
@@ -1,4 +1,4 @@
-use crate::sha512::{compute_sha512_byte_array, compute_sha512_u64_array_safe};
+use crate::sha512::{compute_sha512_byte_array, compute_sha512_u64_array};
 
 #[test]
 fn test_sha512_byte_array() {
@@ -6,85 +6,76 @@ fn test_sha512_byte_array() {
     assert_eq!(
         compute_sha512_byte_array(@"Hello world"),
         [
-            0xb7f783baed8297f0_u64, 0xdb917462184ff4f0_u64, 0x8e69c2d5e5f79a94_u64,
-            0x2600f9725f58ce1f_u64, 0x29c18139bf80b06c_u64, 0x0fff2bdd34738452_u64,
-            0xecf40c488c22a7e3_u64, 0xd80cdf6f9c1c0d47_u64,
+            0xb7f783baed8297f0, 0xdb917462184ff4f0, 0x8e69c2d5e5f79a94, 0x2600f9725f58ce1f,
+            0x29c18139bf80b06c, 0x0fff2bdd34738452, 0xecf40c488c22a7e3, 0xd80cdf6f9c1c0d47,
         ],
     );
     assert_eq!(
         compute_sha512_byte_array(@"Hello world"),
-        compute_sha512_u64_array_safe(array![0x48656c6c6f20776f], 0x726c64, 3),
+        compute_sha512_u64_array(array![0x48656c6c6f20776f], 0x726c64, 3),
     );
     // test length 0
     assert_eq!(
         compute_sha512_byte_array(@""),
         [
-            0xcf83e1357eefb8bd_u64, 0xf1542850d66d8007_u64, 0xd620e4050b5715dc_u64,
-            0x83f4a921d36ce9ce_u64, 0x47d0d13c5d85f2b0_u64, 0xff8318d2877eec2f_u64,
-            0x63b931bd47417a81_u64, 0xa538327af927da3e_u64,
+            0xcf83e1357eefb8bd, 0xf1542850d66d8007, 0xd620e4050b5715dc, 0x83f4a921d36ce9ce,
+            0x47d0d13c5d85f2b0, 0xff8318d2877eec2f, 0x63b931bd47417a81, 0xa538327af927da3e,
         ],
     );
     // test length 3 ("abc" — NIST FIPS 180-4 known answer)
     assert_eq!(
         compute_sha512_byte_array(@"abc"),
         [
-            0xddaf35a193617aba_u64, 0xcc417349ae204131_u64, 0x12e6fa4e89a97ea2_u64,
-            0x0a9eeee64b55d39a_u64, 0x2192992a274fc1a8_u64, 0x36ba3c23a3feebbd_u64,
-            0x454d4423643ce80e_u64, 0x2a9ac94fa54ca49f_u64,
+            0xddaf35a193617aba, 0xcc417349ae204131, 0x12e6fa4e89a97ea2, 0x0a9eeee64b55d39a,
+            0x2192992a274fc1a8, 0x36ba3c23a3feebbd, 0x454d4423643ce80e, 0x2a9ac94fa54ca49f,
         ],
     );
     // test length 5
     assert_eq!(
         compute_sha512_byte_array(@"Hello"),
         [
-            0x3615f80c9d293ed7_u64, 0x402687f94b22d58e_u64, 0x529b8cc7916f8fac_u64,
-            0x7fddf7fbd5af4cf7_u64, 0x77d3d795a7a00a16_u64, 0xbf7e7f3fb9561ee9_u64,
-            0xbaae480da9fe7a18_u64, 0x769e71886b03f315_u64,
+            0x3615f80c9d293ed7, 0x402687f94b22d58e, 0x529b8cc7916f8fac, 0x7fddf7fbd5af4cf7,
+            0x77d3d795a7a00a16, 0xbf7e7f3fb9561ee9, 0xbaae480da9fe7a18, 0x769e71886b03f315,
         ],
     );
     // test length 7
     assert_eq!(
         compute_sha512_byte_array(@"xffidcw"),
         [
-            0x53ccff917edc643b_u64, 0x7fbed8e5bab9bca4_u64, 0x04fc4328c31cc941_u64,
-            0xc6b403e0365fe542_u64, 0x9bd6a44e66aa77da_u64, 0xab8a0820ef5fd5b8_u64,
-            0xd0095c775865ce28_u64, 0xd0fb057c8fe0a701_u64,
+            0x53ccff917edc643b, 0x7fbed8e5bab9bca4, 0x04fc4328c31cc941, 0xc6b403e0365fe542,
+            0x9bd6a44e66aa77da, 0xab8a0820ef5fd5b8, 0xd0095c775865ce28, 0xd0fb057c8fe0a701,
         ],
     );
     // test length 8
     assert_eq!(
         compute_sha512_byte_array(@"szhgvskg"),
         [
-            0x4197b9e27c90c2a9_u64, 0xa3d90023ef91bd39_u64, 0x848e68d5cae5ff40_u64,
-            0x3a99a4df6c6c8e10_u64, 0xb5388b01f9b672b0_u64, 0x49c514e4017df911_u64,
-            0x2e0c81e059fc22de_u64, 0x967354c26bb3e8d1_u64,
+            0x4197b9e27c90c2a9, 0xa3d90023ef91bd39, 0x848e68d5cae5ff40, 0x3a99a4df6c6c8e10,
+            0xb5388b01f9b672b0, 0x49c514e4017df911, 0x2e0c81e059fc22de, 0x967354c26bb3e8d1,
         ],
     );
     // test length 9
     assert_eq!(
         compute_sha512_byte_array(@"nokwxzwsl"),
         [
-            0x4916a813bea33b5a_u64, 0xc64517c1e52ab1a8_u64, 0xbe5602d378d6517c_u64,
-            0xaf5a4acc76f0d67f_u64, 0xeee699efda7fde4b_u64, 0x2d98c587c0dfa9b7_u64,
-            0x6a1fa89b410d7d38_u64, 0x7d675e87ba45022f_u64,
+            0x4916a813bea33b5a, 0xc64517c1e52ab1a8, 0xbe5602d378d6517c, 0xaf5a4acc76f0d67f,
+            0xeee699efda7fde4b, 0x2d98c587c0dfa9b7, 0x6a1fa89b410d7d38, 0x7d675e87ba45022f,
         ],
     );
     // test length 15
     assert_eq!(
         compute_sha512_byte_array(@"bhmvtgdkhgajqaf"),
         [
-            0x285e30b168ec8c7c_u64, 0x3a43e59ab1be93c7_u64, 0x985b9c5e02b391aa_u64,
-            0x1334050d668a4491_u64, 0x9f92508829626456_u64, 0xe1a43fb4bb8fed1a_u64,
-            0xa2654dc2e5ba8cd3_u64, 0x4718965803203768_u64,
+            0x285e30b168ec8c7c, 0x3a43e59ab1be93c7, 0x985b9c5e02b391aa, 0x1334050d668a4491,
+            0x9f92508829626456, 0xe1a43fb4bb8fed1a, 0xa2654dc2e5ba8cd3, 0x4718965803203768,
         ],
     );
     // test length 16
     assert_eq!(
         compute_sha512_byte_array(@"qxwwcxzjiibvkqky"),
         [
-            0x3b066424eab2880b_u64, 0xeb76ecf9d1797163_u64, 0x99e6ed072aac3a12_u64,
-            0xf3f02c8f62715352_u64, 0x541ce9728962a0db_u64, 0xdc6066d35c04c0a9_u64,
-            0x389ea3b53051e74a_u64, 0x0aacaa7c1c13cb80_u64,
+            0x3b066424eab2880b, 0xeb76ecf9d1797163, 0x99e6ed072aac3a12, 0xf3f02c8f62715352,
+            0x541ce9728962a0db, 0xdc6066d35c04c0a9, 0x389ea3b53051e74a, 0x0aacaa7c1c13cb80,
         ],
     );
     // test length 111 (last byte fits in one block)
@@ -93,9 +84,8 @@ fn test_sha512_byte_array() {
             @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         ),
         [
-            0xfa9121c7b32b9e01_u64, 0x733d034cfc78cbf6_u64, 0x7f926c7ed83e8220_u64,
-            0x0ef8681819692176_u64, 0x0b4beff48404df81_u64, 0x1b95382827446167_u64,
-            0x3c68d04e297b0eb7_u64, 0xb2b4d60fc6b566a2_u64,
+            0xfa9121c7b32b9e01, 0x733d034cfc78cbf6, 0x7f926c7ed83e8220, 0x0ef8681819692176,
+            0x0b4beff48404df81, 0x1b95382827446167, 0x3c68d04e297b0eb7, 0xb2b4d60fc6b566a2,
         ],
     );
     // test length 112 (requires a second block)
@@ -104,9 +94,8 @@ fn test_sha512_byte_array() {
             @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         ),
         [
-            0xc01d080efd492776_u64, 0xa1c43bd23dd99d0a_u64, 0x2e626d481e16782e_u64,
-            0x75d54c2503b5dc32_u64, 0xbd05f0f1ba33e568_u64, 0xb88fd2d970929b71_u64,
-            0x9ecbb152f58f130a_u64, 0x407c8830604b70ca_u64,
+            0xc01d080efd492776, 0xa1c43bd23dd99d0a, 0x2e626d481e16782e, 0x75d54c2503b5dc32,
+            0xbd05f0f1ba33e568, 0xb88fd2d970929b71, 0x9ecbb152f58f130a, 0x407c8830604b70ca,
         ],
     );
     // test length 128 (exactly two blocks)
@@ -115,9 +104,8 @@ fn test_sha512_byte_array() {
             @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         ),
         [
-            0xb73d1929aa615934_u64, 0xe61a871596b3f3b3_u64, 0x3359f42b8175602e_u64,
-            0x89f7e06e5f658a24_u64, 0x3667807ed300314b_u64, 0x95cacdd579f3e33a_u64,
-            0xbdfbe351909519a8_u64, 0x46d465c59582f321_u64,
+            0xb73d1929aa615934, 0xe61a871596b3f3b3, 0x3359f42b8175602e, 0x89f7e06e5f658a24,
+            0x3667807ed300314b, 0x95cacdd579f3e33a, 0xbdfbe351909519a8, 0x46d465c59582f321,
         ],
     );
 }


### PR DESCRIPTION
## Summary

`compute_sha512_u64_array_safe` has been removed and merged into `compute_sha512_u64_array`, which now directly accepts `last_input_num_bytes` as a `u3` (a `BoundedInt<0, 7>`) instead of a `u32`. The old `compute_sha512_u64_array` wrapper that performed a runtime `downcast` and panicked on values greater than 7 has been eliminated. Tests have been updated to call `compute_sha512_u64_array` directly.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Having two separate functions — one that panicked at runtime and one that enforced the bound via the type system — was redundant. The `u3` type already statically guarantees that `last_input_num_bytes` is in the range `0..=7`, making the runtime-panicking wrapper unnecessary. Consolidating into a single function with a typed parameter removes the possibility of a runtime panic and simplifies the public API.

---

## What was the behavior or documentation before?

`compute_sha512_u64_array` accepted a `u32` for `last_input_num_bytes` and panicked at runtime if the value exceeded 7. A separate `compute_sha512_u64_array_safe` function accepted a `u3` to enforce the bound at the type level.

---

## What is the behavior or documentation after?

`compute_sha512_u64_array` now accepts `last_input_num_bytes` as a `u3` directly, enforcing the `0..=7` bound at compile time. `compute_sha512_u64_array_safe` no longer exists.

---

## Related issue or discussion (if any)

---

## Additional context

The `u3` type alias (`BoundedInt<0, 7>`) remains part of the public API in `sha512`.