### PR TITLE
docs(corelib): get_curve_size returns the scalar-field order, not the base field.

### DIFF
--- a/corelib/src/starknet/secp256_trait.cairo
+++ b/corelib/src/starknet/secp256_trait.cairo
@@ -130,7 +130,7 @@ pub fn signature_from_vrs(v: u32, r: u256, s: u256) -> Signature {
 /// );
 /// ```
 pub trait Secp256Trait<Secp256Point> {
-    /// Returns the order (size) of the curve's underlying field.
+    /// Returns the order (size) of the curve's scalar field.
     ///
     /// This is the number of points on the curve, also known as the curve order.
     fn get_curve_size() -> u256;


### PR DESCRIPTION
## Summary

Corrects the doc comment for `get_curve_size()` in `Secp256Trait`, changing "underlying field" to "scalar field" to accurately describe what the curve order represents.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The previous wording referred to the "underlying field," which is ambiguous and technically imprecise. An elliptic curve has two associated fields: the base field (over which the curve equation is defined) and the scalar field (whose order equals the number of points on the curve). The curve order corresponds to the scalar field, not the base field, so the original wording was misleading.

---

## What was the behavior or documentation before?

The doc comment read: "Returns the order (size) of the curve's **underlying field**."

---

## What is the behavior or documentation after?

The doc comment reads: "Returns the order (size) of the curve's **scalar field**."

---

## Related issue or discussion (if any)

None.

---

## Additional context

This is a purely cosmetic doc fix with no behavioral changes.