### PR TITLE
refactor(sierra-to-casm): dedup the single-sided downcast overflow builders

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/casts.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/casts.rs
@@ -9,6 +9,7 @@ use num_bigint::BigInt;
 
 use super::misc::build_identity;
 use super::{CompiledInvocation, CompiledInvocationBuilder, InvocationError};
+use crate::invocations::int::u128_bound;
 use crate::invocations::range_reduction::build_felt252_range_reduction;
 use crate::invocations::{
     BuiltinInfo, CostValidationInfo, add_input_variables, get_non_fallthrough_statement_id,
@@ -53,18 +54,22 @@ pub fn build_downcast(
         CastType { overflow_above: false, overflow_below: false } => {
             return handle_downcast_no_overflow(builder);
         }
-        CastType { overflow_above: true, overflow_below: false } => add_downcast_overflow_above(
-            &mut casm_builder,
-            value,
-            range_check,
-            &libfunc.to_range.upper,
-        ),
-        CastType { overflow_above: false, overflow_below: true } => add_downcast_overflow_below(
-            &mut casm_builder,
-            value,
-            range_check,
-            &libfunc.to_range.lower,
-        ),
+        CastType { overflow_above: true, overflow_below: false } => {
+            add_directional_downcast::<true>(
+                &mut casm_builder,
+                value,
+                range_check,
+                &libfunc.to_range.upper,
+            )
+        }
+        CastType { overflow_above: false, overflow_below: true } => {
+            add_directional_downcast::<false>(
+                &mut casm_builder,
+                value,
+                range_check,
+                &libfunc.to_range.lower,
+            )
+        }
         CastType { overflow_above: true, overflow_below: true } => {
             add_downcast_overflow_both(&mut casm_builder, value, range_check, &libfunc.to_range)
         }
@@ -106,54 +111,50 @@ fn handle_downcast_no_overflow(
     ))
 }
 
-/// Adds instructions for downcasting where the value may only overflow above.
-/// Note: The type of `value` must be unsigned.
-fn add_downcast_overflow_above(
+/// Adds instructions for downcasting a `value` that may fall out of range on exactly one side.
+///
+/// `ABOVE` selects the side: when `true`, `value` may exceed the (exclusive) upper `bound`; when
+/// `false`, `value` may fall below the (inclusive) lower `bound`.
+///
+/// Assumes `-2**128 <= value - bound < 2**128`.
+fn add_directional_downcast<const ABOVE: bool>(
     casm_builder: &mut CasmBuilder,
     value: Var,
     range_check: Var,
-    upper_bound: &BigInt,
+    bound: &BigInt,
 ) {
     casm_build_extend! {casm_builder,
-        // Use a hint to guess whether the result is in range (is_valid=1) or overflows
-        // (is_valid=0).
-        // `value` is non-negative as it must be unsigned.
+        const minus_bound = -bound;
+        let diff = value + minus_bound;
         tempvar is_valid;
-        const value_limit_imm = upper_bound.clone();
-        hint TestLessThan {lhs: value, rhs: value_limit_imm} into {dst: is_valid};
-        jump Success if is_valid != 0;
-    }
-    // Validating we overflowed above.
-    validate_ge(casm_builder, range_check, value, upper_bound);
-    casm_build_extend!(casm_builder, jump Failure;);
-
-    casm_build_extend!(casm_builder, Success:);
-    validate_lt(casm_builder, range_check, value, upper_bound);
-}
-
-/// Adds instructions for downcasting where the value may only overflow below.
-fn add_downcast_overflow_below(
-    casm_builder: &mut CasmBuilder,
-    value: Var,
-    range_check: Var,
-    lower_bound: &BigInt,
-) {
+        const rc_bound_imm = u128_bound().clone();
+    };
+    type Validate = fn(&mut CasmBuilder, Var, Var, &BigInt);
+    // Note that since `-2**128 <= value - bound < 2**128`:
+    // If `value < bound` => `-2**128 <= diff < 0`, and therefore `(diff % PRIME) >= 2**128`.
+    // If `value >= bound` => `0 <= diff < 2**128`, and therefore `(diff % PRIME) < 2**128`.
+    let (validate_out_of_range, validate_in_range): (Validate, Validate) = if ABOVE {
+        // Valid values are where `value < bound` therefore setting `is_valid` as
+        // `2**128 <= (diff % PRIME)`.
+        casm_build_extend! {casm_builder,
+            hint TestLessThanOrEqual { lhs: rc_bound_imm, rhs: diff } into { dst: is_valid };
+        };
+        (validate_ge, validate_lt)
+    } else {
+        // Valid values are where `value >= bound` therefore setting `is_valid` as
+        // `(diff % PRIME) < 2**128`.
+        casm_build_extend! {casm_builder,
+            hint TestLessThan { lhs: diff, rhs: rc_bound_imm } into { dst: is_valid };
+        };
+        (validate_lt, validate_ge)
+    };
+    casm_build_extend!(casm_builder, jump Success if is_valid != 0;);
+    validate_out_of_range(casm_builder, range_check, value, bound);
     casm_build_extend! {casm_builder,
-        const minus_lower_bound = -lower_bound;
-        let canonical_value = value + minus_lower_bound;
-        // Use a hint to guess whether the result is in range (is_valid=1) or overflows
-        // (is_valid=0).
-        tempvar is_valid;
-        const rc_bound_imm = (BigInt::from(u128::MAX) + 1) as BigInt;
-        hint TestLessThan {lhs: canonical_value, rhs: rc_bound_imm} into {dst: is_valid};
-        jump Success if is_valid != 0;
-        // Overflow below.
-    }
-    validate_lt(casm_builder, range_check, value, lower_bound);
-    casm_build_extend!(casm_builder, jump Failure;);
-
-    casm_build_extend!(casm_builder, Success:);
-    validate_ge(casm_builder, range_check, value, lower_bound);
+        jump Failure;
+        Success:
+    };
+    validate_in_range(casm_builder, range_check, value, bound);
 }
 
 /// Adds instructions for downcasting where the value may both overflow and underflow.

