### PR TITLE
fix(semantic): correct NegativeImplLongId::is_fully_concrete

### DIFF
--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -428,7 +428,9 @@ impl<'db> NegativeImplLongId<'db> {
     }
     pub fn is_fully_concrete(&self, db: &dyn Database) -> bool {
         match self {
-            NegativeImplLongId::Solved(concrete_trait_id) => concrete_trait_id.is_var_free(db),
+            NegativeImplLongId::Solved(concrete_trait_id) => {
+                concrete_trait_id.is_fully_concrete(db)
+            }
             NegativeImplLongId::GenericParameter(_) | NegativeImplLongId::NegativeImplVar(_) => {
                 false
             }


### PR DESCRIPTION
## Summary

`NegativeImplLongId::is_fully_concrete` now calls `is_fully_concrete` instead of `is_var_free` on the inner `concrete_trait_id` when the variant is `Solved`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

`is_var_free` and `is_fully_concrete` are not equivalent checks. A type can be free of inference variables but still contain generic parameters, meaning it is not fully concrete. Using `is_var_free` in `NegativeImplLongId::is_fully_concrete` caused the method to return `true` in cases where the concrete trait still contained unresolved generic parameters, producing incorrect results.

---

## What was the behavior or documentation before?

`NegativeImplLongId::is_fully_concrete` returned `true` for `Solved` variants as long as the inner `concrete_trait_id` had no inference variables, even if it still contained generic parameters.

---

## What is the behavior or documentation after?

`NegativeImplLongId::is_fully_concrete` correctly returns `true` for `Solved` variants only when the inner `concrete_trait_id` is fully concrete (no inference variables and no generic parameters).

---

## Related issue or discussion (if any)

---

## Additional context