### PR TITLE
bugfix(formatter): Sort merged items via compare_names.

### DIFF
--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -32,10 +32,19 @@ struct UseTree {
 }
 
 /// Represents a terminal node in a `UseTree`, corresponding to a specific `use` path.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 struct Leaf {
     name: String,
     alias: Option<String>,
+}
+impl std::fmt::Display for Leaf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(alias) = &self.alias {
+            write!(f, "{} as {alias}", self.name)
+        } else {
+            write!(f, "{}", self.name)
+        }
+    }
 }
 
 impl UseTree {
@@ -64,17 +73,7 @@ impl UseTree {
     }
 
     /// Merge and organize the `use` paths in a hierarchical structure.
-    pub fn create_merged_use_items(self, allow_duplicate_uses: bool) -> Vec<String> {
-        let mut leaf_paths: Vec<String> = self
-            .leaves
-            .into_iter()
-            .map(
-                |Leaf { name, alias }| {
-                    if let Some(alias) = alias { format!("{name} as {alias}") } else { name }
-                },
-            )
-            .collect();
-
+    pub fn create_merged_use_items(mut self, allow_duplicate_uses: bool) -> Vec<String> {
         let mut nested_paths = vec![];
         for (segment, subtree) in self.children {
             let subtree_merged_use_items = subtree.create_merged_use_items(allow_duplicate_uses);
@@ -84,15 +83,16 @@ impl UseTree {
         }
 
         if !allow_duplicate_uses {
-            leaf_paths.sort();
-            leaf_paths.dedup();
+            self.leaves.sort_by(|a, b| {
+                compare_names(&a.name, &b.name).then_with(|| a.alias.cmp(&b.alias))
+            });
+            self.leaves.dedup();
         }
-
-        match leaf_paths.len() {
-            0 => {}
-            1 if nested_paths.is_empty() => return leaf_paths,
-            1 => nested_paths.extend(leaf_paths),
-            _ => nested_paths.push(format!("{{{}}}", leaf_paths.join(", "))),
+        match self.leaves.as_slice() {
+            [] => {}
+            [leaf] if nested_paths.is_empty() => return vec![leaf.to_string()],
+            [leaf] => nested_paths.push(leaf.to_string()),
+            leaves => nested_paths.push(format!("{{{}}}", leaves.iter().format(", "))),
         }
 
         nested_paths
@@ -1347,9 +1347,13 @@ fn compare_use_paths<'a>(a: &UsePath<'a>, b: &UsePath<'a>, db: &dyn Database) ->
     }
 }
 
-/// Compares two names, with special handling for "super" and "crate".
+/// Compares two names, with special handling for the glob `*` (first), `self` (first) and
+/// `super`/`crate` (last) — matching the ordering of `compare_use_paths`.
 fn compare_names(a: &str, b: &str) -> Ordering {
     match (a, b) {
+        ("*", "*") => Ordering::Equal,
+        ("*", _) => Ordering::Less,
+        (_, "*") => Ordering::Greater,
         ("super" | "crate", "super" | "crate") => a.cmp(b),
         ("self", "self") => Ordering::Equal,
         ("super" | "crate", _) | (_, "self") => Ordering::Greater,

--- a/crates/cairo-lang-formatter/src/test.rs
+++ b/crates/cairo-lang-formatter/src/test.rs
@@ -143,6 +143,17 @@ use crate::{FormatterConfig, get_formatted_file};
     true,
     true
 )]
+// Merge enabled, module-level sorting disabled: merged braces must still honor the
+// `self`-first convention.
+#[test_case(
+    "test_data/cairo_files/use_merge_no_sort.cairo",
+    "test_data/expected_results/use_merge_no_sort.cairo",
+    false,
+    false,
+    false,
+    true,
+    false
+)]
 fn format_and_compare_file(
     unformatted_filename: &str,
     expected_filename: &str,

--- a/crates/cairo-lang-formatter/test_data/cairo_files/use_merge_no_sort.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/use_merge_no_sort.cairo
@@ -1,0 +1,6 @@
+use a::z;
+use a::self;
+use a::b;
+use c::x;
+use c::*;
+use c::self;

--- a/crates/cairo-lang-formatter/test_data/expected_results/use_merge_no_sort.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/use_merge_no_sort.cairo
@@ -1,0 +1,2 @@
+use a::{self, b, z};
+use c::{*, self, x};


### PR DESCRIPTION
## Summary

Fixes incorrect leaf ordering when merging `use` items with `allow_duplicate_uses` disabled. Previously, leaves were converted to strings before deduplication and sorting, which meant the sort operated on formatted strings (e.g., `"x as y"`) rather than on the structured `name`/`alias` fields. This caused `self` to not be placed first in merged braces groups. Now, sorting and deduplication happen directly on `Leaf` structs, sorting by `name` (using `compare_names`) and then by `alias`, before formatting. A `Display` impl and `PartialEq`/`Eq` derives were added to `Leaf` to support this.

A new test case (`use_merge_no_sort.cairo`) covers the scenario where module-level sorting is disabled but merged braces must still honor the `self`-first convention.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When merging `use` paths with duplicate-use checking enabled, leaves like `self`, `b`, and `z` under the same prefix were not being ordered correctly. The old code sorted string representations of leaves (e.g., `"self"`, `"b"`, `"z"`) after formatting them, but `compare_names` (which enforces `self`-first ordering) was never applied to leaves — only to the string-level sort. This meant the output could be `{b, self, z}` instead of the correct `{self, b, z}`.

---

## What was the behavior or documentation before?

Given:
```cairo
use a::z;
use a::self;
use a::b;
```
The formatter could produce `use a::{b, self, z};` instead of `use a::{self, b, z};` when merging was enabled but module-level sorting was disabled.

---

## What is the behavior or documentation after?

The formatter now correctly produces:
```cairo
use a::{self, b, z};
```
Leaf nodes are sorted using `compare_names` on their `name` field (with `alias` as a tiebreaker) before being formatted and merged into braces groups.

---

## Related issue or discussion (if any)

None.

---

## Additional context

The `Leaf` struct now derives `PartialEq` and `Eq` (required for `dedup`) and implements `Display` to avoid duplicating the `name as alias` formatting logic.