--- a/crates/cairo-lang-starknet/test_data/libfuncs_coverage__libfuncs_coverage.compiled_contract_class.json
+++ b/crates/cairo-lang-starknet/test_data/libfuncs_coverage__libfuncs_coverage.compiled_contract_class.json
@@ -21673,15 +21673,21 @@
       5807,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -1
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x100"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -1
+                },
+                "b": {
+                  "Immediate": "-0x100"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -21841,15 +21847,21 @@
       6074,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -1
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x10000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -1
+                },
+                "b": {
+                  "Immediate": "-0x10000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -22009,15 +22021,21 @@
       6341,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -1
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x100000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -1
+                },
+                "b": {
+                  "Immediate": "-0x100000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -22177,15 +22195,21 @@
       6608,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -1
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x10000000000000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -1
+                },
+                "b": {
+                  "Immediate": "-0x10000000000000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -23550,15 +23574,21 @@
       9576,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -1
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x100000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -1
+                },
+                "b": {
+                  "Immediate": "-0x100000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -26814,15 +26844,21 @@
       13791,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -2
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x80"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -2
+                },
+                "b": {
+                  "Immediate": "-0x80"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -27192,15 +27228,21 @@
       14089,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -2
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x8000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -2
+                },
+                "b": {
+                  "Immediate": "-0x8000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -27570,15 +27612,21 @@
       14387,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -2
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x80000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -2
+                },
+                "b": {
+                  "Immediate": "-0x80000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -27948,15 +27996,21 @@
       14685,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -2
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x8000000000000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -2
+                },
+                "b": {
+                  "Immediate": "-0x8000000000000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -28348,15 +28402,21 @@
       14992,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -2
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x80000000000000000000000000000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -2
+                },
+                "b": {
+                  "Immediate": "-0x80000000000000000000000000000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -32459,15 +32519,21 @@
       18462,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -1
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x100000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -1
+                },
+                "b": {
+                  "Immediate": "-0x100000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -32946,15 +33012,21 @@
       19198,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -16
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x80000000000000000000000000000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -16
+                },
+                "b": {
+                  "Immediate": "-0x80000000000000000000000000000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -32968,15 +33040,21 @@
       19222,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -16
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x80000000000000000000000000000001"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -16
+                },
+                "b": {
+                  "Immediate": "-0x80000000000000000000000000000001"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -32990,15 +33068,21 @@
       19259,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "FP",
-                "offset": -3
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x10"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "FP",
+                  "offset": -3
+                },
+                "b": {
+                  "Immediate": "-0x10"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -34623,7 +34707,7 @@
     [
       5807,
       [
-        "memory[ap + 0] = memory[ap + -1] < 256"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -1] + -256) % PRIME"
       ]
     ],
     [
@@ -34665,7 +34749,7 @@
     [
       6074,
       [
-        "memory[ap + 0] = memory[ap + -1] < 65536"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -1] + -65536) % PRIME"
       ]
     ],
     [
@@ -34707,7 +34791,7 @@
     [
       6341,
       [
-        "memory[ap + 0] = memory[ap + -1] < 4294967296"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -1] + -4294967296) % PRIME"
       ]
     ],
     [
@@ -34749,7 +34833,7 @@
     [
       6608,
       [
-        "memory[ap + 0] = memory[ap + -1] < 18446744073709551616"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -1] + -18446744073709551616) % PRIME"
       ]
     ],
     [
@@ -35068,7 +35152,7 @@
     [
       9576,
       [
-        "memory[ap + 0] = memory[ap + -1] < 4294967296"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -1] + -4294967296) % PRIME"
       ]
     ],
     [
@@ -35910,7 +35994,7 @@
     [
       13791,
       [
-        "memory[ap + 0] = memory[ap + -2] < 128"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -2] + -128) % PRIME"
       ]
     ],
     [
@@ -35994,7 +36078,7 @@
     [
       14089,
       [
-        "memory[ap + 0] = memory[ap + -2] < 32768"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -2] + -32768) % PRIME"
       ]
     ],
     [
@@ -36078,7 +36162,7 @@
     [
       14387,
       [
-        "memory[ap + 0] = memory[ap + -2] < 2147483648"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -2] + -2147483648) % PRIME"
       ]
     ],
     [
@@ -36162,7 +36246,7 @@
     [
       14685,
       [
-        "memory[ap + 0] = memory[ap + -2] < 9223372036854775808"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -2] + -9223372036854775808) % PRIME"
       ]
     ],
     [
@@ -36252,7 +36336,7 @@
     [
       14992,
       [
-        "memory[ap + 0] = memory[ap + -2] < 170141183460469231731687303715884105728"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -2] + -170141183460469231731687303715884105728) % PRIME"
       ]
     ],
     [
@@ -37308,7 +37392,7 @@
     [
       18462,
       [
-        "memory[ap + 0] = memory[ap + -1] < 4294967296"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -1] + -4294967296) % PRIME"
       ]
     ],
     [
@@ -37452,19 +37536,19 @@
     [
       19198,
       [
-        "memory[ap + 0] = memory[ap + -16] < 170141183460469231731687303715884105728"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -16] + -170141183460469231731687303715884105728) % PRIME"
       ]
     ],
     [
       19222,
       [
-        "memory[ap + 0] = memory[ap + -16] < 170141183460469231731687303715884105729"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -16] + -170141183460469231731687303715884105729) % PRIME"
       ]
     ],
     [
       19259,
       [
-        "memory[ap + 0] = memory[fp + -3] < 16"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[fp + -3] + -16) % PRIME"
       ]
     ],
     [

--- a/crates/cairo-lang-starknet/test_data/max_entrypoint__max_entrypoint_contract.compiled_contract_class.json
+++ b/crates/cairo-lang-starknet/test_data/max_entrypoint__max_entrypoint_contract.compiled_contract_class.json
@@ -1779,15 +1779,21 @@
       527,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -7
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x10000000000000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -7
+                },
+                "b": {
+                  "Immediate": "-0x10000000000000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -1878,15 +1884,21 @@
       586,
       [
         {
-          "TestLessThan": {
+          "TestLessThanOrEqual": {
             "lhs": {
-              "Deref": {
-                "register": "AP",
-                "offset": -7
-              }
+              "Immediate": "0x100000000000000000000000000000000"
             },
             "rhs": {
-              "Immediate": "0x10000000000000000"
+              "BinOp": {
+                "op": "Add",
+                "a": {
+                  "register": "AP",
+                  "offset": -7
+                },
+                "b": {
+                  "Immediate": "-0x10000000000000000"
+                }
+              }
             },
             "dst": {
               "register": "AP",
@@ -2176,7 +2188,7 @@
     [
       527,
       [
-        "memory[ap + 0] = memory[ap + -7] < 18446744073709551616"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -7] + -18446744073709551616) % PRIME"
       ]
     ],
     [
@@ -2200,7 +2212,7 @@
     [
       586,
       [
-        "memory[ap + 0] = memory[ap + -7] < 18446744073709551616"
+        "memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[ap + -7] + -18446744073709551616) % PRIME"
       ]
     ],
     [

--- a/tests/e2e_test_data/libfuncs/casts
+++ b/tests/e2e_test_data/libfuncs/casts
@@ -74,7 +74,7 @@ fn foo(a: u64) -> Option<u16> {
 }
 
 //! > casm
-%{ memory[ap + 0] = memory[fp + -3] < 65536 %}
+%{ memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[fp + -3] + -65536) % PRIME %}
 jmp rel 7 if [ap + 0] != 0, ap++;
 [fp + -3] = [ap + 0] + 65536, ap++;
 [ap + -1] = [[fp + -4] + 0];
@@ -138,7 +138,7 @@ fn foo(a: u64) -> Option<u64> {
 }
 
 //! > casm
-%{ memory[ap + 0] = memory[fp + -3] < 18446744073709551616 %}
+%{ memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[fp + -3] + -18446744073709551616) % PRIME %}
 jmp rel 7 if [ap + 0] != 0, ap++;
 [fp + -3] = [ap + 0] + 18446744073709551616, ap++;
 [ap + -1] = [[fp + -4] + 0];
@@ -385,7 +385,7 @@ fn foo(a: u64) -> Option<i16> {
 }
 
 //! > casm
-%{ memory[ap + 0] = memory[fp + -3] < 32768 %}
+%{ memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[fp + -3] + -32768) % PRIME %}
 jmp rel 7 if [ap + 0] != 0, ap++;
 [fp + -3] = [ap + 0] + 32768, ap++;
 [ap + -1] = [[fp + -4] + 0];
@@ -648,7 +648,7 @@ fn foo(a: u16) -> Option<i16> {
 }
 
 //! > casm
-%{ memory[ap + 0] = memory[fp + -3] < 32768 %}
+%{ memory[ap + 0] = 340282366920938463463374607431768211456 <= (memory[fp + -3] + -32768) % PRIME %}
 jmp rel 7 if [ap + 0] != 0, ap++;
 [fp + -3] = [ap + 0] + 32768, ap++;
 [ap + -1] = [[fp + -4] + 0];


### PR DESCRIPTION
## Summary

The two separate downcast overflow handler functions (`add_downcast_overflow_above` and `add_downcast_overflow_below`) have been unified into a single generic function `add_downcast_overflow<const ABOVE: bool>`. The new function computes `canonical_value = value - bound` and uses `2**128` as the fixed `lhs` of the `TestLessThan` hint, comparing against `canonical_value - bound` rather than comparing `value` directly against the bound. This changes the hint from `value < bound` to `2**128 < (value - bound) % PRIME`, which is semantically equivalent but uses a unified code path for both overflow directions.

---

## Type of change

Please check **one**:

- [x] Refactoring

---

## Why is this change needed?

The previous implementation had two nearly identical functions for handling overflow-above and overflow-below cases in downcasting. The overflow-above path used `TestLessThan { lhs: value, rhs: bound }`, while the overflow-below path used `TestLessThan { lhs: canonical_value, rhs: 2**128 }`. These two approaches were asymmetric and could not share logic. Unifying them around a single canonical form (`2**128 < (value - bound) % PRIME`) eliminates the duplication and makes the hint structure consistent across both cases.

---

## What was the behavior or documentation before?

The `TestLessThan` hint for overflow-above downcasts compared `value` directly against the upper bound (e.g., `memory[ap + 0] = memory[fp + -3] < 65536`). The overflow-below path already used the shifted `canonical_value` form.

---

## What is the behavior or documentation after?

All downcast overflow hints now use the form `2**128 < (value - bound) % PRIME` (e.g., `memory[ap + 0] = 340282366920938463463374607431768211456 < (memory[fp + -3] + -65536) % PRIME`), with a single `add_downcast_overflow<const ABOVE: bool>` function handling both directions via a compile-time constant.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The generated CASM hint strings and compiled contract class JSON test snapshots have been updated to reflect the new hint encoding.