### PR TITLE
bug fix(semantic): Support struct-update (`..base`) syntax in const expressions.

### DIFF
--- a/corelib/src/test/language_features/const_test.cairo
+++ b/corelib/src/test/language_features/const_test.cairo
@@ -203,6 +203,22 @@ fn test_const_generic_enum_return() {
     assert_eq!(RESULT, Either::Left(7));
 }
 
+#[derive(Copy, Drop, PartialEq, Debug)]
+struct Point {
+    x: felt252,
+    y: felt252,
+    z: felt252,
+}
+
+#[test]
+fn test_const_struct_update() {
+    const BASE: Point = Point { x: 1, y: 2, z: 3 };
+    const UPDATED: Point = Point { y: 20, ..BASE };
+    assert_eq!(UPDATED, Point { x: 1, y: 20, z: 3 });
+    const FROM_UPDATED: Point = Point { x: 10, z: 30, ..UPDATED };
+    assert_eq!(FROM_UPDATED, Point { x: 10, y: 20, z: 30 });
+}
+
 #[test]
 fn test_const_casts_from_felt252() {
     const _U8_UNDER_RANGE: () = assert((-1_felt252).try_into() == None::<u8>, 'U8 under range');

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -590,9 +590,12 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                     self.validate(*item);
                 }
             }
-            Expr::StructCtor(ExprStructCtor { members, base_struct: None, .. }) => {
+            Expr::StructCtor(ExprStructCtor { members, base_struct, .. }) => {
                 for (expr_id, _) in members {
                     self.validate(*expr_id);
+                }
+                if let Some(base) = base_struct {
+                    self.validate(*base);
                 }
             }
             Expr::EnumVariantCtor(expr) => self.validate(expr.value_expr),
@@ -730,27 +733,39 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             .intern(db),
             Expr::StructCtor(ExprStructCtor {
                 members,
-                base_struct: None,
+                base_struct,
                 ty,
                 concrete_struct_id,
                 ..
             }) => {
                 let member_order =
                     or_return!(db.concrete_struct_members(*concrete_struct_id).map_err(to_missing));
+                let ty = or_return!(self.substitute(*ty).map_err(to_missing));
+                let base_members = match base_struct {
+                    Some(base) => match self.evaluate(*base).long(db) {
+                        ConstValue::Struct(values, base_ty) if *base_ty == ty => {
+                            Some(values.as_slice())
+                        }
+                        _ => return to_missing(skip_diagnostic()),
+                    },
+                    None => None,
+                };
                 ConstValue::Struct(
                     member_order
                         .values()
-                        .map(|m| {
+                        .enumerate()
+                        .map(|(index, m)| {
                             members
                                 .iter()
                                 .find(|(_, member_id)| m.id == *member_id)
                                 .map(|(expr_id, _)| self.evaluate(*expr_id))
+                                .or_else(|| Some(base_members?[index]))
                                 // Semantic validation already reported an error, suppress cascading
                                 // errors from const evaluation.
                                 .unwrap_or_else(|| to_missing(skip_diagnostic()))
                         })
                         .collect(),
-                    or_return!(self.substitute(*ty).map_err(to_missing)),
+                    ty,
                 )
                 .intern(db)
             }


### PR DESCRIPTION
## Summary

Adds support for struct update syntax (`Foo { field: value, ..base }`) in constant expressions. Previously, `ConstantEvaluateContext` only handled struct constructors with no base struct (`base_struct: None`), causing struct update syntax to be unsupported in `const` contexts. Now, the base struct expression is validated and evaluated, and its member values are used as fallbacks for any fields not explicitly specified in the constructor.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Struct update syntax (`Point { y: 20, ..BASE }`) was not usable in `const` declarations. The constant evaluator would silently skip or fail on any struct constructor that included a base struct, leaving users unable to derive one constant struct from another using this syntax.

---

## What was the behavior or documentation before?

Struct update syntax in `const` expressions was not supported. The evaluator only matched `ExprStructCtor` with `base_struct: None`, so any use of `..base` in a constant struct constructor would not be evaluated correctly.

---

## What is the behavior or documentation after?

Struct update syntax is now valid in `const` expressions. The base struct is validated and evaluated, and its member values fill in any fields not explicitly provided. Chained updates (e.g., deriving a constant from another already-updated constant) are also supported, as demonstrated by the new test:

```cairo
const BASE: Point = Point { x: 1, y: 2, z: 3 };
const UPDATED: Point = Point { y: 20, ..BASE };
assert_eq!(UPDATED, Point { x: 1, y: 20, z: 3 });
const FROM_UPDATED: Point = Point { x: 10, z: 30, ..UPDATED };
assert_eq!(FROM_UPDATED, Point { x: 10, y: 20, z: 30 });
```

---

## Related issue or discussion (if any)

---

## Additional context

The base struct's evaluated `ConstValue::Struct` values are indexed by member order position and used as fallbacks via `.or_else(|| Some(base_members?[index]))` when a field is not explicitly listed in the constructor.