### PR TITLE
Made Encode::size_hint more exact.

### DIFF
--- a/crates/cairo-lang-utils/src/bigint.rs
+++ b/crates/cairo-lang-utils/src/bigint.rs
@@ -210,7 +210,8 @@ mod impl_parity_scale_codec {
             // sign + len packed in the same byte, it allows numbers of byte size up to 63 (2**504),
             // data.
             let bits = self.value.bits() as usize;
-            core::mem::size_of::<u8>() + bits.div_ceil(8)
+            // `encode` always emits at least one data byte (`0` encodes as `[0]`).
+            core::mem::size_of::<u8>() + bits.div_ceil(8).max(1)
         }
 
         /// /!\ Warning this function panics if the number encoded is too big (>= 2**504).


### PR DESCRIPTION
## Summary

Fixes the `size_hint` implementation for `BigIntAsHex` parity scale codec encoding so that encoding `0` returns the correct size hint of 2 bytes (1 sign/len byte + 1 data byte) instead of 1 byte.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `size_hint` method was computing the encoded size as `1 + bits.div_ceil(8)`, where `bits` is the number of bits in the value. For the value `0`, `bits()` returns `0`, so `div_ceil(8)` also returns `0`, yielding a size hint of `1`. However, the actual `encode` implementation always emits at least one data byte — `0` encodes as `[sign_len_byte, 0x00]`, which is 2 bytes. This mismatch between `size_hint` and the actual encoded length is incorrect.

---

## What was the behavior or documentation before?

`size_hint` for `BigIntAsHex` returned `1` when encoding `0`, underreporting the actual encoded size by 1 byte.

---

## What is the behavior or documentation after?

`size_hint` now returns at least `2` for any value (including `0`), correctly reflecting that the encoder always emits a minimum of one data byte in addition to the sign/length byte.

---

## Related issue or discussion (if any)

---

## Additional context

The fix applies `.max(1)` to the `div_ceil(8)` result, ensuring the data byte count is never reported as zero.