### PR TITLE
performance(parser): Stream the lexer with a lookahead window instead of cloning all tokens.

### DIFF
--- a/crates/cairo-lang-parser/src/lexer.rs
+++ b/crates/cairo-lang-parser/src/lexer.rs
@@ -4,7 +4,7 @@ mod test;
 
 use std::sync::Arc;
 
-use cairo_lang_filesystem::ids::{SmolStrId, Tracked};
+use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
 use cairo_lang_syntax::node::Token;
 use cairo_lang_syntax::node::ast::{
@@ -12,7 +12,6 @@ use cairo_lang_syntax::node::ast::{
     TokenWhitespace, TriviumGreen,
 };
 use cairo_lang_syntax::node::kind::SyntaxKind;
-use cairo_lang_utils::deque::Deque;
 use salsa::Database;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -23,8 +22,9 @@ pub struct Lexer {
 }
 
 impl Lexer {
-    pub fn position(&self) -> TextOffset {
-        self.current_position
+    /// Creates a new lexer with the given text.
+    pub fn new(text: Arc<str>) -> Self {
+        Self { text, previous_position: TextOffset::START, current_position: TextOffset::START }
     }
 
     // Helpers.
@@ -253,7 +253,7 @@ impl Lexer {
         }
     }
 
-    fn match_terminal<'a>(&mut self, db: &'a dyn Database) -> LexerTerminal<'a> {
+    pub fn match_terminal<'a>(&mut self, db: &'a dyn Database) -> LexerTerminal<'a> {
         let leading_trivia = self.match_trivia(db, true);
 
         let kind = if let Some(current) = self.peek() {
@@ -323,27 +323,6 @@ impl Lexer {
         // TODO(yuval): log(verbose) "consumed text: ..."
         LexerTerminal { text, kind: terminal_kind, leading_trivia, trailing_trivia }
     }
-}
-
-/// Tokenizes the entire text and returns a deque of terminals.
-#[salsa::tracked]
-pub fn tokenize_all<'a>(
-    db: &'a dyn Database,
-    _tracked: Tracked,
-    text: Arc<str>,
-) -> cairo_lang_utils::deque::Deque<LexerTerminal<'a>> {
-    let mut lexer =
-        Lexer { text, previous_position: TextOffset::START, current_position: TextOffset::START };
-    let mut result: Deque<LexerTerminal<'a>> = Default::default();
-    loop {
-        let terminal = lexer.match_terminal(db);
-        let is_eof = terminal.kind == SyntaxKind::TerminalEndOfFile;
-        result.push_back(terminal);
-        if is_eof {
-            break;
-        }
-    }
-    result
 }
 
 /// Output terminal emitted by the lexer.

--- a/crates/cairo-lang-parser/src/lexer_test.rs
+++ b/crates/cairo-lang-parser/src/lexer_test.rs
@@ -6,8 +6,9 @@ use cairo_lang_syntax::node::ast::{TokenSingleLineComment, TokenWhitespace};
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_test_utils::test;
 use itertools::Itertools;
+use salsa::Database;
 
-use crate::lexer::{LexerTerminal, tokenize_all};
+use crate::lexer::{Lexer, LexerTerminal};
 use crate::utils::SimpleParserDatabase;
 
 // TODO(spapini): Use snapshot/regression tests.
