### PR TITLE
chore(corelib): drop internal #[panic_with] usages

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -90,7 +90,6 @@ extern fn array_snapshot_multi_pop_front<PoppedT, impl Info: FixedSizedArrayInfo
 extern fn array_snapshot_multi_pop_back<PoppedT, impl Info: FixedSizedArrayInfo<PoppedT>>(
     ref arr: @Array<Info::Element>,
 ) -> Option<@Box<PoppedT>> implicits(RangeCheck) nopanic;
-#[panic_with('Index out of bounds', array_at)]
 extern fn array_get<T>(
     arr: @Array<T>, index: usize,
 ) -> Option<Box<@T>> implicits(RangeCheck) nopanic;
@@ -227,7 +226,7 @@ pub impl ArrayImpl<T> of ArrayTrait<T> {
     /// assert!(arr.at(1) == @4);
     /// ```
     fn at(self: @Array<T>, index: usize) -> @T {
-        array_at(self, index).unbox()
+        array_get(self, index).expect('Index out of bounds').unbox()
     }
 
     /// Returns the length of the array as a `usize` value.
@@ -298,7 +297,7 @@ impl ArrayIndex<T> of IndexView<Array<T>, usize, @T> {
     /// assert!(element == @1);
     /// ```
     fn index(self: @Array<T>, index: usize) -> @T {
-        array_at(self, index).unbox()
+        ArrayTrait::at(self, index)
     }
 }
 
@@ -570,7 +569,7 @@ pub impl SpanImpl<T> of SpanTrait<T> {
     /// ```
     #[inline]
     fn at(self: Span<T>, index: usize) -> @T {
-        array_at(self.snapshot, index).unbox()
+        self.snapshot.at(index)
     }
 
     /// Returns a span containing values from the 'start' index, with
@@ -634,7 +633,7 @@ pub impl SpanIndex<T> of IndexView<Span<T>, usize, @T> {
     /// ```
     #[inline]
     fn index(self: @Span<T>, index: usize) -> @T {
-        array_at(self.snapshot, index).unbox()
+        self.snapshot.at(index)
     }
 }
 

--- a/corelib/src/integer.cairo
+++ b/corelib/src/integer.cairo
@@ -103,7 +103,6 @@ extern const fn u128s_from_felt252(
     a: felt252,
 ) -> U128sFromFelt252Result implicits(RangeCheck) nopanic;
 
-#[panic_with('u128_from Overflow', u128_from_felt252)]
 const fn u128_try_from_felt252(a: felt252) -> Option<u128> implicits(RangeCheck) nopanic {
     match u128s_from_felt252(a) {
         U128sFromFelt252Result::Narrow(x) => Some(x),
@@ -196,7 +195,6 @@ impl U128Add of Add<u128> {
     }
 }
 
-#[panic_with('u128_sub Overflow', u128_sub)]
 fn u128_checked_sub(lhs: u128, rhs: u128) -> Option<u128> implicits(RangeCheck) nopanic {
     match u128_overflowing_sub(lhs, rhs) {
         Ok(r) => Some(r),
@@ -224,7 +222,6 @@ impl U128Mul of Mul<u128> {
     }
 }
 
-#[panic_with('u128 is 0', u128_as_non_zero)]
 const fn u128_try_as_non_zero(a: u128) -> Option<NonZero<u128>> nopanic {
     match u128_is_zero(a) {
         IsZeroResult::Zero => None,
@@ -317,7 +314,6 @@ impl NumericLiteralu8 of NumericLiteral<u8>;
 
 extern const fn u8_to_felt252(a: u8) -> felt252 nopanic;
 
-#[panic_with('u8_from Overflow', u8_from_felt252)]
 extern const fn u8_try_from_felt252(a: felt252) -> Option<u8> implicits(RangeCheck) nopanic;
 
 extern fn u8_eq(lhs: u8, rhs: u8) -> bool implicits() nopanic;
@@ -411,7 +407,6 @@ extern const fn u8_is_zero(a: u8) -> IsZeroResult<u8> implicits() nopanic;
 
 pub extern fn u8_safe_divmod(lhs: u8, rhs: NonZero<u8>) -> (u8, u8) implicits(RangeCheck) nopanic;
 
-#[panic_with('u8 is 0', u8_as_non_zero)]
 const fn u8_try_as_non_zero(a: u8) -> Option<NonZero<u8>> nopanic {
     match u8_is_zero(a) {
         IsZeroResult::Zero => None,
@@ -473,7 +468,6 @@ impl NumericLiteralu16 of NumericLiteral<u16>;
 
 extern const fn u16_to_felt252(a: u16) -> felt252 nopanic;
 
-#[panic_with('u16_from Overflow', u16_from_felt252)]
 extern const fn u16_try_from_felt252(a: felt252) -> Option<u16> implicits(RangeCheck) nopanic;
 
 extern fn u16_eq(lhs: u16, rhs: u16) -> bool implicits() nopanic;
@@ -573,7 +567,6 @@ pub extern fn u16_safe_divmod(
     lhs: u16, rhs: NonZero<u16>,
 ) -> (u16, u16) implicits(RangeCheck) nopanic;
 
-#[panic_with('u16 is 0', u16_as_non_zero)]
 const fn u16_try_as_non_zero(a: u16) -> Option<NonZero<u16>> nopanic {
     match u16_is_zero(a) {
         IsZeroResult::Zero => None,
@@ -635,7 +628,6 @@ impl NumericLiteralu32 of NumericLiteral<u32>;
 
 extern const fn u32_to_felt252(a: u32) -> felt252 nopanic;
 
-#[panic_with('u32_from Overflow', u32_from_felt252)]
 extern const fn u32_try_from_felt252(a: felt252) -> Option<u32> implicits(RangeCheck) nopanic;
 
 extern fn u32_eq(lhs: u32, rhs: u32) -> bool implicits() nopanic;
@@ -735,7 +727,6 @@ pub extern fn u32_safe_divmod(
     lhs: u32, rhs: NonZero<u32>,
 ) -> (u32, u32) implicits(RangeCheck) nopanic;
 
-#[panic_with('u32 is 0', u32_as_non_zero)]
 const fn u32_try_as_non_zero(a: u32) -> Option<NonZero<u32>> nopanic {
     match u32_is_zero(a) {
         IsZeroResult::Zero => None,
@@ -797,7 +788,6 @@ impl NumericLiteralu64 of NumericLiteral<u64>;
 
 extern const fn u64_to_felt252(a: u64) -> felt252 nopanic;
 
-#[panic_with('u64_from Overflow', u64_from_felt252)]
 extern const fn u64_try_from_felt252(a: felt252) -> Option<u64> implicits(RangeCheck) nopanic;
 
 extern fn u64_eq(lhs: u64, rhs: u64) -> bool implicits() nopanic;
@@ -897,7 +887,6 @@ pub extern fn u64_safe_divmod(
     lhs: u64, rhs: NonZero<u64>,
 ) -> (u64, u64) implicits(RangeCheck) nopanic;
 
-#[panic_with('u64 is 0', u64_as_non_zero)]
 const fn u64_try_as_non_zero(a: u64) -> Option<NonZero<u64>> nopanic {
     match u64_is_zero(a) {
         IsZeroResult::Zero => None,
@@ -1050,7 +1039,6 @@ impl U256Add of Add<u256> {
     }
 }
 
-#[panic_with('u256_sub Overflow', u256_sub)]
 fn u256_checked_sub(lhs: u256, rhs: u256) -> Option<u256> implicits(RangeCheck) nopanic {
     let (r, overflow) = u256_overflowing_sub(lhs, rhs);
     if overflow {
@@ -1139,7 +1127,6 @@ fn u256_safe_div_rem(lhs: u256, rhs: NonZero<u256>) -> (u256, u256) implicits(Ra
 #[deprecated(feature: "corelib-internal-use", note: "Use `core::num::traits::Sqrt` instead")]
 pub extern fn u256_sqrt(a: u256) -> u128 implicits(RangeCheck) nopanic;
 
-#[panic_with('u256 is 0', u256_as_non_zero)]
 const fn u256_try_as_non_zero(a: u256) -> Option<NonZero<u256>> nopanic {
     match u256_is_zero(a) {
         IsZeroResult::Zero => None,


### PR DESCRIPTION
## Summary

Removes all `#[panic_with(...)]` attribute usages from `array.cairo` and `integer.cairo`, replacing the generated panic wrapper functions with explicit `expect(...)` calls or direct delegation at the call sites.

- `array_at` (generated from `#[panic_with('Index out of bounds', array_at)]` on `array_get`) is replaced with `array_get(...).expect('Index out of bounds').unbox()` in `ArrayImpl::at`, and call sites in `ArrayIndex`, `SpanImpl::at`, and `SpanIndex` are updated to delegate through `ArrayTrait::at` or `self.snapshot.at(index)`.
- Integer panic wrappers (`u128_from_felt252`, `u128_sub`, `u128_as_non_zero`, `u8_from_felt252`, `u8_as_non_zero`, `u16_from_felt252`, `u16_as_non_zero`, `u32_from_felt252`, `u32_as_non_zero`, `u64_from_felt252`, `u64_as_non_zero`, `u256_sub`, `u256_as_non_zero`) are removed by dropping their `#[panic_with(...)]` attributes from the corresponding `_try_*` functions.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `#[panic_with(...)]` attribute generates a secondary function that panics on `None`, but this pattern bypasses the standard `Option`/`Result` handling idioms and creates implicit, hard-to-trace panic paths. Removing these attributes and replacing usages with explicit `expect(...)` calls makes the panic behavior visible at the call site and consistent with idiomatic Cairo error handling.

---

## What was the behavior or documentation before?

Functions like `array_get`, `u128_try_from_felt252`, `u128_checked_sub`, etc. had `#[panic_with(...)]` attributes that auto-generated wrapper functions (e.g., `array_at`, `u128_from_felt252`, `u128_sub`) which would panic with a fixed message if the underlying `Option` returned `None`.

---

## What is the behavior or documentation after?

The generated wrapper functions are removed. Call sites that previously used them now use the `_try_*` / `_checked_*` variants directly with explicit `.expect(...)` calls, or delegate through a single canonical implementation, making panic behavior explicit and traceable.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

This is a breaking change for any downstream code that directly calls the now-removed generated functions (e.g., `array_at`, `u128_from_felt252`, `u128_sub`, `u256_sub`, `u*_as_non_zero`). Callers should migrate to the corresponding `_try_*` or `_checked_*` variants with explicit error handling.