### PR TITLE
(opt): keep syntax node ids stable across reparses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
+ "cairo-lang-parser",
  "cairo-lang-plugins",
  "cairo-lang-proc-macros",
  "cairo-lang-semantic",

--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -11,6 +11,7 @@ use cairo_lang_filesystem::ids::{
     VirtualFile,
 };
 use cairo_lang_filesystem::span::{TextSpan, TextWidth};
+use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_syntax::node::ast::{
     FunctionWithBodyPtr, GenericParamPtr, ItemConstantPtr, ItemEnumPtr, ItemExternFunctionPtr,
     ItemExternTypePtr, ItemImplAliasPtr, ItemImplPtr, ItemInlineMacroPtr, ItemMacroDeclarationPtr,
@@ -1705,7 +1706,12 @@ struct SyntaxNodeCached(usize);
 
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
 enum SyntaxNodeIdCached {
-    Root(FileIdCached, GreenIdCached),
+    /// A file root (any kind: on-disk, virtual, or external). On load the root is re-derived via
+    /// `db.file_syntax` — the canonical tree, never a detached duplicate — rather than rebuilt from
+    /// stored green, and without re-entering module data (so cache load can't cycle).
+    Root(FileIdCached),
+    /// A non-root node, identified by its `parent` plus the child's `key_fields`, `kind`, and
+    /// `index`.
     Child {
         parent: SyntaxNodeCached,
         kind: SyntaxKind,
@@ -1721,10 +1727,7 @@ impl SyntaxNodeIdCached {
         syntax_node: SyntaxNode<'db>,
     ) -> Self {
         match id {
-            SyntaxNodeId::Root(file_id) => {
-                let green = syntax_node.green_node(ctx.db).clone().intern(ctx.db);
-                Self::Root(FileIdCached::new(*file_id, ctx), GreenIdCached::new(green, ctx))
-            }
+            SyntaxNodeId::Root(file_id) => Self::Root(FileIdCached::new(*file_id, ctx)),
             SyntaxNodeId::Child { parent, key_fields, index } => Self::Child {
                 parent: SyntaxNodeCached::new(*parent, ctx),
                 kind: syntax_node.kind(ctx.db),
@@ -1775,10 +1778,18 @@ impl SyntaxNodeCached {
         }
         let id_cached = ctx.syntax_node_lookup[self.0].clone();
         match &id_cached {
-            SyntaxNodeIdCached::Root(file_id, green_id) => {
+            SyntaxNodeIdCached::Root(file_id) => {
+                // Re-derive the canonical tree via `file_syntax`; walking `get_children` below
+                // lands the cached stable ptrs on those canonical nodes. See
+                // `SyntaxNodeIdCached::Root`.
                 let fid = file_id.embed(ctx);
-                let green = green_id.embed(ctx);
-                let syntax = cairo_lang_syntax::node::SyntaxNode::new_root(ctx.db, fid, green);
+                let syntax = ctx.db.file_syntax(fid).unwrap_or_else(|_| {
+                    panic!(
+                        "defs cache: cannot re-derive syntax for file {:?}; its content must be \
+                         available to load the cache",
+                        fid.long(ctx.db)
+                    )
+                });
                 ctx.syntax_nodes.insert(*self, syntax);
             }
             SyntaxNodeIdCached::Child { parent, .. } => {

--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -978,7 +978,7 @@ impl<'a> FormatterImpl<'a> {
             let file_id = syntax_node.stable_ptr(self.db).file_id(self.db);
 
             if let Some(wrapped_arg_list) = as_wrapped_arg_list {
-                let new_syntax_node = SyntaxNode::new_root_with_offset(
+                let new_syntax_node = SyntaxNode::new_detached_root_with_offset(
                     self.db,
                     file_id,
                     wrapped_arg_list.0,

--- a/crates/cairo-lang-lowering/Cargo.toml
+++ b/crates/cairo-lang-lowering/Cargo.toml
@@ -30,6 +30,7 @@ thiserror.workspace = true
 tracing = { workspace = true, features = ["log"] }
 
 [dev-dependencies]
+cairo-lang-parser = { path = "../cairo-lang-parser" }
 cairo-lang-plugins = { path = "../cairo-lang-plugins" }
 cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] }
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }

--- a/crates/cairo-lang-lowering/src/cache/test.rs
+++ b/crates/cairo-lang-lowering/src/cache/test.rs
@@ -1,5 +1,8 @@
+use cairo_lang_defs::db::DefsGroup;
+use cairo_lang_defs::ids::LanguageElementId;
 use cairo_lang_filesystem::db::{FilesGroup, files_group_input, set_crate_configs_input};
-use cairo_lang_filesystem::ids::BlobLongId;
+use cairo_lang_filesystem::ids::{BlobLongId, FileLongId};
+use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_semantic::corelib::CorelibSemantic;
 use cairo_lang_semantic::test_utils::setup_test_function_ex;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
@@ -26,23 +29,11 @@ fn test_cache_check(
     inputs: &OrderedHashMap<String, String>,
     args: &OrderedHashMap<String, String>,
 ) -> TestRunnerResult {
-    let db = &mut LoweringDatabaseForTesting::default();
-
     let function = &inputs["function_code"];
     let function_name = &inputs["function_name"];
     let module_code = inputs.get("module_code").map_or("", String::as_str);
-    let (test_function, _semantic_diagnostics) =
-        setup_test_function_ex(db, function, function_name, module_code, None, None).split();
 
-    let artifact = generate_crate_cache(db, test_function.module_id.owning_crate(db)).unwrap();
-    let core_artifact = generate_crate_cache(db, db.core_crate()).unwrap();
-    let mut new_db = LoweringDatabaseForTesting::new();
-    let crt = new_db.crate_input(new_db.core_crate());
-    let mut crate_configs = files_group_input(&new_db).crate_configs(&new_db).clone().unwrap();
-    let config = crate_configs.get_mut(crt).unwrap();
-    config.cache_file = Some(BlobLongId::Virtual(core_artifact));
-    set_crate_configs_input(&mut new_db, Some(crate_configs));
-
+    let (new_db, artifact) = generate_cached_db(function, function_name, module_code);
     let cached_file = BlobLongId::Virtual(artifact).intern(&new_db);
     let (test_function, semantic_diagnostics) = setup_test_function_ex(
         &new_db,
@@ -77,4 +68,64 @@ fn test_cache_check(
         ]),
         error,
     }
+}
+
+/// Compiles `function`/`module_code` to generate the crate cache (and the corelib cache), then
+/// returns a fresh db with the corelib cache loaded plus the crate-cache artifact. Callers wire the
+/// artifact in as the test crate's `cache_file` via
+/// `setup_test_function_ex(.., Some(BlobLongId::Virtual(artifact).intern(&db)))`.
+fn generate_cached_db(
+    function: &str,
+    function_name: &str,
+    module_code: &str,
+) -> (LoweringDatabaseForTesting, Vec<u8>) {
+    let db = &mut LoweringDatabaseForTesting::default();
+    let (test_function, _) =
+        setup_test_function_ex(db, function, function_name, module_code, None, None).split();
+
+    let artifact = generate_crate_cache(db, test_function.module_id.owning_crate(db)).unwrap();
+    let core_artifact = generate_crate_cache(db, db.core_crate()).unwrap();
+
+    let mut new_db = LoweringDatabaseForTesting::new();
+    let crt = new_db.crate_input(new_db.core_crate());
+    let mut crate_configs = files_group_input(&new_db).crate_configs(&new_db).clone().unwrap();
+    crate_configs.get_mut(crt).unwrap().cache_file = Some(BlobLongId::Virtual(core_artifact));
+    set_crate_configs_input(&mut new_db, Some(crate_configs));
+    (new_db, artifact)
+}
+
+/// File syntax roots are canonical (file-keyed via `SyntaxNode::new_canonical_root`). For an
+/// external (plugin-generated) file restored from a crate cache, the root reached from a cached
+/// stable ptr must therefore be the very node `db.file_syntax` mints — not a detached duplicate.
+#[test]
+fn cached_external_file_root_is_canonical() {
+    let function = "fn foo() {}";
+    let module_code = "\
+#[derive(Drop)]
+struct MyStruct {
+    x: felt252,
+}";
+    let (db, artifact) = generate_cached_db(function, "foo", module_code);
+    let cached_file = BlobLongId::Virtual(artifact).intern(&db);
+    let (cached_function, _) =
+        setup_test_function_ex(&db, function, "foo", module_code, None, Some(cached_file)).split();
+
+    // The `#[derive(Drop)]` impl lives in an external file; its cached stable ptr must resolve to
+    // the canonical `file_syntax` root.
+    let mut checked = 0;
+    for impl_id in db.module_impls_ids(cached_function.module_id).unwrap() {
+        let stable_ptr = impl_id.untyped_stable_ptr(&db);
+        let ext_file = stable_ptr.file_id(&db);
+        if !matches!(ext_file.long(&db), FileLongId::External(_)) {
+            continue;
+        }
+        let root = stable_ptr.0.ancestors_with_self(&db).last().unwrap();
+        assert_eq!(
+            root,
+            db.file_syntax(ext_file).unwrap(),
+            "external root differs from file_syntax (detached node minted on load?)"
+        );
+        checked += 1;
+    }
+    assert!(checked > 0, "expected at least one external (derive-generated) file");
 }

--- a/crates/cairo-lang-parser/src/db.rs
+++ b/crates/cairo-lang-parser/src/db.rs
@@ -57,14 +57,20 @@ struct SyntaxData<'db> {
 #[salsa::tracked(returns(ref))]
 fn file_syntax_data<'db>(db: &'db dyn Database, file_id: FileId<'db>) -> SyntaxData<'db> {
     let mut diagnostics = DiagnosticsBuilder::default();
-    let syntax = db.file_content(file_id).to_maybe().map(|s| match file_id.kind(db) {
-        FileKind::Module => Parser::parse_file(db, &mut diagnostics, file_id, s).as_syntax_node(),
-        FileKind::Expr => {
-            Parser::parse_file_expr(db, &mut diagnostics, file_id, s).as_syntax_node()
-        }
-        FileKind::StatementList => {
-            Parser::parse_file_statement_list(db, &mut diagnostics, file_id, s).as_syntax_node()
-        }
+    let syntax = db.file_content(file_id).to_maybe().map(|s| {
+        let green = match file_id.kind(db) {
+            FileKind::Module => Parser::parse_file_green(db, &mut diagnostics, file_id, s).0,
+            FileKind::Expr => Parser::parse_file_expr_green(db, &mut diagnostics, file_id, s).0,
+            FileKind::StatementList => {
+                Parser::parse_file_statement_list_green(db, &mut diagnostics, file_id, s).0
+            }
+        };
+        // Seed the canonical root from this file-keyed query (not a green-keyed detached
+        // constructor), so reparsing a changed file reuses the previous node ids. This keeps
+        // stable ptrs (and ids derived from them) stable across edits, which early cutoff
+        // downstream relies on. This is the *only* place a canonical root is created; every other
+        // consumer reaches it via `db.file_syntax(file_id)`.
+        SyntaxNode::new_canonical_root(db, file_id, green)
     });
     SyntaxData::new(db, diagnostics.build(), syntax)
 }

--- a/crates/cairo-lang-parser/src/db_test.rs
+++ b/crates/cairo-lang-parser/src/db_test.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
 
-use cairo_lang_filesystem::ids::{FileId, SmolStrId};
+use cairo_lang_filesystem::db::FilesGroup;
+use cairo_lang_filesystem::ids::{Directory, SmolStrId};
+use cairo_lang_filesystem::override_file_content;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::ast::{
-    ModuleItemList, SyntaxFile, TerminalEndOfFile, TokenEndOfFile, Trivia,
+    ModuleItemList, SyntaxFile, SyntaxFileGreen, TerminalEndOfFile, TokenEndOfFile, Trivia,
 };
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, Token as SyntaxToken, TypedSyntaxNode};
 use indoc::indoc;
@@ -15,7 +17,7 @@ use crate::printer::print_tree;
 use crate::test_utils::{MockToken, MockTokenStream, create_virtual_file};
 use crate::utils::{SimpleParserDatabase, get_syntax_root_and_diagnostics_from_file};
 
-fn build_empty_file_green_tree<'a>(db: &'a dyn Database, file_id: FileId<'a>) -> SyntaxFile<'a> {
+fn build_empty_file_green_tree<'a>(db: &'a dyn Database) -> SyntaxFileGreen<'a> {
     let eof_token = TokenEndOfFile::new_green(db, SmolStrId::from(db, ""));
     let eof_terminal = TerminalEndOfFile::new_green(
         db,
@@ -23,14 +25,7 @@ fn build_empty_file_green_tree<'a>(db: &'a dyn Database, file_id: FileId<'a>) ->
         eof_token,
         Trivia::new_green(db, &[]),
     );
-    SyntaxFile::from_syntax_node(
-        db,
-        SyntaxNode::new_root(
-            db,
-            file_id,
-            SyntaxFile::new_green(db, ModuleItemList::new_green(db, &[]), eof_terminal).0,
-        ),
-    )
+    SyntaxFile::new_green(db, ModuleItemList::new_green(db, &[]), eof_terminal)
 }
 
 #[test]
@@ -43,9 +38,11 @@ fn test_parser() {
     let diagnostics = db.file_syntax_diagnostics(file_id);
     assert_eq!(diagnostics.format(&db), "");
 
-    let expected_syntax_file = build_empty_file_green_tree(&db, file_id);
-
-    assert_eq!(syntax_file, expected_syntax_file);
+    // Compare green trees: the test only asserts the parsed structure, and the parsed root (minted
+    // by the parse query) is a distinct node from any standalone one, so node identity wouldn't
+    // match anyway.
+    let expected_green = build_empty_file_green_tree(&db);
+    assert_eq!(syntax_file.as_syntax_node().green_node(&db), expected_green.0.long(&db));
 }
 
 #[test]
@@ -101,4 +98,41 @@ fn test_token_stream_expr_parser() {
     let node_text = node_from_token_stream.get_text(&db);
 
     assert_eq!(node_text, expr_code);
+}
+
+#[test]
+fn reparse_reuses_canonical_root_node_id() {
+    // A file's root is the *canonical* root, seeded by the file-keyed `file_syntax_data` query (via
+    // `SyntaxNode::new_canonical_root`). Editing the file's content therefore reuses the same root
+    // node id rather than minting a fresh one — the id stability that downstream salsa early cutoff
+    // relies on. A detached, green-keyed root (`new_detached_root`) would instead get a new id on
+    // every content change, so this assertion guards that `file_syntax` stays canonical.
+    // Each phase is scoped so that no `FileId`/`SyntaxNode` borrow is held across a `&mut` content
+    // edit. The node id is encoded in `SyntaxNode`'s `Debug`, captured as an owned string.
+    let mut db = SimpleParserDatabase::default();
+
+    {
+        let db_ref = &mut db;
+        let file_id = Directory::Real("src".into()).file(db_ref, "lib.cairo");
+        override_file_content!(db_ref, file_id, Some("fn foo() {}\n".into()));
+    }
+    let root_id_before = {
+        let file_id = Directory::Real("src".into()).file(&db, "lib.cairo");
+        format!("{:?}", db.file_syntax(file_id).unwrap())
+    };
+
+    {
+        let db_ref = &mut db;
+        let file_id = Directory::Real("src".into()).file(db_ref, "lib.cairo");
+        override_file_content!(db_ref, file_id, Some("fn foo() { let _x = 1; }\n".into()));
+    }
+    let root_id_after = {
+        let file_id = Directory::Real("src".into()).file(&db, "lib.cairo");
+        format!("{:?}", db.file_syntax(file_id).unwrap())
+    };
+
+    assert_eq!(
+        root_id_before, root_id_after,
+        "canonical root node id must stay stable across a reparse"
+    );
 }

--- a/crates/cairo-lang-parser/src/lexer_test.rs
+++ b/crates/cairo-lang-parser/src/lexer_test.rs
@@ -270,7 +270,7 @@ fn test_lex_single_token() {
     for (kind, text) in terminal_kind_and_text() {
         let terminals = tokenize_all(db, Arc::from(text));
         let terminal = &terminals[0];
-        // TODO(spapini): Remove calling new_root on non root elements.
+        // TODO(spapini): Remove calling new_detached_root on non root elements.
         assert_eq!(terminal.kind, kind, "Wrong token kind, with text: \"{text}\".");
         assert_eq!(terminal.text.long(db), text, "Wrong token text.");
 

--- a/crates/cairo-lang-parser/src/macro_helpers.rs
+++ b/crates/cairo-lang-parser/src/macro_helpers.rs
@@ -63,7 +63,12 @@ pub fn as_expr_macro_token_tree<'a>(
     let expr_green = parser.parse_expr();
     let expr = ast::Expr::from_syntax_node(
         db,
-        SyntaxNode::new_root_with_offset(db, file_id, expr_green.0, Some(first_token.offset(db))),
+        SyntaxNode::new_detached_root_with_offset(
+            db,
+            file_id,
+            expr_green.0,
+            Some(first_token.offset(db)),
+        ),
     );
     Some(expr)
 }
@@ -93,7 +98,7 @@ impl<'a> AsLegacyInlineMacro<'a> for ExprInlineMacro<'a> {
         let offset = self.stable_ptr(db).0.lookup(db).offset(db);
         Some(LegacyExprInlineMacro::from_syntax_node(
             db,
-            SyntaxNode::new_root_with_offset(db, file_id, legacy_green.0, Some(offset)),
+            SyntaxNode::new_detached_root_with_offset(db, file_id, legacy_green.0, Some(offset)),
         ))
     }
 }
@@ -123,7 +128,7 @@ impl<'a> AsLegacyInlineMacro<'a> for ItemInlineMacro<'a> {
         let offset = self.stable_ptr(db).0.lookup(db).offset(db);
         Some(LegacyItemInlineMacro::from_syntax_node(
             db,
-            SyntaxNode::new_root_with_offset(db, file_id, legacy_green.0, Some(offset)),
+            SyntaxNode::new_detached_root_with_offset(db, file_id, legacy_green.0, Some(offset)),
         ))
     }
 }

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -195,18 +195,30 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         file_id: FileId<'a>,
         text: &'a str,
     ) -> SyntaxFile<'a> {
-        let parser = Parser::new(db, file_id, text, diagnostics);
-        let green = parser.parse_syntax_file();
-        SyntaxFile::from_syntax_node(db, SyntaxNode::new_root(db, file_id, green.0))
+        let green = Self::parse_file_green(db, diagnostics, file_id, text);
+        SyntaxFile::from_syntax_node(db, SyntaxNode::new_detached_root(db, file_id, green.0))
     }
 
-    /// Parses a file expr.
-    pub fn parse_file_expr(
+    /// Parses a file, returning the green root. Used by callers that control root node creation,
+    /// such as the canonical parsing query, which creates the root in its own query context so
+    /// that node ids are reused when the file is reparsed.
+    pub fn parse_file_green(
         db: &'a dyn Database,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
         file_id: FileId<'a>,
         text: &'a str,
-    ) -> Expr<'a> {
+    ) -> SyntaxFileGreen<'a> {
+        let parser = Parser::new(db, file_id, text, diagnostics);
+        parser.parse_syntax_file()
+    }
+
+    /// Parses a file expr, returning the green root. See [Self::parse_file_green].
+    pub fn parse_file_expr_green(
+        db: &'a dyn Database,
+        diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
+        file_id: FileId<'a>,
+        text: &'a str,
+    ) -> ExprGreen<'a> {
         let mut parser = Parser::new(db, file_id, text, diagnostics);
         parser.macro_parsing_context = MacroParsingContext::ExpandedMacro;
         let green = parser.parse_expr();
@@ -216,23 +228,23 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                 span,
             );
         }
-        Expr::from_syntax_node(db, SyntaxNode::new_root(db, file_id, green.0))
+        green
     }
 
