### PR TITLE
bugfix(plugins): Use all cfg args to extract diagnostics.

### DIFF
--- a/crates/cairo-lang-plugins/src/plugins/config.rs
+++ b/crates/cairo-lang-plugins/src/plugins/config.rs
@@ -203,12 +203,7 @@ fn parse_predicate<'a>(
     attr: Attribute<'a>,
     diagnostics: &mut Vec<PluginDiagnostic<'a>>,
 ) -> Option<PredicateTree> {
-    Some(PredicateTree::And(
-        attr.args
-            .into_iter()
-            .filter_map(|arg| parse_predicate_item(db, arg, diagnostics))
-            .collect(),
-    ))
+    Some(PredicateTree::And(parse_predicate_items(db, attr.args, diagnostics)?))
 }
 
 /// Parse single `#[cfg(...)]` attribute argument as a [`Cfg`] item.
@@ -252,11 +247,7 @@ fn parse_predicate_item<'a>(
                         ));
                         None
                     } else {
-                        Some(PredicateTree::And(
-                            args.into_iter()
-                                .filter_map(|arg| parse_predicate_item(db, arg, diagnostics))
-                                .collect(),
-                        ))
+                        Some(PredicateTree::And(parse_predicate_items(db, args, diagnostics)?))
                     }
                 }
                 "or" => {
@@ -267,11 +258,7 @@ fn parse_predicate_item<'a>(
                         ));
                         None
                     } else {
-                        Some(PredicateTree::Or(
-                            args.into_iter()
-                                .filter_map(|arg| parse_predicate_item(db, arg, diagnostics))
-                                .collect(),
-                        ))
+                        Some(PredicateTree::Or(parse_predicate_items(db, args, diagnostics)?))
                     }
                 }
                 _ => {
@@ -291,6 +278,22 @@ fn parse_predicate_item<'a>(
             None
         }
     }
+}
+
+/// Parses all `args` as predicate items, emitting a diagnostic for each one that fails to parse.
+/// Returns `None` if any argument fails.
+fn parse_predicate_items<'a>(
+    db: &'a dyn Database,
+    args: Vec<AttributeArg<'a>>,
+    diagnostics: &mut Vec<PluginDiagnostic<'a>>,
+) -> Option<Vec<PredicateTree>> {
+    let args = args.into_iter();
+    let expected_size = args.len();
+    let mut items = Vec::with_capacity(expected_size);
+    for arg in args {
+        items.extend(parse_predicate_item(db, arg, diagnostics));
+    }
+    (items.len() == expected_size).then_some(items)
 }
 
 /// Extracts a configuration predicate part from an attribute argument.

--- a/crates/cairo-lang-plugins/src/test_data/config
+++ b/crates/cairo-lang-plugins/src/test_data/config
@@ -443,6 +443,102 @@ error: `or` operator expects at least two arguments.
 
 //! > ==========================================================================
 
+//! > Test logical operators with unparsable inner arguments are kept, not dropped.
+
+//! > test_runner_name
+test_expand_plugin(expect_diagnostics: true)
+
+//! > cfg
+["a", "b", ["k", "a"], ["k", "b"]]
+
+//! > cairo_code
+#[cfg(or(0, 1))]
+const INVALID_OR_ITEMS: felt252 = 0;
+
+#[cfg(and(0, 1))]
+const INVALID_AND_ITEMS: felt252 = 0;
+
+#[cfg(and(or(0, 1), 2))]
+const INVALID_INNER_ITEMS1: felt252 = 0;
+
+#[cfg(or(2, and(0, 1)))]
+const INVALID_INNER_ITEMS2: felt252 = 0;
+
+//! > expanded_cairo_code
+#[cfg(or(0, 1))]
+const INVALID_OR_ITEMS: felt252 = 0;
+
+#[cfg(and(0, 1))]
+const INVALID_AND_ITEMS: felt252 = 0;
+
+#[cfg(and(or(0, 1), 2))]
+const INVALID_INNER_ITEMS1: felt252 = 0;
+
+#[cfg(or(2, and(0, 1)))]
+const INVALID_INNER_ITEMS2: felt252 = 0;
+
+//! > expected_diagnostics
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:1:10
+#[cfg(or(0, 1))]
+         ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:1:13
+#[cfg(or(0, 1))]
+            ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:4:11
+#[cfg(and(0, 1))]
+          ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:4:14
+#[cfg(and(0, 1))]
+             ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:7:14
+#[cfg(and(or(0, 1), 2))]
+             ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:7:17
+#[cfg(and(or(0, 1), 2))]
+                ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:7:21
+#[cfg(and(or(0, 1), 2))]
+                    ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:10:10
+#[cfg(or(2, and(0, 1)))]
+         ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:10:17
+#[cfg(or(2, and(0, 1)))]
+                ^
+
+
+error: Invalid configuration argument.
+ --> test_src/lib.cairo:10:20
+#[cfg(or(2, and(0, 1)))]
+                   ^
+
+//! > ==========================================================================
+
 //! > Test cfg of members does not update visibility.
 
 //! > test_runner_name


### PR DESCRIPTION
## Summary

Introduces `parse_predicate_items`, a helper that collects parsed predicate arguments and returns `None` if any single argument fails to parse. This replaces the previous `filter_map` approach, which silently dropped malformed arguments from `and`/`or`/top-level predicate lists. The old behavior could cause incorrect item inclusion — for example, an `or` predicate containing only invalid arguments would evaluate to `false` (empty `or`) rather than being treated as an error.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a `#[cfg(or(...))]` or `#[cfg(and(...))]` attribute contained unparsable arguments, the previous implementation silently dropped those arguments via `filter_map`. This meant an `or` predicate with only invalid arguments would collapse to an empty `or`, evaluating to `false` and incorrectly excluding the item. The same issue applied to `and` predicates and top-level predicate lists.

---

## What was the behavior or documentation before?

Invalid arguments inside `or(...)`, `and(...)`, or top-level `cfg(...)` predicates were silently dropped. A diagnostic was emitted per invalid argument, but the remaining valid arguments were still evaluated, potentially producing incorrect inclusion/exclusion results.

---

## What is the behavior or documentation after?

If any argument in a predicate list fails to parse, the entire predicate returns `None`, preventing the item from being incorrectly included or excluded due to a partially-evaluated predicate. Diagnostics are still emitted for each invalid argument. A new test case verifies that items annotated with `#[cfg(or(0, 1))]` and `#[cfg(and(0, 1))]` are kept (not dropped) when their arguments are invalid.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `parse_predicate_items` helper uses an explicit loop with `extend` rather than `filter_map`, tracking expected vs. actual parsed count to detect any parse failure and propagate `None` accordingly.