### PR TITLE
(opt): keep tracking array remainders popped through the forgotten prefix in equality analysis

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
@@ -28,7 +28,8 @@ use crate::{
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 struct Placeholder(usize);
 
-/// Allocates a globally unique placeholder, used for unknown struct fields and array runs.
+/// Allocates a globally unique placeholder, used for unknown struct fields and forgotten array
+/// prefixes.
 fn fresh_placeholder(next_placeholder: &mut usize) -> Placeholder {
     *next_placeholder += 1;
     Placeholder(*next_placeholder - 1)
@@ -68,7 +69,7 @@ impl FieldVar {
 /// placeholder prefix (see [`ArrayItems`]).
 const MAX_ARRAY_TRACKED_ITEMS: usize = 5;
 
-/// The tracked contents of an array: a forgotten prefix of elements (at least one, count
+/// The tracked contents of an array: a forgotten prefix of elements (possibly empty, count
 /// unknown), followed by a bounded number of tracked trailing ones.
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 struct ArrayItems {
@@ -108,21 +109,43 @@ impl ArrayItems {
     }
 
     /// Removes one element from the front (`from_front`) or back.
-    fn pop(&self, from_front: bool) -> PopResult {
+    fn pop(&self, from_front: bool, next_placeholder: &mut usize) -> PopResult {
         // Empty case.
         if self.is_empty() {
             return PopResult::KnownEmpty;
         }
-        // Unknown cases are when there is a forgotten prefix and popping from the front, or
-        // popping from the back when the suffix is empty.
-        if self.prefix_placeholder.is_some() && (from_front || self.suffix.is_empty()) {
-            return PopResult::Unknown;
+        if self.prefix_placeholder.is_some() {
+            if from_front {
+                // The prefix may be empty, so the popped element is either a forgotten one or
+                // the first suffix element — unknown either way. That first suffix element's
+                // position is no longer certain, so fold it into the fresh prefix; the rest of
+                // the suffix stays tracked.
+                let [_, rest @ ..] = self.suffix.as_slice() else {
+                    return PopResult::Unknown;
+                };
+                return PopResult::ForgottenElement {
+                    remaining: ArrayItems {
+                        prefix_placeholder: Some(fresh_placeholder(next_placeholder)),
+                        suffix: rest.to_vec(),
+                    },
+                };
+            }
+            if self.suffix.is_empty() {
+                // The popped element comes off the forgotten prefix, and nothing remains
+                // tracked.
+                return PopResult::Unknown;
+            }
         }
-        // Suffix is not empty, so we can pop from it.
-        let mut remaining = self.clone();
-        let element =
-            if from_front { remaining.suffix.remove(0) } else { remaining.suffix.pop().unwrap() };
-        PopResult::Element { element, remaining }
+        let (&element, rest) =
+            if from_front { self.suffix.split_first() } else { self.suffix.split_last() }
+                .expect("suffix is non-empty");
+        PopResult::Element {
+            element,
+            remaining: ArrayItems {
+                prefix_placeholder: self.prefix_placeholder,
+                suffix: rest.to_vec(),
+            },
+        }
     }
 }
 
@@ -130,6 +153,8 @@ impl ArrayItems {
 enum PopResult {
     /// The popped element is individually tracked.
     Element { element: FieldVar, remaining: ArrayItems },
+    /// The popped element's value is unknown, but the remaining contents are still tracked.
+    ForgottenElement { remaining: ArrayItems },
     /// The array is known to be empty, so there is no element to pop.
     KnownEmpty,
     /// The popped element came off the forgotten prefix, whose count is unknown, so neither
@@ -504,7 +529,7 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
         };
 
         let from_front = id != self.array_snapshot_pop_back;
-        let remaining = match items.pop(from_front) {
+        let remaining = match items.pop(from_front, &mut self.next_placeholder) {
             PopResult::Element { element, remaining } => {
                 // TODO(eytan-starkware): Add support for placeholders in boxes and reverse box
                 // relation to unify placeholder.
@@ -523,6 +548,7 @@ impl<'a, 'db> EqualityAnalysis<'a, 'db> {
                 }
                 remaining
             }
+            PopResult::ForgottenElement { remaining } => remaining,
             // `KnownEmpty` is unreachable at runtime (popping a known-empty array fails), so
             // nothing needs to be recorded for it.
             PopResult::KnownEmpty | PopResult::Unknown => return,
@@ -572,34 +598,35 @@ fn merge_field(
     }
 }
 
-/// Meets two arrays' tracked contents at a merge: requires forgotten-prefix presence and
-/// tracked element counts to match. Elements meet like struct fields; the prefix keeps its
-/// placeholder when shared, and otherwise degrades to a fresh one. Returns the met contents
-/// and whether any real data survived, or `None` when the shapes are incompatible.
+/// Meets two arrays' tracked contents at a merge: the common trailing elements meet like
+/// struct fields, and everything before them — when the shapes are not identical — degrades
+/// to a fresh forgotten prefix (which may cover zero elements on a side, so no information
+/// needs to be dropped). Returns the met contents and whether any real data survived.
 fn merge_array_items(
     items1: &ArrayItems,
     items2: &ArrayItems,
     result: &mut EqualityState<'_>,
     next_placeholder: &mut usize,
-) -> Option<(ArrayItems, bool)> {
-    if items1.suffix.len() != items2.suffix.len() {
-        return None;
-    }
+) -> (ArrayItems, bool) {
     let mut any_data = false;
+    // The number of trailing elements tracked on both sides.
+    let kept = items1.suffix.len().min(items2.suffix.len());
+    let same_shape = items1.suffix.len() == items2.suffix.len();
     let prefix_placeholder = match (items1.prefix_placeholder, items2.prefix_placeholder) {
-        (None, None) => None,
-        (Some(p1), Some(p2)) => Some(if p1 == p2 {
+        (None, None) if same_shape => None,
+        (Some(p1), Some(p2)) if p1 == p2 && same_shape => {
             any_data = true;
-            p1
-        } else {
-            fresh_placeholder(next_placeholder)
-        }),
-        (None, Some(_)) | (Some(_), None) => return None,
+            Some(p1)
+        }
+        _ => Some(fresh_placeholder(next_placeholder)),
     };
-    let suffix = zip_eq(&items1.suffix, &items2.suffix)
-        .map(|(f1, f2)| merge_field(*f1, *f2, result, next_placeholder, &mut any_data))
-        .collect();
-    Some((ArrayItems { prefix_placeholder, suffix }, any_data))
+    let suffix = zip_eq(
+        &items1.suffix[items1.suffix.len() - kept..],
+        &items2.suffix[items2.suffix.len() - kept..],
+    )
+    .map(|(f1, f2)| merge_field(*f1, *f2, result, next_placeholder, &mut any_data))
+    .collect();
+    (ArrayItems { prefix_placeholder, suffix }, any_data)
 }
 
 /// Keeps relational edges that survive the join **without** mapping variables across mismatched
@@ -714,11 +741,8 @@ fn merge_relations<'db>(
                     if ty2 != ty {
                         continue;
                     }
-                    let Some((result_items, any_data)) =
-                        merge_array_items(items1, items2, result, next_placeholder)
-                    else {
-                        continue;
-                    };
+                    let (result_items, any_data) =
+                        merge_array_items(items1, items2, result, next_placeholder);
                     if any_data || result_items.is_empty() {
                         result
                             .set_relation(Relation::Array(*ty, result_items), output_intersection);

--- a/crates/cairo-lang-lowering/src/analysis/test_data/equality
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/equality
@@ -1032,8 +1032,8 @@ core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array
 test_equality_analysis
 
 //! > comments
-The popped element comes off the forgotten prefix, so neither it nor the remainder is
-recorded.
+The popped element comes off the forgotten prefix, so its value is unknown; the remainder
+stays tracked under a fresh prefix.
 
 //! > function_code
 fn foo(
@@ -1096,7 +1096,7 @@ Block 0:
 core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v14, core::array::Array::<core::felt252>[] = v7, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v12, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v11, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
 
 Block 1:
-Box(v18) = v16, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v14, core::array::Array::<core::felt252>[] = v7, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v12, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v11, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
+Box(v18) = v16, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v14, core::array::Array::<core::felt252>[?(*), v3, v4, v5, v6] = v15, core::array::Array::<core::felt252>[] = v7, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v12, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v11, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
 
 Block 2:
 ()() = v19, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v13, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v14, core::array::Array::<core::felt252>[] = v7, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v12, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v11, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
@@ -1593,6 +1593,277 @@ Block 1:
 
 Block 2:
 ()() = v11, @v2 = v4, core::array::Span::<core::felt252>(v4) = v5, v2 = v3, v4 = v6
+
+//! > ==========================================================================
+
+//! > Test arrays merge across branches with different lengths
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > comments
+The branches build arrays of different lengths (sharing their trailing elements); the
+common trailing elements survive the merge behind a fresh forgotten prefix.
+
+//! > function_code
+fn foo(a0: felt252, a1: felt252, a2: felt252, a3: felt252, c: bool) -> Array<felt252> {
+    let mut arr = ArrayTrait::new();
+    if c {
+        arr.append(a1);
+        arr.append(a2);
+    } else {
+        arr.append(a0);
+        arr.append(a1);
+        arr.append(a2);
+    }
+    arr.append(a3);
+    arr
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252, v2: core::felt252, v3: core::felt252, v4: core::bool
+blk0 (root):
+Statements:
+  (v5: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+End:
+  Match(match_enum(v4) {
+    bool::False(v6) => blk1,
+    bool::True(v7) => blk2,
+  })
+
+blk1:
+Statements:
+  (v8: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v5, v0)
+  (v9: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v8, v1)
+  (v10: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v9, v2)
+End:
+  Goto(blk3, {v10 -> v11})
+
+blk2:
+Statements:
+  (v12: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v5, v1)
+  (v13: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v12, v2)
+End:
+  Goto(blk3, {v13 -> v11})
+
+blk3:
+Statements:
+  (v14: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v11, v3)
+End:
+  Return(v14)
+
+//! > analysis_state
+Block 0:
+core::array::Array::<core::felt252>[] = v5
+
+Block 1:
+False(v6) = v4, core::array::Array::<core::felt252>[] = v5, core::array::Array::<core::felt252>[v0, v1, v2] = v10, core::array::Array::<core::felt252>[v0, v1] = v9, core::array::Array::<core::felt252>[v0] = v8
+
+Block 2:
+True(v7) = v4, core::array::Array::<core::felt252>[] = v5, core::array::Array::<core::felt252>[v1, v2] = v13, core::array::Array::<core::felt252>[v1] = v12
+
+Block 3:
+core::array::Array::<core::felt252>[?(*), v1, v2, v3] = v14, core::array::Array::<core::felt252>[?(*), v1, v2] = v11, core::array::Array::<core::felt252>[] = v5
+
+//! > ==========================================================================
+
+//! > Test arrays merge across branches with mixed prefix presence
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > comments
+One branch's array has a forgotten prefix while the other's is fully known (sharing the
+trailing elements); all the common trailing elements survive the merge behind a fresh,
+possibly-empty forgotten prefix.
+
+//! > function_code
+fn foo(
+    a0: felt252,
+    a1: felt252,
+    a2: felt252,
+    a3: felt252,
+    a4: felt252,
+    a5: felt252,
+    a6: felt252,
+    c: bool,
+) -> Array<felt252> {
+    let mut arr = ArrayTrait::new();
+    if c {
+        arr.append(a0);
+        arr.append(a1);
+        arr.append(a2);
+        arr.append(a3);
+        arr.append(a4);
+        arr.append(a5);
+    } else {
+        arr.append(a1);
+        arr.append(a2);
+        arr.append(a3);
+        arr.append(a4);
+        arr.append(a5);
+    }
+    arr.append(a6);
+    arr
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252, v2: core::felt252, v3: core::felt252, v4: core::felt252, v5: core::felt252, v6: core::felt252, v7: core::bool
+blk0 (root):
+Statements:
+  (v8: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+End:
+  Match(match_enum(v7) {
+    bool::False(v9) => blk1,
+    bool::True(v10) => blk2,
+  })
+
+blk1:
+Statements:
+  (v11: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v8, v1)
+  (v12: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v11, v2)
+  (v13: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v12, v3)
+  (v14: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v13, v4)
+  (v15: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v14, v5)
+End:
+  Goto(blk3, {v15 -> v16})
+
+blk2:
+Statements:
+  (v17: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v8, v0)
+  (v18: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v17, v1)
+  (v19: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v18, v2)
+  (v20: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v19, v3)
+  (v21: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v20, v4)
+  (v22: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v21, v5)
+End:
+  Goto(blk3, {v22 -> v16})
+
+blk3:
+Statements:
+  (v23: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v16, v6)
+End:
+  Return(v23)
+
+//! > analysis_state
+Block 0:
+core::array::Array::<core::felt252>[] = v8
+
+Block 1:
+False(v9) = v7, core::array::Array::<core::felt252>[] = v8, core::array::Array::<core::felt252>[v1, v2, v3, v4, v5] = v15, core::array::Array::<core::felt252>[v1, v2, v3, v4] = v14, core::array::Array::<core::felt252>[v1, v2, v3] = v13, core::array::Array::<core::felt252>[v1, v2] = v12, core::array::Array::<core::felt252>[v1] = v11
+
+Block 2:
+True(v10) = v7, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v22, core::array::Array::<core::felt252>[] = v8, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v21, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v20, core::array::Array::<core::felt252>[v0, v1, v2] = v19, core::array::Array::<core::felt252>[v0, v1] = v18, core::array::Array::<core::felt252>[v0] = v17
+
+Block 3:
+core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v16, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v23, core::array::Array::<core::felt252>[] = v8
+
+//! > ==========================================================================
+
+//! > Test forgotten prefix is preserved across unrelated branches
+
+//! > test_runner_name
+test_equality_analysis
+
+//! > comments
+The array is built before the branch and untouched by it, so both arms reach the merge with
+the same placeholder and the relation survives intact.
+
+//! > function_code
+fn foo(
+    a0: felt252,
+    a1: felt252,
+    a2: felt252,
+    a3: felt252,
+    a4: felt252,
+    a5: felt252,
+    a6: felt252,
+    c: bool,
+) -> Array<felt252> {
+    let mut arr = ArrayTrait::new();
+    arr.append(a0);
+    arr.append(a1);
+    arr.append(a2);
+    arr.append(a3);
+    arr.append(a4);
+    arr.append(a5);
+    let x = if c {
+        a6 + a0
+    } else {
+        a6 - a0
+    };
+    arr.append(x);
+    arr
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering
+Parameters: v0: core::felt252, v1: core::felt252, v2: core::felt252, v3: core::felt252, v4: core::felt252, v5: core::felt252, v6: core::felt252, v7: core::bool
+blk0 (root):
+Statements:
+  (v8: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
+  (v9: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v8, v0)
+  (v10: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v9, v1)
+  (v11: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v10, v2)
+  (v12: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v11, v3)
+  (v13: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v12, v4)
+  (v14: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v13, v5)
+End:
+  Match(match_enum(v7) {
+    bool::False(v15) => blk1,
+    bool::True(v16) => blk2,
+  })
+
+blk1:
+Statements:
+  (v17: core::felt252) <- core::felt252_sub(v6, v0)
+End:
+  Goto(blk3, {v17 -> v18})
+
+blk2:
+Statements:
+  (v19: core::felt252) <- core::felt252_add(v6, v0)
+End:
+  Goto(blk3, {v19 -> v18})
+
+blk3:
+Statements:
+  (v20: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v14, v18)
+End:
+  Return(v20)
+
+//! > analysis_state
+Block 0:
+core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v14, core::array::Array::<core::felt252>[] = v8, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v13, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v12, core::array::Array::<core::felt252>[v0, v1, v2] = v11, core::array::Array::<core::felt252>[v0, v1] = v10, core::array::Array::<core::felt252>[v0] = v9
+
+Block 1:
+False(v15) = v7, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v14, core::array::Array::<core::felt252>[] = v8, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v13, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v12, core::array::Array::<core::felt252>[v0, v1, v2] = v11, core::array::Array::<core::felt252>[v0, v1] = v10, core::array::Array::<core::felt252>[v0] = v9
+
+Block 2:
+True(v16) = v7, core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v14, core::array::Array::<core::felt252>[] = v8, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v13, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v12, core::array::Array::<core::felt252>[v0, v1, v2] = v11, core::array::Array::<core::felt252>[v0, v1] = v10, core::array::Array::<core::felt252>[v0] = v9
+
+Block 3:
+core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v14, core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v18] = v20, core::array::Array::<core::felt252>[] = v8, core::array::Array::<core::felt252>[v0, v1, v2, v3, v4] = v13, core::array::Array::<core::felt252>[v0, v1, v2, v3] = v12, core::array::Array::<core::felt252>[v0, v1, v2] = v11, core::array::Array::<core::felt252>[v0, v1] = v10, core::array::Array::<core::felt252>[v0] = v9
 
 //! > ==========================================================================
 


### PR DESCRIPTION
## Summary

Extends the equality analysis for arrays to preserve tracked suffix elements after a front-pop that hits the forgotten prefix, and to handle merging arrays with mismatched suffix lengths at control-flow joins.

Previously, popping from the front of an array with a forgotten prefix always returned `PopResult::Unknown`, discarding all knowledge about the remaining array. Now, when the suffix is non-empty, a `PopResult::ForgottenElement` is returned: the popped element's value is unknown (it came off the forgotten prefix), but the remaining suffix elements are still tracked under a fresh prefix placeholder.

Similarly, `merge_array_items` previously required both sides to have identical suffix lengths and identical forgotten-prefix presence, returning `None` otherwise. It now computes the common trailing suffix across both sides, absorbs the oldest kept element into a fresh prefix when the shapes differ, and drops the relation only when one side is too short to contribute even a single element to the prefix.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When popping from the front of an array with a non-empty run and a non-empty suffix, the analysis was throwing away all knowledge of the remaining elements even though the suffix was still fully tracked. This caused the equality analysis to lose valid equalities that could be preserved.

At merge points, the strict shape-matching requirement meant that any two array states with different suffix lengths were immediately dropped, even when a meaningful common suffix existed.

---

## What was the behavior or documentation before?

- `ArrayItems::pop` with `from_front = true` and a forgotten prefix always returned `PopResult::Unknown`, losing all suffix tracking.
- `merge_array_items` returned `None` whenever the two sides had different suffix lengths or mismatched run presence.

---

## What is the behavior or documentation after?

- `ArrayItems::pop` with `from_front = true` and a forgotten prefix now returns `PopResult::ForgottenElement { remaining }` when the suffix is non-empty, preserving the trailing elements under a fresh prefix placeholder.
- `merge_array_items` computes the minimum common suffix length, absorbs the oldest kept element into a fresh run when shapes differ, and only drops the relation when no common suffix can be maintained.
- The test data reflects that `v25` (`[?(*), v8, v9, v10, v11]`) is now tracked in Block 1 where it previously was not.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `next_placeholder` counter is now threaded into `ArrayItems::pop` so that fresh placeholders can be minted when a front-pop produces a `ForgottenElement` result.
