### PR TITLE
refactor(corelib): Refactored integer.cairo by additional uses.

### DIFF
--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -68,8 +68,9 @@
 use crate::RangeCheck;
 #[allow(unused_imports)]
 use crate::array::{ArrayTrait, SpanTrait};
+use crate::internal::OptionRev;
 #[feature("bounded-int-utils")]
-use crate::internal::bounded_int::{downcast, upcast};
+use crate::internal::bounded_int::{self, downcast, upcast};
 use crate::option::OptionTrait;
 use crate::result::ResultTrait;
 use crate::traits::{BitAnd, BitNot, BitOr, BitXor, Default, Felt252DictValue, Into, TryInto};
@@ -1210,10 +1211,9 @@ pub fn u256_wide_mul(a: u256, b: u256) -> u512 nopanic {
 
 /// Helper function for implementation of `u256_wide_mul`.
 /// Used for adding two u128s and receiving a BoundedInt for the carry result.
-#[feature("bounded-int-utils")]
 pub(crate) fn u128_add_with_bounded_int_carry(
     a: u128, b: u128,
-) -> (u128, crate::internal::bounded_int::BoundedInt<0, 1>) nopanic {
+) -> (u128, bounded_int::BoundedInt<0, 1>) nopanic {
     match u128_overflowing_add(a, b) {
         Ok(v) => (v, 0),
         Err(v) => (v, 1),
@@ -1981,12 +1981,11 @@ impl I8Sub of Sub<i8> {
 
 impl I8Neg of Neg<i8> {
     #[inline]
-    #[feature("bounded-int-utils")]
     fn neg(a: i8) -> i8 {
-        let core::internal::OptionRev::Some(a) = core::internal::bounded_int::trim_min(a) else {
-            crate::panic_with_felt252('i8_neg Underflow');
-        };
-        upcast(core::internal::bounded_int::NegateHelper::negate(a))
+        match bounded_int::trim_min(a) {
+            OptionRev::Some(a) => upcast(bounded_int::NegateHelper::negate(a)),
+            OptionRev::None => crate::panic_with_felt252('i8_neg Underflow'),
+        }
     }
 }
 
@@ -2071,12 +2070,11 @@ impl I16Sub of Sub<i16> {
 
 impl I16Neg of Neg<i16> {
     #[inline]
-    #[feature("bounded-int-utils")]
     fn neg(a: i16) -> i16 {
-        let core::internal::OptionRev::Some(a) = core::internal::bounded_int::trim_min(a) else {
-            crate::panic_with_felt252('i16_neg Underflow');
-        };
-        upcast(core::internal::bounded_int::NegateHelper::negate(a))
+        match bounded_int::trim_min(a) {
+            OptionRev::Some(a) => upcast(bounded_int::NegateHelper::negate(a)),
+            OptionRev::None => crate::panic_with_felt252('i16_neg Underflow'),
+        }
     }
 }
 
@@ -2162,12 +2160,11 @@ impl I32Sub of Sub<i32> {
 
 impl I32Neg of Neg<i32> {
     #[inline]
-    #[feature("bounded-int-utils")]
     fn neg(a: i32) -> i32 {
-        let core::internal::OptionRev::Some(a) = core::internal::bounded_int::trim_min(a) else {
-            crate::panic_with_felt252('i32_neg Underflow');
-        };
-        upcast(core::internal::bounded_int::NegateHelper::negate(a))
+        match bounded_int::trim_min(a) {
+            OptionRev::Some(a) => upcast(bounded_int::NegateHelper::negate(a)),
+            OptionRev::None => crate::panic_with_felt252('i32_neg Underflow'),
+        }
     }
 }
 
@@ -2253,12 +2250,11 @@ impl I64Sub of Sub<i64> {
 
 impl I64Neg of Neg<i64> {
     #[inline]
-    #[feature("bounded-int-utils")]
     fn neg(a: i64) -> i64 {
-        let core::internal::OptionRev::Some(a) = core::internal::bounded_int::trim_min(a) else {
-            crate::panic_with_felt252('i64_neg Underflow');
-        };
-        upcast(core::internal::bounded_int::NegateHelper::negate(a))
+        match bounded_int::trim_min(a) {
+            OptionRev::Some(a) => upcast(bounded_int::NegateHelper::negate(a)),
+            OptionRev::None => crate::panic_with_felt252('i64_neg Underflow'),
+        }
     }
 }
 
@@ -2349,21 +2345,19 @@ impl I128Sub of Sub<i128> {
 
 impl I128Neg of Neg<i128> {
     #[inline]
-    #[feature("bounded-int-utils")]
     fn neg(a: i128) -> i128 {
-        let core::internal::OptionRev::Some(a) = core::internal::bounded_int::trim_min(a) else {
-            crate::panic_with_felt252('i128_neg Underflow');
-        };
-        upcast(core::internal::bounded_int::NegateHelper::negate(a))
+        match bounded_int::trim_min(a) {
+            OptionRev::Some(a) => upcast(bounded_int::NegateHelper::negate(a)),
+            OptionRev::None => crate::panic_with_felt252('i128_neg Underflow'),
+        }
     }
 }
 
 impl I128Mul of Mul<i128> {
     fn mul(lhs: i128, rhs: i128) -> i128 {
         let (lhs_u127, lhs_neg) = lhs.abs_and_sign();
-        #[feature("bounded-int-utils")]
-        let (rhs_u127, res_neg) = match core::internal::bounded_int::constrain::<i128, 0>(rhs) {
-            Ok(lt0) => (upcast(core::internal::bounded_int::NegateHelper::negate(lt0)), !lhs_neg),
+        let (rhs_u127, res_neg) = match bounded_int::constrain::<i128, 0>(rhs) {
+            Ok(lt0) => (upcast(bounded_int::NegateHelper::negate(lt0)), !lhs_neg),
             Err(ge0) => (upcast(ge0), lhs_neg),
         };
         let res_as_u128 = lhs_u127 * rhs_u127;
@@ -3384,50 +3378,45 @@ pub(crate) trait AbsAndSign<Signed, Unsigned> {
 }
 
 impl I8ToU8 of AbsAndSign<i8, u8> {
-    #[feature("bounded-int-utils")]
     fn abs_and_sign(self: i8) -> (u8, bool) {
-        match core::internal::bounded_int::constrain::<i8, 0>(self) {
-            Ok(lt0) => (upcast(core::internal::bounded_int::NegateHelper::negate(lt0)), true),
+        match bounded_int::constrain::<i8, 0>(self) {
+            Ok(lt0) => (upcast(bounded_int::NegateHelper::negate(lt0)), true),
             Err(ge0) => (upcast(ge0), false),
         }
     }
 }
 
 impl I16ToU16 of AbsAndSign<i16, u16> {
-    #[feature("bounded-int-utils")]
     fn abs_and_sign(self: i16) -> (u16, bool) {
-        match core::internal::bounded_int::constrain::<i16, 0>(self) {
-            Ok(lt0) => (upcast(core::internal::bounded_int::NegateHelper::negate(lt0)), true),
+        match bounded_int::constrain::<i16, 0>(self) {
+            Ok(lt0) => (upcast(bounded_int::NegateHelper::negate(lt0)), true),
             Err(ge0) => (upcast(ge0), false),
         }
     }
 }
 
 impl I32ToU32 of AbsAndSign<i32, u32> {
-    #[feature("bounded-int-utils")]
     fn abs_and_sign(self: i32) -> (u32, bool) {
-        match core::internal::bounded_int::constrain::<i32, 0>(self) {
-            Ok(lt0) => (upcast(core::internal::bounded_int::NegateHelper::negate(lt0)), true),
+        match bounded_int::constrain::<i32, 0>(self) {
+            Ok(lt0) => (upcast(bounded_int::NegateHelper::negate(lt0)), true),
             Err(ge0) => (upcast(ge0), false),
         }
     }
 }
 
 impl I64ToU64 of AbsAndSign<i64, u64> {
-    #[feature("bounded-int-utils")]
     fn abs_and_sign(self: i64) -> (u64, bool) {
-        match core::internal::bounded_int::constrain::<i64, 0>(self) {
-            Ok(lt0) => (upcast(core::internal::bounded_int::NegateHelper::negate(lt0)), true),
+        match bounded_int::constrain::<i64, 0>(self) {
+            Ok(lt0) => (upcast(bounded_int::NegateHelper::negate(lt0)), true),
             Err(ge0) => (upcast(ge0), false),
         }
     }
 }
 
 impl I128ToU128 of AbsAndSign<i128, u128> {
-    #[feature("bounded-int-utils")]
     fn abs_and_sign(self: i128) -> (u128, bool) {
-        match core::internal::bounded_int::constrain::<i128, 0>(self) {
-            Ok(lt0) => (upcast(core::internal::bounded_int::NegateHelper::negate(lt0)), true),
+        match bounded_int::constrain::<i128, 0>(self) {
+            Ok(lt0) => (upcast(bounded_int::NegateHelper::negate(lt0)), true),
             Err(ge0) => (upcast(ge0), false),
         }
     }


### PR DESCRIPTION
## Summary

Consolidates `bounded_int` and `OptionRev` usage in `integer.cairo` by importing `bounded_int` as a module-level alias and `OptionRev` directly, replacing all fully-qualified `core::internal::bounded_int::` and `core::internal::OptionRev::` paths with the shorter aliases. The per-function `#[feature("bounded-int-utils")]` attributes on `neg`, `abs_and_sign`, `I128Mul`, and `u128_add_with_bounded_int_carry` are removed in favor of a single module-level `#[feature("bounded-int-utils")]` import. The `let … else` pattern in the `Neg` implementations for `i8`, `i16`, `i32`, `i64`, and `i128` is replaced with explicit `match` expressions on `OptionRev`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The repeated fully-qualified paths (`core::internal::bounded_int::NegateHelper::negate`, `core::internal::OptionRev::Some`, etc.) and scattered per-function feature attributes made the code verbose and harder to read. Centralizing the imports and using shorter aliases reduces noise and keeps the feature gate in one place.

---

## What was the behavior or documentation before?

Each function using `bounded_int` utilities carried its own `#[feature("bounded-int-utils")]` attribute and referenced all types and functions via their full `core::internal::bounded_int::` paths. `OptionRev` variants were matched using `let … else` with the full `core::internal::OptionRev::Some` path.

---

## What is the behavior or documentation after?

`bounded_int` is imported once as a module alias and `OptionRev` is imported directly at the top of the file. All usages reference the shorter `bounded_int::` prefix. The `Neg` implementations use `match` on `OptionRev` instead of `let … else`. Per-function `#[feature("bounded-int-utils")]` attributes are removed.

---

## Related issue or discussion (if any)

None.

---

## Additional context

No behavioral changes; this is a purely cosmetic/structural cleanup of internal corelib code.