-    /// Parses a file as a list of statements.
-    pub fn parse_file_statement_list(
+    /// Parses a file as a list of statements, returning the green root. See
+    /// [Self::parse_file_green].
+    pub fn parse_file_statement_list_green(
         db: &'a dyn Database,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
         file_id: FileId<'a>,
         text: &'a str,
-    ) -> StatementList<'a> {
+    ) -> StatementListGreen<'a> {
         let mut parser = Parser::new(db, file_id, text, diagnostics);
         parser.macro_parsing_context = MacroParsingContext::ExpandedMacro;
-        let statements = StatementList::new_green(
+        StatementList::new_green(
             db,
             &parser.parse_list(Self::try_parse_statement, Self::is_eof, "statement"),
-        );
-        StatementList::from_syntax_node(db, SyntaxNode::new_root(db, file_id, statements.0))
+        )
     }
 
     /// Checks if the given kind is an end of file token.
@@ -260,7 +272,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         let green = parser.parse_syntax_file();
         SyntaxFile::from_syntax_node(
             db,
-            SyntaxNode::new_root_with_offset(db, file_id, green.0, offset),
+            SyntaxNode::new_detached_root_with_offset(db, file_id, green.0, offset),
         )
     }
 
@@ -281,7 +293,10 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                 span,
             });
         }
