### PR TITLE
feat(semantic): support tuple element access via `t.0` syntax

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -10,7 +10,7 @@ use cairo_lang_syntax::node::TypedStablePtr;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, require};
 use itertools::{Itertools, chain, zip_eq};
-use semantic::{ConcreteTypeId, ExprVarMemberPath, TypeLongId};
+use semantic::{ConcreteTypeId, ExprVarMemberPath, MemberAccessKind, TypeLongId};
 
 use super::context::{LoweredExpr, LoweringContext, LoweringFlowError, LoweringResult, VarRequest};
 use super::generators;
@@ -221,8 +221,11 @@ impl<'db> BlockBuilder<'db> {
         if let Some(var_id) = ctx.snapped_semantics.get::<MemberPath<'_>>(&member_path.into()) {
             return Some(VarUsage { var_id: *var_id, location });
         }
-        let ExprVarMemberPath::Member { parent, member_id, concrete_struct_id, .. } = member_path
-        else {
+        let ExprVarMemberPath::Member { parent, kind, .. } = member_path else {
+            return None;
+        };
+        // TODO(TomerStarkware): Support lowering of tuple index access (`t.0`).
+        let MemberAccessKind::Struct { concrete_struct_id, member_id } = kind else {
             return None;
         };
         let parent_var = self.get_snap_ref(ctx, parent)?;
@@ -419,9 +422,17 @@ fn get_ty<'db>(
 ) -> semantic::TypeId<'db> {
     match member_path {
         MemberPath::Var(var) => ctx.semantic_defs[var].ty(),
-        MemberPath::Member { member_id, concrete_struct_id, .. } => {
-            ctx.db.concrete_struct_members(*concrete_struct_id).unwrap()[&member_id.name(ctx.db)].ty
-        }
+        MemberPath::Member { kind, .. } => match kind {
+            MemberAccessKind::Struct { concrete_struct_id, member_id } => {
+                ctx.db.concrete_struct_members(*concrete_struct_id).unwrap()
+                    [&member_id.name(ctx.db)]
+                    .ty
+            }
+            // TODO(TomerStarkware): Support lowering of tuple index access (`t.0`).
+            MemberAccessKind::Index { .. } => {
+                unreachable!("Tuple index access is not supported in lowering.")
+            }
+        },
     }
 }
 
@@ -480,7 +491,7 @@ pub type SealedBlockBuilder<'db> = Option<SealedGotoCallsite<'db>>;
 pub struct BlockStructRecomposer<'a, 'b, 'db> {
     statements: &'a mut StatementsBuilder<'db>,
     pub ctx: &'a mut LoweringContext<'db, 'b>,
