### PR TITLE
Added sha384 implementation.

### DIFF
--- a/corelib/src/lib.cairo
+++ b/corelib/src/lib.cairo
@@ -386,6 +386,7 @@ pub mod serde;
 pub mod sha256;
 
 mod sha2_64_core;
+pub mod sha384;
 pub mod sha512;
 #[allow(unused_imports)]
 use pedersen::Pedersen;

--- a/corelib/src/sha384.cairo
+++ b/corelib/src/sha384.cairo
@@ -1,0 +1,92 @@
+//! Implementation of the SHA-384 cryptographic hash function.
+//!
+//! This module provides functions to compute SHA-384 hashes of data.
+//! The input data can be an array of 64-bit words, or a `ByteArray`.
+//!
+//! # Examples
+//!
+//! ```
+//! use core::sha384::compute_sha384_byte_array;
+//!
+//! let data = "Hello world";
+//! let hash = compute_sha384_byte_array(@data);
+//! assert!(
+//!     hash == [
+//!         0x9203b0c4439fd1e6, 0xae5878866337b7c5, 0x32acd6d9260150c8,
+//!         0x0318e8ab8c27ce33, 0x0189f8df94fb890d, 0xf1d298ff360627e1,
+//!     ],
+//! );
+//! ```
+
+pub use crate::sha2_64_core::u3;
+use crate::sha2_64_core::{compute_sha2_64_byte_array, compute_sha2_64_u64_array};
+
+/// Initial hash values for SHA-384 as specified in FIPS 180-4.
+const SHA384_INITIAL_STATE: [u64; 8] = [
+    0xcbbb9d5dc1059ed8, 0x629a292a367cd507, 0x9159015a3070dd17, 0x152fecd8f70e5939,
+    0x67332667ffc00b31, 0x8eb44a8768581511, 0xdb0c2e0d64f98fa7, 0x47b5481dbefa4fa4,
+];
+
+/// Computes the SHA-384 hash of an input provided as 64-bit words, with optional trailing bytes.
+///
+/// # Arguments
+///
+/// * `input` - The main input, expressed as an array of `u64` words.
+/// * `last_input_word` - A partial final word containing any remaining bytes when the input is not
+/// word-aligned.
+/// * `last_input_num_bytes` - The number of valid bytes in `last_input_word`.
+///
+/// # Returns
+///
+/// * The SHA-384 hash of `input` followed by the `last_input_num_bytes` most significant bytes of
+/// `last_input_word`, interpreted in big-endian order.
+///
+/// # Examples
+///
+/// ```
+/// use core::sha384::compute_sha384_u64_array;
+///
+/// // SHA-384("Hello world")
+/// let hash = compute_sha384_u64_array(array![0x48656c6c6f20776f], 0x726c64, 3);
+/// assert!(
+///     hash == [
+///         0x9203b0c4439fd1e6, 0xae5878866337b7c5, 0x32acd6d9260150c8,
+///         0x0318e8ab8c27ce33, 0x0189f8df94fb890d, 0xf1d298ff360627e1,
+///     ],
+/// );
+/// ```
+pub fn compute_sha384_u64_array(
+    mut input: Array<u64>, last_input_word: u64, last_input_num_bytes: u3,
+) -> [u64; 6] {
+    truncate_hash(
+        compute_sha2_64_u64_array(
+            input, last_input_word, last_input_num_bytes, BoxTrait::new(SHA384_INITIAL_STATE),
+        ),
+    )
+}
+
+/// Computes the SHA-384 hash of the input `ByteArray`.
+///
+/// # Examples
+///
+/// ```
+/// use core::sha384::compute_sha384_byte_array;
+///
+/// let data = "Hello world";
+/// let hash = compute_sha384_byte_array(@data);
+/// assert!(
+///     hash == [
+///         0x9203b0c4439fd1e6, 0xae5878866337b7c5, 0x32acd6d9260150c8,
+///         0x0318e8ab8c27ce33, 0x0189f8df94fb890d, 0xf1d298ff360627e1,
+///     ],
+/// );
+/// ```
+pub fn compute_sha384_byte_array(arr: @ByteArray) -> [u64; 6] {
+    truncate_hash(compute_sha2_64_byte_array(arr, BoxTrait::new(SHA384_INITIAL_STATE)))
+}
+
+/// Truncates a SHA-384 hash to 48 bytes by dropping the final 16 bytes.
+fn truncate_hash(hash: Box<[u64; 8]>) -> [u64; 6] {
+    let [w0, w1, w2, w3, w4, w5, _w6, _w7] = hash.unbox();
+    [w0, w1, w2, w3, w4, w5]
+}

