### PR TITLE
(opt): track arrays as a bounded suffix behind a forgotten prefix placeholder in equality analysis

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
@@ -3,9 +3,9 @@
 //! This module tracks semantic equivalence between variables as information flows through the
 //! program. Two variables are equivalent if they hold the same value. Additionally, the analysis
 //! tracks `Box`/unbox, snapshot/desnap, struct construct, and array construct relationships between
-//! equivalence classes via unified forward/reverse maps. Structs track every field and arrays
-//! every element (see `ArrayItems`) — array pop operations act as destructures on the array
-//! relation.
+//! equivalence classes via unified forward/reverse maps. Structs track every field; arrays track
+//! a bounded number of trailing elements behind a placeholder for the forgotten prefix (see
+//! `ArrayItems`) — array pop operations act as destructures on the array relation.
 
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{ExternFunctionId, NamedLanguageElementId};
@@ -13,6 +13,7 @@ use cairo_lang_semantic::corelib::option_some_variant;
 use cairo_lang_semantic::helper::ModuleHelper;
 use cairo_lang_semantic::{ConcreteVariant, GenericArgumentId, MatchArmSelector, TypeId};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use itertools::zip_eq;
 use salsa::Database;
 
 use crate::analysis::core::Edge;
@@ -21,13 +22,13 @@ use crate::{
     BlockEnd, BlockId, Lowered, MatchArm, MatchExternInfo, MatchInfo, Statement, VariableId,
 };
 
-/// A globally unique token for an unknown value tracked by the analysis. Allocated by
-/// [`fresh_placeholder`]; equality means "the very same unknown", so distinct unknowns never
-/// compare equal.
+/// A globally unique token for an unknown value or forgotten array prefix tracked by the analysis.
+/// Allocated by [`fresh_placeholder`]; equality means "the very same unknown", so distinct unknowns
+/// never compare equal.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 struct Placeholder(usize);
 
-/// Allocates a globally unique placeholder.
+/// Allocates a globally unique placeholder, used for unknown struct fields and array runs.
 fn fresh_placeholder(next_placeholder: &mut usize) -> Placeholder {
     *next_placeholder += 1;
     Placeholder(*next_placeholder - 1)
@@ -60,41 +61,67 @@ impl FieldVar {
     }
 }
 
-/// The tracked contents of an array.
+/// Maximum number of trailing elements tracked per array.
+///
+/// Tracking every element is quadratic in the number of appends, so only the last
+/// [`MAX_ARRAY_TRACKED_ITEMS`] are tracked; everything before them is forgotten into a
+/// placeholder prefix (see [`ArrayItems`]).
+const MAX_ARRAY_TRACKED_ITEMS: usize = 5;
+
+/// The tracked contents of an array: a forgotten prefix of elements (at least one, count
+/// unknown), followed by a bounded number of tracked trailing ones.
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 struct ArrayItems {
-    /// The elements, in order.
-    elements: Vec<FieldVar>,
+    /// The identity of the forgotten prefix, or `None` when the contents are fully known. Two
+    /// prefixes describe the same element sequence only if their placeholders match, so any
+    /// change to a prefix's contents allocates a fresh placeholder.
+    prefix_placeholder: Option<Placeholder>,
+    /// The trailing elements, at most [`MAX_ARRAY_TRACKED_ITEMS`].
+    suffix: Vec<FieldVar>,
 }
 
 impl ArrayItems {
+    /// Whether this tracks an array known to be empty.
+    fn is_empty(&self) -> bool {
+        self.prefix_placeholder.is_none() && self.suffix.is_empty()
+    }
+
     /// Returns an iterator over the real variables of the tracked elements.
     fn referenced_vars(&self) -> impl Iterator<Item = VariableId> + '_ {
-        self.elements.iter().filter_map(|f| f.as_var())
+        self.suffix.iter().filter_map(|f| f.as_var())
     }
 
     /// Resolves the tracked elements' variables to their representatives.
     fn find_rep(self, info: &mut EqualityState<'_>) -> Self {
-        Self { elements: self.elements.into_iter().map(|f| f.find_rep(info)).collect() }
+        Self { suffix: self.suffix.into_iter().map(|f| f.find_rep(info)).collect(), ..self }
     }
 