-    location: LocationId<'db>,
+    pub(crate) location: LocationId<'db>,
 }
 impl<'db> BlockStructRecomposer<'_, '_, 'db> {
     pub fn deconstruct(

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -44,7 +44,7 @@ use semantic::items::constant::ConstValue;
 use semantic::types::wrap_in_snapshots;
 use semantic::{
     ExprFunctionCallArg, ExprId, ExprPropagateError, ExprVarMemberPath, GenericArgumentId,
-    MatchArmSelector, SemanticDiagnostic, TypeLongId,
+    MatchArmSelector, MemberAccessKind, SemanticDiagnostic, TypeLongId,
 };
 
 use self::block_builder::{BlockBuilder, SealedBlockBuilder, SealedGotoCallsite};
@@ -1536,12 +1536,11 @@ fn lower_expr_loop<'db>(
             ExprVarMemberPath::Var(var) => {
                 ExprVarMemberPath::Var(ExprVar { ty: wrap_in_snapshots(db, var.ty, 1), ..*var })
             }
-            ExprVarMemberPath::Member { parent, member_id, stable_ptr, concrete_struct_id, ty } => {
+            ExprVarMemberPath::Member { parent, kind, stable_ptr, ty } => {
                 ExprVarMemberPath::Member {
                     parent: parent.clone(),
-                    member_id: *member_id,
+                    kind: kind.clone(),
                     stable_ptr: *stable_ptr,
-                    concrete_struct_id: *concrete_struct_id,
                     ty: wrap_in_snapshots(db, *ty, 1),
                 }
             }
@@ -1803,6 +1802,12 @@ fn lower_expr_member_access<'db>(
     builder: &mut BlockBuilder<'db>,
 ) -> LoweringResult<'db, LoweredExpr<'db>> {
     log::trace!("Lowering a member-access expression: {:?}", expr.debug(&ctx.expr_formatter));
+    // TODO(TomerStarkware): Support lowering of tuple index access (`t.0`).
+    let MemberAccessKind::Struct { concrete_struct_id, member_id } = expr.kind else {
+        return Err(LoweringFlowError::Failed(
+            ctx.diagnostics.report(expr.stable_ptr.untyped(), Unsupported),
+        ));
+    };
     if let Some(member_path) = &expr.member_path {
         return Ok(LoweredExpr::MemberPath(
             member_path.clone(),
@@ -1810,12 +1815,10 @@ fn lower_expr_member_access<'db>(
         ));
     }
     let location = ctx.get_location(expr.stable_ptr.untyped());
-    let members = ctx
-        .db
-        .concrete_struct_members(expr.concrete_struct_id)
-        .map_err(LoweringFlowError::Failed)?;
+    let members =
+        ctx.db.concrete_struct_members(concrete_struct_id).map_err(LoweringFlowError::Failed)?;
     let member_idx =
-        members.iter().position(|(_, member)| member.id == expr.member).ok_or_else(|| {
+        members.iter().position(|(_, member)| member.id == member_id).ok_or_else(|| {
             LoweringFlowError::Failed(
                 ctx.diagnostics.report(expr.stable_ptr.untyped(), UnexpectedError),
             )
@@ -1861,9 +1864,11 @@ fn lower_expr_struct_ctor<'db>(
                 };
                 let member_path = ExprVarMemberPath::Member {
                     parent: Box::new(path.clone()),
-                    member_id: member.id,
+                    kind: MemberAccessKind::Struct {
+                        concrete_struct_id: expr.concrete_struct_id,
+                        member_id: member.id,
+                    },
                     stable_ptr: path.stable_ptr(),
-                    concrete_struct_id: expr.concrete_struct_id,
                     ty: member.ty,
                 };
                 entry

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -4,7 +4,7 @@ use cairo_lang_semantic::expr::fmt::ExprFormatter;
 use cairo_lang_semantic::expr::inference::InferenceError;
 use cairo_lang_semantic::items::structure::StructSemantic;
 use cairo_lang_semantic::usage::MemberPath;
-use cairo_lang_semantic::{self as semantic};
+use cairo_lang_semantic::{self as semantic, MemberAccessKind};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{extract_matches, try_extract_matches};
 use itertools::{Itertools, chain};
@@ -12,6 +12,7 @@ use itertools::{Itertools, chain};
 use super::block_builder::BlockStructRecomposer;
 use super::context::VarRequest;
 use crate::VariableId;
+use crate::diagnostic::{LoweringDiagnosticKind, LoweringDiagnosticsBuilder};
 use crate::ids::LocationId;
 
 /// Information about members captured by the closure and their types.
@@ -163,7 +164,15 @@ impl<'db> SemanticLoweringMapping<'db> {
             return self.scattered.get_mut(path);
         }
 
-        let &MemberPath::Member { ref parent, member_id, concrete_struct_id, .. } = path else {
+        let MemberPath::Member { parent, kind } = path else {
+            return None;
+        };
+        // TODO(TomerStarkware): Support lowering of tuple index access (`t.0`).
+        let &MemberAccessKind::Struct { member_id, concrete_struct_id } = kind else {
+            ctx.ctx.diagnostics.report_by_location(
+                ctx.location.long(ctx.ctx.db).clone(),
+                LoweringDiagnosticKind::Unsupported,
+            );
             return None;
         };
 
@@ -332,8 +341,7 @@ fn compute_remapped_variables<'db>(
         .map(|member_id| {
             let member_path = MemberPath::Member {
                 parent: parent_path.clone().into(),
-                member_id: *member_id,
-                concrete_struct_id,
+                kind: MemberAccessKind::Struct { concrete_struct_id, member_id: *member_id },
             };
             // Call `compute_remapped_variables` recursively on the scattered values.
             // If there is a [Value::Var], `require_remapping` will be set to `true` to account

--- a/crates/cairo-lang-semantic/src/cache/mod.rs
+++ b/crates/cairo-lang-semantic/src/cache/mod.rs
@@ -58,7 +58,8 @@ use crate::{
     ConcreteEnumId, ConcreteExternTypeId, ConcreteFunction, ConcreteFunctionWithBodyId,
     ConcreteImplId, ConcreteImplLongId, ConcreteStructId, ConcreteTraitId, ConcreteTraitLongId,
     ConcreteTypeId, ConcreteVariant, ExprVar, ExprVarMemberPath, FunctionId, FunctionLongId,
-    GenericArgumentId, GenericParam, MatchArmSelector, TypeId, TypeLongId, ValueSelectorArm,
+    GenericArgumentId, GenericParam, MatchArmSelector, MemberAccessKind, TypeId, TypeLongId,
+    ValueSelectorArm,
 };
 
 type SemanticCache<'db> = (CrateSemanticCache, SemanticCacheLookups);
@@ -477,12 +478,55 @@ impl FeatureKindCached {
 }
 
 #[derive(Serialize, Deserialize)]
+pub enum MemberAccessKindCached {
+    Struct { concrete_struct_id: ConcreteStructCached, member_id: LanguageElementCached },
+    Index { tuple_ty: TypeIdCached, index: usize },
+}
+impl MemberAccessKindCached {
+    pub fn new<'db>(
+        kind: MemberAccessKind<'db>,
+        ctx: &mut SemanticCacheSavingContext<'db>,
+    ) -> Self {
+        match kind {
+            MemberAccessKind::Struct { concrete_struct_id, member_id } => {
+                MemberAccessKindCached::Struct {
+                    concrete_struct_id: ConcreteStructCached::new(concrete_struct_id, ctx),
+                    member_id: LanguageElementCached::new(member_id, &mut ctx.defs_ctx),
+                }
+            }
+            MemberAccessKind::Index { tuple_ty, index } => {
+                MemberAccessKindCached::Index { tuple_ty: TypeIdCached::new(tuple_ty, ctx), index }
+            }
+        }
+    }
+    pub fn get_embedded<'db>(
+        self,
+        data: &Arc<SemanticCacheLoadingData<'db>>,
+        db: &'db dyn Database,
+    ) -> MemberAccessKind<'db> {
+        match self {
+            MemberAccessKindCached::Struct { concrete_struct_id, member_id } => {
+                let (module_id, member_stable_ptr) =
+                    member_id.get_embedded(&data.defs_loading_data);
+                let member_id = MemberLongId(module_id, MemberPtr(member_stable_ptr)).intern(db);
+                MemberAccessKind::Struct {
+                    concrete_struct_id: concrete_struct_id.get_embedded(data, db),
+                    member_id,
+                }
+            }
+            MemberAccessKindCached::Index { tuple_ty, index } => {
+                MemberAccessKind::Index { tuple_ty: tuple_ty.get_embedded(data), index }
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
 pub enum ExprVarMemberPathCached {
     Var(ExprVarCached),
     Member {
         parent: Box<ExprVarMemberPathCached>,
-        member_id: LanguageElementCached,
-        concrete_struct_id: ConcreteStructCached,
+        kind: MemberAccessKindCached,
         stable_ptr: SyntaxStablePtrIdCached,
         ty: TypeIdCached,
     },
@@ -496,11 +540,10 @@ impl ExprVarMemberPathCached {
             ExprVarMemberPath::Var(var) => {
                 ExprVarMemberPathCached::Var(ExprVarCached::new(var, ctx))
             }
-            ExprVarMemberPath::Member { parent, member_id, concrete_struct_id, stable_ptr, ty } => {
+            ExprVarMemberPath::Member { parent, kind, stable_ptr, ty } => {
                 ExprVarMemberPathCached::Member {
                     parent: Box::new(ExprVarMemberPathCached::new(*parent, ctx)),
-                    member_id: LanguageElementCached::new(member_id, &mut ctx.defs_ctx),
-                    concrete_struct_id: ConcreteStructCached::new(concrete_struct_id, ctx),
+                    kind: MemberAccessKindCached::new(kind, ctx),
                     stable_ptr: SyntaxStablePtrIdCached::new(
                         stable_ptr.untyped(),
                         &mut ctx.defs_ctx,
@@ -517,21 +560,11 @@ impl ExprVarMemberPathCached {
     ) -> ExprVarMemberPath<'db> {
         match self {
             ExprVarMemberPathCached::Var(var) => ExprVarMemberPath::Var(var.get_embedded(data, db)),
-            ExprVarMemberPathCached::Member {
-                parent,
-                member_id,
-                concrete_struct_id,
-                stable_ptr,
-                ty,
-            } => {
+            ExprVarMemberPathCached::Member { parent, kind, stable_ptr, ty } => {
                 let parent = Box::new(parent.get_embedded(data, db));
-                let (module_id, member_stable_ptr) =
-                    member_id.get_embedded(&data.defs_loading_data);
-                let member_id = MemberLongId(module_id, MemberPtr(member_stable_ptr)).intern(db);
                 ExprVarMemberPath::Member {
                     parent,
-                    member_id,
-                    concrete_struct_id: concrete_struct_id.get_embedded(data, db),
+                    kind: kind.get_embedded(data, db),
                     stable_ptr: ExprPtr(stable_ptr.get_embedded(&data.defs_loading_data)),
                     ty: ty.get_embedded(data),
                 }

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -89,8 +89,8 @@ use crate::items::visibility;
 use crate::keyword::MACRO_CALL_SITE;
 use crate::lsp_helpers::LspHelpers;
 use crate::resolve::{
-    AsSegments, EnrichedMembers, EnrichedTypeMemberAccess, ResolutionContext, ResolvedConcreteItem,
-    ResolvedGenericItem, Resolver, ResolverMacroData,
+    AsSegments, EnrichedMember, EnrichedMembers, EnrichedTypeMemberAccess, ResolutionContext,
+    ResolvedConcreteItem, ResolvedGenericItem, Resolver, ResolverMacroData,
 };
 use crate::semantic::{self, Binding, FunctionId, LocalVariable, TypeId, TypeLongId};
 use crate::substitution::{HasDb, SemanticRewriter};
@@ -101,8 +101,9 @@ use crate::types::{
 };
 use crate::usage::Usages;
 use crate::{
-    ConcreteEnumId, ConcreteVariant, GenericArgumentId, GenericParam, LocalItem, Member,
-    Mutability, Parameter, PatternStringLiteral, PatternStruct, Signature, StatementItemKind,
+    ConcreteEnumId, ConcreteStructId, ConcreteVariant, GenericArgumentId, GenericParam, LocalItem,
+    Member, Mutability, Parameter, PatternStringLiteral, PatternStruct, Signature,
+    StatementItemKind,
 };
 
 /// The information of a macro expansion.
@@ -3043,7 +3044,13 @@ fn maybe_compute_pattern_semantic<'db>(
                             },
                         );
                     })?;
-                    check_struct_member_is_visible(ctx, &member, stable_ptr, member_name);
+                    check_struct_member_is_visible(
+                        ctx,
+                        member.id,
+                        member.visibility,
+                        stable_ptr,
+                        member_name,
+                    );
                     used_members.insert(member_name);
                     Some(member)
                 };
@@ -3573,7 +3580,8 @@ fn struct_ctor_expr<'db>(
                 };
                 check_struct_member_is_visible(
                     ctx,
-                    member,
+                    member.id,
+                    member.visibility,
                     arg_identifier.stable_ptr(db).untyped(),
                     arg_name,
                 );
@@ -3663,7 +3671,8 @@ fn struct_ctor_expr<'db>(
         if base_struct.is_some() {
             check_struct_member_is_visible(
                 ctx,
-                member,
+                member.id,
+                member.visibility,
                 base_struct.clone().unwrap().1.stable_ptr(db).untyped(),
                 member_name,
             );
@@ -3852,10 +3861,24 @@ fn dot_expr<'db>(
     rhs_syntax: ast::Expr<'db>,
     stable_ptr: ast::ExprPtr<'db>,
 ) -> Maybe<Expr<'db>> {
+    let db = ctx.db;
     // Find MemberId.
     match rhs_syntax {
-        ast::Expr::Path(expr) => member_access_expr(ctx, lexpr, expr, stable_ptr),
+        ast::Expr::Path(expr) => {
+            let member_name = expr_as_identifier(ctx, &expr, db)?;
+            member_access_expr(ctx, lexpr, member_name, expr.stable_ptr(db).untyped(), stable_ptr)
+        }
         ast::Expr::FunctionCall(expr) => method_call_expr(ctx, lexpr, expr, stable_ptr),
+        ast::Expr::Literal(literal) => {
+            let literal_stable_ptr = literal.stable_ptr(db).untyped();
+            // A tuple index must be a plain non-negative decimal integer, with no base prefix
+            // (e.g. `0x1`) and no type suffix (e.g. `0_u8`).
+            let text = literal.text(db);
+            if !text.long(db).bytes().all(|b| b.is_ascii_digit()) {
+                return Err(ctx.diagnostics.report(literal_stable_ptr, InvalidMemberExpression));
+            }
+            member_access_expr(ctx, lexpr, text, literal_stable_ptr, stable_ptr)
+        }
         _ => Err(ctx.diagnostics.report(rhs_syntax.stable_ptr(ctx.db), InvalidMemberExpression)),
     }
 }
@@ -4001,50 +4024,57 @@ fn method_call_expr<'db>(
     expr_function_call(ctx, function_id, named_args, expr.stable_ptr(db), stable_ptr)
 }
 
-/// Computes the semantic model of a member access expression (e.g. "expr.member").
+/// Computes the semantic model of a member access expression: either a named struct member
+/// (`expr.member`) or a positional tuple element (`t.0`).
 fn member_access_expr<'db>(
     ctx: &mut ComputationContext<'db, '_>,
     lexpr: ExprAndId<'db>,
-    rhs_syntax: ast::ExprPath<'db>,
+    member_name: SmolStrId<'db>,
+    rhs_stable_ptr: SyntaxStablePtrId<'db>,
     stable_ptr: ast::ExprPtr<'db>,
 ) -> Maybe<Expr<'db>> {
     let db = ctx.db;
 
-    // Find MemberId.
-    let member_name = expr_as_identifier(ctx, &rhs_syntax, db)?;
-    let (n_snapshots, long_ty) =
-        finalized_snapshot_peeled_ty(ctx, lexpr.ty(), rhs_syntax.stable_ptr(db))?;
+    let (n_snapshots, long_ty) = finalized_snapshot_peeled_ty(ctx, lexpr.ty(), rhs_stable_ptr)?;
 
     match &long_ty {
         TypeLongId::Concrete(_) | TypeLongId::Tuple(_) | TypeLongId::FixedSizeArray { .. } => {
-            let Some(EnrichedTypeMemberAccess { member, deref_functions }) =
-                get_enriched_type_member_access(ctx, lexpr.clone(), stable_ptr, member_name)?
+            // Resolve the accessed member - a named struct member or a positional tuple element -
+            // following the `Deref` chain if needed.
+            let Some(EnrichedTypeMemberAccess {
+                member: EnrichedMember { kind, ty: member_ty, visibility },
+                deref_functions,
+            }) = get_enriched_type_member_access(ctx, lexpr.clone(), stable_ptr, member_name)?
             else {
                 return Err(ctx.diagnostics.report(
-                    rhs_syntax.stable_ptr(db),
-                    NoSuchTypeMember { ty: long_ty.intern(ctx.db), member_name },
+                    rhs_stable_ptr,
+                    NoSuchTypeMember { ty: long_ty.intern(db), member_name },
                 ));
             };
-            check_struct_member_is_visible(
-                ctx,
-                &member,
-                rhs_syntax.stable_ptr(db).untyped(),
-                member_name,
-            );
-            let member_path = match &long_ty {
-                TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id))
-                    if n_snapshots == 0 && deref_functions.is_empty() =>
-                {
-                    lexpr.as_member_path().map(|parent| ExprVarMemberPath::Member {
-                        parent: Box::new(parent),
-                        member_id: member.id,
-                        stable_ptr,
-                        concrete_struct_id: *concrete_struct_id,
-                        ty: member.ty,
-                    })
-                }
-                _ => None,
+            if let MemberAccessKind::Struct { member_id, .. } = kind {
+                check_struct_member_is_visible(
+                    ctx,
+                    member_id,
+                    visibility.unwrap(),
+                    rhs_stable_ptr,
+                    member_name,
+                );
+            }
+
+            // A member is an assignable place only if it is directly on the (owned) aggregate -
+            // i.e. not behind a snapshot or a deref.
+            let member_path = if n_snapshots == 0 && deref_functions.is_empty() {
+                lexpr.as_member_path().map(|parent| ExprVarMemberPath::Member {
+                    parent: Box::new(parent),
+                    kind: kind.clone(),
+                    stable_ptr,
+                    ty: member_ty,
+                })
+            } else {
+                None
             };
+
+            // Replay the deref functions to build the actual accessed expression.
             let mut derefed_expr: ExprAndId<'_> = lexpr;
             for (deref_function, mutability) in &deref_functions {
                 let cur_expr = expr_function_call(
@@ -4059,19 +4089,15 @@ fn member_access_expr<'db>(
                 derefed_expr =
                     ExprAndId { expr: cur_expr.clone(), id: ctx.arenas.exprs.alloc(cur_expr) };
             }
-            let (n_snapshots, long_ty) =
-                finalized_snapshot_peeled_ty(ctx, derefed_expr.ty(), rhs_syntax.stable_ptr(db))?;
-            let derefed_expr_concrete_struct_id = match long_ty {
-                TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)) => {
-                    concrete_struct_id
-                }
-                _ => unreachable!(),
-            };
-            let ty = wrap_in_snapshots(ctx.db, member.ty, n_snapshots);
+            // The member access is performed on the (possibly derefed) aggregate, so the resulting
+            // type and desnaps are governed by the snapshots of `derefed_expr`.
+            let (n_snapshots, _) =
+                finalized_snapshot_peeled_ty(ctx, derefed_expr.ty(), rhs_stable_ptr)?;
+
+            let ty = wrap_in_snapshots(db, member_ty, n_snapshots);
             let mut final_expr = Expr::MemberAccess(ExprMemberAccess {
                 expr: derefed_expr.id,
-                concrete_struct_id: derefed_expr_concrete_struct_id,
-                member: member.id,
+                kind,
                 ty,
                 member_path,
                 n_snapshots,
@@ -4092,29 +4118,61 @@ fn member_access_expr<'db>(
 
         TypeLongId::Snapshot(_) => {
             // TODO(spapini): Handle snapshot members.
-            Err(ctx.diagnostics.report(rhs_syntax.stable_ptr(db), Unsupported))
+            Err(ctx.diagnostics.report(rhs_stable_ptr, Unsupported))
         }
-        TypeLongId::Closure(_) => {
-            Err(ctx.diagnostics.report(rhs_syntax.stable_ptr(db), Unsupported))
-        }
+        TypeLongId::Closure(_) => Err(ctx.diagnostics.report(rhs_stable_ptr, Unsupported)),
         TypeLongId::Var(_) | TypeLongId::NumericLiteral(_) => Err(ctx.diagnostics.report(
-            rhs_syntax.stable_ptr(db),
+            rhs_stable_ptr,
             InternalInferenceError(InferenceError::TypeNotInferred(long_ty.intern(ctx.db))),
         )),
         TypeLongId::ImplType(_) | TypeLongId::GenericParameter(_) | TypeLongId::Coupon(_) => {
-            Err(ctx.diagnostics.report(
-                rhs_syntax.stable_ptr(db),
-                TypeHasNoMembers { ty: long_ty.intern(ctx.db), member_name },
-            ))
+            Err(ctx
+                .diagnostics
+                .report(rhs_stable_ptr, TypeHasNoMembers { ty: long_ty.intern(db), member_name }))
         }
         TypeLongId::Missing(diag_added) => Err(*diag_added),
     }
 }
 
+/// Builds the enriched members for the named members of a struct, each reachable through
+/// `n_derefs` deref operations.
+fn struct_enriched_members<'db, 'm>(
+    concrete_struct_id: ConcreteStructId<'db>,
+    members: &'m OrderedHashMap<SmolStrId<'db>, Member<'db>>,
+    n_derefs: usize,
+) -> impl Iterator<Item = (SmolStrId<'db>, (EnrichedMember<'db>, usize))> + 'm {
+    members.iter().map(move |(name, member)| {
+        let member = EnrichedMember {
+            kind: MemberAccessKind::Struct { concrete_struct_id, member_id: member.id },
+            ty: member.ty,
+            visibility: Some(member.visibility),
+        };
+        (*name, (member, n_derefs))
+    })
+}
+
+/// Builds the enriched members for the positional elements of a tuple, keyed by their decimal
+/// index (`"0"`, `"1"`, ...), each reachable through `n_derefs` deref operations.
+fn tuple_index_members<'db, 'a>(
+    db: &'db dyn Database,
+    tys: &'a [TypeId<'db>],
+    n_derefs: usize,
+) -> impl Iterator<Item = (SmolStrId<'db>, (EnrichedMember<'db>, usize))> + 'a {
+    let tuple_ty = TypeLongId::Tuple(tys.to_vec()).intern(db);
+    tys.iter().enumerate().map(move |(index, ty)| {
+        let member = EnrichedMember {
+            kind: MemberAccessKind::Index { tuple_ty, index },
+            ty: *ty,
+            visibility: None,
+        };
+        (SmolStrId::from(db, index.to_string()), (member, n_derefs))
+    })
+}
+
 /// Returns the member and the deref operations needed for its access.
 ///
-/// Enriched members include both direct members (in case of a struct), and members of derefed types
-/// if the type implements the Deref trait into a struct.
+/// Enriched members include both direct members (in case of a struct or a tuple), and members of
+/// derefed types if the type implements the Deref trait into a struct or a tuple.
 fn get_enriched_type_member_access<'db>(
     ctx: &mut ComputationContext<'db, '_>,
     expr: ExprAndId<'db>,
@@ -4149,20 +4207,28 @@ fn get_enriched_type_member_access<'db>(
         }
         Entry::Vacant(_) => {
             let (_, long_ty) = finalized_snapshot_peeled_ty(ctx, ty, stable_ptr)?;
-            let members =
-                if let TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)) = long_ty {
+            let members = match long_ty {
+                TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)) => {
                     let members = ctx.db.concrete_struct_members(concrete_struct_id)?;
                     if let Some(member) = members.get(&accessed_member_name) {
                         // Found direct member access - so directly returning it.
                         return Ok(Some(EnrichedTypeMemberAccess {
-                            member: member.clone(),
+                            member: EnrichedMember {
+                                kind: MemberAccessKind::Struct {
+                                    concrete_struct_id,
+                                    member_id: member.id,
+                                },
+                                ty: member.ty,
+                                visibility: Some(member.visibility),
+                            },
                             deref_functions: vec![],
                         }));
                     }
-                    members.iter().map(|(k, v)| (*k, (v.clone(), 0))).collect()
-                } else {
-                    Default::default()
-                };
+                    struct_enriched_members(concrete_struct_id, members, 0).collect()
+                }
+                TypeLongId::Tuple(tys) => tuple_index_members(ctx.db, &tys, 0).collect(),
+                _ => Default::default(),
+            };
 
             EnrichedMembers {
                 members,
@@ -4192,21 +4258,34 @@ fn enrich_members<'db>(
 ) -> Maybe<()> {
     let EnrichedMembers { members: enriched, deref_chain, explored_derefs } = enriched_members;
 
-    // Add members of derefed types.
+    // Add members of derefed types. A struct contributes its named members; a tuple contributes
+    // its positional elements (a tuple cannot itself have a `Deref` impl, but a type may `Deref`
+    // into a tuple).
     for deref_info in deref_chain.iter().skip(*explored_derefs).cloned() {
         *explored_derefs += 1;
         let (_, long_ty) = finalized_snapshot_peeled_ty(ctx, deref_info.target_ty, stable_ptr)?;
-        if let TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)) = long_ty {
-            let members = ctx.db.concrete_struct_members(concrete_struct_id)?;
-            for (member_name, member) in members.iter() {
-                // Insert member if there is not already a member with the same name.
-                enriched.entry(*member_name).or_insert_with(|| (member.clone(), *explored_derefs));
+        match &long_ty {
+            TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)) => {
+                let members = ctx.db.concrete_struct_members(*concrete_struct_id)?;
+                for (name, value) in
+                    struct_enriched_members(*concrete_struct_id, members, *explored_derefs)
+                {
+                    // Insert member if there is not already a member with the same name.
+                    enriched.entry(name).or_insert(value);
+                }
             }
-            // If member is contained we can stop the calculation post the lookup.
-            if members.contains_key(&accessed_member_name) {
-                // Found member, so exploration isn't done.
-                break;
+            TypeLongId::Tuple(tys) => {
+                for (name, value) in tuple_index_members(ctx.db, tys, *explored_derefs) {
+                    // Insert member if there is not already a member with the same name.
+                    enriched.entry(name).or_insert(value);
+                }
             }
+            _ => continue,
+        };
+
+        // If the member is found we can stop the calculation post the lookup.
+        if enriched.contains_key(&accessed_member_name) {
+            break;
         }
     }
     Ok::<(), cairo_lang_diagnostics::DiagnosticAdded>(())
@@ -5018,17 +5097,18 @@ fn compute_bool_condition_semantic<'db>(
 /// Validates a struct member is visible and otherwise adds a diagnostic.
 fn check_struct_member_is_visible<'db>(
     ctx: &mut ComputationContext<'db, '_>,
-    member: &Member<'db>,
+    member_id: MemberId<'db>,
+    visibility: visibility::Visibility,
     stable_ptr: SyntaxStablePtrId<'db>,
     member_name: SmolStrId<'db>,
 ) {
     let db = ctx.db;
-    let containing_module_id = member.id.parent_module(db);
+    let containing_module_id = member_id.parent_module(db);
     if ctx.resolver.ignore_visibility_checks(containing_module_id) {
         return;
     }
     let user_module_id = ctx.resolver.module_id;
-    if !visibility::peek_visible_in(db, member.visibility, containing_module_id, user_module_id) {
+    if !visibility::peek_visible_in(db, visibility, containing_module_id, user_module_id) {
         ctx.diagnostics.report(stable_ptr, MemberNotVisible(member_name));
     }
 }

--- a/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/canonic.rs
@@ -38,8 +38,8 @@ use crate::{
     ConcreteEnumId, ConcreteExternTypeId, ConcreteFunction, ConcreteImplId, ConcreteImplLongId,
     ConcreteStructId, ConcreteTraitId, ConcreteTraitLongId, ConcreteTypeId, ConcreteVariant,
     ExprId, ExprVar, ExprVarMemberPath, FunctionId, FunctionLongId, GenericArgumentId,
-    GenericParam, MatchArmSelector, Parameter, Signature, TypeId, TypeLongId, ValueSelectorArm,
-    add_basic_rewrites,
+    GenericParam, MatchArmSelector, MemberAccessKind, Parameter, Signature, TypeId, TypeLongId,
+    ValueSelectorArm, add_basic_rewrites,
 };
 
 /// A canonical representation of a concrete trait that needs to be solved.

--- a/crates/cairo-lang-semantic/src/expr/objects.rs
+++ b/crates/cairo-lang-semantic/src/expr/objects.rs
@@ -340,10 +340,9 @@ pub enum ExprVarMemberPath<'db> {
     Var(ExprVar<'db>),
     Member {
         parent: Box<ExprVarMemberPath<'db>>,
-        member_id: MemberId<'db>,
+        kind: MemberAccessKind<'db>,
         #[dont_rewrite]
         stable_ptr: ast::ExprPtr<'db>,
-        concrete_struct_id: ConcreteStructId<'db>,
         // Type of the member.
         ty: TypeId<'db>,
     },
@@ -374,9 +373,14 @@ impl<'db> DebugWithDb<'db> for ExprVarMemberPath<'db> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db dyn Database) -> std::fmt::Result {
         match self {
             ExprVarMemberPath::Var(var) => var.fmt(f, db),
-            ExprVarMemberPath::Member { parent, member_id, .. } => {
-                write!(f, "{:?}::{}", parent.debug(db), member_id.name(db).long(db))
-            }
+            ExprVarMemberPath::Member { parent, kind, .. } => match kind {
+                MemberAccessKind::Struct { member_id, .. } => {
+                    write!(f, "{:?}::{}", parent.debug(db), member_id.name(db).long(db))
+                }
+                MemberAccessKind::Index { index, .. } => {
+                    write!(f, "{:?}::{}", parent.debug(db), index)
+                }
+            },
         }
     }
 }
