### PR TITLE
bugfix(return-opt): Fixed issue with identical variants on return building.

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/return_optimization.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/return_optimization.rs
@@ -51,15 +51,25 @@ pub fn return_optimization<'db>(db: &'db dyn Database, lowered: &mut Lowered<'db
 struct EarlyReturnContext<'db, 'a> {
     /// The lowering database.
     db: &'db dyn Database,
-    /// A map from (type, inputs) to the variable_id for Structs/Enums that were created
+    /// A map from a `Construction` to the variable_id for Structs that were created
     /// while processing the early return.
-    constructed: UnorderedHashMap<(TypeId<'db>, Vec<VariableId>), VariableId>,
+    constructed: UnorderedHashMap<Construction<'db>, VariableId>,
     /// A variable allocator.
     variables: &'a mut VariableArena<'db>,
     /// The statements in the block where the early return is going to happen.
     statements: &'a mut Vec<Statement<'db>>,
     /// The location associated with the early return.
     location: LocationId<'db>,
+}
+
+/// A `Construction` represents a struct or enum construction that was created while processing
+/// the early return.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Construction<'db> {
+    /// A construction of a struct.
+    Struct(TypeId<'db>, Vec<VariableId>),
+    /// A construction of an enum.
+    Enum(semantic::ConcreteVariant<'db>, VariableId),
 }
 
 impl<'db, 'a> EarlyReturnContext<'db, 'a> {
@@ -78,7 +88,10 @@ impl<'db, 'a> EarlyReturnContext<'db, 'a> {
                     let inputs = self.prepare_early_return_vars(var_infos);
                     let output = *self
                         .constructed
-                        .entry((*ty, inputs.iter().map(|var_usage| var_usage.var_id).collect()))
+                        .entry(Construction::Struct(
+                            *ty,
+                            inputs.iter().map(|var_usage| var_usage.var_id).collect(),
+                        ))
                         .or_insert_with(|| {
                             let output = self.variables.alloc(Variable::with_default_context(
                                 self.db,
@@ -98,8 +111,10 @@ impl<'db, 'a> EarlyReturnContext<'db, 'a> {
                     let ty = TypeLongId::Concrete(ConcreteTypeId::Enum(variant.concrete_enum_id))
                         .intern(self.db);
 
-                    let output =
-                        *self.constructed.entry((ty, vec![input.var_id])).or_insert_with(|| {
+                    let output = *self
+                        .constructed
+                        .entry(Construction::Enum(*variant, input.var_id))
+                        .or_insert_with(|| {
                             let output = self.variables.alloc(Variable::with_default_context(
                                 self.db,
                                 ty,

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/return_optimization
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/return_optimization
@@ -790,3 +790,49 @@ blk0 (root):
 Statements:
 End:
   Return(v0)
+
+//! > ==========================================================================
+
+//! > Test enum construct memo does not collide across variants (same enum, same input var).
+
+//! > test_runner_name
+test_return_optimizer
+
+//! > module_code
+#[derive(Drop, Copy)]
+enum MyEnum {
+    A: u32,
+    B: u32,
+}
+
+//! > function_code
+fn foo(x: u32) -> (MyEnum, MyEnum) {
+    (MyEnum::A(x), MyEnum::B(x))
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > before
+Parameters: v0: core::integer::u32
+blk0 (root):
+Statements:
+  (v1: test::MyEnum) <- MyEnum::A(v0)
+  (v2: test::MyEnum) <- MyEnum::B(v0)
+  (v3: (test::MyEnum, test::MyEnum)) <- struct_construct(v1, v2)
+End:
+  Return(v3)
+
+//! > after
+Parameters: v0: core::integer::u32
+blk0 (root):
+Statements:
+  (v4: test::MyEnum) <- MyEnum::A(v0)
+  (v5: test::MyEnum) <- MyEnum::B(v0)
+  (v6: (test::MyEnum, test::MyEnum)) <- struct_construct(v4, v5)
+End:
+  Return(v6)


### PR DESCRIPTION
## Summary

Replaces the `(TypeId, Vec<VariableId>)` tuple key used in `EarlyReturnContext::constructed` with a dedicated `Construction` enum that has distinct `Struct` and `Enum` variants. The `Enum` variant stores a `semantic::ConcreteVariant` and a single `VariableId`, rather than a `TypeId` and a `Vec<VariableId>`, ensuring that different enum variants with the same input variable cannot collide in the memoization map.

A regression test is added covering the case where two different variants of the same enum (`MyEnum::A(x)` and `MyEnum::B(x)`) are constructed from the same input variable, verifying they produce distinct output variables.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous key `(TypeId, Vec<VariableId>)` for enum constructions used the enum's type ID and the input variable wrapped in a `Vec`. Because two different variants of the same enum share the same `TypeId`, constructing `MyEnum::A(x)` and `MyEnum::B(x)` would produce identical keys, causing the second construction to incorrectly reuse the variable allocated for the first. This led to wrong lowered IR when both variants appeared in the same early-return path.

---

## What was the behavior or documentation before?

Constructing two different variants of the same enum from the same input variable during return optimization would collide in the `constructed` map, causing the second enum construct statement to reuse the output variable of the first variant instead of allocating a new one.

---

## What is the behavior or documentation after?

Each enum construction is keyed by its `ConcreteVariant` (which encodes the specific variant, not just the enum type) and its input `VariableId`. Struct constructions continue to be keyed by `TypeId` and the full list of input `VariableId`s. The two cases are now structurally separate and cannot collide.

---

## Related issue or discussion (if any)

None.

---

## Additional context

The new `Construction` enum derives `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash`, making it a well-typed, self-documenting replacement for the ad-hoc tuple key.