-    /// Appends `elem` to the tracked contents.
-    fn append(mut self, elem: FieldVar) -> Self {
-        self.elements.push(elem);
+    /// Appends `elem`: when the budget is full, the oldest tracked element is forgotten into
+    /// the prefix.
+    fn append(mut self, elem: FieldVar, next_placeholder: &mut usize) -> Self {
+        if self.suffix.len() == MAX_ARRAY_TRACKED_ITEMS {
+            self.prefix_placeholder = Some(fresh_placeholder(next_placeholder));
+            self.suffix.remove(0);
+        }
+        self.suffix.push(elem);
         self
     }
 
     /// Removes one element from the front (`from_front`) or back.
     fn pop(&self, from_front: bool) -> PopResult {
-        if self.elements.is_empty() {
+        // Empty case.
+        if self.is_empty() {
             return PopResult::KnownEmpty;
         }
+        // Unknown cases are when there is a forgotten prefix and popping from the front, or
+        // popping from the back when the suffix is empty.
+        if self.prefix_placeholder.is_some() && (from_front || self.suffix.is_empty()) {
+            return PopResult::Unknown;
+        }
+        // Suffix is not empty, so we can pop from it.
         let mut remaining = self.clone();
-        let element = if from_front {
-            remaining.elements.remove(0)
-        } else {
-            remaining.elements.pop().unwrap()
-        };
+        let element =
+            if from_front { remaining.suffix.remove(0) } else { remaining.suffix.pop().unwrap() };
         PopResult::Element { element, remaining }
     }
 }
@@ -105,6 +132,9 @@ enum PopResult {
     Element { element: FieldVar, remaining: ArrayItems },
     /// The array is known to be empty, so there is no element to pop.
     KnownEmpty,
+    /// The popped element came off the forgotten prefix, whose count is unknown, so neither
+    /// the element nor the remainder is known.
+    Unknown,
 }
 
 /// A relationship between equivalence classes, carrying its payload data.
@@ -314,18 +344,17 @@ impl<'db> DebugWithDb<'db> for EqualityState<'db> {
                         .join(", ");
                     lines.push(format!("{type_name}({fields}) = {}", v(output)));
                 }
-                // Arrays render as `Type[..]` (vs `Type(..)` for structs).
+                // Arrays render as `Type[..]` (vs `Type(..)` for structs); runs of forgotten
+                // elements render as `?(len)` / `?(*)`.
                 Relation::Array(ty, items) => {
                     let type_name = ty.format(db);
-                    let rendered = items
-                        .elements
-                        .iter()
-                        .map(|f| match f {
-                            FieldVar::Var(id) => v(*id),
-                            FieldVar::Placeholder(_) => "?".to_string(),
-                        })
-                        .collect::<Vec<_>>()
-                        .join(", ");
+                    let elem = |f: &FieldVar| match f {
+                        FieldVar::Var(id) => v(*id),
+                        FieldVar::Placeholder(_) => "?".to_string(),
+                    };
+                    let prefix = items.prefix_placeholder.iter().map(|_| "?(*)".to_string());
+                    let rendered =
+                        prefix.chain(items.suffix.iter().map(elem)).collect::<Vec<_>>().join(", ");
                     lines.push(format!("{type_name}[{rendered}] = {}", v(output)));
                 }
             }
