### PR TITLE
(opt): preallocate lowering pipeline buffers and skip SubStrategy clone

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/backward.rs
+++ b/crates/cairo-lang-lowering/src/analysis/backward.rs
@@ -15,11 +15,16 @@ pub struct BackAnalysis<'db, 'a, TAnalyzer: Analyzer<'db, 'a>> {
 impl<'db, 'a, TAnalyzer: Analyzer<'db, 'a>> BackAnalysis<'db, 'a, TAnalyzer> {
     /// Creates a new BackAnalysis instance.
     pub fn new(lowered: &'a Lowered<'db>, analyzer: TAnalyzer) -> Self {
-        Self { lowered, analyzer, block_info: Default::default() }
+        Self {
+            lowered,
+            analyzer,
+            block_info: UnorderedHashMap::with_capacity(lowered.blocks.len()),
+        }
     }
     /// Gets the analysis info for the entire function.
     pub fn get_root_info(&mut self) -> TAnalyzer::Info {
-        let mut dfs_stack = vec![BlockId::root()];
+        let mut dfs_stack = Vec::with_capacity(self.lowered.blocks.len());
+        dfs_stack.push(BlockId::root());
         while let Some(block_id) = dfs_stack.last() {
             let end = &self.lowered.blocks[*block_id].end;
             if !self.add_missing_dependency_blocks(&mut dfs_stack, end) {

--- a/crates/cairo-lang-lowering/src/objects/blocks.rs
+++ b/crates/cairo-lang-lowering/src/objects/blocks.rs
@@ -38,6 +38,10 @@ impl<'db> BlocksBuilder<'db> {
     pub fn new() -> Self {
         Self(vec![])
     }
+    /// Creates a new builder with pre-allocated capacity for `n` blocks.
+    pub fn with_capacity(n: usize) -> Self {
+        Self(Vec::with_capacity(n))
+    }
     pub fn alloc(&mut self, block: Block<'db>) -> BlockId {
         let id = BlockId(self.0.len());
         self.0.push(block);

--- a/crates/cairo-lang-lowering/src/reorganize_blocks.rs
+++ b/crates/cairo-lang-lowering/src/reorganize_blocks.rs
@@ -33,9 +33,6 @@ pub fn reorganize_blocks<'db>(lowered: &mut Lowered<'db>) {
 
     DataflowBackAnalysis::new(lowered, &mut ctx).run();
 
-    // Rebuild the blocks in the correct order.
-    let mut new_blocks = BlocksBuilder::default();
-
     // Keep only blocks that can't be merged or have more than 1 incoming
     // goto.
     // Note that unreachable blocks were not added to `ctx.old_block_rev_order` during
@@ -50,6 +47,9 @@ pub fn reorganize_blocks<'db>(lowered: &mut Lowered<'db>) {
     old_block_rev_order.push(BlockId::root());
 
     let n_visited_blocks = old_block_rev_order.len();
+
+    // Rebuild the blocks in the correct order.
+    let mut new_blocks = BlocksBuilder::with_capacity(n_visited_blocks);
 
     let mut rebuilder = RebuildContext {
         block_remapping: UnorderedHashMap::from_iter(
@@ -67,9 +67,8 @@ pub fn reorganize_blocks<'db>(lowered: &mut Lowered<'db>) {
     }
 
     for block_id in old_block_rev_order.into_iter().rev() {
-        let mut statements = vec![];
-
         let mut block = &lowered.blocks[block_id];
+        let mut statements = Vec::with_capacity(block.statements.len());
         loop {
             statements.extend(
                 block.statements.iter().map(|stmt| {
@@ -211,7 +210,11 @@ pub struct VarReassigner<'db, 'a> {
 
 impl<'db, 'a> VarReassigner<'db, 'a> {
     pub fn new(old_vars: &'a VariableArena<'db>) -> Self {
-        Self { old_vars, new_vars: Default::default(), vars: vec![None; old_vars.len()] }
+        Self {
+            old_vars,
+            new_vars: VariableArena::with_capacity(old_vars.len()),
+            vars: vec![None; old_vars.len()],
+        }
     }
 }
 

--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -86,6 +86,13 @@ impl<Key, Value, BH> UnorderedHashMap<Key, Value, BH> {
     }
 }
 
+impl<Key, Value, BH: Default> UnorderedHashMap<Key, Value, BH> {
+    /// Creates an empty map with the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(HashMap::<Key, Value, BH>::with_capacity_and_hasher(capacity, Default::default()))
+    }
+}
+
 impl<Key, Value, BH> PartialEq for UnorderedHashMap<Key, Value, BH>
 where
     Key: Eq + Hash,


### PR DESCRIPTION
## Summary

Pre-allocates capacity for collections in the block reorganization and backward analysis passes. This includes:
- `BackAnalysis::block_info` map pre-allocated to the number of blocks
- `BackAnalysis::get_root_info` DFS stack pre-allocated to the number of blocks
- `BlocksBuilder::with_capacity` constructor for pre-allocating block storage, used in `reorganize_blocks`
- `statements` vector in `reorganize_blocks` pre-allocated to the block's statement count
- `VarReassigner::new_vars` arena pre-allocated to the old variable count
- `UnorderedHashMap::with_capacity` constructor backed by `HashMap::with_capacity_and_hasher`

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Without pre-allocated capacities, these collections grow dynamically through repeated reallocations during the block reorganization and backward analysis passes. Since the final sizes are known or estimable upfront, pre-allocating avoids unnecessary heap reallocations during compilation.

---

## What was the behavior or documentation before?

Collections such as `block_info`, the DFS stack, `new_blocks`, `statements`, and `new_vars` were all initialized with default (zero) capacity and resized on demand.

---

## What is the behavior or documentation after?

These collections are initialized with a capacity matching the expected number of elements, reducing allocator pressure during the block reorganization and backward analysis passes.

---

## Related issue or discussion (if any)

---

## Additional context

The `BlocksBuilder::with_capacity` and `UnorderedHashMap::with_capacity` constructors added here are general-purpose and may be useful in other passes as well.