### PR TITLE
(test): Added a test for early panic with multiple sideeffects

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/test_data/early_unsafe_panic
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/early_unsafe_panic
@@ -173,3 +173,59 @@ Statements:
 End:
   Match(match core::panics::unsafe_panic() {
   })
+
+//! > ==========================================================================
+
+//! > Test two side-effecting statements in a row before the dead tail are preserved.
+
+//! > test_runner_name
+test_early_unsafe_panic
+
+//! > function_code
+use core::debug::PrintTrait;
+
+fn foo(a: Option<u32>) -> u32 {
+    'error1'.print();
+    'error2'.print();
+    core::panic_with_felt252('error3')
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > before
+Parameters: v0: core::option::Option::<core::integer::u32>
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 111542220583473
+  (v2: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v3: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v2, v1)
+  () <- core::debug::print(v3)
+  (v4: core::felt252) <- 111542220583474
+  (v5: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v6: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v5, v4)
+  () <- core::debug::print(v6)
+  (v7: core::never) <- core::panic_with_const_felt252::<111542220583475>()
+End:
+  Match(match_enum(v7) {
+  })
+
+//! > after
+Parameters: v0: core::option::Option::<core::integer::u32>
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 111542220583473
+  (v2: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v3: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v2, v1)
+  () <- core::debug::print(v3)
+  (v4: core::felt252) <- 111542220583474
+  (v5: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v6: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v5, v4)
+  () <- core::debug::print(v6)
+End:
+  Match(match core::panics::unsafe_panic() {
+  })


### PR DESCRIPTION
## Summary

Adds a test case to `early_unsafe_panic` that verifies two consecutive side-effecting statements (calls to `core::debug::print`) appearing before a dead tail are both preserved when the optimization runs. The test confirms that the `before` block retains both `print` calls and the final `panic_with_const_felt252`, and the `after` block retains both `print` calls while replacing the tail with `unsafe_panic`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The existing test coverage for the `early_unsafe_panic` optimization did not include a case with multiple sequential side-effecting statements before the dead tail. Without this test, a regression that incorrectly drops one of the side-effecting calls could go undetected.

---

## What was the behavior or documentation before?

The test data only covered single side-effecting statement scenarios before the dead tail, leaving the multi-statement case untested.

---

## What is the behavior or documentation after?

A new test case exercises the scenario where two `print` calls precede a `panic_with_felt252`, ensuring both side-effecting statements are preserved in the optimized output and only the tail is replaced with `unsafe_panic`.

---

## Related issue or discussion (if any)

None.

---

## Additional context

None.