@@ -352,8 +381,8 @@ impl<'db> DebugWithDb<'db> for EqualityState<'db> {
 pub struct EqualityAnalysis<'a, 'db> {
     db: &'db dyn Database,
     lowered: &'a Lowered<'db>,
-    /// Counter for allocating globally unique `Placeholder` IDs for unknown struct/array fields
-    /// after merge.
+    /// Counter for allocating globally unique ids: `FieldVar::Placeholder`s for unknown fields
+    /// after merge, and forgotten array prefix ids.
     next_placeholder: usize,
     /// The `array_new` extern function id.
     array_new: ExternFunctionId<'db>,
@@ -408,7 +437,7 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
     /// The `None` arms are intentionally ignored: recording empty-array relations or unions there
     /// would backedge-merge older SSA equivalence classes based on branch discrimination.
     fn transfer_extern_match_arm(
-        &self,
+        &mut self,
         info: &mut EqualityState<'db>,
         extern_info: &MatchExternInfo<'db>,
         arm: &MatchArm<'db>,
@@ -438,7 +467,7 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
 
     /// Handles the actual array pop arm transfer after validating the Option variant.
     fn transfer_array_pop_arm(
-        &self,
+        &mut self,
         info: &mut EqualityState<'db>,
         extern_info: &MatchExternInfo<'db>,
         arm: &MatchArm<'db>,
@@ -460,7 +489,7 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
                         }
                         remaining
                     }
-                    PopResult::KnownEmpty => return,
+                    PopResult::KnownEmpty | PopResult::Unknown => return,
                 };
                 info.set_relation(Relation::Array(ty, remaining), remaining_arr);
             }
@@ -505,9 +534,9 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
                     }
                     remaining
                 }
-                // This arm is unreachable at runtime (popping a known-empty array fails), so any
-                // state is sound; keep tracking the remainder as empty.
-                PopResult::KnownEmpty => ArrayItems::default(),
+                // `KnownEmpty` is unreachable at runtime (popping a known-empty array fails),
+                // so nothing needs to be recorded for it.
+                PopResult::KnownEmpty | PopResult::Unknown => return,
             };
             info.set_relation(Relation::Array(snap_ty, remaining), remaining_snap_arr);
         }
@@ -554,10 +583,40 @@ fn merge_field(
     }
 }
 
+/// Meets two arrays' tracked contents at a merge: requires forgotten-prefix presence and
+/// tracked element counts to match. Elements meet like struct fields; the prefix keeps its
+/// placeholder when shared, and otherwise degrades to a fresh one. Returns the met contents
+/// and whether any real data survived, or `None` when the shapes are incompatible.
+fn merge_array_items(
+    items1: &ArrayItems,
+    items2: &ArrayItems,
+    result: &mut EqualityState<'_>,
+    next_placeholder: &mut usize,
+) -> Option<(ArrayItems, bool)> {
+    if items1.suffix.len() != items2.suffix.len() {
+        return None;
+    }
+    let mut any_data = false;
+    let prefix_placeholder = match (items1.prefix_placeholder, items2.prefix_placeholder) {
+        (None, None) => None,
+        (Some(p1), Some(p2)) => Some(if p1 == p2 {
+            any_data = true;
+            p1
+        } else {
+            fresh_placeholder(next_placeholder)
+        }),
+        (None, Some(_)) | (Some(_), None) => return None,
+    };
+    let suffix = zip_eq(&items1.suffix, &items2.suffix)
+        .map(|(f1, f2)| merge_field(*f1, *f2, result, next_placeholder, &mut any_data))
+        .collect();
+    Some((ArrayItems { prefix_placeholder, suffix }, any_data))
+}
+
 /// Keeps relational edges that survive the join **without** mapping variables across mismatched
-/// branch equivalence roots: struct/array fields become placeholders unless both sides cite the
-/// same SSA `VariableId`. Box/Snapshot/Enum reuse an edge only when merged outputs coincide in
-/// `result`.
+/// branch equivalence roots: struct fields become placeholders and array runs lose their
+/// identity unless both sides cite the same SSA `VariableId` / prefix id. Box/Snapshot/Enum reuse
+/// an edge only when merged outputs coincide in `result`.
 fn merge_relations<'db>(
     info1: &EqualityState<'db>,
     info2: &EqualityState<'db>,
