### PR TITLE
feat(plugins): deprecate #[panic_with]

### DIFF
--- a/crates/cairo-lang-plugins/src/plugins/panicable.rs
+++ b/crates/cairo-lang-plugins/src/plugins/panicable.rs
@@ -18,13 +18,16 @@ use salsa::Database;
 pub struct PanicablePlugin;
 
 const PANIC_WITH_ATTR: &str = "panic_with";
+/// The feature gating the deprecated `#[panic_with]` macro. Stored with quotes, as
+/// `allowed_features` holds the raw string-literal text.
+const DEPRECATED_PANIC_WITH_FEATURE: &str = r#""deprecated-panic-with""#;
 
 impl MacroPlugin for PanicablePlugin {
     fn generate_code<'db>(
         &self,
         db: &'db dyn Database,
         item_ast: ast::ModuleItem<'db>,
-        _metadata: &MacroPluginMetadata<'_>,
+        metadata: &MacroPluginMetadata<'_>,
     ) -> PluginResult<'db> {
         let (declaration, attributes, visibility) = match item_ast {
             ast::ModuleItem::ExternFunction(extern_func_ast) => (
@@ -40,7 +43,7 @@ impl MacroPlugin for PanicablePlugin {
             _ => return PluginResult::default(),
         };
 
-        generate_panicable_code(db, declaration, attributes, visibility)
+        generate_panicable_code(db, declaration, attributes, visibility, metadata)
     }
 
     fn declared_attributes<'db>(&self, db: &'db dyn Database) -> Vec<SmolStrId<'db>> {
@@ -54,6 +57,7 @@ fn generate_panicable_code<'db>(
     declaration: ast::FunctionDeclaration<'db>,
     attributes: ast::AttributeList<'db>,
     visibility: ast::Visibility<'db>,
+    metadata: &MacroPluginMetadata<'_>,
 ) -> PluginResult<'db> {
     let mut attrs = attributes.query_attr(db, PANIC_WITH_ATTR);
     let Some(attr) = attrs.next() else {
@@ -61,6 +65,17 @@ fn generate_panicable_code<'db>(
         return PluginResult::default();
     };
     let mut diagnostics = vec![];
