### PR TITLE
bugfix(formatter): Made all single line comment prevent removing line-breaks.

### DIFF
--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -780,9 +780,10 @@ impl fmt::Display for CommentLine {
     }
 }
 
-/// Formats a comment to fit in the line width. There are no merges of lines, as this is not clear
-/// when to merge two lines the user chose to write on separate lines, so all original line breaks
-/// are preserved.
+/// Formats a comment to fit in the line width. Line breaks the user wrote are preserved, as it is
+/// not clear when to merge two lines the user chose to write separately; the only merges are of
+/// continuation lines that the formatter itself broke off an over-long open line (see the
+/// `is_open_line` check below).
 fn format_leading_comment(content: &str, cur_indent: usize, max_line_width: usize) -> String {
     let mut formatted_comment = String::new();
     let mut prev_comment_line = CommentLine::from_string("".to_string());

--- a/crates/cairo-lang-formatter/src/node_properties.rs
+++ b/crates/cairo-lang-formatter/src/node_properties.rs
@@ -1084,10 +1084,12 @@ fn is_statement_list_break_point_optional(db: &dyn Database, node: &SyntaxNode<'
         node.grandparent_kind(db),
         Some(SyntaxKind::MatchArm | SyntaxKind::GenericArgNamed | SyntaxKind::GenericArgUnnamed)
     ) && node.get_children(db).len() == 1
-        && node.descendants(db).all(|d| {
-            d.kind(db) != SyntaxKind::Trivia
-                || ast::Trivia::from_syntax_node(db, d)
-                    .elements(db)
-                    .all(|t| !matches!(t, ast::Trivium::SingleLineComment(_)))
+        && !node.descendants(db).any(|d| {
+            matches!(
+                d.kind(db),
+                SyntaxKind::TokenSingleLineComment
+                    | SyntaxKind::TokenSingleLineDocComment
+                    | SyntaxKind::TokenSingleLineInnerComment
+            )
         })
 }

--- a/crates/cairo-lang-formatter/src/test.rs
+++ b/crates/cairo-lang-formatter/src/test.rs
@@ -108,6 +108,15 @@ use crate::{FormatterConfig, get_formatted_file};
     false
 )]
 #[test_case(
+    "test_data/cairo_files/match_arm_doc_comment.cairo",
+    "test_data/expected_results/match_arm_doc_comment.cairo",
+    false,
+    false,
+    false,
+    false,
+    false
+)]
+#[test_case(
     "test_data/cairo_files/use_merge.cairo",
     "test_data/expected_results/use_merge.cairo",
     true,

--- a/crates/cairo-lang-formatter/test_data/cairo_files/match_arm_doc_comment.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/match_arm_doc_comment.cairo
@@ -1,0 +1,19 @@
+fn inner(x: felt252) -> felt252 {
+    match x {
+        0 => {
+            //! inner comment
+            1
+        },
+        _ => 2,
+    }
+}
+
+fn doc(x: felt252) -> felt252 {
+    match x {
+        0 => {
+            /// doc comment
+            1
+        },
+        _ => 2,
+    }
+}

--- a/crates/cairo-lang-formatter/test_data/expected_results/match_arm_doc_comment.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/match_arm_doc_comment.cairo
@@ -1,0 +1,19 @@
+fn inner(x: felt252) -> felt252 {
+    match x {
+        0 => {
+            //! inner comment
+            1
+        },
+        _ => 2,
+    }
+}
+
+fn doc(x: felt252) -> felt252 {
+    match x {
+        0 => {
+            /// doc comment
+            1
+        },
+        _ => 2,
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the Cairo formatter incorrectly collapsing match arm bodies that contain doc comments (`///`) or inner comments (`//!`) into a single line, stripping the comment in the process. The fix updates `is_statement_list_break_point_optional` to check for `TokenSingleLineComment`, `TokenSingleLineDocComment`, and `TokenSingleLineInnerComment` syntax kinds directly, rather than walking through `Trivia` nodes and checking for `SingleLineComment` trivium variants (which did not cover doc/inner comment token kinds). A test case covering both `///` and `//!` in match arm bodies is added.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Match arm bodies containing doc comments (`///`) or inner comments (`//!`) were being incorrectly treated as candidates for collapsing to a single line. The previous check only recognized `ast::Trivium::SingleLineComment`, missing the doc and inner comment token kinds, so those comments were silently dropped when the formatter collapsed the block.

---

## What was the behavior or documentation before?

A match arm like:

```cairo
0 => {
    /// doc comment
    1
},
```

would be incorrectly formatted (the comment was dropped and the block collapsed).

---

## What is the behavior or documentation after?

Match arm bodies containing `///` or `//!` comments are preserved as multi-line blocks, keeping the comment intact:

```cairo
0 => {
    /// doc comment
    1
},
```

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `format_leading_comment` doc comment was also updated to clarify that the formatter only merges continuation lines it broke off from over-long open lines, not lines the user wrote separately.