### PR TITLE
bugfix(doc): Add commas between generics - fix by refactor.

### DIFF
--- a/crates/cairo-lang-doc/src/helpers.rs
+++ b/crates/cairo-lang-doc/src/helpers.rs
@@ -29,18 +29,18 @@ pub fn get_generic_params<'db>(
     let mut location_links: Vec<LocationLink<'_>> = Vec::new();
 
     if !generic_params.is_empty() {
-        let mut count = generic_params.len();
         buff.push('<');
-
-        for param in generic_params {
+        for (i, param) in generic_params.iter().enumerate() {
+            if i > 0 {
+                buff.push_str(", ");
+            }
             match param {
                 GenericParam::Type(param_type) => {
-                    let name = extract_and_format(param_type.id.format(db).long(db));
-                    buff.push_str(&format!("{}{}", name, if count == 1 { "" } else { ", " }));
+                    buff.push_str(&extract_and_format(param_type.id.format(db).long(db)));
                 }
                 GenericParam::Const(param_const) => {
-                    let name = extract_and_format(param_const.id.format(db).long(db));
-                    buff.push_str(&format!("const {}{}", name, if count == 1 { "" } else { ", " }));
+                    buff.push_str("const ");
+                    buff.push_str(&extract_and_format(param_const.id.format(db).long(db)));
                 }
                 GenericParam::Impl(param_impl) => {
                     let name = extract_and_format(param_impl.id.format(db).long(db));
@@ -61,40 +61,31 @@ pub fn get_generic_params<'db>(
                             } else {
                                 buff.push_str(&format!("impl {name}: "));
 
-                                let concrete_trait_name = concrete_trait.name(db);
-                                let concrete_trait_generic_args_formatted = concrete_trait
+                                let concrete_trait_name = concrete_trait.name(db).long(db);
+                                let concrete_trait_generic_args = concrete_trait
                                     .generic_args(db)
                                     .iter()
                                     .map(|arg| extract_and_format(&arg.format(db)))
-                                    .collect::<Vec<_>>()
                                     .join(", ");
 
                                 location_links.push(LocationLink::new(
                                     buff.len(),
-                                    buff.len() + concrete_trait_name.to_string(db).len(),
+                                    buff.len() + concrete_trait_name.len(),
                                     documentable_id,
                                     0,
                                 ));
-                                buff.push_str(&concrete_trait_name.to_string(db));
+                                buff.push_str(concrete_trait_name);
 
-                                if !concrete_trait_generic_args_formatted.is_empty() {
-                                    let f = format!("<{concrete_trait_generic_args_formatted}>");
-                                    buff.push_str(&f);
+                                if !concrete_trait_generic_args.is_empty() {
+                                    buff.push_str(&format!("<{concrete_trait_generic_args}>"));
                                 }
                             }
                         }
-                        Err(_) => {
-                            buff.push_str(&format!(
-                                "{}{}",
-                                name,
-                                if count == 1 { "" } else { ", " }
-                            ));
-                        }
+                        Err(_) => buff.push_str(&name),
                     }
                 }
                 GenericParam::NegImpl(_) => buff.push_str(crate::documentable_formatter::MISSING),
-            };
-            count -= 1;
+            }
         }
         buff.push('>');
     }

--- a/crates/cairo-lang-doc/src/tests/test-data/signature.txt
+++ b/crates/cairo-lang-doc/src/tests/test-data/signature.txt
@@ -108,6 +108,12 @@ macro square_brackets_redundant_whitespace {
 	};
 }
 
+trait CTrait {}
+
+struct StructLeadingImplParam<+CTrait, T> {
+    value: T,
+}
+
 //! > Item signature #1
 
 //! > Item documentation #1
@@ -385,3 +391,26 @@ macro square_brackets_redundant_whitespace {
 //! > Item documentation #35
 
 //! > Item documentation tokens #35
+
+//! > Item signature #36
+trait CTrait
+
+//! > Item documentation #36
+
+//! > Item documentation tokens #36
+
+//! > Item signature #37
+struct StructLeadingImplParam<+CTrait, T> {
+    value: T,
+}
+
+//! > Item documentation #37
+
+//! > Item documentation tokens #37
+
+//! > Item signature #38
+value: T
+
+//! > Item documentation #38
+
+//! > Item documentation tokens #38


### PR DESCRIPTION
## Summary

Fixes incorrect comma placement in generic parameter formatting by replacing the count-based trailing comma logic with an index-based leading comma approach. Additionally resolves a bug where `impl` generic parameters appearing before other parameters (e.g., `<+CTrait, T>`) were rendered incorrectly due to the old separator logic.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous implementation tracked a `count` variable that decremented on each iteration to decide whether to append a trailing `, ` after each generic parameter. This approach was error-prone and produced incorrect output when an `impl` parameter (e.g., `+CTrait`) appeared before other parameters — the separator was appended in the wrong place or omitted entirely.

---

## What was the behavior or documentation before?

Generic parameter lists with a leading `impl` constraint followed by other type parameters (e.g., `<+CTrait, T>`) were not formatted correctly. The count-based separator logic also resulted in redundant intermediate variables and unnecessary `format!` calls.

---

## What is the behavior or documentation after?

Generic parameters are now separated using an index-based check (`if i > 0 { push ", " }`), which correctly inserts commas between parameters regardless of their kind. A new test case covering `struct StructLeadingImplParam<+CTrait, T>` is added to `signature.txt` to verify correct formatting of structs with a leading `impl` generic parameter.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `concrete_trait_name` resolution was also simplified by calling `.long(db)` directly and avoiding a redundant `.to_string(db)` call, reducing intermediate allocations.