### PR TITLE
performance(general): Rewrite join into format - removing intermediary strings.

### DIFF
--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -346,7 +346,7 @@ impl fmt::Display for LineBuilder {
         if self.is_only_indents() {
             write!(f, "")
         } else {
-            write!(f, "{}", self.children.iter().map(|child| child.to_string()).join(""))
+            write!(f, "{}", self.children.iter().format(""))
         }
     }
 }

--- a/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
+++ b/crates/cairo-lang-lowering/src/analysis/equality_analysis.rs
@@ -13,7 +13,7 @@ use cairo_lang_semantic::corelib::option_some_variant;
 use cairo_lang_semantic::helper::ModuleHelper;
 use cairo_lang_semantic::{ConcreteVariant, GenericArgumentId, MatchArmSelector, TypeId};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use itertools::zip_eq;
+use itertools::{Itertools, zip_eq};
 use salsa::Database;
 
 use crate::analysis::core::Edge;
@@ -391,7 +391,11 @@ impl<'db> DebugWithDb<'db> for EqualityState<'db> {
             }
         }
         lines.sort();
-        if lines.is_empty() { write!(f, "(empty)") } else { write!(f, "{}", lines.join(", ")) }
+        if lines.is_empty() {
+            write!(f, "(empty)")
+        } else {
+            write!(f, "{}", lines.iter().format(", "))
+        }
     }
 }
 

--- a/crates/cairo-lang-lowering/src/fmt.rs
+++ b/crates/cairo-lang-lowering/src/fmt.rs
@@ -146,7 +146,7 @@ impl<'db> DebugWithDb<'db> for VarUsage<'db> {
                     .long(ctx.db)
                     .lines()
                     .map(|s| s.trim())
-                    .join(" ")
+                    .format(" ")
             )?;
         }
         Ok(())

--- a/crates/cairo-lang-lowering/src/lower/flow_control/graph.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/graph.rs
@@ -118,7 +118,7 @@ impl<'db> std::fmt::Debug for EnumMatch<'db> {
             f,
             "EnumMatch {{ matched_var: {:?}, variants: {}}}",
             self.matched_var,
-            self.variants.iter().map(|(_, node, var)| format!("({node:?}, {var:?})")).join(", ")
+            self.variants.iter().map(|(_, node, var)| format!("({node:?}, {var:?})")).format(", ")
         )
     }
 }

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -405,7 +405,7 @@ impl<'db> std::fmt::Display for Value<'db> {
                 write!(
                     f,
                     "Scattered({})",
-                    scattered.members.values().map(|value| value.to_string()).join(", ")
+                    scattered.members.values().map(|value| value.to_string()).format(", ")
                 )
             }
             Value::MovedVar(..) => write!(f, "MovedVar"),

--- a/crates/cairo-lang-plugins/src/plugins/derive/default.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/default.rs
@@ -50,7 +50,7 @@ pub fn handle_default<'db>(
                         .is_generics_dependent
                         .then(|| format!("impl {imp}: {DEFAULT_TRAIT}<{}>", default_variant.ty))
                 )
