### PR TITLE
fix(parser): validate literal in negative const generic arg

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -3192,7 +3192,11 @@ impl<'a, 'mt> Parser<'a, 'mt> {
             SyntaxKind::TerminalLiteralNumber => self.take_terminal_literal_number().into(),
             SyntaxKind::TerminalMinus => {
                 let op = self.take::<TerminalMinus<'_>>().into();
-                let expr = self.parse_token::<TerminalLiteralNumber<'_>>().into();
+                let expr = if self.peek().kind == SyntaxKind::TerminalLiteralNumber {
+                    self.take_terminal_literal_number().into()
+                } else {
+                    self.create_and_report_missing_terminal::<TerminalLiteralNumber<'_>>().into()
+                };
                 ExprUnary::new_green(self.db, op, expr).into()
             }
             SyntaxKind::TerminalShortString => self.take_terminal_short_string().into(),

--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/generic_params
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/generic_params
@@ -46,3 +46,82 @@ error[E1000]: Skipped tokens. Expected: generic param.
  --> dummy_file.cairo:1:41
 fn f<+I[a : b], impl C: G<A, B>[c],T[a:b]>() {}
                                         ^
+
+//! > ==========================================================================
+
+//! > Test negative const generic arg with invalid numeric literal.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+type T = Foo<-0x>;
+
+//! > expected_diagnostics
+error[E1016]: Literal is not a valid number.
+ --> dummy_file.cairo:1:15
+type T = Foo<-0x>;
+              ^^
+
+//! > ==========================================================================
+
+//! > Test negative const generic arg with trailing underscore literal.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+type T = Foo<-1_>;
+
+//! > expected_diagnostics
+error[E1015]: Missing literal suffix.
+ --> dummy_file.cairo:1:17
+type T = Foo<-1_>;
+                ^
+
+//! > ==========================================================================
+
+//! > Test negative const generic arg with no literal following the minus.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+type T = Foo<->;
+
+//! > expected_diagnostics
+error[E1001]: Missing token '>'.
+ --> dummy_file.cairo:1:17
+type T = Foo<->;
+                ^
+
+error[E1001]: Missing token ';'.
+ --> dummy_file.cairo:1:17
+type T = Foo<->;
+                ^
+
+error[E1000]: Skipped tokens. Expected: generic arg.
+ --> dummy_file.cairo:1:14
+type T = Foo<->;
+             ^^^
+
+//! > ==========================================================================
+
+//! > Test negative const generic arg followed by an identifier instead of a literal.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+type T = Foo<-x>;
+
+//! > expected_diagnostics
+error[E1001]: Missing token TerminalLiteralNumber.
+ --> dummy_file.cairo:1:15
+type T = Foo<-x>;
+              ^
+
+error[E1001]: Missing token ','.
+ --> dummy_file.cairo:1:15
+type T = Foo<-x>;
+              ^


### PR DESCRIPTION
## Summary

Fixes parsing of negative const generic arguments (e.g., `Foo<-1>`) by replacing `parse_token` with `take_terminal_literal_number` when parsing the numeric literal in a unary minus expression. This ensures that invalid numeric literals in negative const generic args (such as `Foo<-0x>` or `Foo<-1_>`) produce proper diagnostic errors rather than being silently skipped or mishandled.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When parsing a negative const generic argument, the literal number following the minus sign was parsed using `parse_token`, which does not emit diagnostics for malformed numeric literals. This meant that inputs like `Foo<-0x>` (invalid hex literal) or `Foo<-1_>` (trailing underscore) would not produce the expected diagnostic errors.

---

## What was the behavior or documentation before?

Malformed numeric literals in negative const generic arguments (e.g., `Foo<-0x>`, `Foo<-1_>`) were not diagnosed with the appropriate `E1016` ("Literal is not a valid number") or `E1015` ("Missing literal suffix") errors.

---

## What is the behavior or documentation after?

Malformed numeric literals in negative const generic arguments now correctly produce diagnostics:
- `Foo<-0x>` → `error[E1016]: Literal is not a valid number.`
- `Foo<-1_>` → `error[E1015]: Missing literal suffix.`

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Two new test cases were added to the `generic_params` diagnostics test file to cover these scenarios.