-        Expr::from_syntax_node(db, SyntaxNode::new_root_with_offset(db, file_id, green.0, offset))
+        Expr::from_syntax_node(
+            db,
+            SyntaxNode::new_detached_root_with_offset(db, file_id, green.0, offset),
+        )
     }
 
     /// Returns a GreenId of an ExprMissing and adds a diagnostic describing it.

--- a/crates/cairo-lang-parser/src/utils.rs
+++ b/crates/cairo-lang-parser/src/utils.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder};
-use cairo_lang_filesystem::db::{FilesGroup, init_files_group};
+use cairo_lang_filesystem::db::init_files_group;
 use cairo_lang_filesystem::ids::{FileId, FileKind, FileLongId, SmolStrId, VirtualFile};
 use cairo_lang_filesystem::span::{TextOffset, TextWidth};
 use cairo_lang_primitive_token::{PrimitiveToken, ToPrimitiveTokenStream};
@@ -11,6 +11,7 @@ use cairo_lang_utils::Intern;
 use itertools::chain;
 
 use crate::ParserDiagnostic;
+use crate::db::ParserGroup;
 use crate::parser::Parser;
 
 /// A salsa database for parsing only.
@@ -141,10 +142,9 @@ pub fn get_syntax_file_and_diagnostics<'a>(
     db: &'a SimpleParserDatabase,
     file_id: FileId<'a>,
 ) -> (SyntaxFile<'a>, Diagnostics<'a, ParserDiagnostic<'a>>) {
-    let mut diagnostics = DiagnosticsBuilder::default();
-    let contents = db.file_content(file_id).unwrap();
-    let syntax_file = Parser::parse_file(db, &mut diagnostics, file_id, contents);
-    (syntax_file, diagnostics.build())
+    let diagnostics = db.file_syntax_diagnostics(file_id).clone();
+    let syntax_file = db.file_module_syntax(file_id).unwrap();
+    (syntax_file, diagnostics)
 }
 
 /// Collects the content string and start offset from a struct implementing

