### PR TITLE
feat(defs): populate MacroPluginMetadata::allowed_features

### DIFF
--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -1150,8 +1150,10 @@ fn module_sub_files<'db>(
     let crate_id = module_id.owning_crate(db);
 
     let allowed_attributes = db.allowed_attributes(crate_id);
-    // TODO(orizi): Actually extract the allowed features per module.
-    let allowed_features = Default::default();
+    let declared_derives = db.declared_derives(crate_id);
+    // The features allowed at the module scope; each item additionally grants its own
+    // `#[feature]`s.
+    let module_features = module_allowed_features(db, (), module_id);
 
     let cfg_set = db
         .crate_config(crate_id)
@@ -1161,12 +1163,6 @@ fn module_sub_files<'db>(
         .crate_config(module_id.owning_crate(db))
         .map(|cfg| cfg.settings.edition)
         .unwrap_or_default();
-    let metadata = MacroPluginMetadata {
-        cfg_set,
-        declared_derives: db.declared_derives(crate_id),
-        allowed_features: &allowed_features,
-        edition,
-    };
 
     let mut files = OrderedHashMap::<_, _>::default();
     let mut aux_data = OrderedHashMap::default();
@@ -1175,6 +1171,16 @@ fn module_sub_files<'db>(
     let mut diagnostics_notes = OrderedHashMap::default();
     for item_ast in item_asts.elements(db) {
         let mut remove_original_item = false;
+        // The features in scope for this item: the module's, plus the item's own `#[feature]`s.
+        // Reuse the module set directly when the item adds nothing, to avoid a per-item allocation.
+        let mut item_allowed_features = extract_allowed_features(db, &item_ast);
+        let allowed_features = if item_allowed_features.is_empty() {
+            module_features
+        } else {
+            item_allowed_features.extend(module_features.iter().copied());
+            &item_allowed_features
+        };
+        let metadata = MacroPluginMetadata { cfg_set, declared_derives, allowed_features, edition };
         // Iterate through the plugins by their order. The first one to change something (either
         // generate new code, remove the original code, or both), breaks the loop. If more
         // plugins might act on the item, they can do it on the generated code.
@@ -1454,6 +1460,50 @@ pub fn get_all_path_stars<'db>(
         }
     }
     res
+}
+
+/// Collects the feature names granted by `#[feature("...")]` attributes on `item`.
+///
+/// The values are kept *with* their surrounding quotes, matching how `allowed_features` is
+/// represented elsewhere. Malformed `#[feature]` attributes are ignored here; they are diagnosed by
+/// the semantic model.
+fn extract_allowed_features<'db>(
+    db: &'db dyn Database,
+    item: &impl QueryAttrs<'db>,
+) -> OrderedHashSet<SmolStrId<'db>> {
+    let mut allowed_features = OrderedHashSet::default();
+    for attr in item.query_attr(db, FEATURE_ATTR) {
+        for arg in attr.structurize(db).args {
+            if let Some(ast::Expr::String(value)) = try_extract_unnamed_arg(db, &arg.arg) {
+                allowed_features.insert(value.text(db));
+            }
+        }
+    }
+    allowed_features
+}
+
+/// Returns the feature names allowed in `module_id`'s scope: the `#[feature("...")]` attributes on
+/// the module declaration accumulated with those of all its ancestor modules, up to the crate root.
+///
+/// Mirrors the semantic feature-config walk, but at the defs level and without diagnostics (the
+/// semantic model owns feature diagnostics). Memoized per `ModuleId` so the parent walk runs once.
+#[salsa::tracked(returns(ref))]
+fn module_allowed_features<'db>(
+    db: &'db dyn Database,
+    _tracked: Tracked,
+    module_id: ModuleId<'db>,
+) -> OrderedHashSet<SmolStrId<'db>> {
+    let (parent_module, mut allowed_features) = match module_id {
+        ModuleId::CrateRoot(_) => return Default::default(),
+        ModuleId::Submodule(id) => {
+            (id.parent_module(db), extract_allowed_features(db, &id.stable_ptr(db).lookup(db)))
+        }
+        ModuleId::MacroCall { id, .. } => {
+            (id.parent_module(db), extract_allowed_features(db, &id.stable_ptr(db).lookup(db)))
+        }
+    };
+    allowed_features.extend(module_allowed_features(db, (), parent_module).iter().copied());
+    allowed_features
 }
 
 #[salsa::tracked(returns(ref))]

--- a/crates/cairo-lang-defs/src/test.rs
+++ b/crates/cairo-lang-defs/src/test.rs
@@ -6,13 +6,14 @@ use cairo_lang_filesystem::db::{CrateConfiguration, FilesGroup, init_files_group
 use cairo_lang_filesystem::ids::{CrateId, Directory, FileLongId, SmolStrId};
 use cairo_lang_filesystem::{override_file_content, set_crate_config};
 use cairo_lang_parser::db::ParserGroup;
-use cairo_lang_syntax::node::helpers::QueryAttrs;
+use cairo_lang_syntax::node::helpers::{HasName, QueryAttrs};
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode, ast};
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, extract_matches, try_extract_matches};
 use indoc::indoc;
