### PR TITLE
fix(corelib): Take::nth(usize::MAX) returns None instead of overflowing

### DIFF
--- a/corelib/src/iter/adapters/take.cairo
+++ b/corelib/src/iter/adapters/take.cairo
@@ -1,4 +1,4 @@
-use crate::num::traits::CheckedSub;
+use crate::num::traits::{CheckedAdd, CheckedSub};
 
 /// An iterator that only iterates over the first `n` iterations of `iter`.
 ///
@@ -29,7 +29,8 @@ impl TakeIterator<I, impl TIter: Iterator<I>, +Drop<I>> of Iterator<Take<I>> {
     fn nth<+Destruct<Take<I>>, +Destruct<Self::Item>>(
         ref self: Take<I>, n: usize,
     ) -> Option<Self::Item> {
-        if let Some(updated_n) = self.n.checked_sub(n + 1) {
+        if let Some(n_plus_1) = n.checked_add(1)
+            && let Some(updated_n) = self.n.checked_sub(n_plus_1) {
             self.n = updated_n;
             self.iter.nth(n)
         } else {

--- a/corelib/src/test/iter_test.cairo
+++ b/corelib/src/test/iter_test.cairo
@@ -135,6 +135,10 @@ fn test_iter_adapter_take_nth() {
     // Test when n = 0
     let mut iter = (1_u8..=3).into_iter().take(0);
     assert_eq!(iter.nth(0), None);
+
+    // `nth(usize::MAX)` must return `None`, not overflow on `n + 1`.
+    let mut iter = (1_u8..=10).into_iter().take(5);
+    assert_eq!(iter.nth(core::num::traits::Bounded::<usize>::MAX), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes an integer overflow in `Take::nth()` when called with `n = usize::MAX`. Previously, the implementation computed `n + 1` directly before calling `checked_sub`, which would overflow when `n` is `usize::MAX`. The fix splits the operation into two checked steps: first using `checked_add(1)` on `n`, then passing the result to `checked_sub`, so that overflow is handled safely and `None` is returned instead of panicking or producing incorrect results.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Calling `iter.take(n).nth(usize::MAX)` would overflow when computing `n + 1` before the checked subtraction, causing incorrect behavior instead of safely returning `None`.

---

## What was the behavior or documentation before?

`Take::nth(usize::MAX)` would overflow on the `n + 1` arithmetic, since the addition was performed before any overflow check.

---

## What is the behavior or documentation after?

`Take::nth(usize::MAX)` now correctly returns `None` without overflowing, because `n.checked_add(1)` is evaluated first and short-circuits the rest of the expression on overflow.

---

## Related issue or discussion (if any)

None.

---

## Additional context

A regression test was added to `iter_test.cairo` to assert that `nth(usize::MAX)` returns `None` on a `Take` iterator, preventing this overflow from being reintroduced.