### PR TITLE
refactor(doc): Made indent of tables not duplicate indent.

### DIFF
--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -98,18 +98,16 @@ pub fn parse_documentation_comment(documentation_comment: &str) -> Vec<Documenta
         |list_nesting: &mut Vec<DocCommentListItem>,
          tokens: &mut Vec<DocumentationCommentToken>| {
             if !list_nesting.is_empty() {
-                let indent = "  ".repeat(list_nesting.len() - 1);
+                let indent = "    ".repeat(list_nesting.len() - 1);
                 let list_nesting = list_nesting.last_mut().unwrap();
 
-                let item_delimiter = if list_nesting.is_ordered_list {
+                tokens.push(DocumentationCommentToken::Content(if list_nesting.is_ordered_list {
                     let delimiter = list_nesting.delimiter.unwrap_or(0);
                     list_nesting.delimiter = Some(delimiter + 1);
-                    format!("{indent}{delimiter}.",)
+                    format!("{indent}{delimiter}. ",)
                 } else {
-                    format!("{indent}-")
-                };
-                tokens
-                    .push(DocumentationCommentToken::Content(format!("{indent}{item_delimiter} ")));
+                    format!("{indent}- ")
+                }));
             }
         };
     let mut prefix_list_item = false;


### PR DESCRIPTION
## Summary

Fixes list item formatting in documentation comment parsing by correcting the indentation width from 2 spaces to 4 spaces per nesting level, and moves the trailing space inside the formatted string for both ordered and unordered list item delimiters (e.g., `"1. "` and `"- "` instead of constructing the space separately).

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The list item delimiter formatting in `parse_documentation_comment` was producing incorrect output: indentation used 2-space increments instead of 4, and the space separator between the delimiter and list item content was being appended redundantly via a separate `format!` call that also re-included the indent, resulting in duplicated indentation in the final token.

---

## What was the behavior or documentation before?

- Each nesting level added 2 spaces of indentation.
- The delimiter string was constructed separately and then wrapped in another `format!("{indent}{item_delimiter} ")`, which caused the indent to appear twice.

---

## What is the behavior or documentation after?

- Each nesting level adds 4 spaces of indentation.
- The trailing space is included directly in the delimiter format string (`"1. "` / `"- "`), and the token is pushed directly without a redundant outer format call.

---

## Related issue or discussion (if any)

---

## Additional context

The refactoring also simplifies the code by inlining the `item_delimiter` variable directly into the `DocumentationCommentToken::Content(...)` push call.