@@ -522,12 +526,27 @@ pub struct ExprStringLiteral<'db> {
     pub stable_ptr: ast::ExprPtr<'db>,
 }
 
+/// Identifies the accessed member of an aggregate, either a named struct member or a positional
+/// element of a tuple (e.g. `t.0`).
+#[derive(Clone, Debug, Hash, PartialEq, Eq, DebugWithDb, SemanticObject, salsa::Update)]
+#[debug_db(dyn Database)]
+pub enum MemberAccessKind<'db> {
+    /// A named member of a struct.
+    Struct { concrete_struct_id: ConcreteStructId<'db>, member_id: MemberId<'db> },
+    /// A positional element of a tuple, accessed by index (e.g. `t.0`).
+    Index {
+        /// The type of the tuple being accessed.
+        tuple_ty: TypeId<'db>,
+        #[dont_rewrite]
+        index: usize,
+    },
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq, DebugWithDb, SemanticObject)]
 #[debug_db(ExprFormatter<'db>)]
 pub struct ExprMemberAccess<'db> {
     pub expr: semantic::ExprId,
-    pub concrete_struct_id: ConcreteStructId<'db>,
-    pub member: MemberId<'db>,
+    pub kind: MemberAccessKind<'db>,
     pub ty: semantic::TypeId<'db>,
     #[hide_field_debug_with_db]
     pub member_path: Option<ExprVarMemberPath<'db>>,

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/repr_ptr
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/repr_ptr
@@ -537,13 +537,17 @@ FunctionCall(
                                         expr: Var(
                                             LocalVarId(test::p),
                                         ),
-                                        concrete_struct_id: test::PPoint,
-                                        member: MemberId(test::PPoint::point),
+                                        kind: Struct {
+                                            concrete_struct_id: test::PPoint,
+                                            member_id: MemberId(test::PPoint::point),
+                                        },
                                         ty: test::Point,
                                     },
                                 ),
