### PR TITLE
fix(semantic): canonicalize felt252 inside NonZero when matching const patterns

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -192,6 +192,12 @@ const NZ_FELT_FIELD_NEG_ONE: NonZero<felt252> =
     .try_into()
     .unwrap();
 const VALID_EQ_NONZERO_FELT_CROSS_FORM: () = assert(NZ_FELT_NEG_ONE == NZ_FELT_FIELD_NEG_ONE);
+const VALID_MATCH_NONZERO_FELT_CROSS_FORM: () = assert(
+    match NZ_FELT_NEG_ONE {
+        0x800000000000011000000000000000000000000000000000000000000000000 => true,
+        _ => false,
+    },
+);
 const VALID_EQ_TUPLE_FELT_CROSS_FORM: () = assert(
     (-1_felt252, 5) == (0x800000000000011000000000000000000000000000000000000000000000000, 5),
 );
@@ -295,21 +301,21 @@ note: In `test::assert`:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2129]: Constant calculation depth exceeded.
- --> lib.cairo:86:43
+ --> lib.cairo:92:43
 const FUNC_CALC_STACK_EXCEEDED: felt252 = call_myself();
                                           ^^^^^^^^^^^^^
 
 error[E2130]: Failed to calculate constant.
- --> lib.cairo:93:37
+ --> lib.cairo:99:37
 const NON_ZERO_ZERO: NonZero<u64> = my_unwrap(ZERO.try_into());
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: In `test::my_unwrap::<core::zeroable::NonZero::<core::integer::u64>>`:
-  --> lib.cairo:99:17
+  --> lib.cairo:105:17
         None => core::panic_with_felt252('bad value'),
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2128]: Failed to calculate constant.
- --> lib.cairo:105:9
+ --> lib.cairo:111:9
         core::panic_with_felt252('should fail')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -1162,11 +1162,10 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
         match pattern {
             Pattern::Missing(_) | Pattern::StringLiteral(_) => None,
             Pattern::Otherwise(_) => Some(()),
-            Pattern::Literal(v) => require(self.eq_in_type(
-                &numeric_arg_value(db, value)?,
-                &v.literal.value,
-                value.ty(db).ok()?,
-            )),
+            Pattern::Literal(v) => {
+                let arg = NumericArg::try_new(db, value)?;
+                require(self.eq_in_type(&arg.v, &v.literal.value, arg.ty))
+            }
             Pattern::Variable(pattern) => {
                 self.vars.insert(VarId::Local(pattern.var.id), value);
                 Some(())
@@ -1261,29 +1260,25 @@ impl<'db, 'r> std::ops::Deref for ConstantEvaluateContext<'db, 'r, '_> {
 struct NumericArg<'db> {
     /// The arg's integer value.
     v: BigInt,
-    /// The arg's type.
+    /// The arg's type, unwrapping `NonZero` types.
     ty: TypeId<'db>,
 }
 impl<'db> NumericArg<'db> {
+    /// Extracts the numeric value and its type from `arg`, unwrapping `NonZero` values and reading
+    /// a struct of 2 values as a `u256`.
     fn try_new(db: &'db dyn Database, arg: ConstValueId<'db>) -> Option<Self> {
-        Some(Self { ty: arg.ty(db).ok()?, v: numeric_arg_value(db, arg)? })
-    }
-}
-
-/// Helper for creating a `NumericArg` value.
-/// This includes unwrapping of `NonZero` values and struct of 2 values as a `u256`.
-fn numeric_arg_value<'db>(db: &'db dyn Database, value: ConstValueId<'db>) -> Option<BigInt> {
-    match value.long(db) {
-        ConstValue::Int(value, _) => Some(value.clone()),
-        ConstValue::Struct(v, _) => {
-            if let [low, high] = &v[..] {
-                Some(low.to_int(db)? + (high.to_int(db)? << 128))
-            } else {
-                None
+        match arg.long(db) {
+            ConstValue::Int(v, ty) => Some(Self { v: v.clone(), ty: *ty }),
+            ConstValue::Struct(v, ty) if *ty == db.core_info().u256 => {
+                if let [low, high] = &v[..] {
+                    Some(Self { v: low.to_int(db)? + (high.to_int(db)? << 128), ty: *ty })
+                } else {
+                    None
+                }
             }
+            ConstValue::NonZero(inner) => Self::try_new(db, *inner),
+            _ => None,
         }
-        ConstValue::NonZero(const_value) => numeric_arg_value(db, *const_value),
-        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes constant evaluation of `NonZero` values in match patterns. Previously, when a `NonZero`-wrapped value appeared as the scrutinee in a `match` expression during constant evaluation, the pattern matching logic did not unwrap the `NonZero` layer before comparing against literal patterns, causing the match to fail. The fix propagates the `NonZero`-unwrapping behavior (already present in `NumericArg::try_new`) into the literal pattern matching branch, and consolidates the `numeric_arg_value` free function into `NumericArg::try_new` so that the type is correctly carried through after unwrapping.

A new test case (`VALID_MATCH_NONZERO_FELT_CROSS_FORM`) is added to verify that matching a `NonZero<felt252>` constant against its field-equivalent hex literal evaluates correctly.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Matching a `NonZero`-wrapped constant value against a literal pattern in a `const` context would silently fail because the pattern matching code called `numeric_arg_value` (which discarded the type after unwrapping `NonZero`) rather than `NumericArg::try_new` (which preserves the unwrapped type). This meant cross-form equality checks using `match` on `NonZero` values were broken at compile-time constant evaluation.

---

## What was the behavior or documentation before?

A `const` expression using `match` on a `NonZero<felt252>` value against a literal pattern would not evaluate correctly, even when the values were semantically equal.

---

## What is the behavior or documentation after?

`NonZero`-wrapped values are correctly unwrapped during literal pattern matching in constant evaluation, and the unwrapped type is preserved. The `numeric_arg_value` helper is removed in favor of the unified `NumericArg::try_new`.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The line number shifts in the test snapshot reflect the insertion of the new `VALID_MATCH_NONZERO_FELT_CROSS_FORM` constant (6 lines added before the error-producing constants).