### PR TITLE
bugfix(parser): Improved missing comma diag.

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -2159,7 +2159,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         let rparen = self.parse_token::<TerminalRParen<'_>>();
         if let [ExprListElementOrSeparatorGreen::Element(_)] = &exprs[..] {
             self.add_diagnostic(
-                ParserDiagnosticKind::MissingToken(SyntaxKind::TokenComma),
+                ParserDiagnosticKind::MissingToken(SyntaxKind::TerminalComma),
                 TextSpan::cursor(self.offset),
             );
         }

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/function_signature
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/function_signature
@@ -23,7 +23,7 @@ error[E1004]: Unexpected token, expected ':' followed by a type.
 fn foo(a: int, mut b: felt252, ref c{}, mut ref d: felt252) -> felt252 implicits(RangeCheck, Hash) nopanic {
                                     ^
 
-error[E1001]: Missing token TokenComma.
+error[E1001]: Missing token ','.
  --> dummy_file.cairo:5:21
 fn bar() -> (felt252) {
                     ^


### PR DESCRIPTION
## Summary

Fixes the diagnostic message for a missing comma in single-element tuple expressions. The `ParserDiagnosticKind::MissingToken` was referencing `SyntaxKind::TokenComma` instead of `SyntaxKind::TerminalComma`, which caused the error message to display `Missing token TokenComma.` instead of the human-readable `Missing token ','.`

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The diagnostic emitted when a single-element tuple is missing its trailing comma was referencing the wrong `SyntaxKind` variant (`TokenComma` instead of `TerminalComma`). This caused the error message to expose an internal token kind name rather than the expected human-readable punctuation character.

---

## What was the behavior or documentation before?

When writing a single-element tuple without a trailing comma (e.g., `(felt252)`), the parser emitted:

```
error[E1001]: Missing token TokenComma.
```

---

## What is the behavior or documentation after?

The parser now correctly emits:

```
error[E1001]: Missing token ','.
```

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A