### PR TITLE
docs(corelib): fix sha384/sha512 "most" -> "least" significant bytes

### DIFF
--- a/corelib/src/sha384.cairo
+++ b/corelib/src/sha384.cairo
@@ -38,7 +38,7 @@ const SHA384_INITIAL_STATE: [u64; 8] = [
 ///
 /// # Returns
 ///
-/// * The SHA-384 hash of `input` followed by the `last_input_num_bytes` most significant bytes of
+/// * The SHA-384 hash of `input` followed by the `last_input_num_bytes` least significant bytes of
 /// `last_input_word`, interpreted in big-endian order.
 ///
 /// # Examples

--- a/corelib/src/sha512.cairo
+++ b/corelib/src/sha512.cairo
@@ -38,7 +38,7 @@ const SHA512_INITIAL_STATE: [u64; 8] = [
 ///
 /// # Returns
 ///
-/// * The SHA-512 hash of `input` followed by the `last_input_num_bytes` most significant bytes of
+/// * The SHA-512 hash of `input` followed by the `last_input_num_bytes` least significant bytes of
 /// `last_input_word`, interpreted in big-endian order.
 ///
 /// # Examples


### PR DESCRIPTION
## Summary

Corrects the documentation for `sha384::compute_sha384_byte_array` and `sha512::compute_sha512_byte_array` to state that `last_input_num_bytes` refers to the **least** significant bytes of `last_input_word`, not the most significant bytes.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The documentation incorrectly described `last_input_num_bytes` as selecting the **most** significant bytes of `last_input_word`. The actual behavior uses the **least** significant bytes. This mismatch could cause developers to pass incorrectly formatted input, resulting in wrong hash outputs.

---

## What was the behavior or documentation before?

Both `sha384.cairo` and `sha512.cairo` documented the return value as hashing `input` followed by the `last_input_num_bytes` **most significant** bytes of `last_input_word`.

---

## What is the behavior or documentation after?

Both files now correctly document the return value as hashing `input` followed by the `last_input_num_bytes` **least significant** bytes of `last_input_word`.

---

## Related issue or discussion (if any)

---

## Additional context

This correction applies symmetrically to both the SHA-384 and SHA-512 modules, as they share the same interface contract for handling the final partial word of input.