### PR TITLE
bugfix(semantic): Reformated diagnostic message.

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -209,7 +209,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 concrete_trait_id,
             } => {
                 format!(
-                    "Cannot infer implicit impl `{}.`\nCould not find implementation of trait \
+                    "Cannot infer implicit impl `{}`.\nCould not find implementation of trait \
                      `{:?}`",
                     trait_impl_id.name(db).long(db),
                     concrete_trait_id.debug(db)

--- a/crates/cairo-lang-semantic/src/items/tests/trait
+++ b/crates/cairo-lang-semantic/src/items/tests/trait
@@ -467,7 +467,7 @@ error[E0004]: Not all trait items are implemented. Missing: 'foo1', 'foo2', 'X',
 impl MyImpl of MyTrait;
      ^^^^^^
 
-error[E2015]: Cannot infer implicit impl `Z.`
+error[E2015]: Cannot infer implicit impl `Z`.
 Could not find implementation of trait `test::OtherTrait`
  --> lib.cairo:9:1
 impl MyImpl of MyTrait;
@@ -520,7 +520,7 @@ error[E0004]: Not all trait items are implemented. Missing: 'foo1', 'foo3', 'Y',
 impl MyImpl of MyTrait {
      ^^^^^^
 
-error[E2015]: Cannot infer implicit impl `F.`
+error[E2015]: Cannot infer implicit impl `F`.
 Could not find implementation of trait `test::OtherTrait`
  --> lib.cairo:16:1-21:1
   impl MyImpl of MyTrait {
@@ -1112,7 +1112,7 @@ impl FooIntoIterator of core::iter::IntoIterator<Foo> {
 }
 
 //! > expected_diagnostics
-error[E2015]: Cannot infer implicit impl `Iterator.`
+error[E2015]: Cannot infer implicit impl `Iterator`.
 Could not find implementation of trait `core::iter::traits::iterator::Iterator::<test::FooIter>`
  --> lib.cairo:5:1-12:1
   #[feature("collections-into-iter")]

--- a/crates/cairo-lang-semantic/src/items/tests/trait_impl
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_impl
@@ -1127,7 +1127,7 @@ trait MyTrait {
 impl MyImpl of MyTrait {}
 
 //! > expected_diagnostics
-error[E2015]: Cannot infer implicit impl `I.`
+error[E2015]: Cannot infer implicit impl `I`.
 Could not find implementation of trait `test::OtherTrait`
  --> lib.cairo:7:1
 impl MyImpl of MyTrait {}
@@ -1346,7 +1346,7 @@ error[E2046]: Ambiguous method call. More than one applicable trait function wit
         self.into()
              ^^^^
 
-error[E2015]: Cannot infer implicit impl `InnerImpl.`
+error[E2015]: Cannot infer implicit impl `InnerImpl`.
 Could not find implementation of trait `test::Inner::<core::integer::u32>`
  --> lib.cairo:24:1-29:1
   impl OuterU32 of Outer<u32> {


### PR DESCRIPTION
## Summary

Fixes a misplaced period in the `E2015` diagnostic message for implicit impl inference failures. The backtick-enclosed impl name was followed by a period inside the closing backtick context, producing messages like `` Cannot infer implicit impl `Z.` `` instead of the correct `` Cannot infer implicit impl `Z`. ``.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The period terminating the sentence was placed inside the format string before the closing backtick, making the impl name appear to include a trailing dot (e.g., `` `Z.` ``). This is grammatically incorrect and visually confusing in compiler output.

---

## What was the behavior or documentation before?

Diagnostic messages read:
```
Cannot infer implicit impl `Z.`
```

---

## What is the behavior or documentation after?

Diagnostic messages now correctly read:
```
Cannot infer implicit impl `Z`.
```

---

## Related issue or discussion (if any)

None.

---

## Additional context

The fix is a one-character positional change in the format string in `diagnostic.rs`. All affected test snapshots have been updated to reflect the corrected output.