### PR TITLE
bugfix(sierra-sim): Fixed `u128_guarantee_mul` simulation.

### DIFF
--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -419,11 +419,11 @@ fn simulate_u128_libfunc(
         }
         Uint128Concrete::GuaranteeMul(_) => {
             take_inputs!(let [CoreValue::Uint128(lhs), CoreValue::Uint128(rhs)] = inputs);
-            let (limb1, limb0) = (BigInt::from(lhs) * rhs).div_rem(&BigInt::one().pow(128));
+            let (high, low) = (BigInt::from(lhs) * rhs).div_rem(&(BigInt::one() << 128));
             (
                 vec![
-                    CoreValue::Uint128(limb0.to_u128().unwrap()),
-                    CoreValue::Uint128(limb1.to_u128().unwrap()),
+                    CoreValue::Uint128(high.to_u128().unwrap()),
+                    CoreValue::Uint128(low.to_u128().unwrap()),
                     CoreValue::U128MulGuarantee,
                 ],
                 0,

--- a/crates/cairo-lang-sierra/src/simulation/test.rs
+++ b/crates/cairo-lang-sierra/src/simulation/test.rs
@@ -7,7 +7,8 @@ use super::LibfuncSimulationError::{
     self, FunctionSimulationError, WrongArgType, WrongNumberOfArgs,
 };
 use super::value::CoreValue::{
-    self, Array, Felt252, GasBuiltin, RangeCheck, Uint32, Uint64, Uint128, Uninitialized,
+    self, Array, Felt252, GasBuiltin, RangeCheck, U128MulGuarantee, Uint32, Uint64, Uint128,
+    Uninitialized,
 };
 use super::{SimulationError, core};
 use crate::extensions::GenericLibfunc;
@@ -186,6 +187,11 @@ fn simulate_branch(
              => Ok(vec![Uint128(3), Uint128(5)]); "function_call<identity>()")]
 #[test_case("u64_to_felt252", vec![], vec![Uint64(5)]
              => Ok(vec![Felt252(5u64.into())]); "u64_to_felt252(5)")]
+#[test_case("u128_guarantee_mul", vec![], vec![Uint128(2), Uint128(3)]
+             => Ok(vec![Uint128(0), Uint128(6), U128MulGuarantee]); "u128_guarantee_mul(2, 3)")]
+#[test_case("u128_guarantee_mul", vec![], vec![Uint128(1 << 64), Uint128(1 << 64)]
+             => Ok(vec![Uint128(1), Uint128(0), U128MulGuarantee]);
+            "u128_guarantee_mul(2**64, 2**64) -> high limb")]
 fn simulate_none_branch(
     id: &str,
     generic_args: Vec<GenericArg>,

--- a/crates/cairo-lang-sierra/src/test_utils.rs
+++ b/crates/cairo-lang-sierra/src/test_utils.rs
@@ -51,6 +51,7 @@ pub fn build_bijective_mapping() -> BiMap<ConcreteTypeId, ConcreteTypeLongId> {
     elements.insert("Uninitializedu128".into(), as_type_long_id("Uninitialized", &["u128"]));
     elements.insert("GasBuiltin".into(), as_type_long_id("GasBuiltin", &[]));
     elements.insert("RangeCheck".into(), as_type_long_id("RangeCheck", &[]));
+    elements.insert("U128MulGuarantee".into(), as_type_long_id("U128MulGuarantee", &[]));
     elements.insert("System".into(), as_type_long_id("System", &[]));
     elements.insert("StorageBaseAddress".into(), as_type_long_id("StorageBaseAddress", &[]));
     elements.insert("StorageAddress".into(), as_type_long_id("StorageAddress", &[]));


### PR DESCRIPTION
## Summary

Fixes the `u128_guarantee_mul` simulation to correctly compute the high and low 128-bit limbs of a 128×128-bit multiplication. The division was previously using `BigInt::one().pow(128)` (which equals `1`, not `2^128`) instead of `BigInt::one() << 128`, causing incorrect limb splitting. Variable names are also updated from `limb0`/`limb1` to `high`/`low` to match their semantic meaning, and the output order is corrected to `[high, low, U128MulGuarantee]`. Test cases are added to verify both the no-overflow case and the case where the product overflows into the high limb.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`BigInt::one().pow(128)` evaluates to `1` (one raised to the power of 128), not `2^128`. This meant the `div_rem` was dividing by `1`, producing a remainder of `0` and a quotient equal to the full product — making the high/low limb split completely wrong for any non-trivial multiplication.

---

## What was the behavior or documentation before?

The simulation of `u128_guarantee_mul` produced incorrect high and low limb values due to the division being performed against `1` instead of `2^128`.

---

## What is the behavior or documentation after?

The simulation correctly splits the 256-bit product of two `u128` values into a high 128-bit limb and a low 128-bit limb using a bitshift (`<< 128`) for the divisor, and returns them in the order `[high, low, U128MulGuarantee]`.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

`U128MulGuarantee` is also registered in the bijective type mapping in `test_utils.rs` to support the new simulation tests.