### PR TITLE
bugfix(corelib): Fixed ByteSpan::get OOB empty range.

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -859,7 +859,13 @@ impl ByteSpanGetRange of crate::ops::Get<ByteSpan, crate::ops::Range<usize>> {
     fn get(self: @ByteSpan, index: crate::ops::Range<usize>) -> Option<ByteSpan> {
         let range = index;
         if range.start == range.end {
-            return Some(Default::default());
+            return if range.start <= (*self).len() {
+                // If range is within bounds, return the empty slice.
+                Some(Default::default())
+            } else {
+                // If range is out of bounds, return `None`.
+                None
+            };
         }
         if range.start > range.end {
             return None;

--- a/corelib/src/test/byte_array_test.cairo
+++ b/corelib/src/test/byte_array_test.cairo
@@ -550,15 +550,25 @@ fn test_span_slice_is_empty() {
     assert!(empty.is_empty());
     assert_eq!(empty.to_byte_array(), "");
 
+    assert_eq!(span.get(5..5).map(is_empty), Some(true));
+    assert_eq!(span.get(6..6).map(is_empty), None);
+    assert_eq!(span.get(2..6).map(is_empty), None);
+    assert_eq!(span.get(0..10).map(is_empty), None);
+
     let ba_31: ByteArray = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcde";
     assert_eq!(ba_31.span().get(30..30).map(is_empty), Some(true));
     assert_eq!(ba_31.span().get(31..31).map(is_empty), Some(true));
     assert_eq!(ba_31.span().get(15..30).map(is_empty), Some(false));
+    assert_eq!(ba_31.span().get(32..32).map(is_empty), None);
+    assert_eq!(ba_31.span().get(15..32).map(is_empty), None);
+    assert_eq!(ba_31.span().get(0..70).map(is_empty), None);
 
     let ba_30: ByteArray = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcd";
     assert_eq!(ba_30.span().get(29..29).map(is_empty), Some(true));
     assert_eq!(ba_30.span().get(30..30).map(is_empty), Some(true));
     assert_eq!(ba_30.span().get(15..29).map(is_empty), Some(false));
+    assert_eq!(ba_30.span().get(31..31).map(is_empty), None);
+    assert_eq!(ba_30.span().get(15..31).map(is_empty), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`ByteSpan::get` with a range where `start == end` previously always returned `Some(Default::default())` (an empty slice), even when the range was entirely out of bounds. It now returns `None` when `range.start > self.len()`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

An empty range (`start == end`) that falls beyond the end of the span was silently returning a valid empty slice instead of signaling that the index is out of bounds. This is inconsistent with how non-empty out-of-bounds ranges are handled (they return `None`) and with the general contract that `get` returns `None` for invalid indices.

---

## What was the behavior or documentation before?

`span.get(n..n)` returned `Some("")` for any value of `n`, regardless of whether `n` was within the bounds of the span.

---

## What is the behavior or documentation after?

`span.get(n..n)` returns `Some("")` only when `n <= span.len()`, and returns `None` when `n > span.len()`, matching the behavior of out-of-bounds non-empty range queries.

---

## Related issue or discussion (if any)

---

## Additional context

Tests were added for out-of-bounds empty-range queries on spans of various lengths (including spans backed by 30-byte and 31-byte `ByteArray`s) to cover the boundary conditions around word alignment.