+use itertools::Itertools;
 use salsa::{Database, Setter};
 
 use crate::db::{DefsGroup, defs_group_input, init_defs_group, init_external_files};
@@ -465,4 +466,106 @@ fn test_plugin_chain() {
         "[FreeFunctionId(test::foo), FreeFunctionId(test::bar), ExternTypeId(test::B), \
          ExternTypeId(test::B)]"
     )
+}
+
+#[test]
+fn test_allowed_features_accumulated_with_item() {
+    let mut db = DatabaseForTesting::default();
+    defs_group_input(&db)
+        .set_default_macro_plugins(&mut db)
+        .to(Some(vec![MacroPluginLongId(Arc::new(ReportAllowedFeaturesPlugin))]));
+    setup_test_module(
+        &mut db,
+        indoc! {r#"
+            mod m1 {
+                fn f1() {}
+            }
+            #[feature("outer2")]
+            mod m2 {
+                fn f2() {}
+            }
+            mod m3 {
+                #[feature("inner3")]
+                fn f3() {}
+            }
+            #[feature("outer4")]
+            mod m4 {
+                #[feature("inner4")]
+                fn f4() {}
+            }
+            #[feature("outer5")]
+            mod m5 {
+                #[feature("mid5")]
+                mod m6 {
+                    #[feature("inner5")]
+                    fn f5() {}
+                }
+            }
+    "#},
+    );
+    let modules = db.crate_modules(get_crate_id(&db));
+    let diags = modules
+        .iter()
+        .flat_map(|m| {
+            m.module_data(&db)
+                .unwrap()
+                .plugin_diagnostics(&db)
+                .iter()
+                .map(|(_, diag)| &diag.message)
+        })
+        .sorted()
+        .join("");
+    assert_eq!(
+        diags,
+        indoc! {r#"
+            f1: []
+            f2: ["outer2"]
+            f3: ["inner3"]
+            f4: ["inner4", "outer4"]
+            f5: ["inner5", "mid5", "outer5"]
+            m1: []
+            m2: ["outer2"]
+            m3: []
+            m4: ["outer4"]
+            m5: ["outer5"]
+            m6: ["mid5", "outer5"]
+        "#}
+    );
+}
+
+/// Reports, as a warning for each item the sorted `allowed_features` for it.
+#[derive(Debug)]
+struct ReportAllowedFeaturesPlugin;
+impl MacroPlugin for ReportAllowedFeaturesPlugin {
+    fn generate_code<'db>(
+        &self,
+        db: &'db dyn Database,
+        item_ast: ast::ModuleItem<'db>,
+        metadata: &MacroPluginMetadata<'_>,
+    ) -> PluginResult<'db> {
+        let name = match &item_ast {
+            ast::ModuleItem::Module(item) => item.name(db),
+            ast::ModuleItem::FreeFunction(item) => item.name(db),
+            _ => return PluginResult::default(),
+        }
+        .text(db);
+        let features = metadata
+            .allowed_features
+            .iter()
+            .map(|feature| feature.long(db).to_string())
+            .sorted()
+            .join(", ");
+        PluginResult {
+            code: None,
+            diagnostics: vec![PluginDiagnostic::warning(
+                item_ast.stable_ptr(db),
+                format!("{}: [{features}]\n", name.long(db)),
+            )],
+            remove_original_item: false,
+        }
+    }
+
+    fn declared_attributes<'db>(&self, _db: &'db dyn Database) -> Vec<SmolStrId<'db>> {
+        vec![]
+    }
 }

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -2922,3 +2922,54 @@ error[E2158]: No matching rule found in inline macro `mymac`.
  --> lib.cairo:6:5
     mymac!($(x));
     ^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > A `#[feature]` on an item-scope macro call propagates into the expanded items.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro make_const {
+    () => { const C: felt252 = consteval_int!(4 + 5); };
+}
+
+#[feature("deprecated-consteval-int-macro")]
+make_const!();
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Without the feature on the call, the expanded `consteval_int!` is still deprecated.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro make_const {
+    () => { const C: felt252 = consteval_int!(4 + 5); };
+}
+
+make_const!();
+
+//! > expected_diagnostics
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:6:1
+make_const!();
+^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/feature_kind.rs
+++ b/crates/cairo-lang-semantic/src/items/feature_kind.rs
@@ -279,37 +279,36 @@ fn module_feature_config<'db>(
     _tracked: Tracked,
     module_id: ModuleId<'db>,
 ) -> FeatureConfig<'db> {
-    let mut current_module_id = module_id;
     let crate_id = module_id.owning_crate(db);
