### PR TITLE
docs(corelib): document inv_mod panic on a T::MIN modulus

### DIFF
--- a/corelib/src/math.cairo
+++ b/corelib/src/math.cairo
@@ -88,6 +88,11 @@ pub fn egcd<
 /// We consider the cases of negative `n` to be equivalent to the cases of positive `n`, as it
 /// defines the same equivalence classes.
 ///
+/// # Panics
+///
+/// Panics for a signed `T` when `n == T::MIN`, since the computation relies on `|n|`, and
+/// `|T::MIN|` is not representable in `T`.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
## Summary

Adds a `# Panics` documentation section to the `egcd` function in `corelib/src/math.cairo`, noting that it panics for signed `T` when `n == T::MIN` because `|T::MIN|` is not representable in `T`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The panic condition for signed integer types when `n == T::MIN` was previously undocumented. Users calling `egcd` with a signed type at its minimum value would encounter an unexpected panic with no prior warning in the API docs.

---

## What was the behavior or documentation before?

The `egcd` function had no `# Panics` section, leaving the edge case of `n == T::MIN` for signed types entirely undocumented.

---

## What is the behavior or documentation after?

The `egcd` function now explicitly documents that it panics when called with a signed `T` and `n == T::MIN`, with a clear explanation that the computation depends on `|n|`, which is not representable for `T::MIN`.

---

## Related issue or discussion (if any)

None.

---

## Additional context

This is a correctness-relevant documentation addition, as the panic is a real behavioral constraint that callers need to be aware of when working with signed integer types.