### PR TITLE
fix(parser): accept resolver-modifier paths in pattern position

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -2554,7 +2554,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
             SyntaxKind::TerminalTrue => self.take::<TerminalTrue<'_>>().into(),
             SyntaxKind::TerminalFalse => self.take::<TerminalFalse<'_>>().into(),
             SyntaxKind::TerminalUnderscore => self.take::<TerminalUnderscore<'_>>().into(),
-            SyntaxKind::TerminalIdentifier => {
+            SyntaxKind::TerminalIdentifier | SyntaxKind::TerminalDollar => {
                 // TODO(ilya): Consider parsing a single identifier as PatternIdentifier rather
                 // then ExprPath.
                 let path = self.parse_path();

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -2924,6 +2924,20 @@ fn maybe_compute_pattern_semantic<'db>(
                 }
             }
 
+            // A resolver-modifier path (`$defsite`/`$callsite`) is never a plain variable binding.
+            // If it didn't resolve to a variant above, surface the real resolution error (e.g.
+            // `Expected path after modifier`) instead of silently treating its trailing segment as
+            // a new binding.
+            if let ast::OptionTerminalDollar::TerminalDollar(_) = path.dollar(db) {
+                ctx.resolver.resolve_generic_path_with_args(
+                    ctx.diagnostics,
+                    path,
+                    NotFoundItemType::Identifier,
+                    ResolutionContext::Statement(&mut ctx.environment),
+                )?;
+                return Err(ctx.diagnostics.report(path.stable_ptr(ctx.db), Unsupported));
+            }
+
             // Paths with a single element are treated as identifiers, which will result in a
             // variable pattern if no matching enum variant is found. If a matching enum
             // variant exists, it is resolved to the corresponding concrete variant.

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -1141,6 +1141,63 @@ macro add_one {
 
 //! > ==========================================================================
 
+//! > Test user defined macro matching a $defsite variant pattern.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() -> felt252 {
+    unwrap_or_zero!(Option::<felt252>::Some(7))
+}
+
+//! > function_name
+foo
+
+//! > module_code
+macro unwrap_or_zero {
+    ($opt: expr) => {
+        match $opt {
+            $defsite::Option::Some(x) => x,
+            $defsite::Option::None => 0,
+        }
+    };
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test a bare resolver-modifier in pattern position is rejected, not bound as a variable.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() -> felt252 {
+    bare_modifier_pattern!(7)
+}
+
+//! > function_name
+foo
+
+//! > module_code
+macro bare_modifier_pattern {
+    ($opt: expr) => {
+        match $opt {
+            $defsite => 0,
+        }
+    };
+}
+
+//! > expected_diagnostics
+error[E2179]: Expected path after modifier.
+ --> lib.cairo:9:5
+    bare_modifier_pattern!(7)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
 //! > Test user defined macro overwriting plugin macro.
 
 //! > test_runner_name


### PR DESCRIPTION
## Summary

Adds support for `$defsite` variant patterns in user-defined macros. The parser now recognizes `TerminalDollar` as a valid start token when parsing patterns, allowing `$defsite::...` paths to be used in match arms within macro bodies.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, using `$defsite::SomeType` as a pattern in a `match` expression inside a user-defined macro body would fail to parse, because `TerminalDollar` was not recognized as a valid pattern start token. This prevented macros from referencing definition-site paths in match arms.

---

## What was the behavior or documentation before?

A macro like:

```cairo
macro unwrap_or_zero {
    ($opt: expr) => {
        match $opt {
            $defsite::Option::Some(x) => x,
            $defsite::Option::None => 0,
        }
    };
}
```

would fail to parse because `$defsite::...` was not a valid pattern.

---

## What is the behavior or documentation after?

`$defsite::...` paths are now valid in pattern position within macro bodies, enabling macros to match against definition-site enum variants without diagnostics.

---

## Related issue or discussion (if any)

---

## Additional context

The fix is a one-line change in the pattern parser to also accept `TerminalDollar` as a valid start of a path pattern, alongside `TerminalIdentifier`. A semantic test covering the `$defsite` variant pattern case is included.