### PR TITLE
fix(semantic): extract generic params from FixedSizeArray size field in negative impl resolution

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
+++ b/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
@@ -360,3 +360,35 @@ foo
 //! > module_code
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Negative impl with fixed-size array whose size is a const generic param.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait IsSpecificSize<T>;
+impl IsSpecificSizeImpl of IsSpecificSize<[u32; 3]>;
+
+trait NotSpecificSize<T>;
+impl NotSpecificSizeImpl<T, -IsSpecificSize<T>> of NotSpecificSize<T>;
+
+fn bar<T, +NotSpecificSize<T>>() {}
+
+fn generic_bar<const N: usize>() {
+    bar::<[u32; N]>();
+}
+
+//! > expected_diagnostics
+error[E2313]: Negative impl has an unsupported generic argument GenericParamConst(test::generic_bar::N).
+ --> lib.cairo:10:5
+    bar::<[u32; N]>();
+    ^^^

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -246,8 +246,9 @@ impl<'db> TypeLongId<'db> {
             TypeLongId::Var(_) => {}
             TypeLongId::NumericLiteral(_) => {}
             TypeLongId::Coupon(_) => {}
-            TypeLongId::FixedSizeArray { type_id, .. } => {
-                type_id.extract_generic_params(db, generic_parameters, visited)?
+            TypeLongId::FixedSizeArray { type_id, size } => {
+                type_id.extract_generic_params(db, generic_parameters, visited)?;
+                size.extract_generic_params(db, generic_parameters, visited)?;
             }
             TypeLongId::ImplType(impl_type_id) => {
                 let concrete_trait_id = impl_type_id.impl_id.concrete_trait(db)?;


### PR DESCRIPTION
## Summary

When extracting generic parameters from a `FixedSizeArray` type for negative impl checking, the array's `size` field (which can be a const generic parameter) was not being traversed — only the element `type_id` was. This meant that a const generic parameter used as the array size was invisible to the negative impl resolution logic, causing it to silently proceed instead of emitting a diagnostic.

Now, `size.extract_generic_params(...)` is also called for `FixedSizeArray`, so const generic parameters appearing in the size position are properly detected. A new test case covers the scenario where a fixed-size array with a const generic size (e.g., `[u32; N]`) is passed to a function constrained by a negative impl, confirming that `E2313` is correctly raised.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a `FixedSizeArray` type is used as a generic argument in a negative impl context, the array size could itself be a const generic parameter (e.g., `[u32; N]`). Because `size` was not traversed during generic parameter extraction, the compiler failed to detect this unsupported generic argument and did not emit the expected `E2313` diagnostic.

---

## What was the behavior or documentation before?

Calling a function with a negative impl constraint using a fixed-size array whose size is a const generic parameter (e.g., `bar::<[u32; N]>()`) would not produce a diagnostic, even though the const generic `N` is an unsupported argument for negative impl resolution.

---

## What is the behavior or documentation after?

The compiler now correctly emits:

```
error[E2313]: Negative impl has an unsupported generic argument GenericParamConst(test::generic_bar::N).
```

when a fixed-size array with a const generic size is used in a negative impl context.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The fix is minimal: a single additional call to `size.extract_generic_params(...)` in the `FixedSizeArray` arm of `TypeLongId::extract_generic_params`, mirroring how the element type is already handled.