### PR TITLE
fix(sierra-gen): don't mark constant aliases as needing local storage

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/local_variables.rs
+++ b/crates/cairo-lang-sierra-generator/src/local_variables.rs
@@ -284,14 +284,17 @@ impl<'db, 'a> FindLocalsContext<'db, 'a> {
             return false;
         }
         let mut peeled = self.peel_aliases(var);
-        if self.non_ap_based.contains(peeled) {
+        if self.non_ap_based.contains(peeled) || self.constants.contains(peeled) {
             return false;
         }
         // In the case of partial params, we check if one of its ancestors is a local variable, or
         // will become a local variable. If that is the case, then 'var' doesn't need to be local.
         while let Some(parent) = self.partial_param_parents.get(peeled) {
             peeled = self.peel_aliases(parent);
-            if self.non_ap_based.contains(peeled) || peeled_local_candidates.contains(peeled) {
+            if self.non_ap_based.contains(peeled)
+                || peeled_local_candidates.contains(peeled)
+                || self.constants.contains(peeled)
+            {
                 return false;
             }
         }

--- a/crates/cairo-lang-sierra-generator/src/local_variables_test_data/snapshot
+++ b/crates/cairo-lang-sierra-generator/src/local_variables_test_data/snapshot
@@ -42,3 +42,95 @@ End:
 
 //! > local_variables
 v2
+
+//! > ==========================================================================
+
+//! > Test that an alias (snapshot) of a constant live across a revoke does not need local storage.
+
+//! > test_runner_name
+check_find_local_variables
+
+//! > function_name
+foo
+
+//! > function_code
+fn foo() -> @felt252 {
+    let c = 5;
+    let s = @c;
+    immovable(s);
+    revoke_ap();
+    s
+}
+
+//! > module_code
+#[inline(never)]
+fn immovable<T, +Drop<T>>(t: T) -> T {
+    t
+}
+
+// Revokes ap since this function is recursive.
+fn revoke_ap() -> felt252 {
+    revoke_ap()
+}
+
+//! > lowering_format
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 5
+  (v1: core::felt252, v2: @core::felt252) <- snapshot(v0)
+  (v3: @core::felt252) <- test::immovable::<@core::felt252, core::traits::SnapshotDrop::<core::felt252>>(v2)
+  (v4: core::felt252) <- test::revoke_ap()
+End:
+  Return(v2)
+
+//! > local_variables
+
+//! > ==========================================================================
+
+//! > Test that a field of a constant struct (partial param) live across a revoke needs no local.
+
+//! > test_runner_name
+check_find_local_variables
+
+//! > function_name
+foo
+
+//! > function_code
+fn foo() -> felt252 {
+    let S { a, b } = C;
+    immovable(b);
+    revoke_ap();
+    a
+}
+
+//! > module_code
+#[derive(Copy, Drop)]
+struct S {
+    a: felt252,
+    b: felt252,
+}
+const C: S = S { a: 1, b: 2 };
+
+#[inline(never)]
+fn immovable<T, +Drop<T>>(t: T) -> T {
+    t
+}
+
+// Revokes ap since this function is recursive.
+fn revoke_ap() -> felt252 {
+    revoke_ap()
+}
+
+//! > lowering_format
+Parameters:
+blk0 (root):
+Statements:
+  (v0: test::S) <- { 1: core::felt252, 2: core::felt252 }
+  (v1: core::felt252, v2: core::felt252) <- struct_destructure(v0)
+  (v3: core::felt252) <- test::immovable::<core::felt252, core::felt252Drop>(v2)
+  (v4: core::felt252) <- test::revoke_ap()
+End:
+  Return(v1)
+
+//! > local_variables


### PR DESCRIPTION
## Summary

Fixes a bug where an alias (snapshot) of a constant variable that is live across an AP-revoking call was incorrectly marked as requiring local storage. The fix adds a check in `needs_local_var` so that variables identified as constants are excluded from needing local variable allocation, in the same way `non_ap_based` variables are excluded.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a snapshot of a constant (e.g., `let s = @c` where `c = 5`) was used across a function call that revokes AP, the local variable analysis incorrectly determined that `s` needed local storage. Constants are not AP-based and do not require local variable allocation, but the `constants` set was not being consulted during this check.

---

## What was the behavior or documentation before?

A snapshot alias of a constant value live across an AP-revoking call was incorrectly flagged as needing a local variable, leading to unnecessary (and incorrect) local storage allocation.

---

## What is the behavior or documentation after?

Variables that are in the `constants` set are now treated the same as `non_ap_based` variables in the `needs_local_var` check — they are excluded from requiring local storage. The added test case confirms that `v2` (a snapshot of a constant) is no longer listed as a local variable when it lives across a `revoke_ap()` call.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A new test case was added to `local_variables_test_data/snapshot` to cover the scenario of a snapshot of a constant living across an AP-revoking call, verifying that no local variables are required in that case.