### PR TITLE
fix(semantic): use exclusive upper bound in ExpansionOffset::mapped TextSpan.end is exclusive throughout the codebase, so an offset   exactly at a mapping's span.end lies outside that mapping. Replace the   inclusive `<= span.end` check with an exclusive 

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -126,7 +126,7 @@ impl ExpansionOffset {
     pub fn mapped(self, mappings: &[CodeMapping]) -> Option<Self> {
         let mapping = mappings
             .iter()
-            .find(|mapping| mapping.span.start <= self.0 && self.0 <= mapping.span.end)?;
+            .find(|mapping| (mapping.span.start..mapping.span.end).contains(&self.0))?;
         Some(Self::new(match mapping.origin {
             CodeOrigin::Start(offset) => offset.add_width(self.0 - mapping.span.start),
             CodeOrigin::Span(span) | CodeOrigin::CallSite(span) => span.start,


### PR DESCRIPTION
## Summary

Replaces the inclusive range check `mapping.span.start <= self.0 && self.0 <= mapping.span.end` with an exclusive range check using `(mapping.span.start..mapping.span.end).contains(&self.0)` in the `ExpansionOffset::mapped` method.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous span containment check used `<=` on both ends, making it an inclusive range on the end boundary. Using the standard `Range::contains` method with an exclusive upper bound is more idiomatic Rust and aligns with how span/offset ranges are typically handled (exclusive end).

---

## What was the behavior or documentation before?

The mapping lookup included `mapping.span.end` as a valid position, treating the range as fully inclusive (`start <= offset <= end`).

---

## What is the behavior or documentation after?

The mapping lookup uses an exclusive upper bound (`start <= offset < end`), expressed via `(mapping.span.start..mapping.span.end).contains(&self.0)`.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Care should be taken to verify that no existing behavior depended on the end offset being inclusive, as this is a subtle semantic change in the range boundary.