### PR TITLE
bug fix(semantic): Validate quotient in const DivRem to avoid signed MIN/-1 ICE.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "postcard",
  "pretty_assertions",

--- a/crates/cairo-lang-semantic/Cargo.toml
+++ b/crates/cairo-lang-semantic/Cargo.toml
@@ -26,6 +26,7 @@ id-arena.workspace = true
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }
 num-bigint = { workspace = true, default-features = true }
+num-integer = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
 postcard.workspace = true
 salsa.workspace = true

--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -211,6 +211,9 @@ const VALID_LE: () = assert(1_usize <= 1);
 const VALID_GT: () = assert(2_usize > 1);
 const VALID_GE: () = assert(1_usize >= 1);
 const VALID_DIVREM: () = assert(DivRem::div_rem(5_u8, 2) == (2, 1));
+// The quotient of signed `MIN / -1` overflows the type, and should emit a clean diagnostic
+// rather than silently storing an out-of-range value (which later ICEs in sierra-gen).
+const DIVREM_SIGNED_MIN_OVERFLOW: (i8, i8) = DivRem::div_rem(-128_i8, -1);
 
 const MATCH_VALUE: () = assert(match 1_u8 {
     _ => 1,
@@ -300,22 +303,27 @@ note: In `test::assert`:
         core::panic_with_felt252('failed assertion')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E2008]: The value does not fit within the range of type core::integer::i8.
+ --> lib.cairo:69:46
+const DIVREM_SIGNED_MIN_OVERFLOW: (i8, i8) = DivRem::div_rem(-128_i8, -1);
+                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E2129]: Constant calculation depth exceeded.
- --> lib.cairo:92:43
+ --> lib.cairo:95:43
 const FUNC_CALC_STACK_EXCEEDED: felt252 = call_myself();
                                           ^^^^^^^^^^^^^
 
 error[E2130]: Failed to calculate constant.
- --> lib.cairo:99:37
+ --> lib.cairo:102:37
 const NON_ZERO_ZERO: NonZero<u64> = my_unwrap(ZERO.try_into());
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: In `test::my_unwrap::<core::zeroable::NonZero::<core::integer::u64>>`:
-  --> lib.cairo:105:17
+  --> lib.cairo:108:17
         None => core::panic_with_felt252('bad value'),
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2128]: Failed to calculate constant.
- --> lib.cairo:111:9
+ --> lib.cairo:114:9
         core::panic_with_felt252('should fail')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -22,6 +22,7 @@ use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 use cairo_lang_utils::{Intern, define_short_id, extract_matches, require, try_extract_matches};
 use itertools::Itertools;
 use num_bigint::BigInt;
+use num_integer::Integer;
 use num_traits::{ToPrimitive, Zero};
 use salsa::Database;
 use starknet_types_core::felt::{CAIRO_PRIME_BIGINT, Felt as Felt252};
@@ -931,12 +932,17 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             id if id == self.ge_fn => return bool_value(args[0].v >= args[1].v),
             id if id == self.div_rem_fn => {
                 // No need for non-zero check as this is type checked to begin with.
-                // Also results are always in the range of the input type, so `unwrap`s are ok.
+                let (q, r) = args[0].v.div_rem(&args[1].v);
+                let ty = args[0].ty;
+                // The quotient may overflow for signed `MIN / -1`, so it must be validated.
+                if let Err(err) = validate_literal(db, ty, &q) {
+                    return to_missing(self.diagnostics.report(
+                        expr.stable_ptr.untyped(),
+                        SemanticDiagnosticKind::LiteralError(err),
+                    ));
+                }
                 return ConstValue::Struct(
-                    vec![
-                        ConstValueId::from_int(db, args[0].ty, &(&args[0].v / &args[1].v)),
-                        ConstValueId::from_int(db, args[0].ty, &(&args[0].v % &args[1].v)),
-                    ],
+                    vec![ConstValueId::from_int(db, ty, &q), ConstValueId::from_int(db, ty, &r)],
                     expr.ty,
                 )
                 .intern(db);


### PR DESCRIPTION
## Summary

Adds overflow detection for signed integer `MIN / -1` in constant evaluation. When evaluating `DivRem::div_rem` at compile time, the quotient is now validated against the target type's range using `validate_literal`. If the quotient overflows (e.g., `-128_i8 / -1`), a clean `E2008` diagnostic is emitted instead of silently storing an out-of-range value that would later cause an ICE in sierra-gen. The `num-integer` crate is introduced to use `div_rem` for computing both quotient and remainder together.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

For signed integers, `MIN / -1` produces a quotient that overflows the type (e.g., `i8::MIN / -1 = 128`, which exceeds `i8::MAX`). Previously, the constant evaluator would silently store this out-of-range value, which caused an ICE (internal compiler error) later during sierra code generation. The compiler should instead emit a clear, user-facing diagnostic at the point of the constant definition.

---

## What was the behavior or documentation before?

`DivRem::div_rem(-128_i8, -1)` in a constant expression would silently produce an out-of-range quotient value, leading to an ICE in sierra-gen rather than a proper compiler diagnostic.

---

## What is the behavior or documentation after?

`DivRem::div_rem(-128_i8, -1)` in a constant expression now emits:

```
error[E2008]: The value does not fit within the range of type core::integer::i8.
```

at the site of the offending expression, cleanly rejecting the invalid constant.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A test case (`DIVREM_SIGNED_MIN_OVERFLOW`) has been added to the constant evaluation test data to cover this overflow scenario and verify the diagnostic output.