### PR TITLE
bugfix(sierra-generator): represent user-defined phantom types as `never`

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/function_generator_test_data/generics
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test_data/generics
@@ -27,3 +27,91 @@ const_as_box<Const<Tuple<felt252, felt252, felt252>, Const<felt252, 10>, Const<f
 span_from_tuple<Tuple<felt252, felt252, felt252>>([0]) -> ([1])
 store_temp<Snapshot<Array<felt252>>>([1]) -> ([1])
 return([1])
+
+//! > ==========================================================================
+
+//! > Test a user-defined phantom type in a container specializes (represented as `never`).
+
+//! > test_runner_name
+test_function_generator
+
+//! > function_code
+fn foo(x: Option<Ph>) -> felt252 {
+    match x {
+        Option::Some(p) => match p {},
+        Option::None => 0,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[phantom]
+enum Ph {}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_gen_diagnostics
+
+//! > sierra_code
+label_test::foo::0:
+enum_match<core::option::Option::<test::Ph>>([0]) { fallthrough([1]) label_test::foo::1([2]) }
+branch_align() -> ()
+enum_match<core::never>([1]) { }
+label_test::foo::3:
+label_test::foo::1:
+branch_align() -> ()
+drop<Unit>([2]) -> ()
+const_as_immediate<Const<felt252, 0>>() -> ([3])
+store_temp<felt252>([3]) -> ([3])
+return([3])
+label_test::foo::2:
+
+//! > ==========================================================================
+
+//! > Test a tuple of a user-defined phantom keeps its struct shape with `never` members.
+
+//! > test_runner_name
+test_function_generator
+
+//! > function_code
+fn foo(x: Option<(Ph,)>) -> felt252 {
+    match x {
+        Option::Some(t) => {
+            let (p,) = t;
+            match p {}
+        },
+        Option::None => 0,
+    }
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[phantom]
+enum Ph {}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_gen_diagnostics
+
+//! > sierra_code
+label_test::foo::0:
+enum_match<core::option::Option::<(test::Ph,)>>([0]) { fallthrough([1]) label_test::foo::1([2]) }
+branch_align() -> ()
+struct_deconstruct<Tuple<core::never>>([1]) -> ([3])
+enum_match<core::never>([3]) { }
+label_test::foo::3:
+label_test::foo::1:
+branch_align() -> ()
+drop<Unit>([2]) -> ()
+const_as_immediate<Const<felt252, 0>>() -> ([4])
+store_temp<felt252>([4]) -> ([4])
+return([4])
+label_test::foo::2:

--- a/crates/cairo-lang-sierra-generator/src/types.rs
+++ b/crates/cairo-lang-sierra-generator/src/types.rs
@@ -40,15 +40,42 @@ pub fn get_concrete_type_id<'db>(
         ) if db.is_self_referential(type_id)? => {
             return Ok(db.intern_concrete_type(SierraGeneratorTypeLongId::CycleBreaker(type_id)));
         }
-        _ => {
-            if type_id.is_phantom(db) {
-                return Ok(db.intern_concrete_type(SierraGeneratorTypeLongId::Phantom(type_id)));
-            }
+        // Extern phantom types - and tuples/arrays of them - keep their dedicated `Phantom` long
+        // id: their identity matters to the libfuncs that consume them (e.g. circuit
+        // gates).
+        _ if contains_extern_phantom(db, type_id) => {
+            return Ok(db.intern_concrete_type(SierraGeneratorTypeLongId::Phantom(type_id)));
         }
+        // A user-defined phantom struct/enum is uninhabited, so represent it as the (representable)
+        // `never` type - it has no values, but a container of it (e.g. `Option<Ph>`) must still
+        // specialize. A tuple/array of user phantoms falls through to the regular representation
+        // below, keeping its struct shape with `never` members.
+        semantic::TypeLongId::Concrete(
+            semantic::ConcreteTypeId::Enum(_) | semantic::ConcreteTypeId::Struct(_),
+        ) if type_id.is_phantom(db) => {
+            return Ok(db.get_concrete_type_id(semantic::corelib::never_ty(db))?.clone());
+        }
+        _ => {}
     }
     Ok(db.intern_concrete_type(SierraGeneratorTypeLongId::Regular(
         db.get_concrete_long_type_id(type_id)?.clone(),
     )))
+}
+
+/// Whether `ty` is, or transitively (through tuples / fixed-size arrays) contains, an extern
+/// phantom type. Such types keep their dedicated `Phantom` Sierra long id, since the libfuncs that
+/// consume them (e.g. circuit gates) rely on it; other phantom types are represented as `never`.
+fn contains_extern_phantom<'db>(db: &'db dyn Database, ty: semantic::TypeId<'db>) -> bool {
+    match ty.long(db) {
+        semantic::TypeLongId::Concrete(semantic::ConcreteTypeId::Extern(_)) => ty.is_phantom(db),
+        semantic::TypeLongId::Tuple(types) => {
+            types.iter().any(|inner| contains_extern_phantom(db, *inner))
+        }
+        semantic::TypeLongId::FixedSizeArray { type_id, .. } => {
+            contains_extern_phantom(db, *type_id)
+        }
+        _ => false,
+    }
 }
 
 /// See [SierraGenGroup::get_index_enum_type_id] for documentation.


### PR DESCRIPTION
## Summary

User-defined phantom structs and enums are now represented as the `never` type in Sierra, rather than using the dedicated `Phantom` long id. This allows containers such as `Option<Ph>` (where `Ph` is a `#[phantom]` enum) to specialize correctly without causing an ICE. Extern phantom types retain their `Phantom` long id, since their identity is required by the libfuncs that consume them (e.g. circuit gates).

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a user-defined phantom type (struct or enum) appeared inside a generic container like `Option<Ph>`, the Sierra generator would ICE because the phantom type could not be represented in a way that allowed the container to specialize. Since user-defined phantom types are uninhabited, mapping them to `never` is semantically correct and allows the container to specialize without issues.

---

## What was the behavior or documentation before?

User-defined phantom structs and enums were given a dedicated `Phantom` long id, the same as extern phantom types. Placing them inside a generic container (e.g. `Option<Ph>`) caused an ICE during Sierra generation.

---

## What is the behavior or documentation after?

User-defined phantom structs and enums are mapped to the `never` type in Sierra. A container such as `Option<Ph>` now generates valid Sierra code, with the `Some` branch represented as `enum_match<core::never>` (an uninhabited match). Extern phantom types are unaffected and continue to use the `Phantom` long id.

---

## Related issue or discussion (if any)

Fixes #10113

---

## Additional context

A new test case (`Test a user-defined phantom type in a container specializes (represented as never)`) was added to `generics` to cover the `Option<Ph>` pattern and verify the generated Sierra output.