### PR TITLE
(feat): Adding a topological block order analysis

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/mod.rs
+++ b/crates/cairo-lang-lowering/src/analysis/mod.rs
@@ -15,6 +15,7 @@ pub mod equality_analysis;
 pub mod forward;
 pub mod use_sites;
 pub use forward::ForwardDataflowAnalysis;
+pub mod topological_order;
 
 #[cfg(test)]
 mod equality_analysis_test;

--- a/crates/cairo-lang-lowering/src/analysis/test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/test.rs
@@ -10,6 +10,7 @@ use super::core::{DataflowAnalyzer, Direction, StatementLocation};
 use super::def_site::DefSiteAnalysis;
 use super::dominator::Dominators;
 use super::forward::ForwardDataflowAnalysis;
+use super::topological_order::TopologicalOrder;
 use super::use_sites::UseSites;
 use crate::db::LoweringGroup;
 use crate::ids::{ConcreteFunctionWithBodyId, FunctionWithBodyLongId};
@@ -29,6 +30,7 @@ cairo_lang_test_utils::test_file_test!(
         dominator: "dominator",
         def_site: "def_site",
         use_sites: "use_sites",
+        topological_order: "topological_order",
     },
     test_analysis,
     ["analysis"]
@@ -54,6 +56,7 @@ fn test_analysis(
             "dominator" => format!("{:#?}", Dominators::analyze(lowered)),
             "def_site" => format!("{:#?}", DefSiteAnalysis::analyze(lowered)),
             "use_sites" => format!("{:#?}", UseSites::analyze(lowered)),
+            "topological_order" => format!("{:#?}", TopologicalOrder::analyze(lowered)),
             _ => panic!("unknown analysis: {analysis_name}"),
         };
         (lowering_str, result_str)

