### PR TITLE
fix(runner): correct n_steps by removing erroneous -1 offsets

### DIFF
--- a/crates/cairo-lang-runner/src/lib.rs
+++ b/crates/cairo-lang-runner/src/lib.rs
@@ -286,10 +286,9 @@ impl SierraCasmRunner {
         // The execution from the header created by self.builder.create_entry_code().
         // We expect the last trace entry to be the `ret` instruction at the end of the header.
         let header_end = relocated_trace.last().unwrap().pc;
+        used_resources.n_steps -= relocated_trace.iter().position(|e| e.pc > header_end).unwrap();
         used_resources.n_steps -=
-            relocated_trace.iter().position(|e| e.pc > header_end).unwrap() - 1;
-        used_resources.n_steps -=
-            relocated_trace.iter().rev().position(|e| e.pc > header_end).unwrap() - 1;
+            relocated_trace.iter().rev().position(|e| e.pc > header_end).unwrap();
 
         let (results_data, gas_counter) = self.get_results_data(&return_types, &memory, ap);
         assert!(results_data.len() <= 1);


### PR DESCRIPTION
## Summary

Fixes an off-by-one error in the step count subtraction when calculating `used_resources.n_steps`. The `- 1` was incorrectly applied when removing header and footer steps from the relocated trace, causing the step count to be under-subtracted by 1 for both the forward and reverse trace position lookups.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `position()` call on the relocated trace already returns a 0-based index representing the number of steps to exclude. Subtracting an additional `1` from each result caused the reported step count to be 2 steps higher than the actual number of steps executed by the user's code (1 step over-counted from the header, 1 from the footer).

---

## What was the behavior or documentation before?

`used_resources.n_steps` was reduced by `(position - 1)` for both the header and footer, leaving 2 extra steps attributed to the user's function execution.

---

## What is the behavior or documentation after?

`used_resources.n_steps` is now correctly reduced by the full `position` value for both the header and footer, accurately reflecting only the steps belonging to the user's code.

---

## Related issue or discussion (if any)

---

## Additional context

The fix applies symmetrically to both the forward trace scan (header exclusion) and the reverse trace scan (footer exclusion).