### PR TITLE
bugfix(doc): Made doc not ignore `@`.

### DIFF
--- a/crates/cairo-lang-doc/src/helpers.rs
+++ b/crates/cairo-lang-doc/src/helpers.rs
@@ -146,7 +146,7 @@ pub fn get_syntactic_visibility(semantic_visibility: &Visibility) -> &str {
 /// Formats the full paths of complex types. For example, input "Result<Error::NotFound,
 /// System::Error>" results in output "Result<NotFound, Error>".
 pub(crate) fn extract_and_format(input: &str) -> String {
-    let delimiters = [',', '<', '>', '(', ')', '[', ']'];
+    let delimiters = [',', '<', '>', '(', ')', '[', ']', '@'];
     let mut output = String::new();
     let mut slice_start = 0;
     let mut in_slice = false;
@@ -173,17 +173,17 @@ pub(crate) fn extract_and_format(input: &str) -> String {
 
 /// Formats a single type path. For example, input "core::felt252" results in output "felt252".
 fn format_final_part(slice: &str) -> String {
-    let parts: Vec<&str> = slice.split("::").collect();
-    let ensure_whitespace =
-        if let Some(first) = parts.first() { first.starts_with(" ") } else { false };
-    let result = {
-        match parts[..] {
-            [.., before_last, ""] => before_last.to_string(),
-            [.., last] => last.to_string(),
-            _ => slice.to_string(),
-        }
+    let mut parts = slice.rsplit("::");
+    let result = if let Some(last) = parts.next().map(str::trim)
+        && !last.is_empty()
+    {
+        last
+    } else if let Some(before_last) = parts.next() {
+        before_last.trim()
+    } else {
+        return slice.to_string();
     };
-    if ensure_whitespace && !result.starts_with(' ') { format!(" {result}") } else { result }
+    if slice.starts_with(" ") { format!(" {result}") } else { result.to_string() }
 }
 
 /// Takes a list of [`GenericParamId`]s and formats it into a string representation used for


### PR DESCRIPTION
## Summary

Adds `@` as a delimiter in `extract_and_format` for parsing complex type paths, and rewrites `format_final_part` to use `rsplit("::")` instead of `split("::")` with index-based matching. The new implementation trims whitespace from parts directly and preserves leading-space formatting by checking the original slice rather than the first split element.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Type paths containing snapshot references (prefixed with `@`) were not being split correctly, causing the `@` symbol to appear in the formatted output instead of being treated as a delimiter. Additionally, the previous `format_final_part` logic used forward `split("::")` with slice pattern matching, which could produce incorrect results when extracting the last meaningful segment of a path.

---

## What was the behavior or documentation before?

- `@` was not recognized as a delimiter, so snapshot types like `@core::felt252` would not be formatted correctly.
- `format_final_part` split on `::` from the left and used index-based slice patterns to find the last segment, with whitespace detection relying on the first element of the split.

---

## What is the behavior or documentation after?

- `@` is treated as a delimiter in `extract_and_format`, allowing snapshot-prefixed types to be parsed and formatted correctly.
- `format_final_part` now uses `rsplit("::")` to directly find the last non-empty segment from the right, with trimming applied per-part and leading-space preservation checked against the original input slice.

---

## Related issue or discussion (if any)

---

## Additional context

The refactored `format_final_part` is simpler and more robust, avoiding the previous reliance on positional slice patterns that could behave unexpectedly with certain path structures.