### PR TITLE
chore(semantic): fix copy/drop comment in check_special_impls

### DIFF
--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -1612,7 +1612,7 @@ fn check_special_impls<'db>(
                 inference_error,
                 InferenceError::Ambiguity(Ambiguity::MultipleImplsFound { .. })
             ) {
-                // Having multiple drop implementations for a member is not an actual error.
+                // Having multiple copy implementations for a member is not an actual error.
                 continue;
             }
             return Err(diagnostics.report(stable_ptr, InvalidCopyTraitImpl(inference_error)));


### PR DESCRIPTION
## Summary

Fixes an incorrect comment in `check_special_impls` that referred to "drop implementations" when the surrounding code is actually handling the `Copy` trait (`InvalidCopyTraitImpl`). The comment now correctly reads "copy implementations".

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The comment incorrectly stated "drop implementations" in a branch that handles ambiguous `Copy` trait implementations. This was misleading to anyone reading the code, as the logic and surrounding error (`InvalidCopyTraitImpl`) are specifically about the `Copy` trait, not `Drop`.

---

## What was the behavior or documentation before?

The comment read: `// Having multiple drop implementations for a member is not an actual error.`

---

## What is the behavior or documentation after?

The comment reads: `// Having multiple copy implementations for a member is not an actual error.`

---

## Related issue or discussion (if any)

None.

---

## Additional context

This was likely a copy-paste error from a nearby `Drop` trait handling block.