@@ -267,7 +268,7 @@ fn test_lex_single_token() {
     let db_val = SimpleParserDatabase::default();
     let db = &db_val;
     for (kind, text) in terminal_kind_and_text() {
-        let terminals = tokenize_all(db, (), Arc::from(text));
+        let terminals = tokenize_all(db, Arc::from(text));
         let terminal = &terminals[0];
         // TODO(spapini): Remove calling new_root on non root elements.
         assert_eq!(terminal.kind, kind, "Wrong token kind, with text: \"{text}\".");
@@ -294,7 +295,7 @@ fn test_lex_double_token() {
             }
             for separator in separators {
                 let text = format!("{text0}{separator}{text1}");
-                let terminals = tokenize_all(db, (), Arc::from(text.as_str()));
+                let terminals = tokenize_all(db, Arc::from(text.as_str()));
                 let terminal = &terminals[0];
                 let token_text = terminal.text(db);
                 assert_eq!(
@@ -343,7 +344,7 @@ fn test_lex_token_with_trivia() {
         for leading_trivia in trivia_texts() {
             for trailing_trivia in trivia_texts() {
                 let text = format!("{leading_trivia}{expected_token_text} {trailing_trivia}");
-                let terminals = tokenize_all(db, (), Arc::from(text.as_str()));
+                let terminals = tokenize_all(db, Arc::from(text.as_str()));
                 let terminal = &terminals[0];
                 let token_text = terminal.text(db);
                 assert_eq!(terminal.kind, kind, "Wrong token kind, with text: \"{text}\".");
@@ -365,7 +366,7 @@ fn test_lex_token_with_trivia() {
 fn test_cases() {
     let db_val = SimpleParserDatabase::default();
     let db = &db_val;
-    let res = tokenize_all(db, (), Arc::from("let x: &T = ` 6; //  5+ 3;"));
+    let res = tokenize_all(db, Arc::from("let x: &T = ` 6; //  5+ 3;"));
     assert_eq!(
         res.into_iter().collect::<Vec<_>>(),
         vec![
@@ -453,7 +454,7 @@ fn test_doc_comment_classification() {
     let db_val = SimpleParserDatabase::default();
     let db = &db_val;
     let text = "// regular\n/// doc\n//! inner\n//// regular\n///// regular\n";
-    let terminal = tokenize_all(db, (), Arc::from(text)).into_iter().exactly_one().unwrap();
+    let terminal = tokenize_all(db, Arc::from(text)).into_iter().exactly_one().unwrap();
     assert_eq!(
         terminal.leading_trivia.into_iter().map(|t| t.0.long(db).kind).collect_vec(),
         [
@@ -477,7 +478,7 @@ fn test_bad_character() {
     let db = &db_val;
 
     let text = "`";
-    let terminals = tokenize_all(db, (), Arc::from(text));
+    let terminals = tokenize_all(db, Arc::from(text));
     let terminal = &terminals[0];
     let token_text = terminal.text(db);
     assert_eq!(
@@ -493,4 +494,19 @@ fn test_bad_character() {
         "Wrong eof token, with text: \"{text}\"."
     );
     assert_eq!(terminals.len(), 2, "Expected exactly 2 terminals (bad char + EOF).");
+}
+
+/// Tokenizes the entire text and returns a vector of terminals.
+pub fn tokenize_all<'db>(db: &'db dyn Database, text: Arc<str>) -> Vec<LexerTerminal<'db>> {
+    let mut lexer = Lexer::new(text);
+    let mut result = vec![];
+    loop {
+        let terminal = lexer.match_terminal(db);
+        let is_eof = terminal.kind == SyntaxKind::TerminalEndOfFile;
+        result.push(terminal);
+        if is_eof {
+            break;
+        }
+    }
+    result
 }

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::mem;
 use std::sync::Arc;
 
@@ -11,7 +12,6 @@ use cairo_lang_syntax::node::ast::*;
 use cairo_lang_syntax::node::helpers::GetIdentifier;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, Token, TypedSyntaxNode};
-use cairo_lang_utils::deque::Deque;
 use cairo_lang_utils::{extract_matches, require};
 use salsa::Database;
 use syntax::node::green::{GreenNode, GreenNodeDetails};
@@ -19,7 +19,7 @@ use syntax::node::ids::GreenId;
 
 use crate::ParserDiagnostic;
 use crate::diagnostic::ParserDiagnosticKind;
-use crate::lexer::{LexerTerminal, tokenize_all};
+use crate::lexer::{Lexer, LexerTerminal};
 use crate::operators::{get_post_operator_precedence, get_unary_operator_precedence};
 use crate::recovery::is_of_kind;
 use crate::utils::primitive_token_stream_content_and_offset;
@@ -47,8 +47,13 @@ enum MacroParsingContext {
 pub struct Parser<'a, 'mt> {
     db: &'a dyn Database,
     file_id: FileId<'a>,
-    /// A queue of lexed tokens to be parsed.
-    terminals: Deque<LexerTerminal<'a>>,
+    /// The lexer producing the tokens, pulled lazily into `current_terminals` as parsing advances.
+    lexer: Lexer,
+    /// A small lookahead window of already-lexed, not-yet-consumed terminals, kept filled by
+    /// `ensure_next_k_exists`. The front is the next terminal to parse.
+    current_terminals: VecDeque<LexerTerminal<'a>>,
+    /// Whether the lexer has produced the end-of-file terminal (no more tokens to pull).
+    eof: bool,
     /// A vector of pending trivia to be added as leading trivia to the next valid terminal.
     pending_trivia: Vec<TriviumGreen<'a>>,
     /// The current offset, excluding the current terminal.
@@ -67,19 +72,32 @@ pub struct Parser<'a, 'mt> {
 
 impl<'a> Parser<'a, '_> {
     fn next_terminal(&self) -> &LexerTerminal<'a> {
-        &self.terminals[0]
+        &self.current_terminals[0]
     }
 
     fn next_next_terminal(&self) -> &LexerTerminal<'a> {
-        &self.terminals[1]
+        &self.current_terminals[1]
     }
 
     fn advance(&mut self) -> LexerTerminal<'a> {
-        self.terminals.pop_front().unwrap()
+        // Keep the two-terminal lookahead (`next_terminal`/`next_next_terminal`) valid after the
+        // pop by refilling to 3 (the popped terminal plus the two peeked ones) before popping.
+        self.ensure_next_k_exists(3);
+        self.current_terminals.pop_front().unwrap()
+    }
+
+    /// Pulls terminals from the lexer until the lookahead window holds at least `k` of them (or the
+    /// lexer reaches end-of-file).
+    fn ensure_next_k_exists(&mut self, k: usize) {
+        while !self.eof && self.current_terminals.len() < k {
+            let terminal = self.lexer.match_terminal(self.db);
+            self.eof = terminal.kind == SyntaxKind::TerminalEndOfFile;
+            self.current_terminals.push_back(terminal);
+        }
     }
 
     fn next_terminal_mut(&mut self) -> &mut LexerTerminal<'a> {
-        &mut self.terminals[0]
+        &mut self.current_terminals[0]
     }
 }
 
@@ -147,11 +165,12 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         text: &'a str,
         diagnostics: &'mt mut DiagnosticsBuilder<'a, ParserDiagnostic<'a>>,
     ) -> Self {
-        let tokens: Deque<LexerTerminal<'a>> = tokenize_all(db, (), Arc::from(text));
-        Parser {
+        let mut parser = Parser {
             db,
             file_id,
-            terminals: tokens,
+            lexer: Lexer::new(Arc::from(text)),
+            current_terminals: VecDeque::with_capacity(8),
+            eof: false,
             pending_trivia: Vec::new(),
             offset: Default::default(),
             current_width: Default::default(),
@@ -159,7 +178,9 @@ impl<'a, 'mt> Parser<'a, 'mt> {
             diagnostics,
             pending_skipped_token_diagnostics: Vec::new(),
             macro_parsing_context: MacroParsingContext::None,
-        }
+        };
+        parser.ensure_next_k_exists(2);
+        parser
     }
 
     /// Adds a diagnostic to the parser diagnostics collection.
@@ -3530,14 +3551,14 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         // Consume the original token and grab its trivia.
         let orig = self.advance();
         // Pushing the second first, with the trailing trivia.
-        self.terminals.push_front(LexerTerminal {
+        self.current_terminals.push_front(LexerTerminal {
             text: SmolStrId::from(self.db, second),
             kind: Second::KIND,
             leading_trivia: vec![],
             trailing_trivia: orig.trailing_trivia,
         });
         // Pushing the first second, with the leading trivia.
-        self.terminals.push_front(LexerTerminal {
+        self.current_terminals.push_front(LexerTerminal {
             text: SmolStrId::from(self.db, first),
             kind: First::KIND,
             leading_trivia: orig.leading_trivia,


### PR DESCRIPTION
## Summary

Replaces the pre-tokenized `Deque<LexerTerminal>` in `Parser` with a lazily-driven `Lexer` instance. Instead of calling `tokenize_all` upfront to lex the entire file before parsing begins, the parser now pulls tokens from the lexer on demand via a small `VecDeque<LexerTerminal>` lookahead window (`current_terminals`). The window is kept filled to at least two terminals (for `next_terminal`/`next_next_terminal`) and refilled to three before each `advance()` call. An `eof` flag tracks when the lexer has emitted `TerminalEndOfFile` so no further pulls are attempted. `Lexer::new` and `Lexer::match_terminal` are made `pub` to support this.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, the parser eagerly lexed the entire source file into a `Deque` before any parsing work began. This meant the full token stream was allocated in memory upfront. By switching to lazy lexing, tokens are produced only as the parser consumes them, reducing peak memory usage and avoiding unnecessary work for early-exit or partial-parse scenarios.

---

## What was the behavior or documentation before?

`Parser::new` called `tokenize_all`, which lexed the entire input into a `Deque<LexerTerminal>` before returning. The parser then consumed from that pre-filled deque.

---

## What is the behavior or documentation after?

`Parser::new` constructs a `Lexer` directly and pre-fills only the first two terminals needed for lookahead. Subsequent terminals are pulled from the lexer one at a time as parsing advances, with the lookahead window never growing beyond a small constant size.

---

## Related issue or discussion (if any)

---

## Additional context

The `cairo_lang_utils::deque::Deque` import is replaced by `std::collections::VecDeque`, and the `tokenize_all` function is no longer used by the parser.