--- a/crates/cairo-lang-lowering/src/analysis/test_data/topological_order
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/topological_order
@@ -1,0 +1,265 @@
+//! > Test simple linear function
+
+//! > test_runner_name
+test_analysis(analysis: topological_order)
+
+//! > function_code
+fn foo(x: felt252, y: felt252) -> felt252 {
+    x + y
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252
+blk0 (root):
+Statements:
+  (v2: core::felt252) <- core::felt252_add(v0, v1)
+End:
+  Return(v2)
+
+//! > result
+[
+    blk0,
+]
+
+//! > ==========================================================================
+
+//! > Test if-else with no merge
+
+//! > test_runner_name
+test_analysis(analysis: topological_order)
+
+//! > function_code
+fn foo(x: bool) -> felt252 {
+    if x {
+        1
+    } else {
+        2
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 2
+End:
+  Return(v3)
+
+blk2:
+Statements:
+  (v4: core::felt252) <- 1
+End:
+  Return(v4)
+
+//! > result
+[
+    blk0,
+    blk2,
+    blk1,
+]
+
+//! > ==========================================================================
+
+//! > Test diamond CFG — if-else with merge block
+
+//! > test_runner_name
+test_analysis(analysis: topological_order)
+
+//! > function_code
+fn foo(x: bool) -> felt252 {
+    let y = if x {
+        1
+    } else {
+        2
+    };
+    y + 3
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v1) => blk1,
+    bool::True(v2) => blk2,
+  })
+
+blk1:
+Statements:
+  (v3: core::felt252) <- 2
+End:
+  Goto(blk3, {v3 -> v4})
+
+blk2:
+Statements:
+  (v5: core::felt252) <- 1
+End:
+  Goto(blk3, {v5 -> v4})
+
+blk3:
+Statements:
+  (v6: core::felt252) <- 3
+  (v7: core::felt252) <- core::felt252_add(v4, v6)
+End:
+  Return(v7)
+
+//! > result
+[
+    blk0,
+    blk2,
+    blk1,
+    blk3,
+]
+
+//! > ==========================================================================
+
+//! > Test nested if-else
+
+//! > test_runner_name
+test_analysis(analysis: topological_order)
+
+//! > function_code
+fn foo(x: bool, y: bool) -> felt252 {
+    if x {
+        if y {
+            1
+        } else {
+            2
+        }
+    } else {
+        3
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::bool, v1: core::bool
+blk0 (root):
+Statements:
+End:
+  Match(match_enum(v0) {
+    bool::False(v2) => blk1,
+    bool::True(v3) => blk2,
+  })
+
+blk1:
+Statements:
+  (v4: core::felt252) <- 3
+End:
+  Return(v4)
+
+blk2:
+Statements:
+End:
+  Match(match_enum(v1) {
+    bool::False(v5) => blk3,
+    bool::True(v6) => blk4,
+  })
+
+blk3:
+Statements:
+  (v7: core::felt252) <- 2
+End:
+  Return(v7)
+
+blk4:
+Statements:
+  (v8: core::felt252) <- 1
+End:
+  Return(v8)
+
+//! > result
+[
+    blk0,
+    blk2,
+    blk4,
+    blk3,
+    blk1,
+]
+
+//! > ==========================================================================
+
+//! > Test match with multiple arms
+
+//! > test_runner_name
+test_analysis(analysis: topological_order)
+
+//! > function_code
+fn foo(x: felt252) -> felt252 {
+    match x {
+        0 => 10,
+        _ => 20,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+End:
+  Match(match core::felt252_is_zero(v0) {
+    IsZeroResult::Zero => blk1,
+    IsZeroResult::NonZero(v1) => blk2,
+  })
+
+blk1:
+Statements:
+  (v2: core::felt252) <- 10
+End:
+  Return(v2)
+
+blk2:
+Statements:
+  (v3: core::felt252) <- 20
+End:
+  Return(v3)
+
+//! > result
+[
+    blk0,
+    blk2,
+    blk1,
+]

--- a/crates/cairo-lang-lowering/src/analysis/topological_order.rs
+++ b/crates/cairo-lang-lowering/src/analysis/topological_order.rs
@@ -1,0 +1,68 @@
+use std::fmt;
+use std::ops::Deref;
+
+use crate::analysis::core::{DataflowAnalyzer, Direction, StatementLocation};
+use crate::analysis::forward::ForwardDataflowAnalysis;
+use crate::{Block, BlockEnd, BlockId, Lowered};
+
+/// Block visitation order produced by forward dataflow traversal.
+///
+/// Blocks appear in topological order (from entry towards exits), following
+/// actual CFG edges rather than block-index ordering.
+pub struct TopologicalOrder {
+    blocks: Vec<BlockId>,
+}
+
+impl TopologicalOrder {
+    /// Runs topological order analysis on a lowered function.
+    pub fn analyze(lowered: &Lowered<'_>) -> Self {
+        let mut fwd = ForwardDataflowAnalysis::new(lowered, TopologicalOrderAnalyzer::default());
+        fwd.run();
+        Self { blocks: fwd.analyzer.blocks }
+    }
+}
+
+impl Deref for TopologicalOrder {
+    type Target = Vec<BlockId>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.blocks
+    }
+}
+
+impl fmt::Debug for TopologicalOrder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.blocks.iter()).finish()
+    }
+}
+
+/// Forward dataflow pass that collects blocks in topological order.
+#[derive(Default, Clone)]
+struct TopologicalOrderAnalyzer {
+    blocks: Vec<BlockId>,
+}
+
+impl<'db, 'a> DataflowAnalyzer<'db, 'a> for TopologicalOrderAnalyzer {
+    type Info = ();
+    const DIRECTION: Direction = Direction::Forward;
+
+    fn initial_info(&mut self, _block_id: BlockId, _block_end: &'a BlockEnd<'db>) -> Self::Info {}
+
+    fn merge(
+        &mut self,
+        _lowered: &Lowered<'db>,
+        _statement_location: StatementLocation,
+        _info1: Self::Info,
+        _info2: Self::Info,
+    ) -> Self::Info {
+    }
+
+    fn transfer_block(
+        &mut self,
+        _info: &mut Self::Info,
+        block_id: BlockId,
+        _block: &'a Block<'db>,
+    ) {
+        self.blocks.push(block_id);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `TopologicalOrder` analysis to the lowering analysis framework. It uses the existing `ForwardDataflowAnalysis` infrastructure to traverse the CFG and collect `BlockId`s in topological order (entry toward exits), following actual CFG edges rather than block-index ordering. A `TopologicalOrderAnalyzer` implements `DataflowAnalyzer` with a no-op info type, recording each block as it is visited via `transfer_block`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

There was no existing way to obtain a topological visitation order of lowered function blocks through the dataflow analysis framework. Downstream passes that need to process blocks in CFG order (rather than by block index) had no standard utility to rely on.

---

## What was the behavior or documentation before?

No `TopologicalOrder` analysis existed. Consumers needing CFG-ordered block traversal had to implement their own traversal logic.

---

## What is the behavior or documentation after?

`TopologicalOrder::analyze(lowered)` returns a `TopologicalOrder` value whose `blocks()` method yields `BlockId`s in the order they are first reached by a forward CFG traversal. Test cases cover linear functions, if-else without a merge block, diamond CFGs with a merge block, nested if-else, and multi-arm matches.

---

## Related issue or discussion (if any)

---

## Additional context

The implementation is intentionally minimal: `TopologicalOrderAnalyzer` carries no dataflow state beyond the ordered block list, and all `merge` and `initial_info` methods are no-ops. The analysis is registered in the test harness under the key `"topological_order"` alongside the existing analyses.