### PR TITLE
bugfix(sierra): Match on @never with enum_snapshot_match.

### DIFF
--- a/crates/cairo-lang-sierra/src/extensions/modules/enm.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/enm.rs
@@ -342,6 +342,7 @@ impl SignatureOnlyGenericLibfunc for EnumSnapshotMatchLibfunc {
     ) -> Result<LibfuncSignature, SpecializationError> {
         let enum_type = args_as_single_type(args)?;
         let variant_types = EnumConcreteType::try_from_concrete_type(context, enum_type)?.variants;
+        let is_empty = variant_types.is_empty();
         let branch_signatures = variant_types
             .into_iter()
             .map(|ty| {
@@ -364,7 +365,7 @@ impl SignatureOnlyGenericLibfunc for EnumSnapshotMatchLibfunc {
         Ok(LibfuncSignature {
             param_signatures: vec![snapshot_ty(context, enum_type.clone())?.into()],
             branch_signatures,
-            fallthrough: Some(0),
+            fallthrough: (!is_empty).then_some(0),
         })
     }
 }

--- a/tests/e2e_test_data/libfuncs/enum_snapshot
+++ b/tests/e2e_test_data/libfuncs/enum_snapshot
@@ -249,3 +249,32 @@ store_temp<felt252>([6]) -> ([6]);
 return([6]);
 
 test::foo@F0([0]: Snapshot<test::Color>) -> (felt252);
+
+//! > ==========================================================================
+
+//! > match on snapshot never.
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+extern fn enum_snapshot_match<T>(e: @T) -> never nopanic;
+
+fn foo(n: @never) -> never {
+    enum_snapshot_match::<never>(n)
+}
+
+//! > casm
+
+//! > function_costs
+test::foo: SmallOrderedMap({})
+
+//! > sierra_code
+type core::never = Enum<ut@core::never> [storable: true, drop: true, dup: true, zero_sized: false];
+
+libfunc enum_snapshot_match<core::never> = enum_snapshot_match<core::never>;
+
+F0:
+enum_snapshot_match<core::never>([0]) { };
+
+test::foo@F0([0]: core::never) -> (core::never);


### PR DESCRIPTION
## Summary

Fixes `enum_snapshot_match` to correctly handle the `never` type (an enum with no variants) by setting `fallthrough` to `None` instead of `Some(0)` when the enum has no variants. Previously, the libfunc signature always set `fallthrough: Some(0)`, which is invalid for empty enums since there are no branches to fall through to.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`enum_snapshot_match` on the `never` type (an enum with zero variants) was incorrectly assigning `fallthrough: Some(0)`, referencing a branch index that does not exist. Since `never` has no variants, there are no branches, and `fallthrough` must be `None`.

---

## What was the behavior or documentation before?

`EnumSnapshotMatchLibfunc::specialize_signature` always set `fallthrough: Some(0)`, even when the enum had no variants, producing an invalid signature for the `never` type.

---

## What is the behavior or documentation after?

`fallthrough` is now set to `None` when the enum has no variants, and `Some(0)` otherwise. This allows `enum_snapshot_match<never>` to compile correctly, generating a Sierra instruction with an empty branch target list (`{ }`).

---

## Related issue or discussion (if any)

N/A

---

## Additional context

An end-to-end test case for matching on a snapshot of `never` has been added to `tests/e2e_test_data/libfuncs/enum_snapshot`, verifying that the generated Sierra and CASM are correct for this edge case.