-    let mut config_stack = vec![];
-    let mut config = loop {
-        match current_module_id {
-            ModuleId::CrateRoot(crate_id) => {
-                let all_declarations_pub = db
-                    .crate_config(crate_id)
-                    .map(|config| config.settings.edition.ignore_visibility())
-                    .unwrap_or_else(|| default_crate_settings(db).edition.ignore_visibility());
-                let mut allowed_lints = OrderedHashSet::default();
-                if all_declarations_pub {
-                    let _already_allowed =
-                        allowed_lints.insert(SmolStrId::from(db, UNUSED_IMPORTS));
-                }
-                break FeatureConfig { allowed_features: OrderedHashSet::default(), allowed_lints };
+    let (parent_module_id, mut config) = match module_id {
+        ModuleId::CrateRoot(crate_id) => {
+            let all_declarations_pub = db
+                .crate_config(crate_id)
+                .map(|config| config.settings.edition.ignore_visibility())
+                .unwrap_or_else(|| default_crate_settings(db).edition.ignore_visibility());
+            let mut allowed_lints = OrderedHashSet::default();
+            if all_declarations_pub {
+                let _already_allowed = allowed_lints.insert(SmolStrId::from(db, UNUSED_IMPORTS));
             }
-            ModuleId::Submodule(id) => {
-                current_module_id = id.parent_module(db);
-                let module = &current_module_id.module_data(db).unwrap().submodules(db)[&id];
-                // TODO(orizi): Add parent module diagnostics.
-                let ignored = &mut SemanticDiagnostics::new(current_module_id);
-                config_stack.push(feature_config_from_ast_item(db, crate_id, module, ignored));
-            }
-            ModuleId::MacroCall { id, .. } => {
-                current_module_id = id.parent_module(db);
-            }
+            return FeatureConfig { allowed_features: OrderedHashSet::default(), allowed_lints };
+        }
+        ModuleId::Submodule(id) => {
+            let parent_module_id = id.parent_module(db);
+            let module = &parent_module_id.module_data(db).unwrap().submodules(db)[&id];
+            // TODO(orizi): Add parent module diagnostics.
+            let ignored = &mut SemanticDiagnostics::new(module_id);
+            (parent_module_id, feature_config_from_ast_item(db, crate_id, module, ignored))
+        }
+        ModuleId::MacroCall { id, .. } => {
+            let parent_module_id = id.parent_module(db);
+            let macro_call = &parent_module_id.module_data(db).unwrap().macro_calls(db)[&id];
+            // TODO(orizi): Add parent module diagnostics.
+            let ignored = &mut SemanticDiagnostics::new(module_id);
+            (parent_module_id, feature_config_from_ast_item(db, crate_id, macro_call, ignored))
         }
     };
-    for module_config in config_stack.into_iter().rev() {
-        config.override_with(module_config);
-    }
+    let parent_config = module_feature_config(db, (), parent_module_id);
+    config.allowed_features.extend(parent_config.allowed_features.iter().copied());
+    config.allowed_lints.extend(parent_config.allowed_lints.iter().copied());
     config
 }


### PR DESCRIPTION
## Summary

`MacroPluginMetadata::allowed_features` now reflects the full set of features in scope for each item: the `#[feature("...")]` attributes declared on the item itself **plus** those inherited from all ancestor modules up to the crate root.

Previously, `allowed_features` was always an empty `Default::default()`, meaning macro plugins had no visibility into which features were enabled for a given item. Now, `module_allowed_features` (a memoized `#[salsa::tracked]` function) walks the module hierarchy once per `ModuleId` and accumulates `#[feature]` attributes from each submodule declaration. Per-item, `extract_allowed_features` collects the item's own `#[feature]` attributes and merges them with the module-level set. When an item adds no features of its own, the module set is reused directly to avoid a per-item allocation.

A new test (`test_allowed_features_accumulated_with_item`) verifies the four cases: no features, module-only features, item-only features, and both combined.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Macro plugins receive a `MacroPluginMetadata` struct that is supposed to communicate which features are allowed in scope. The `allowed_features` field was always empty, so plugins could not correctly gate behavior on feature availability. This made the feature-gating mechanism non-functional at the macro expansion level.

---

## What was the behavior or documentation before?

`allowed_features` in `MacroPluginMetadata` was always an empty set, regardless of any `#[feature("...")]` attributes present on the item or its enclosing modules.

---

## What is the behavior or documentation after?

`allowed_features` contains the union of `#[feature("...")]` attributes from the item itself and all of its ancestor modules. Module-level feature sets are memoized per `ModuleId` so the ancestor walk is not repeated for every item in the same module.

---

## Related issue or discussion (if any)

Resolves the `TODO(orizi): Actually extract the allowed features per module.` comment that was previously left in `module_sub_files`.

---

## Additional context

The `module_allowed_features` function handles all three `ModuleId` variants: `CrateRoot` returns an empty set, `Submodule` extracts features from the submodule declaration node and merges with the parent's set, and `MacroCall` delegates directly to its parent module's set.