### PR TITLE
bugfix(orizi): Improved DictEntry's doc to compile and be clearer.

### DIFF
--- a/corelib/src/dict.cairo
+++ b/corelib/src/dict.cairo
@@ -181,17 +181,17 @@ pub trait Felt252DictEntryTrait<T> {
     /// # Examples
     ///
     /// ```
-    /// use core::dict::Felt252DictEntryTrait;
+    /// use core::dict::{Felt252Dict, Felt252DictEntryTrait};
     ///
-    /// // Create a dictionary that stores arrays
+    /// // A dictionary that stores arrays (a non-`Copy` type).
     /// let mut dict: Felt252Dict<Nullable<Array<felt252>>> = Default::default();
-    ///
     /// dict.insert(0, NullableTrait::new(array![1, 2, 3]));
     ///
+    /// // `entry` takes the dictionary and the previous value; `finalize` stores the
+    /// // new value and gives the dictionary back.
     /// let (entry, prev_value) = dict.entry(0);
     /// dict = entry.finalize(NullableTrait::new(array![4, 5, 6]));
     /// assert!(prev_value.deref() == array![1, 2, 3]);
-    /// assert!(dict.get(0).deref() == array![4, 5, 6]);
     /// ```
     fn finalize(self: Felt252DictEntry<T>, new_value: T) -> Felt252Dict<T>;
 }


### PR DESCRIPTION
## Summary

Fixes the `Felt252DictEntryTrait::finalize` doc example to add the missing `Felt252Dict` import alongside `Felt252DictEntryTrait`, adds an inline comment explaining the `entry`/`finalize` ownership pattern, and removes the trailing `assert!` that verified `dict.get(0)` after finalization (since the dictionary is consumed and returned by `finalize`, the example ends after the round-trip is complete).

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous example was missing the `Felt252Dict` import, which would cause the snippet to fail to compile as written. The `entry`/`finalize` ownership pattern (where the dictionary is consumed by `entry` and returned by `finalize`) was not explained, making the example harder to understand for users unfamiliar with this idiom.

---

## What was the behavior or documentation before?

The example imported only `Felt252DictEntryTrait`, omitting the required `Felt252Dict` import, and provided no explanation of why `entry` takes ownership of the dictionary or why `finalize` returns it.

---

## What is the behavior or documentation after?

The example now imports both `Felt252Dict` and `Felt252DictEntryTrait`, includes a comment clarifying the ownership transfer through `entry` and `finalize`, and removes the now-unnecessary post-finalize assertion.

---

## Related issue or discussion (if any)

None.

---

## Additional context

None.