### PR TITLE
Update gitignore to include .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ensure-no_std/target/
 
 .claude/settings.local.json
 .reviews/
+.claude/worktrees


### PR DESCRIPTION
## Summary

Adds `.claude/worktrees` to `.gitignore` to prevent Claude AI worktree directories from being tracked by git.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `.claude/worktrees` directory is generated locally by Claude AI tooling and should not be committed to the repository, similar to the existing `.claude/settings.local.json` entry already in `.gitignore`.

---

## What was the behavior or documentation before?

The `.claude/worktrees` directory was not ignored, meaning it could accidentally be staged and committed.

---

## What is the behavior or documentation after?

The `.claude/worktrees` directory is ignored by git and will not appear as untracked or staged files.

---

## Related issue or discussion (if any)

None.

---

## Additional context

This follows the same pattern as the existing `.claude/settings.local.json` ignore rule already present in the file.