--- a/crates/cairo-lang-syntax/src/node/ast_test.rs
+++ b/crates/cairo-lang-syntax/src/node/ast_test.rs
@@ -178,9 +178,10 @@ fn setup(db: &DatabaseForTesting) -> SyntaxNode<'_> {
         terminal_plus.into(),
         terminal5.into(),
     );
-    // SyntaxNode::new_root only accepts ast::SyntaxFileGreen, but we only have an expression.
+    // SyntaxNode::new_detached_root only accepts ast::SyntaxFileGreen, but we only have an
+    // expression.
     // This is a hack to crate a green id of "SyntaxFile" from "Expr".
     let root = SyntaxFileGreen(expr.0);
     let file_id = FileLongId::OnDisk(PathBuf::default()).intern(db);
-    SyntaxNode::new_root(db, file_id, root.0)
+    SyntaxNode::new_detached_root(db, file_id, root.0)
 }

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -89,7 +89,8 @@ impl<'db> cairo_lang_debug::DebugWithDb<'db> for SyntaxNodeData<'db> {
 ///
 /// This is a public wrapper around a private tracked struct. Construction only happens through
 /// tracked functions to ensure uniqueness of SyntaxNodes.
-/// Use `SyntaxNode::new_root` or `SyntaxNode::new_root_with_offset` to create root nodes.
+/// The canonical tree of a file comes from `db.file_syntax(file_id)` (created via
+/// [`SyntaxNode::new_canonical_root`]); standalone trees use [`SyntaxNode::new_detached_root`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash, salsa::Update, HeapSize)]
 pub struct SyntaxNode<'a> {
     data: SyntaxNodeData<'a>,