-                                concrete_struct_id: test::Point,
-                                member: MemberId(test::Point::x),
+                                kind: Struct {
+                                    concrete_struct_id: test::Point,
+                                    member_id: MemberId(test::Point::x),
+                                },
                                 ty: core::integer::u32,
                             },
                         ),

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/structure
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/structure
@@ -39,8 +39,10 @@ Block(
                             expr: Var(
                                 LocalVarId(test::a),
                             ),
-                            concrete_struct_id: test::A,
-                            member: MemberId(test::A::a),
+                            kind: Struct {
+                                concrete_struct_id: test::A,
+                                member_id: MemberId(test::A::a),
+                            },
                             ty: (core::felt252,),
                         },
                     ),
@@ -53,8 +55,10 @@ Block(
                             expr: Var(
                                 LocalVarId(test::a),
                             ),
-                            concrete_struct_id: test::A,
-                            member: MemberId(test::A::b),
+                            kind: Struct {
+                                concrete_struct_id: test::A,
+                                member_id: MemberId(test::A::b),
+                            },
                             ty: core::felt252,
                         },
                     ),
@@ -67,8 +71,10 @@ Block(
                             expr: Var(
                                 LocalVarId(test::a),
                             ),
-                            concrete_struct_id: test::A,
-                            member: MemberId(test::A::c),
+                            kind: Struct {
+                                concrete_struct_id: test::A,
+                                member_id: MemberId(test::A::c),
+                            },
                             ty: test::B,
                         },
                     ),
