### PR TITLE
fix(syntax): include TokenMissing in generated is_missing() generate_kinds_code built the missing-kinds set only from enum   `missing_variant` nodes, so SyntaxKind::TokenMissing was excluded and   is_missing() returned false for it. The inline-macro expan

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/expansion_test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/expansion_test_data/inline_macros
@@ -271,3 +271,21 @@ error[E2158]: No matching rule found in inline macro `take_ident`.
 take_ident!($)
 ^^^^^^^^^^^^^^
 
+//! > ==========================================================================
+
+//! > Test that a macro call with a missing token is not expanded (the parse error is enough).
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: true)
+
+//! > expr_code
+array![1, 2
+
+//! > expanded_code
+array![1, 2
+
+//! > diagnostics
+error[E1001]: Missing token ']'.
+ --> lib.cairo:2:12
+array![1, 2
+           ^

--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -74,12 +74,10 @@ fn generate_kinds_code() -> rust::Tokens {
     let terminal_kinds = name_tokens(&spec, |k| matches!(k, NodeKind::Terminal { .. }));
     let keyword_terminal_kinds =
         name_tokens(&spec, |k| matches!(k, NodeKind::Terminal { is_keyword, .. } if *is_keyword));
-    let missing_kinds = spec.iter().filter_map(|n| {
-        if let NodeKind::Enum { missing_variant, .. } = &n.kind {
-            missing_variant.as_ref().map(|v| v.kind.as_str())
-        } else {
-            None
-        }
+    let missing_kinds = spec.iter().filter_map(|n| match &n.kind {
+        NodeKind::Enum { missing_variant, .. } => missing_variant.as_ref().map(|v| v.kind.as_str()),
+        NodeKind::Token { .. } if n.name == "TokenMissing" => Some(n.name.as_str()),
+        _ => None,
     });
 
     tokens.extend(quote! {

--- a/crates/cairo-lang-syntax/src/node/kind.rs
+++ b/crates/cairo-lang-syntax/src/node/kind.rs
@@ -632,6 +632,7 @@ impl SyntaxKind {
                 | SyntaxKind::WrappedTokenTreeMissing
                 | SyntaxKind::MacroRepetitionOperatorMissing
                 | SyntaxKind::MacroParamKindMissing
+                | SyntaxKind::TokenMissing
         )
     }
 }


### PR DESCRIPTION
## Summary

`TokenMissing` is now included in the `is_missing` classification for `SyntaxKind`, and macro calls that contain a missing token (i.e., a parse error) are no longer expanded — the parse error diagnostic is considered sufficient. A test case is added to confirm that an incomplete macro invocation like `array![1, 2` produces only the missing token parse error and is left unexpanded.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a macro call contained a missing token due to a parse error, the macro expander would still attempt to expand it, potentially producing confusing or redundant diagnostics. The root cause was that `TokenMissing` was not recognized as a "missing" kind in `SyntaxKind::is_missing`, so the expander had no way to detect this condition and bail out early.

---

## What was the behavior or documentation before?

`TokenMissing` was not included in `SyntaxKind::is_missing`, so macro calls with missing tokens (e.g., an unclosed bracket) could still be passed to the macro expander, leading to expansion attempts on malformed syntax.

---

## What is the behavior or documentation after?

`TokenMissing` is now recognized by `SyntaxKind::is_missing`. Macro calls that contain a missing token are skipped during expansion, and only the original parse error diagnostic (e.g., `Missing token ']'`) is reported.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The code generation for `missing_kinds` in `generator.rs` was also updated to include `TokenMissing` alongside enum missing variants, ensuring the generated kind classification stays consistent with the new behavior.