### PR TITLE
docs(corelib): drop false Option/Result claim from Iterator::sum.

### DIFF
--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -733,8 +733,7 @@ pub trait Iterator<T> {
     ///
     /// An empty iterator returns the zero value of the type.
     ///
-    /// `sum()` can be used to sum any type implementing [`Sum`][`core::iter::Sum`],
-    /// including [`Option`][`Option::sum`] and [`Result`][`Result::sum`].
+    /// `sum()` can be used to sum any type implementing [`Sum`][`core::iter::Sum`].
     ///
     /// # Panics
     ///


### PR DESCRIPTION
## Summary

Removes the claim from `sum()` documentation that `Option` and `Result` implement `Sum`, as those links (`Option::sum` and `Result::sum`) were inaccurate or misleading references.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The documentation for `sum()` incorrectly referenced `Option::sum` and `Result::sum` as implementations of `Sum`, which do not exist or are not valid references. This could mislead users into believing these types have a `sum()` implementation when they may not.

---

## What was the behavior or documentation before?

The `sum()` doc comment stated:

> `sum()` can be used to sum any type implementing `Sum`, including `Option` and `Result`.

---

## What is the behavior or documentation after?

The `sum()` doc comment now states:

> `sum()` can be used to sum any type implementing `Sum`.

The incorrect references to `Option::sum` and `Result::sum` are removed.

---

## Related issue or discussion (if any)

None provided.

---

## Additional context

None.