### PR TITLE
performance(strings): Using less interim strings.

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/flow_control/graph.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/graph.rs
@@ -118,7 +118,9 @@ impl<'db> std::fmt::Debug for EnumMatch<'db> {
             f,
             "EnumMatch {{ matched_var: {:?}, variants: {}}}",
             self.matched_var,
-            self.variants.iter().map(|(_, node, var)| format!("({node:?}, {var:?})")).format(", ")
+            self.variants
+                .iter()
+                .format_with(", ", |(_, node, var), f| f(&format_args!("({node:?}, {var:?})")))
         )
     }
 }

--- a/crates/cairo-lang-lowering/src/optimizations/cse.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/cse.rs
@@ -189,8 +189,7 @@ pub fn cse<'db>(lowered: &mut Lowered<'db>) {
         "Some blocks were not processed: [{}]",
         block_expression_map
             .iter_sorted_by_key(|(k, _)| k.0)
-            .map(|(k, _)| format!("{k:?}"))
-            .join(", ")
+            .format_with(", ", |(k, _), f| f(&format_args!("{k:?}")))
     );
     let CseContext { var_replacements: renamed_vars, .. } = ctx;
     let mut renamer = VarRenamer { renamed_vars };

--- a/crates/cairo-lang-plugins/src/plugins/derive/destruct.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/destruct.rs
@@ -32,14 +32,11 @@ pub fn handle_destruct(info: &PluginTypeInfo<'_>) -> String {
                 format!(
                     "let {ty} {{ {} }} = self;{}",
                     info.members_info.iter().map(|member| &member.name).format(", "),
-                    info.members_info
-                        .iter()
-                        .map(|member| format!(
-                            "\n{imp}::destruct({});",
-                            member.name,
-                            imp = member.impl_name(DESTRUCT_TRAIT),
-                        ))
-                        .format(""),
+                    info.members_info.iter().format_with("", |member, f| f(&format_args!(
+                        "\n{imp}::destruct({});",
+                        member.name,
+                        imp = member.impl_name(DESTRUCT_TRAIT),
+                    ))),
                 )
             }
         },

--- a/crates/cairo-lang-plugins/src/plugins/derive/panic_destruct.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/panic_destruct.rs
@@ -32,14 +32,11 @@ pub fn handle_panic_destruct(info: &PluginTypeInfo<'_>) -> String {
                 format!(
                     "let {ty} {{ {} }} = self;{}",
                     info.members_info.iter().map(|member| &member.name).format(", "),
-                    info.members_info
-                        .iter()
-                        .map(|member| format!(
-                            "\n{imp}::panic_destruct({}, ref panic);",
-                            member.name,
-                            imp = member.impl_name(PANIC_DESTRUCT_TRAIT),
-                        ))
-                        .format(""),
+                    info.members_info.iter().format_with("", |member, f| f(&format_args!(
+                        "\n{imp}::panic_destruct({}, ref panic);",
+                        member.name,
+                        imp = member.impl_name(PANIC_DESTRUCT_TRAIT),
+                    ))),
                 )
             }
         },

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -663,8 +663,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     "Ambiguous path. Multiple matching items: {}",
                     module_items
                         .iter()
-                        .map(|item| format!("`{}`", item.full_path(db)))
-                        .format(", ")
+                        .format_with(", ", |item, f| f(&format_args!("`{}`", item.full_path(db))))
                 )
             }
             SemanticDiagnosticKind::UseSelfNonMulti => {
@@ -718,10 +717,9 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     } else {
                         format!(
                             " through any of the modules: {}",
-                            containing_modules
-                                .iter()
-                                .map(|module_id| format!("`{}`", module_id.full_path(db)))
-                                .format(", ")
+                            containing_modules.iter().format_with(", ", |module_id, f| {
+                                f(&format_args!("`{}`", module_id.full_path(db)))
+                            })
                         )
                     }
                 )
