### PR TITLE
doc(sierra-to-casm): Updated enm.rs comment.

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/enm.rs
@@ -298,8 +298,8 @@ fn build_enum_match_short_ex(
 /// jmp rel <jump_offset_3000>
 /// ```
 /// Where in the first location of the enum_var there will be the jmp_table_idx (2*n-1 for
-/// branch index 0 (where n is the number of variants of this enum), 1 for branch index 1, 3 for
-/// branch index 2 and so on: (2 * k - 1) for branch index k).
+/// branch index 0 (where n is the number of variants of this enum), 2*n-3 for branch index 1, 2*n-5
+/// for branch index n-2 and so on: (2 * (n - k) - 1) for branch index k).
 ///
 /// Assumes that builder.invocation.branches.len() == output_expressions.len() > 2.
 fn build_enum_match_long(


### PR DESCRIPTION
## Summary

Fixes an incorrect comment describing the jump table index formula used in `build_enum_match_long`. The previous comment stated the index for branch `k` was `(2 * k - 1)`, which was wrong. The correct formula is `(2 * (n - k) - 1)`, meaning the indices decrease as the branch index increases (e.g., `2*n-3` for branch index 1, `2*n-5` for branch index `n-2`, etc.).

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The comment describing the jump table index encoding for `build_enum_match_long` had the formula backwards. It claimed the index for branch `k` was `(2 * k - 1)`, but the actual encoding uses `(2 * (n - k) - 1)`, where `n` is the number of variants. This was misleading to anyone reading the code and trying to understand how the jump table indices are assigned.

---

## What was the behavior or documentation before?

The comment stated the jump table index for branch `k` was `(2 * k - 1)`, implying indices increase with branch index.

---

## What is the behavior or documentation after?

The comment now correctly states the jump table index for branch `k` is `(2 * (n - k) - 1)`, with explicit examples showing `2*n-3` for branch index 1 and `2*n-5` for branch index `n-2`, clarifying that indices decrease as the branch index increases.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A