### PR TITLE
refactor(utils): Removed `write_comma_separated` using equivalent .format all around.

### DIFF
--- a/crates/cairo-lang-executable/src/compile.rs
+++ b/crates/cairo-lang-executable/src/compile.rs
@@ -20,7 +20,7 @@ use cairo_lang_sierra_generator::debug_info::SierraProgramDebugInfo;
 use cairo_lang_sierra_generator::executables::find_executable_function_ids;
 use cairo_lang_sierra_generator::program_generator::SierraProgramWithDebug;
 use cairo_lang_sierra_to_casm::compiler::CairoProgram;
-use cairo_lang_utils::{CloneableDatabase, write_comma_separated};
+use cairo_lang_utils::CloneableDatabase;
 use cairo_vm::types::builtin_name::BuiltinName;
 use itertools::Itertools;
 use salsa::Database;
@@ -36,8 +36,7 @@ impl std::fmt::Display for CompiledFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "// builtins:")?;
         if !self.wrapper.builtins.is_empty() {
-            write!(f, " ")?;
-            write_comma_separated(f, self.wrapper.builtins.iter().map(|b| b.to_str()))?;
+            write!(f, " {}", self.wrapper.builtins.iter().map(|b| b.to_str()).format(", "))?;
         }
         writeln!(f)?;
         writeln!(f, "// header")?;

--- a/crates/cairo-lang-sierra-generator/src/pre_sierra.rs
+++ b/crates/cairo-lang-sierra-generator/src/pre_sierra.rs
@@ -6,7 +6,8 @@ use cairo_lang_proc_macros::HeapSize;
 use cairo_lang_sierra as sierra;
 use cairo_lang_sierra::ids::ConcreteTypeId;
 use cairo_lang_sierra::program;
-use cairo_lang_utils::{define_short_id, write_comma_separated};
+use cairo_lang_utils::define_short_id;
+use itertools::Itertools;
 use salsa::Database;
 
 /// Represents the long ID of a pre-Sierra label.
@@ -117,19 +118,16 @@ impl<'db> std::fmt::Display for StatementWithDb<'db> {
                 write!(f, "{}:", id.with_db(self.db))
             }
             Statement::PushValues(values) => {
-                write!(f, "PushValues(")?;
-                write_comma_separated(
+                write!(
                     f,
-                    values.iter().map(|PushValue { var, ty, .. }| format!("{var}: {ty}")),
-                )?;
-                write!(f, ") -> (")?;
-                write_comma_separated(
-                    f,
-                    values.iter().map(|PushValue { var_on_stack, dup, .. }| {
-                        if *dup { format!("{var_on_stack}*") } else { format!("{var_on_stack}") }
-                    }),
-                )?;
-                write!(f, ")")
+                    "PushValues({}) -> ({})",
+                    values.iter().format_with(", ", |PushValue { var, ty, .. }, f| f(
+                        &format_args!("{var}: {ty}")
+                    )),
+                    values.iter().format_with(", ", |PushValue { var_on_stack, dup, .. }, f| {
+                        if *dup { f(&format_args!("{var_on_stack}*")) } else { f(var_on_stack) }
+                    })
+                )
             }
         }
     }

--- a/crates/cairo-lang-sierra-to-casm/src/references.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/references.rs
@@ -6,7 +6,7 @@ use cairo_lang_sierra::program::{Function, StatementIdx};
 use cairo_lang_sierra_type_size::TypeSizeMap;
 use cairo_lang_utils::casts::IntoOrPanic;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::write_comma_separated;
+use itertools::Itertools;
 use thiserror::Error;
 
 use crate::invocations::InvocationError;
@@ -137,9 +137,7 @@ impl ApplyApChange for ReferenceExpression {
 
 impl core::fmt::Display for ReferenceExpression {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "[")?;
-        write_comma_separated(f, &self.cells)?;
-        write!(f, "]")
+        write!(f, "[{}]", self.cells.iter().format(", "))
     }
 }
 

--- a/crates/cairo-lang-sierra/src/fmt.rs
+++ b/crates/cairo-lang-sierra/src/fmt.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
-use cairo_lang_utils::write_comma_separated;
+use itertools::Itertools;
 
 use crate::ids::{
     ConcreteLibfuncId, ConcreteTypeId, FunctionId, GenericLibfuncId, GenericTypeId, UserTypeId,
@@ -110,11 +110,14 @@ impl fmt::Display for ConcreteLibfuncLongId {
 
 impl<StatementId: fmt::Display> fmt::Display for GenFunction<StatementId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}@{}(", self.id, self.entry_point)?;
-        write_comma_separated(f, &self.params)?;
-        write!(f, ") -> (")?;
-        write_comma_separated(f, &self.signature.ret_types)?;
-        write!(f, ")")
+        write!(
+            f,
+            "{}@{}({}) -> ({})",
+            self.id,
+            self.entry_point,
+            self.params.iter().format(", "),
+            self.signature.ret_types.iter().format(", ")
+        )
     }
 }
 
