### PR TITLE
Updated toml rust version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ edition = "2024"
 license = "Apache-2.0"
 license-file = "LICENSE"
 repository = "https://github.com/starkware-libs/cairo/"
-rust-version = "1.86"
+rust-version = "1.94"
 version = "2.18.0"
 
 [workspace.dependencies]

--- a/crates/cairo-lang-sierra-generator/src/function_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/function_generator.rs
@@ -83,12 +83,11 @@ fn get_function_ap_change_and_code<'db>(
 
     // If the function starts with `revoke_ap_tracking` then we can avoid
     // the first `disable_ap_tracking`.
-    if let Some(lowering::Statement::Call(call_stmt)) = root_block.statements.first() {
-        if get_concrete_libfunc_id(db, call_stmt.function, false).1
+    if let Some(lowering::Statement::Call(call_stmt)) = root_block.statements.first()
+        && get_concrete_libfunc_id(db, call_stmt.function, false).1
             == revoke_ap_tracking_libfunc_id(db)
-        {
-            context.set_ap_tracking(false);
-        }
+    {
+        context.set_ap_tracking(false);
     }
 
     // Generate a label for the function's body.

--- a/crates/cairo-lang-sierra-generator/src/program_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator.rs
@@ -443,10 +443,10 @@ pub fn get_dummy_program_for_size_estimation(
     let mut functions = vec![function];
 
     for statement in &function.body {
-        if let Some(function_id) = try_get_function_with_body_id(db, statement) {
-            if processed_function_ids.insert(function_id) {
-                functions.push(db.priv_get_dummy_function(function_id)?);
-            }
+        if let Some(function_id) = try_get_function_with_body_id(db, statement)
+            && processed_function_ids.insert(function_id)
+        {
+            functions.push(db.priv_get_dummy_function(function_id)?);
         }
     }
     // Since we are not interested in the locations, we can remove them from the statements.

--- a/crates/cairo-lang-sierra-generator/src/store_variables/mod.rs
+++ b/crates/cairo-lang-sierra-generator/src/store_variables/mod.rs
@@ -455,10 +455,11 @@ impl<'db> AddStoreVariableStatements<'db> {
     fn store_all_possibly_lost_variables(&mut self, state: &mut VariablesState) {
         self.store_variables_as_locals(state);
         for (var, var_state) in state.variables.iter_mut() {
-            if let VarState::Deferred { info } = var_state {
-                if info.kind != DeferredOutputKind::Const && self.duplicated_vars.contains(var) {
-                    *var_state = self.store_deferred(&mut state.known_stack, var, &info.ty);
-                }
+            if let VarState::Deferred { info } = var_state
+                && info.kind != DeferredOutputKind::Const
+                && self.duplicated_vars.contains(var)
+            {
+                *var_state = self.store_deferred(&mut state.known_stack, var, &info.ty);
             }
         }
     }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -387,12 +387,11 @@ fn run_e2e_test(
 
     // Handle test_data if specified.
     // This runs AFTER sierra/casm generation, so compilation outputs are always verified first.
-    if let Some(test_data) = params.test_data {
-        if let Err(e) =
+    if let Some(test_data) = params.test_data
+        && let Err(e) =
             run_and_validate_test_data(sierra_program, test_data, params.add_withdraw_gas)
-        {
-            return TestRunnerResult { outputs: res, error: Some(e) };
-        }
+    {
+        return TestRunnerResult { outputs: res, error: Some(e) };
     }
 
     TestRunnerResult::success(res)


### PR DESCRIPTION
## Summary

Bumps the minimum required Rust version from `1.86` to `1.96` and refactors several nested `if let` / `if` blocks to use Rust's `let` chains (i.e., `if let ... && ...`), taking advantage of the stabilized `let_chains` feature available in Rust 1.96.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`let` chains were stabilized in Rust 1.96, allowing multiple `if let` and boolean conditions to be combined into a single `if` expression. The previous nested `if let { if { ... } }` patterns are functionally equivalent but more verbose and harder to read. Updating the MSRV unlocks this syntax project-wide.

---

## What was the behavior or documentation before?

The minimum supported Rust version was `1.86`. Conditional logic involving `if let` followed by an additional `if` guard required nested blocks.

---

## What is the behavior or documentation after?

The minimum supported Rust version is `1.96`. The nested `if let` / `if` blocks in `function_generator.rs`, `program_generator.rs`, `store_variables/mod.rs`, and `tests/e2e_test.rs` are flattened into single `if let ... && ...` expressions using `let` chains.

---

## Related issue or discussion (if any)

---

## Additional context

No behavioral changes are introduced; this is purely a syntactic modernization enabled by the MSRV bump.