### PR TITLE
Refactored plugin test.

### DIFF
--- a/corelib/src/test/plugins_test.cairo
+++ b/corelib/src/test/plugins_test.cairo
@@ -41,31 +41,11 @@ fn test_derive_serde_enum() {
     b.serialize(ref output);
     a.serialize(ref output);
     let mut serialized = output.span();
-    assert_eq(
-        @Serde::<EnumForSerde>::deserialize(ref serialized).expect('failed to read'),
-        @a,
-        'expected a',
-    );
-    assert_eq(
-        @Serde::<EnumForSerde>::deserialize(ref serialized).expect('failed to read'),
-        @a,
-        'expected a',
-    );
-    assert_eq(
-        @Serde::<EnumForSerde>::deserialize(ref serialized).expect('failed to read'),
-        @c,
-        'expected c',
-    );
-    assert_eq(
-        @Serde::<EnumForSerde>::deserialize(ref serialized).expect('failed to read'),
-        @b,
-        'expected b',
-    );
-    assert_eq(
-        @Serde::<EnumForSerde>::deserialize(ref serialized).expect('failed to read'),
-        @a,
-        'expected a',
-    );
+    assert_eq!(Serde::deserialize(ref serialized), Some(a));
+    assert_eq!(Serde::deserialize(ref serialized), Some(a));
+    assert_eq!(Serde::deserialize(ref serialized), Some(c));
+    assert_eq!(Serde::deserialize(ref serialized), Some(b));
+    assert_eq!(Serde::deserialize(ref serialized), Some(a));
     assert(serialized.is_empty(), 'expected empty');
 }
 
@@ -74,10 +54,9 @@ fn test_derive_serde_struct_with_serialized_field() {
     let mut output = array![];
     StructWithSerializedField { serialized: 3, other: 5 }.serialize(ref output);
     let mut serialized = output.span();
-    assert_eq(
-        @Serde::<StructWithSerializedField>::deserialize(ref serialized).expect('failed to read'),
-        @StructWithSerializedField { serialized: 3, other: 5 },
-        'bad round-trip',
+    assert_eq!(
+        Serde::deserialize(ref serialized),
+        Some(StructWithSerializedField { serialized: 3, other: 5 }),
     );
     assert(serialized.is_empty(), 'expected empty');
 }
@@ -101,7 +80,7 @@ enum LongEnum5 {
     E,
 }
 #[derive(Copy, Debug, Drop, Serde, PartialEq)]
-enum longEnum10 {
+enum LongEnum10 {
     A,
     B,
     C,
@@ -114,7 +93,7 @@ enum longEnum10 {
     J,
 }
 #[derive(Copy, Debug, Drop, Serde, PartialEq)]
-enum longEnum15 {
+enum LongEnum15 {
     A,
     B,
     C,
@@ -135,35 +114,22 @@ enum longEnum15 {
 
 #[test]
 fn test_long_enum5_deserialize() {
-    let x = LongEnum5::E;
     let mut output = Default::default();
-    x.serialize(ref output);
+    LongEnum5::E.serialize(ref output);
     let mut serialized = output.span();
-    assert_eq(
-        @Serde::<LongEnum5>::deserialize(ref serialized).expect('failed to read'), @x, 'expected E',
-    );
+    assert_eq!(Serde::deserialize(ref serialized), Some(LongEnum5::E));
 }
 #[test]
 fn test_long_enum10_deserialize() {
-    let x = longEnum10::J;
     let mut output = Default::default();
-    x.serialize(ref output);
+    LongEnum10::J.serialize(ref output);
     let mut serialized = output.span();
-    assert_eq(
-        @Serde::<longEnum10>::deserialize(ref serialized).expect('failed to read'),
-        @x,
-        'expected J',
-    );
+    assert_eq!(Serde::deserialize(ref serialized), Some(LongEnum10::J));
 }
 #[test]
 fn test_long_enum15_deserialize() {
-    let x = longEnum15::O;
     let mut output = Default::default();
-    x.serialize(ref output);
+    LongEnum15::O.serialize(ref output);
     let mut serialized = output.span();
-    assert_eq(
-        @Serde::<longEnum15>::deserialize(ref serialized).expect('failed to read'),
-        @x,
-        'expected O',
-    );
+    assert_eq!(Serde::deserialize(ref serialized), Some(LongEnum15::O));
 }


### PR DESCRIPTION
## Summary

Replaces legacy `assert_eq(...)` calls with the `assert_eq!(...)` macro in `plugins_test.cairo`, and renames `longEnum10` and `longEnum15` to `LongEnum10` and `LongEnum15` to follow consistent naming conventions. The deserialization assertions are simplified by directly comparing against `Some(value)` instead of calling `.expect(...)` and comparing references.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The test assertions were using the older `assert_eq(...)` function with snapshot references and error message strings, while the rest of the codebase has moved toward the `assert_eq!(...)` macro. Additionally, `longEnum10` and `longEnum15` violated the PascalCase naming convention used for all other enums in the same file.

---

## What was the behavior or documentation before?

Tests used `assert_eq(@Serde::<T>::deserialize(...).expect('failed to read'), @value, 'message')` and enum names `longEnum10` / `longEnum15`.

---

## What is the behavior or documentation after?

Tests use `assert_eq!(Serde::deserialize(...), Some(value))`, and the enums are renamed to `LongEnum10` and `LongEnum15`.

---

## Related issue or discussion (if any)

None.

---

## Additional context

None.