@@ -663,23 +722,17 @@ fn merge_relations<'db>(
                     let Some((ty2, items2)) = info2_arrays_by_output.get(&output2_rep) else {
                         continue;
                     };
-                    if ty2 != ty || items2.elements.len() != items1.elements.len() {
+                    if ty2 != ty {
                         continue;
                     }
-                    let mut any_data = false;
-                    let elements: Vec<FieldVar> = items1
-                        .elements
-                        .iter()
-                        .zip(&items2.elements)
-                        .map(|(f1, f2)| {
-                            merge_field(*f1, *f2, result, next_placeholder, &mut any_data)
-                        })
-                        .collect();
-                    if any_data || elements.is_empty() {
-                        result.set_relation(
-                            Relation::Array(*ty, ArrayItems { elements }),
-                            output_intersection,
-                        );
+                    let Some((result_items, any_data)) =
+                        merge_array_items(items1, items2, result, next_placeholder)
+                    else {
+                        continue;
+                    };
+                    if any_data || result_items.is_empty() {
+                        result
+                            .set_relation(Relation::Array(*ty, result_items), output_intersection);
                     }
                 }
             }
@@ -835,10 +888,8 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for EqualityAnalysis<'a, 'db> {
                     // Only track append if the input array is already tracked. Arrays from
                     // function parameters or external calls are conservatively ignored.
                     let elem = FieldVar::Var(info.find(call_stmt.inputs[1].var_id));
-                    info.set_relation(
-                        Relation::Array(ty, items.append(elem)),
-                        call_stmt.outputs[0],
-                    );
+                    let new_items = items.append(elem, &mut self.next_placeholder);
+                    info.set_relation(Relation::Array(ty, new_items), call_stmt.outputs[0]);
                 }
             }
 

