### PR TITLE
fix(lowering): give reconstructed structs the original variable's location in E3002

### DIFF
--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
@@ -1124,9 +1124,9 @@ note: variable was previously used here:
 note: Trait has no implementation in context: core::traits::Copy::<test::Wrapper>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:9:15
-        use_x(x); // First use.
-              ^
+ --> lib.cairo:7:8
+fn foo(x: Wrapper) {
+       ^
 note: the variable needs to be dropped due to the divergence here:
   --> lib.cairo:8:5-10:5
       if x.inner.is_zero() {
@@ -1167,6 +1167,156 @@ Statements:
   (v6: ()) <- struct_construct()
 End:
   Return(v6)
+
+//! > ==========================================================================
+
+//! > E3002 location points to local variable declaration, not use site.
+
+//! > test_runner_name
+test_borrow_check
+
+//! > function_code
+fn foo() {
+    let x = Wrapper { inner: 5 };
+    if x.inner.is_zero() {
+        use_x(x);
+    } else {
+        use_snap_x(@x);
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+struct Wrapper {
+    inner: u16,
+}
+
+extern fn use_x(x: Wrapper) nopanic;
+extern fn use_snap_x(x: @Wrapper) nopanic;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3002]: Variable not dropped.
+ --> lib.cairo:8:9
+    let x = Wrapper { inner: 5 };
+        ^
+note: Trait has no implementation in context: core::traits::Drop::<test::Wrapper>.
+note: Trait has no implementation in context: core::traits::Destruct::<test::Wrapper>.
+
+//! > lowering
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::integer::u16) <- 5
+  (v1: test::Wrapper) <- struct_construct(v0{`5`})
+  (v2: core::integer::u16) <- struct_destructure(v1{`x.inner`})
+  (v3: core::bool) <- core::zeroable::zero_based::ZeroableImpl::<core::integer::u16, core::integer::U16Zero, core::integer::u16Drop, core::integer::u16Copy>::is_zero(v2{`x.inner`})
+End:
+  Match(match_enum(v3{`x.inner.is_zero()`}) {
+    bool::False(v5) => blk2,
+    bool::True(v4) => blk1,
+  })
+
+blk1:
+Statements:
+  (v9: test::Wrapper) <- struct_construct(v2{`x`})
+  () <- test::use_x(v9{`x`})
+End:
+  Goto(blk3, {})
+
+blk2:
+Statements:
+  (v6: test::Wrapper) <- struct_construct(v2{`x`})
+  (v7: test::Wrapper, v8: @test::Wrapper) <- snapshot(v6{`x`})
+  () <- test::use_snap_x(v8{`@x`})
+End:
+  Goto(blk3, {})
+
+blk3:
+Statements:
+  (v10: ()) <- struct_construct()
+End:
+  Return(v10)
+
+//! > ==========================================================================
+
+//! > E3002 location points to original variable for nested struct reconstruction.
+
+//! > test_runner_name
+test_borrow_check
+
+//! > function_code
+fn foo(o: Outer) {
+    if o.inner.x.is_zero() {
+        use_outer(o);
+    } else {
+        use_snap_outer(@o);
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+struct Inner {
+    x: u16,
+}
+
+struct Outer {
+    inner: Inner,
+}
+
+extern fn use_outer(x: Outer) nopanic;
+extern fn use_snap_outer(x: @Outer) nopanic;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3002]: Variable not dropped.
+ --> lib.cairo:11:8
+fn foo(o: Outer) {
+       ^
+note: Trait has no implementation in context: core::traits::Drop::<test::Outer>.
+note: Trait has no implementation in context: core::traits::Destruct::<test::Outer>.
+
+//! > lowering
+Parameters: v0: test::Outer
+blk0 (root):
+Statements:
+  (v1: test::Inner) <- struct_destructure(v0{`o.inner.x`})
+  (v2: core::integer::u16) <- struct_destructure(v1{`o.inner.x`})
+  (v3: core::bool) <- core::zeroable::zero_based::ZeroableImpl::<core::integer::u16, core::integer::U16Zero, core::integer::u16Drop, core::integer::u16Copy>::is_zero(v2{`o.inner.x`})
+End:
+  Match(match_enum(v3{`o.inner.x.is_zero()`}) {
+    bool::False(v5) => blk2,
+    bool::True(v4) => blk1,
+  })
+
+blk1:
+Statements:
+  (v10: test::Inner) <- struct_construct(v2{`o`})
+  (v11: test::Outer) <- struct_construct(v10{`o`})
+  () <- test::use_outer(v11{`o`})
+End:
+  Goto(blk3, {})
+
+blk2:
+Statements:
+  (v6: test::Inner) <- struct_construct(v2{`o`})
+  (v7: test::Outer) <- struct_construct(v6{`o`})
+  (v8: test::Outer, v9: @test::Outer) <- snapshot(v7{`o`})
+  () <- test::use_snap_outer(v9{`@o`})
+End:
+  Goto(blk3, {})
+
+blk3:
+Statements:
+  (v12: ()) <- struct_construct()
+End:
+  Return(v12)
 
 //! > ==========================================================================
 
@@ -1325,3 +1475,129 @@ Statements:
   (v6: ()) <- struct_construct()
 End:
   Return(v6)
+
+//! > ==========================================================================
+
+//! > E3002 location for doubly-scattered var after reassignment merge.
+
+//! > test_runner_name
+test_borrow_check
+
+//! > function_code
+fn foo(mut o: Outer) {
+    if some_cond() {
+        use_outer(o);
+        o = Outer { inner: Inner { x: 5_u16 } };
+    }
+    if o.inner.x.is_zero() {
+        use_outer(o);
+    } else {
+        use_snap_outer(@o);
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+struct Inner {
+    x: u16,
+}
+
+struct Outer {
+    inner: Inner,
+}
+
+extern fn use_outer(x: Outer) nopanic;
+extern fn use_snap_outer(x: @Outer) nopanic;
+extern fn some_cond() -> bool nopanic;
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3002]: Variable not dropped.
+ --> lib.cairo:12:12
+fn foo(mut o: Outer) {
+           ^
+note: Trait has no implementation in context: core::traits::Drop::<test::Outer>.
+note: Trait has no implementation in context: core::traits::Destruct::<test::Outer>.
+
+//! > lowering
+Parameters: v0: test::Outer
+blk0 (root):
+Statements:
+End:
+  Match(match test::some_cond() {
+    bool::False => blk1,
+    bool::True => blk2,
+  })
+
+blk1:
+Statements:
+  (v1: ()) <- struct_construct()
+  (v2: core::bool) <- bool::False(v1{`some_cond()`})
+End:
+  Goto(blk3, {v2 -> v5})
+
+blk2:
+Statements:
+  (v3: ()) <- struct_construct()
+  (v4: core::bool) <- bool::True(v3{`some_cond()`})
+End:
+  Goto(blk3, {v4 -> v5})
+
+blk3:
+Statements:
+End:
+  Match(match_enum(v5{`some_cond()`}) {
+    bool::False(v7) => blk5,
+    bool::True(v6) => blk4,
+  })
+
+blk4:
+Statements:
+  () <- test::use_outer(v0{`o`})
+  (v8: core::integer::u16) <- 5
+  (v9: test::Inner) <- struct_construct(v8{`5_u16`})
+  (v10: test::Outer) <- struct_construct(v9{`Inner { x: 5_u16 }`})
+End:
+  Goto(blk6, {v10 -> v11})
+
+blk5:
+Statements:
+End:
+  Goto(blk6, {v0 -> v11})
+
+blk6:
+Statements:
+  (v12: test::Inner) <- struct_destructure(v11{`o.inner.x`})
+  (v13: core::integer::u16) <- struct_destructure(v12{`o.inner.x`})
+  (v14: core::bool) <- core::zeroable::zero_based::ZeroableImpl::<core::integer::u16, core::integer::U16Zero, core::integer::u16Drop, core::integer::u16Copy>::is_zero(v13{`o.inner.x`})
+End:
+  Match(match_enum(v14{`o.inner.x.is_zero()`}) {
+    bool::False(v16) => blk8,
+    bool::True(v15) => blk7,
+  })
+
+blk7:
+Statements:
+  (v21: test::Inner) <- struct_construct(v13{`o`})
+  (v22: test::Outer) <- struct_construct(v21{`o`})
+  () <- test::use_outer(v22{`o`})
+End:
+  Goto(blk9, {})
+
+blk8:
+Statements:
+  (v17: test::Inner) <- struct_construct(v13{`o`})
+  (v18: test::Outer) <- struct_construct(v17{`o`})
+  (v19: test::Outer, v20: @test::Outer) <- snapshot(v18{`o`})
+  () <- test::use_snap_outer(v20{`@o`})
+End:
+  Goto(blk9, {})
+
+blk9:
+Statements:
+  (v23: ()) <- struct_construct()
+End:
+  Return(v23)

--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -518,17 +518,17 @@ impl<'db> BlockStructRecomposer<'_, '_, 'db> {
         &mut self,
         concrete_struct_id: semantic::ConcreteStructId<'db>,
         members: Vec<VariableId>,
+        location: LocationId<'db>,
     ) -> VariableId {
         let ty =
             TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)).intern(self.ctx.db);
-        // TODO(ilya): Is using the `self.location` correct here?
         generators::StructConstruct {
             inputs: members
                 .into_iter()
                 .map(|var_id| VarUsage { var_id, location: self.location })
                 .collect_vec(),
             ty,
-            location: self.location,
+            location,
         }
         .add(self.ctx, self.statements)
         .var_id

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -1,4 +1,4 @@
-use cairo_lang_defs::ids::MemberId;
+use cairo_lang_defs::ids::{LanguageElementId, MemberId};
 use cairo_lang_proc_macros::DebugWithDb;
 use cairo_lang_semantic::expr::fmt::ExprFormatter;
 use cairo_lang_semantic::expr::inference::InferenceError;
@@ -74,7 +74,13 @@ impl<'db> SemanticLoweringMapping<'db> {
         path: &MemberPath<'db>,
     ) -> Result<VariableId, AssembleValueError<'db>> {
         let value = self.break_into_value(&mut ctx, path).ok_or(AssembleValueError::Missing)?;
-        Self::assemble_value(&mut ctx, value).map_err(AssembleValueError::Moved)
+        let base_var = path.base_var();
+        let location_stable_ptr = match ctx.ctx.semantic_defs.get(&base_var) {
+            Some(binding) => binding.stable_ptr(ctx.ctx.db),
+            None => base_var.untyped_stable_ptr(ctx.ctx.db),
+        };
+        let location = ctx.ctx.get_location(location_stable_ptr);
+        Self::assemble_value(&mut ctx, value, location).map_err(AssembleValueError::Moved)
     }
 
     pub fn introduce(&mut self, path: MemberPath<'db>, var: VariableId) {
@@ -117,6 +123,7 @@ impl<'db> SemanticLoweringMapping<'db> {
     fn assemble_value(
         ctx: &mut BlockStructRecomposer<'_, '_, 'db>,
         value: &mut Value<'db>,
+        location: LocationId<'db>,
     ) -> Result<VariableId, MovedVar<'db>> {
         match value {
             Value::Var(var) => Ok(*var),
@@ -126,7 +133,7 @@ impl<'db> SemanticLoweringMapping<'db> {
                 let members = scattered
                     .members
                     .iter_mut()
-                    .map(|(_, value)| match Self::assemble_value(ctx, value) {
+                    .map(|(_, value)| match Self::assemble_value(ctx, value, location) {
                         Ok(var) => var,
                         Err(moved) => {
                             let var = moved.var_id;
@@ -135,7 +142,7 @@ impl<'db> SemanticLoweringMapping<'db> {
                         }
                     })
                     .collect_vec();
-                let var = ctx.reconstruct(scattered.concrete_struct_id, members);
+                let var = ctx.reconstruct(scattered.concrete_struct_id, members, location);
                 *value = Value::Var(var);
                 if let Some(MovedVar { var_id: _, inference_error, last_use_location }) = moved_var
                 {
@@ -156,39 +163,39 @@ impl<'db> SemanticLoweringMapping<'db> {
             return self.scattered.get_mut(path);
         }
 
-        let MemberPath::Member { parent, member_id, concrete_struct_id, .. } = path else {
+        let &MemberPath::Member { ref parent, member_id, concrete_struct_id, .. } = path else {
             return None;
         };
 
         let parent_value = self.break_into_value(ctx, parent)?;
         match parent_value {
             Value::Var(var) => {
-                let members = ctx.deconstruct(*concrete_struct_id, *var);
+                let members = ctx.deconstruct(concrete_struct_id, *var);
                 let members = OrderedHashMap::from_iter(
                     members.into_iter().map(|(member_id, var)| (member_id, Value::Var(var))),
                 );
-                let scattered = Scattered { concrete_struct_id: *concrete_struct_id, members };
+                let scattered = Scattered { concrete_struct_id, members };
                 *parent_value = Value::Scattered(Box::new(scattered));
             }
-            Value::MovedVar(MovedVar { var_id: var, inference_error, last_use_location }) => {
-                let member_map = ctx.ctx.db.concrete_struct_members(*concrete_struct_id).unwrap();
-                let location = ctx.ctx.variables[*var].location;
+            &mut Value::MovedVar(MovedVar { var_id, ref inference_error, last_use_location }) => {
+                let member_map = ctx.ctx.db.concrete_struct_members(concrete_struct_id).unwrap();
+                let location = ctx.ctx.variables[var_id].location;
                 let members = OrderedHashMap::from_iter(member_map.values().map(|member| {
                     (
                         member.id,
                         Value::MovedVar(MovedVar {
                             var_id: ctx.ctx.new_var(VarRequest { ty: member.ty, location }),
                             inference_error: inference_error.clone(),
-                            last_use_location: *last_use_location,
+                            last_use_location,
                         }),
                     )
                 }));
-                let scattered = Scattered { concrete_struct_id: *concrete_struct_id, members };
+                let scattered = Scattered { concrete_struct_id, members };
                 *parent_value = Value::Scattered(Box::new(scattered));
             }
             Value::Scattered(..) => {}
         };
-        extract_matches!(parent_value, Value::Scattered).members.get_mut(member_id)
+        extract_matches!(parent_value, Value::Scattered).members.get_mut(&member_id)
     }
 }
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/closure
@@ -520,7 +520,7 @@ error[E2061]: `?` can only be used in a function with `Option` or `Result` retur
 warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
  --> lib.cairo:6:17
     let bar2 = |b: Option<u32>| {
-                ^^^^^^^^^^^^^^
+                ^
 
 error[E0006]: Function not found.
  --> lib.cairo:10:19

--- a/crates/cairo-lang-semantic/src/semantic.rs
+++ b/crates/cairo-lang-semantic/src/semantic.rs
@@ -123,7 +123,7 @@ impl<'db> Binding<'db> {
     pub fn stable_ptr(&self, db: &'db dyn Database) -> SyntaxStablePtrId<'db> {
         match self {
             Binding::LocalVar(local) => local.stable_ptr(db).untyped(),
-            Binding::Param(param) => param.stable_ptr(db).untyped(),
+            Binding::Param(param) => param.stable_ptr.untyped(),
             Binding::LocalItem(local) => local.id.name_stable_ptr(db),
         }
     }


### PR DESCRIPTION
## Summary

When a variable is scattered into members (e.g., via struct destructuring) and later reconstructed, the reconstructed variable now carries the location of the original variable rather than the location of the reconstruction site. This ensures that `E3002` ("Variable not dropped") diagnostics point to the variable's declaration or parameter site instead of an internal use site.

A `var_location: Option<LocationId>` field was added to `Scattered` to track the original variable's location through the scattering process. When `reconstruct` is called, this location is passed through and used as the location of the newly constructed variable. The location is also propagated correctly when merging scattered values across branches (using `all_equal` to only preserve the location when all branches agree on it).

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`E3002` diagnostics were pointing to an internal use site (e.g., `use_x(x)`) rather than the variable's declaration or function parameter. This made it harder for users to identify which variable was not being dropped.

---

## What was the behavior or documentation before?

The error pointed to the first use of the variable after it was scattered:

```
error[E3002]: Variable not dropped.
 --> lib.cairo:9:15
        use_x(x); // First use.
              ^
```

---

## What is the behavior or documentation after?

The error now points to the variable's declaration or parameter:

```
error[E3002]: Variable not dropped.
 --> lib.cairo:7:8
fn foo(x: Wrapper) {
       ^
```

For locally declared variables, it points to the `let` binding site. For nested struct access, it points back to the original top-level variable.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Two new test cases were added: one for local variable declarations and one for nested struct reconstruction, both verifying that the diagnostic location points to the original variable rather than a use site.