### PR TITLE
(refactor): introduce a Placeholder struct in equality analysis

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
@@ -21,13 +21,25 @@ use crate::{
     BlockEnd, BlockId, Lowered, MatchArm, MatchExternInfo, MatchInfo, Statement, VariableId,
 };
 
+/// A globally unique token for an unknown value tracked by the analysis. Allocated by
+/// [`fresh_placeholder`]; equality means "the very same unknown", so distinct unknowns never
+/// compare equal.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+struct Placeholder(usize);
+
+/// Allocates a globally unique placeholder.
+fn fresh_placeholder(next_placeholder: &mut usize) -> Placeholder {
+    *next_placeholder += 1;
+    Placeholder(*next_placeholder - 1)
+}
+
 /// A struct field variable: either a real variable or a unique placeholder for an unknown field.
 /// Placeholders are created during merge when a field has no intersection representative.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 enum FieldVar {
     Var(VariableId),
     /// A globally unique placeholder representing an unknown field.
-    Placeholder(usize),
+    Placeholder(Placeholder),
 }
 
 impl FieldVar {
@@ -572,10 +584,7 @@ fn merge_relations<'db>(
                                 any_data = true;
                                 FieldVar::Var(result.find(*v))
                             }
-                            (_, _) => {
-                                *next_placeholder += 1;
-                                FieldVar::Placeholder(*next_placeholder - 1)
-                            }
+                            (_, _) => FieldVar::Placeholder(fresh_placeholder(next_placeholder)),
                         })
                         .collect();
                     if any_data || result_fields.is_empty() {


### PR DESCRIPTION
## Summary

Extracts placeholder allocation logic into a dedicated `Placeholder` newtype and a `fresh_placeholder` helper function. The inline increment-and-index pattern (`*next_placeholder += 1; FieldVar::Placeholder(*next_placeholder - 1)`) is replaced with a call to `fresh_placeholder(next_placeholder)`, which returns a typed `Placeholder(usize)` value. `FieldVar::Placeholder` now wraps `Placeholder` instead of a raw `usize`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The raw `usize` used for placeholders had no type-level distinction from other integers, and the allocation logic was duplicated inline. Introducing the `Placeholder` newtype makes the intent explicit in the type system, and centralizing allocation in `fresh_placeholder` removes the error-prone off-by-one arithmetic at the call site.

---

## What was the behavior or documentation before?

Placeholder allocation was done inline with a manual increment and an immediate subtract-one dereference, and placeholders were stored as raw `usize` values inside `FieldVar::Placeholder`.

---

## What is the behavior or documentation after?

Placeholder allocation is handled by `fresh_placeholder`, which encapsulates the counter increment and returns a typed `Placeholder` value. `FieldVar::Placeholder` wraps `Placeholder` instead of `usize`, making the distinction between a placeholder and an arbitrary integer clear at the type level.

---

## Related issue or discussion (if any)

---

## Additional context

No behavioral change is introduced; this is a purely structural refactor of the placeholder allocation mechanism in the equality analysis pass.