### PR TITLE
fix(lowering): propagate destruct-impl error in closure lowering

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -2149,12 +2149,8 @@ fn lower_expr_closure<'db>(
     let (capture_var_usage, closure_info) = builder.capture(ctx, usage, expr);
     let closure_variable = LoweredExpr::AtVariable(capture_var_usage);
     let closure_ty = extract_matches!(expr.ty.long(ctx.db), TypeLongId::Closure);
-    let _ = add_capture_destruct_impl(
-        ctx,
-        capture_var_usage,
-        &closure_info,
-        closure_ty.params_location,
-    );
+    add_capture_destruct_impl(ctx, capture_var_usage, &closure_info, closure_ty.params_location)
+        .map_err(LoweringFlowError::Failed)?;
     add_closure_call_function(
         ctx,
         expr,


### PR DESCRIPTION
## Summary

Propagates the error returned by `add_capture_destruct_impl` instead of silently discarding it. The result was previously bound to `_` and ignored; it is now mapped to `LoweringFlowError::Failed` and propagated with `?`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`add_capture_destruct_impl` can return an error, but the previous code discarded it with `let _ = ...`. This meant that failures during closure capture destructor registration were silently swallowed, potentially allowing lowering to continue in an invalid state.

---

## What was the behavior or documentation before?

Errors from `add_capture_destruct_impl` were ignored entirely, so any failure in that call had no effect on the lowering pipeline.

---

## What is the behavior or documentation after?

Errors from `add_capture_destruct_impl` are now mapped to `LoweringFlowError::Failed` and propagated via `?`, ensuring that failures are correctly surfaced during closure lowering.

---

## Related issue or discussion (if any)

---

## Additional context

This is a correctness fix in the closure lowering path. The change is minimal but important for ensuring error handling is not accidentally bypassed.