### PR TITLE
fix(formatter): drop trailing empty lines when building the output

### DIFF
--- a/corelib/src/debug.cairo
+++ b/corelib/src/debug.cairo
@@ -144,4 +144,3 @@ pub fn print_byte_array_as_string(self: @ByteArray) {
     self.serialize(ref serialized);
     print(serialized)
 }
-

--- a/corelib/src/iter/traits/collect.cairo
+++ b/corelib/src/iter/traits/collect.cairo
@@ -246,4 +246,3 @@ pub trait Extend<T, A> {
         ref self: T, iter: I,
     );
 }
-

--- a/corelib/src/metaprogramming.cairo
+++ b/corelib/src/metaprogramming.cairo
@@ -54,4 +54,3 @@ pub(crate) trait SnapRemove<T> {
 impl SnapRemoveSnap<T> of SnapRemove<@T> {
     type Result = T;
 }
-

--- a/corelib/src/pedersen.cairo
+++ b/corelib/src/pedersen.cairo
@@ -97,4 +97,3 @@ impl HashStateImpl of crate::hash::HashStateTrait<HashState> {
         self.state
     }
 }
-

--- a/corelib/src/test/language_features/const_test.cairo
+++ b/corelib/src/test/language_features/const_test.cairo
@@ -296,4 +296,3 @@ fn test_starknet_consts() {
             .unbox() == STARKNET_CONSTS,
     );
 }
-

--- a/corelib/src/test/plugins_test.cairo
+++ b/corelib/src/test/plugins_test.cairo
@@ -147,4 +147,3 @@ fn test_long_enum15_deserialize() {
         'expected O',
     );
 }
-

--- a/corelib/src/test/sha256_test.cairo
+++ b/corelib/src/test/sha256_test.cairo
@@ -169,4 +169,3 @@ fn sha256_as_u256(input: ByteArray) -> u256 {
     }
     value
 }
-

--- a/corelib/src/traits.cairo
+++ b/corelib/src/traits.cairo
@@ -1131,4 +1131,3 @@ pub trait Felt252DictValue<T> {
     #[must_use]
     fn zero_default() -> T nopanic;
 }
-

--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -644,7 +644,12 @@ impl LineBuilder {
     /// several lines (separated by '\n'), where each line length is
     /// less than max_line_width (if possible).
     pub fn build(&self, max_line_width: usize, tab_size: usize) -> String {
-        self.break_line_tree(max_line_width, tab_size).iter().join("\n") + "\n"
+        let mut lines = self.break_line_tree(max_line_width, tab_size);
+        // Removing extra trailing newlines.
+        while lines.last().is_some_and(|line| line.is_empty()) {
+            lines.pop();
+        }
+        lines.iter().join("\n") + "\n"
     }
     /// Returns the highest protected zone precedence (minimum number) from within all the protected
     /// zones which are direct children of this builder, or None if there are no protected zones

--- a/crates/cairo-lang-formatter/src/test.rs
+++ b/crates/cairo-lang-formatter/src/test.rs
@@ -117,6 +117,15 @@ use crate::{FormatterConfig, get_formatted_file};
     false
 )]
 #[test_case(
+    "test_data/cairo_files/trailing_comment.cairo",
+    "test_data/expected_results/trailing_comment.cairo",
+    false,
+    false,
+    false,
+    false,
+    false
+)]
+#[test_case(
     "test_data/cairo_files/use_merge.cairo",
     "test_data/expected_results/use_merge.cairo",
     true,

--- a/crates/cairo-lang-formatter/test_data/cairo_files/trailing_comment.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/trailing_comment.cairo
@@ -1,0 +1,2 @@
+fn f() {}
+// a trailing comment at end of file

--- a/crates/cairo-lang-formatter/test_data/expected_results/trailing_comment.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/trailing_comment.cairo
@@ -1,0 +1,2 @@
+fn f() {}
+// a trailing comment at end of file

--- a/crates/cairo-lang-starknet/cairo_level_tests/contracts/hello_starknet.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/contracts/hello_starknet.cairo
@@ -24,4 +24,3 @@ mod hello_starknet {
         }
     }
 }
-

--- a/tests/bug_samples/merge_const_member.cairo
+++ b/tests/bug_samples/merge_const_member.cairo
@@ -41,4 +41,3 @@ fn const_with_snap() {
 
     revoke(x);
 }
-


### PR DESCRIPTION
## Summary

Fixes the Cairo formatter to strip extra trailing newlines from formatted output. Previously, files ending with a trailing comment (or other constructs that produced empty trailing lines) would have an extra blank line appended. The `LineBuilder::build` method now removes any empty trailing lines before joining, ensuring the output ends with exactly one newline. Trailing newlines have also been removed from several corelib and test files to reflect the corrected formatter behavior.

A new formatter test case (`trailing_comment.cairo`) is added to cover files that end with a comment and no trailing blank line.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The formatter was emitting an extra trailing newline at the end of files that ended with certain constructs such as trailing comments. This caused formatted output to differ from the expected single-newline termination, producing spurious diffs when formatting was applied repeatedly.

---

## What was the behavior or documentation before?

Files ending with a trailing comment or similar construct would be formatted with an extra blank line appended at the end of the file.

---

## What is the behavior or documentation after?

The formatter strips any empty trailing lines before emitting output, so files end with exactly one newline regardless of their content. Files that previously had a spurious trailing newline in the corelib and test suite have been corrected to match.

---

## Related issue or discussion (if any)

None specified.

---

## Additional context

The fix is localized to `LineBuilder::build` in `formatter_impl.rs`, where a loop removes empty strings from the end of the line vector before joining them with `"\n"` and appending the final newline.