--- a/crates/cairo-lang-lowering/src/analysis/test_data/equality
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/equality
@@ -974,6 +974,242 @@ core::array::Array::<core::felt252>[] = v2, core::array::Array::<core::felt252>[
 
 //! > ==========================================================================
 
+//! > Test long arrays keep bounded suffix tracking
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > comments
+Only the last MAX_ARRAY_TRACKED_ITEMS elements stay individually tracked; everything before
+them is forgotten into a placeholder prefix (rendered `?(*)`).
+
+//! > function_code
+fn foo(
+    a0: felt252, a1: felt252, a2: felt252, a3: felt252, a4: felt252, a5: felt252, a6: felt252,
+) -> Array<felt252> {
+    let mut arr = ArrayTrait::new();
+    arr.append(a0);
+    arr.append(a1);
+    arr.append(a2);
+    arr.append(a3);
+    arr.append(a4);
+    arr.append(a5);
+    arr.append(a6);
+    arr
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252, v2: core::felt252, v3: core::felt252, v4: core::felt252, v5: core::felt252, v6: core::felt252
+blk0 (root):
+Statements:
+  (v7: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v8: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v7, v0)
+  (v9: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v8, v1)
+  (v10: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v9, v2)
+  (v11: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v10, v3)
+  (v12: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v11, v4)
+  (v13: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v12, v5)
+  (v14: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v13, v6)
+End:
+  Return(v14)
+
+//! > analysis_state
+Block 0:
+core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v14, core::array::Array::<core::felt252>[] = v7, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v12, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v11, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
+
+//! > ==========================================================================
+
+//! > Test pop_front on a long array with a forgotten prefix
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > comments
+The popped element comes off the forgotten prefix, so neither it nor the remainder is
+recorded.
+
+//! > function_code
+fn foo(
+    a0: felt252, a1: felt252, a2: felt252, a3: felt252, a4: felt252, a5: felt252, a6: felt252,
+) -> felt252 {
+    let mut arr = ArrayTrait::new();
+    arr.append(a0);
+    arr.append(a1);
+    arr.append(a2);
+    arr.append(a3);
+    arr.append(a4);
+    arr.append(a5);
+    arr.append(a6);
+    match arr.pop_front() {
+        Some(x) => x,
+        None => 0,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252, v2: core::felt252, v3: core::felt252, v4: core::felt252, v5: core::felt252, v6: core::felt252
+blk0 (root):
+Statements:
+  (v7: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v8: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v7, v0)
+  (v9: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v8, v1)
+  (v10: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v9, v2)
+  (v11: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v10, v3)
+  (v12: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v11, v4)
+  (v13: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v12, v5)
+  (v14: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v13, v6)
+End:
+  Match(match core::array::array_pop_front::<core::felt252>(v14) {
+    Option::Some(v15, v16) => blk1,
+    Option::None(v17) => blk2,
+  })
+
+blk1:
+Statements:
+  (v18: core::felt252) <- unbox(v16)
+End:
+  Return(v18)
+
+blk2:
+Statements:
+  (v19: ()) <- struct_construct()
+  (v20: core::felt252) <- 0
+End:
+  Return(v20)
+
+//! > analysis_state
+Block 0:
+core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v14, core::array::Array::<core::felt252>[] = v7, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v12, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v11, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
+
+Block 1:
+Box(v18) = v16, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v14, core::array::Array::<core::felt252>[] = v7, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v12, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v11, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
+
+Block 2:
+()() = v19, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v14, core::array::Array::<core::felt252>[] = v7, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v12, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v11, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
+
+//! > ==========================================================================
+
+//! > Test long arrays merge across branches keeping suffix elements
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > comments
+Both branches build the same 7-element array, whose forgotten prefix has a branch-local
+placeholder; the merge keeps the shared suffix elements under a fresh placeholder, and the
+post-merge append extends the merged relation.
+
+//! > function_code
+fn foo(
+    a0: felt252,
+    a1: felt252,
+    a2: felt252,
+    a3: felt252,
+    a4: felt252,
+    a5: felt252,
+    a6: felt252,
+    a7: felt252,
+    c: bool,
+) -> Array<felt252> {
+    let mut arr = ArrayTrait::new();
+    if c {
+        arr.append(a0);
+        arr.append(a1);
+        arr.append(a2);
+        arr.append(a3);
+        arr.append(a4);
+        arr.append(a5);
+        arr.append(a6);
+    } else {
+        arr.append(a0);
+        arr.append(a1);
+        arr.append(a2);
+        arr.append(a3);
+        arr.append(a4);
+        arr.append(a5);
+        arr.append(a6);
+    }
+    arr.append(a7);
+    arr
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252, v2: core::felt252, v3: core::felt252, v4: core::felt252, v5: core::felt252, v6: core::felt252, v7: core::felt252, v8: core::bool
+blk0 (root):
+Statements:
+  (v9: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+End:
+  Match(match_enum(v8) {
+    bool::False(v10) => blk1,
+    bool::True(v11) => blk2,
+  })
+
+blk1:
+Statements:
+  (v12: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v9, v0)
+  (v13: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v12, v1)
+  (v14: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v13, v2)
+  (v15: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v14, v3)
+  (v16: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v15, v4)
+  (v17: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v16, v5)
+  (v18: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v17, v6)
+End:
+  Goto(blk3, {v18 -> v19})
+
+blk2:
+Statements:
+  (v20: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v9, v0)
+  (v21: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v20, v1)
+  (v22: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v21, v2)
+  (v23: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v22, v3)
+  (v24: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v23, v4)
+  (v25: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v24, v5)
+  (v26: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v25, v6)
+End:
+  Goto(blk3, {v26 -> v19})
+
+blk3:
+Statements:
+  (v27: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v19, v7)
+End:
+  Return(v27)
+
+//! > analysis_state
+Block 0:
+core::array::Array::<core::felt252>[] = v9
+
+Block 1:
+False(v10) = v8, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v17, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v18, core::array::Array::<core::felt252>[] = v9, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v16, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v15, core::array::Array::<core::felt252>[v0, v1, v2] = v14, core::array::Array::<core::felt252>[v0, v1] = v13, core::array::Array::<core::felt252>[v0] = v12
+
+Block 2:
+True(v11) = v8, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v25, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v26, core::array::Array::<core::felt252>[] = v9, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v24, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v23, core::array::Array::<core::felt252>[v0, v1, v2] = v22, core::array::Array::<core::felt252>[v0, v1] = v21, core::array::Array::<core::felt252>[v0] = v20
+
+Block 3:
+core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v19, core::array::Array::<core::felt252>[?(*), v3, v4, v5, v6, v7] = v27, core::array::Array::<core::felt252>[] = v9
+
+//! > ==========================================================================
+
 //! > Test array pop_front recovers elements and merge works correctly
 
 //! > test_runner_name


### PR DESCRIPTION
Fixes the 2.19.0-rc compile-time regression reported on s2morrow (cairo-test build 1.5s on 2.18 → 16.6s on rc.2) by changing how the equality analysis tracks array contents.

## Root cause

Every `array_append` on a tracked array recorded a fresh `Relation::Array` holding *all* elements appended so far — O(N²) state for an `array![e0..eN]` literal, kept per block, cloned at every CFG edge, and amplified ×5 per function (`OptimizeMatches` runs the analysis 3 times — already in rc.2 — and `VariableForwarding` 2 more in rc.3). The passes themselves are cheap; the cost is purely analysis state size.

## The new representation

An array's tracked contents (`ArrayItems`) are now:

- `suffix: Vec<FieldVar>` — the last up-to-`MAX_ARRAY_TRACKED_ITEMS` (5) elements, individually tracked;
- `prefix_placeholder: Option<Placeholder>` — the identity of everything before them: a forgotten prefix with unknown count (`None` means the contents are fully known).

On append past the budget, the oldest tracked element is forgotten into the prefix under a fresh placeholder. Popping the back yields the tracked last element; popping the front of an array with a forgotten prefix conservatively drops tracking — the element and remainder are unknown (a follow-up, #10085, keeps the remainder tracked). At merges, suffixes meet element-wise and the prefix keeps its placeholder only when shared by both branches, degrading to a fresh one otherwise.

Prefix placeholders are globally unique (like unknown-field placeholders): two prefixes describe the same element sequence only when their placeholders match, so array relations only hashcons when their forgotten parts share a lineage — this keeps the forward-map dedup sound.

The trade-off vs. earlier revisions of this PR (bounded prefix tracking + size-typed runs): front-element forwarding is kept only for arrays that fit the budget — `arr.pop_front()` on a >5-element literal no longer yields `Box(first)` — in exchange for a substantially simpler representation. Back-element forwarding (`Span::pop_back`) keeps full fidelity on arrays of any size, and arrays of ≤5 elements stay fully tracked.

## Affected code

The change is confined to `equality_analysis.rs`: the only external consumers (`match_optimizer` via `get_enum_construct`, `variable_forwarding` via `find_immut`) read the union-find, which array relations influence only through the unions they generate. Golden tests cover the bounded tracking, front pops on arrays with a forgotten prefix, and the cross-branch merge of long arrays.

## Numbers

- s2morrow `sphincs_plus` (1965-element test vector): **44.9s / 14.5GB → ~3s / ~1GB** (2.18-like baseline with no equality analysis: 2.20s / 1.0GB; measured on the initial revision of this fix — the current representation tracks strictly less state).
- `cairo-to-sierra/big_array` canary (parent PR #10075): **18.2s → 1.5s** (re-measured on this revision).
- Other canaries (struct/enum/nesting/loops) and the staking contract: unchanged.
- Full workspace test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
