### PR TITLE
bug fix(semantic): Substitute result of generic const function calls.

### DIFF
--- a/corelib/src/test/language_features/const_test.cairo
+++ b/corelib/src/test/language_features/const_test.cairo
@@ -159,6 +159,50 @@ fn test_complex_consts() {
     assert_eq!(IF_CONST_FALSE, 7);
 }
 
+#[derive(Copy, Drop, PartialEq, Debug)]
+struct Pair<T> {
+    a: T,
+    b: T,
+}
+
+#[derive(Copy, Drop, PartialEq, Debug)]
+enum Either<T> {
+    Left: T,
+    Right: T,
+}
+
+const fn make_pair<T, +Copy<T>, +Drop<T>>(a: T, b: T) -> Pair<T> {
+    Pair { a, b }
+}
+
+const fn make_tuple<T, +Copy<T>, +Drop<T>>(a: T, b: T) -> (T, T) {
+    (a, b)
+}
+
+const fn make_left<T, +Copy<T>, +Drop<T>>(value: T) -> Either<T> {
+    Either::Left(value)
+}
+
+// A generic const fn returning an aggregate must tag the result with the concrete (substituted)
+// type, rather than the generic type from the function body.
+#[test]
+fn test_const_generic_struct_ctor() {
+    const RESULT: Pair<felt252> = make_pair(1, 2);
+    assert_eq!(RESULT, Pair { a: 1, b: 2 });
+}
+
+#[test]
+fn test_const_generic_tuple_return() {
+    const RESULT: (felt252, felt252) = make_tuple(1, 2);
+    assert_eq!(RESULT, (1, 2));
+}
+
+#[test]
+fn test_const_generic_enum_return() {
+    const RESULT: Either<felt252> = make_left(7);
+    assert_eq!(RESULT, Either::Left(7));
+}
+
 #[test]
 fn test_const_casts_from_felt252() {
     const _U8_UNDER_RANGE: () = assert((-1_felt252).try_into() == None::<u8>, 'U8 under range');

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -725,7 +725,7 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             Expr::Literal(expr) => ConstValueId::from_int(db, expr.ty, &expr.value),
             Expr::Tuple(expr) => ConstValue::Struct(
                 expr.items.iter().map(|expr_id| self.evaluate(*expr_id)).collect(),
-                expr.ty,
+                or_return!(self.substitute(expr.ty).map_err(to_missing)),
             )
             .intern(db),
             Expr::StructCtor(ExprStructCtor {
@@ -750,13 +750,15 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                                 .unwrap_or_else(|| to_missing(skip_diagnostic()))
                         })
                         .collect(),
-                    *ty,
+                    or_return!(self.substitute(*ty).map_err(to_missing)),
                 )
                 .intern(db)
             }
-            Expr::EnumVariantCtor(expr) => {
-                ConstValue::Enum(expr.variant, self.evaluate(expr.value_expr)).intern(db)
-            }
+            Expr::EnumVariantCtor(expr) => ConstValue::Enum(
+                or_return!(self.substitute(expr.variant).map_err(to_missing)),
+                self.evaluate(expr.value_expr),
+            )
+            .intern(db),
             Expr::MemberAccess(expr) => {
                 self.evaluate_member_access(expr).unwrap_or_else(to_missing)
             }
@@ -778,7 +780,7 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
                         }
                     }
                 },
-                expr.ty,
+                or_return!(self.substitute(expr.ty).map_err(to_missing)),
             )
             .intern(db),
             Expr::Snapshot(expr) => self.evaluate(expr.inner),


### PR DESCRIPTION
## Summary

When a generic `const fn` returns an aggregate value (struct, tuple, or enum), the returned `ConstValue` was tagged with the generic types from the function body rather than the concrete types at the call site. This caused type mismatches when using generic const functions that construct and return aggregate types.

The fix applies `substitute` to the type of each aggregate `ConstValue` (struct, tuple, and enum variant) during constant evaluation, replacing generic type parameters with the concrete types from the call site.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Generic `const fn`s that return structs, tuples, or enums were producing `ConstValue`s tagged with the generic type parameters from the function body. At the call site, the expected type is the concrete substituted type, so the mismatch caused incorrect constant evaluation results.

---

## What was the behavior or documentation before?

A generic `const fn` returning an aggregate (e.g., `Pair<T>`, `(T, T)`, or `Either<T>`) would produce a `ConstValue` whose inner type was still the generic `T` rather than the concrete type (e.g., `felt252`) supplied at the call site.

---

## What is the behavior or documentation after?

After evaluating each aggregate expression inside a generic `const fn`, the type attached to the resulting `ConstValue` is passed through `self.substitute(...)` so that structs, tuples, and enum variants are tagged with the concrete types from the call site. Three new tests cover this behavior:

- `test_const_generic_struct_ctor` — generic const fn returning a struct
- `test_const_generic_tuple_return` — generic const fn returning a tuple
- `test_const_generic_enum_return` — generic const fn returning an enum variant

---

## Related issue or discussion (if any)

---

## Additional context

For enum variants, `substitute` is applied to the entire `ConcreteVariant` (not just its type) to ensure all generic parameters embedded in the variant descriptor are also resolved to their concrete forms.