### PR TITLE
fix(corelib): add /= and %= for i32/i64/i128 via non-deprecated *Assign

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -2634,6 +2634,24 @@ mod op_eq_by_op {
     }
 }
 
+/// Non-deprecated `*Assign` analog of `op_eq_by_op`: derives an assignment operator from the
+/// corresponding binary operator.
+mod op_assign_by_op {
+    use crate::ops::{DivAssign, RemAssign};
+
+    pub impl DivAssignImpl<T, +Div<T>> of DivAssign<T, T> {
+        fn div_assign(ref self: T, rhs: T) {
+            self = Div::div(self, rhs);
+        }
+    }
+
+    pub impl RemAssignImpl<T, +Rem<T>> of RemAssign<T, T> {
+        fn rem_assign(ref self: T, rhs: T) {
+            self = Rem::rem(self, rhs);
+        }
+    }
+}
+
 impl I8AddEq = op_eq_by_op::AddEqImpl<i8>;
 impl I8SubEq = op_eq_by_op::SubEqImpl<i8>;
 impl I8MulEq = op_eq_by_op::MulEqImpl<i8>;
@@ -2647,12 +2665,18 @@ impl I16RemEq = op_eq_by_op::RemEqImpl<i16>;
 impl I32AddEq = op_eq_by_op::AddEqImpl<i32>;
 impl I32SubEq = op_eq_by_op::SubEqImpl<i32>;
 impl I32MulEq = op_eq_by_op::MulEqImpl<i32>;
+impl I32DivAssign = op_assign_by_op::DivAssignImpl<i32>;
+impl I32RemAssign = op_assign_by_op::RemAssignImpl<i32>;
 impl I64AddEq = op_eq_by_op::AddEqImpl<i64>;
 impl I64SubEq = op_eq_by_op::SubEqImpl<i64>;
 impl I64MulEq = op_eq_by_op::MulEqImpl<i64>;
+impl I64DivAssign = op_assign_by_op::DivAssignImpl<i64>;
+impl I64RemAssign = op_assign_by_op::RemAssignImpl<i64>;
 impl I128AddEq = op_eq_by_op::AddEqImpl<i128>;
 impl I128SubEq = op_eq_by_op::SubEqImpl<i128>;
 impl I128MulEq = op_eq_by_op::MulEqImpl<i128>;
+impl I128DivAssign = op_assign_by_op::DivAssignImpl<i128>;
+impl I128RemAssign = op_assign_by_op::RemAssignImpl<i128>;
 impl U8AddEq = op_eq_by_op::AddEqImpl<u8>;
 impl U8SubEq = op_eq_by_op::SubEqImpl<u8>;
 impl U8MulEq = op_eq_by_op::MulEqImpl<u8>;

--- a/corelib/src/test/integer_test.cairo
+++ b/corelib/src/test/integer_test.cairo
@@ -1853,6 +1853,29 @@ fn test_i128_divmod_overflow() {
 }
 
 #[test]
+fn test_signed_div_rem_assign() {
+    // `i32`/`i64`/`i128` previously lacked `/=` and `%=` (only `i8`/`i16` had them).
+    let mut a: i32 = 10;
+    a /= 3;
+    assert_eq!(a, 3);
+    let mut a: i32 = 10;
+    a %= 3;
+    assert_eq!(a, 1);
+    let mut a: i64 = -20;
+    a /= 4;
+    assert_eq!(a, -5);
+    let mut a: i64 = -20;
+    a %= 7;
+    assert_eq!(a, -6);
+    let mut a: i128 = 100;
+    a /= -9;
+    assert_eq!(a, -11);
+    let mut a: i128 = 17;
+    a %= 5;
+    assert_eq!(a, 2);
+}
+
+#[test]
 fn test_signed_int_diff() {
     assert_eq(@integer::i8_diff(3, 3).unwrap(), @0, 'i8: 3 - 3 == 0');
     assert_eq(@integer::i8_diff(4, 3).unwrap(), @1, 'i8: 4 - 3 == 1');


### PR DESCRIPTION
## Summary

Adds `DivAssign` (`/=`) and `RemAssign` (`%=`) implementations for `i32`, `i64`, and `i128` signed integer types, which were previously missing. A new `op_assign_by_op` module is introduced to derive these assignment operators from their corresponding binary operators (`Div` and `Rem`), mirroring the existing `op_eq_by_op` pattern.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`i8` and `i16` had `/=` and `%=` operators, but `i32`, `i64`, and `i128` did not, creating an inconsistency across signed integer types.

---

## What was the behavior or documentation before?

Using `/=` or `%=` on `i32`, `i64`, or `i128` values was not supported, while the same operators worked on `i8` and `i16`.

---

## What is the behavior or documentation after?

`/=` and `%=` are now supported uniformly across all signed integer types (`i8`, `i16`, `i32`, `i64`, `i128`). Tests cover division and remainder assignment for positive and negative values across all three newly supported types.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The new `op_assign_by_op` module is intentionally kept separate from the existing `op_eq_by_op` module to avoid using deprecated traits.