### PR TITLE
bugfix(semantic): Fixed suggested `crate::` context paths.

### DIFF
--- a/crates/cairo-lang-semantic/src/path.rs
+++ b/crates/cairo-lang-semantic/src/path.rs
@@ -145,6 +145,10 @@ fn get_contextualized_path<'db>(
     }
 
     if owning_crate == context_module.owning_crate(db) {
+        // Removing the crate name for the provided path, as `crate::` prefix already denotes the
+        // crate root.
+        let mut path_items = path_items;
+        path_items.pop();
         return Ok(ItemAccessInfo::new(ItemAccessKind::ViaCrate, path_items, item_name));
     }
 

--- a/crates/cairo-lang-semantic/src/path_test_data/tests
+++ b/crates/cairo-lang-semantic/src/path_test_data/tests
@@ -1,3 +1,45 @@
+//! > Path via crate does not double-encode the crate name.
+
+//! > test_runner_name
+test_path_diagnostics(expect_diagnostics: true)
+
+//! > crate_settings
+edition = "2024_07"
+
+//! > module_code
+mod provider1 {
+    pub trait T {
+        fn foo(self: @felt252);
+    }
+    impl I of T {
+        fn foo(self: @felt252) {}
+    }
+}
+mod provider2 {
+    pub trait T {
+        fn foo(self: @felt252);
+    }
+    impl I of T {
+        fn foo(self: @felt252) {}
+    }
+}
+mod caller {
+    use crate::provider1::*;
+    use crate::provider2::*;
+    fn go() {
+        let x = 1_felt252;
+        x.foo();
+    }
+}
+
+//! > expected_diagnostics
+error[E2046]: Ambiguous method call. More than one applicable trait function with a suitable self type was found: crate::provider1::T::foo and crate::provider2::T::foo. Consider adding type annotations or explicitly refer to the impl function.
+ --> lib.cairo:22:11
+        x.foo();
+          ^^^
+
+//! > ==========================================================================
+
 //! > Ambiguous trait function via glob use
 
 //! > test_runner_name


### PR DESCRIPTION
## Summary

Fixes a bug where the `crate::` path prefix was incorrectly double-encoding the crate name. When resolving a path via the crate root, the crate name was being included in `path_items` in addition to the `ViaCrate` kind prefix, resulting in paths like `crate::my_crate::module::Item` instead of the correct `crate::module::Item`. The fix removes the crate name from `path_items` before constructing the `ItemAccessInfo` when the owning crate matches the context module's crate.

A regression test was added to verify that ambiguous method call diagnostics using `crate::` paths display the correct path format (e.g., `crate::provider1::T::foo` rather than a double-encoded variant).

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When two traits were imported via `use crate::provider::*` glob imports and an ambiguous method call occurred, the diagnostic message was generating malformed paths that included the crate name twice — once from `path_items` and once implicitly from the `ViaCrate` kind prefix.

---

## What was the behavior or documentation before?

Ambiguous method call diagnostics for items resolved via `crate::` would produce incorrectly formed paths, including the crate name redundantly alongside the `crate::` prefix.

---

## What is the behavior or documentation after?

Ambiguous method call diagnostics correctly display paths in the form `crate::provider1::T::foo` and `crate::provider2::T::foo`, without duplicating the crate name.

---

## Related issue or discussion (if any)

None specified.

---

## Additional context

None.