### PR TITLE
bugfix(corelib): Disable ability to dict-new on illegal types.

### DIFF
--- a/corelib/src/dict.cairo
+++ b/corelib/src/dict.cairo
@@ -203,7 +203,7 @@ impl Felt252DictEntryImpl<T, +Felt252DictValue<T>> of Felt252DictEntryTrait<T> {
     }
 }
 
-impl Felt252DictDefault<T> of Default<Felt252Dict<T>> {
+impl Felt252DictDefault<T, +Felt252DictValue<T>> of Default<Felt252Dict<T>> {
     /// Returns a new empty dictionary.
     ///
     /// # Examples


### PR DESCRIPTION
## Summary

Adds the `Felt252DictValue<T>` trait bound to the `Felt252DictDefault` implementation, ensuring that `Default<Felt252Dict<T>>` is only implemented for types that are valid dictionary value types.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `Felt252DictDefault` implementation was missing the `Felt252DictValue<T>` constraint, meaning `Default<Felt252Dict<T>>` could theoretically be invoked for types that are not valid dictionary value types. This constraint is required for correctness, as `Felt252Dict<T>` is only meaningful when `T` implements `Felt252DictValue`.

---

## What was the behavior or documentation before?

`Felt252DictDefault<T>` implemented `Default<Felt252Dict<T>>` for any `T`, without requiring `T` to implement `Felt252DictValue`.

---

## What is the behavior or documentation after?

`Felt252DictDefault<T>` now requires `T: Felt252DictValue<T>`, aligning the `Default` implementation with the actual constraints needed to construct and use a `Felt252Dict<T>`.

---

## Related issue or discussion (if any)

#10098

---

## Additional context

This is a minimal, targeted constraint fix with no behavioral change for valid usage, but it closes a gap where the trait bound was inconsistently applied compared to the rest of the `Felt252Dict` API.