### PR TITLE
bugfix(plugins): Made compile_error! diag not include `"`s.

### DIFF
--- a/crates/cairo-lang-plugins/src/plugins/compile_error.rs
+++ b/crates/cairo-lang-plugins/src/plugins/compile_error.rs
@@ -3,7 +3,7 @@ use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginDiagnostic
 use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
-use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
 use salsa::Database;
 
 /// Plugin that allows writing item level `compile_error!` causing a diagnostic.
@@ -38,8 +38,10 @@ impl MacroPlugin for CompileErrorPlugin {
             item_ast_ptr
         );
         PluginResult::diagnostic_only(
-            if let ast::Expr::String(err_message) = compilation_error_arg {
-                PluginDiagnostic::error(item_ast_ptr, err_message.text(db).to_string(db))
+            if let ast::Expr::String(err_message_arg) = &compilation_error_arg
+                && let Some(err_message) = err_message_arg.string_value(db)
+            {
+                PluginDiagnostic::error(item_ast_ptr, err_message)
             } else {
                 PluginDiagnostic::error_with_inner_span(
                     db,

--- a/crates/cairo-lang-plugins/src/test_data/compile_error
+++ b/crates/cairo-lang-plugins/src/test_data/compile_error
@@ -33,7 +33,7 @@ compile_error!("message", "extra");
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-error: "error message"
+error: error message
  --> test_src/lib.cairo:7:1
 compile_error!("error message");
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +58,7 @@ compile_error!("ignore");
 //! > expanded_cairo_code
 
 //! > expected_diagnostics
-error: "show"
+error: show
  --> test_src/lib.cairo:1:1-2:23
   #[cfg(noignore)]
  _^


### PR DESCRIPTION
## Summary

The `compile_error!` macro plugin now uses `string_value(db)` to extract the raw string content from the error message argument, stripping the surrounding quotes from the diagnostic output.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

Error messages emitted by `compile_error!` were being displayed with their surrounding quotes included (e.g., `"error message"` instead of `error message`), which is inconsistent with how error messages are typically presented and mirrors the behavior of Rust's `compile_error!` macro.

---

## What was the behavior or documentation before?

Diagnostics produced by `compile_error!("error message")` displayed the message as `"error message"` — with the quotes included as part of the diagnostic text.

---

## What is the behavior or documentation after?

Diagnostics produced by `compile_error!("error message")` now display the message as `error message`, without surrounding quotes.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The change also adds a guard to handle the case where `string_value(db)` returns `None`, falling through to the existing error path for invalid arguments.