### PR TITLE
fix(parser): don't panic on $(...) without operator in macro calls (#9993)

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -1792,13 +1792,16 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                             SyntaxKind::TerminalComma => self.take::<TerminalComma<'_>>().into(),
                             _ => OptionTerminalCommaEmpty::new_green(self.db).into(),
                         };
+                        // Unlike macro definitions, a missing operator at a call site is not a
+                        // parse error: the semantic layer validates the call against the macro
+                        // declaration and decides whether the shape is legal.
                         let operator = match self.peek().kind {
                             SyntaxKind::TerminalQuestionMark => {
                                 self.take::<TerminalQuestionMark<'_>>().into()
                             }
                             SyntaxKind::TerminalPlus => self.take::<TerminalPlus<'_>>().into(),
                             SyntaxKind::TerminalMul => self.take::<TerminalMul<'_>>().into(),
-                            _ => unreachable!(),
+                            _ => MacroRepetitionOperator::missing(self.db),
                         };
                         TokenTreeRepetition::new_green(
                             self.db, dollar, lparen, elements, rparen, separator, operator,

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/inline_macro
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/inline_macro
@@ -442,3 +442,45 @@ error[E1001]: Missing token ';'.
     │       │       └── semicolon: Missing
     │       └── rbrace (kind: TokenRBrace): '}'
     └── eof (kind: TokenEndOfFile).
+
+//! > ==========================================================================
+
+//! > Test inline macro call with repetition missing operator (allowed at call site).
+
+//! > test_runner_name
+test_partial_parser_tree(expect_diagnostics: false)
+
+//! > cairo_code
+fn main() -> u32 {
+    foo!($(x))
+}
+
+//! > top_level_kind
+ExprInlineMacro
+
+//! > ignored_kinds
+
+//! > expected_diagnostics
+
+//! > expected_tree
+└── Top level kind: ExprInlineMacro
+    ├── path (kind: ExprPath)
+    │   ├── dollar (kind: OptionTerminalDollarEmpty) []
+    │   └── segments (kind: ExprPathInner)
+    │       └── item #0 (kind: PathSegmentSimple)
+    │           └── ident (kind: TokenIdentifier): 'foo'
+    ├── bang (kind: TokenNot): '!'
+    └── arguments (kind: TokenTreeNode)
+        └── subtree (kind: ParenthesizedTokenTree)
+            ├── lparen (kind: TokenLParen): '('
+            ├── tokens (kind: TokenList)
+            │   └── child #0 (kind: TokenTreeRepetition)
+            │       ├── dollar (kind: TokenDollar): '$'
+            │       ├── lparen (kind: TokenLParen): '('
+            │       ├── elements (kind: TokenList)
+            │       │   └── child #0 (kind: TokenTreeLeaf)
+            │       │       └── leaf (kind: TokenIdentifier): 'x'
+            │       ├── rparen (kind: TokenRParen): ')'
+            │       ├── separator (kind: OptionTerminalCommaEmpty) []
+            │       └── operator: Missing []
+            └── rparen (kind: TokenRParen): ')'

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/macro_declaration
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/macro_declaration
@@ -325,3 +325,74 @@ error[E1031]: Missing macro repetition operator. Expected `?`, `+`, or `*` after
     │       │       └── semicolon (kind: TokenSemicolon): ';'
     │       └── rbrace (kind: TokenRBrace): '}'
     └── eof (kind: TokenEndOfFile).
+
+//! > ==========================================================================
+
+//! > Test macro definition with body repetition missing operator.
+
+//! > test_runner_name
+test_partial_parser_tree(expect_diagnostics: true)
+
+//! > cairo_code
+macro macro_name {
+    ($($x:expr),*) => { $($x) };
+}
+
+//! > top_level_kind
+
+//! > ignored_kinds
+
+//! > expected_diagnostics
+error[E1031]: Missing macro repetition operator. Expected `?`, `+`, or `*` after `$(...)`.
+ --> dummy_file.cairo:2:30
+    ($($x:expr),*) => { $($x) };
+                             ^
+
+//! > expected_tree
+└── root (kind: SyntaxFile)
+    ├── items (kind: ModuleItemList)
+    │   └── child #0 (kind: ItemMacroDeclaration)
+    │       ├── attributes (kind: AttributeList) []
+    │       ├── visibility (kind: VisibilityDefault) []
+    │       ├── macro_kw (kind: TokenMacro): 'macro'
+    │       ├── name (kind: TokenIdentifier): 'macro_name'
+    │       ├── lbrace (kind: TokenLBrace): '{'
+    │       ├── rules (kind: MacroRulesList)
+    │       │   └── child #0 (kind: MacroRule)
+    │       │       ├── lhs (kind: ParenthesizedMacro)
+    │       │       │   ├── lparen (kind: TokenLParen): '('
+    │       │       │   ├── elements (kind: MacroElements)
+    │       │       │   │   └── child #0 (kind: MacroRepetition)
+    │       │       │   │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       ├── lparen (kind: TokenLParen): '('
+    │       │       │   │       ├── elements (kind: MacroElements)
+    │       │       │   │       │   └── child #0 (kind: MacroParam)
+    │       │       │   │       │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       │       ├── name (kind: TokenIdentifier): 'x'
+    │       │       │   │       │       └── kind (kind: ParamKind)
+    │       │       │   │       │           ├── colon (kind: TokenColon): ':'
+    │       │       │   │       │           └── kind (kind: ParamExpr)
+    │       │       │   │       │               └── expr (kind: TokenIdentifier): 'expr'
+    │       │       │   │       ├── rparen (kind: TokenRParen): ')'
+    │       │       │   │       ├── separator (kind: TokenComma): ','
+    │       │       │   │       └── operator (kind: TokenMul): '*'
+    │       │       │   └── rparen (kind: TokenRParen): ')'
+    │       │       ├── fat_arrow (kind: TokenMatchArrow): '=>'
+    │       │       ├── rhs (kind: BracedMacro)
+    │       │       │   ├── lbrace (kind: TokenLBrace): '{'
+    │       │       │   ├── elements (kind: MacroElements)
+    │       │       │   │   └── child #0 (kind: MacroRepetition)
+    │       │       │   │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       ├── lparen (kind: TokenLParen): '('
+    │       │       │   │       ├── elements (kind: MacroElements)
+    │       │       │   │       │   └── child #0 (kind: MacroParam)
+    │       │       │   │       │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       │       ├── name (kind: TokenIdentifier): 'x'
+    │       │       │   │       │       └── kind (kind: OptionParamKindEmpty) []
+    │       │       │   │       ├── rparen (kind: TokenRParen): ')'
+    │       │       │   │       ├── separator (kind: OptionTerminalCommaEmpty) []
+    │       │       │   │       └── operator: Missing []
+    │       │       │   └── rbrace (kind: TokenRBrace): '}'
+    │       │       └── semicolon (kind: TokenSemicolon): ';'
+    │       └── rbrace (kind: TokenRBrace): '}'
+    └── eof (kind: TokenEndOfFile).


### PR DESCRIPTION
## Summary

In the parser, a missing repetition operator inside a macro call site (`$(...)` without `?`, `+`, or `*`) previously hit an `unreachable!()` panic. The operator arm now produces a `MacroRepetition​Operator::missing` node instead, deferring validation to the semantic layer. Macro *definitions* continue to emit a hard parse error (`E1031`) when the operator is absent.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

At a macro call site, `$(x)` without a trailing operator is syntactically ambiguous but not necessarily illegal — the semantic layer is responsible for checking whether the shape matches the macro declaration. Hitting `unreachable!()` in the parser caused a panic instead of a recoverable missing-node, preventing any downstream diagnostic or recovery.

---

## What was the behavior or documentation before?

Parsing a macro invocation containing `$(...)` with no repetition operator caused the parser to panic via `unreachable!()`.

---

## What is the behavior or documentation after?

The parser emits a `MacroRepetitionOperator::missing` node and continues without a diagnostic. The semantic layer is then responsible for deciding whether the missing operator is valid given the macro declaration. A new test case (`expect_diagnostics: false`) confirms that `foo!($(x))` parses cleanly. Macro definitions still produce `E1031` when the operator is missing, as validated by an additional test case (`expect_diagnostics: true`).

---

## Related issue or discussion (if any)

---

## Additional context

The distinction between call-site leniency and definition-site strictness is now documented with an inline comment in `parser.rs`.