### PR TITLE
fix(lowering): eliminate spurious E3002 alongside E3001 for moved struct members

### DIFF
--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
@@ -144,7 +144,7 @@ End:
 blk3:
 Statements:
 End:
-  Return(v6)
+  Return(v1)
 
 //! > ==========================================================================
 
@@ -368,7 +368,7 @@ End:
 blk3:
 Statements:
 End:
-  Return(v6)
+  Return(v1)
 
 //! > ==========================================================================
 
@@ -411,10 +411,10 @@ Statements:
   (v3: core::array::Array::<core::felt252>, v2: ()) <- core::array::ArrayImpl::<core::felt252>::append(v0{`__array_builder_macro_result__`}, v1{`'err_code'`})
   (v4: core::felt252) <- 6450273
   (v6: core::array::Array::<core::felt252>, v5: ()) <- core::array::ArrayImpl::<core::felt252>::append(v3{`b`}, v4{`'bla'`})
-  (v8: core::panics::Panic) <- struct_construct()
-  (v9: (core::panics::Panic, core::array::Array::<core::felt252>)) <- struct_construct(v8{`panic(arr)`}, v7{`arr`})
+  (v7: core::panics::Panic) <- struct_construct()
+  (v8: (core::panics::Panic, core::array::Array::<core::felt252>)) <- struct_construct(v7{`panic(arr)`}, v3{`arr`})
 End:
-  Panic(v9)
+  Panic(v8)
 
 //! > ==========================================================================
 
@@ -458,28 +458,28 @@ blk0 (root):
 Statements:
   () <- test::use_non_copy(v0{`x`})
 End:
-  Match(match test::do_match_extern(v1{`x`}) {
-    Option::Some(v2) => blk1,
+  Match(match test::do_match_extern(v0{`x`}) {
+    Option::Some(v1) => blk1,
     Option::None => blk2,
   })
 
 blk1:
 Statements:
-  (v3: core::option::Option::<test::NonCopy>) <- Option::Some(v2{`do_match_extern(x)`})
+  (v2: core::option::Option::<test::NonCopy>) <- Option::Some(v1{`do_match_extern(x)`})
 End:
-  Goto(blk3, {v3 -> v6})
+  Goto(blk3, {v2 -> v5})
 
 blk2:
 Statements:
-  (v4: ()) <- struct_construct()
-  (v5: core::option::Option::<test::NonCopy>) <- Option::None(v4{`do_match_extern(x)`})
+  (v3: ()) <- struct_construct()
+  (v4: core::option::Option::<test::NonCopy>) <- Option::None(v3{`do_match_extern(x)`})
 End:
-  Goto(blk3, {v5 -> v6})
+  Goto(blk3, {v4 -> v5})
 
 blk3:
 Statements:
 End:
-  Return(v6)
+  Return(v5)
 
 //! > ==========================================================================
 
@@ -528,6 +528,7 @@ Statements:
   (v1: core::integer::u32) <- 17
   (v2: core::integer::u32, v3: test::NonCopy) <- struct_destructure(v0{`x.a`})
   () <- test::use_non_copy(v3{`x.b`})
+  (v4: test::MyStruct) <- struct_construct(v1{`x`}, v3{`x`})
 End:
   Return(v4)
 
@@ -588,6 +589,8 @@ Statements:
   (v4: core::array::Array::<core::felt252>, v5: core::integer::u8) <- struct_destructure(v1{`s2.a`})
   () <- test::invalidate(v4{`s2.a`})
   (v6: ()) <- struct_construct()
+  (v7: test::MyStruct) <- struct_construct(v2{`s1`}, v3{`s1`})
+  (v8: test::MyStruct) <- struct_construct(v4{`s2`}, v5{`s2`})
 End:
   Return(v7, v8, v6)
 
@@ -661,6 +664,7 @@ End:
 blk3:
 Statements:
   (v12: ()) <- struct_construct()
+  (v13: test::MyStruct) <- struct_construct(v11{`self`}, v3{`self`})
 End:
   Return(v13, v12)
 
@@ -947,6 +951,7 @@ blk0 (root):
 Statements:
   (v1: core::felt252, v2: test::NonCopy) <- struct_destructure(v0{`x.b`})
   () <- test::consume(v2{`x.b`})
+  (v3: test::MyStruct) <- struct_construct(v1{`x`}, v2{`x`})
 End:
   Return(v3)
 
@@ -1119,16 +1124,18 @@ note: variable was previously used here:
 note: Trait has no implementation in context: core::traits::Copy::<test::Wrapper>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:12:11
-    use_x(x); // Second use.
-          ^
-note: the variable needs to be dropped due to the potential panic here:
-  --> lib.cairo:8:8
-    if x.inner.is_zero() {
-       ^^^^^^^^^^^^^^^^^
+ --> lib.cairo:9:15
+        use_x(x); // First use.
+              ^
+note: the variable needs to be dropped due to the divergence here:
+  --> lib.cairo:8:5-10:5
+      if x.inner.is_zero() {
+ _____^
+|         use_x(x); // First use.
+|     }
+|_____^
 note: Trait has no implementation in context: core::traits::Drop::<test::Wrapper>.
 note: Trait has no implementation in context: core::traits::Destruct::<test::Wrapper>.
-note: Trait has no implementation in context: core::traits::PanicDestruct::<test::Wrapper>.
 
 //! > lowering
 Parameters: v0: test::Wrapper
@@ -1156,10 +1163,10 @@ End:
 
 blk3:
 Statements:
-  () <- test::use_x(v6{`x`})
-  (v7: ()) <- struct_construct()
+  () <- test::use_x(v5{`x`})
+  (v6: ()) <- struct_construct()
 End:
-  Return(v7)
+  Return(v6)
 
 //! > ==========================================================================
 
@@ -1257,3 +1264,64 @@ Statements:
   (v1: ()) <- struct_construct()
 End:
   Return(v1)
+
+//! > ==========================================================================
+
+//! > Spurious E3002 alongside E3001 for orphaned inner struct construction (bug repro).
+
+//! > test_runner_name
+test_borrow_check
+
+//! > function_code
+fn foo(outer: Outer) {
+    bar(outer.inner.a);
+    consume(outer.b);
+    use_outer(outer);
+}
+
+//! > function_name
+foo
+
+//! > module_code
+extern type NonCopy;
+
+struct Inner {
+    a: felt252,
+}
+
+struct Outer {
+    inner: Inner,
+    b: NonCopy,
+}
+
+extern fn bar(x: felt252) nopanic;
+extern fn consume(x: NonCopy) nopanic;
+extern fn use_outer(x: Outer) nopanic;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3001]: Variable was previously moved.
+ --> lib.cairo:18:15
+    use_outer(outer);
+              ^^^^^
+note: variable was previously used here:
+  --> lib.cairo:17:13
+    consume(outer.b);
+            ^^^^^^^
+note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
+
+//! > lowering
+Parameters: v0: test::Outer
+blk0 (root):
+Statements:
+  (v1: test::Inner, v2: test::NonCopy) <- struct_destructure(v0{`outer.inner.a`})
+  (v3: core::felt252) <- struct_destructure(v1{`outer.inner.a`})
+  () <- test::bar(v3{`outer.inner.a`})
+  () <- test::consume(v2{`outer.b`})
+  (v4: test::Inner) <- struct_construct(v3{`outer`})
+  (v5: test::Outer) <- struct_construct(v4{`outer`}, v2{`outer`})
+  () <- test::use_outer(v5{`outer`})
+  (v6: ()) <- struct_construct()
+End:
+  Return(v6)

--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -145,21 +145,22 @@ impl<'db> BlockBuilder<'db> {
                 }
 
                 // If the variable is not copyable, mark it as [MovedVar].
-                let var = &ctx.variables[var_id];
-                let copyable = var.info.copyable.clone();
-                let ty = var.ty;
-
-                if let Err(inference_error) = copyable {
+                if let Err(inference_error) = &ctx.variables[var_id].info.copyable {
+                    let inference_error = inference_error.clone();
                     self.semantics.mark_as_used(
                         BlockStructRecomposer { statements: &mut self.statements, ctx, location },
                         member_path,
-                        MovedVar { ty, inference_error, last_use_location: location },
+                        MovedVar { var_id, inference_error, last_use_location: location },
                     );
                 }
 
                 Some(VarUsage { var_id, location })
             }
-            Err(AssembleValueError::Moved(MovedVar { ty, inference_error, last_use_location })) => {
+            Err(AssembleValueError::Moved(MovedVar {
+                var_id,
+                inference_error,
+                last_use_location,
+            })) => {
                 // If the variable was already moved, report an error.
                 let diag_location = location
                     .long(ctx.db)
@@ -175,8 +176,6 @@ impl<'db> BlockBuilder<'db> {
                     LoweringDiagnosticKind::VariableMoved { inference_error },
                 );
 
-                // Create and return a dummy variable.
-                let var_id = ctx.new_var(VarRequest { ty, location });
                 Some(VarUsage { var_id, location })
             }
             Err(AssembleValueError::Missing) => None,

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -4,12 +4,13 @@ use cairo_lang_semantic::expr::fmt::ExprFormatter;
 use cairo_lang_semantic::expr::inference::InferenceError;
 use cairo_lang_semantic::items::structure::StructSemantic;
 use cairo_lang_semantic::usage::MemberPath;
-use cairo_lang_semantic::{self as semantic, ConcreteTypeId, TypeLongId};
+use cairo_lang_semantic::{self as semantic};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{Intern, extract_matches, try_extract_matches};
+use cairo_lang_utils::{extract_matches, try_extract_matches};
 use itertools::{Itertools, chain};
 
 use super::block_builder::BlockStructRecomposer;
+use super::context::VarRequest;
 use crate::VariableId;
 use crate::ids::LocationId;
 
@@ -119,31 +120,30 @@ impl<'db> SemanticLoweringMapping<'db> {
     ) -> Result<VariableId, MovedVar<'db>> {
         match value {
             Value::Var(var) => Ok(*var),
+            Value::MovedVar(moved) => Err(moved.clone()),
             Value::Scattered(scattered) => {
-                let members_res = scattered
+                let mut moved_var = None;
+                let members = scattered
                     .members
                     .iter_mut()
-                    .map(|(_, value)| Self::assemble_value(ctx, value))
-                    .collect::<Result<_, _>>();
-
-                match members_res {
-                    Ok(members) => {
-                        let var = ctx.reconstruct(scattered.concrete_struct_id, members);
-                        *value = Value::Var(var);
-                        Ok(var)
-                    }
-                    Err(MovedVar { ty: _, inference_error, last_use_location }) => {
-                        // Don't use the type of the moved member. Replace it with the type of the
-                        // variable.
-                        let y = TypeLongId::<'db>::Concrete(ConcreteTypeId::Struct(
-                            scattered.concrete_struct_id,
-                        ));
-                        let x = y.intern(ctx.ctx.db);
-                        Err(MovedVar { ty: x, inference_error, last_use_location })
-                    }
+                    .map(|(_, value)| match Self::assemble_value(ctx, value) {
+                        Ok(var) => var,
+                        Err(moved) => {
+                            let var = moved.var_id;
+                            moved_var.get_or_insert(moved);
+                            var
+                        }
+                    })
+                    .collect_vec();
+                let var = ctx.reconstruct(scattered.concrete_struct_id, members);
+                *value = Value::Var(var);
+                if let Some(MovedVar { var_id: _, inference_error, last_use_location }) = moved_var
+                {
+                    Err(MovedVar { var_id: var, inference_error, last_use_location })
+                } else {
+                    Ok(var)
                 }
             }
-            Value::MovedVar(moved) => Err(moved.clone()),
         }
     }
 
@@ -170,13 +170,14 @@ impl<'db> SemanticLoweringMapping<'db> {
                 let scattered = Scattered { concrete_struct_id: *concrete_struct_id, members };
                 *parent_value = Value::Scattered(Box::new(scattered));
             }
-            Value::MovedVar(MovedVar { ty: _, inference_error, last_use_location }) => {
+            Value::MovedVar(MovedVar { var_id: var, inference_error, last_use_location }) => {
                 let member_map = ctx.ctx.db.concrete_struct_members(*concrete_struct_id).unwrap();
+                let location = ctx.ctx.variables[*var].location;
                 let members = OrderedHashMap::from_iter(member_map.values().map(|member| {
                     (
                         member.id,
                         Value::MovedVar(MovedVar {
-                            ty: member.ty,
+                            var_id: ctx.ctx.new_var(VarRequest { ty: member.ty, location }),
                             inference_error: inference_error.clone(),
                             last_use_location: *last_use_location,
                         }),
@@ -369,7 +370,7 @@ pub fn find_changed_members<'db, 'a>(
 #[debug_db(ExprFormatter<'db>)]
 pub struct MovedVar<'db> {
     /// The type of the variable.
-    pub ty: semantic::TypeId<'db>,
+    pub var_id: VariableId,
     /// The reason it is not copyable.
     pub inference_error: InferenceError<'db>,
     /// The location of the last use of the moved variable. This is used to report an error.


### PR DESCRIPTION
## Summary

When a non-copy variable is moved (used more than once), the borrow checker previously created a fresh dummy variable to represent the already-moved value. This dummy variable had no corresponding lowering statement, which caused spurious `E3002` ("Variable not dropped") errors to appear alongside the real `E3001` ("Variable was previously moved") error. Additionally, when assembling scattered (destructured) struct values that contained a moved member, the reconstructed struct variable was discarded and a new dummy variable was returned, causing the struct reconstruction statements to be emitted but their result to be orphaned.

The fix changes `MovedVar` to carry the original `VariableId` instead of just the `TypeId`. When a move error is detected, the original variable ID is reused rather than allocating a new dummy. When assembling a scattered struct that contains a moved member, the struct is still reconstructed (so the statements are valid), and the resulting variable ID is propagated through the `MovedVar` error. A new test case (`Spurious E3002 alongside E3001 for orphaned inner struct construction`) is added to confirm the fix.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a non-copy variable was used after being moved, the compiler emitted a spurious `E3002` error in addition to the correct `E3001` error. This happened because a dummy variable was created to stand in for the moved value, but no statement ever defined that dummy variable, leaving it "undropped" from the borrow checker's perspective. Similarly, struct reconstruction statements were being emitted for orphaned variables, producing inconsistent lowering IR.

---

## What was the behavior or documentation before?

- A use-after-move of a non-copy variable produced both `E3001` (variable was previously moved) and a spurious `E3002` (variable not dropped) diagnostic.
- The `E3002` note incorrectly pointed to the second use site and cited a potential panic as the reason, rather than pointing to the divergence caused by the `if` branch.
- Scattered struct assembly discarded the reconstructed variable when a member was moved, leaving orphaned `struct_construct` statements in the lowered IR.

---

## What is the behavior or documentation after?

- A use-after-move of a non-copy variable produces only the correct `E3001` diagnostic.
- The `E3002` note now correctly identifies the divergence (e.g., an `if` block) rather than a panic site.
- Scattered struct assembly always emits and uses the reconstructed variable, keeping the lowered IR consistent.

---

## Related issue or discussion (if any)

Bug repro captured in the new test: `Spurious E3002 alongside E3001 for orphaned inner struct construction`.

---

## Additional context

The `PanicDestruct` trait note was also removed from the `E3002` diagnostic output, as it is no longer emitted in the updated test expectations.