@@ -173,9 +176,7 @@ impl<StatementId: fmt::Display> fmt::Display for GenStatement<StatementId> {
         match self {
             GenStatement::Invocation(invocation) => write!(f, "{invocation}"),
             GenStatement::Return(ids) => {
-                write!(f, "return(")?;
-                write_comma_separated(f, ids)?;
-                write!(f, ")")
+                write!(f, "return({})", ids.iter().format(", "))
             }
         }
     }
@@ -183,16 +184,13 @@ impl<StatementId: fmt::Display> fmt::Display for GenStatement<StatementId> {
 
 impl<StatementId: fmt::Display> fmt::Display for GenInvocation<StatementId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}(", self.libfunc_id)?;
-        write_comma_separated(f, &self.args)?;
+        write!(f, "{}({}) ", self.libfunc_id, self.args.iter().format(", "))?;
         if let [GenBranchInfo { target: GenBranchTarget::Fallthrough, results }] =
             &self.branches[..]
         {
-            write!(f, ") -> (")?;
-            write_comma_separated(f, results)?;
-            write!(f, ")")
+            write!(f, "-> ({})", results.iter().format(", "))
         } else {
-            write!(f, ") {{ ")?;
+            write!(f, "{{ ")?;
             self.branches.iter().try_for_each(|branch_info| write!(f, "{branch_info} "))?;
             write!(f, "}}")
         }
@@ -201,9 +199,7 @@ impl<StatementId: fmt::Display> fmt::Display for GenInvocation<StatementId> {
 
 impl<StatementId: fmt::Display> fmt::Display for GenBranchInfo<StatementId> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}(", self.target)?;
-        write_comma_separated(f, &self.results)?;
-        write!(f, ")")
+        write!(f, "{}({})", self.target, self.results.iter().format(", "))
     }
 }
 
@@ -223,11 +219,5 @@ impl fmt::Display for StatementIdx {
 }
 
 fn write_template_args(f: &mut fmt::Formatter<'_>, args: &[GenericArg]) -> fmt::Result {
-    if args.is_empty() {
-        Ok(())
-    } else {
-        write!(f, "<")?;
-        write_comma_separated(f, args)?;
-        write!(f, ">")
-    }
+    if args.is_empty() { Ok(()) } else { write!(f, "<{}>", args.iter().format(", ")) }
 }

--- a/crates/cairo-lang-utils/src/lib.rs
+++ b/crates/cairo-lang-utils/src/lib.rs
@@ -5,8 +5,6 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use core::fmt;
-
 /// Re-exporting the [`smol_str`] crate so that downstream projects can always use the same
 /// instance the compiler does.
 pub use ::smol_str;
@@ -37,20 +35,6 @@ pub use heap_size::HeapSize;
 /// Similar to From / TryFrom, but returns an option.
 pub trait OptionFrom<T>: Sized {
     fn option_from(other: T) -> Option<Self>;
-}
-
-pub fn write_comma_separated<Iter: IntoIterator<Item = V>, V: core::fmt::Display>(
-    f: &mut fmt::Formatter<'_>,
-    values: Iter,
-) -> fmt::Result {
-    let mut iter = values.into_iter();
-    if let Some(value) = iter.next() {
-        write!(f, "{value}")?;
-    }
-    for value in iter {
-        write!(f, ", {value}")?;
-    }
-    Ok(())
 }
 
 /// Helper operations on `Option<T>`.


### PR DESCRIPTION
## Summary

Removes the custom `write_comma_separated` utility function from `cairo-lang-utils` and replaces all call sites with `itertools`'s `format` and `format_with` methods, which provide equivalent functionality more idiomatically.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`write_comma_separated` duplicated functionality already available via `itertools::Itertools::format` and `format_with`. Removing it reduces maintenance burden and consolidates formatting logic around the already-present `itertools` dependency.

---

## What was the behavior or documentation before?

Comma-separated formatting in `Display` implementations was handled by a custom `write_comma_separated` function in `cairo-lang-utils`, requiring multiple `write!` calls (one for the opening delimiter, one for the content, one for the closing delimiter).

---

## What is the behavior or documentation after?

The same formatting is achieved using `itertools`'s `.format(", ")` and `.format_with(", ", ...)`, allowing the entire formatted output to be expressed in a single `write!` call with inline format strings.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `write_comma_separated` function and its associated `use core::fmt` import have been fully removed from `cairo-lang-utils/src/lib.rs`. All previously dependent crates (`cairo-lang-executable`, `cairo-lang-sierra-generator`, `cairo-lang-sierra-to-casm`, `cairo-lang-sierra`) now import `itertools::Itertools` directly.