### PR TITLE
bugfix(semantic): Include captured_types in closure occurs-check.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference/conform.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/conform.rs
@@ -5,7 +5,7 @@ use cairo_lang_diagnostics::Maybe;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::{Entry, OrderedHashMap};
-use itertools::zip_eq;
+use itertools::{chain, zip_eq};
 
 use super::canonic::{NoError, ResultNoErrEx};
 use super::{
@@ -861,8 +861,8 @@ impl<'db> Inference<'db, '_> {
                 self.internal_ty_contains_var(*type_id, var)
             }
             TypeLongId::Closure(closure) => {
-                closure.param_tys.iter().any(|ty| self.internal_ty_contains_var(*ty, var))
-                    || self.internal_ty_contains_var(closure.ret_ty, var)
+                chain!(&closure.param_tys, [&closure.ret_ty], &closure.captured_types)
+                    .any(|ty| self.internal_ty_contains_var(*ty, var))
             }
         }
     }

--- a/crates/cairo-lang-semantic/src/expr/test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/closure
@@ -833,3 +833,29 @@ error[E2121]: Named arguments are not supported in this context.
  --> lib.cairo:5:7
     c(b: 2_u32, a: 1_u32);
       ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Closure capturing an inferred-type value, unified with the closure type (occurs-check regression: must not stack-overflow).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn unify<T, +Drop<T>>(_a: T, _b: T) {}
+fn foo() {
+    let x = Default::default();
+    let f = || {
+        let _s = @x;
+    };
+    unify(x, f);
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+error[E2041]: Unexpected argument type. Expected: "?0", found: "{closure@lib.cairo:4:13: 4:15}".
+ --> lib.cairo:7:14
+    unify(x, f);
+             ^


### PR DESCRIPTION
## Summary

Fixes a stack-overflow (occurs-check infinite loop) that occurred when a closure capturing a variable of inferred type was unified with that same variable. The `internal_ty_contains_var` check for `TypeLongId::Closure` was not including `captured_types` in its occurs-check traversal, meaning the inference engine could not detect the cyclic type constraint and would recurse indefinitely.

The fix extends the occurs-check to also iterate over `closure.captured_types` alongside `param_tys` and `ret_ty`, using `itertools::chain!` to unify the three into a single iterator.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a closure captured a variable whose type was still being inferred, and that closure was then passed to a function expecting the same inferred type, the occurs-check (`internal_ty_contains_var`) failed to detect the cycle because it did not inspect `captured_types`. This caused the compiler to stack-overflow instead of emitting a proper type mismatch diagnostic.

---

## What was the behavior or documentation before?

Compiling code like:

```rust
fn unify<T, +Drop<T>>(_a: T, _b: T) {}
fn foo() {
    let x = Default::default();
    let f = || { let _s = @x; };
    unify(x, f);
}
```

would cause a stack overflow in the compiler.

---

## What is the behavior or documentation after?

The compiler now correctly detects the cyclic type constraint and emits a proper diagnostic:

```
error[E2041]: Unexpected argument type. Expected: "?0", found: "{closure@lib.cairo:4:13: 4:15}".
```

---

## Related issue or discussion (if any)

Occurs-check regression for closures capturing inferred-type variables.

---

## Additional context

A regression test has been added to `crates/cairo-lang-semantic/src/expr/test_data/closure` covering this exact scenario.