### PR TITLE
fix(semantic): const_values_eq must canonicalize felt252 inside compounds

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -186,6 +186,20 @@ const VALID_MATCH_FELT_CROSS_FORM: () = assert(
         _ => false,
     },
 );
+const NZ_FELT_NEG_ONE: NonZero<felt252> = (-1_felt252).try_into().unwrap();
+const NZ_FELT_FIELD_NEG_ONE: NonZero<felt252> =
+    0x800000000000011000000000000000000000000000000000000000000000000
+    .try_into()
+    .unwrap();
+const VALID_EQ_NONZERO_FELT_CROSS_FORM: () = assert(NZ_FELT_NEG_ONE == NZ_FELT_FIELD_NEG_ONE);
+const VALID_EQ_TUPLE_FELT_CROSS_FORM: () = assert(
+    (-1_felt252, 5) == (0x800000000000011000000000000000000000000000000000000000000000000, 5),
+);
+const VALID_EQ_ENUM_FELT_CROSS_FORM: () = assert(
+    Option::<
+        felt252,
+    >::Some(-1) == Option::Some(0x800000000000011000000000000000000000000000000000000000000000000),
+);
 const VALID_LT: () = assert(1_usize < 2);
 const VALID_LE: () = assert(1_usize <= 1);
 const VALID_GT: () = assert(2_usize > 1);
@@ -281,21 +295,21 @@ note: In `test::assert`:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2129]: Constant calculation depth exceeded.
- --> lib.cairo:72:43
+ --> lib.cairo:86:43
 const FUNC_CALC_STACK_EXCEEDED: felt252 = call_myself();
                                           ^^^^^^^^^^^^^
 
 error[E2130]: Failed to calculate constant.
- --> lib.cairo:79:37
+ --> lib.cairo:93:37
 const NON_ZERO_ZERO: NonZero<u64> = my_unwrap(ZERO.try_into());
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: In `test::my_unwrap::<core::zeroable::NonZero::<core::integer::u64>>`:
-  --> lib.cairo:85:17
+  --> lib.cairo:99:17
         None => core::panic_with_felt252('bad value'),
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2128]: Failed to calculate constant.
- --> lib.cairo:91:9
+ --> lib.cairo:105:9
         core::panic_with_felt252('should fail')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -1226,21 +1226,31 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
         }
     }
 
-    /// Compares two const values for `felt252` field-element equality.
+    /// Compares two const values for value equality, treating `felt252` as a field.
     ///
     /// Direct `felt252` literals are stored in their original signed form (`-1` vs `PRIME - 1` are
     /// distinct `ConstValueId`s). The PartialEq operator must agree with the field, not with the
-    /// stored representation, so we canonicalize both sides before comparing for `felt252` ints.
-    /// Non-felt252 types keep id equality.
+    /// stored representation, so we canonicalize `felt252` ints before comparing, and recurse into
+    /// the structural variants - a `felt252` may be nested inside a struct, enum or `NonZero`.
     fn const_values_eq(&self, a: ConstValueId<'a>, b: ConstValueId<'a>) -> bool {
         if a == b {
             return true;
         }
-        let (ConstValue::Int(va, ty), ConstValue::Int(vb, _)) = (a.long(self.db), b.long(self.db))
-        else {
-            return false;
-        };
-        self.eq_in_type(va, vb, *ty)
+        match (a.long(self.db), b.long(self.db)) {
+            (ConstValue::Int(va, ty), ConstValue::Int(vb, _)) => self.eq_in_type(va, vb, *ty),
+            (ConstValue::Struct(a_members, a_ty), ConstValue::Struct(b_members, b_ty)) => {
+                a_ty == b_ty
+                    && a_members.len() == b_members.len()
+                    && zip(a_members, b_members).all(|(a, b)| self.const_values_eq(*a, *b))
+            }
+            (ConstValue::Enum(a_variant, a_value), ConstValue::Enum(b_variant, b_value)) => {
+                a_variant.id == b_variant.id && self.const_values_eq(*a_value, *b_value)
+            }
+            (ConstValue::NonZero(a_value), ConstValue::NonZero(b_value)) => {
+                self.const_values_eq(*a_value, *b_value)
+            }
+            _ => false,
+        }
     }
 
     /// Compares two `BigInt`s of type `ty` for value equality, treating `felt252` as a field.


### PR DESCRIPTION
## Summary

`const_values_eq` previously only handled the case where both sides were `ConstValue::Int`, returning `false` for any other variant pair. This meant that `felt252` values nested inside structs, enums, or `NonZero` wrappers were compared by identity rather than by field-element value, causing `-1` and `PRIME - 1` to be treated as unequal even though they represent the same field element.

The function now recurses into `ConstValue::Struct`, `ConstValue::Enum`, and `ConstValue::NonZero` variants, applying field-element canonicalization at every level where a `felt252` integer may appear.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `PartialEq` operator for `felt252` must agree with the field, meaning `-1` and `0x800000000000011000000000000000000000000000000000000000000000000` (i.e., `PRIME - 1`) are the same value. The previous implementation only canonicalized top-level `felt252` integers, so equality checks on `NonZero<felt252>`, tuples containing `felt252`, or enums wrapping `felt252` would incorrectly return `false` when comparing these two representations.

---

## What was the behavior or documentation before?

Constant expressions such as:

```cairo
const VALID_EQ_NONZERO_FELT_CROSS_FORM: () = assert(NZ_FELT_NEG_ONE == NZ_FELT_FIELD_NEG_ONE);
const VALID_EQ_TUPLE_FELT_CROSS_FORM: () = assert((-1_felt252, 5) == (0x800...000, 5));
const VALID_EQ_ENUM_FELT_CROSS_FORM: () = assert(Option::Some(-1) == Option::Some(0x800...000));
```

would fail constant evaluation because the structural wrappers were compared by identity rather than recursively by field value.

---

## What is the behavior or documentation after?

The above constant expressions now evaluate correctly. `const_values_eq` recurses into structs, enums, and `NonZero` wrappers, canonicalizing `felt252` integers at every nesting level before comparing.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Test cases for all three new cross-form equality scenarios (`NonZero<felt252>`, tuple, and enum) have been added to the constant expression test data.