### PR TITLE
bugfix(semantic): Prevent crash on `?` on generics.

### DIFF
--- a/crates/cairo-lang-semantic/src/corelib.rs
+++ b/crates/cairo-lang-semantic/src/corelib.rs
@@ -506,11 +506,8 @@ pub fn unwrap_error_propagation_type<'db>(
                 None
             }
         }
-        TypeLongId::GenericParameter(_) => todo!(
-            "When generic types are supported, if type is of matching type, allow unwrapping it \
-             to type."
-        ),
-        TypeLongId::Concrete(
+        TypeLongId::GenericParameter(_)
+        | TypeLongId::Concrete(
             semantic::ConcreteTypeId::Struct(_) | semantic::ConcreteTypeId::Extern(_),
         )
         | TypeLongId::Tuple(_)

--- a/crates/cairo-lang-semantic/src/expr/test_data/error_propagate
+++ b/crates/cairo-lang-semantic/src/expr/test_data/error_propagate
@@ -153,3 +153,30 @@ error[E2063]: Type "core::integer::u32" cannot error propagate
  --> lib.cairo:2:5
     6_u32?;
     ^^^^^^
+
+//! > ==========================================================================
+
+//! > Test generics operand for error propagation.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(a: Option<felt252>) -> Option<felt252> {
+    bar(a)
+}
+
+//! > function_name
+foo
+
+//! > module_code
+fn bar<T, +Copy<T>>(t: T) -> T {
+    t?;
+    t
+}
+
+//! > expected_diagnostics
+error[E2061]: `?` can only be used in a function with `Option` or `Result` return type.
+ --> lib.cairo:2:5
+    t?;
+    ^^


### PR DESCRIPTION
## Summary

Replaces the `todo!()` panic for `TypeLongId::GenericParameter` in `unwrap_error_propagation_type` with a proper `None` return, treating generic parameter types the same as structs, extern types, and tuples — i.e., not unwrappable for error propagation. Adds a test case confirming that using `?` on a generic type `T` inside a function with a generic return type correctly produces a diagnostic error.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, calling `?` on a value of a generic parameter type would trigger a `todo!()` panic at runtime instead of producing a proper diagnostic. This caused a compiler crash rather than a user-friendly error message.

---

## What was the behavior or documentation before?

When `?` was used on a generic type parameter, the compiler would panic with an unimplemented message: `"When generic types are supported, if type is of matching type, allow unwrapping it to type."`.

---

## What is the behavior or documentation after?

Using `?` on a generic type parameter now returns `None` from `unwrap_error_propagation_type`, which causes the semantic layer to emit the appropriate diagnostic:

```
error[E2061]: `?` can only be used in a function with `Option` or `Result` return type.
```

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The fix is minimal — the `GenericParameter` arm is merged into the existing match arm that returns `None`, avoiding any runtime panic while keeping the behavior consistent with other non-propagatable types.