### PR TITLE
(feat): add staking-contract memory benchmark to dhat_compile

### DIFF
--- a/tests/benches/common/mod.rs
+++ b/tests/benches/common/mod.rs
@@ -26,6 +26,8 @@ use cairo_lang_starknet::starknet_plugin_suite;
 use cairo_lang_test_plugin::{TestsCompilationConfig, compile_test_prepared_db, test_plugin_suite};
 use cairo_lang_test_runner::{TestRunConfig, TestRunner, run_tests};
 
+pub mod staking;
+
 /// Configuration for a benchmarked project.
 pub struct BenchConfig {
     pub name: &'static str,
@@ -37,6 +39,11 @@ pub struct BenchConfig {
     /// `#[cfg(test)]`), which are unrecognized without the test plugin, or when the project
     /// contains only contract code with no program entry point.
     pub sierra_phases: bool,
+    /// If set, only this crate (by name) is compiled as the entry point, instead of every crate
+    /// root in the project. Used for projects whose `cairo_project.toml` registers many dependency
+    /// crate roots (e.g. the staking contract pulls in openzeppelin) but where we only want to
+    /// measure compiling the single top-level crate plus the dependency code it actually reaches.
+    pub main_crate: Option<&'static str>,
 }
 
 /// Returns the list of projects to benchmark across all phases.
@@ -50,24 +57,28 @@ pub fn bench_configs() -> Vec<BenchConfig> {
             path: examples.join("fib.cairo"),
             starknet: false,
             sierra_phases: true,
+            main_crate: None,
         },
         BenchConfig {
             name: "corelib",
             path: root.join("corelib"),
             starknet: false,
             sierra_phases: true,
+            main_crate: None,
         },
         BenchConfig {
             name: "bug_samples",
             path: tests.join("bug_samples"),
             starknet: true,
             sierra_phases: false,
+            main_crate: None,
         },
         BenchConfig {
             name: "cairo_level_tests",
             path: root.join("crates").join("cairo-lang-starknet").join("cairo_level_tests"),
             starknet: true,
             sierra_phases: true,
+            main_crate: None,
         },
     ]
 }
