### PR TITLE
doc(starknet-class): Minor doc fix.

### DIFF
--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs
@@ -289,7 +289,7 @@ impl TypeResolver<'_> {
             return false;
         };
 
-        // The data field must be a Span<felt252>.
+        // The data field must be an Array<felt252>.
         self.is_felt252_array(err_data_ty)
     }
 


### PR DESCRIPTION
## Summary

Corrects a comment in `casm_contract_class.rs` that incorrectly described the `err_data` field type as `Span<felt252>` when it should be `Array<felt252>`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The comment stated the `data` field must be a `Span<felt252>`, but the actual type being validated is `Array<felt252>`. This mismatch between the comment and the code could mislead developers reading or maintaining the type resolution logic.

---

## What was the behavior or documentation before?

The comment read: `// The data field must be a Span<felt252>.`

---

## What is the behavior or documentation after?

The comment now reads: `// The data field must be an Array<felt252>.`

---

## Related issue or discussion (if any)

None.

---

## Additional context

The code itself calls `is_felt252_array`, which confirms the correct type is `Array<felt252>`, making the previous comment clearly incorrect.