### PR TITLE
bugfix(plugins): Fix derive(Hash)/derive(Serde) codegen for enums.

### DIFF
--- a/crates/cairo-lang-plugins/src/plugins/derive/hash.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/hash.rs
@@ -14,8 +14,12 @@ pub fn handle_hash(info: &PluginTypeInfo<'_>) -> String {
     match &info.type_variant {
         TypeVariant::Enum => {
             let impl_additional_generics = info
-                .impl_generics(&[HASH_TRAIT], |trt, ty| {
-                    format!("{trt}<{ty}, __State, __SHashState>")
+                .impl_generics(&[HASH_TRAIT, DROP_TRAIT], |trt, ty| {
+                    if trt == HASH_TRAIT {
+                        format!("{HASH_TRAIT}<{ty}, __State, __SHashState>")
+                    } else {
+                        format!("{trt}<{ty}>")
+                    }
                 })
                 .join(", ");
             let extra_comma = if impl_additional_generics.is_empty() { "" } else { ",\n    " };
@@ -36,11 +40,13 @@ pub fn handle_hash(info: &PluginTypeInfo<'_>) -> String {
                 indent_by(12,
                 info.members_info.iter().enumerate().map(|(idx, variant)| formatdoc!{"
                             {ty}::{variant}(x) => {{
+                                let x = {drop_with} {{ value: x }};
                                 let state = {HASH_TRAIT}::update_state(state, {idx}_felt252);
-                                {imp}::update_state(state, x)
+                                {imp}::update_state(state, x.value)
                             }},",
                         variant=variant.name,
                         imp = variant.impl_name(HASH_TRAIT),
+                        drop_with = variant.drop_with(),
                     }
                 ).join("\n"))
             }

--- a/crates/cairo-lang-plugins/src/plugins/derive/serde.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/serde.rs
@@ -12,15 +12,7 @@ pub fn handle_serde(info: &PluginTypeInfo<'_>, member_access_desnaps: bool) -> S
     let ty = &info.name;
     let full_typename = info.full_typename();
     let header = match &info.type_variant {
-        TypeVariant::Enum => {
-            let impl_additional_generics =
-                info.impl_generics(&[SERDE_TRAIT], |trt, ty| format!("{trt}<{ty}>")).join(", ");
-            formatdoc! {"
-            impl {ty}Serde<
-                    {impl_additional_generics}
-                > of {SERDE_TRAIT}<{full_typename}>
-            "}
-        }
+        TypeVariant::Enum => info.impl_header(SERDE_TRAIT, &[SERDE_TRAIT]),
         TypeVariant::Struct => info.impl_header(SERDE_TRAIT, &[SERDE_TRAIT, DESTRUCT_TRAIT]),
     };
     let serialize_body = indent_by(

--- a/crates/cairo-lang-plugins/src/test_data/derive
+++ b/crates/cairo-lang-plugins/src/test_data/derive
@@ -53,6 +53,26 @@ enum TwoVariantEnum {
     Second: B,
 }
 
+#[derive(Drop, Hash)]
+enum GenericEnum<T> {
+    Variant: T,
+    Other: felt252,
+}
+
+#[derive(Drop, Hash)]
+enum GenericEnumMulti<T> {
+    First: T,
+    Second: T,
+    Third: felt252,
+}
+
+#[derive(Drop, Hash)]
+enum GenericEnumMultiType<T, U> {
+    First: T,
+    Second: U,
+    Third: felt252,
+}
+
 //! > expanded_cairo_code
 #[derive(Copy, Debug, Default, Drop, Hash)]
 struct A {}
@@ -101,6 +121,26 @@ enum TwoVariantEnum {
     First: A,
     #[default]
     Second: B,
+}
+
+#[derive(Drop, Hash)]
+enum GenericEnum<T> {
+    Variant: T,
+    Other: felt252,
+}
+
+#[derive(Drop, Hash)]
+enum GenericEnumMulti<T> {
+    First: T,
+    Second: T,
+    Third: felt252,
+}
+
+#[derive(Drop, Hash)]
+enum GenericEnumMultiType<T, U> {
+    First: T,
+    Second: U,
+    Third: felt252,
 }
 impl ACopy<> of core::traits::Copy::<A>;
 impl ADebug<> of core::fmt::Debug::<A> {
@@ -536,12 +576,14 @@ impl TwoVariantEnumHash<
     fn update_state(state: __State, value: TwoVariantEnum) -> __State {
         match value {
             TwoVariantEnum::First(x) => {
+                let x = core::internal::InferDrop::<A> { value: x };
                 let state = core::hash::Hash::update_state(state, 0_felt252);
-                core::hash::Hash::<A>::update_state(state, x)
+                core::hash::Hash::<A>::update_state(state, x.value)
             },
             TwoVariantEnum::Second(x) => {
+                let x = core::internal::InferDrop::<B> { value: x };
                 let state = core::hash::Hash::update_state(state, 1_felt252);
-                core::hash::Hash::<B>::update_state(state, x)
+                core::hash::Hash::<B>::update_state(state, x.value)
             },
         }
     }
@@ -568,10 +610,7 @@ impl TwoVariantEnumPartialEq<> of core::traits::PartialEq::<TwoVariantEnum> {
         }
     }
 }
-impl TwoVariantEnumSerde<
-        
-    > of core::serde::Serde<TwoVariantEnum>
- {
+impl TwoVariantEnumSerde<> of core::serde::Serde::<TwoVariantEnum> {
     fn serialize(self: @TwoVariantEnum, ref output: core::array::Array<felt252>) {
         match self {
             TwoVariantEnum::First(x) => { core::serde::Serde::<felt252>::serialize(@0, ref output); core::serde::Serde::<A>::serialize(x, ref output); },
@@ -587,6 +626,85 @@ impl TwoVariantEnumSerde<
                 _ => { return core::option::Option::None; }
             }
         )
+    }
+}
+impl GenericEnumDrop<T, impl __MEMBER_IMPL_Variant_Drop: core::traits::Drop<T>> of core::traits::Drop::<GenericEnum<T>>;
+impl GenericEnumHash<
+    __State,
+    impl __SHashState: core::hash::HashStateTrait<__State>,
+    +core::traits::Drop<__State>,
+    T, impl __MEMBER_IMPL_Variant_Hash: core::hash::Hash<T, __State, __SHashState>, impl __MEMBER_IMPL_Variant_Drop: core::traits::Drop<T>
+> of core::hash::Hash<GenericEnum<T>, __State, __SHashState> {
+    #[inline(always)]
+    fn update_state(state: __State, value: GenericEnum<T>) -> __State {
+        match value {
+            GenericEnum::Variant(x) => {
+                let x = core::internal::DropWith::<T, __MEMBER_IMPL_Variant_Drop> { value: x };
+                let state = core::hash::Hash::update_state(state, 0_felt252);
+                __MEMBER_IMPL_Variant_Hash::update_state(state, x.value)
+            },
+            GenericEnum::Other(x) => {
+                let x = core::internal::InferDrop::<felt252> { value: x };
+                let state = core::hash::Hash::update_state(state, 1_felt252);
+                core::hash::Hash::<felt252>::update_state(state, x.value)
+            },
+        }
+    }
+}
+impl GenericEnumMultiDrop<T, impl __MEMBER_IMPL_First_Drop: core::traits::Drop<T>, impl __MEMBER_IMPL_Second_Drop: core::traits::Drop<T>> of core::traits::Drop::<GenericEnumMulti<T>>;
+impl GenericEnumMultiHash<
+    __State,
+    impl __SHashState: core::hash::HashStateTrait<__State>,
+    +core::traits::Drop<__State>,
+    T, impl __MEMBER_IMPL_First_Hash: core::hash::Hash<T, __State, __SHashState>, impl __MEMBER_IMPL_First_Drop: core::traits::Drop<T>, impl __MEMBER_IMPL_Second_Hash: core::hash::Hash<T, __State, __SHashState>, impl __MEMBER_IMPL_Second_Drop: core::traits::Drop<T>
+> of core::hash::Hash<GenericEnumMulti<T>, __State, __SHashState> {
+    #[inline(always)]
+    fn update_state(state: __State, value: GenericEnumMulti<T>) -> __State {
+        match value {
+            GenericEnumMulti::First(x) => {
+                let x = core::internal::DropWith::<T, __MEMBER_IMPL_First_Drop> { value: x };
+                let state = core::hash::Hash::update_state(state, 0_felt252);
+                __MEMBER_IMPL_First_Hash::update_state(state, x.value)
+            },
+            GenericEnumMulti::Second(x) => {
+                let x = core::internal::DropWith::<T, __MEMBER_IMPL_Second_Drop> { value: x };
+                let state = core::hash::Hash::update_state(state, 1_felt252);
+                __MEMBER_IMPL_Second_Hash::update_state(state, x.value)
+            },
+            GenericEnumMulti::Third(x) => {
+                let x = core::internal::InferDrop::<felt252> { value: x };
+                let state = core::hash::Hash::update_state(state, 2_felt252);
+                core::hash::Hash::<felt252>::update_state(state, x.value)
+            },
+        }
+    }
+}
+impl GenericEnumMultiTypeDrop<T, U, impl __MEMBER_IMPL_First_Drop: core::traits::Drop<T>, impl __MEMBER_IMPL_Second_Drop: core::traits::Drop<U>> of core::traits::Drop::<GenericEnumMultiType<T, U>>;
+impl GenericEnumMultiTypeHash<
+    __State,
+    impl __SHashState: core::hash::HashStateTrait<__State>,
+    +core::traits::Drop<__State>,
+    T, U, impl __MEMBER_IMPL_First_Hash: core::hash::Hash<T, __State, __SHashState>, impl __MEMBER_IMPL_First_Drop: core::traits::Drop<T>, impl __MEMBER_IMPL_Second_Hash: core::hash::Hash<U, __State, __SHashState>, impl __MEMBER_IMPL_Second_Drop: core::traits::Drop<U>
+> of core::hash::Hash<GenericEnumMultiType<T, U>, __State, __SHashState> {
+    #[inline(always)]
+    fn update_state(state: __State, value: GenericEnumMultiType<T, U>) -> __State {
+        match value {
+            GenericEnumMultiType::First(x) => {
+                let x = core::internal::DropWith::<T, __MEMBER_IMPL_First_Drop> { value: x };
+                let state = core::hash::Hash::update_state(state, 0_felt252);
+                __MEMBER_IMPL_First_Hash::update_state(state, x.value)
+            },
+            GenericEnumMultiType::Second(x) => {
+                let x = core::internal::DropWith::<U, __MEMBER_IMPL_Second_Drop> { value: x };
+                let state = core::hash::Hash::update_state(state, 1_felt252);
+                __MEMBER_IMPL_Second_Hash::update_state(state, x.value)
+            },
+            GenericEnumMultiType::Third(x) => {
+                let x = core::internal::InferDrop::<felt252> { value: x };
+                let state = core::hash::Hash::update_state(state, 2_felt252);
+                core::hash::Hash::<felt252>::update_state(state, x.value)
+            },
+        }
     }
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/user_defined_types
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/user_defined_types
@@ -446,10 +446,7 @@ lib.cairo:20:5
 impls:
 
 impl SimpleEnumDrop<> of core::traits::Drop::<SimpleEnum>;
-impl SimpleEnumSerde<
-        
-    > of core::serde::Serde<SimpleEnum>
- {
+impl SimpleEnumSerde<> of core::serde::Serde::<SimpleEnum> {
     fn serialize(self: @SimpleEnum, ref output: core::array::Array<felt252>) {
         match self {
             SimpleEnum::A(x) => { core::serde::Serde::<felt252>::serialize(@0, ref output); core::serde::Serde::<u8>::serialize(x, ref output); },
@@ -559,10 +556,7 @@ lib.cairo:26:5
 impls:
 
 impl EnumWithDefaultDrop<> of core::traits::Drop::<EnumWithDefault>;
-impl EnumWithDefaultSerde<
-        
-    > of core::serde::Serde<EnumWithDefault>
- {
+impl EnumWithDefaultSerde<> of core::serde::Serde::<EnumWithDefault> {
     fn serialize(self: @EnumWithDefault, ref output: core::array::Array<felt252>) {
         match self {
             EnumWithDefault::A(x) => { core::serde::Serde::<felt252>::serialize(@0, ref output); core::serde::Serde::<u8>::serialize(x, ref output); },
@@ -696,10 +690,7 @@ lib.cairo:34:5
 impls:
 
 impl BadEnumWithDefaultDrop<> of core::traits::Drop::<BadEnumWithDefault>;
-impl BadEnumWithDefaultSerde<
-        
-    > of core::serde::Serde<BadEnumWithDefault>
- {
+impl BadEnumWithDefaultSerde<> of core::serde::Serde::<BadEnumWithDefault> {
     fn serialize(self: @BadEnumWithDefault, ref output: core::array::Array<felt252>) {
         match self {
             BadEnumWithDefault::A(x) => { core::serde::Serde::<felt252>::serialize(@0, ref output); core::serde::Serde::<u8>::serialize(x, ref output); },
@@ -727,10 +718,7 @@ lib.cairo:43:5
 impls:
 
 impl EmptyEnumDrop<> of core::traits::Drop::<EmptyEnum>;
-impl EmptyEnumSerde<
-        
-    > of core::serde::Serde<EmptyEnum>
- {
+impl EmptyEnumSerde<> of core::serde::Serde::<EmptyEnum> {
     fn serialize(self: @EmptyEnum, ref output: core::array::Array<felt252>) {
         match self {
             


### PR DESCRIPTION
## Summary

Fixes `#[derive(Hash)]` for generic enums by ensuring variant values are properly dropped after hashing. Each enum variant's value is now wrapped in a `DropWith` or `InferDrop` struct before calling `update_state`, so the value is consumed through `x.value` rather than directly. The `Hash` derive for enums now also requires `Drop` bounds on generic type parameters, adding `DROP_TRAIT` to the list of impl generics alongside `HASH_TRAIT`.

Additionally, the `Serde` derive for non-generic enums is simplified to use `impl_header` (consistent with structs), which removes the spurious empty whitespace in the generated impl header.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Deriving `Hash` on a generic enum previously did not require or use `Drop` bounds on the generic type parameters. After `update_state` consumes the variant value, the remaining matched value would not be properly dropped, causing a compilation error for generic enums. The fix wraps each variant value in a `DropWith`/`InferDrop` struct so the compiler can infer the correct drop behavior.

---

## What was the behavior or documentation before?

`#[derive(Hash)]` on a generic enum (e.g., `enum GenericEnum<T>`) would fail to compile because the derived implementation did not include `Drop<T>` bounds and did not properly drop the matched variant values.

---

## What is the behavior or documentation after?

`#[derive(Hash)]` on generic enums now generates correct implementations that include `Drop<T>` bounds for each generic member and wrap variant values in `DropWith`/`InferDrop` before hashing, ensuring values are properly consumed.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Test cases for `GenericEnum<T>` and `GenericEnumMulti<T>` have been added to the derive test data to cover single and multiple generic variant scenarios.