### PR TITLE
fix(lowering): early_unsafe_panic must keep side-effecting statements

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic.rs
@@ -106,14 +106,14 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for UnsafePanicContext<'db> {
         {
             self.fixes.push(((block_id, block.statements.len()), *match_info.location()));
         }
-        if ReachableSideEffects::Reachable == *info {
+        let ReachableSideEffects::Unreachable(location) = *info else {
             return;
-        }
-        for (i, stmt) in block.statements.iter().enumerate() {
-            if self.has_side_effects(stmt)
-                && let ReachableSideEffects::Unreachable(locations) = *info
-            {
-                self.fixes.push(((block_id, i), locations));
+        };
+        // Everything past the last side-effecting statement is dead (no `return` is reachable
+        // from here), so replace it with an early panic — but keep the side effects themselves.
+        for (i, stmt) in block.statements.iter().enumerate().rev() {
+            if self.has_side_effects(stmt) {
+                self.fixes.push(((block_id, i + 1), location));
                 *info = ReachableSideEffects::Reachable;
                 break;
             }

--- a/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic_test.rs
@@ -33,7 +33,9 @@ fn test_early_unsafe_panic(
     let function_id =
         ConcreteFunctionWithBodyId::from_semantic(db, test_function.concrete_function_id);
 
-    let before = db.lowered_body(function_id, LoweringStage::PreOptimizations).unwrap().clone();
+    // `EarlyUnsafePanic` runs in the final optimization strategy, i.e. on `PostBaseline` lowering
+    // (after inlining). Use that stage so side-effecting externs like `debug::print` are visible.
+    let before = db.lowered_body(function_id, LoweringStage::PostBaseline).unwrap().clone();
 
     let lowering_diagnostics = db.module_lowering_diagnostics(test_function.module_id).unwrap();
     let mut after = before.clone();

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/early_unsafe_panic
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/early_unsafe_panic
@@ -31,20 +31,14 @@ End:
 blk1:
 Statements:
 End:
-  Goto(blk3, {v1 -> v5})
+  Return(v1)
 
 blk2:
 Statements:
-  (v3: core::felt252) <- 435711799154
-  (v4: core::never) <- core::panic_with_felt252(v3)
+  (v3: core::never) <- core::panic_with_const_felt252::<435711799154>()
 End:
-  Match(match_enum(v4) {
+  Match(match_enum(v3) {
   })
-
-blk3:
-Statements:
-End:
-  Return(v5)
 
 //! > after
 Parameters: v0: core::option::Option::<core::integer::u32>
@@ -59,18 +53,13 @@ End:
 blk1:
 Statements:
 End:
-  Goto(blk3, {v1 -> v5})
+  Return(v1)
 
 blk2:
 Statements:
 End:
   Match(match core::panics::unsafe_panic() {
   })
-
-blk3:
-Statements:
-End:
-  Return(v5)
 
 //! > ==========================================================================
 
@@ -96,17 +85,91 @@ foo
 Parameters: v0: core::option::Option::<core::integer::u32>
 blk0 (root):
 Statements:
-  (v1: core::integer::u32) <- core::option::OptionTraitImpl::<core::integer::u32>::unwrap(v0)
-  (v2: core::felt252) <- 435711799154
-  (v3: core::never) <- core::panic_with_felt252(v2)
+End:
+  Match(match_enum(v0) {
+    Option::Some(v1) => blk1,
+    Option::None(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::never) <- core::panic_with_const_felt252::<435711799154>()
 End:
   Match(match_enum(v3) {
+  })
+
+blk2:
+Statements:
+  (v4: core::never) <- core::panic_with_const_felt252::<29721761890975875353235833581453094220424382983267374>()
+End:
+  Match(match_enum(v4) {
   })
 
 //! > after
 Parameters: v0: core::option::Option::<core::integer::u32>
 blk0 (root):
 Statements:
+End:
+  Match(match core::panics::unsafe_panic() {
+  })
+
+blk1:
+Statements:
+  (v3: core::never) <- core::panic_with_const_felt252::<435711799154>()
+End:
+  Match(match_enum(v3) {
+  })
+
+blk2:
+Statements:
+  (v4: core::never) <- core::panic_with_const_felt252::<29721761890975875353235833581453094220424382983267374>()
+End:
+  Match(match_enum(v4) {
+  })
+
+//! > ==========================================================================
+
+//! > Test that a side-effecting statement (debug::print) before the dead tail is preserved.
+
+//! > test_runner_name
+test_early_unsafe_panic
+
+//! > function_code
+use core::debug::PrintTrait;
+
+fn foo(a: Option<u32>) -> u32 {
+    'error'.print();
+    core::panic_with_felt252('error')
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > before
+Parameters: v0: core::option::Option::<core::integer::u32>
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 435711799154
+  (v2: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v3: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v2, v1)
+  () <- core::debug::print(v3)
+  (v4: core::never) <- core::panic_with_const_felt252::<435711799154>()
+End:
+  Match(match_enum(v4) {
+  })
+
+//! > after
+Parameters: v0: core::option::Option::<core::integer::u32>
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 435711799154
+  (v2: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v3: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v2, v1)
+  () <- core::debug::print(v3)
 End:
   Match(match core::panics::unsafe_panic() {
   })


### PR DESCRIPTION
## Summary

Fixes the `early_unsafe_panic` optimization so that the `unsafe_panic` insertion point is placed **after** the last side-effecting statement in a block, rather than at the statement itself. Previously, the loop iterated forward and pushed the fix at index `i` (overwriting the side-effecting statement), and the test harness ran against `PreOptimizations` lowering where inlined externs like `debug::print` were not yet visible. Now the loop iterates in reverse, finds the last side-effecting statement, and inserts the early panic at `i + 1` — preserving the side effect. The test stage is also updated to `PostBaseline` so that inlined side-effecting externs are present when the optimization runs.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous forward-iterating loop pushed a fix at index `i` for the first side-effecting statement it found, which would replace that statement with an `unsafe_panic` call instead of inserting the panic after it. This caused side-effecting statements (e.g., `debug::print`) to be dropped from the lowered output. Additionally, the test harness used `PreOptimizations` lowering, which does not include inlined externs, so the bug was not caught by the existing test for the side-effect-preservation case.

---

## What was the behavior or documentation before?

When a block contained a side-effecting statement followed by dead code (no reachable `return`), the optimization replaced the side-effecting statement itself with `unsafe_panic`, discarding the side effect.

---

## What is the behavior or documentation after?

The optimization now inserts `unsafe_panic` immediately after the last side-effecting statement, preserving all side effects. A new test case (`Test that a side-effecting statement (debug::print) before the dead tail is preserved`) verifies this behavior using `PostBaseline` lowering.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The fix also simplifies the conditional logic: instead of checking `ReachableSideEffects::Reachable` to early-return and then re-checking `Unreachable` inside the loop, the new code destructures `Unreachable` upfront and returns early if the state is `Reachable`.