### PR TITLE
fix(parser): treat //// as a regular comment, not a doc comment.

### DIFF
--- a/crates/cairo-lang-parser/src/lexer.rs
+++ b/crates/cairo-lang-parser/src/lexer.rs
@@ -99,7 +99,9 @@ impl Lexer {
     /// Assumes the next 2 characters are "//".
     fn match_trivium_single_line_comment<'a>(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
         match self.peek_nth(2) {
-            Some('/') => {
+            // `///` is a doc comment, but `////` (4+ slashes) is a regular comment. This matches
+            // `cairo-lang-doc`, which discards a doc comment whose content starts with `/`.
+            Some('/') if self.peek_nth(3) != Some('/') => {
                 self.take_while(|c| c != '\n');
                 let span = self.consume_text_span();
                 let text = span.take(&self.text);

--- a/crates/cairo-lang-parser/src/lexer_test.rs
+++ b/crates/cairo-lang-parser/src/lexer_test.rs
@@ -5,6 +5,7 @@ use cairo_lang_syntax::node::Token;
 use cairo_lang_syntax::node::ast::{TokenSingleLineComment, TokenWhitespace};
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_test_utils::test;
+use itertools::Itertools;
 
 use crate::lexer::{LexerTerminal, tokenize_all};
 use crate::utils::SimpleParserDatabase;
@@ -441,6 +442,31 @@ fn test_cases() {
                 leading_trivia: vec![],
                 trailing_trivia: vec![]
             }
+        ]
+    );
+}
+
+/// `///` is a doc comment and `//!` an inner doc comment, but `////` (4+ slashes) is a regular
+/// comment, matching `cairo-lang-doc` (which discards a doc comment whose content starts with `/`).
+#[test]
+fn test_doc_comment_classification() {
+    let db_val = SimpleParserDatabase::default();
+    let db = &db_val;
+    let text = "// regular\n/// doc\n//! inner\n//// regular\n///// regular\n";
+    let terminal = tokenize_all(db, (), Arc::from(text)).into_iter().exactly_one().unwrap();
+    assert_eq!(
+        terminal.leading_trivia.into_iter().map(|t| t.0.long(db).kind).collect_vec(),
+        [
+            SyntaxKind::TokenSingleLineComment,
+            SyntaxKind::TokenNewline,
+            SyntaxKind::TokenSingleLineDocComment,
+            SyntaxKind::TokenNewline,
+            SyntaxKind::TokenSingleLineInnerComment,
+            SyntaxKind::TokenNewline,
+            SyntaxKind::TokenSingleLineComment,
+            SyntaxKind::TokenNewline,
+            SyntaxKind::TokenSingleLineComment,
+            SyntaxKind::TokenNewline
         ]
     );
 }


### PR DESCRIPTION
## Summary

Fix the lexer so that `////` (four or more slashes) is classified as a regular `TokenSingleLineComment` rather than a `TokenSingleLineDocComment`. Previously, any line starting with `///` was treated as a doc comment, including `////`, `////`, etc. Now, only exactly `///` (where the fourth character is not `/`) is recognized as a doc comment, aligning the lexer with `cairo-lang-doc`'s behavior of discarding doc comments whose content begins with `/`.

A test is added to verify that `// regular`, `/// doc`, `//! inner`, `////`, and `/////` are each classified into the correct token kinds.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`cairo-lang-doc` already discards any doc comment whose content starts with `/`, meaning `////` was never treated as a real doc comment at the documentation-generation level. However, the lexer was still emitting `TokenSingleLineDocComment` for `////`, creating an inconsistency between the lexer's token classification and how the doc tooling actually interprets those tokens.

---

## What was the behavior or documentation before?

Any comment beginning with `///` — including `////`, `/////`, etc. — was lexed as `TokenSingleLineDocComment`.

---

## What is the behavior or documentation after?

Only `///` where the fourth character is not `/` is lexed as `TokenSingleLineDocComment`. Four or more consecutive slashes produce a plain `TokenSingleLineComment`, consistent with `cairo-lang-doc`.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The guard `self.peek_nth(3) != Some('/')` is added to the `Some('/')` match arm in `match_trivium_single_line_comment`, and a dedicated test `test_doc_comment_classification` covers all relevant cases.