### PR TITLE
bugfix(semantic): Prevented doubled `use self;` diagnostic.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/tests/use_
+++ b/crates/cairo-lang-semantic/src/items/tests/use_
@@ -179,6 +179,28 @@ use {self, u8};
 
 //! > ==========================================================================
 
+//! > standalone `self` use reports a single diagnostic.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+use self;
+
+//! > expected_diagnostics
+error[E2089]: `self` in `use` items is not allowed for empty path.
+ --> lib.cairo:1:5
+use self;
+    ^^^^
+
+//! > ==========================================================================
+
 //! > Use star on a module that was imported with use star.
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -594,14 +594,14 @@ impl<'db> Resolver<'db> {
         if let Some(last) = segments.segments.last()
             && last.identifier(self.db).long(self.db) == SELF_PARAM_KW
         {
+            segments.segments.pop();
+            if segments.segments.is_empty() {
+                return Err(diagnostics.report(use_path.stable_ptr(self.db), UseSelfEmptyPath));
+            }
             // If the `self` keyword is used in a non-multi-use path, report an error.
             if use_path.as_syntax_node().parent_kind(self.db).unwrap() != SyntaxKind::UsePathList {
                 diagnostics.report(use_path.stable_ptr(self.db), UseSelfNonMulti);
             }
-            segments.segments.pop();
-        }
-        if segments.segments.is_empty() {
-            return Err(diagnostics.report(use_path.stable_ptr(self.db), UseSelfEmptyPath));
         }
         self.resolve_generic_path(diagnostics, segments, NotFoundItemType::Identifier, ctx)
     }


### PR DESCRIPTION
## Summary

Fixes a bug where `use self;` (a standalone `self` in a use path) was emitting two diagnostics instead of one. The fix reorders the logic in `resolve_use_path` so that the empty-path check occurs immediately after popping the `self` segment, before the non-multi-use check. This ensures that `use self;` reports only the `UseSelfEmptyPath` error and exits early, rather than also triggering `UseSelfNonMulti`. A test case is added to verify that `use self;` produces exactly one diagnostic.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, `use self;` would trigger two separate diagnostics: one for `UseSelfEmptyPath` and one for `UseSelfNonMulti`. Only the `UseSelfEmptyPath` error is appropriate here, since the path is empty and the non-multi check is redundant and misleading in this case.

---

## What was the behavior or documentation before?

`use self;` produced two diagnostics: an error for using `self` in a non-multi-use path, and an error for `self` being used with an empty path.

---

## What is the behavior or documentation after?

`use self;` produces a single diagnostic:
```
error[E2089]: `self` in `use` items is not allowed for empty path.
 --> lib.cairo:1:5
use self;
    ^^^^
```

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A