@@ -83,13 +89,17 @@ Block(
                                     expr: Var(
                                         LocalVarId(test::a),
                                     ),
-                                    concrete_struct_id: test::A,
-                                    member: MemberId(test::A::c),
+                                    kind: Struct {
+                                        concrete_struct_id: test::A,
+                                        member_id: MemberId(test::A::c),
+                                    },
                                     ty: test::B,
                                 },
                             ),
-                            concrete_struct_id: test::B,
-                            member: MemberId(test::B::a),
+                            kind: Struct {
+                                concrete_struct_id: test::B,
+                                member_id: MemberId(test::B::a),
+                            },
                             ty: core::felt252,
                         },
                     ),

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/tuple
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/tuple
@@ -62,3 +62,158 @@ Tuple(
 )
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test tuple index access
+
+//! > test_runner_name
+test_expr_semantics(expect_diagnostics: false)
+
+//! > function_body
+let t = (1_felt252, (2_u8, 3_u16));
+
+//! > expr_code
+{
+    t.0;
+    t.1.1;
+}
+
+//! > expected_semantics
+Block(
+    ExprBlock {
+        statements: [
+            Expr(
+                StatementExpr {
+                    expr: MemberAccess(
+                        ExprMemberAccess {
+                            expr: Var(
+                                LocalVarId(test::t),
+                            ),
+                            kind: Index {
+                                tuple_ty: (core::felt252, (core::integer::u8, core::integer::u16)),
+                                index: 0,
+                            },
+                            ty: core::felt252,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StatementExpr {
+                    expr: MemberAccess(
+                        ExprMemberAccess {
+                            expr: MemberAccess(
+                                ExprMemberAccess {
+                                    expr: Var(
+                                        LocalVarId(test::t),
+                                    ),
+                                    kind: Index {
+                                        tuple_ty: (core::felt252, (core::integer::u8, core::integer::u16)),
+                                        index: 1,
+                                    },
+                                    ty: (core::integer::u8, core::integer::u16),
+                                },
+                            ),
+                            kind: Index {
+                                tuple_ty: (core::integer::u8, core::integer::u16),
+                                index: 1,
+                            },
+                            ty: core::integer::u16,
+                        },
+                    ),
+                },
+            ),
+        ],
+        tail: None,
+        ty: (),
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test tuple index access through a snapshot
+
+//! > test_runner_name
+test_expr_semantics(expect_diagnostics: false)
+
+//! > function_body
+let t = (1_felt252, 2_u8);
+
+//! > expr_code
+(@t).1
+
+//! > expected_semantics
+MemberAccess(
+    ExprMemberAccess {
+        expr: Snapshot(
+            ExprSnapshot {
+                inner: Var(
+                    LocalVarId(test::t),
+                ),
+                ty: @(core::felt252, core::integer::u8),
+            },
+        ),
+        kind: Index {
+            tuple_ty: (core::felt252, core::integer::u8),
+            index: 1,
+        },
+        ty: @core::integer::u8,
+    },
+)
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test tuple index access through Deref
+
+//! > test_runner_name
+test_expr_semantics(expect_diagnostics: false)
+
+//! > module_code
+#[derive(Drop, Copy)]
+struct Wrapper {
+    inner: (felt252, u8),
+}
+impl WrapperDeref of core::ops::Deref<Wrapper> {
+    type Target = (felt252, u8);
+    fn deref(self: Wrapper) -> (felt252, u8) {
+        self.inner
+    }
+}
+
+//! > function_body
+let w = Wrapper { inner: (1, 2) };
+
+//! > expr_code
+w.1
+
+//! > expected_semantics
+MemberAccess(
+    ExprMemberAccess {
+        expr: FunctionCall(
+            ExprFunctionCall {
+                function: test::WrapperDeref::deref,
+                args: [
+                    Value(
+                        Var(
+                            LocalVarId(test::w),
+                        ),
+                    ),
+                ],
+                coupon_arg: None,
+                ty: (core::felt252, core::integer::u8),
+            },
+        ),
+        kind: Index {
+            tuple_ty: (core::felt252, core::integer::u8),
+            index: 1,
+        },
+        ty: core::integer::u8,
+    },
+)
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test.rs
+++ b/crates/cairo-lang-semantic/src/expr/test.rs
@@ -63,6 +63,7 @@ cairo_lang_test_utils::test_file_test!(
         snapshot: "snapshot",
         statements: "statements",
         structure: "structure",
+        tuple: "tuple",
         while_: "while",
         impl_: "impl",
     },

--- a/crates/cairo-lang-semantic/src/expr/test_data/structure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/structure
@@ -87,15 +87,10 @@ error[E2085]: Invalid member expression.
     a.a::b;
       ^^^^
 
-error[E2085]: Invalid member expression.
+error[E0007]: Type "test::A" has no member "4"
  --> lib.cairo:9:7
     a.4.4;
       ^
-
-error[E2085]: Invalid member expression.
- --> lib.cairo:9:9
-    a.4.4;
-        ^
 
 error[E0007]: Type "core::felt252" has no member "a"
  --> lib.cairo:10:15

--- a/crates/cairo-lang-semantic/src/expr/test_data/tuple
+++ b/crates/cairo-lang-semantic/src/expr/test_data/tuple
@@ -1,0 +1,185 @@
+//! > Test tuple index access - valid
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo(t: (felt252, u8)) -> u8 {
+    t.1
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test tuple index access - out of bounds
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(t: (felt252, u8)) -> felt252 {
+    t.5
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error[E0007]: Type "(core::felt252, core::integer::u8)" has no member "5"
+ --> lib.cairo:2:7
+    t.5
+      ^
+
+//! > ==========================================================================
+
+//! > Test tuple index access - non-tuple type
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(x: felt252) -> felt252 {
+    x.0
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error[E0007]: Type "core::felt252" has no member "0"
+ --> lib.cairo:2:7
+    x.0
+      ^
+
+//! > ==========================================================================
+
+//! > Test tuple index access - type suffix rejected
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(t: (felt252, u8)) -> felt252 {
+    t.0_u8
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error[E2085]: Invalid member expression.
+ --> lib.cairo:2:7
+    t.0_u8
+      ^^^^
+
+//! > ==========================================================================
+
+//! > Test tuple index access - hex base rejected
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(t: (felt252, u8)) -> u8 {
+    t.0x1
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error[E2085]: Invalid member expression.
+ --> lib.cairo:2:7
+    t.0x1
+      ^^^
+
+//! > ==========================================================================
+
+//! > Test tuple index access - leading zero rejected
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(t: (felt252, u8)) -> (felt252, felt252) {
+    (t.00, t.0x1)
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error[E0007]: Type "(core::felt252, core::integer::u8)" has no member "00"
+ --> lib.cairo:2:8
+    (t.00, t.0x1)
+       ^^
+
+error[E2085]: Invalid member expression.
+ --> lib.cairo:2:14
+    (t.00, t.0x1)
+             ^^^
+
+//! > ==========================================================================
+
+//! > Test tuple index access - assignment to element
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo(mut t: (felt252, u8)) {
+    t.0 = 5;
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test tuple index access - through Deref
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo(w: Wrapper) -> u8 {
+    w.1
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop, Copy)]
+struct Wrapper {
+    inner: (felt252, u8),
+}
+
+impl WrapperDeref of core::ops::Deref<Wrapper> {
+    type Target = (felt252, u8);
+    fn deref(self: Wrapper) -> (felt252, u8) {
+        self.inner
+    }
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -52,8 +52,8 @@ use crate::types::resolve_type;
 use crate::{
     Arenas, ConcreteFunction, ConcreteTypeId, ConcreteVariant, Condition, Expr, ExprBlock,
     ExprConstant, ExprFunctionCall, ExprFunctionCallArg, ExprId, ExprMemberAccess, ExprStructCtor,
-    FunctionId, GenericParam, LogicalOperator, Pattern, PatternId, SemanticDiagnostic, Statement,
-    TypeId, TypeLongId, semantic_object_for_id,
+    FunctionId, GenericParam, LogicalOperator, MemberAccessKind, Pattern, PatternId,
+    SemanticDiagnostic, Statement, TypeId, TypeLongId, semantic_object_for_id,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, DebugWithDb)]
@@ -1171,11 +1171,18 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             // A semantic diagnostic should have been reported.
             return Err(skip_diagnostic());
         };
-        let members = self.db.concrete_struct_members(expr.concrete_struct_id)?;
-        let Some(member_idx) = members.iter().position(|(_, member)| member.id == expr.member)
-        else {
-            // A semantic diagnostic should have been reported.
-            return Err(skip_diagnostic());
+        let member_idx = match &expr.kind {
+            MemberAccessKind::Struct { concrete_struct_id, member_id } => {
+                let members = self.db.concrete_struct_members(*concrete_struct_id)?;
+                let Some(member_idx) =
+                    members.iter().position(|(_, member)| member.id == *member_id)
+                else {
+                    // A semantic diagnostic should have been reported.
+                    return Err(skip_diagnostic());
+                };
+                member_idx
+            }
+            MemberAccessKind::Index { index, .. } => *index,
         };
         Ok(values[member_idx])
     }

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -77,7 +77,7 @@ use crate::types::{
 };
 use crate::{
     ConcreteFunction, ConcreteTypeId, ConcreteVariant, FunctionId, FunctionLongId,
-    GenericArgumentId, GenericParam, Member, Mutability, TypeId, TypeLongId,
+    GenericArgumentId, GenericParam, MemberAccessKind, Mutability, TypeId, TypeLongId,
 };
 
 #[cfg(test)]
@@ -132,9 +132,9 @@ impl<'db> ResolvedItems<'db> {
 #[derive(Debug, PartialEq, Eq, DebugWithDb, Clone, salsa::Update)]
 #[debug_db(dyn Database)]
 pub struct EnrichedMembers<'db> {
-    /// A map from member names to their semantic representation and the number of deref operations
-    /// needed to access them.
-    pub members: OrderedHashMap<SmolStrId<'db>, (Member<'db>, usize)>,
+    /// A map from member names to the member and the number of deref operations needed to access
+    /// them.
+    pub members: OrderedHashMap<SmolStrId<'db>, (EnrichedMember<'db>, usize)>,
     /// The sequence of deref needed to access the members.
     pub deref_chain: Arc<Vec<DerefInfo<'db>>>,
     // The number of derefs that were explored.
@@ -156,11 +156,24 @@ impl<'db> EnrichedMembers<'db> {
     }
 }
 
+/// A member accessible on a type: a named struct member or a positional tuple element.
+#[derive(Debug, PartialEq, Eq, DebugWithDb, Clone, salsa::Update)]
+#[debug_db(dyn Database)]
+pub struct EnrichedMember<'db> {
+    /// How the member is accessed: a struct member id or a tuple index.
+    pub kind: MemberAccessKind<'db>,
+    /// The type of the member.
+    pub ty: TypeId<'db>,
+    /// The visibility of the member. `Some` for struct members; `None` for tuple elements (which
+    /// are always visible).
+    pub visibility: Option<visibility::Visibility>,
+}
+
 /// The enriched member of a type, including the member itself and the deref functions needed to
 /// access it.
 pub struct EnrichedTypeMemberAccess<'db> {
-    /// The member itself.
-    pub member: Member<'db>,
+    /// The accessible member.
+    pub member: EnrichedMember<'db>,
     /// The sequence of deref functions needed to access the member.
     pub deref_functions: Vec<(FunctionId<'db>, Mutability)>,
 }

--- a/crates/cairo-lang-semantic/src/substitution.rs
+++ b/crates/cairo-lang-semantic/src/substitution.rs
@@ -43,8 +43,8 @@ use crate::{
     ConcreteEnumId, ConcreteExternTypeId, ConcreteFunction, ConcreteImplId, ConcreteImplLongId,
     ConcreteStructId, ConcreteTraitId, ConcreteTraitLongId, ConcreteTypeId, ConcreteVariant,
     ExprId, ExprVar, ExprVarMemberPath, FunctionId, FunctionLongId, GenericArgumentId,
-    GenericParam, MatchArmSelector, Parameter, Signature, TypeId, TypeLongId, ValueSelectorArm,
-    VarId,
+    GenericParam, MatchArmSelector, MemberAccessKind, Parameter, Signature, TypeId, TypeLongId,
+    ValueSelectorArm, VarId,
 };
 
 pub enum RewriteResult {
@@ -387,6 +387,7 @@ macro_rules! add_basic_rewrites {
         $crate::prune_single!(__regular_helper, UninferredGeneratedImplLongId, $($exclude)*);
         $crate::prune_single!(__regular_helper, UninferredImpl, $($exclude)*);
         $crate::prune_single!(__regular_helper, ExprVarMemberPath, $($exclude)*);
+        $crate::prune_single!(__regular_helper, MemberAccessKind, $($exclude)*);
         $crate::prune_single!(__regular_helper, ExprVar, $($exclude)*);
         $crate::prune_single!(__regular_helper, ImplVarTraitItemMappings, $($exclude)*);
         $crate::prune_single!(__regular_helper, CanonicalTrait, $($exclude)*);

--- a/crates/cairo-lang-semantic/src/usage/mod.rs
+++ b/crates/cairo-lang-semantic/src/usage/mod.rs
@@ -1,7 +1,6 @@
 //! Introduces [Usages], which is responsible for computing variables usage in semantic blocks\
 //! of a function.
 
-use cairo_lang_defs::ids::MemberId;
 use cairo_lang_proc_macros::DebugWithDb;
 use cairo_lang_utils::extract_matches;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -10,8 +9,8 @@ use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use crate::expr::fmt::ExprFormatter;
 use crate::expr::objects::Arenas;
 use crate::{
-    ConcreteStructId, Condition, Expr, ExprClosure, ExprFor, ExprFunctionCall, ExprFunctionCallArg,
-    ExprId, ExprLoop, ExprVarMemberPath, ExprWhile, FixedSizeArrayItems, FunctionBody, Parameter,
+    Condition, Expr, ExprClosure, ExprFor, ExprFunctionCall, ExprFunctionCallArg, ExprId, ExprLoop,
+    ExprVarMemberPath, ExprWhile, FixedSizeArrayItems, FunctionBody, MemberAccessKind, Parameter,
     Pattern, PatternArena, PatternId, Statement, StatementBreak, StatementExpr, StatementLet,
     StatementReturn, VarId,
 };
@@ -25,11 +24,7 @@ mod test;
 #[debug_db(ExprFormatter<'db>)]
 pub enum MemberPath<'db> {
     Var(VarId<'db>),
-    Member {
-        parent: Box<MemberPath<'db>>,
-        member_id: MemberId<'db>,
-        concrete_struct_id: ConcreteStructId<'db>,
-    },
+    Member { parent: Box<MemberPath<'db>>, kind: MemberAccessKind<'db> },
 }
 impl<'db> MemberPath<'db> {
     pub fn base_var(&self) -> VarId<'db> {
@@ -43,12 +38,8 @@ impl<'db> From<&ExprVarMemberPath<'db>> for MemberPath<'db> {
     fn from(value: &ExprVarMemberPath<'db>) -> Self {
         match value {
             ExprVarMemberPath::Var(expr) => MemberPath::Var(expr.var),
-            ExprVarMemberPath::Member { parent, member_id, concrete_struct_id, .. } => {
-                MemberPath::Member {
-                    parent: Box::new(parent.as_ref().into()),
-                    member_id: *member_id,
-                    concrete_struct_id: *concrete_struct_id,
-                }
+            ExprVarMemberPath::Member { parent, kind, .. } => {
+                MemberPath::Member { parent: Box::new(parent.as_ref().into()), kind: kind.clone() }
             }
         }
     }


### PR DESCRIPTION
Adds positional tuple element access by index using dot notation (e.g. `t.0`, `t.1`), resolved in the semantic model. Member access is generalized via a new `MemberAccessKind` enum (`Struct{..}` | `Index{..}`) threaded through `ExprMemberAccess`, `ExprVarMemberPath` and `usage::MemberPath`, so a member is identified either by a struct member id or by a numeric tuple index.

The index must be a plain non-negative decimal literal (no base prefix or type suffix); out-of-bounds and non-tuple accesses are reported. Lowering of tuple index access is not yet implemented and currently reports an "Unsupported" error; it will be added in a follow-up.