### PR TITLE
fix(documentation): Fixed docs issues in te repo.

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -546,7 +546,7 @@ pub impl SpanImpl<T> of SpanTrait<T> {
     /// # Examples
     ///
     /// ```
-    /// let span = array![2, 3, 4];
+    /// let span = array![2, 3, 4].span();
     /// assert!(span.get(1).unwrap().unbox() == @3);
     /// ```
     #[inline]

--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -269,7 +269,7 @@ pub impl ByteArrayImpl of ByteArrayTrait {
     /// Appends the reverse of the given word to the end of `self`.
     ///
     /// This function assumes that:
-    /// 1. len < 31
+    /// 1. len <= 31
     /// 2. word is validly convertible to bytes31 of length `len`.
     ///
     /// # Examples

--- a/crates/cairo-lang-filesystem/src/span.rs
+++ b/crates/cairo-lang-filesystem/src/span.rs
@@ -270,7 +270,8 @@ impl TextPosition {
 pub struct FileSummary {
     /// Starting offsets of all lines in this file.
     pub line_offsets: Vec<TextOffset>,
-    /// Offset of the last character in the file.
+    /// Offset of the end of the file, i.e. one past the last character (equal to the file's byte
+    /// length).
     pub last_offset: TextOffset,
 }
 impl FileSummary {


### PR DESCRIPTION
## Summary

Fixes three documentation inaccuracies:

- In `array.cairo`, the `SpanTrait::get` example was missing `.span()` — the variable was assigned an `Array` rather than a `Span`.
- In `byte_array.cairo`, the precondition for `append_word_rev` incorrectly stated `len < 31` when the actual constraint is `len <= 31`.
- In `span.rs`, the `FileSummary::last_offset` field comment was misleading — it now clarifies that `last_offset` is one past the last character (i.e., equal to the file's byte length), not the offset of the last character itself.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous documentation contained factually incorrect statements:

- The `get` example would not compile as written because `array![2, 3, 4]` returns an `Array`, not a `Span`.
- The `len < 31` bound was wrong; the function accepts `len == 31` as valid input.
- The `last_offset` description implied it pointed to the last character, when it actually points one past it (exclusive end), which is a meaningful semantic distinction for offset arithmetic.

---

## What was the behavior or documentation before?

- `get` example used a bare array literal without calling `.span()`.
- `append_word_rev` documented a strict upper bound (`< 31`) on `len`.
- `last_offset` was described as "offset of the last character in the file."

---

## What is the behavior or documentation after?

- `get` example correctly calls `.span()` on the array literal.
- `append_word_rev` documents the correct inclusive upper bound (`<= 31`) on `len`.
- `last_offset` is described as the offset one past the last character, equal to the file's byte length.

---

## Related issue or discussion (if any)

None.

---

## Additional context

None.