### PR TITLE
bugfix(lowering): Removed extra diag in cases of out of range u256 match.

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
@@ -648,44 +648,40 @@ fn create_node_for_tuple_inner<'db>(
 
     // Collect the patterns on the current item.
     let mut patterns_on_current_item = Vec::<Option<semantic::Pattern<'db>>>::default();
-    for pattern in patterns {
-        match pattern {
+    let mut live_filter = FilteredPatterns::default();
+    for (idx, pattern) in patterns.iter().enumerate() {
+        let item_pattern = match pattern {
             Some(semantic::Pattern::Tuple(PatternTuple { field_patterns, .. }))
                 if current_member.is_none() =>
             {
-                patterns_on_current_item
-                    .push(Some(get_pattern(ctx, field_patterns[item_idx]).clone()));
+                Some(get_pattern(ctx, field_patterns[item_idx]).clone())
             }
             Some(semantic::Pattern::Struct(PatternStruct { field_patterns, .. }))
                 if current_member.is_some() =>
             {
                 // Extract the pattern for the current member, or `None` if the member is not
                 // listed in the pattern (e.g., with `MyStruct { a: 0, .. }`).
-                let item_pattern = field_patterns
+                field_patterns
                     .iter()
                     .find(|(_, member)| member.id == current_member.unwrap().id)
-                    .map(|(pattern, _)| get_pattern(ctx, *pattern));
-                patterns_on_current_item.push(item_pattern.cloned());
+                    .map(|(pattern, _)| get_pattern(ctx, *pattern).clone())
             }
-            Some(semantic::Pattern::Otherwise(..)) | None => {
-                patterns_on_current_item.push(None);
-            }
+            Some(semantic::Pattern::Otherwise(..)) | None => None,
             Some(semantic::Pattern::Variable(..)) => unreachable!(),
             Some(semantic::Pattern::Literal(pattern_literal))
                 if pattern_literal.literal.ty == ctx.db.core_info().u256 =>
             {
-                if let Ok(inner_pattern) =
-                    handle_u256_literal(ctx, graph, pattern_literal, item_idx)
-                {
-                    patterns_on_current_item.push(Some(inner_pattern))
+                match handle_u256_literal(ctx, graph, pattern_literal, item_idx) {
+                    Ok(inner_pattern) => Some(inner_pattern),
+                    // Out-of-range `u256` literal, drop the arm.
+                    Err(_) => continue,
                 }
             }
             Some(semantic::Pattern::FixedSizeArray(semantic::PatternFixedSizeArray {
                 elements_patterns,
                 ..
             })) if current_member.is_none() => {
-                patterns_on_current_item
-                    .push(Some(get_pattern(ctx, elements_patterns[item_idx]).clone()));
+                Some(get_pattern(ctx, elements_patterns[item_idx]).clone())
             }
             Some(
                 pattern @ (semantic::Pattern::StringLiteral(..)
@@ -702,7 +698,9 @@ fn create_node_for_tuple_inner<'db>(
                     LoweringDiagnosticKind::UnexpectedError,
                 );
             }
-        }
+        };
+        live_filter.add(idx);
+        patterns_on_current_item.push(item_pattern);
     }
 
     // Create a node to handle the current item. The callback will handle the rest of the tuple.
@@ -713,6 +711,9 @@ fn create_node_for_tuple_inner<'db>(
             graph,
             patterns: &patterns_ref,
             build_node_callback: &mut |graph, pattern_indices, path_head| {
+                // Lift the survivors from the compacted (dropped-arm) indexing back to this level's
+                // arm indexing. When no arm was dropped this is the identity.
+                let pattern_indices = pattern_indices.lift(&live_filter);
                 // Call `create_node_for_tuple_inner` recursively to handle the rest of the tuple.
                 create_node_for_tuple_inner(
                     CreateNodeParams {

--- a/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
@@ -2043,6 +2043,79 @@ error[E3009]: The value does not fit within the range of type core::integer::u25
 
 //! > ==========================================================================
 
+//! > Match u256 with out-of-range literal before wildcard
+
+//! > test_runner_name
+test_create_graph(expect_diagnostics: true, skip_lowering: true)
+
+//! > function_code
+fn foo(x: u256) -> felt252 {
+    match x {
+        // Value out of range: must report E3009 only, no spurious E3004 non-exhaustive.
+        0x10000000000000000000000000000000000000000000000000000000000000000 => 1,
+        _ => 0,
+    }
+}
+
+//! > graph
+Root: 3
+3 EvaluateExpr { expr: ExprId(0), var_id: v0, next: NodeId(2) }
+2 Deconstruct { input: v0, outputs: [v1, v2], next: NodeId(1) }
+1 ArmExpr { expr: ExprId(2) }
+0 ArmExpr { expr: ExprId(1) }
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3009]: The value does not fit within the range of type core::integer::u256.
+ --> lib.cairo:4:9
+        0x10000000000000000000000000000000000000000000000000000000000000000 => 1,
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+//! > lowered
+
+//! > ==========================================================================
+
+//! > Match u256 with out-of-range literal and no wildcard
+
+//! > test_runner_name
+test_create_graph(expect_diagnostics: true, skip_lowering: true)
+
+//! > function_code
+fn foo(x: u256) -> felt252 {
+    match x {
+        // Out of range: the arm can never match, so the match is non-exhaustive (E3009 + E3004).
+        0x10000000000000000000000000000000000000000000000000000000000000000 => 1,
+    }
+}
+
+//! > graph
+Root: 3
+3 EvaluateExpr { expr: ExprId(0), var_id: v0, next: NodeId(2) }
+2 Deconstruct { input: v0, outputs: [v1, v2], next: NodeId(1) }
+1 Missing
+0 ArmExpr { expr: ExprId(1) }
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+error[E3009]: The value does not fit within the range of type core::integer::u256.
+ --> lib.cairo:4:9
+        0x10000000000000000000000000000000000000000000000000000000000000000 => 1,
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E3004]: Match is non-exhaustive: `u256{low: _, high: _}` not covered.
+ --> lib.cairo:2:5-5:5
+      match x {
+ _____^
+| ...
+|     }
+|_____^
+
+//! > lowered
+
+//! > ==========================================================================
+
 //! > Match u256 with optimized numeric match on low
 
 //! > test_runner_name


### PR DESCRIPTION
## Summary

When a `u256` match arm contains an out-of-range literal (triggering `E3009`) followed by a wildcard arm, the code previously failed to push a `None` entry into `patterns_on_current_item` for the invalid literal case. This broke the one-entry-per-arm invariant, causing the wildcard arm's entry to be misaligned, which produced a spurious `E3004` non-exhaustive match error in addition to the legitimate `E3009` diagnostic.

The fix adds an `else` branch that pushes `None` when `handle_u256_literal` does not return an inner pattern, preserving the invariant and ensuring only the correct `E3009` diagnostic is emitted.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a `u256` pattern literal was out of range, the missing `None` push caused subsequent arm entries to be offset by one position relative to their expected index. This misalignment made the match appear non-exhaustive even when a wildcard `_` arm was present, emitting a false `E3004` diagnostic alongside the real `E3009`.

---

## What was the behavior or documentation before?

A match on `u256` with an out-of-range literal followed by a wildcard arm would emit both `E3009` (value out of range) and a spurious `E3004` (non-exhaustive match).

---

## What is the behavior or documentation after?

The same match now emits only `E3009`. The wildcard arm is correctly recognized, and no false non-exhaustive diagnostic is produced.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A new test case `Match u256 with out-of-range literal before wildcard` is added to the match test data to cover this scenario, verifying that only `E3009` appears and no `E3004` is emitted.