### PR TITLE
bugfix(compiler): Fix punctuation/newline of bare crate-root diagnostics.

### DIFF
--- a/crates/cairo-lang-compiler/src/diagnostics.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics.rs
@@ -160,7 +160,7 @@ impl<'a> DiagnosticsReporter<'a> {
                 self.callback.on_diagnostic(FormattedDiagnosticEntry::new(
                     Severity::Error,
                     None,
-                    "Failed to get main module file".to_string(),
+                    "Failed to get main module file.\n".to_string(),
                 ));
                 continue;
             };
@@ -171,7 +171,7 @@ impl<'a> DiagnosticsReporter<'a> {
                         self.callback.on_diagnostic(FormattedDiagnosticEntry::new(
                             Severity::Error,
                             None,
-                            format!("{} not found\n", path.display()),
+                            format!("{} not found.\n", path.display()),
                         ))
                     }
                     FileLongId::Virtual(_) => panic!("Missing virtual file."),

--- a/crates/cairo-lang-compiler/src/diagnostics_test.rs
+++ b/crates/cairo-lang-compiler/src/diagnostics_test.rs
@@ -16,5 +16,5 @@ fn test_diagnostics() {
         Some(CrateConfiguration::default_for_root(Directory::Real("no/such/path".into())))
     );
 
-    assert_eq!(get_diagnostics_as_string(&db, None), "error: no/such/path/lib.cairo not found\n");
+    assert_eq!(get_diagnostics_as_string(&db, None), "error: no/such/path/lib.cairo not found.\n");
 }


### PR DESCRIPTION
## Summary

Adds a trailing period to two diagnostic error messages: `"Failed to get main module file"` and `"{path} not found"`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

Other diagnostic error messages in the codebase end with a period for consistency. These two messages were missing the trailing period, making them inconsistent with the rest of the diagnostic output.

---

## What was the behavior or documentation before?

Error messages read:
- `"Failed to get main module file"`
- `"{path} not found"`

---

## What is the behavior or documentation after?

Error messages read:
- `"Failed to get main module file."`
- `"{path} not found."`

---

## Related issue or discussion (if any)

---

## Additional context