### PR TITLE
Ignoring later fields instead of overriding when getting dup fields.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/structure.rs
+++ b/crates/cairo-lang-semantic/src/items/structure.rs
@@ -10,7 +10,7 @@ use cairo_lang_proc_macros::{DebugWithDb, SemanticObject};
 use cairo_lang_syntax::attribute::structured::{Attribute, AttributeListStructurize};
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::Intern;
-use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use cairo_lang_utils::ordered_hash_map::{Entry, OrderedHashMap};
 use salsa::Database;
 
 use super::attribute::SemanticQueryAttrs;
@@ -156,9 +156,18 @@ fn struct_definition_data<'db>(
         let ty = resolve_type(db, &mut diagnostics, &mut resolver, &member.type_clause(db).ty(db));
         let visibility = Visibility::from_ast(db, &mut diagnostics, &member.visibility(db));
         let member_name = member.name(db).text(db);
-        if let Some(_other_member) = members.insert(member_name, Member { id, ty, visibility }) {
-            diagnostics
-                .report(member.stable_ptr(db), StructMemberRedefinition { struct_id, member_name });
+        // Keep the first declaration on a redefinition (matching enum variants), rather than
+        // overwriting with the last - the later duplicate is reported and rejected below.
+        match members.entry(member_name) {
+            Entry::Vacant(e) => {
+                e.insert(Member { id, ty, visibility });
+            }
+            Entry::Occupied(_) => {
+                diagnostics.report(
+                    member.stable_ptr(db),
+                    StructMemberRedefinition { struct_id, member_name },
+                );
+            }
         }
         resolver.restore_feature_config(feature_restore);
     }

--- a/crates/cairo-lang-semantic/src/items/structure_test.rs
+++ b/crates/cairo-lang-semantic/src/items/structure_test.rs
@@ -63,7 +63,7 @@ fn test_struct() {
     assert_eq!(
         actual,
         indoc! {"
-            a: Member { id: MemberId(test::A::a), ty: (), visibility: Private },
+            a: Member { id: MemberId(test::A::a), ty: core::felt252, visibility: Private },
             b: Member { id: MemberId(test::A::b), ty: (core::felt252, core::felt252), visibility: Public },
             c: Member { id: MemberId(test::A::c), ty: (), visibility: PublicInCrate }"}
     );


### PR DESCRIPTION
## Summary

When a struct has duplicate member names, the first declaration is now preserved instead of being overwritten by the last one. This matches the existing behavior for enum variant redefinition. Additionally, a test expectation for member `a`'s type was corrected from `()` to `core::felt252`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a struct member was redefined (declared more than once), the map insertion via `insert` would overwrite the first declaration with the duplicate. This meant the type and visibility of the *last* duplicate were retained, even though the duplicate is the one being reported as an error and rejected. This is inconsistent with how enum variant redefinitions are handled.

---

## What was the behavior or documentation before?

On a `StructMemberRedefinition` error, the last duplicate member's `id`, `ty`, and `visibility` were stored in the members map, discarding the original declaration.

---

## What is the behavior or documentation after?

On a `StructMemberRedefinition` error, the first (original) member declaration is kept in the members map. The duplicate triggers the diagnostic and is discarded, consistent with enum variant redefinition handling.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `Entry`-based approach (`Entry::Vacant` / `Entry::Occupied`) replaces the previous `insert`-and-check pattern to avoid overwriting the original entry on collision.