### PR TITLE
docs: update adoc for #[panic_with] deprecation and //// comment behavior

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/comments.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/comments.adoc
@@ -18,9 +18,12 @@ let span = ba.span();
 
 == Doc Comments
 
-Doc comments begin with `///` and are used to document items like types,
+Doc comments begin with exactly `///` and are used to document items like types,
 functions, and traits.
 They appear directly before the item they document:
+
+NOTE: Four or more consecutive slashes (`////`) are treated as a regular line comment,
+not a doc comment.
 
 [source,cairo]
 ----

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
@@ -42,8 +42,7 @@ but not for integer types (which may overflow).
 
 == `panic_with` Attribute
 
-IMPORTANT: `#[panic_with]` is deprecated. Prefer direct error handling expressions, which are
-supported in `const` context.
+IMPORTANT: `#[panic_with]` is deprecated. Prefer direct error handling expressions.
 
 Functions returning `Option` or `Result` may use the `panic_with` attribute to generate a wrapper
 function that panics on `None` or `Err`. Using it emits a deprecation warning unless suppressed

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/panic.adoc
@@ -42,8 +42,12 @@ but not for integer types (which may overflow).
 
 == `panic_with` Attribute
 
-Functions returning `Option` or `Result` may use the `panic_with` attribute
-to generate a wrapper function that panics on `None` or `Err`:
+IMPORTANT: `#[panic_with]` is deprecated. Prefer direct error handling expressions, which are
+supported in `const` context.
+
+Functions returning `Option` or `Result` may use the `panic_with` attribute to generate a wrapper
+function that panics on `None` or `Err`. Using it emits a deprecation warning unless suppressed
+with `#[feature("deprecated-panic-with")]`.
 
 [source,cairo]
 ----


### PR DESCRIPTION
Two small doc updates based on recent commits:

- **`panic.adoc`**: Mark the `#[panic_with]` attribute as deprecated (landed in #10096).
  Notes that it emits a warning without `#[feature("deprecated-panic-with")]` and
  recommends using direct expressions instead.

- **`comments.adoc`**: Clarify that exactly `///` is a doc comment. Four or more
  consecutive slashes (`////`) are treated as a regular line comment (fixed in #10107).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9YDdsAoTbTKTwyV56a6mB)_