+    let deprecation_feature = SmolStrId::from(db, DEPRECATED_PANIC_WITH_FEATURE);
+    if !metadata.allowed_features.contains(&deprecation_feature) {
+        diagnostics.push(PluginDiagnostic::warning(
+            attr.stable_ptr(db),
+            format!(
+                "Usage of deprecated macro `{PANIC_WITH_ATTR}` with no \
+                 `#[feature({DEPRECATED_PANIC_WITH_FEATURE})]` attribute. Use simple calculations \
+                 instead, as these are supported in const context.",
+            ),
+        ));
+    }
     if let Some(extra_attr) = attrs.next() {
         diagnostics.push(PluginDiagnostic::error(
             extra_attr.stable_ptr(db),

--- a/crates/cairo-lang-plugins/src/test_data/panicable
+++ b/crates/cairo-lang-plugins/src/test_data/panicable
@@ -4,40 +4,50 @@
 test_expand_plugin(expect_diagnostics: false)
 
 //! > cairo_code
+#[feature("deprecated-panic-with")]
 #[panic_with('1', foo_improved)]
 extern fn foo(a: felt252, ref b: other) -> Option<()> implicits(RangeCheck, GasBuiltin) nopanic;
 
+#[feature("deprecated-panic-with")]
 #[panic_with('2', bar_changed)]
 extern fn bar() -> Result<felt252, Err> nopanic;
 
+#[feature("deprecated-panic-with")]
 #[panic_with('3', non_extern_stuff)]
 fn non_extern(_a: some_type) -> Option<(felt252, other)> nopanic {
     (4, 56)
 }
 
+#[feature("deprecated-panic-with")]
 #[panic_with('4', generic_panic)]
 extern fn generic<T>(t: T, v: felt252) -> Result<T, Err> nopanic;
 
+#[feature("deprecated-panic-with")]
 #[panic_with('5', wrapped_possibly_panic)]
 fn possibly_panic() -> Result<felt252, Err> {
     Result::<felt252, Err>::Ok(1)
 }
 
 //! > expanded_cairo_code
+#[feature("deprecated-panic-with")]
 #[panic_with('1', foo_improved)]
 extern fn foo(a: felt252, ref b: other) -> Option<()> implicits(RangeCheck, GasBuiltin) nopanic;
 
+#[feature("deprecated-panic-with")]
 #[panic_with('2', bar_changed)]
 extern fn bar() -> Result<felt252, Err> nopanic;
 
+#[feature("deprecated-panic-with")]
 #[panic_with('3', non_extern_stuff)]
 fn non_extern(_a: some_type) -> Option<(felt252, other)> nopanic {
     (4, 56)
 }
 
+#[feature("deprecated-panic-with")]
 #[panic_with('4', generic_panic)]
 extern fn generic<T>(t: T, v: felt252) -> Result<T, Err> nopanic;
 
+#[feature("deprecated-panic-with")]
 #[panic_with('5', wrapped_possibly_panic)]
 fn possibly_panic() -> Result<felt252, Err> {
     Result::<felt252, Err>::Ok(1)
@@ -111,10 +121,22 @@ extern fn bad_ret_type(_a: some_type) -> felt252 nopanic;
 extern fn bar() -> Result<felt252, Err> nopanic;
 
 //! > expected_diagnostics
+error: Usage of deprecated macro `panic_with` with no `#[feature("deprecated-panic-with")]` attribute. Use simple calculations instead, as these are supported in const context.
+ --> test_src/lib.cairo:1:1
+#[panic_with(123, foo_bad_err_code)]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
 error: Failed to extract panic data attribute
  --> test_src/lib.cairo:1:1
 #[panic_with(123, foo_bad_err_code)]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+error: Usage of deprecated macro `panic_with` with no `#[feature("deprecated-panic-with")]` attribute. Use simple calculations instead, as these are supported in const context.
+ --> test_src/lib.cairo:4:1
+#[panic_with(missing_args)]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Failed to extract panic data attribute
@@ -123,10 +145,22 @@ error: Failed to extract panic data attribute
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+error: Usage of deprecated macro `panic_with` with no `#[feature("deprecated-panic-with")]` attribute. Use simple calculations instead, as these are supported in const context.
+ --> test_src/lib.cairo:7:1
+#[panic_with(missing_args)]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
 error: Currently only wrapping functions returning an Option<T> or Result<T, E>
  --> test_src/lib.cairo:8:39
 extern fn bad_ret_type(_a: some_type) -> felt252 nopanic;
                                       ^^^^^^^^^^
+
+
+error: Usage of deprecated macro `panic_with` with no `#[feature("deprecated-panic-with")]` attribute. Use simple calculations instead, as these are supported in const context.
+ --> test_src/lib.cairo:10:1
+#[panic_with('2', bar_changed)]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: `#[panic_with]` cannot be applied multiple times to the same item.


### PR DESCRIPTION
## Summary

Deprecates the `#[panic_with]` macro by emitting a warning diagnostic when it is used without an explicit `#[feature("deprecated-panic-with")]` opt-in attribute. The warning message directs users to use simple calculations instead, noting that these are supported in const context.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `#[panic_with]` macro is being deprecated in favor of simple calculations, which are now supported in const context. Without a deprecation warning, users have no signal to migrate away from this macro.

---

## What was the behavior or documentation before?

Using `#[panic_with]` produced no deprecation warning. The macro expanded silently regardless of whether the user acknowledged its deprecated status.

---

## What is the behavior or documentation after?

Using `#[panic_with]` without `#[feature("deprecated-panic-with")]` on the same item now emits a warning:

```
Usage of deprecated macro `panic_with` with no `#[feature("deprecated-panic-with")]` attribute.
Use simple calculations instead, as these are supported in const context.
```

Users who need to continue using the macro can suppress the warning by adding `#[feature("deprecated-panic-with")]` to the item.

---

## Related issue or discussion (if any)

---

## Additional context

The feature gate string `"deprecated-panic-with"` is stored with surrounding quotes because `allowed_features` holds raw string-literal text.