### PR TITLE
fix(starknet): respect #[cfg] when generating deploy_for_test

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
@@ -460,3 +460,194 @@ impl StorageStorageBaseMutDrop<> of core::traits::Drop::<StorageStorageBaseMut>;
 impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test that a constructor behind an inactive #[cfg] is not used for deploy_for_test.
+
+//! > test_runner_name
+ExpandContractTestRunner(expect_diagnostics: false)
+
+//! > cairo_code
+#[starknet::contract]
+mod test_contract {
+    #[storage]
+    struct Storage {}
+
+    #[cfg(feature: 'xyz')]
+    #[constructor]
+    fn constructor(ref self: ContractState, special_arg: u256) {}
+}
+
+//! > generated_cairo_code
+lib.cairo:
+
+#[starknet::contract]
+mod test_contract {
+    #[storage]
+    struct Storage {}
+
+    #[cfg(feature: 'xyz')]
+    #[constructor]
+    fn constructor(ref self: ContractState, special_arg: u256) {}
+}
+
+lib.cairo:1:1
+#[starknet::contract]
+^^^^^^^^^^^^^^^^^^^^^
+contract:
+
+#[event]
+#[derive(Drop, starknet::Event)]
+pub enum Event {}
+
+
+#[phantom]
+pub struct Storage {
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct StorageStorageBase {
+}
+#[doc(hidden)]
+impl StorageStorageImpl of starknet::storage::StorageTrait<Storage> {
+    type BaseType = StorageStorageBase;
+    fn storage(self: starknet::storage::FlattenedStorage<Storage>) -> StorageStorageBase {
+        StorageStorageBase {
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct StorageStorageBaseMut {
+}
+#[doc(hidden)]
+impl StorageStorageMutImpl of starknet::storage::StorageTraitMut<Storage> {
+    type BaseType = StorageStorageBaseMut;
+    fn storage_mut(self: starknet::storage::FlattenedStorage<starknet::storage::Mutable::<Storage>>) -> StorageStorageBaseMut {
+        StorageStorageBaseMut {
+        }
+    }
+}
+
+pub struct ContractState {
+}
+
+impl ContractStateDrop of Drop<ContractState> {}
+
+impl ContractStateDeref of core::ops::Deref<@ContractState> {
+    type Target = starknet::storage::FlattenedStorage<Storage>;
+    fn deref(self: @ContractState) -> starknet::storage::FlattenedStorage<Storage> {
+        starknet::storage::FlattenedStorage {}
+    }
+}
+impl ContractStateDerefMut of core::ops::DerefMut<ContractState> {
+    type Target = starknet::storage::FlattenedStorage<starknet::storage::Mutable<Storage>> ;
+    fn deref_mut(ref self: ContractState) -> starknet::storage::FlattenedStorage<starknet::storage::Mutable<Storage>> {
+        starknet::storage::FlattenedStorage {}
+    }
+}
+pub fn unsafe_new_contract_state() -> ContractState {
+    ContractState {
+    }
+}
+#[cfg(target: 'test')]
+#[inline(always)]
+pub fn contract_state_for_testing() -> ContractState {
+    unsafe_new_contract_state()
+}
+
+// TODO(Gil): This generates duplicate diagnostics because of the plugin system, squash the duplicates into one.
+#[deprecated(
+    feature: "deprecated_legacy_map",
+    note: "Use `starknet::storage::Map` instead."
+)]
+#[allow(unused_imports)]
+use starknet::storage::Map as LegacyMap;
+#[cfg(target: 'test')]
+pub const TEST_CLASS_HASH: starknet::ClassHash = 0x19e877991b74c1b921fadcea48b83b3d8a5a0e86737a0ad2db0c95d8768eaea.try_into().unwrap();
+
+
+#[doc(hidden)]
+pub mod __external {
+}
+#[doc(hidden)]
+pub mod __l1_handler {
+}
+#[doc(hidden)]
+pub mod __constructor {
+}
+    impl ContractStateEventEmitter of starknet::event::EventEmitter<
+        ContractState, Event
+    > {
+        fn emit<S, impl IntoImp: core::traits::Into<S, Event>>(
+            ref self: ContractState, event: S
+        ) {
+            let event: Event = core::traits::Into::into(event);
+            let mut keys = Default::<core::array::Array>::default();
+            let mut data = Default::<core::array::Array>::default();
+            starknet::Event::append_keys_and_data(@event, ref keys, ref data);
+            starknet::SyscallResultTrait::unwrap_syscall(
+                starknet::syscalls::emit_event_syscall(
+                    core::array::ArrayTrait::span(@keys),
+                    core::array::ArrayTrait::span(@data),
+                )
+            )
+        }
+    }
+
+
+
+lib.cairo:1:1
+#[starknet::contract]
+^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+impl EventDrop<> of core::traits::Drop::<Event>;
+
+
+lib.cairo:1:1
+#[starknet::contract]
+^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl EventIsEvent of starknet::Event<Event> {
+    fn append_keys_and_data(
+        self: @Event, ref keys: Array<felt252>, ref data: Array<felt252>
+    ) {
+        match self {
+        }
+    }
+    fn deserialize(
+        ref keys: Span<felt252>, ref data: Span<felt252>,
+    ) -> Option<Event> {
+        let __selector__ = *core::array::SpanTrait::pop_front(ref keys)?;
+        Option::None
+    }
+}
+
+
+
+lib.cairo:3:5
+    #[storage]
+    ^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl StorageStorageBaseDrop<> of core::traits::Drop::<StorageStorageBase>;
+#[doc(hidden)]
+impl StorageStorageBaseCopy<> of core::traits::Copy::<StorageStorageBase>;
+
+
+lib.cairo:3:5
+    #[storage]
+    ^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl StorageStorageBaseMutDrop<> of core::traits::Drop::<StorageStorageBaseMut>;
+#[doc(hidden)]
+impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
@@ -1,13 +1,14 @@
 use cairo_lang_defs::patcher::RewriteNode;
 use cairo_lang_defs::plugin::{MacroPluginMetadata, PluginDiagnostic, PluginResult};
 use cairo_lang_defs::plugin_utils::not_legacy_macro_diagnostic;
+use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_plugins::plugins::HasItemsInCfgEx;
 use cairo_lang_starknet_classes::keccak::starknet_keccak;
 use cairo_lang_syntax::node::ast::{Attribute, OptionTypeClause};
 use cairo_lang_syntax::node::helpers::{
-    BodyItems, GetIdentifier, PathSegmentEx, QueryAttrs, is_single_arg_attr,
+    GetIdentifier, PathSegmentEx, QueryAttrs, is_single_arg_attr,
 };
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
@@ -259,7 +260,7 @@ fn handle_contract_item<'db, 'a>(
                 db,
                 diagnostics,
                 item_impl,
-                metadata,
+                metadata.cfg_set,
                 &mut data.specific.entry_points_code,
             );
         }
@@ -332,7 +333,8 @@ pub(super) fn generate_contract_specific_code<'db, 'a>(
 
     let test_class_hash_node = generate_test_class_hash(db, module_ast);
 
-    let deploy_function_node = generate_constructor_deploy_function(db, diagnostics, body);
+    let deploy_function_node =
+        generate_constructor_deploy_function(db, diagnostics, body, metadata.cfg_set);
 
     generation_data.specific.test_config =
         RewriteNode::new_modified(vec![test_class_hash_node, deploy_function_node]);
@@ -364,10 +366,11 @@ fn generate_constructor_deploy_function<'db>(
     db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     body: &ast::ModuleBody<'db>,
+    cfg_set: &CfgSet,
 ) -> RewriteNode<'db> {
     let mut deploy_function_node = RewriteNode::empty();
 
-    for item in body.iter_items(db) {
+    for item in body.iter_items_in_cfg(db, cfg_set) {
         if let ast::ModuleItem::FreeFunction(func) = item
             && let Some((EntryPointKind::Constructor, _)) = func.entry_point_kind(db, diagnostics)
         {
@@ -464,11 +467,11 @@ fn handle_contract_free_function<'db>(
 }
 
 /// Handles an impl inside a contract module.
-fn handle_contract_impl<'db, 'a>(
+fn handle_contract_impl<'db>(
     db: &'db dyn Database,
     diagnostics: &mut Vec<PluginDiagnostic<'db>>,
     imp: &ast::ItemImpl<'db>,
-    metadata: &'a MacroPluginMetadata<'a>,
+    cfg_set: &CfgSet,
     data: &mut EntryPointsGenerationData<'db>,
 ) {
     let Some((abi_config, abi_attr)) = impl_abi_config(db, diagnostics, imp) else {
@@ -479,7 +482,7 @@ fn handle_contract_impl<'db, 'a>(
     };
     let impl_name = imp.name(db);
     let impl_name_node = RewriteNode::from_ast_trimmed(&impl_name);
-    for item in impl_body.iter_items_in_cfg(db, metadata.cfg_set) {
+    for item in impl_body.iter_items_in_cfg(db, cfg_set) {
         if abi_config == ImplAbiConfig::Embed {
             forbid_attributes_in_impl(db, diagnostics, &item, "#[abi(embed_v0)]");
         } else if abi_config == ImplAbiConfig::External {


### PR DESCRIPTION
## Summary

When a `#[constructor]` function is annotated with `#[cfg(feature: 'xyz')]` and that feature is inactive, the constructor was still being picked up by `generate_constructor_deploy_function` and used to generate the `deploy_for_test` function. This happened because the body was iterated with `iter_items` instead of `iter_items_in_cfg`, ignoring cfg conditions entirely.

The fix passes the active `CfgSet` down to `generate_constructor_deploy_function` and `handle_contract_impl`, replacing `iter_items` with `iter_items_in_cfg` so that constructors (and impl items) behind inactive `#[cfg]` attributes are correctly excluded.

A new test case is added to verify that a constructor behind an inactive `#[cfg(feature: 'xyz')]` does not appear in the generated `__constructor` module or influence `deploy_for_test`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

A constructor gated behind an inactive `#[cfg]` attribute was being included in the generated contract code because `iter_items` does not respect cfg conditions. This caused incorrect code generation — the inactive constructor's signature would influence the `deploy_for_test` helper, leading to a mismatch between what is actually compiled and what the test infrastructure expects.

---

## What was the behavior or documentation before?

`generate_constructor_deploy_function` iterated over all module body items unconditionally, so a `#[constructor]` behind an inactive `#[cfg]` would still be treated as the contract's constructor when generating test deployment code.

---

## What is the behavior or documentation after?

`generate_constructor_deploy_function` and `handle_contract_impl` now filter items through `iter_items_in_cfg`, so only constructors and impl items that are active under the current `CfgSet` are considered during code generation.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `MacroPluginMetadata` argument to `handle_contract_impl` was narrowed to just `&CfgSet` since that is the only field used, which also makes the dependency explicit.