-                .join(", "),
+                .format(", "),
             );
 
             Some(formatdoc! {"

--- a/crates/cairo-lang-plugins/src/plugins/derive/destruct.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/destruct.rs
@@ -31,7 +31,7 @@ pub fn handle_destruct(info: &PluginTypeInfo<'_>) -> String {
             TypeVariant::Struct => {
                 format!(
                     "let {ty} {{ {} }} = self;{}",
-                    info.members_info.iter().map(|member| &member.name).join(", "),
+                    info.members_info.iter().map(|member| &member.name).format(", "),
                     info.members_info
                         .iter()
                         .map(|member| format!(
@@ -39,7 +39,7 @@ pub fn handle_destruct(info: &PluginTypeInfo<'_>) -> String {
                             member.name,
                             imp = member.impl_name(DESTRUCT_TRAIT),
                         ))
-                        .join(""),
+                        .format(""),
                 )
             }
         },

--- a/crates/cairo-lang-plugins/src/plugins/derive/panic_destruct.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/panic_destruct.rs
@@ -31,7 +31,7 @@ pub fn handle_panic_destruct(info: &PluginTypeInfo<'_>) -> String {
             TypeVariant::Struct => {
                 format!(
                     "let {ty} {{ {} }} = self;{}",
-                    info.members_info.iter().map(|member| &member.name).join(", "),
+                    info.members_info.iter().map(|member| &member.name).format(", "),
                     info.members_info
                         .iter()
                         .map(|member| format!(
@@ -39,7 +39,7 @@ pub fn handle_panic_destruct(info: &PluginTypeInfo<'_>) -> String {
                             member.name,
                             imp = member.impl_name(PANIC_DESTRUCT_TRAIT),
                         ))
-                        .join(""),
+                        .format(""),
                 )
             }
         },

--- a/crates/cairo-lang-plugins/src/plugins/utils.rs
+++ b/crates/cairo-lang-plugins/src/plugins/utils.rs
@@ -123,8 +123,10 @@ impl<'a> PluginTypeInfo<'a> {
         format!(
             "impl {name}{derived_trait_name}<{generics}> of {derived_trait}::<{full_typename}>",
             name = self.name,
-            generics =
-                self.impl_generics(dependent_traits, |trt, ty| format!("{trt}<{ty}>")).join(", "),
+            generics = self
+                .impl_generics(dependent_traits, |trt, ty| format!("{trt}<{ty}>"))
+                .iter()
+                .format(", "),
             full_typename = self.full_typename(),
         )
     }
@@ -154,7 +156,7 @@ impl<'a> PluginTypeInfo<'a> {
         if self.generics.param_names.is_empty() {
             self.name.to_string()
         } else {
-            format!("{}<{}>", self.name, self.generics.param_names.iter().join(", "))
+            format!("{}<{}>", self.name, self.generics.param_names.iter().format(", "))
         }
     }
 }

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -2516,8 +2516,11 @@ where
     while let Some(item) = format_next_item(&mut felts) {
         items.push(item.quote_if_string());
     }
-    let panic_values_string =
-        if let [item] = &items[..] { item.clone() } else { format!("({})", items.join(", ")) };
+    let panic_values_string = if let [item] = &items[..] {
+        item.clone()
+    } else {
+        format!("({})", items.iter().format(", "))
+    };
     format!("Panicked with {panic_values_string}.")
 }
 

--- a/crates/cairo-lang-runner/src/profiling.rs
+++ b/crates/cairo-lang-runner/src/profiling.rs
@@ -276,16 +276,14 @@ impl Display for StackTraceWeights {
         if let Some(sierra_stack_trace_weights) = &self.sierra_stack_trace_weights {
             writeln!(f, "Weight by Sierra stack trace:")?;
             for (stack_trace, weight) in sierra_stack_trace_weights.iter() {
-                let stack_trace_str = stack_trace.join(" -> ");
-                writeln!(f, "  {stack_trace_str}: {weight}")?;
+                writeln!(f, "  {}: {weight}", stack_trace.iter().format(" -> "))?;
             }
         }
 
         if let Some(cairo_stack_trace_weights) = &self.cairo_stack_trace_weights {
             writeln!(f, "Weight by Cairo stack trace:")?;
             for (stack_trace, weight) in cairo_stack_trace_weights.iter() {
-                let stack_trace_str = stack_trace.join(" -> ");
-                writeln!(f, "  {stack_trace_str}: {weight}")?;
+                writeln!(f, "  {}: {weight}", stack_trace.iter().format(" -> "))?;
             }
         }
         Ok(())
@@ -758,7 +756,7 @@ fn format_scoped_sierra_statement_weights(
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
     for (key, weight) in weights.iter() {
-        f.write_fmt(format_args!("{} {weight}\n", key.join(";")))?;
+        f.write_fmt(format_args!("{} {weight}\n", key.iter().format(";")))?;
     }
     Ok(())
 }

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -178,7 +178,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::UnknownTrait => "Unknown trait.".into(),
             SemanticDiagnosticKind::UnknownImpl => "Unknown impl.".into(),
             SemanticDiagnosticKind::UnexpectedElement { expected, actual } => {
-                let expected_str = expected.iter().map(|kind| kind.to_string()).join(" or ");
+                let expected_str = expected.iter().map(|kind| kind.to_string()).format(" or ");
                 format!("Expected {expected_str}, found {actual}.")
             }
             SemanticDiagnosticKind::UnknownType => "Unknown type.".into(),
@@ -661,7 +661,10 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::AmbiguousPath(module_items) => {
                 format!(
                     "Ambiguous path. Multiple matching items: {}",
-                    module_items.iter().map(|item| format!("`{}`", item.full_path(db))).join(", ")
+                    module_items
+                        .iter()
+                        .map(|item| format!("`{}`", item.full_path(db)))
+                        .format(", ")
                 )
             }
             SemanticDiagnosticKind::UseSelfNonMulti => {
@@ -718,7 +721,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                             containing_modules
                                 .iter()
                                 .map(|module_id| format!("`{}`", module_id.full_path(db)))
-                                .join(", ")
+                                .format(", ")
                         )
                     }
                 )
@@ -776,7 +779,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::MissingItemsInImpl(item_names) => {
                 format!(
                     "Not all trait items are implemented. Missing: {}.",
-                    item_names.iter().map(|name| format!("'{}'", name.long(db))).join(", ")
+                    item_names.iter().map(|name| format!("'{}'", name.long(db))).format(", ")
                 )
             }
             SemanticDiagnosticKind::PassPanicAsNopanic { impl_function_id, trait_id } => {
@@ -916,8 +919,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     let suggestions = relevant_traits
                         .iter()
                         .map(|trait_path| format!("`{trait_path}`"))
-                        .collect::<Vec<_>>()
-                        .join(", ");
+                        .format(", ");
 
                     format!(
                         "Method `{}` not found on type `{}`. Consider importing one of the \
@@ -1169,7 +1171,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     path.segments(db)
                         .elements(db)
                         .map(|seg| seg.identifier(db).long(db))
-                        .join("::")
+                        .format("::")
                 )
             }
             SemanticDiagnosticKind::UndefinedMacroPlaceholder(name) => {

--- a/crates/cairo-lang-semantic/src/expr/inference/solver.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/solver.rs
@@ -81,7 +81,8 @@ impl<'db> Ambiguity<'db> {
     pub fn format(&self, db: &dyn Database) -> String {
         match self {
             Ambiguity::MultipleImplsFound { concrete_trait_id, impls } => {
-                let impls_str = impls.iter().map(|imp| format!("`{}`", imp.format(db))).join(", ");
+                let impls_str =
+                    impls.iter().map(|imp| format!("`{}`", imp.format(db))).format(", ");
                 format!(
                     "Trait `{:?}` has multiple implementations, in: {impls_str}",
                     concrete_trait_id.debug(db)

--- a/crates/cairo-lang-semantic/src/path.rs
+++ b/crates/cairo-lang-semantic/src/path.rs
@@ -60,7 +60,7 @@ impl<'db> ItemAccessInfo<'db> {
             self.path_segments.iter().rev().map(|id| id.name(db).long(db)),
             [self.name.long(db)]
         )
-        .join("::");
+        .format("::");
         format!("{prefix}{path}")
     }
 

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -296,7 +296,7 @@ impl<'db> DebugWithDb<'db> for TypeLongId<'db> {
                 if inner_types.len() == 1 {
                     write!(f, "({},)", inner_types[0].format(db))
                 } else {
-                    write!(f, "({})", inner_types.iter().map(|ty| ty.format(db)).join(", "))
+                    write!(f, "({})", inner_types.iter().map(|ty| ty.format(db)).format(", "))
                 }
             }
             TypeLongId::Snapshot(ty) => write!(f, "@{}", ty.format(db)),

--- a/crates/cairo-lang-sierra-generator/src/program_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator.rs
@@ -250,7 +250,7 @@ impl<'db> DebugWithDb<'db> for SierraProgramWithDebug<'db> {
                     &self.debug_info.statements_locations.locations.get(&StatementIdx(i))
                 {
                     let loc = get_location_marks(db, &loc.first().unwrap().span_in_file(db), true);
-                    writeln!(f, "{}", loc.split('\n').map(|l| format!("// {l}")).join("\n"))?;
+                    writeln!(f, "{}", loc.split('\n').map(|l| format!("// {l}")).format("\n"))?;
                 }
             }
         }

--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -94,7 +94,7 @@ pub fn handle_trait<'db>(
     let forward_impl_name = format!("{base_name}ForwardImpl");
     let unsafe_new_state_trait_name = format!("UnsafeNewContractStateTraitFor{forward_impl_name}");
     let implicit_precedence_attr =
-        format!("#[{IMPLICIT_PRECEDENCE_ATTR}({})]", IMPLICIT_PRECEDENCE.iter().join(", "));
+        format!("#[{IMPLICIT_PRECEDENCE_ATTR}({})]", IMPLICIT_PRECEDENCE.iter().format(", "));
     let dispatcher_trait_name = format!("{base_name}DispatcherTrait");
     let safe_dispatcher_trait_name = format!("{base_name}SafeDispatcherTrait");
     let contract_caller_name = format!("{base_name}Dispatcher");

--- a/crates/cairo-lang-starknet/src/plugin/entry_point.rs
+++ b/crates/cairo-lang-starknet/src/plugin/entry_point.rs
@@ -314,7 +314,7 @@ fn generate_entry_point_wrapper<'db>(
     );
 
     let implicit_precedence = RewriteNode::Text(format!("#[{IMPLICIT_PRECEDENCE_ATTR}({})]", {
-        IMPLICIT_PRECEDENCE.iter().join(", ")
+        IMPLICIT_PRECEDENCE.iter().format(", ")
     }));
 
     let arg_definitions = RewriteNode::Text(arg_definitions.join("\n    "));

--- a/crates/cairo-lang-starknet/src/plugin/storage_interfaces.rs
+++ b/crates/cairo-lang-starknet/src/plugin/storage_interfaces.rs
@@ -450,8 +450,8 @@ fn handle_storage_interface_for_interface_type<'db>(
         [RewriteNode::empty(), RewriteNode::empty()]
     } else {
         [
-            format!("<{}>", generics.param_names.join(", ")),
-            format!("<{}>", generics.full_params.join(", ")),
+            format!("<{}>", generics.param_names.iter().format(", ")),
+            format!("<{}>", generics.full_params.iter().format(", ")),
         ]
         .map(RewriteNode::Text)
     };
@@ -547,8 +547,8 @@ pub fn handle_storage_interface_enum<'db>(
         [RewriteNode::empty(), RewriteNode::empty()]
     } else {
         [
-            format!("<{}>", generics.param_names.join(", ")),
-            format!("<{}>", generics.full_params.join(", ")),
+            format!("<{}>", generics.param_names.iter().format(", ")),
+            format!("<{}>", generics.full_params.iter().format(", ")),
         ]
         .map(RewriteNode::Text)
     };

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -555,7 +555,7 @@ fn print_resource_map(m: impl ExactSizeIterator<Item = (String, usize)>, resourc
     if m.len() != 0 {
         println!(
             "    {resource_type}: ({})",
-            m.into_iter().sorted().map(|(k, v)| format!(r#""{k}": {v}"#)).join(", ")
+            m.into_iter().sorted().map(|(k, v)| format!(r#""{k}": {v}"#)).format(", ")
         );
     }
 }


### PR DESCRIPTION
## Summary

Replaces uses of `.join(...)` (which allocates an intermediate `String`) with itertools' `.format(...)` (which formats lazily without allocation) across the codebase. This applies to iterator chains that were calling `.join(...)` directly or after `.map(...)`, switching them to use the `Itertools::format` adapter instead.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`.join(...)` on iterators collects all elements into an intermediate `String` before writing the result. `Itertools::format(...)` is a lazy adapter that writes each element directly into the formatter without allocating an intermediate buffer, reducing unnecessary heap allocations in string formatting paths.

---

## What was the behavior or documentation before?

Iterator chains used `.join(separator)` (or `.map(...).join(separator)`) to produce formatted strings, allocating an intermediate `String` in the process.

---

## What is the behavior or documentation after?

The same iterator chains use `.format(separator)` from `itertools::Itertools`, producing identical output while avoiding intermediate allocations.

---

## Related issue or discussion (if any)

---

## Additional context

In one case (`PluginTypeInfo::impl_header`), an explicit `.iter()` call was added before `.format(...)` since the return type of `impl_generics` is a `Vec`, which required going through an iterator first. All other changes are straightforward substitutions.