### PR TITLE
doc(corelib): Minor extensions and fixes to the corelib doc.

### DIFF
--- a/corelib/src/keccak.cairo
+++ b/corelib/src/keccak.cairo
@@ -176,7 +176,7 @@ fn add_padding(ref input: Array<u64>, last_input_word: u64, last_input_num_bytes
     // The first word to append would be of the form
     //     0x1<`last_input_num_bytes` LSB bytes of `last_input_word`>.
     // For example, for `last_input_num_bytes == 4`:
-    //     0x1000000 + (last_input_word & 0xffffff)
+    //     0x100000000 + (last_input_word & 0xffffffff)
     let first_word_to_append = if last_input_num_bytes == 0 {
         // This case is handled separately to avoid unnecessary computations.
         1

--- a/corelib/src/math.cairo
+++ b/corelib/src/math.cairo
@@ -21,6 +21,11 @@ use crate::zeroable::{IsZeroResult, NonZeroIntoImpl, Zeroable};
 /// Returns a tuple (g, s, t, sub_direction) where g is the GCD and `(s, -t)` or `(-s, t)` are the
 /// Bezout coefficients (according to `sub_direction`).
 ///
+/// # Panics
+///
+/// Panics for a signed `T` when `a` or `b` is `T::MIN`, since the computation relies on the
+/// absolute value, and `|T::MIN|` is not representable in `T`.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
## Summary

Fixes an incorrect hex literal in a comment within `add_padding` in `keccak.cairo` (the example for `last_input_num_bytes == 4` showed `0x1000000` and `0xffffff` instead of the correct `0x100000000` and `0xffffffff`), and adds a `# Panics` doc section to `math.cairo` documenting that `extended_gcd` panics for signed types when `a` or `b` equals `T::MIN`, since the absolute value of `T::MIN` is not representable in `T`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The comment in `add_padding` contained wrong hex values for the 4-byte case — the mask and offset were both one nibble short, which could mislead anyone reading or auditing the padding logic. Additionally, the `extended_gcd` function had no documentation of its panic condition, leaving callers unaware that passing `T::MIN` for a signed type would cause a panic at runtime.

---

## What was the behavior or documentation before?

- The comment in `keccak.cairo` showed `0x1000000 + (last_input_word & 0xffffff)` for the `last_input_num_bytes == 4` example, which is incorrect (off by one byte).
- `math.cairo` had no `# Panics` section documenting the `T::MIN` restriction.

---

## What is the behavior or documentation after?

- The comment now correctly shows `0x100000000 + (last_input_word & 0xffffffff)`, matching the actual 4-byte (32-bit) mask.
- `math.cairo` now includes a `# Panics` section explaining that the function panics for signed `T` when `a` or `b` is `T::MIN`.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The keccak comment fix is purely cosmetic (the code itself was correct), but accurate comments are important for auditability of cryptographic code. The panic documentation is a concrete correctness concern for callers using signed integer types.