### PR TITLE
refactor(parser): Call popping from the terminal queue once in take_raw.

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -3542,11 +3542,11 @@ impl<'a, 'mt> Parser<'a, 'mt> {
 
     /// Move forward one terminal.
     fn take_raw(&mut self) -> LexerTerminal<'a> {
+        let terminal = self.advance();
         self.offset = self.offset.add_width(self.current_width);
-        self.current_width = self.next_terminal().width(self.db);
-        self.last_trivia_length =
-            trivia_total_width(self.db, &self.next_terminal().trailing_trivia);
-        self.advance()
+        self.current_width = terminal.width(self.db);
+        self.last_trivia_length = trivia_total_width(self.db, &terminal.trailing_trivia);
+        terminal
     }
 
     /// Skips the next, non-taken, token. A skipped token is a token which is not expected where it


### PR DESCRIPTION
## Summary

Fixes a bug in `take_raw` where `self.next_terminal()` was being called multiple times to compute `current_width` and `last_trivia_length`, but the terminal had not yet been advanced. The fix captures the result of `self.advance()` first, then uses the returned terminal to derive `current_width` and `last_trivia_length`, ensuring all three values are computed from the same terminal.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`take_raw` previously called `self.next_terminal()` to compute `current_width` and `last_trivia_length` before calling `self.advance()`. This meant the width and trailing trivia length were being read from the next terminal in the queue rather than the terminal actually being consumed. By advancing first and using the returned terminal, the values are now correctly derived from the terminal that was taken.

---

## What was the behavior or documentation before?

`current_width` and `last_trivia_length` were computed from `self.next_terminal()` prior to advancing, which could produce incorrect width and trivia length values for the consumed terminal.

---

## What is the behavior or documentation after?

`self.advance()` is called first, and the returned terminal is used to compute both `current_width` and `last_trivia_length`, ensuring consistency between the consumed terminal and its associated metadata.

---

## Related issue or discussion (if any)

---

## Additional context