### PR TITLE
docs(corelib): correct DivRem heterogeneous example.

### DIFF
--- a/corelib/src/num/traits/ops/divrem.cairo
+++ b/corelib/src/num/traits/ops/divrem.cairo
@@ -24,16 +24,13 @@ use crate::zeroable::NonZero;
 /// assert!(DivRem::<u32, u32>::div_rem(lhs, rhs) == (2, 1));
 /// ```
 ///
-/// Heterogeneous division (`u256` by `u128`):
-/// ```cairo
-/// use core::num::traits::DivRem;
+/// Heterogeneous operands:
 ///
-/// let big: u256 = 1_000_000;     // dividend
-/// let nz10: NonZero<u128> = 10;  // divisor
-///
-/// let (q, r) = DivRem::<u256, u128>::div_rem(big, nz10);
-/// // q : u256, r : u128
-/// ```
+/// The `T` (dividend) and `U` (divisor) type parameters may differ, and the
+/// [`Quotient`] / [`Remainder`] associated types let the result types differ as
+/// well. The core library only provides the symmetric `DivRem<T, T>` impls
+/// (`u8` through `u256`); a heterogeneous pair such as `DivRem<u256, u128>` can
+/// be supplied by a user-defined implementation.
 pub trait DivRem<T, U> {
     /// Quotient returned by the division.
     type Quotient;


### PR DESCRIPTION
## Summary

Replaces the heterogeneous `DivRem<u256, u128>` code example in the `DivRem` trait doc comment with a prose explanation clarifying that `T` and `U` may differ, that `Quotient` and `Remainder` associated types allow the result types to differ as well, and that the core library only ships symmetric `DivRem<T, T>` impls — leaving heterogeneous pairs to user-defined implementations.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The previous doc comment included a `DivRem<u256, u128>` code example that implied the core library provides a heterogeneous impl for that pair. In reality, no such impl exists in the core library, making the example misleading and potentially confusing to users who try to use it.

---

## What was the behavior or documentation before?

The doc comment showed a runnable code example using `DivRem::<u256, u128>::div_rem`, suggesting that dividing a `u256` by a `NonZero<u128>` was supported out of the box.

---

## What is the behavior or documentation after?

The example is replaced with a prose section that accurately describes the heterogeneous capability of the trait's type parameters and associated types, and explicitly states that only symmetric `DivRem<T, T>` impls (for `u8` through `u256`) are provided by the core library. Users are directed to supply their own implementation for heterogeneous pairs.

---

## Related issue or discussion (if any)

---

## Additional context

Removing the misleading example prevents users from hitting a compile error when attempting to use `DivRem<u256, u128>` based on the documentation.