--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -30,6 +30,7 @@ mod result_test;
 mod secp256k1_test;
 mod secp256r1_test;
 mod sha256_test;
+mod sha384_test;
 mod sha512_test;
 mod test_utils;
 mod testing_test;

--- a/corelib/src/test/sha384_test.cairo
+++ b/corelib/src/test/sha384_test.cairo
@@ -1,0 +1,111 @@
+use crate::sha384::{compute_sha384_byte_array, compute_sha384_u64_array};
+
+#[test]
+fn test_sha384_byte_array() {
+    // docstring examples
+    assert_eq!(
+        compute_sha384_byte_array(@"Hello world"),
+        [
+            0x9203b0c4439fd1e6, 0xae5878866337b7c5, 0x32acd6d9260150c8, 0x0318e8ab8c27ce33,
+            0x0189f8df94fb890d, 0xf1d298ff360627e1,
+        ],
+    );
+    assert_eq!(
+        compute_sha384_byte_array(@"Hello world"),
+        compute_sha384_u64_array(array![0x48656c6c6f20776f], 0x726c64, 3),
+    );
+    // test length 0
+    assert_eq!(
+        compute_sha384_byte_array(@""),
+        [
+            0x38b060a751ac9638, 0x4cd9327eb1b1e36a, 0x21fdb71114be0743, 0x4c0cc7bf63f6e1da,
+            0x274edebfe76f65fb, 0xd51ad2f14898b95b,
+        ],
+    );
+    // test length 3 ("abc" — NIST FIPS 180-4 known answer)
+    assert_eq!(
+        compute_sha384_byte_array(@"abc"),
+        [
+            0xcb00753f45a35e8b, 0xb5a03d699ac65007, 0x272c32ab0eded163, 0x1a8b605a43ff5bed,
+            0x8086072ba1e7cc23, 0x58baeca134c825a7,
+        ],
+    );
+    // test length 5
+    assert_eq!(
+        compute_sha384_byte_array(@"Hello"),
+        [
+            0x3519fe5ad2c596ef, 0xe3e276a6f351b8fc, 0x0b03db861782490d, 0x45f7598ebd0ab5fd,
+            0x5520ed102f38c4a5, 0xec834e98668035fc,
+        ],
+    );
+    // test length 7
+    assert_eq!(
+        compute_sha384_byte_array(@"xffidcw"),
+        [
+            0x8004d8e41704e1ba, 0x90dd7e4394acd0d4, 0xe18f8d90a52280f3, 0x17ae31024afb4481,
+            0xc0a13e96483fb5cf, 0x1ae8d9d5fc0dbf28,
+        ],
+    );
+    // test length 8
+    assert_eq!(
+        compute_sha384_byte_array(@"szhgvskg"),
+        [
+            0x1620bc53aa63ae0f, 0x94f12067555b2e04, 0xa2b2c6d1d48abc20, 0x564882a13bfe3ebf,
+            0x98508234002a98cf, 0x9c6c5621d764afec,
+        ],
+    );
+    // test length 9
+    assert_eq!(
+        compute_sha384_byte_array(@"nokwxzwsl"),
+        [
+            0x09caee8ea56924ad, 0x4b27f96a9d22c0db, 0xf26ab9cea075bbc6, 0x848a9ea7324cb08e,
+            0x53dfaac4c4fc927a, 0xe2e6e92e08f0bd5d,
+        ],
+    );
+    // test length 15
+    assert_eq!(
+        compute_sha384_byte_array(@"bhmvtgdkhgajqaf"),
+        [
+            0x29197f1097c99ae9, 0x770903aca2a0a602, 0xe15c40ed6de2268c, 0x2553f1dc34148ee7,
+            0xecfbce6e1010ac7f, 0x826bb2de8f86d9ff,
+        ],
+    );
+    // test length 16
+    assert_eq!(
+        compute_sha384_byte_array(@"qxwwcxzjiibvkqky"),
+        [
+            0xfa4bc74d58001242, 0x5c629c33b42bc487, 0xdfd2dfb465541161, 0xdf08cc68eb725d97,
+            0xa23098ffecbfa5a5, 0x54d95609df87692d,
+        ],
+    );
+    // test length 111 (last byte fits in one block)
+    assert_eq!(
+        compute_sha384_byte_array(
+            @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ),
+        [
+            0x3c37955051cb5c30, 0x26f94d551d5b5e2a, 0xc38d572ae4e07172, 0x085fed81f8466b8f,
+            0x90dc23a8ffcdea0b, 0x8d8e58e8fdacc80a,
+        ],
+    );
+    // test length 112 (requires a second block)
+    assert_eq!(
+        compute_sha384_byte_array(
+            @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ),
+        [
+            0x187d4e07cb306103, 0xc69967bf544d0dfb, 0xe9042577599c73c3, 0x30abc0cb64c61236,
+            0xd5ed565ee19119d8, 0xc31779a38f791fcd,
+        ],
+    );
+    // test length 128 (exactly two blocks)
+    assert_eq!(
+        compute_sha384_byte_array(
+            @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ),
+        [
+            0xedb12730a366098b, 0x3b2beac75a3bef1b, 0x0969b15c48e2163c, 0x23d96994f8d1bef7,
+            0x60c7e27f3c464d38, 0x29f56c0d53808b0b,
+        ],
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `sha384` module to the Cairo corelib, exposing `compute_sha384_byte_array` and `compute_sha384_u64_array` functions. The implementation builds on the existing `sha2_64_core` infrastructure (shared with SHA-512), using SHA-384's distinct initial hash values from FIPS 180-4 and truncating the 512-bit intermediate result to 384 bits (6 × `u64` words).

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

SHA-384 is a widely used cryptographic hash function (e.g., in TLS certificates and Ethereum's BLS12-381 operations), but Cairo's corelib previously had no native support for it. Users needing SHA-384 had no standard library path to compute it.

---

## What was the behavior or documentation before?

Only SHA-256 and SHA-512 were available in the corelib. SHA-384 had to be implemented externally or approximated.

---

## What is the behavior or documentation after?

`core::sha384` is now a public module providing:

- `compute_sha384_u64_array(input, last_input_word, last_input_num_bytes)` — hashes an array of `u64` words with optional trailing bytes.
- `compute_sha384_byte_array(arr)` — hashes a `ByteArray` directly.

Both return a `[u64; 6]` representing the 384-bit digest. The module includes inline documentation with worked examples and is covered by a test suite validating inputs of varying lengths (0, 3, 5, 7, 8, 9, 15, 16, 111, 112, and 128 bytes), including the NIST FIPS 180-4 known-answer test for `"abc"`.

---

## Related issue or discussion (if any)

---

## Additional context

The implementation reuses `sha2_64_core`'s `compute_sha2_64_byte_array` and `compute_sha2_64_u64_array`, parameterized by the SHA-384-specific initial state constants. The `truncate_hash` helper discards the final two `u64` words of the 8-word SHA-2 state to produce the 384-bit output.