### PR TITLE
fix(formatter): sort `use self::...` items by their full path compare_names("self", "self") returned Greater, violating sort   reflexivity. Multiple `use self::x;` statements were therefore ordered   only on the leading `self` segment and never recursed t

### DIFF
--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -1343,6 +1343,7 @@ fn compare_use_paths<'a>(a: &UsePath<'a>, b: &UsePath<'a>, db: &dyn Database) ->
 fn compare_names(a: &str, b: &str) -> Ordering {
     match (a, b) {
         ("super" | "crate", "super" | "crate") => a.cmp(b),
+        ("self", "self") => Ordering::Equal,
         ("super" | "crate", _) | (_, "self") => Ordering::Greater,
         (_, "super" | "crate") | ("self", _) => Ordering::Less,
         _ => a.cmp(b),

--- a/crates/cairo-lang-formatter/src/test.rs
+++ b/crates/cairo-lang-formatter/src/test.rs
@@ -44,6 +44,15 @@ use crate::{FormatterConfig, get_formatted_file};
     false
 )]
 #[test_case(
+    "test_data/cairo_files/sort_self_use.cairo",
+    "test_data/expected_results/sort_self_use.cairo",
+    true,
+    false,
+    false,
+    false,
+    false
+)]
+#[test_case(
     "test_data/cairo_files/fmt_skip.cairo",
     "test_data/expected_results/fmt_skip.cairo",
     false,

--- a/crates/cairo-lang-formatter/test_data/cairo_files/sort_self_use.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/sort_self_use.cairo
@@ -1,0 +1,5 @@
+use self::e;
+use self::c;
+use self::a;
+use self::d;
+use self::b;

--- a/crates/cairo-lang-formatter/test_data/expected_results/sort_self_use.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/sort_self_use.cairo
@@ -1,0 +1,5 @@
+use self::a;
+use self::b;
+use self::c;
+use self::d;
+use self::e;


### PR DESCRIPTION
## Summary

Fixes a bug in `compare_names` where `"self"` compared against itself did not return `Ordering::Equal`, causing `use self::*` imports to not be sorted correctly among themselves.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `compare_names` function handled `"self"` in ordering rules relative to other keywords (`super`, `crate`) but was missing an explicit case for `("self", "self")`. Without it, the comparison fell through to the catch-all rules, which could produce an incorrect ordering (e.g., `Ordering::Greater` instead of `Ordering::Equal`), preventing `use self::*` imports from being sorted alphabetically.

---

## What was the behavior or documentation before?

Multiple `use self::*` imports were not sorted correctly by the formatter. For example:

```cairo
use self::e;
use self::c;
use self::a;
use self::d;
use self::b;
```

would not be reordered.

---

## What is the behavior or documentation after?

`use self::*` imports are now sorted alphabetically:

```cairo
use self::a;
use self::b;
use self::c;
use self::d;
use self::e;
```

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A new test case (`sort_self_use`) was added with input and expected output files to cover this scenario.