### PR TITLE
performance(semantic): Made substitute be faster on empty subs.

### DIFF
--- a/corelib/src/test/language_features/const_test.cairo
+++ b/corelib/src/test/language_features/const_test.cairo
@@ -203,6 +203,29 @@ fn test_const_generic_enum_return() {
     assert_eq!(RESULT, Either::Left(7));
 }
 
+trait AssocConst<const N: usize> {
+    const VALUE: usize;
+}
+
+impl AssocConstImpl of AssocConst<7> {
+    const VALUE: usize = 70;
+}
+
+const fn assoc_const_via_generic<const N: usize, impl A: AssocConst<N>>() -> usize {
+    A::VALUE
+}
+
+// Associated-const (impl-constant projection) evaluation in const context: both direct concrete
+// access (evaluated under an empty substitution) and through a generic const fn must yield the
+// concrete value, not an unresolved projection.
+#[test]
+fn test_const_assoc_const() {
+    const DIRECT: usize = AssocConstImpl::VALUE;
+    assert_eq!(DIRECT, 70);
+    const VIA_GENERIC: usize = assoc_const_via_generic::<7, AssocConstImpl>();
+    assert_eq!(VIA_GENERIC, 70);
+}
+
 #[derive(Copy, Drop, PartialEq, Debug)]
 struct Point {
     x: felt252,

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -1251,11 +1251,7 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
     where
         SubstitutionRewriter<'a, 'w>: SemanticRewriter<Obj, DiagnosticAdded>,
     {
-        if self.generic_substitution.is_empty() {
-            Ok(obj)
-        } else {
-            self.generic_substitution.substitute(self.db, obj)
-        }
+        self.generic_substitution.substitute(self.db, obj)
     }
     /// Compares two const values for value equality, treating `felt252` as a field.
     ///

--- a/crates/cairo-lang-semantic/src/substitution.rs
+++ b/crates/cairo-lang-semantic/src/substitution.rs
@@ -93,7 +93,11 @@ impl<'db> GenericSubstitution<'db> {
         'db: 'a,
         SubstitutionRewriter<'a, 'r>: SemanticRewriter<Obj, DiagnosticAdded>,
     {
-        SubstitutionRewriter { db, substitution: self }.rewrite(obj)
+        if self.is_empty() {
+            Ok(obj)
+        } else {
+            SubstitutionRewriter { db, substitution: self }.rewrite(obj)
+        }
     }
 }
 impl<'db> Deref for GenericSubstitution<'db> {


### PR DESCRIPTION
## Summary

Moves the `is_empty()` short-circuit check from `ConstantEvaluateContext::substitute` into `GenericSubstitution::substitute`, so that all callers of `GenericSubstitution::substitute` benefit from the optimization rather than only the constant evaluation path.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [x] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The early-exit guard that avoids constructing a `SubstitutionRewriter` when the substitution map is empty was only present in `ConstantEvaluateContext::substitute`. Any other caller of `GenericSubstitution::substitute` would unconditionally allocate and run the rewriter even when there is nothing to substitute.

---

## What was the behavior or documentation before?

`GenericSubstitution::substitute` always constructed a `SubstitutionRewriter` and ran a full rewrite, regardless of whether the substitution was empty. `ConstantEvaluateContext` worked around this with a local `is_empty()` check before calling through.

---

## What is the behavior or documentation after?

`GenericSubstitution::substitute` itself checks `is_empty()` and returns the object unchanged without constructing a `SubstitutionRewriter`. The redundant local check in `ConstantEvaluateContext::substitute` is removed.

---

## Related issue or discussion (if any)

---

## Additional context

This is a purely mechanical refactor with no behavioral change; the optimization is identical, just applied at the right abstraction level.