### PR TITLE
bugfix(parser): Skipped-token diagnostic spans the token, not its leading comment.

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -3659,14 +3659,14 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         let mut diag_start = None;
         let mut diag_end = None;
         while !should_stop(self.peek().kind) {
-            let terminal = self.take_raw();
-            diag_start.get_or_insert(self.offset);
-            diag_end =
-                Some(self.offset.add_width(TextWidth::from_str(terminal.text.long(self.db))));
+            let LexerTerminal { leading_trivia, text, trailing_trivia, .. } = self.take_raw();
+            let text_start = self.offset.add_width(trivia_total_width(self.db, &leading_trivia));
+            diag_start.get_or_insert(text_start);
+            diag_end = Some(text_start.add_width(TextWidth::from_str(text.long(self.db))));
 
-            self.pending_trivia.extend(terminal.leading_trivia);
-            self.pending_trivia.push(TokenSkipped::new_green(self.db, terminal.text).into());
-            self.pending_trivia.extend(terminal.trailing_trivia);
+            self.pending_trivia.extend(leading_trivia);
+            self.pending_trivia.push(TokenSkipped::new_green(self.db, text).into());
+            self.pending_trivia.extend(trailing_trivia);
         }
         if let (Some(diag_start), Some(diag_end)) = (diag_start, diag_end) {
             Err(SkippedError(TextSpan::new(diag_start, diag_end)))

--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/skipped_tokens
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/skipped_tokens
@@ -116,3 +116,23 @@ error[E1000]: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Fun
  --> dummy_file.cairo:3:9
   tokens  fn foo() {}
         ^
+
+//! > ==========================================================================
+
+//! > Skipped token whose leading trivia is a full-line comment: span points at the token, not the comment.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+fn foo()
+    // a leading comment
+    )
+{
+}
+
+//! > expected_diagnostics
+error[E1000]: Skipped tokens. Expected: '{'.
+ --> dummy_file.cairo:3:5
+    )
+    ^


### PR DESCRIPTION
## Summary

Fix the diagnostic span for skipped tokens so that it points to the token itself rather than to any leading trivia (e.g., a comment) that precedes it. Previously, `diag_start` was set to `self.offset` before accounting for leading trivia width, causing the reported error span to begin at the start of the leading trivia. Now, `text_start` is computed by advancing past the leading trivia, and `diag_start`/`diag_end` are derived from that position.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a skipped token was preceded by a leading comment or other trivia, the diagnostic span incorrectly pointed at the beginning of that trivia rather than at the actual skipped token. This made error messages misleading, as the caret would appear under the comment rather than the offending token.

---

## What was the behavior or documentation before?

The error span for a skipped token started at `self.offset`, which is the position before leading trivia is consumed. For example, a `)` preceded by `// a leading comment` would have its error caret pointing at the comment line rather than at `)`.

---

## What is the behavior or documentation after?

The error span now starts at `text_start`, which is `self.offset` advanced by the total width of the leading trivia. The caret in the diagnostic correctly points at the skipped token itself, not at any preceding comment or whitespace.

---

## Related issue or discussion (if any)

---

## Additional context

Two new test cases are added to `skipped_tokens` to cover both the `skip_until` path and the single-token skip path, verifying that the diagnostic span targets the token rather than its leading comment.