@@ -779,7 +777,9 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::MissingItemsInImpl(item_names) => {
                 format!(
                     "Not all trait items are implemented. Missing: {}.",
-                    item_names.iter().map(|name| format!("'{}'", name.long(db))).format(", ")
+                    item_names
+                        .iter()
+                        .format_with(", ", |name, f| f(&format_args!("'{}'", name.long(db))))
                 )
             }
             SemanticDiagnosticKind::PassPanicAsNopanic { impl_function_id, trait_id } => {
@@ -918,15 +918,13 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 if !relevant_traits.is_empty() {
                     let suggestions = relevant_traits
                         .iter()
-                        .map(|trait_path| format!("`{trait_path}`"))
-                        .format(", ");
+                        .format_with(", ", |trait_path, f| f(&format_args!("`{trait_path}`")));
 
                     format!(
                         "Method `{}` not found on type `{}`. Consider importing one of the \
-                         following traits: {}.",
+                         following traits: {suggestions}.",
                         method_name.long(db),
                         ty.format(db),
-                        suggestions
                     )
                 } else {
                     format!(

--- a/crates/cairo-lang-semantic/src/expr/inference/solver.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/solver.rs
@@ -81,10 +81,11 @@ impl<'db> Ambiguity<'db> {
     pub fn format(&self, db: &dyn Database) -> String {
         match self {
             Ambiguity::MultipleImplsFound { concrete_trait_id, impls } => {
-                let impls_str =
-                    impls.iter().map(|imp| format!("`{}`", imp.format(db))).format(", ");
+                let impls = impls
+                    .iter()
+                    .format_with(", ", |imp, f| f(&format_args!("`{}`", imp.format(db))));
                 format!(
-                    "Trait `{:?}` has multiple implementations, in: {impls_str}",
+                    "Trait `{:?}` has multiple implementations, in: {impls}",
                     concrete_trait_id.debug(db)
                 )
             }

--- a/crates/cairo-lang-sierra-generator/src/program_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator.rs
@@ -250,7 +250,11 @@ impl<'db> DebugWithDb<'db> for SierraProgramWithDebug<'db> {
                     &self.debug_info.statements_locations.locations.get(&StatementIdx(i))
                 {
                     let loc = get_location_marks(db, &loc.first().unwrap().span_in_file(db), true);
-                    writeln!(f, "{}", loc.split('\n').map(|l| format!("// {l}")).format("\n"))?;
+                    writeln!(
+                        f,
+                        "{}",
+                        loc.split('\n').format_with("\n", |l, f| f(&format_args!("// {l}")))
+                    )?;
                 }
             }
         }

--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -545,7 +545,7 @@ fn declaration_method_impl<'db>(
         RewriteNode::Text(if unwrap {
             ret_decode.clone()
         } else {
-            ret_decode.split('\n').map(|x| format!("    {x}")).join("\n")
+            ret_decode.split('\n').format_with("\n", |x, f| f(&format_args!("    {x}"))).to_string()
         })
     };
     let return_code = RewriteNode::interpolate_patched(

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -555,7 +555,7 @@ fn print_resource_map(m: impl ExactSizeIterator<Item = (String, usize)>, resourc
     if m.len() != 0 {
         println!(
             "    {resource_type}: ({})",
-            m.into_iter().sorted().map(|(k, v)| format!(r#""{k}": {v}"#)).format(", ")
+            m.into_iter().sorted().format_with(", ", |(k, v), f| f(&format_args!(r#""{k}": {v}"#)))
         );
     }
 }


### PR DESCRIPTION
## Summary

Replaces `.map(|x| format!(...)).format(sep)` and `.map(|x| format!(...)).join(sep)` patterns with `.format_with(sep, |x, f| f(&format_args!(...)))` across several crates. This avoids allocating an intermediate `String` for each element during formatting.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous pattern called `.map(|x| format!(...))` to produce a `String` per element before joining or formatting them together. `itertools::format_with` allows formatting each element directly into the output buffer via `format_args!`, eliminating the per-element heap allocation.

---

## What was the behavior or documentation before?

Each formatted element was first heap-allocated as a `String`, then those strings were joined or formatted into the final output string.

---

## What is the behavior or documentation after?

Each element is formatted directly into the output using `format_args!`, avoiding intermediate `String` allocations per element.

---

## Related issue or discussion (if any)

None.

---

## Additional context

The affected sites are all in diagnostic/debug formatting paths (`DiagnosticEntry`, `Debug` impls, assertion messages, and test output), so correctness is unchanged — only allocation behavior differs.