### PR TITLE
chore: add shebangs to executable helper scripts

### DIFF
--- a/scripts/release_crates.sh
+++ b/scripts/release_crates.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # An optional argument, '-s | --skip-first <#num_to_skip>', can be passed to skip the first #num_to_skip crates, otherwise SKIP_FIRST is set to 0.
 if [ "$1" = "-s" ] || [ "$1" = "--skip-first" ]; then
     if [ -z "$2" ]; then

--- a/scripts/taplo.sh
+++ b/scripts/taplo.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 taplo format --check


### PR DESCRIPTION
Adds explicit Bash shebangs to two executable helper scripts:

- `scripts/release_crates.sh`
- `scripts/taplo.sh`