### PR TITLE
bugfix(sierra-sim): Fixed implementation of u128s_from_felt.

### DIFF
--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -387,7 +387,18 @@ fn simulate_u128_libfunc(
             take_inputs!(let [CoreValue::RangeCheck, CoreValue::Felt252(value)] = inputs);
             match value.to_u128() {
                 Some(value) => (vec![CoreValue::RangeCheck, CoreValue::Uint128(value)], 0),
-                None => (vec![CoreValue::RangeCheck], 1),
+                None => {
+                    let (high, low) =
+                        BigInt::from(value.to_biguint()).div_rem(&(BigInt::one() << 128));
+                    (
+                        vec![
+                            CoreValue::RangeCheck,
+                            CoreValue::Uint128(high.to_u128().unwrap()),
+                            CoreValue::Uint128(low.to_u128().unwrap()),
+                        ],
+                        1,
+                    )
+                }
             }
         }
         Uint128Concrete::ToFelt252(_) => {

--- a/crates/cairo-lang-sierra/src/simulation/test.rs
+++ b/crates/cairo-lang-sierra/src/simulation/test.rs
@@ -148,6 +148,12 @@ fn simulate(
 #[test_case("u128_overflowing_sub", vec![], vec![RangeCheck, Uint128(3), Uint128(5)]
              => Ok((vec![RangeCheck, Uint128(u128::MAX - 1)], 1));
             "u128_overflowing_sub(3, 5)")]
+#[test_case("u128s_from_felt252", vec![], vec![RangeCheck, Felt252(5u64.into())]
+             => Ok((vec![RangeCheck, Uint128(5)], 0)); "u128s_from_felt252(5)")]
+#[test_case("u128s_from_felt252", vec![],
+             vec![RangeCheck, Felt252(((BigInt::from(3) << 128_u32) + BigInt::from(7)).into())]
+             => Ok((vec![RangeCheck, Uint128(3), Uint128(7)], 1));
+            "u128s_from_felt252(3 * 2**128 + 7)")]
 fn simulate_branch(
     id: &str,
     generic_args: Vec<GenericArg>,


### PR DESCRIPTION
## Summary

Fixes the simulation of `u128s_from_felt252` to correctly return both the high and low 128-bit components when the input `Felt252` value does not fit in a `u128`. Previously, the failure branch returned only the `RangeCheck` value with no decomposition. Now, when the value exceeds `u128::MAX`, it is split via `div_rem` by `2^128` into a high part and a low part, both returned as `Uint128` values alongside `RangeCheck`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The simulation of `u128s_from_felt252` was incomplete: when the felt252 value was too large to fit in a `u128`, the failure branch only returned `RangeCheck` without providing the high and low decomposed `u128` values. This made the simulation diverge from the actual semantics of the libfunc, which decomposes the value into `(high, low)` parts.

---

## What was the behavior or documentation before?

When `u128s_from_felt252` was simulated with a value that does not fit in a `u128`, the failure branch returned `vec![CoreValue::RangeCheck]` with no decomposition of the input value.

---

## What is the behavior or documentation after?

The failure branch now computes `(high, low) = value / 2^128` and returns `vec![CoreValue::RangeCheck, CoreValue::Uint128(high), CoreValue::Uint128(low)]`, matching the expected libfunc semantics. Tests covering both the success case (e.g., `5`) and the failure case (e.g., `3 * 2^128 + 7`) are added.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A