### PR TITLE
feat: dev and rc tags are not marked as latest release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,3 +50,5 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           body: "Cairo compiler."
+          prerelease: ${{ contains(github.ref, 'rc') }}
+          make_latest: ${{ !contains(github.ref, 'dev') && !contains(github.ref, 'rc') }}


### PR DESCRIPTION
## Summary

Adds `prerelease` and `make_latest` flags to the GitHub release workflow. Releases with `rc` in the tag are marked as pre-releases, and only releases that do not contain `dev` or `rc` in the tag are marked as the latest release.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Release candidates (`rc`) were being published as full stable releases and marked as the latest release, which could mislead users into treating pre-release versions as stable.

---

## What was the behavior or documentation before?

All releases, including release candidates and dev builds, were published without any pre-release designation and were all eligible to be marked as the latest release.

---

## What is the behavior or documentation after?

- Tags containing `rc` are published as pre-releases.
- Only tags that contain neither `dev` nor `rc` are marked as the latest release.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A