@@ -109,7 +120,28 @@ fn test_run_config() -> TestRunConfig {
 pub fn run_cairo_to_sierra(config: &BenchConfig) -> Program {
     let mut db = build_db(config, false);
     let inputs = setup_project(&mut db, &config.path).unwrap();
-    let diagnostics_reporter = DiagnosticsReporter::ignoring().with_crates(&inputs);
+    // When `main_crate` is set, compile only that crate as the entry point; the other crate roots
+    // registered by `setup_project` stay available as dependencies (resolved on demand) rather than
+    // being eagerly lowered in full.
+    let inputs = match config.main_crate {
+        Some(main) => {
+            let filtered: Vec<_> = inputs
+                .into_iter()
+                .filter(|input| matches!(input, CrateInput::Real { name, .. } if name == main))
+                .collect();
+            assert!(
+                !filtered.is_empty(),
+                "main crate `{main}` not found in {}",
+                config.path.display()
+            );
+            filtered
+        }
+        None => inputs,
+    };
+    // Allow warnings so third-party projects (e.g. the staking contract, which has unused-import
+    // warnings) still compile to Sierra for benchmarking; `ensure` only aborts on real errors.
+    let diagnostics_reporter =
+        DiagnosticsReporter::ignoring().with_crates(&inputs).allow_warnings();
     let crate_ids = CrateInput::into_crate_ids(&db, inputs);
     compile_prepared_db_program(
         &db,

--- a/tests/benches/common/staking.rs
+++ b/tests/benches/common/staking.rs
@@ -1,0 +1,135 @@
+//! StarkWare staking contract benchmark scenario.
+//!
+//! The staking contract (https://github.com/starkware-libs/starknet-staking) is a large real-world
+//! Starknet project, which makes it a useful memory stress test for the front end. It depends on
+//! openzeppelin and starkware_utils, so it isn't a self-contained crate.
+//!
+//! The compiler can't read Scarb manifests, so it needs a `cairo_project.toml`. Rather than invoke
+//! Scarb at benchmark time (it isn't available on CI, and we can't rely on a pre-populated Scarb
+//! cache either), we generated one *once* locally from `scarb metadata` and checked it in as
+//! `staking/cairo_project.toml.template`, with the per-repository source roots replaced by
+//! `{STAKING_SRC}` / `{OZ_SRC}` / `{UTILS_SRC}` placeholders.
+//!
+//! At benchmark time [`prepare_staking`] needs only `git`: it shallow-clones all three pinned
+//! sources (the contract plus its two dependency repos) and substitutes the placeholders with their
+//! `src` directories to produce a usable project file. The dependency revisions match the staking
+//! `Scarb.lock`, and the in-repo `src` trees were verified byte-identical to the published registry
+//! sources, so this compiles exactly what Scarb would resolve. The whole checkout (clones + project
+//! file) is removed when the returned [`StakingCheckout`] is dropped.
+//!
+//! The scenario is best-effort: if `git` is missing or the network is unavailable (e.g. on CI),
+//! preparation logs why and yields `None` so the rest of the benchmark still runs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::BenchConfig;
+
+const STAKING_REPO_URL: &str = "https://github.com/starkware-libs/starknet-staking";
+/// Tag `@staking/contracts-v1.0.1-dev.978` on `main`. Pinned (rather than tracking a branch) so the
+/// measured heap numbers stay comparable across runs.
+const STAKING_REV: &str = "6467407bb81862b30ad44d6028351032a5c369b8";
+const OPENZEPPELIN_REPO_URL: &str = "https://github.com/OpenZeppelin/cairo-contracts";
+/// Tag `v2.0.0`.
+const OPENZEPPELIN_REV: &str = "f1c15a30a44311166e0368081c5f79ab5a02c1d3";
+const STARKWARE_UTILS_REPO_URL: &str = "https://github.com/starkware-libs/starkware-starknet-utils";
+/// Matches the `starkware_utils` revision pinned in the staking `Scarb.lock`.
+const STARKWARE_UTILS_REV: &str = "c19a9487eb7377a147a63189bc8dd4c126b61522";
+/// The checked-in `cairo_project.toml`, generated once from `scarb metadata` (see module docs). Its
+/// source roots are the `{STAKING_SRC}` / `{OZ_SRC}` / `{UTILS_SRC}` placeholders.
+const STAKING_PROJECT_TEMPLATE: &str = include_str!("../staking/cairo_project.toml.template");
+
+/// A throwaway checkout of the staking contract, prepared for benchmarking. The underlying
+/// directory (source clones + generated `cairo_project.toml`) is deleted on drop, so all paths
+/// created by [`prepare_staking`] are cleaned up even if the benchmark panics mid-run.
+pub struct StakingCheckout {
+    dir: PathBuf,
+}
+
+impl StakingCheckout {
+    /// Builds the [`BenchConfig`] pointing at this checkout. Only the `staking` crate is compiled
+    /// as the entry point; openzeppelin/starkware_utils are reached as dependencies.
+    pub fn config(&self) -> BenchConfig {
+        BenchConfig {
+            name: "staking",
+            path: self.dir.clone(),
+            starknet: true,
+            sierra_phases: false,
+            main_crate: Some("staking"),
+        }
+    }
+}
+
+impl Drop for StakingCheckout {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Clones the pinned staking contract and its dependency repos under `dir`, then writes a
+/// `cairo_project.toml` describing the staking-contract-only compilation. Returns `None` (after
+/// cleaning up any partial checkout) if any step fails, so the scenario is simply skipped.
+pub fn prepare_staking(dir: &Path) -> Option<StakingCheckout> {
+    // Start from a clean slate: a leftover dir from an aborted run would break `git init`.
+    let _ = std::fs::remove_dir_all(dir);
+
+    let result = clone_sources(dir).and_then(|()| write_cairo_project(dir));
+    match result {
+        Ok(()) => Some(StakingCheckout { dir: dir.to_path_buf() }),
+        Err(e) => {
+            eprintln!("dhat: skipping staking scenario: {e}");
+            let _ = std::fs::remove_dir_all(dir);
+            None
+        }
+    }
+}
+
+/// Shallow-clones the contract and both dependency repos into fixed subdirectories of `dir`
+/// (`staking`, `openzeppelin`, `starkware_utils`), matching the placeholders in the project
+/// template.
+fn clone_sources(dir: &Path) -> Result<(), String> {
+    clone_repo(STAKING_REPO_URL, STAKING_REV, &dir.join("staking"))?;
+    clone_repo(OPENZEPPELIN_REPO_URL, OPENZEPPELIN_REV, &dir.join("openzeppelin"))?;
+    clone_repo(STARKWARE_UTILS_REPO_URL, STARKWARE_UTILS_REV, &dir.join("starkware_utils"))?;
+    Ok(())
+}
+
+/// Shallow-fetches exactly `git_ref` (a commit SHA or tag) from `url` into `dest`. Fetching the
+/// single revision directly (rather than `git clone`) avoids downloading unrelated history.
+fn clone_repo(url: &str, git_ref: &str, dest: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(dest)
+        .map_err(|e| format!("failed to create {}: {e}", dest.display()))?;
+    // Initialize an empty repo in `dest`, fetch just the pinned revision, then check it out.
+    let steps: [&[&str]; 3] = [
+        &["init", "-q"],
+        &["fetch", "-q", "--depth", "1", url, git_ref],
+        &["-c", "advice.detachedHead=false", "checkout", "-q", "FETCH_HEAD"],
+    ];
+    for args in steps {
+        let status = Command::new("git")
+            .current_dir(dest)
+            .args(args)
+            .status()
+            .map_err(|e| format!("failed to run git in {}: {e}", dest.display()))?;
+        if !status.success() {
+            return Err(format!("`git {}` failed in {}", args.join(" "), dest.display()));
+        }
+    }
+    Ok(())
+}
+
+/// Substitutes the template's source-root placeholders with the cloned repositories' `src`
+/// directories and writes `<dir>/cairo_project.toml`.
+fn write_cairo_project(dir: &Path) -> Result<(), String> {
+    // The template embeds these roots inside double-quoted TOML strings, so escape them — chiefly
+    // so Windows backslashes aren't interpreted as TOML escape sequences.
+    let toml_path = |subdir: &str| {
+        dir.join(subdir).to_string_lossy().replace('\\', "\\\\").replace('"', "\\\"")
+    };
+    let content = STAKING_PROJECT_TEMPLATE
+        .replace("{STAKING_SRC}", &toml_path("staking"))
+        .replace("{OZ_SRC}", &toml_path("openzeppelin"))
+        .replace("{UTILS_SRC}", &toml_path("starkware_utils"));
+    let path = dir.join("cairo_project.toml");
+    std::fs::write(&path, content).map_err(|e| format!("failed to write {}: {e}", path.display()))
+}

--- a/tests/benches/dhat_compile.rs
+++ b/tests/benches/dhat_compile.rs
@@ -21,6 +21,7 @@ static GLOBAL: dhat::Alloc = dhat::Alloc;
 
 mod common;
 
+use common::staking::prepare_staking;
 use common::{bench_configs, run_cairo_to_sierra, run_cairo_to_testing, run_sierra_to_casm};
 
 /// Cargo's target directory, used to place bench outputs alongside `target/`. Honors
@@ -46,22 +47,21 @@ struct Sample {
     stats: HeapStats,
 }
 
-/// Runs `f` under a fresh `dhat::Profiler` writing to `<dir>/dhat-heap-<phase>-<project>.json`,
-/// then appends a `Sample` to `out`. No-ops when `filter` is `Some` and doesn't substring-match
-/// the combined `<phase>-<project>` scenario name. The closure's return value is discarded.
-fn record_scenario<R>(
+/// Whether the `<phase>-<project>` scenario passes `filter` (always matches when `filter` is
+/// `None`). Single source of truth for the substring match, shared by all the `record_*` helpers.
+fn scenario_matches(filter: Option<&str>, phase: &str, project: &str) -> bool {
+    filter.is_none_or(|needle| format!("{phase}-{project}").contains(needle))
+}
+
+/// Profiles `f` under a fresh `dhat::Profiler` writing to `<dir>/dhat-heap-<phase>-<project>.json`,
+/// then appends a `Sample` to `out`. The closure's return value is discarded.
+fn profile_scenario<R>(
     dir: &Path,
     out: &mut Vec<Sample>,
-    filter: Option<&str>,
     phase: &'static str,
     project: &'static str,
     f: impl FnOnce() -> R,
 ) {
-    if let Some(needle) = filter
-        && !format!("{phase}-{project}").contains(needle)
-    {
-        return;
-    }
     let path = dir.join(format!("dhat-heap-{phase}-{project}.json"));
     eprintln!("dhat: profiling {phase}/{project}");
     let _profiler = dhat::Profiler::builder().file_name(&path).build();
@@ -69,38 +69,94 @@ fn record_scenario<R>(
     out.push(Sample { phase, project, stats: HeapStats::get() });
 }
 
+/// Profiles scenario `<phase>/<project>`, unless it's filtered out. A [`record_scenario_with`]
+/// whose setup is a no-op. Returns whether the scenario matched the filter, so the caller can tell
+/// "filter matched nothing" apart from "a matched scenario produced no sample".
+fn record_scenario<R>(
+    dir: &Path,
+    out: &mut Vec<Sample>,
+    filter: Option<&str>,
+    phase: &'static str,
+    project: &'static str,
+    f: impl FnOnce() -> R,
+) -> bool {
+    record_scenario_with(dir, out, filter, phase, project, || Some(()), |_| f())
+}
+
+/// Like [`record_scenario`], but runs `setup` (un-profiled) just before the profiled compile, and
+/// only once the scenario is known to be selected — so expensive, non-measured preparation (e.g.
+/// cloning the staking sources) is paid for only when needed. If `setup` returns `None` the
+/// scenario is skipped without recording a sample, but still counts as matched so a failed setup
+/// isn't mistaken for a filter typo.
+fn record_scenario_with<S, R>(
+    dir: &Path,
+    out: &mut Vec<Sample>,
+    filter: Option<&str>,
+    phase: &'static str,
+    project: &'static str,
+    setup: impl FnOnce() -> Option<S>,
+    run: impl FnOnce(&S) -> R,
+) -> bool {
+    if !scenario_matches(filter, phase, project) {
+        return false;
+    }
+    if let Some(state) = setup() {
+        profile_scenario(dir, out, phase, project, || run(&state));
+    }
+    true
+}
+
 /// Representative scenarios chosen to sample distinct (project size, domain, phase) combinations
 /// without the full N×M sweep. Each added scenario costs minutes of wall time because dhat
 /// captures a backtrace per allocation; the criterion timing bench (`compile.rs`) still covers
 /// the full matrix.
-fn run_scenarios(dir: &Path, filter: Option<&str>, out: &mut Vec<Sample>) {
+fn run_scenarios(dir: &Path, filter: Option<&str>, out: &mut Vec<Sample>) -> bool {
     let configs = bench_configs();
     let by_name = |name: &str| configs.iter().find(|c| c.name == name).expect(name);
     let fib = by_name("fib");
     let corelib = by_name("corelib");
     let starknet = by_name("cairo_level_tests");
 
+    let mut matched = false;
+
     // Tiny Cairo project, full pipeline — cheap canary.
-    record_scenario(dir, out, filter, "cairo-to-testing", fib.name, || run_cairo_to_testing(fib));
+    matched |= record_scenario(dir, out, filter, "cairo-to-testing", fib.name, || {
+        run_cairo_to_testing(fib)
+    });
 
     // Large pure-Cairo project — front-end + sierra at scale, then sierra-to-casm (codegen).
     // We re-run the cairo-to-sierra compile outside the profiler to capture the Program for the
     // next scenario; the second scenario isolates casm emission. sierra-to-casm only works for
     // non-Starknet programs.
-    record_scenario(dir, out, filter, "cairo-to-sierra", corelib.name, || {
+    matched |= record_scenario(dir, out, filter, "cairo-to-sierra", corelib.name, || {
         run_cairo_to_sierra(corelib)
     });
     let corelib_sierra = run_cairo_to_sierra(corelib);
-    record_scenario(dir, out, filter, "sierra-to-casm", corelib.name, || {
+    matched |= record_scenario(dir, out, filter, "sierra-to-casm", corelib.name, || {
         run_sierra_to_casm(&corelib_sierra)
     });
 
     // Starknet project — exercises contract codegen via the starknet plugin (enabled in build_db
     // when config.starknet is set). We profile only the compile side: the test VM dominates with
     // interpreter allocations that aren't a useful signal for compiler memory regressions.
-    record_scenario(dir, out, filter, "cairo-to-sierra", starknet.name, || {
+    matched |= record_scenario(dir, out, filter, "cairo-to-sierra", starknet.name, || {
         run_cairo_to_sierra(starknet)
     });
+
+    // Large real-world Starknet project (the staking contract). Its sources are cloned by
+    // `prepare_staking` as an un-profiled setup step — run only when this scenario is selected and
+    // just before the profiled compile. A failed clone (e.g. no network) skips it without a sample.
+    matched |= record_scenario_with(
+        dir,
+        out,
+        filter,
+        "cairo-to-sierra",
+        "staking",
+        || prepare_staking(&dir.join("staking-checkout")),
+        |checkout| run_cairo_to_sierra(&checkout.config()),
+    );
+
+    matched
 }
 
 /// Writes `dhat-output.json` in the `customSmallerIsBetter` format consumed by
@@ -139,10 +195,14 @@ fn main() {
     std::fs::create_dir_all(&dir).expect("failed to create dhat output directory");
 
     let mut results = Vec::new();
-    run_scenarios(&dir, filter.as_deref(), &mut results);
+    let matched = run_scenarios(&dir, filter.as_deref(), &mut results);
 
     if results.is_empty() {
-        eprintln!("dhat: no scenarios matched filter");
+        // Distinguish a filter that selected nothing from a matched scenario that was skipped
+        // (e.g. the staking clone failed, which `prepare_staking` already logged).
+        if !matched {
+            eprintln!("dhat: no scenarios matched filter");
+        }
         return;
     }
 

--- a/tests/benches/staking/cairo_project.toml.template
+++ b/tests/benches/staking/cairo_project.toml.template
@@ -1,0 +1,291 @@
+[crate_roots]
+"openzeppelin 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/src"
+"openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/access/src"
+"openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/account/src"
+"openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/finance/src"
+"openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/governance/src"
+"openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/introspection/src"
+"openzeppelin_merkle_tree 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/merkle_tree/src"
+"openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/presets/src"
+"openzeppelin_security 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/security/src"
+"openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/token/src"
+"openzeppelin_upgrades 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/upgrades/src"
+"openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)" = "{OZ_SRC}/packages/utils/src"
+"staking 1.14.5 (path+file://{STAKING_SRC}/workspace/apps/staking/contracts/Scarb.toml)" = "{STAKING_SRC}/workspace/apps/staking/contracts/src"
+"starkware_utils 1.0.0 (git+https://github.com/starkware-libs/starkware-starknet-utils?rev=c19a9487eb7377a147a63189bc8dd4c126b61522#c19a9487eb7377a147a63189bc8dd4c126b61522)" = "{UTILS_SRC}/packages/utils/src"
+
+[config.global]
+edition = "2024_07"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin"
+edition = "2024_07"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin]
+discriminator = "openzeppelin 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_access]
+discriminator = "openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_account]
+discriminator = "openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_finance]
+discriminator = "openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_governance]
+discriminator = "openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_introspection]
+discriminator = "openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_merkle_tree]
+discriminator = "openzeppelin_merkle_tree 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_presets]
+discriminator = "openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_security]
+discriminator = "openzeppelin_security 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_token]
+discriminator = "openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_upgrades]
+discriminator = "openzeppelin_upgrades 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_utils]
+discriminator = "openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_access"
+edition = "2024_07"
+
+[config.override."openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_access]
+discriminator = "openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_introspection]
+discriminator = "openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_account"
+edition = "2024_07"
+
+[config.override."openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_account]
+discriminator = "openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_introspection]
+discriminator = "openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_utils]
+discriminator = "openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_finance"
+edition = "2024_07"
+
+[config.override."openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_access]
+discriminator = "openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_finance]
+discriminator = "openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_token]
+discriminator = "openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_governance"
+edition = "2024_07"
+
+[config.override."openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_access]
+discriminator = "openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_account]
+discriminator = "openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_governance]
+discriminator = "openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_introspection]
+discriminator = "openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_token]
+discriminator = "openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_governance 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_utils]
+discriminator = "openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_introspection"
+edition = "2024_07"
+
+[config.override."openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_introspection]
+discriminator = "openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_merkle_tree 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_merkle_tree"
+edition = "2024_07"
+
+[config.override."openzeppelin_merkle_tree 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_merkle_tree 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_merkle_tree]
+discriminator = "openzeppelin_merkle_tree 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_presets"
+edition = "2024_07"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_access]
+discriminator = "openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_account]
+discriminator = "openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_finance]
+discriminator = "openzeppelin_finance 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_introspection]
+discriminator = "openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_presets]
+discriminator = "openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_token]
+discriminator = "openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_upgrades]
+discriminator = "openzeppelin_upgrades 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_presets 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_utils]
+discriminator = "openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_security 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_security"
+edition = "2024_07"
+
+[config.override."openzeppelin_security 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_security 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_security]
+discriminator = "openzeppelin_security 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_token"
+edition = "2024_07"
+
+[config.override."openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_access]
+discriminator = "openzeppelin_access 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_account]
+discriminator = "openzeppelin_account 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_introspection]
+discriminator = "openzeppelin_introspection 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_token]
+discriminator = "openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_token 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_utils]
+discriminator = "openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_upgrades 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_upgrades"
+edition = "2024_07"
+
+[config.override."openzeppelin_upgrades 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_upgrades 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_upgrades]
+discriminator = "openzeppelin_upgrades 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)"]
+name = "openzeppelin_utils"
+edition = "2024_07"
+
+[config.override."openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)".dependencies.openzeppelin_utils]
+discriminator = "openzeppelin_utils 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."staking 1.14.5 (path+file://{STAKING_SRC}/workspace/apps/staking/contracts/Scarb.toml)"]
+name = "staking"
+edition = "2024_07"
+
+[config.override."staking 1.14.5 (path+file://{STAKING_SRC}/workspace/apps/staking/contracts/Scarb.toml)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."staking 1.14.5 (path+file://{STAKING_SRC}/workspace/apps/staking/contracts/Scarb.toml)".dependencies.openzeppelin]
+discriminator = "openzeppelin 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."staking 1.14.5 (path+file://{STAKING_SRC}/workspace/apps/staking/contracts/Scarb.toml)".dependencies.staking]
+discriminator = "staking 1.14.5 (path+file://{STAKING_SRC}/workspace/apps/staking/contracts/Scarb.toml)"
+
+[config.override."staking 1.14.5 (path+file://{STAKING_SRC}/workspace/apps/staking/contracts/Scarb.toml)".dependencies.starkware_utils]
+discriminator = "starkware_utils 1.0.0 (git+https://github.com/starkware-libs/starkware-starknet-utils?rev=c19a9487eb7377a147a63189bc8dd4c126b61522#c19a9487eb7377a147a63189bc8dd4c126b61522)"
+
+[config.override."starkware_utils 1.0.0 (git+https://github.com/starkware-libs/starkware-starknet-utils?rev=c19a9487eb7377a147a63189bc8dd4c126b61522#c19a9487eb7377a147a63189bc8dd4c126b61522)"]
+name = "starkware_utils"
+edition = "2024_07"
+
+[config.override."starkware_utils 1.0.0 (git+https://github.com/starkware-libs/starkware-starknet-utils?rev=c19a9487eb7377a147a63189bc8dd4c126b61522#c19a9487eb7377a147a63189bc8dd4c126b61522)".experimental_features]
+negative_impls = true
+associated_item_constraints = false
+coupons = false
+
+[config.override."starkware_utils 1.0.0 (git+https://github.com/starkware-libs/starkware-starknet-utils?rev=c19a9487eb7377a147a63189bc8dd4c126b61522#c19a9487eb7377a147a63189bc8dd4c126b61522)".dependencies.openzeppelin]
+discriminator = "openzeppelin 2.0.0 (registry+https://scarbs.xyz/)"
+
+[config.override."starkware_utils 1.0.0 (git+https://github.com/starkware-libs/starkware-starknet-utils?rev=c19a9487eb7377a147a63189bc8dd4c126b61522#c19a9487eb7377a147a63189bc8dd4c126b61522)".dependencies.starkware_utils]
+discriminator = "starkware_utils 1.0.0 (git+https://github.com/starkware-libs/starkware-starknet-utils?rev=c19a9487eb7377a147a63189bc8dd4c126b61522#c19a9487eb7377a147a63189bc8dd4c126b61522)"


### PR DESCRIPTION
## Summary

Adds a `cairo-to-sierra-staking` benchmark scenario to the `dhat_compile` benchmark suite. The StarkWare staking contract (`starknet-staking` @ `6467407b`) with its OpenZeppelin (`v2.0.0`) and `starkware_utils` dependencies is shallow-cloned at benchmark time via `git`, a `cairo_project.toml` is generated from a checked-in template (`staking/cairo_project.toml.template`) by substituting `{STAKING_SRC}` / `{OZ_SRC}` / `{UTILS_SRC}` placeholders with the cloned `src` directories, and the resulting project is compiled to Sierra. The checkout is cleaned up automatically when the `StakingCheckout` guard drops.

A new `main_crate: Option<&'static str>` field on `BenchConfig` allows restricting compilation to a single named crate root (here `"staking"`) so that the many OpenZeppelin crate roots registered in the project file are available as on-demand dependencies rather than being eagerly lowered in full. `DiagnosticsReporter` is also switched to `allow_warnings()` so third-party projects with unused-import warnings still compile successfully for benchmarking.

The scenario is best-effort: if `git` is unavailable or the network is unreachable, `prepare_staking` logs the reason and returns `None`, and the rest of the benchmark continues unaffected. The clone is also guarded behind the scenario filter so unrelated filter runs do not pay the network cost.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The existing benchmark projects (`fib`, `corelib`, `bug_samples`, `cairo_level_tests`) are relatively small. A large real-world multi-crate Starknet project is needed as a memory stress test for the compiler front end to catch regressions in heap usage that the smaller projects would not surface.

---

## What was the behavior or documentation before?

The `dhat_compile` benchmark had no scenario covering a large, multi-dependency real-world Starknet contract.

---

## What is the behavior or documentation after?

Running `dhat_compile` (or filtering to `cairo-to-sierra-staking`) shallow-clones the staking contract and its two dependency repos, compiles the staking crate to Sierra, records heap allocation metrics, and removes the checkout on completion.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `cairo_project.toml.template` was generated once locally from `scarb metadata` with the per-repository source roots replaced by placeholders. The pinned dependency revisions match the staking `Scarb.lock`, and the `src` trees were verified byte-identical to the published registry sources, so this compiles exactly what Scarb would resolve without requiring Scarb to be installed on CI.