### PR TITLE
bugfix(semantic): Removed extra diagnostic for type mismatches on `missing`.

### DIFF
--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -2732,7 +2732,7 @@ fn validate_impl_item_constant<'db>(
 
     let expected_ty = inference.rewrite(concrete_trait_constant_ty).no_err();
     let actual_ty = inference.rewrite(constant_ty).no_err();
-    if expected_ty != actual_ty {
+    if expected_ty != actual_ty && !expected_ty.is_missing(db) && !actual_ty.is_missing(db) {
         diagnostics.report(
             impl_constant_type_clause_ast.ty(db).stable_ptr(db),
             WrongType { expected_ty, actual_ty },

--- a/crates/cairo-lang-semantic/src/items/tests/trait_const
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_const
@@ -844,3 +844,32 @@ impl SomeImpl of SomeTrait {
 }
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test impl const with an unresolvable type reports only the resolution error (no spurious
+
+//! > type-mismatch cascade).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait MyTrait {
+    const X: u32;
+}
+impl MyImpl of MyTrait {
+    const X: Nonexistent = 0;
+}
+
+//! > expected_diagnostics
+error[E0006]: Type not found.
+ --> lib.cairo:5:14
+    const X: Nonexistent = 0;
+             ^^^^^^^^^^^


### PR DESCRIPTION
## Summary

When an impl constant references an unresolvable type (e.g., `const X: Nonexistent = 0;`), the compiler was previously emitting both a "Type not found" error and a spurious "WrongType" mismatch diagnostic. The type mismatch check in `validate_impl_item_constant` now skips reporting when either the expected or actual type is a missing (error sentinel) type, suppressing the cascading false diagnostic.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a type in an impl constant declaration could not be resolved, the compiler would report the legitimate "Type not found" error and then also emit a spurious "WrongType" diagnostic, because the missing type sentinel did not match the expected concrete type. This caused confusing double-error output for a single root cause.

---

## What was the behavior or documentation before?

Given:
```cairo
trait MyTrait {
    const X: u32;
}
impl MyImpl of MyTrait {
    const X: Nonexistent = 0;
}
```
The compiler emitted both a "Type not found" error for `Nonexistent` and a secondary "WrongType" mismatch error.

---

## What is the behavior or documentation after?

The compiler now emits only the "Type not found" error, suppressing the cascading type-mismatch diagnostic when either type involved in the comparison is a missing/error sentinel type.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A new test case was added to `trait_const` to assert that only the resolution error is reported and no spurious type-mismatch diagnostic appears.