### PR TITLE
fix(semantic): validate inferred numeric literal values against their type

### DIFF
--- a/crates/cairo-lang-lowering/src/diagnostic.rs
+++ b/crates/cairo-lang-lowering/src/diagnostic.rs
@@ -4,7 +4,6 @@ use cairo_lang_diagnostics::{
 };
 use cairo_lang_filesystem::ids::SpanInFile;
 use cairo_lang_semantic as semantic;
-use cairo_lang_semantic::corelib::LiteralError;
 use cairo_lang_semantic::expr::inference::InferenceError;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use salsa::Database;
@@ -43,7 +42,7 @@ pub struct LoweringDiagnostic<'db> {
 }
 
 impl<'db> DiagnosticEntry<'db> for LoweringDiagnostic<'db> {
-    fn format(&self, db: &'db dyn Database) -> String {
+    fn format(&self, _db: &'db dyn Database) -> String {
         match &self.kind {
             LoweringDiagnosticKind::Unreachable { .. } => "Unreachable code".into(),
             LoweringDiagnosticKind::VariableMoved { .. } => "Variable was previously moved.".into(),
@@ -67,7 +66,6 @@ impl<'db> DiagnosticEntry<'db> for LoweringDiagnostic<'db> {
             LoweringDiagnosticKind::NoPanicFunctionCycle => {
                 "Call cycle of `nopanic` functions is not allowed.".into()
             }
-            LoweringDiagnosticKind::LiteralError(literal_error) => literal_error.format(db),
             LoweringDiagnosticKind::RefutablePattern => "Refutable pattern in irrefutable \
                                                           binding. Refutable patterns are only \
                                                           supported in `match`, `if let`, \
@@ -118,7 +116,6 @@ impl<'db> DiagnosticEntry<'db> for LoweringDiagnostic<'db> {
             LoweringDiagnosticKind::MemberPathLoop => error_code!(E3006),
             LoweringDiagnosticKind::UnexpectedError => error_code!(E3007),
             LoweringDiagnosticKind::NoPanicFunctionCycle => error_code!(E3008),
-            LoweringDiagnosticKind::LiteralError(_) => error_code!(E3009),
             LoweringDiagnosticKind::RefutablePattern => error_code!(E3010),
             LoweringDiagnosticKind::Unsupported => error_code!(E3011),
             LoweringDiagnosticKind::FixedSizeArrayNonCopyableType => error_code!(E3012),
@@ -217,7 +214,6 @@ pub enum LoweringDiagnosticKind<'db> {
     CannotInlineFunctionThatMightCallItself,
     MemberPathLoop,
     NoPanicFunctionCycle,
-    LiteralError(LiteralError<'db>),
     FixedSizeArrayNonCopyableType,
     EmptyRepeatedElementFixedSizeArray,
     RefutablePattern,

--- a/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
@@ -1,8 +1,8 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::NamedLanguageElementId;
-use cairo_lang_diagnostics::{DiagnosticNote, Maybe};
+use cairo_lang_diagnostics::DiagnosticNote;
 use cairo_lang_filesystem::flag::FlagsGroup;
-use cairo_lang_semantic::corelib::{CorelibSemantic, validate_literal};
+use cairo_lang_semantic::corelib::CorelibSemantic;
 use cairo_lang_semantic::expr::compute::unwrap_pattern_type;
 use cairo_lang_semantic::items::enm::SemanticEnumEx;
 use cairo_lang_semantic::items::structure::StructSemantic;
@@ -647,10 +647,10 @@ fn create_node_for_tuple_inner<'db>(
     let current_member = struct_members.map(|members| members[item_idx]);
 
     // Collect the patterns on the current item.
-    let mut patterns_on_current_item = Vec::<Option<semantic::Pattern<'db>>>::default();
-    let mut live_filter = FilteredPatterns::default();
-    for (idx, pattern) in patterns.iter().enumerate() {
-        let item_pattern = match pattern {
+    let mut patterns_on_current_item =
+        Vec::<Option<semantic::Pattern<'db>>>::with_capacity(patterns.len());
+    for pattern in patterns {
+        patterns_on_current_item.push(match pattern {
             Some(semantic::Pattern::Tuple(PatternTuple { field_patterns, .. }))
                 if current_member.is_none() =>
             {
@@ -671,11 +671,7 @@ fn create_node_for_tuple_inner<'db>(
             Some(semantic::Pattern::Literal(pattern_literal))
                 if pattern_literal.literal.ty == ctx.db.core_info().u256 =>
             {
-                match handle_u256_literal(ctx, graph, pattern_literal, item_idx) {
-                    Ok(inner_pattern) => Some(inner_pattern),
-                    // Out-of-range `u256` literal, drop the arm.
-                    Err(_) => continue,
-                }
+                Some(handle_u256_literal(ctx, pattern_literal, item_idx))
             }
             Some(semantic::Pattern::FixedSizeArray(semantic::PatternFixedSizeArray {
                 elements_patterns,
@@ -698,9 +694,7 @@ fn create_node_for_tuple_inner<'db>(
                     LoweringDiagnosticKind::UnexpectedError,
                 );
             }
-        };
-        live_filter.add(idx);
-        patterns_on_current_item.push(item_pattern);
+        });
     }
 
     // Create a node to handle the current item. The callback will handle the rest of the tuple.
@@ -711,9 +705,6 @@ fn create_node_for_tuple_inner<'db>(
             graph,
             patterns: &patterns_ref,
             build_node_callback: &mut |graph, pattern_indices, path_head| {
-                // Lift the survivors from the compacted (dropped-arm) indexing back to this level's
-                // arm indexing. When no arm was dropped this is the identity.
-                let pattern_indices = pattern_indices.lift(&live_filter);
                 // Call `create_node_for_tuple_inner` recursively to handle the rest of the tuple.
                 create_node_for_tuple_inner(
                     CreateNodeParams {
@@ -775,18 +766,13 @@ fn add_item_to_path<'db>(
 /// pattern.
 fn handle_u256_literal<'db>(
     ctx: &LoweringContext<'db, '_>,
-    graph: &mut FlowControlGraphBuilder<'db>,
     pattern_literal: &semantic::PatternLiteral<'db>,
     item_idx: usize,
-) -> Maybe<semantic::Pattern<'db>> {
+) -> semantic::Pattern<'db> {
     let PatternLiteral {
-        literal: ExprNumericLiteral { value, ty, stable_ptr: expr_stable_ptr },
+        literal: ExprNumericLiteral { value, ty: _, stable_ptr: expr_stable_ptr },
         stable_ptr,
     } = pattern_literal;
-    if let Err(err) = validate_literal(ctx.db, *ty, value) {
-        return Err(graph.report(*stable_ptr, LoweringDiagnosticKind::LiteralError(err)));
-    }
-
     let inner_value = if item_idx == 0 {
         value.clone() & ((BigInt::from(1) << 128) - 1)
     } else if item_idx == 1 {
@@ -795,14 +781,14 @@ fn handle_u256_literal<'db>(
         unreachable!("Unexpected number of members for u256.")
     };
 
-    Ok(semantic::Pattern::Literal(semantic::PatternLiteral {
+    semantic::Pattern::Literal(semantic::PatternLiteral {
         literal: semantic::ExprNumericLiteral {
             value: inner_value,
             ty: ctx.db.core_info().u128,
             stable_ptr: *expr_stable_ptr,
         },
         stable_ptr: *stable_ptr,
-    }))
+    })
 }
 
 /// Creates a node for matching over numeric values, using a combination of [EnumMatch] and
@@ -825,10 +811,6 @@ fn create_node_for_value<'db>(
     for (pattern_index, pattern) in patterns.iter().enumerate() {
         match pattern {
             Some(semantic::Pattern::Literal(semantic::PatternLiteral { literal, .. })) => {
-                if let Err(err) = validate_literal(ctx.db, var_ty, &literal.value) {
-                    graph.report(literal.stable_ptr, LoweringDiagnosticKind::LiteralError(err));
-                    continue;
-                }
                 literals_map
                     .entry(literal.value.clone())
                     .or_insert((otherwise_filter.clone(), literal.stable_ptr))

--- a/crates/cairo-lang-lowering/src/lower/flow_control/graph.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/graph.rs
@@ -479,15 +479,6 @@ impl<'db> FlowControlGraphBuilder<'db> {
         self.graph.var_locations[input_var.0]
     }
 
-    /// Reports a diagnostic.
-    pub fn report(
-        &mut self,
-        stable_ptr: impl Into<SyntaxStablePtrId<'db>>,
-        kind: LoweringDiagnosticKind<'db>,
-    ) -> DiagnosticAdded {
-        self.diagnostics.report(stable_ptr, kind)
-    }
-
     /// Reports a diagnostic, and returns a new [FlowControlNode::Missing] node.
     pub fn report_with_missing_node(
         &mut self,

--- a/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
@@ -1498,25 +1498,27 @@ fn foo(a: u8) -> bool {
 }
 
 //! > graph
-Root: 4
-4 EvaluateExpr { expr: ExprId(0), var_id: v0, next: NodeId(3) }
-3 Upcast { input: v0, output: v1, next: NodeId(2) }
-2 EqualsLiteral { input: v1, literal: 255, true_branch: NodeId(0), false_branch: NodeId(1) }
+Root: 6
+6 EvaluateExpr { expr: ExprId(0), var_id: v0, next: NodeId(5) }
+5 Upcast { input: v0, output: v1, next: NodeId(4) }
+4 EqualsLiteral { input: v1, literal: 255, true_branch: NodeId(0), false_branch: NodeId(3) }
+3 EqualsLiteral { input: v1, literal: 256, true_branch: NodeId(0), false_branch: NodeId(2) }
+2 EqualsLiteral { input: v1, literal: 257, true_branch: NodeId(0), false_branch: NodeId(1) }
 1 ArmExpr { expr: ExprId(4) }
 0 ArmExpr { expr: ExprId(2) }
 
 //! > semantic_diagnostics
-
-//! > lowering_diagnostics
-error[E3009]: The value does not fit within the range of type core::integer::u8.
+error[E2008]: The value does not fit within the range of type core::integer::u8.
  --> lib.cairo:3:15
         255 | 256 | 257 => false,
               ^^^
 
-error[E3009]: The value does not fit within the range of type core::integer::u8.
+error[E2008]: The value does not fit within the range of type core::integer::u8.
  --> lib.cairo:3:21
         255 | 256 | 257 => false,
                     ^^^
+
+//! > lowering_diagnostics
 
 //! > lowered
 
@@ -2032,12 +2034,12 @@ Root: 19
 0 ArmExpr { expr: ExprId(1) }
 
 //! > semantic_diagnostics
-
-//! > lowering_diagnostics
-error[E3009]: The value does not fit within the range of type core::integer::u256.
+error[E2008]: The value does not fit within the range of type core::integer::u256.
  --> lib.cairo:10:9
         0x10000000000000000000000000000000000000000000000000000000000000000 => 7,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+//! > lowering_diagnostics
 
 //! > lowered
 
@@ -2058,19 +2060,23 @@ fn foo(x: u256) -> felt252 {
 }
 
 //! > graph
-Root: 3
-3 EvaluateExpr { expr: ExprId(0), var_id: v0, next: NodeId(2) }
-2 Deconstruct { input: v0, outputs: [v1, v2], next: NodeId(1) }
+Root: 7
+7 EvaluateExpr { expr: ExprId(0), var_id: v0, next: NodeId(6) }
+6 Deconstruct { input: v0, outputs: [v1, v2], next: NodeId(5) }
+5 Upcast { input: v1, output: v3, next: NodeId(4) }
+4 EqualsLiteral { input: v3, literal: 0, true_branch: NodeId(3), false_branch: NodeId(1) }
+3 Upcast { input: v2, output: v4, next: NodeId(2) }
+2 EqualsLiteral { input: v4, literal: 340282366920938463463374607431768211456, true_branch: NodeId(0), false_branch: NodeId(1) }
 1 ArmExpr { expr: ExprId(2) }
 0 ArmExpr { expr: ExprId(1) }
 
 //! > semantic_diagnostics
-
-//! > lowering_diagnostics
-error[E3009]: The value does not fit within the range of type core::integer::u256.
+error[E2008]: The value does not fit within the range of type core::integer::u256.
  --> lib.cairo:4:9
         0x10000000000000000000000000000000000000000000000000000000000000000 => 1,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+//! > lowering_diagnostics
 
 //! > lowered
 
@@ -2090,20 +2096,23 @@ fn foo(x: u256) -> felt252 {
 }
 
 //! > graph
-Root: 3
-3 EvaluateExpr { expr: ExprId(0), var_id: v0, next: NodeId(2) }
-2 Deconstruct { input: v0, outputs: [v1, v2], next: NodeId(1) }
+Root: 7
+7 EvaluateExpr { expr: ExprId(0), var_id: v0, next: NodeId(6) }
+6 Deconstruct { input: v0, outputs: [v1, v2], next: NodeId(5) }
+5 Upcast { input: v1, output: v3, next: NodeId(4) }
+4 EqualsLiteral { input: v3, literal: 0, true_branch: NodeId(3), false_branch: NodeId(1) }
+3 Upcast { input: v2, output: v4, next: NodeId(2) }
+2 EqualsLiteral { input: v4, literal: 340282366920938463463374607431768211456, true_branch: NodeId(0), false_branch: NodeId(1) }
 1 Missing
 0 ArmExpr { expr: ExprId(1) }
 
 //! > semantic_diagnostics
-
-//! > lowering_diagnostics
-error[E3009]: The value does not fit within the range of type core::integer::u256.
+error[E2008]: The value does not fit within the range of type core::integer::u256.
  --> lib.cairo:4:9
         0x10000000000000000000000000000000000000000000000000000000000000000 => 1,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+//! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `u256{low: _, high: _}` not covered.
  --> lib.cairo:2:5-5:5
       match x {

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -6,7 +6,7 @@ use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::corelib::{
     CorelibSemantic, ErrorPropagationType, bounded_int_ty, get_enum_concrete_variant,
-    try_get_ty_by_name, unwrap_error_propagation_type, validate_literal,
+    try_get_ty_by_name, unwrap_error_propagation_type,
 };
 use cairo_lang_semantic::expr::compute::unwrap_pattern_type;
 use cairo_lang_semantic::items::constant::ConstValueId;
@@ -55,7 +55,7 @@ use self::context::{
 use self::external::{extern_facade_expr, extern_facade_return_tys};
 use self::logical_op::lower_logical_op;
 use crate::blocks::Blocks;
-use crate::diagnostic::LoweringDiagnosticKind::{self, *};
+use crate::diagnostic::LoweringDiagnosticKind::*;
 use crate::diagnostic::LoweringDiagnosticsBuilder;
 use crate::ids::{
     EnrichedSemanticSignature, FunctionLongId, FunctionWithBodyId, FunctionWithBodyLongId,
@@ -960,14 +960,7 @@ fn lower_expr_literal_to_var_usage<'db>(
     value: &BigInt,
     builder: &mut BlockBuilder<'db>,
 ) -> VarUsage<'db> {
-    let value = if let Err(err) = validate_literal(ctx.db, ty, value) {
-        ConstValue::Missing(
-            ctx.diagnostics.report(stable_ptr, LoweringDiagnosticKind::LiteralError(err)),
-        )
-        .intern(ctx.db)
-    } else {
-        ConstValueId::from_int(ctx.db, ty, value)
-    };
+    let value = ConstValueId::from_int(ctx.db, ty, value);
     let location = ctx.get_location(stable_ptr);
     generators::Const { value, ty, location }.add(ctx, &mut builder.statements)
 }

--- a/crates/cairo-lang-lowering/src/test_data/literal
+++ b/crates/cairo-lang-lowering/src/test_data/literal
@@ -20,50 +20,50 @@ fn foo() {
 foo
 
 //! > lowering_diagnostics
-error[E3009]: The value does not fit within the range of type core::integer::u8.
- --> lib.cairo:3:18
-    let _a: u8 = 0x100;
-                 ^^^^^
-
-error[E3009]: The value does not fit within the range of type core::integer::u16.
- --> lib.cairo:4:19
-    let _a: u16 = 0x10000;
-                  ^^^^^^^
-
-error[E3009]: The value does not fit within the range of type core::integer::u32.
- --> lib.cairo:5:19
-    let _a: u32 = 0x100000000;
-                  ^^^^^^^^^^^
-
-error[E3009]: The value does not fit within the range of type core::integer::u64.
- --> lib.cairo:6:19
-    let _b: u64 = 0x10000000000000000;
-                  ^^^^^^^^^^^^^^^^^^^
-
-error[E3009]: The value does not fit within the range of type core::integer::u128.
- --> lib.cairo:7:20
-    let _c: u128 = 0x100000000000000000000000000000000;
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E3009]: The value does not fit within the range of type core::felt252.
- --> lib.cairo:8:23
-    let _d: felt252 = 0x800000000000011000000000000000000000000000000000000000000000001;
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E3009]: The value does not fit within the range of type core::zeroable::NonZero::<core::felt252>.
- --> lib.cairo:9:32
-    let _e: NonZero<felt252> = 0;
-                               ^
-
-error[E3009]: The value does not fit within the range of type core::internal::bounded_int::BoundedInt::<3, 15>.
- --> lib.cairo:10:62
-    let _f: core::internal::bounded_int::BoundedInt<3, 15> = 2;
-                                                             ^
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
 
 //! > semantic_diagnostics
+error[E2008]: The value does not fit within the range of type core::integer::u8.
+ --> lib.cairo:3:18
+    let _a: u8 = 0x100;
+                 ^^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u16.
+ --> lib.cairo:4:19
+    let _a: u16 = 0x10000;
+                  ^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u32.
+ --> lib.cairo:5:19
+    let _a: u32 = 0x100000000;
+                  ^^^^^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u64.
+ --> lib.cairo:6:19
+    let _b: u64 = 0x10000000000000000;
+                  ^^^^^^^^^^^^^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u128.
+ --> lib.cairo:7:20
+    let _c: u128 = 0x100000000000000000000000000000000;
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::felt252.
+ --> lib.cairo:8:23
+    let _d: felt252 = 0x800000000000011000000000000000000000000000000000000000000000001;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::zeroable::NonZero::<core::felt252>.
+ --> lib.cairo:9:32
+    let _e: NonZero<felt252> = 0;
+                               ^
+
+error[E2008]: The value does not fit within the range of type core::internal::bounded_int::BoundedInt::<3, 15>.
+ --> lib.cairo:10:62
+    let _f: core::internal::bounded_int::BoundedInt<3, 15> = 2;
+                                                             ^
 
 //! > ==========================================================================
 
@@ -86,40 +86,40 @@ fn foo() {
 foo
 
 //! > lowering_diagnostics
-error[E3009]: The value does not fit within the range of type core::integer::u8.
- --> lib.cairo:2:18
-    let _a: u8 = 'aa';
-                 ^^^^
-
-error[E3009]: The value does not fit within the range of type core::integer::u16.
- --> lib.cairo:3:19
-    let _a: u16 = 'aba';
-                  ^^^^^
-
-error[E3009]: The value does not fit within the range of type core::integer::u32.
- --> lib.cairo:4:19
-    let _b: u32 = 'abcda';
-                  ^^^^^^^
-
-error[E3009]: The value does not fit within the range of type core::integer::u64.
- --> lib.cairo:5:19
-    let _b: u64 = 'abcdabcda';
-                  ^^^^^^^^^^^
-
-error[E3009]: The value does not fit within the range of type core::integer::u128.
- --> lib.cairo:6:20
-    let _c: u128 = 'abcdabcdabcdabcda';
-                   ^^^^^^^^^^^^^^^^^^^
-
-error[E3009]: The value does not fit within the range of type core::felt252.
- --> lib.cairo:7:23
-    let _d: felt252 = 'abcdabcdabcdabcdabcdabcdabcdabcd';
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
 
 //! > semantic_diagnostics
+error[E2008]: The value does not fit within the range of type core::integer::u8.
+ --> lib.cairo:2:18
+    let _a: u8 = 'aa';
+                 ^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u16.
+ --> lib.cairo:3:19
+    let _a: u16 = 'aba';
+                  ^^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u32.
+ --> lib.cairo:4:19
+    let _b: u32 = 'abcda';
+                  ^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u64.
+ --> lib.cairo:5:19
+    let _b: u64 = 'abcdabcda';
+                  ^^^^^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u128.
+ --> lib.cairo:6:20
+    let _c: u128 = 'abcdabcdabcdabcda';
+                   ^^^^^^^^^^^^^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::felt252.
+ --> lib.cairo:7:23
+    let _d: felt252 = 'abcdabcdabcdabcdabcdabcdabcdabcd';
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -91,7 +91,7 @@ use crate::resolve::{
     ResolvedGenericItem, Resolver, ResolverMacroData,
 };
 use crate::semantic::{self, Binding, FunctionId, LocalVariable, TypeId, TypeLongId};
-use crate::substitution::SemanticRewriter;
+use crate::substitution::{HasDb, SemanticRewriter};
 use crate::types::{
     ClosureTypeLongId, ConcreteTypeId, add_type_based_diagnostics, are_coupons_enabled,
     extract_fixed_size_array_size, peel_snapshots, peel_snapshots_ex, resolve_type_ex,
@@ -441,29 +441,54 @@ impl<'ctx, 'mt> ComputationContext<'ctx, 'mt> {
         self.resolver.inference().rewrite(ty).no_err()
     }
 
-    /// Applies inference rewriter to all the expressions in the computation context, and adds
-    /// errors on types from the final expressions.
-    pub fn apply_inference_rewriter_to_exprs(&mut self) {
+    /// Applies inference rewriter to all the rewritable things in the computation context.
+    pub fn apply_inference_rewriter(&mut self) {
         let mut analyzed_types = UnorderedHashSet::<_>::default();
+        let inference = &mut self.resolver.inference();
         for (_id, expr) in &mut self.arenas.exprs {
-            self.resolver.inference().internal_rewrite(expr).no_err();
+            if let Expr::Literal(literal) = expr {
+                handle_literal_rewrite(inference, self.diagnostics, literal);
+            } else {
+                inference.internal_rewrite(expr).no_err();
+            }
             // Adding an error only once per type.
             if analyzed_types.insert(expr.ty()) {
                 add_type_based_diagnostics(self.db, self.diagnostics, expr.ty(), &*expr);
             }
         }
-    }
-
-    /// Applies inference rewriter to all the rewritable things in the computation context.
-    fn apply_inference_rewriter(&mut self) {
-        self.apply_inference_rewriter_to_exprs();
         for (_id, pattern) in &mut self.arenas.patterns {
-            self.resolver.inference().internal_rewrite(pattern).no_err();
+            if let Pattern::Literal(literal) = pattern {
+                handle_literal_rewrite(inference, self.diagnostics, &mut literal.literal);
+            } else {
+                inference.internal_rewrite(pattern).no_err();
+            }
         }
         for (_id, stmt) in &mut self.arenas.statements {
-            self.resolver.inference().internal_rewrite(stmt).no_err();
+            inference.internal_rewrite(stmt).no_err();
+        }
+
+        /// Rewrites a numeric `literal`'s type with the inference results, and - if its type was a
+        /// still-unresolved `NumericLiteral` var (a suffix-less literal, whose value was never
+        /// checked against a concrete type) - validates the value is in range, reporting
+        /// `OutOfRange`. An invalid literal type is not reported here; it is already reported at
+        /// conform time.
+        fn handle_literal_rewrite<'db>(
+            inference: &mut Inference<'db, '_>,
+            diagnostics: &mut SemanticDiagnostics<'db>,
+            literal: &mut ExprNumericLiteral<'db>,
+        ) {
+            let db = inference.get_db();
+            let was_unresolved = matches!(literal.ty.long(db), TypeLongId::NumericLiteral(_));
+            inference.internal_rewrite(literal).no_err();
+            if was_unresolved
+                && let Err(err @ LiteralError::OutOfRange(_)) =
+                    validate_literal(db, literal.ty, &literal.value)
+            {
+                diagnostics.report(literal.stable_ptr, SemanticDiagnosticKind::LiteralError(err));
+            }
         }
     }
+
     /// Returns whether the current context is inside a loop.
     fn is_inside_loop(&self) -> bool {
         let Some(inner_ctx) = &self.inner_ctx else {

--- a/crates/cairo-lang-semantic/src/expr/test_data/literal
+++ b/crates/cairo-lang-semantic/src/expr/test_data/literal
@@ -19,6 +19,27 @@ error[E2008]: A numeric literal of type core::pedersen::Pedersen cannot be creat
 
 //! > ==========================================================================
 
+//! > Inferred-type numeric literal whose value is out of range.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let _x: u8 = 256;
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2008]: The value does not fit within the range of type core::integer::u8.
+ --> lib.cairo:2:18
+    let _x: u8 = 256;
+                 ^^^
+
+//! > ==========================================================================
+
 //! > Numeric literal with a non-type suffix.
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -478,10 +478,7 @@ pub fn resolve_const_expr_and_evaluate<'db, 'mt>(
     } else if let Err(err_set) = inference.solve() {
         inference.report_on_pending_error(err_set, ctx.diagnostics, const_stable_ptr);
     }
-
-    // TODO(orizi): Consider moving this to be called only upon creating const values, other callees
-    // don't necessarily need it.
-    ctx.apply_inference_rewriter_to_exprs();
+    ctx.apply_inference_rewriter();
 
     match &value.expr {
         Expr::Constant(ExprConstant { const_value_id, .. }) => *const_value_id,
@@ -572,14 +569,8 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                     );
                 }
             }
-            Expr::Literal(expr) => {
-                if let Err(err) = validate_literal(self.db, expr.ty, &expr.value) {
-                    self.diagnostics.report(
-                        expr.stable_ptr.untyped(),
-                        SemanticDiagnosticKind::LiteralError(err),
-                    );
-                }
-            }
+            // Already validated by `apply_inference_rewriter`.
+            Expr::Literal(_) => {}
             Expr::Tuple(expr) => {
                 for item in &expr.items {
                     self.validate(*item);


### PR DESCRIPTION
## Summary

Moves out-of-range literal validation from the lowering phase (`E3009`) to the semantic phase (`E2008`). This is done by performing literal range checks inside `apply_inference_rewriter` after inference has resolved the literal's type, and removing the redundant validation that was previously done in `ConstantEvaluateContext`. The lowering test data is updated to reflect that these errors now appear as semantic diagnostics, and a new semantic test case is added for an inferred-type numeric literal whose value is out of range.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Out-of-range literal errors were being reported during lowering (`E3009`) rather than during semantic analysis (`E2008`). Since the type of a numeric literal is resolved during inference (which happens in the semantic phase), the range check should also occur there. Reporting it at the wrong phase meant the error code was incorrect and the diagnostic was emitted later than necessary.

---

## What was the behavior or documentation before?

Out-of-range numeric literal errors were reported as `E3009` (a lowering-phase error) after inference had already resolved the literal type. The `LiteralError` variant existed in `LoweringDiagnosticKind` and validation was scattered across `lower_expr_literal_to_var_usage`, `create_node_for_value`, and `handle_u256_literal`.

---

## What is the behavior or documentation after?

Out-of-range numeric literal errors are reported as `E2008` (a semantic-phase error) during `apply_inference_rewriter`, immediately after inference resolves the literal's type. For suffix-less literals whose type was still an unresolved `NumericLiteral` var, only `OutOfRange` errors are reported to avoid cascading from already-reported type errors. The `LiteralError` variant is removed from `LoweringDiagnosticKind` entirely, along with the `report` helper on `FlowControlGraphBuilder` that was only used for that purpose.

---

## Related issue or discussion (if any)

---

## Additional context

The `ConstantEvaluateContext::validate` method previously had a dedicated `Expr::Literal` arm that re-ran literal validation. This is now removed since `apply_inference_rewriter` already handles it. The `handle_u256_literal` function no longer needs to validate or return a `Maybe` result, since out-of-range u256 patterns are now caught semantically and the lowering-level arm-dropping logic is removed.