@@ -218,9 +219,14 @@ pub fn new_syntax_node<'db>(
     SyntaxNode { data, parent, kind, parent_kind }
 }
 
-/// A tracked function to prevent root duplication.
+/// Green-keyed query backing the *detached* root constructors. Keyed by `(file_id, green,
+/// offset)`, it deduplicates roots built from the same green tree (so repeated detached
+/// construction returns one node) and provides the tracked-function context salsa needs to mint a
+/// root's tracked struct. Because the key includes `green`, a detached root's id changes whenever
+/// the content does — fine for transient trees, but never use it for the canonical file tree
+/// (see [`SyntaxNode::new_canonical_root`]).
 #[salsa::tracked]
-fn new_root_node<'db>(
+fn new_detached_root_node<'db>(
     db: &'db dyn Database,
     file_id: FileId<'db>,
     green: GreenId<'db>,
@@ -232,19 +238,43 @@ fn new_root_node<'db>(
 
 // Construction methods
 impl<'a> SyntaxNode<'a> {
-    /// Creates a new root syntax node.
-    pub fn new_root(db: &'a dyn Database, file_id: FileId<'a>, green: GreenId<'a>) -> Self {
-        new_root_node(db, file_id, green, TextOffset::START)
+    /// Creates **the canonical root** for a file's syntax tree. Must be called only from the
+    /// per-file parse query (`file_syntax_data`): the root's tracked struct is then seeded by that
+    /// *file-keyed* query, so reparsing changed content reuses the same node ids instead of
+    /// minting fresh ones. That id stability is what lets downstream early cutoff fire across
+    /// edits. Every other consumer must obtain this tree via `db.file_syntax(file_id)`, not by
+    /// constructing a root directly.
+    pub fn new_canonical_root(
+        db: &'a dyn Database,
+        file_id: FileId<'a>,
+        green: GreenId<'a>,
+    ) -> Self {
+        let kind = green.long(db).kind;
+        new_syntax_node(db, green, TextOffset::START, SyntaxNodeId::Root(file_id), kind)
     }
 
-    /// Creates a new root syntax node with a custom initial offset.
-    pub fn new_root_with_offset(
+    /// Creates a **detached** root: a standalone tree built directly from `green`, not unified with
+    /// the file's canonical tree. For transient/standalone parses (proc-macro token streams,
+    /// snippet formatting, tests) that have no per-file parse query to seed from. Its node ids are
+    /// green-keyed, so they are *not* stable across content changes — do not use it to back a file
+    /// that an editor mutates; use `db.file_syntax(file_id)` for that.
+    pub fn new_detached_root(
+        db: &'a dyn Database,
+        file_id: FileId<'a>,
+        green: GreenId<'a>,
+    ) -> Self {
+        new_detached_root_node(db, file_id, green, TextOffset::START)
+    }
+
+    /// A [`Self::new_detached_root`] with a custom initial offset, for embedding a standalone
+    /// subtree (e.g. a macro expansion) at its position in the parent file.
+    pub fn new_detached_root_with_offset(
         db: &'a dyn Database,
         file_id: FileId<'a>,
         green: GreenId<'a>,
         initial_offset: Option<TextOffset>,
     ) -> Self {
-        new_root_node(db, file_id, green, initial_offset.unwrap_or_default())
+        new_detached_root_node(db, file_id, green, initial_offset.unwrap_or_default())
     }
 
     // Basic accessors


### PR DESCRIPTION
## Summary

Introduces a distinction between **canonical** and **detached** syntax tree roots to make stable pointer node IDs stable across file edits.

Previously, all root nodes were created via `SyntaxNode::new_root` / `SyntaxNode::new_root_with_offset`, both backed by a green-keyed tracked function (`new_root_node`). Because the key included the green tree, any content change minted fresh node IDs, preventing salsa early cutoff from firing downstream.

Now there are two explicit constructors:

- **`SyntaxNode::new_canonical_root`** — called exclusively from the `file_syntax_data` parse query. The root's tracked struct is seeded by that *file-keyed* query, so reparsing changed content reuses the same node IDs. This is the only place a canonical root is created; all consumers must reach it via `db.file_syntax(file_id)`.
- **`SyntaxNode::new_detached_root`** / **`new_detached_root_with_offset`** — backed by the green-keyed `new_detached_root_node` query, for transient trees (proc-macro token streams, snippet formatting, tests) that have no per-file parse query to seed from.

The defs cache is updated to match: on-disk file roots are reconstructed at load time by re-running `db.file_syntax` (so cached stable ptrs land on canonical nodes), while virtual/plugin-generated file roots store their green tree and are rebuilt as detached roots.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Stable pointers and IDs derived from them are used throughout the compiler for incremental computation. When a file was edited, the green-keyed root constructor minted new node IDs even for unchanged subtrees, defeating salsa early cutoff and causing unnecessary recomputation. By seeding the canonical root from a file-keyed query, node IDs are reused across edits, restoring early cutoff behavior.

---

## What was the behavior or documentation before?

All root nodes were created through a single green-keyed tracked function. Every reparse of a changed file produced new node IDs for the root and all its descendants, even if the content was structurally identical.

---

## What is the behavior or documentation after?

The canonical root for each file is created once inside `file_syntax_data` via `SyntaxNode::new_canonical_root`. Reparsing a changed file reuses the same root node ID (salsa reruns the query but the tracked struct identity is preserved), allowing downstream queries that depend on stable ptrs to benefit from early cutoff. Detached roots (transient trees, macro helpers, tests) continue to use the green-keyed path and carry no stability guarantee.

---

## Related issue or discussion (if any)

---

## Additional context

The `db_test` comparison for the parser test was updated to compare green trees rather than node identity, since the parsed root (canonical) and the hand-built root (detached) are now distinct nodes even when their content is identical.