### PR TITLE
feat(semantic): Warn when an extern type/function is declared outside the corelib.

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/test_data/equality
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/equality
@@ -1236,6 +1236,7 @@ fn foo(a: felt252, b: felt252) -> Array<felt252> {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_arr(x: @Array<felt252>) nopanic;
 
 //! > semantic_diagnostics
@@ -1350,6 +1351,7 @@ fn foo(a: felt252, b: felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_snap_felt(x: @felt252) nopanic;
 
 //! > semantic_diagnostics
@@ -1457,6 +1459,7 @@ fn foo(a: felt252, b: felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_snap_felt(x: @felt252) nopanic;
 
 //! > semantic_diagnostics
@@ -1552,6 +1555,7 @@ fn foo(mut arr: Array<felt252>) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_snap_felt(x: @felt252) nopanic;
 
 //! > semantic_diagnostics
@@ -1943,6 +1947,7 @@ fn foo(x: felt252, y: felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_boxes(a: Box<Option<felt252>>, b: Box<Option<felt252>>) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
@@ -18,12 +18,16 @@ fn foo(x: ACopy, y: ADrop) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type ACopy;
 impl ACopyCopy of Copy<ACopy>;
+#[allow(extern_outside_corelib)]
 extern type ADrop;
 impl ADropDrop of Drop<ADrop>;
 
+#[allow(extern_outside_corelib)]
 extern fn use_a_copy(x: ACopy) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
 
 //! > semantic_diagnostics
@@ -82,33 +86,37 @@ fn foo(x: ACopy, y: ADrop) -> ADrop {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type ACopy;
 impl ACopyCopy of Copy<ACopy>;
+#[allow(extern_outside_corelib)]
 extern type ADrop;
 impl ADropDrop of Drop<ADrop>;
 
+#[allow(extern_outside_corelib)]
 extern fn use_a_copy(x: ACopy) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:13:5
+ --> lib.cairo:17:5
     y
     ^
 note: variable was previously used here:
-  --> lib.cairo:11:20
+  --> lib.cairo:15:20
         use_a_drop(y);
                    ^
 note: Trait has no implementation in context: core::traits::Copy::<test::ADrop>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:8:8
+ --> lib.cairo:12:8
 fn foo(x: ACopy, y: ADrop) -> ADrop {
        ^
 note: the variable needs to be dropped due to the divergence here:
-  --> lib.cairo:9:5-12:13
+  --> lib.cairo:13:5-16:13
       if true {
  _____^
 | ...
@@ -170,12 +178,16 @@ fn bar() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type ACopy;
 impl ACopyCopy of Copy<ACopy>;
+#[allow(extern_outside_corelib)]
 extern type ADrop;
 impl ADropDrop of Drop<ADrop>;
 
+#[allow(extern_outside_corelib)]
 extern fn use_a_copy(x: ACopy) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
 
 //! > semantic_diagnostics
@@ -324,20 +336,22 @@ fn foo(x: ADrop, mut y: ADrop) -> ADrop {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type ADrop;
 impl ADropDrop of Drop<ADrop>;
 
+#[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:12:12
+ --> lib.cairo:14:12
     return y;
            ^
 note: variable was previously used here:
-  --> lib.cairo:7:20
+  --> lib.cairo:9:20
         use_a_drop(y);
                    ^
 note: Trait has no implementation in context: core::traits::Copy::<test::ADrop>.
@@ -433,21 +447,24 @@ fn foo(x: NonCopy) -> Option<NonCopy> {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type NonCopy;
 
+#[allow(extern_outside_corelib)]
 extern fn use_non_copy(x: NonCopy) nopanic;
 
+#[allow(extern_outside_corelib)]
 extern fn do_match_extern(x: NonCopy) -> Option<NonCopy> nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:8:21
+ --> lib.cairo:11:21
     do_match_extern(x)
                     ^
 note: variable was previously used here:
-  --> lib.cairo:7:18
+  --> lib.cairo:10:18
     use_non_copy(x);
                  ^
 note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
@@ -499,8 +516,10 @@ fn foo(mut x: MyStruct) -> MyStruct {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type NonCopy;
 
+#[allow(extern_outside_corelib)]
 extern fn use_non_copy(x: NonCopy) nopanic;
 
 struct MyStruct {
@@ -512,11 +531,11 @@ struct MyStruct {
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:12:12
+ --> lib.cairo:14:12
     return x;
            ^
 note: variable was previously used here:
-  --> lib.cairo:11:18
+  --> lib.cairo:13:18
     use_non_copy(x.b);
                  ^^^
 note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
@@ -549,6 +568,7 @@ fn foo(ref s1: MyStruct, ref s2: MyStruct) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn invalidate(a: Array<felt252>) nopanic;
 
 #[derive(Drop)]
@@ -561,21 +581,21 @@ struct MyStruct {
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:8:12
+ --> lib.cairo:9:12
 fn foo(ref s1: MyStruct, ref s2: MyStruct) {
            ^^
 note: variable was previously used here:
-  --> lib.cairo:9:16
+  --> lib.cairo:10:16
     invalidate(s1.a);
                ^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
 
 error[E3001]: Variable was previously moved.
- --> lib.cairo:8:30
+ --> lib.cairo:9:30
 fn foo(ref s1: MyStruct, ref s2: MyStruct) {
                              ^^
 note: variable was previously used here:
-  --> lib.cairo:10:16
+  --> lib.cairo:11:16
     invalidate(s2.a);
                ^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
@@ -613,6 +633,7 @@ fn foo(ref self: MyStruct) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn invalidate(a: Array<felt252>) nopanic;
 
 #[derive(Drop)]
@@ -625,11 +646,11 @@ struct MyStruct {
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:8:12
+ --> lib.cairo:9:12
 fn foo(ref self: MyStruct) {
            ^^^^
 note: variable was previously used here:
-  --> lib.cairo:11:20
+  --> lib.cairo:12:20
         invalidate(self.a);
                    ^^^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
@@ -688,6 +709,7 @@ fn foo(mut v: MyStruct) -> u8 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn invalidate(a: Array<felt252>) nopanic;
 
 #[derive(Drop)]
@@ -750,8 +772,10 @@ fn foo(mut x: MyStruct) -> MyStruct {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type NonCopy;
 
+#[allow(extern_outside_corelib)]
 extern fn use_non_copy(x: NonCopy) nopanic;
 
 struct MyStruct {
@@ -763,11 +787,11 @@ struct MyStruct {
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:9:12
+ --> lib.cairo:11:12
 fn foo(mut x: MyStruct) -> MyStruct {
            ^
 note: the variable needs to be dropped due to the potential panic here:
-  --> lib.cairo:11:5
+  --> lib.cairo:13:5
     x.a += 1;
     ^^^^^^^^
 note: Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
@@ -869,6 +893,7 @@ fn foo(mut x: MyStruct) -> MyStruct {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type NonCopy;
 
 struct MyStruct {
@@ -880,11 +905,11 @@ struct MyStruct {
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:7:12
+ --> lib.cairo:8:12
 fn foo(mut x: MyStruct) -> MyStruct {
            ^
 note: the variable needs to be dropped due to the potential panic here:
-  --> lib.cairo:10:9
+  --> lib.cairo:11:9
         x.a += 1;
         ^^^^^^^^
 note: Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
@@ -923,8 +948,10 @@ fn foo(x: MyStruct) -> MyStruct {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type NonCopy;
 
+#[allow(extern_outside_corelib)]
 extern fn consume(x: NonCopy) nopanic;
 
 struct MyStruct {
@@ -936,11 +963,11 @@ struct MyStruct {
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:11:5
+ --> lib.cairo:13:5
     x
     ^
 note: variable was previously used here:
-  --> lib.cairo:10:13
+  --> lib.cairo:12:13
     consume(x.b);
             ^^^
 note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
@@ -973,8 +1000,10 @@ fn foo(x: NonDrop) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type NonDrop;
 
+#[allow(extern_outside_corelib)]
 extern fn maybe_consume(x: NonDrop) -> Option<NonDrop> nopanic;
 
 //! > semantic_diagnostics
@@ -1009,11 +1038,11 @@ End:
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:4:8
+ --> lib.cairo:6:8
 fn foo(x: NonDrop) {
        ^
 note: the variable needs to be dropped due to the potential panic here:
-  --> lib.cairo:4:1-8:1
+  --> lib.cairo:6:1-10:1
   fn foo(x: NonDrop) {
  _^
 | ...
@@ -1047,6 +1076,7 @@ struct Wrapper {
     inner: u16,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn use_x(x: Wrapper) nopanic;
 
 //! > semantic_diagnostics
@@ -1108,27 +1138,28 @@ struct Wrapper {
     inner: u16,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn use_x(x: Wrapper) nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:12:11
+ --> lib.cairo:13:11
     use_x(x); // Second use.
           ^
 note: variable was previously used here:
-  --> lib.cairo:9:15
+  --> lib.cairo:10:15
         use_x(x); // First use.
               ^
 note: Trait has no implementation in context: core::traits::Copy::<test::Wrapper>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:7:8
+ --> lib.cairo:8:8
 fn foo(x: Wrapper) {
        ^
 note: the variable needs to be dropped due to the divergence here:
-  --> lib.cairo:8:5-10:5
+  --> lib.cairo:9:5-11:5
       if x.inner.is_zero() {
  _____^
 |         use_x(x); // First use.
@@ -1193,14 +1224,16 @@ struct Wrapper {
     inner: u16,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn use_x(x: Wrapper) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_snap_x(x: @Wrapper) nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:8:9
+ --> lib.cairo:10:9
     let x = Wrapper { inner: 5 };
         ^
 note: Trait has no implementation in context: core::traits::Drop::<test::Wrapper>.
@@ -1269,14 +1302,16 @@ struct Outer {
     inner: Inner,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn use_outer(x: Outer) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_snap_outer(x: @Outer) nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:11:8
+ --> lib.cairo:13:8
 fn foo(o: Outer) {
        ^
 note: Trait has no implementation in context: core::traits::Drop::<test::Outer>.
@@ -1433,6 +1468,7 @@ fn foo(outer: Outer) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type NonCopy;
 
 struct Inner {
@@ -1444,19 +1480,22 @@ struct Outer {
     b: NonCopy,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar(x: felt252) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn consume(x: NonCopy) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_outer(x: Outer) nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:18:15
+ --> lib.cairo:22:15
     use_outer(outer);
               ^^^^^
 note: variable was previously used here:
-  --> lib.cairo:17:13
+  --> lib.cairo:21:13
     consume(outer.b);
             ^^^^^^^
 note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
@@ -1508,15 +1547,18 @@ struct Outer {
     inner: Inner,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn use_outer(x: Outer) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_snap_outer(x: @Outer) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn some_cond() -> bool nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:12:12
+ --> lib.cairo:15:12
 fn foo(mut o: Outer) {
            ^
 note: Trait has no implementation in context: core::traits::Drop::<test::Outer>.

--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/closure
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/closure
@@ -130,17 +130,18 @@ struct S {
     a: u32,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn use_s(s: S) nopanic;
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:13:13
+ --> lib.cairo:14:13
     let _ = a.a;
             ^^^
 note: variable was previously used here:
-  --> lib.cairo:9:15
+  --> lib.cairo:10:15
         use_s(a)
               ^
 note: Trait has no implementation in context: core::traits::Copy::<test::S>.
@@ -149,7 +150,7 @@ note: Trait has no implementation in context: core::traits::Copy::<test::S>.
 Parameters: v0: test::S
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:8:5: 8:7}) <- struct_construct(v0{`a`})
+  (v1: {closure@lib.cairo:9:5: 9:7}) <- struct_construct(v0{`a`})
   (v3: ()) <- struct_construct()
 End:
   Return(v3)
@@ -174,11 +175,12 @@ fn foo(mut a: Array<u32>) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_f<T>(f: T) nopanic;
 
 //! > semantic_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:4:17
+ --> lib.cairo:5:17
         let _ = a.append(b);
                 ^
 
@@ -208,6 +210,7 @@ fn foo(a: Array<u32>) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_value<T>(f: T) nopanic;
 
 //! > semantic_diagnostics
@@ -219,9 +222,9 @@ Parameters: v0: core::array::Array::<core::integer::u32>
 blk0 (root):
 Statements:
   (v1: core::array::Array::<core::integer::u32>, v2: @core::array::Array::<core::integer::u32>) <- snapshot(v0{`a`})
-  (v3: {closure@lib.cairo:3:13: 3:22}) <- struct_construct(v2{`|_b: u32| { let _ = a.len(); }`})
+  (v3: {closure@lib.cairo:4:13: 4:22}) <- struct_construct(v2{`|_b: u32| { let _ = a.len(); }`})
   () <- test::use_value::<core::array::Array::<core::integer::u32>>(v1{`a`})
-  () <- test::use_value::<{closure@lib.cairo:3:13: 3:22}>(v3{`f`})
+  () <- test::use_value::<{closure@lib.cairo:4:13: 4:22}>(v3{`f`})
   (v4: ()) <- struct_construct()
 End:
   Return(v4)
@@ -245,11 +248,12 @@ fn foo(mut a: Array<u32>) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_f<T>(f: T) nopanic;
 
 //! > semantic_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:4:9
+ --> lib.cairo:5:9
         a = array![];
         ^
 

--- a/crates/cairo-lang-lowering/src/cache/test_data/cache
+++ b/crates/cairo-lang-lowering/src/cache/test_data/cache
@@ -18,12 +18,16 @@ fn foo(x: ACopy, y: ADrop) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type ACopy;
 impl ACopyCopy of Copy<ACopy>;
+#[allow(extern_outside_corelib)]
 extern type ADrop;
 impl ADropDrop of Drop<ADrop>;
 
+#[allow(extern_outside_corelib)]
 extern fn use_a_copy(x: ACopy) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/lower/flow_control/test_data/if
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/test_data/if
@@ -122,6 +122,7 @@ fn foo(mut x: felt252, mut y: felt252) -> felt252 {
 }
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn modify(ref x: felt252) -> felt252 nopanic;
 
 //! > graph
@@ -212,6 +213,7 @@ struct MyStruct {
     b: felt252,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn modify(ref x: felt252) -> felt252 nopanic;
 
 //! > graph

--- a/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
@@ -1746,6 +1746,7 @@ struct MyStruct {
     c: u8,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar(ref x: felt252) -> MyEnum nopanic;
 
 //! > graph
@@ -1872,6 +1873,7 @@ fn foo() -> felt252 {
 }
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar() -> Option<felt252> nopanic;
 
 //! > graph
@@ -1949,6 +1951,7 @@ fn foo() -> felt252 {
 }
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar() -> Option<felt252> nopanic;
 
 //! > graph

--- a/crates/cairo-lang-lowering/src/lower/test_data/loop
+++ b/crates/cairo-lang-lowering/src/lower/test_data/loop
@@ -1239,7 +1239,9 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn ex(a: u32) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn ex1(a: @B) nopanic;
 #[derive(Drop)]
 struct B {
@@ -1365,7 +1367,9 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn ex(a: @u32) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn ex1(a: B) nopanic;
 #[derive(Drop, Copy)]
 struct B {
@@ -1492,6 +1496,7 @@ foo
 struct A {
     x: felt252,
 }
+#[allow(extern_outside_corelib)]
 extern fn use_a(a: @A) nopanic;
 
 //! > semantic_diagnostics
@@ -3047,6 +3052,7 @@ fn foo() -> Result<(), u32> {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar() -> Result<(), u32> nopanic;
 
 //! > expected_diagnostics
@@ -3517,6 +3523,7 @@ fn foo(a: felt252, b: felt252, c: felt252) -> bool {
         }
     }
 }
+#[allow(extern_outside_corelib)]
 extern fn bar(a: S) nopanic;
 #[derive(Drop, Copy)]
 struct S {
@@ -3726,6 +3733,7 @@ fn foo(s: S) -> bool {
         }
     }
 }
+#[allow(extern_outside_corelib)]
 extern fn bar(a: Outer) nopanic;
 #[derive(Drop, Copy)]
 struct S {

--- a/crates/cairo-lang-lowering/src/lower/test_data/specialized
+++ b/crates/cairo-lang-lowering/src/lower/test_data/specialized
@@ -18,6 +18,7 @@ fn bar(keep: bool, x: felt252) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(x: felt252) nopanic;
 
 //! > caller_lowering
@@ -65,6 +66,7 @@ fn bar(keep: bool, x: Box<felt252>) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(x: Box<felt252>) nopanic;
 
 //! > caller_lowering
@@ -112,6 +114,7 @@ fn bar(keep: bool, x: Array<felt252>) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(x: Array<felt252>) nopanic;
 
 //! > caller_lowering
@@ -218,6 +221,7 @@ fn bar(keep: bool, x: Array<felt252>) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(x: Array<felt252>) nopanic;
 
 //! > caller_lowering
@@ -269,6 +273,7 @@ fn bar(
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(
     ref arr: Array<felt252>, d: Span<felt252>, x: felt252, y: felt252, z: Box<felt252>,
 ) nopanic;
@@ -334,6 +339,7 @@ fn bar(keep: bool, s: S6) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(s: S6) nopanic;
 
 //! > caller_lowering
@@ -392,6 +398,7 @@ fn bar(keep: bool, s: SA1) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(s: SA1) nopanic;
 
 //! > caller_lowering
@@ -455,6 +462,7 @@ fn bar(keep: bool, s: SA1) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(s: SA1) nopanic;
 
 //! > caller_lowering
@@ -531,6 +539,7 @@ fn bar(keep: bool, s: SB) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(s: SB) nopanic;
 
 //! > caller_lowering
@@ -588,6 +597,7 @@ fn bar(keep: bool, s: S) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(s: S) nopanic;
 
 //! > caller_lowering
@@ -650,6 +660,7 @@ fn bar(keep: bool, x: Array<Outer>) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(arr: Array<Outer>) nopanic;
 
 //! > caller_lowering
@@ -722,6 +733,7 @@ fn bar(keep: bool, e: E) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(e: E) nopanic;
 
 //! > semantic_diagnostics
@@ -781,6 +793,7 @@ fn bar(keep: bool, e: E) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(e: E) nopanic;
 
 //! > semantic_diagnostics
@@ -903,6 +916,7 @@ fn bar(keep: bool, t: (felt252, felt252, felt252)) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(t: (felt252, felt252, felt252)) nopanic;
 
 //! > semantic_diagnostics
@@ -953,6 +967,7 @@ fn bar(keep: bool, t: (felt252, felt252, felt252)) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(t: (felt252, felt252, felt252)) nopanic;
 
 //! > semantic_diagnostics
@@ -1002,6 +1017,7 @@ fn bar(keep: bool, arr: [felt252; 3]) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(arr: [felt252; 3]) nopanic;
 
 //! > semantic_diagnostics
@@ -1052,6 +1068,7 @@ fn bar(keep: bool, arr: [felt252; 3]) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(arr: [felt252; 3]) nopanic;
 
 //! > semantic_diagnostics
@@ -1107,6 +1124,7 @@ fn bar(keep: bool, s: S) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(s: S) nopanic;
 
 //! > semantic_diagnostics
@@ -1163,6 +1181,7 @@ fn bar(keep: bool, s: S) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar_ext(s: S) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/lower/test_data/while
+++ b/crates/cairo-lang-lowering/src/lower/test_data/while
@@ -311,6 +311,7 @@ enum MyEnum {
     B,
     C,
 }
+#[allow(extern_outside_corelib)]
 extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/arm_pattern_destructure
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/arm_pattern_destructure
@@ -32,6 +32,7 @@ enum MyEnum {
     g: (felt252,),
     h: felt252,
 }
+#[allow(extern_outside_corelib)]
 extern fn bar(ref r: felt252) -> MyEnum implicits(RangeCheck) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
@@ -334,6 +334,7 @@ End:
 test_match_optimizer
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_box<T>(b: @Box<T>) nopanic;
 
 //! > function_code

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/match_optimization
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/match_optimization
@@ -16,6 +16,7 @@ fn foo() -> Option<u16> {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn get_option() -> Option<u16> nopanic;
 
 //! > semantic_diagnostics
@@ -158,6 +159,7 @@ fn foo(a: felt252) -> Option<u16> {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn get_option() -> Option<u16> nopanic;
 
 //! > semantic_diagnostics
@@ -340,6 +342,7 @@ fn foo() -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn get_option() -> Option<felt252> nopanic;
 
 //! > semantic_diagnostics
@@ -1990,6 +1993,7 @@ fn foo(b: bool) -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_var(a: bool) nopanic;
 
 fn bar(b: bool) -> felt252 {

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/reorder_statements
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/reorder_statements
@@ -30,6 +30,7 @@ fn foo(x: felt252) -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn get_option() -> Option<u16> nopanic;
 
 //! > semantic_diagnostics
@@ -203,6 +204,7 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn get_option() -> Option<u16> nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/scrub_units
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/scrub_units
@@ -22,6 +22,7 @@ pub impl MyDestruct of Destruct<()> {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn my_fn() nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/split_structs
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/split_structs
@@ -140,6 +140,7 @@ fn foo(a: felt252) -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn consume(arg: (felt252, Array<felt252>)) nopanic;
 
 //! > semantic_diagnostics
@@ -280,6 +281,7 @@ fn foo(a: felt252) -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_tuple<T>(a: (felt252, T)) nopanic;
 
 //! > semantic_diagnostics
@@ -382,6 +384,7 @@ fn foo(a: felt252) -> (felt252, felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_tuple<T>(a: (felt252, T)) nopanic;
 
 //! > semantic_diagnostics
@@ -468,6 +471,7 @@ fn foo(a: felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_tuple<T>(a: (felt252, T)) nopanic;
 
 //! > semantic_diagnostics
@@ -559,8 +563,10 @@ fn foo(a: felt252) -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_tuple<T>(a: (felt252, T)) nopanic;
 
+#[allow(extern_outside_corelib)]
 extern fn get_tuple<T>() -> (felt252, T) nopanic;
 
 //! > semantic_diagnostics
@@ -865,7 +871,9 @@ fn foo(a: felt252, e: ThreeCases) -> (felt252, NonDupStruct) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn use_tuple<T>(a: (felt252, T)) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn use_struct(a: NonDupStruct) nopanic;
 
 struct NonDupStruct {

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/variable_forwarding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/variable_forwarding
@@ -563,6 +563,7 @@ End:
 test_variable_forwarding
 
 //! > function_code
+#[allow(extern_outside_corelib)]
 extern fn keep_snap(s: @Option<Array<felt252>>) -> bool nopanic;
 
 fn foo(arr: Array<felt252>) -> Array<felt252> {
@@ -689,7 +690,9 @@ End:
 test_variable_forwarding
 
 //! > function_code
+#[allow(extern_outside_corelib)]
 extern fn drop_nondrop<T>(c: T) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn make_mixed() -> Mixed nopanic;
 
 fn foo() -> Array<felt252> {
@@ -756,8 +759,11 @@ End:
 test_variable_forwarding
 
 //! > function_code
+#[allow(extern_outside_corelib)]
 extern fn make_arr() -> Array<felt252> nopanic;
+#[allow(extern_outside_corelib)]
 extern fn make_copy_only() -> CopyOnly nopanic;
+#[allow(extern_outside_corelib)]
 extern fn consume_copy_only(c: CopyOnly) nopanic;
 
 fn foo() -> Array<felt252> {
@@ -844,6 +850,7 @@ fn foo(a: felt252) -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn consume(arg: (felt252, Array<felt252>)) nopanic;
 
 //! > semantic_diagnostics
@@ -1207,6 +1214,7 @@ End:
 test_variable_forwarding
 
 //! > function_code
+#[allow(extern_outside_corelib)]
 extern fn sink(a: Array<felt252>) -> felt252 nopanic;
 
 fn foo(flag: bool, a: Array<felt252>) -> felt252 {

--- a/crates/cairo-lang-lowering/src/test_data/arm_pattern_destructure
+++ b/crates/cairo-lang-lowering/src/test_data/arm_pattern_destructure
@@ -127,6 +127,7 @@ enum MyEnum {
     g: (felt252,),
     h: felt252,
 }
+#[allow(extern_outside_corelib)]
 extern fn bar(ref a: felt252) -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -225,6 +226,7 @@ enum MyEnum {
     g: (felt252,),
     h: felt252,
 }
+#[allow(extern_outside_corelib)]
 extern fn bar() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -322,6 +324,7 @@ enum MyEnum {
     g: (felt252,),
     h: felt252,
 }
+#[allow(extern_outside_corelib)]
 extern fn bar(ref r: felt252) -> MyEnum implicits(RangeCheck) nopanic;
 
 //! > semantic_diagnostics
@@ -420,6 +423,7 @@ enum MyEnum {
     g: (felt252,),
     h: felt252,
 }
+#[allow(extern_outside_corelib)]
 extern fn bar(ref r: felt252) -> MyEnum implicits(RangeCheck) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/destruct
+++ b/crates/cairo-lang-lowering/src/test_data/destruct
@@ -295,6 +295,7 @@ pub impl MyDestruct of Destruct<()> {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn my_fn() nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/extern
+++ b/crates/cairo-lang-lowering/src/test_data/extern
@@ -15,9 +15,13 @@ fn foo(ref a: felt252, b: felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn f(ref a: felt252, b: felt252) -> felt252 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn g(ref a: felt252, b: felt252) -> (felt252,) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn h(ref a: felt252, b: felt252) -> (felt252, felt252) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn i(ref a: felt252, b: felt252) -> ((felt252,),) nopanic;
 
 //! > semantic_diagnostics
@@ -61,6 +65,7 @@ enum MyEnum {
     B: (felt252,),
     C: (felt252, felt252),
 }
+#[allow(extern_outside_corelib)]
 extern fn f(ref a: felt252, b: felt252) -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -118,6 +123,7 @@ enum MyEnum {
     B: (felt252,),
     C: (felt252, felt252),
 }
+#[allow(extern_outside_corelib)]
 extern fn f(a: felt252, b: felt252) -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -175,6 +181,7 @@ enum MyEnum {
     B: (felt252,),
     C: (felt252, felt252),
 }
+#[allow(extern_outside_corelib)]
 extern fn f(ref a: felt252, b: felt252) -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -233,6 +240,7 @@ enum MyEnum {
     B: (felt252,),
     C: (felt252, felt252),
 }
+#[allow(extern_outside_corelib)]
 extern fn f(ref a: felt252, b: felt252) -> MyEnum implicits(RangeCheck) nopanic;
 
 //! > semantic_diagnostics
@@ -290,6 +298,7 @@ enum MyEnum {
     B: (felt252,),
     C: (felt252, felt252),
 }
+#[allow(extern_outside_corelib)]
 extern fn f(ref a: felt252, b: felt252) -> MyEnum implicits(RangeCheck) nopanic;
 
 //! > semantic_diagnostics
@@ -344,6 +353,7 @@ foo
 enum MyEnum {
     A: felt252,
 }
+#[allow(extern_outside_corelib)]
 extern fn f(ref arr: Array<felt252>, ref b: (felt252,)) -> MyEnum nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/generics
+++ b/crates/cairo-lang-lowering/src/test_data/generics
@@ -23,6 +23,7 @@ impl MyImpl of MyTrait<felt252> {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn immovable<T>(t: T) -> T nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/if
+++ b/crates/cairo-lang-lowering/src/test_data/if
@@ -331,6 +331,7 @@ enum MyEnum {
     B,
     C,
 }
+#[allow(extern_outside_corelib)]
 extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -402,6 +403,7 @@ enum MyEnum {
     B,
     C,
 }
+#[allow(extern_outside_corelib)]
 extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -510,6 +512,7 @@ enum MyEnum {
     B,
     C,
 }
+#[allow(extern_outside_corelib)]
 extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/let_else
+++ b/crates/cairo-lang-lowering/src/test_data/let_else
@@ -12,6 +12,7 @@ fn foo(a: MyEnum) {
     bar(x);
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar(x: felt252) nopanic;
 
 //! > function_name
@@ -66,6 +67,7 @@ fn foo(a: MyEnum) {
     bar(x + y + z);
 }
 
+#[allow(extern_outside_corelib)]
 extern fn bar(x: felt252) nopanic;
 
 //! > function_name

--- a/crates/cairo-lang-lowering/src/test_data/logical_operator
+++ b/crates/cairo-lang-lowering/src/test_data/logical_operator
@@ -12,6 +12,7 @@ fn foo(a: bool, b: bool) -> bool {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn extern_get_bool() -> bool nopanic;
 #[inline(never)]
 fn get_bool() -> bool {

--- a/crates/cairo-lang-lowering/src/test_data/match
+++ b/crates/cairo-lang-lowering/src/test_data/match
@@ -547,6 +547,7 @@ enum A {
     Three: (),
 }
 
+#[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
 
 //! > semantic_diagnostics
@@ -692,6 +693,7 @@ enum A {
     Two: (),
 }
 
+#[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
 
 //! > semantic_diagnostics
@@ -1429,6 +1431,7 @@ enum A {
     Three: (),
     Four: (),
 }
+#[allow(extern_outside_corelib)]
 extern fn get_bool() -> bool nopanic;
 
 //! > semantic_diagnostics
@@ -3152,6 +3155,7 @@ enum A {
     One: Option<Option<felt252>>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
 
 //! > semantic_diagnostics
@@ -3228,6 +3232,7 @@ enum A {
     One: @Option<@@Option<@felt252>>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
 
 //! > semantic_diagnostics
@@ -3466,6 +3471,7 @@ foo
 //! > module_code
 enum A {}
 
+#[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/members
+++ b/crates/cairo-lang-lowering/src/test_data/members
@@ -25,6 +25,7 @@ struct B {
 struct C {
     f: felt252,
 }
+#[allow(extern_outside_corelib)]
 extern fn mutate(ref f: felt252) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/rebindings
+++ b/crates/cairo-lang-lowering/src/test_data/rebindings
@@ -14,6 +14,7 @@ fn foo(ref a: felt252, b: felt252, c: felt252) -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar() -> felt252 nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/repr_ptr
+++ b/crates/cairo-lang-lowering/src/test_data/repr_ptr
@@ -17,7 +17,9 @@ struct Point {
     x: u32,
     y: u32,
 }
+#[allow(extern_outside_corelib)]
 extern fn bar(x: &u32) nopanic;
+#[allow(extern_outside_corelib)]
 extern fn baz(y: &u32) nopanic;
 
 //! > semantic_diagnostics
@@ -55,6 +57,7 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar(x: &u32, y: &&u32, z: &&&u32) nopanic;
 
 //! > semantic_diagnostics
@@ -93,6 +96,7 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar(x: &u32) nopanic;
 
 //! > semantic_diagnostics
@@ -125,6 +129,7 @@ fn foo(x: @u32) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar(x: &@u32) nopanic;
 
 //! > semantic_diagnostics
@@ -160,6 +165,7 @@ fn foo(opt: Option<u32>) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar(x: &u32) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/snapshot
+++ b/crates/cairo-lang-lowering/src/test_data/snapshot
@@ -12,6 +12,7 @@ fn foo(x: felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar(x: @felt252) nopanic;
 
 //! > semantic_diagnostics
@@ -208,6 +209,7 @@ foo
 struct A {
     b: usize,
 }
+#[allow(extern_outside_corelib)]
 extern fn bar(x: @usize) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/struct
+++ b/crates/cairo-lang-lowering/src/test_data/struct
@@ -165,7 +165,9 @@ struct MyStruct {
     a: (),
     c: (felt252, felt252),
 }
+#[allow(extern_outside_corelib)]
 extern fn f1() -> felt252 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn f2() -> (felt252, felt252) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/while
+++ b/crates/cairo-lang-lowering/src/test_data/while
@@ -130,6 +130,7 @@ enum MyEnum {
     B,
     C,
 }
+#[allow(extern_outside_corelib)]
 extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -190,6 +191,7 @@ enum MyEnum {
     B,
     C,
 }
+#[allow(extern_outside_corelib)]
 extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
@@ -251,6 +253,7 @@ enum MyEnum {
     B,
     C,
 }
+#[allow(extern_outside_corelib)]
 extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-plugins/src/test_data/derive
+++ b/crates/cairo-lang-plugins/src/test_data/derive
@@ -734,6 +734,7 @@ struct NonSimplePath {}
 fn unsupportedItem() {}
 
 #[derive(Clone)]
+#[allow(extern_outside_corelib)]
 extern type NotCloneable;
 
 #[derive(Default)]
@@ -767,6 +768,7 @@ struct NonSimplePath {}
 fn unsupportedItem() {}
 
 #[derive(Clone)]
+#[allow(extern_outside_corelib)]
 extern type NotCloneable;
 
 #[derive(Default)]
@@ -826,12 +828,12 @@ error: `derive` may only be applied to `struct`s and `enum`s
 
 
 error: derive `Default` for enum only supported with a default variant.
- --> test_src/lib.cairo:19:10
+ --> test_src/lib.cairo:20:10
 #[derive(Default)]
          ^^^^^^^
 
 
 error: Multiple variants annotated with `#[default]`
- --> test_src/lib.cairo:29:5
+ --> test_src/lib.cairo:30:5
     #[default]
     ^^^^^^^^^^

--- a/crates/cairo-lang-plugins/src/test_data/panicable
+++ b/crates/cairo-lang-plugins/src/test_data/panicable
@@ -6,10 +6,12 @@ test_expand_plugin(expect_diagnostics: false)
 //! > cairo_code
 #[feature("deprecated-panic-with")]
 #[panic_with('1', foo_improved)]
+#[allow(extern_outside_corelib)]
 extern fn foo(a: felt252, ref b: other) -> Option<()> implicits(RangeCheck, GasBuiltin) nopanic;
 
 #[feature("deprecated-panic-with")]
 #[panic_with('2', bar_changed)]
+#[allow(extern_outside_corelib)]
 extern fn bar() -> Result<felt252, Err> nopanic;
 
 #[feature("deprecated-panic-with")]
@@ -20,6 +22,7 @@ fn non_extern(_a: some_type) -> Option<(felt252, other)> nopanic {
 
 #[feature("deprecated-panic-with")]
 #[panic_with('4', generic_panic)]
+#[allow(extern_outside_corelib)]
 extern fn generic<T>(t: T, v: felt252) -> Result<T, Err> nopanic;
 
 #[feature("deprecated-panic-with")]
@@ -31,10 +34,12 @@ fn possibly_panic() -> Result<felt252, Err> {
 //! > expanded_cairo_code
 #[feature("deprecated-panic-with")]
 #[panic_with('1', foo_improved)]
+#[allow(extern_outside_corelib)]
 extern fn foo(a: felt252, ref b: other) -> Option<()> implicits(RangeCheck, GasBuiltin) nopanic;
 
 #[feature("deprecated-panic-with")]
 #[panic_with('2', bar_changed)]
+#[allow(extern_outside_corelib)]
 extern fn bar() -> Result<felt252, Err> nopanic;
 
 #[feature("deprecated-panic-with")]
@@ -45,6 +50,7 @@ fn non_extern(_a: some_type) -> Option<(felt252, other)> nopanic {
 
 #[feature("deprecated-panic-with")]
 #[panic_with('4', generic_panic)]
+#[allow(extern_outside_corelib)]
 extern fn generic<T>(t: T, v: felt252) -> Result<T, Err> nopanic;
 
 #[feature("deprecated-panic-with")]
@@ -94,30 +100,38 @@ test_expand_plugin(expect_diagnostics: true)
 
 //! > cairo_code
 #[panic_with(123, foo_bad_err_code)]
+#[allow(extern_outside_corelib)]
 extern fn foo(a: felt252, b: other) -> Option<()> implicits(RangeCheck, GasBuiltin) nopanic;
 
 #[panic_with(missing_args)]
+#[allow(extern_outside_corelib)]
 extern fn non_extern(_a: some_type) -> Option<(felt252, other)> nopanic;
 
 #[panic_with(missing_args)]
+#[allow(extern_outside_corelib)]
 extern fn bad_ret_type(_a: some_type) -> felt252 nopanic;
 
 #[panic_with('2', bar_changed)]
 #[panic_with('3', bar_changed)]
+#[allow(extern_outside_corelib)]
 extern fn bar() -> Result<felt252, Err> nopanic;
 
 //! > expanded_cairo_code
 #[panic_with(123, foo_bad_err_code)]
+#[allow(extern_outside_corelib)]
 extern fn foo(a: felt252, b: other) -> Option<()> implicits(RangeCheck, GasBuiltin) nopanic;
 
 #[panic_with(missing_args)]
+#[allow(extern_outside_corelib)]
 extern fn non_extern(_a: some_type) -> Option<(felt252, other)> nopanic;
 
 #[panic_with(missing_args)]
+#[allow(extern_outside_corelib)]
 extern fn bad_ret_type(_a: some_type) -> felt252 nopanic;
 
 #[panic_with('2', bar_changed)]
 #[panic_with('3', bar_changed)]
+#[allow(extern_outside_corelib)]
 extern fn bar() -> Result<felt252, Err> nopanic;
 
 //! > expected_diagnostics
@@ -134,36 +148,36 @@ error: Failed to extract panic data attribute
 
 
 error: Usage of deprecated macro `panic_with` with no `#[feature("deprecated-panic-with")]` attribute. Use simple calculations instead, as these are supported in const context.
- --> test_src/lib.cairo:4:1
+ --> test_src/lib.cairo:5:1
 #[panic_with(missing_args)]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Failed to extract panic data attribute
- --> test_src/lib.cairo:4:1
+ --> test_src/lib.cairo:5:1
 #[panic_with(missing_args)]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Usage of deprecated macro `panic_with` with no `#[feature("deprecated-panic-with")]` attribute. Use simple calculations instead, as these are supported in const context.
- --> test_src/lib.cairo:7:1
+ --> test_src/lib.cairo:9:1
 #[panic_with(missing_args)]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: Currently only wrapping functions returning an Option<T> or Result<T, E>
- --> test_src/lib.cairo:8:39
+ --> test_src/lib.cairo:11:39
 extern fn bad_ret_type(_a: some_type) -> felt252 nopanic;
                                       ^^^^^^^^^^
 
 
 error: Usage of deprecated macro `panic_with` with no `#[feature("deprecated-panic-with")]` attribute. Use simple calculations instead, as these are supported in const context.
- --> test_src/lib.cairo:10:1
+ --> test_src/lib.cairo:13:1
 #[panic_with('2', bar_changed)]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 error: `#[panic_with]` cannot be applied multiple times to the same item.
- --> test_src/lib.cairo:11:1
+ --> test_src/lib.cairo:14:1
 #[panic_with('3', bar_changed)]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-runner/src/profiling_test_data/profiling
+++ b/crates/cairo-lang-runner/src/profiling_test_data/profiling
@@ -335,6 +335,7 @@ test_profiling
 //! > cairo_code
 use core::num::traits::WrappingAdd;
 
+#[allow(extern_outside_corelib)]
 extern fn coupon_buy<T>() -> T nopanic;
 
 fn add_with_coupon(a: u128, b: u128) -> u128 {

--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -8,7 +8,9 @@ use cairo_lang_defs::ids::{
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder, Maybe};
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CrateId, CrateInput, FileId, FileLongId, SmolStrId, Tracked};
-use cairo_lang_syntax::attribute::consts::{DEPRECATED_ATTR, UNUSED_IMPORTS, UNUSED_VARIABLES};
+use cairo_lang_syntax::attribute::consts::{
+    DEPRECATED_ATTR, EXTERN_OUTSIDE_CORELIB, UNUSED_IMPORTS, UNUSED_VARIABLES,
+};
 use cairo_lang_syntax::node::{TypedStablePtr, ast};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
@@ -349,7 +351,7 @@ fn crate_analyzer_plugins<'db>(
 
 #[salsa::tracked]
 fn declared_allows(db: &dyn Database, crate_id: CrateId<'_>) -> Arc<OrderedHashSet<String>> {
-    let base_lints = [DEPRECATED_ATTR, UNUSED_IMPORTS, UNUSED_VARIABLES];
+    let base_lints = [DEPRECATED_ATTR, UNUSED_IMPORTS, UNUSED_VARIABLES, EXTERN_OUTSIDE_CORELIB];
 
     let crate_analyzer_plugins = db.crate_analyzer_plugins(crate_id);
 

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -804,6 +804,12 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::PanicableExternFunction => {
                 "An extern function must be marked as nopanic.".into()
             }
+            SemanticDiagnosticKind::ExternItemOutsideCorelib => {
+                "Extern types and functions are expected only in the core library. To allow them, \
+                 use `#[allow(extern_outside_corelib)]`, but note that they may cause compiler \
+                 crashes."
+                    .into()
+            }
             SemanticDiagnosticKind::PluginDiagnostic(diagnostic) => {
                 format!("Plugin diagnostic: {}", diagnostic.message)
             }
@@ -1238,6 +1244,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             | SemanticDiagnosticKind::UnusedConstant
             | SemanticDiagnosticKind::UnusedUse
             | SemanticDiagnosticKind::PatternMissingArgs(_)
+            | SemanticDiagnosticKind::ExternItemOutsideCorelib
             | SemanticDiagnosticKind::UnsupportedAllowAttrArguments => Severity::Warning,
             SemanticDiagnosticKind::PluginDiagnostic(diag) => diag.severity,
             _ => Severity::Error,
@@ -1468,6 +1475,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::NonNeverLetElseType => error_code!(E2195),
             SemanticDiagnosticKind::OnlyTypeOrConstParamsInNegImpl => error_code!(E2196),
             SemanticDiagnosticKind::UnsupportedItemInStatement => error_code!(E2197),
+            SemanticDiagnosticKind::ExternItemOutsideCorelib => error_code!(E2201),
             SemanticDiagnosticKind::PluginDiagnostic(diag) => {
                 diag.error_code.unwrap_or(error_code!(E2200))
             }
@@ -1763,6 +1771,7 @@ pub enum SemanticDiagnosticKind<'db> {
     },
     PanicableFromNonPanicable,
     PanicableExternFunction,
+    ExternItemOutsideCorelib,
     MacroGeneratedCodeParserDiagnostic(ParserDiagnostic<'db>),
     PluginDiagnostic(PluginDiagnostic<'db>),
     NameDefinedMultipleTimes(SmolStrId<'db>),

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -109,6 +109,7 @@ impl MacroPlugin for AddInlineModuleDummyPlugin {
                 builder.add_modified(RewriteNode::interpolate_patched(
                     indoc! {"
                         mod inner_mod {{
+                            #[allow(extern_outside_corelib)]
                             extern type NewType;
                             // Comment 1.
                             // Comment $$.

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/allow
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/allow
@@ -187,3 +187,55 @@ mod broad_parent {
 //! > function_body
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test extern type/function declared outside the corelib produces a warning.
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: warnings_only)
+
+//! > expr_code
+{}
+
+//! > module_code
+extern fn extern_func() nopanic;
+extern type ExternType;
+
+//! > generated_cairo_code
+
+//! > function_body
+
+//! > expected_diagnostics
+warning[E2201]: Extern types and functions are expected only in the core library. To allow them, use `#[allow(extern_outside_corelib)]`, but note that they may cause compiler crashes.
+ --> lib.cairo:1:1
+extern fn extern_func() nopanic;
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning[E2201]: Extern types and functions are expected only in the core library. To allow them, use `#[allow(extern_outside_corelib)]`, but note that they may cause compiler crashes.
+ --> lib.cairo:2:1
+extern type ExternType;
+^^^^^^^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test allow(extern_outside_corelib) silences the extern warning.
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: false)
+
+//! > expr_code
+{}
+
+//! > module_code
+#[allow(extern_outside_corelib)]
+extern fn extern_func() nopanic;
+
+#[allow(extern_outside_corelib)]
+extern type ExternType;
+
+//! > generated_cairo_code
+
+//! > function_body
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/inline
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/inline
@@ -111,9 +111,11 @@ test_expr_diagnostics
 
 //! > module_code
 #[inline(always)]
+#[allow(extern_outside_corelib)]
 extern fn foo() nopanic;
 
 #[inline(never)]
+#[allow(extern_outside_corelib)]
 extern fn bar() nopanic;
 
 //! > function_body
@@ -125,6 +127,6 @@ error[E2142]: `inline` attribute is not allowed for extern functions.
 ^^^^^^^^^^^^^^^^^
 
 error[E2142]: `inline` attribute is not allowed for extern functions.
- --> lib.cairo:4:1
+ --> lib.cairo:5:1
 #[inline(never)]
 ^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/coupon
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/coupon
@@ -7,6 +7,7 @@ test_expr_semantics
 fn foo(x: u8) {
     6;
 }
+#[allow(extern_outside_corelib)]
 extern fn get_coupon() -> foo::Coupon nopanic;
 
 //! > expr_code

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/use
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/use
@@ -410,7 +410,9 @@ test_expr_semantics(expect_diagnostics: false)
 
 //! > module_code
 mod X {
+    #[allow(extern_outside_corelib)]
     extern type R;
+    #[allow(extern_outside_corelib)]
     extern fn new_r() -> R nopanic;
 }
 use X::{R as RR, new_r};
@@ -480,7 +482,9 @@ test_expr_semantics(expect_diagnostics: warnings_only)
 
 //! > module_code
 mod X {
+    #[allow(extern_outside_corelib)]
     extern type R<T>;
+    #[allow(extern_outside_corelib)]
     extern fn new_r<T>() -> R<T> nopanic;
 }
 use X::{R as RR, new_r};
@@ -541,12 +545,12 @@ Block(
 
 //! > expected_diagnostics
 warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:8:9
+ --> lib.cairo:10:9
     let y: RR::<u8> = new_r();
         ^
 
 warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:10:9
+ --> lib.cairo:12:9
     let x: R::<u16> = new_r();
         ^
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/assignment
+++ b/crates/cairo-lang-semantic/src/expr/test_data/assignment
@@ -17,31 +17,32 @@ fn foo(p: felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type MyType;
 
 //! > expected_diagnostics
 error[E2083]: Cannot assign to an immutable variable.
- --> lib.cairo:3:5
+ --> lib.cairo:4:5
     p = 7;
     ^^^^^
 
 error[E0006]: Identifier not found.
- --> lib.cairo:4:5
+ --> lib.cairo:5:5
     a = 1 + 2;
     ^
 
 error[E2084]: Invalid left-hand side of assignment.
- --> lib.cairo:4:5
+ --> lib.cairo:5:5
     a = 1 + 2;
     ^
 
 error[E2083]: Cannot assign to an immutable variable.
- --> lib.cairo:6:24
+ --> lib.cairo:7:24
     let _c: felt252 = (b = 5);
                        ^^^^^
 
 error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "()".
- --> lib.cairo:6:23
+ --> lib.cairo:7:23
     let _c: felt252 = (b = 5);
                       ^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -930,12 +930,13 @@ fn foo() {}
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern const fn f() -> felt252 nopanic;
 const X: felt252 = f();
 
 //! > expected_diagnostics
 error[E2127]: This expression is not supported as constant.
- --> lib.cairo:2:20
+ --> lib.cairo:3:20
 const X: felt252 = f();
                    ^^^
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/coupon
+++ b/crates/cairo-lang-semantic/src/expr/test_data/coupon
@@ -20,6 +20,7 @@ fn foo(x: foo::Coupon) {
     x.a;
 }
 
+#[allow(extern_outside_corelib)]
 extern fn extern_func() nopanic;
 
 //! > function_name

--- a/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
+++ b/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
@@ -234,6 +234,7 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar<const N: usize>() -> [felt252; N] nopanic;
 
 //! > expected_diagnostics
@@ -254,11 +255,12 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar<const N: usize>() -> [felt252; N] nopanic;
 
 //! > expected_diagnostics
 error[E2108]: Wrong number of fixed size array elements in pattern. Expected: 3. Got: 2.
- --> lib.cairo:3:9
+ --> lib.cairo:4:9
     let [_a, _b] = bar::<3>();
         ^^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/generics
+++ b/crates/cairo-lang-semantic/src/expr/test_data/generics
@@ -4,7 +4,9 @@
 test_function_diagnostics(expect_diagnostics: true)
 
 //! > function_code
+#[allow(extern_outside_corelib)]
 extern type A<S>;
+#[allow(extern_outside_corelib)]
 extern fn bar<T>(x: T) -> A<T> nopanic;
 
 fn foo(a: A<felt252>) -> A<A<felt252>> {
@@ -18,7 +20,7 @@ foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::A::<test::A::<core::bool>>", found: "test::A::<test::A::<core::felt252>>".
- --> lib.cairo:6:28
+ --> lib.cairo:8:28
     let _bad: A<A<bool>> = res;
                            ^^^
 
@@ -165,9 +167,13 @@ fn foo() {
 trait MyTrait<T> {}
 impl MyImpl of MyTrait<felt252> {}
 fn bar<impl C: MyTrait<felt252>>() {}
+#[allow(extern_outside_corelib)]
 extern type A<impl C: MyTrait<felt252>>;
+#[allow(extern_outside_corelib)]
 extern type B<T>;
+#[allow(extern_outside_corelib)]
 extern fn hoo<impl C: MyTrait<felt252>>() nopanic;
+#[allow(extern_outside_corelib)]
 extern fn ioo<T, impl C: MyTrait<felt252>, S>() nopanic;
 
 
@@ -179,12 +185,12 @@ foo
 
 //! > expected_diagnostics
 error[E2132]: Extern types with impl generics are not supported.
- --> lib.cairo:4:15
+ --> lib.cairo:5:15
 extern type A<impl C: MyTrait<felt252>>;
               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2134]: Expected an impl of `test::MyTrait::<core::felt252>`. Got an impl of `test::AnotherTrait::<core::felt252>`.
- --> lib.cairo:14:11
+ --> lib.cairo:18:11
     bar::<AnotherImpl>();
           ^^^^^^^^^^^
 
@@ -283,6 +289,7 @@ fn foo() {
 //! > module_code
 struct MyStruct<S, T> {}
 
+#[allow(extern_outside_corelib)]
 extern fn bar<S, T>() -> MyStruct<S, T> nopanic;
 
 //! > function_name
@@ -290,7 +297,7 @@ foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::MyStruct::<core::felt252, core::integer::u8>", found: "test::MyStruct::<core::integer::u16, core::integer::u32>".
- --> lib.cairo:8:9
+ --> lib.cairo:9:9
     x = bar::<u16, u32>();
         ^^^^^^^^^^^^^^^^^
 
@@ -579,6 +586,7 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar<const M: felt252>() nopanic;
 
 //! > function_body
@@ -601,7 +609,9 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type S<const N: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn bar() -> S<{ 3 + 8 }> nopanic;
 const K: felt252 = 98;
 mod A {
@@ -614,12 +624,12 @@ mod A {
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::S::<-1>", found: "test::S::<11>".
- --> lib.cairo:10:28
+ --> lib.cairo:12:28
     let _s: S<{ 1 - 2 }> = bar();
                            ^^^^^
 
 error[E2041]: Unexpected argument type. Expected: "test::S::<107>", found: "test::S::<11>".
- --> lib.cairo:6:46
+ --> lib.cairo:8:46
         let _x: super::S<{ super::K + 9 }> = super::bar();
                                              ^^^^^^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/operators
+++ b/crates/cairo-lang-semantic/src/expr/test_data/operators
@@ -12,11 +12,12 @@ fn foo(a: MyType) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern type MyType;
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: core::traits::Add::<test::MyType>.
- --> lib.cairo:3:5
+ --> lib.cairo:4:5
     a + a * a;
     ^^^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/items/extern_function.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_function.rs
@@ -14,6 +14,7 @@ use salsa::Database;
 use super::function_with_body::get_inline_config;
 use super::functions::{FunctionDeclarationData, GenericFunctionId, InlineConfiguration};
 use super::generics::{GenericParamsData, semantic_generic_params};
+use super::report_extern_item_outside_corelib;
 use crate::corelib::get_core_generic_function_id;
 use crate::diagnostic::SemanticDiagnosticKind::*;
 use crate::diagnostic::{SemanticDiagnostics, SemanticDiagnosticsBuilder};
@@ -96,6 +97,8 @@ fn priv_extern_function_declaration_data<'db>(
         FunctionTitleId::Extern(extern_function_id),
         &mut environment,
     );
+
+    report_extern_item_outside_corelib(db, &mut diagnostics, &resolver, &extern_function_syntax);
 
     if signature.panicable {
         let panic_function = extract_matches!(

--- a/crates/cairo-lang-semantic/src/items/extern_function_test.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_function_test.rs
@@ -16,6 +16,7 @@ fn test_extern_function() {
     let test_module = setup_test_module(
         db,
         indoc::indoc! {"
+            #[allow(extern_outside_corelib)]
             extern fn foo<A, B>() nopanic;
         "},
     )

--- a/crates/cairo-lang-semantic/src/items/extern_type.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_type.rs
@@ -11,6 +11,7 @@ use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 use salsa::Database;
 
 use super::generics::{GenericParamsData, semantic_generic_params};
+use super::report_extern_item_outside_corelib;
 use crate::diagnostic::SemanticDiagnosticKind::*;
 use crate::diagnostic::{SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::inference::InferenceId;
@@ -96,6 +97,7 @@ fn extern_type_declaration_data<'db>(
         (*generic_params_data.resolver_data).clone_with_inference_id(db, inference_id),
     );
     diagnostics.extend(generic_params_data.diagnostics.clone());
+    report_extern_item_outside_corelib(db, &mut diagnostics, &resolver, &extern_type_syntax);
     let attributes = extern_type_syntax.attributes(db).structurize(db);
 
     // Check fully resolved.

--- a/crates/cairo-lang-semantic/src/items/extern_type_test.rs
+++ b/crates/cairo-lang-semantic/src/items/extern_type_test.rs
@@ -16,6 +16,7 @@ fn test_extern_type() {
     let test_module = setup_test_module(
         db,
         indoc::indoc! {"
+            #[allow(extern_outside_corelib)]
             extern type S<A, B>;
         "},
     )

--- a/crates/cairo-lang-semantic/src/items/mod.rs
+++ b/crates/cairo-lang-semantic/src/items/mod.rs
@@ -1,12 +1,15 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{ImplDefId, TraitId};
 use cairo_lang_diagnostics::Maybe;
-use cairo_lang_syntax::node::TypedSyntaxNode;
+use cairo_lang_filesystem::ids::SmolStrId;
+use cairo_lang_syntax::attribute::consts::EXTERN_OUTSIDE_CORELIB;
 use cairo_lang_syntax::node::ast::ExprPath;
+use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::try_extract_matches;
 use salsa::Database;
 
-use crate::diagnostic::SemanticDiagnosticKind::NotATrait;
+use crate::corelib::CorelibSemantic;
+use crate::diagnostic::SemanticDiagnosticKind::{ExternItemOutsideCorelib, NotATrait};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::resolve::{ResolutionContext, ResolvedGenericItem, Resolver};
 
@@ -55,6 +58,24 @@ fn resolve_trait_path<'db>(
         ResolvedGenericItem::Trait
     )
     .ok_or_else(|| diagnostics.report(trait_path_syntax.stable_ptr(db), NotATrait))
+}
+
+/// Reports a warning if an extern type or function is declared outside the core library, unless the
+/// `extern_outside_corelib` lint is allowed for the item.
+fn report_extern_item_outside_corelib<'db>(
+    db: &'db dyn Database,
+    diagnostics: &mut SemanticDiagnostics<'db>,
+    resolver: &Resolver<'db>,
+    item: &impl TypedSyntaxNode<'db>,
+) {
+    if resolver.owning_crate_id == db.core_crate() {
+        return;
+    }
+    if resolver.feature_config.allowed_lints.contains(&SmolStrId::from(db, EXTERN_OUTSIDE_CORELIB))
+    {
+        return;
+    }
+    diagnostics.report(item.stable_ptr(db).untyped(), ExternItemOutsideCorelib);
 }
 
 /// A context of a trait or an impl, if in any of those. This is used in the resolver to resolve

--- a/crates/cairo-lang-semantic/src/items/tests/extern_func
+++ b/crates/cairo-lang-semantic/src/items/tests/extern_func
@@ -12,15 +12,18 @@ fn foo() {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn bar() -> bad_type;
 
 //! > expected_diagnostics
 error[E0006]: Type not found.
- --> lib.cairo:1:20
+ --> lib.cairo:2:20
 extern fn bar() -> bad_type;
                    ^^^^^^^^
 
 error[E2116]: An extern function must be marked as nopanic.
- --> lib.cairo:1:1
-extern fn bar() -> bad_type;
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:1:1-2:28
+  #[allow(extern_outside_corelib)]
+ _^
+| extern fn bar() -> bad_type;
+|____________________________^

--- a/crates/cairo-lang-semantic/src/items/tests/trait
+++ b/crates/cairo-lang-semantic/src/items/tests/trait
@@ -20,7 +20,9 @@ impl MyImpl of MyTrait::<A>;
 impl MyImpl2<T> of MyTrait::<T> {
     mod a;
     use b;
+    #[allow(extern_outside_corelib)]
     extern fn extern_func() nopanic;
+    #[allow(extern_outside_corelib)]
     extern type DummyType;
 
     trait DummyTrait;
@@ -48,22 +50,22 @@ impl abc of abc;
 
 //! > expected_diagnostics
 error[E1001]: Missing token '='.
- --> lib.cairo:16:20
+ --> lib.cairo:18:20
     impl DummyImpl2 of MyTrait::<T>;
                    ^
 
 error[E1001]: Missing token ';'.
- --> lib.cairo:16:23
+ --> lib.cairo:18:23
     impl DummyImpl2 of MyTrait::<T>;
                       ^
 
 error[E1013]: 'of' is a reserved identifier.
- --> lib.cairo:16:21
+ --> lib.cairo:18:21
     impl DummyImpl2 of MyTrait::<T>;
                     ^^
 
 error[E1000]: Skipped tokens. Expected: Const/Function/Impl/Type or an attribute.
- --> lib.cairo:16:24
+ --> lib.cairo:18:24
     impl DummyImpl2 of MyTrait::<T>;
                        ^^^^^^^^^^^^^
 
@@ -88,32 +90,32 @@ error[E2112]: `use` is not allowed inside impl.
     ^^^
 
 error[E2112]: `extern` is not allowed inside impl.
- --> lib.cairo:11:5
+ --> lib.cairo:12:5
     extern fn extern_func() nopanic;
     ^^^^^^
 
 error[E2112]: `extern` is not allowed inside impl.
- --> lib.cairo:12:5
+ --> lib.cairo:14:5
     extern type DummyType;
     ^^^^^^
 
 error[E2112]: `trait` is not allowed inside impl.
- --> lib.cairo:14:5
+ --> lib.cairo:16:5
     trait DummyTrait;
     ^^^^^
 
 error[E2112]: `struct` is not allowed inside impl.
- --> lib.cairo:18:5
+ --> lib.cairo:20:5
     struct DummyStruct {}
     ^^^^^^
 
 error[E2112]: `enum` is not allowed inside impl.
- --> lib.cairo:20:5
+ --> lib.cairo:22:5
     enum DummyEnum {}
     ^^^^
 
 error[E2014]: Impl item function `MyImpl2::my_bar` is not a member of trait `MyTrait`.
- --> lib.cairo:22:5-24:5
+ --> lib.cairo:24:5-26:5
       fn my_bar() {
  _____^
 | 
@@ -121,27 +123,27 @@ error[E2014]: Impl item function `MyImpl2::my_bar` is not a member of trait `MyT
 |_____^
 
 error[E2029]: The number of parameters in the impl function `MyImpl2::param_test` is incompatible with `MyTrait::param_test`. Expected: 1, actual: 3.
- --> lib.cairo:26:19
+ --> lib.cairo:28:19
     fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2031]: Parameter type of impl function `MyImpl2::param_test` is incompatible with `MyTrait::param_test`. Expected: `core::integer::u128`, actual: `core::felt252`.
- --> lib.cairo:26:22
+ --> lib.cairo:28:22
     fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
                      ^^^^^^^
 
 error[E2034]: Parameter of impl function MyImpl2::param_test is incompatible with MyTrait::param_test. It should be a reference.
- --> lib.cairo:26:19
+ --> lib.cairo:28:19
     fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
                   ^
 
 error[E2113]: The signature of function `param_test` is incompatible with trait `MyTrait`. The trait function is declared as nopanic.
- --> lib.cairo:26:18
+ --> lib.cairo:28:18
     fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "()".
- --> lib.cairo:26:63-28:5
+ --> lib.cairo:28:63-30:5
       fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
  _______________________________________________________________^
 | 
@@ -149,32 +151,32 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "(
 |_____^
 
 error[E2035]: Parameter of impl function MyImpl2::no_ret_ty is incompatible with MyTrait::no_ret_ty. It should not be a reference.
- --> lib.cairo:30:18
+ --> lib.cairo:32:18
     fn no_ret_ty(ref a: u128) {
                  ^^^
 
 error[E2045]: Return type of impl function `MyImpl2::no_ret_ty` is incompatible with `MyTrait::no_ret_ty`. Expected: `core::felt252`, actual: `()`.
- --> lib.cairo:30:31
+ --> lib.cairo:32:31
     fn no_ret_ty(ref a: u128) {
                               ^
 
 error[E2014]: Impl item impl `MyImpl2::DummyImpl1` is not a member of trait `MyTrait`.
- --> lib.cairo:15:5
+ --> lib.cairo:17:5
     impl DummyImpl1 = MyImpl;
     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2014]: Impl item impl `MyImpl2::DummyImpl2` is not a member of trait `MyTrait`.
- --> lib.cairo:16:5
+ --> lib.cairo:18:5
     impl DummyImpl2 of MyTrait::<T>;
     ^^^^^^^^^^^^^^^
 
 error[E0006]: Impl not found.
- --> lib.cairo:16:21
+ --> lib.cairo:18:21
     impl DummyImpl2 of MyTrait::<T>;
                     ^
 
 error[E2012]: Not a trait.
- --> lib.cairo:35:13
+ --> lib.cairo:37:13
 impl abc of abc;
             ^^^
 
@@ -234,6 +236,7 @@ enum D {
     X: felt252,
     Y: NonCopy,
 }
+#[allow(extern_outside_corelib)]
 extern type E;
 
 impl ACopy of Copy<A>;
@@ -253,32 +256,32 @@ impl T2Drop of Drop<(felt252, NonCopy)>;
 
 //! > expected_diagnostics
 error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
- --> lib.cairo:19:1
+ --> lib.cairo:20:1
 impl CCopy of Copy<C>;
 ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
- --> lib.cairo:20:1
+ --> lib.cairo:21:1
 impl CDrop of Drop<C>;
 ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
- --> lib.cairo:21:1
+ --> lib.cairo:22:1
 impl DCopy of Copy<D>;
 ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
- --> lib.cairo:22:1
+ --> lib.cairo:23:1
 impl DDrop of Drop<D>;
 ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
- --> lib.cairo:27:1
+ --> lib.cairo:28:1
 impl T2Copy of Copy<(felt252, NonCopy)>;
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
- --> lib.cairo:28:1
+ --> lib.cairo:29:1
 impl T2Drop of Drop<(felt252, NonCopy)>;
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/crates/cairo-lang-semantic/src/resolve/test.rs
+++ b/crates/cairo-lang-semantic/src/resolve/test.rs
@@ -24,7 +24,9 @@ fn test_resolve_path() {
         db,
         indoc! {"
             use core::Box;
+            #[allow(extern_outside_corelib)]
             extern type S<T>;
+            #[allow(extern_outside_corelib)]
             extern fn bar<T>(value: S::<felt252>) -> S::<()> nopanic;
 
             fn foo<Q>(value: S::<felt252>, b: Q, c: Box::<Q>) {

--- a/crates/cairo-lang-semantic/src/test.rs
+++ b/crates/cairo-lang-semantic/src/test.rs
@@ -24,6 +24,7 @@ fn test_resolve() {
         &db_val,
         indoc! {"
             fn foo() -> felt252 { 5 }
+            #[allow(extern_outside_corelib)]
             extern fn felt252_add(a: felt252, b: felt252) -> felt252 nopanic;
         "},
     )

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test_data/function_call
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test_data/function_call
@@ -129,6 +129,7 @@ fn foo() -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn felt252_add(a: felt252, b: felt252) -> felt252 nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-sierra-generator/src/dummy_program_generator_test_data/simple
+++ b/crates/cairo-lang-sierra-generator/src/dummy_program_generator_test_data/simple
@@ -27,6 +27,7 @@ fn baz(x: u32, y: u32) -> u32 {
     bar(x, y, x)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn coupon_refund<T>(c: T) nopanic;
 
 //! > sierra_code

--- a/crates/cairo-lang-sierra-generator/src/function_generator_test_data/generics
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test_data/generics
@@ -13,6 +13,7 @@ foo
 
 //! > module_code
 // Function needs to be a real libfunc for the test
+#[allow(extern_outside_corelib)]
 extern fn span_from_tuple<T, +Copy<T>>(x: Box<@T>) -> @Array<felt252> nopanic;
 
 //! > semantic_diagnostics
@@ -157,6 +158,7 @@ fn bar<Ph>() -> felt252 {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn drop_ph<Ph>(ph: Ph) nopanic;
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-sierra-generator/src/function_generator_test_data/stack_tracking
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test_data/stack_tracking
@@ -57,6 +57,7 @@ fn foo() -> (felt252, felt252) {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn drop<T, +Drop<T>>(value: T) nopanic;
 
 #[inline(never)]

--- a/crates/cairo-lang-sierra-generator/src/local_variables_test_data/e2e
+++ b/crates/cairo-lang-sierra-generator/src/local_variables_test_data/e2e
@@ -169,6 +169,7 @@ fn foo() -> felt252 {
 foo
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn dup<T, +Copy<T>>(value: T) -> (T, T) nopanic;
 
 fn revoke_ap() -> felt252 {

--- a/crates/cairo-lang-sierra-generator/src/local_variables_test_data/simple
+++ b/crates/cairo-lang-sierra-generator/src/local_variables_test_data/simple
@@ -99,6 +99,7 @@ fn foo(x: felt252) -> felt252 {
 }
 
 //! > module_code
+#[allow(extern_outside_corelib)]
 extern fn dup<T, +Copy<T>>(value: T) -> (T, T) nopanic;
 
 // Revokes ap since this function is recursive.

--- a/crates/cairo-lang-sierra-generator/src/program_generator_test_data/coupon
+++ b/crates/cairo-lang-sierra-generator/src/program_generator_test_data/coupon
@@ -4,6 +4,7 @@
 test_program_generator
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn coupon_buy<T>() -> T nopanic;
 
 fn foo() -> bar::<u8>::Coupon {
@@ -42,6 +43,7 @@ test::bar::<core::integer::u8>@F1() -> (felt252);
 test_program_generator
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn coupon_refund<T>(c: T) nopanic;
 
 fn foo(c: bar::<u8>::Coupon) {

--- a/crates/cairo-lang-starknet/cairo_level_tests/contracts/libfuncs_coverage.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/contracts/libfuncs_coverage.cairo
@@ -549,17 +549,29 @@ fn starknet_libfuncs(libfuncs: StarknetLibfuncs) {
     }
 }
 
+#[allow(extern_outside_corelib)]
 extern fn felt252_const<const VALUE: felt252>() -> felt252 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn u8_const<const VALUE: u8>() -> u8 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn u16_const<const VALUE: u16>() -> u16 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn u32_const<const VALUE: u32>() -> u32 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn u64_const<const VALUE: u64>() -> u64 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn u128_const<const VALUE: u128>() -> u128 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn i8_const<const VALUE: i8>() -> i8 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn i16_const<const VALUE: i16>() -> i16 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn i32_const<const VALUE: i32>() -> i32 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn i64_const<const VALUE: i64>() -> i64 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn i128_const<const VALUE: i128>() -> i128 nopanic;
+#[allow(extern_outside_corelib)]
 extern fn bytes31_const<const VALUE: felt252>() -> bytes31 nopanic;
 
 #[feature("deprecated-starknet-consts")]

--- a/crates/cairo-lang-syntax/src/attribute/consts.rs
+++ b/crates/cairo-lang-syntax/src/attribute/consts.rs
@@ -39,6 +39,10 @@ pub const UNUSED_VARIABLES: &str = "unused_variables";
 /// Also included in the [`UNUSED`] lint group.
 pub const UNUSED_IMPORTS: &str = "unused_imports";
 
+/// An argument to the `allow` attribute that suppresses the warning for declaring an extern type or
+/// function outside the core library.
+pub const EXTERN_OUTSIDE_CORELIB: &str = "extern_outside_corelib";
+
 /// An attribute to allow additional attributes on an item.
 pub const ALLOW_ATTR_ATTR: &str = "allow_attr";
 

--- a/tests/bug_samples/issue6968.cairo
+++ b/tests/bug_samples/issue6968.cairo
@@ -1,3 +1,4 @@
+#[allow(extern_outside_corelib)]
 extern fn array_snapshot_pop_front<T>(ref arr: @Array<T>) -> Option<Box<@T>> nopanic;
 
 fn fn1() -> (@Array<felt252>, felt252) {

--- a/tests/e2e_test_data/libfuncs/array
+++ b/tests/e2e_test_data/libfuncs/array
@@ -884,6 +884,7 @@ test::foo@F0([0]: Array<core::integer::u256>) -> (Array<core::integer::u256>, u3
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn span_from_tuple<T>(struct_like: Box<@T>) -> @Array<felt252> nopanic;
 
 fn foo(x1: Box<@(felt252, felt252, felt252)>) -> @Array<felt252> {
@@ -923,6 +924,7 @@ test::foo@F0([0]: Box<Tuple<felt252, felt252, felt252>>) -> (Snapshot<Array<felt
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn tuple_from_span<T>(span: @Array<felt252>) -> Option<@Box<T>> nopanic;
 
 fn foo(span: @Array<felt252>) -> Option<@Box<(felt252, felt252, felt252)>> {

--- a/tests/e2e_test_data/libfuncs/blake
+++ b/tests/e2e_test_data/libfuncs/blake
@@ -189,6 +189,7 @@ use core::blake::{Blake2sInputGuarantee, Blake2sState, blake2s_finalize_guarante
 #[feature("bounded-int-utils")]
 type U32Guarantee =
     core::internal::bounded_int::BoundedIntGuarantee<0, 0xffffffff>;
+#[allow(extern_outside_corelib)]
 extern fn u128_to_u32_guarantees(
     value: u128,
 ) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) nopanic;

--- a/tests/e2e_test_data/libfuncs/bounded_int
+++ b/tests/e2e_test_data/libfuncs/bounded_int
@@ -4,11 +4,13 @@
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 const MIN_I8: felt252 = -128;
 const MAX_I8: felt252 = 127;
 type AddType = BoundedInt<{ MIN_I8 + MIN_I8 }, { MAX_I8 + MAX_I8 }>;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_add<T1, T2>(a: T1, b: T2) -> AddType nopanic;
 
 fn foo(a: i8, b: i8) -> AddType {
@@ -44,11 +46,13 @@ test::foo@F0([0]: i8, [1]: i8) -> (BoundedInt<-256, 254>);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 const MIN_I8: felt252 = -128;
 const MAX_I8: felt252 = 127;
 type SubType = BoundedInt<{ MIN_I8 - MAX_I8 }, { MAX_I8 - MIN_I8 }>;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_sub<T1, T2>(a: T1, b: T2) -> SubType nopanic;
 
 fn foo(a: i8, b: i8) -> SubType {
@@ -84,11 +88,13 @@ test::foo@F0([0]: i8, [1]: i8) -> (BoundedInt<-255, 255>);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 const MIN_I8: felt252 = -128;
 const MAX_I8: felt252 = 127;
 type MulType = BoundedInt<{ MIN_I8 * MAX_I8 }, { MIN_I8 * MIN_I8 }>;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_mul<T1, T2>(a: T1, b: T2) -> MulType nopanic;
 
 fn foo(a: i8, b: i8) -> MulType {
@@ -124,11 +130,13 @@ test::foo@F0([0]: i8, [1]: i8) -> (BoundedInt<-16256, 16384>);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 const MIN_I8: felt252 = -128;
 const MAX_I8: felt252 = 127;
 type MulType = NonZero<BoundedInt<{ MIN_I8 * MAX_I8 }, { MIN_I8 * MIN_I8 }>>;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_mul<T1, T2>(a: T1, b: T2) -> MulType nopanic;
 
 fn foo(a: NonZero<i8>, b: NonZero<i8>) -> MulType {
@@ -166,11 +174,13 @@ test::foo@F0([0]: NonZero<i8>, [1]: NonZero<i8>) -> (NonZero<BoundedInt<-16256, 
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 const MIN_I8: felt252 = -128;
 const MAX_I8: felt252 = 127;
 type AddType = BoundedInt<{ MIN_I8 + MIN_I8 }, { MAX_I8 + MAX_I8 }>;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_add<T1, T2>(a: T1, b: T2) -> AddType nopanic;
 
 fn foo(a: i8) -> AddType {
@@ -209,9 +219,11 @@ test::foo@F0([0]: i8) -> (BoundedInt<-256, 254>);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type DivRemType = (BoundedInt<16, 85>, BoundedInt<0, 7>);
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_div_rem<T1, T2>(
     a: T1, b: NonZero<T2>,
 ) -> DivRemType implicits(RangeCheck) nopanic;
@@ -268,12 +280,14 @@ test::foo@F0([0]: RangeCheck, [1]: BoundedInt<128, 255>, [2]: NonZero<BoundedInt
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type DivRemType = (
     BoundedInt<0, 0xffffffffffffffffffffffffffffffff>,
     BoundedInt<0, 0xfffffffffffffffffffffffffffffffe>,
 );
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_div_rem<T1, T2>(
     a: T1, b: NonZero<T2>,
 ) -> DivRemType implicits(RangeCheck) nopanic;
@@ -336,9 +350,11 @@ test::foo@F0([0]: RangeCheck, [1]: u128, [2]: NonZero<BoundedInt<1, 340282366920
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type DivRemType = (BoundedInt<0, 0xf>, BoundedInt<0, 0xfffffffffffffffffffffffffffffff>);
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_div_rem<T1, T2>(
     a: T1, b: NonZero<T2>,
 ) -> DivRemType implicits(RangeCheck) nopanic;
@@ -400,9 +416,11 @@ test::foo@F0([0]: RangeCheck, [1]: u128, [2]: NonZero<BoundedInt<212676479325586
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type Res = Result<BoundedInt<0, 0x7f>, BoundedInt<0x80, 0xff>>;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_constrain<T, const BOUNDARY: felt252>(
     value: T,
 ) -> Res implicits(RangeCheck) nopanic;
@@ -469,9 +487,11 @@ test::foo@F0([0]: RangeCheck, [1]: u8) -> (RangeCheck, core::result::Result::<te
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type Res = Result<BoundedInt<-0x80, -1>, BoundedInt<0, 0x7f>>;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_constrain<T, const BOUNDARY: felt252>(
     value: T,
 ) -> Res implicits(RangeCheck) nopanic;
@@ -538,6 +558,7 @@ test::foo@F0([0]: RangeCheck, [1]: i8) -> (RangeCheck, core::result::Result::<te
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type Res =
     Result<
@@ -545,6 +566,7 @@ type Res =
         BoundedInt<0x100000000000000000000000000000000, 0x1ffffffffffffffffffffffffffffffff>,
     >;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_constrain<T, const BOUNDARY: felt252>(
     value: T,
 ) -> Res implicits(RangeCheck) nopanic;
@@ -611,9 +633,11 @@ test::foo@F0([0]: RangeCheck, [1]: BoundedInt<0, 6805647338418769269267492148635
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type Res = Result<NonZero<BoundedInt<0, 0x7f>>, NonZero<BoundedInt<0x80, 0xff>>>;
 
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_constrain<T, const BOUNDARY: felt252>(
     value: T,
 ) -> Res implicits(RangeCheck) nopanic;
@@ -684,6 +708,7 @@ SmallE2ETestRunner
 
 //! > cairo_code
 use core::zeroable::IsZeroResult;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_is_zero<T>(value: T) -> IsZeroResult<T> implicits() nopanic;
 
 fn foo(value: i8) -> IsZeroResult<i8> {
@@ -739,7 +764,9 @@ SmallE2ETestRunner
 
 //! > cairo_code
 use core::zeroable::IsZeroResult;
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_is_zero<T>(value: T) -> IsZeroResult<T> implicits() nopanic;
 
 fn foo(
@@ -796,7 +823,9 @@ test::foo@F0([0]: BoundedInt<0, 680564733841876926926749214863536422911>) -> (co
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_wrap_non_zero<T>(value: T) -> NonZero<T> implicits() nopanic;
 
 fn foo(
@@ -834,7 +863,9 @@ test::foo@F0([0]: BoundedInt<1, 680564733841876926926749214863536422911>) -> (No
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_wrap_non_zero<T>(value: T) -> NonZero<T> implicits() nopanic;
 
 fn foo(
@@ -872,8 +903,10 @@ test::foo@F0([0]: BoundedInt<-680564733841876926926749214863536422911, -1>) -> (
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type Res = core::internal::OptionRev<BoundedInt<1, 0xff>>;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_trim_min<T>(value: T) -> Res nopanic;
 
 fn foo(value: u8) -> Res {
@@ -928,8 +961,10 @@ test::foo: SmallOrderedMap({Const: 300})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type Res = core::internal::OptionRev<BoundedInt<-0xff, -1>>;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_trim_max<T>(value: T) -> Res nopanic;
 
 fn foo(value: BoundedInt<-0xff, 0>) -> Res {
@@ -984,8 +1019,10 @@ test::foo: SmallOrderedMap({Const: 300})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type Res = core::internal::OptionRev<BoundedInt<-0x7f, 0x7f>>;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_trim_min<T>(value: T) -> Res nopanic;
 
 fn foo(value: i8) -> Res {
@@ -1041,8 +1078,10 @@ test::foo: SmallOrderedMap({Const: 400})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 type Res = core::internal::OptionRev<BoundedInt<0, 0xfe>>;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_trim_max<T>(value: T) -> Res nopanic;
 
 fn foo(value: u8) -> Res {
@@ -1098,7 +1137,9 @@ test::foo: SmallOrderedMap({Const: 400})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedIntGuarantee<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn bounded_int_guarantee_verify<const MIN: felt252, const MAX: felt252>(
     value: BoundedIntGuarantee<MIN, MAX>,
 ) implicits(RangeCheck) nopanic;
@@ -1139,9 +1180,11 @@ test::foo@F0([0]: RangeCheck, [1]: BoundedIntGuarantee<0, 4294967295>) -> (Range
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedIntGuarantee<const MIN: felt252, const MAX: felt252>;
 type U32Guarantee = BoundedIntGuarantee<0, 0xffffffff>;
 
+#[allow(extern_outside_corelib)]
 extern fn u128_to_u32_guarantees(
     value: u128,
 ) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) nopanic;

--- a/tests/e2e_test_data/libfuncs/box
+++ b/tests/e2e_test_data/libfuncs/box
@@ -313,6 +313,7 @@ fn foo(value: Box<A>) -> (Box<u256>, Box<u256>) {
     struct_boxed_deconstruct(value)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u256>, Box<u256>) nopanic;
 
 struct A {
@@ -360,6 +361,7 @@ fn foo(value: Box<Single>) -> (Box<Array<felt252>>,) {
     struct_boxed_deconstruct(value)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<Array<felt252>>,) nopanic;
 
 struct Single {
@@ -405,6 +407,7 @@ fn foo(value: Box<Many>) -> (Box<u256>, Box<felt252>, Box<Array<felt252>>, Box<u
     struct_boxed_deconstruct(value)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(
     value: Box<T>,
 ) -> (Box<u256>, Box<felt252>, Box<Array<felt252>>, Box<u256>) nopanic;
@@ -462,6 +465,7 @@ fn foo(value: Box<Empty>) -> () {
     struct_boxed_deconstruct(value)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> () nopanic;
 
 struct Empty {}
@@ -496,6 +500,7 @@ fn foo(value: Box<@A>) -> (Box<@u256>, Box<@u256>) {
     struct_boxed_deconstruct(value)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<@u256>, Box<@u256>) nopanic;
 
 struct A {
@@ -543,6 +548,7 @@ fn foo(value: Box<@Single>) -> (Box<@Array<felt252>>,) {
     struct_boxed_deconstruct(value)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<@Array<felt252>>,) nopanic;
 
 struct Single {
@@ -590,6 +596,7 @@ fn foo(value: Box<@Many>) -> (Box<@u256>, Box<@felt252>, Box<@Array<felt252>>, B
     struct_boxed_deconstruct(value)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(
     value: Box<T>,
 ) -> (Box<@u256>, Box<@felt252>, Box<@Array<felt252>>, Box<@u256>) nopanic;
@@ -655,6 +662,7 @@ fn foo() -> (Box<u256>, Box<u256>) {
     struct_boxed_deconstruct::<A>(b)
 }
 
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u256>, Box<u256>) nopanic;
 
 struct A {
@@ -736,10 +744,12 @@ SmallE2ETestRunner
 
 //! > cairo_code
 mod a {
+    #[allow(extern_outside_corelib)]
     extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u256>, Box<u256>) nopanic;
 }
 
 mod b {
+    #[allow(extern_outside_corelib)]
     extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u128>, Box<u128>) nopanic;
 }
 
@@ -792,6 +802,7 @@ test::foo: SmallOrderedMap({Const: 400})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u128>, Box<u128>) nopanic;
 
 fn foo(a: Box<u256>) -> (u128, u128) {
@@ -842,6 +853,7 @@ test::foo: SmallOrderedMap({Const: 300})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<()>, Box<()>, Box<u128>) nopanic;
 
 fn foo(a: Box<((), (), u128)>) -> u128 {
@@ -887,6 +899,7 @@ test::foo: SmallOrderedMap({Const: 100})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn local_into_box<T>(value: T) -> Box<T> nopanic;
 fn foo(x: felt252) -> Box<felt252> {
     local_into_box(x)
@@ -922,6 +935,7 @@ test::foo@F0([0]: felt252) -> (Box<felt252>);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn local_into_box<T>(value: T) -> Box<T> nopanic;
 fn foo(x: ()) -> Box<()> {
     local_into_box(x)
@@ -957,6 +971,7 @@ test::foo@F0([0]: Unit) -> (Box<Unit>);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn local_into_box<T>(value: T) -> Box<T> nopanic;
 
 fn foo() -> Box<()> {
@@ -995,6 +1010,7 @@ test::foo: SmallOrderedMap({Const: 300})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn local_into_box<T>(value: T) -> Box<T> nopanic;
 fn foo(x: (felt252, felt252, felt252)) -> Box<(felt252, felt252, felt252)> {
     local_into_box(x)
@@ -1031,6 +1047,7 @@ test::foo@F0([0]: Tuple<felt252, felt252, felt252>) -> (Box<Tuple<felt252, felt2
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn local_into_box<T>(value: T) -> Box<T> nopanic;
 
 #[inline(never)]
@@ -1147,7 +1164,9 @@ test::foo@F0([0]: test::LargeStruct) -> (Box<test::LargeStruct>);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn local_into_box<T>(value: T) -> Box<T> nopanic;
+#[allow(extern_outside_corelib)]
 extern fn struct_boxed_deconstruct<T>(value: Box<T>) -> (Box<u128>, Box<u128>, Box<u128>) nopanic;
 
 fn foo(a: (u128, u128, u128)) -> Box<u128> {

--- a/tests/e2e_test_data/libfuncs/casts
+++ b/tests/e2e_test_data/libfuncs/casts
@@ -707,6 +707,7 @@ test::foo@F0([0]: RangeCheck, [1]: u16) -> (RangeCheck, core::option::Option::<c
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 fn foo(a: i8) -> Option<BoundedInt<-3, 5>> {
@@ -780,6 +781,7 @@ test::foo@F0([0]: RangeCheck, [1]: i8) -> (RangeCheck, core::option::Option::<te
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 fn foo(a: i8) -> Option<BoundedInt<0, 5>> {
@@ -853,6 +855,7 @@ test::foo@F0([0]: RangeCheck, [1]: i8) -> (RangeCheck, core::option::Option::<te
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 fn foo(a: i8) -> Option<BoundedInt<-5, 0>> {
@@ -926,6 +929,7 @@ test::foo@F0([0]: RangeCheck, [1]: i8) -> (RangeCheck, core::option::Option::<te
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 fn foo(a: i8) -> Option<BoundedInt<-5, -1>> {
@@ -998,6 +1002,7 @@ test::foo@F0([0]: RangeCheck, [1]: i8) -> (RangeCheck, core::option::Option::<te
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 fn foo(a: BoundedInt<100, 200>) -> Option<BoundedInt<120, 180>> {
@@ -1071,6 +1076,7 @@ test::foo: SmallOrderedMap({Const: 940})
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 fn foo(

--- a/tests/e2e_test_data/libfuncs/consts
+++ b/tests/e2e_test_data/libfuncs/consts
@@ -554,7 +554,9 @@ test::foo@F0() -> (Tuple<Box<felt252>, BuiltinCosts>);
 WithOptsE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type Const<T, const VALUE: T>;
+#[allow(extern_outside_corelib)]
 extern fn const_as_box<T, const SEGMENT_INDEX: felt252>() -> Box<felt252> nopanic;
 
 fn foo() -> (Box<felt252>, Box<felt252>, Box<felt252>, Box<felt252>, Box<felt252>, Box<felt252>) {
@@ -980,14 +982,18 @@ WithOptsE2ETestRunner
 use core::integer::u512;
 
 mod value {
+    #[allow(extern_outside_corelib)]
     extern type Const<T, const VALUE: T>;
 }
 mod struct4 {
+    #[allow(extern_outside_corelib)]
     extern type Const<T, C0, C1, C2, C3>;
 }
 mod nz {
+    #[allow(extern_outside_corelib)]
     extern type Const<T, C>;
 }
+#[allow(extern_outside_corelib)]
 extern fn const_as_box<T, const SEGMENT_INDEX: felt252>() -> Box<NonZero<u512>> nopanic;
 
 fn foo() -> Box<NonZero<u512>> {
@@ -1048,8 +1054,10 @@ WithOptsE2ETestRunner
 use core::ec::EcPoint;
 
 mod value {
+    #[allow(extern_outside_corelib)]
     extern type Const<T, const X: felt252, const Y: felt252>;
 }
+#[allow(extern_outside_corelib)]
 extern fn const_as_box<T, const SEGMENT_INDEX: felt252>() -> Box<EcPoint> nopanic;
 
 fn foo() -> Box<EcPoint> {
@@ -1098,8 +1106,10 @@ WithOptsE2ETestRunner
 use core::ec::EcPoint;
 
 mod value {
+    #[allow(extern_outside_corelib)]
     extern type Const<T, const X: felt252, const Y: felt252>;
 }
+#[allow(extern_outside_corelib)]
 extern fn const_as_box<T, const SEGMENT_INDEX: felt252>() -> Box<EcPoint> nopanic;
 
 fn foo() -> Box<EcPoint> {
@@ -1141,11 +1151,14 @@ WithOptsE2ETestRunner
 use core::ec::EcPoint;
 
 mod value {
+    #[allow(extern_outside_corelib)]
     extern type Const<T, const X: felt252, const Y: felt252>;
 }
 mod nz {
+    #[allow(extern_outside_corelib)]
     extern type Const<T, C>;
 }
+#[allow(extern_outside_corelib)]
 extern fn const_as_box<T, const SEGMENT_INDEX: felt252>() -> Box<NonZero<EcPoint>> nopanic;
 
 fn foo() -> Box<NonZero<EcPoint>> {

--- a/tests/e2e_test_data/libfuncs/coupon
+++ b/tests/e2e_test_data/libfuncs/coupon
@@ -64,6 +64,7 @@ SmallE2ETestRunner
 
 //! > cairo_code
 impl DropCoupon<T, impl DropImpl: Drop<T>> of Drop<bar::<T, DropImpl>::Coupon>;
+#[allow(extern_outside_corelib)]
 extern fn coupon_buy<T>() -> T nopanic;
 
 fn foo() {
@@ -150,6 +151,7 @@ test::bar::<core::integer::u8, core::integer::u8Drop>@F2([0]: u8) -> (felt252);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn coupon_refund<T>(c: T) nopanic;
 
 fn foo(c: bar::<u8>::Coupon) {
@@ -214,6 +216,7 @@ test::bar::<core::integer::u8, core::integer::u8Drop>@F1([0]: u8) -> (felt252);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn drop<T>(c: T) nopanic;
 
 struct NonDroppable {
@@ -321,7 +324,9 @@ test::destruct@F0([0]: Bitwise, [1]: Array<Tuple<test::NonDroppable, Coupon<user
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn coupon_buy<T>() -> T nopanic;
+#[allow(extern_outside_corelib)]
 extern fn coupon_refund<T>(c: T) nopanic;
 impl CouponRecursiveBuyDrop of Drop<recursive_buy::<u8>::Coupon>;
 impl CouponRecursiveRefundDrop of Drop<recursive_refund::<u8>::Coupon>;

--- a/tests/e2e_test_data/libfuncs/enum
+++ b/tests/e2e_test_data/libfuncs/enum
@@ -359,9 +359,11 @@ enum IndexEnum5 {
     Three,
     Four,
 }
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 
+#[allow(extern_outside_corelib)]
 extern fn enum_from_bounded_int<T>(index: BoundedInt<0, 4>) -> T nopanic;
 
 // This wrapper is required so that the compiler won't assume extern `enum_from_bounded_int` is a
@@ -409,9 +411,11 @@ enum IndexEnum2 {
     Zero,
     One,
 }
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 
+#[allow(extern_outside_corelib)]
 extern fn enum_from_bounded_int<T>(index: BoundedInt<0, 1>) -> T nopanic;
 
 // This wrapper is required so that the compiler won't assume extern `enum_from_bounded_int` is a
@@ -457,9 +461,11 @@ SmallE2ETestRunner
 enum IndexEnum1 {
     Zero,
 }
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
 
 
+#[allow(extern_outside_corelib)]
 extern fn enum_from_bounded_int<T>(index: BoundedInt<0, 0>) -> T nopanic;
 
 // This wrapper is required so that the compiler won't assume extern `enum_from_bounded_int` is a
@@ -506,6 +512,7 @@ enum Single {
     Value: felt252,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<T>(e: Box<T>) -> Box<felt252> nopanic;
 
 fn foo(e: Box<Single>) -> Box<felt252> {
@@ -548,6 +555,7 @@ enum BoxedOption {
     None: Box<()>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedOption nopanic;
 
 fn foo(e: Box<Option<felt252>>) -> BoxedOption {
@@ -616,6 +624,7 @@ enum BoxedColor {
     Blue: Box<felt252>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<Color>(e: Box<Color>) -> BoxedColor nopanic;
 
 fn foo(e: Box<Color>) -> BoxedColor {
@@ -691,6 +700,7 @@ enum BoxedData {
     Large: Box<(felt252, felt252, felt252)>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<Data>(e: Box<Data>) -> BoxedData nopanic;
 
 fn foo(e: Box<Data>) -> BoxedData {
@@ -756,10 +766,12 @@ enum B {
 }
 
 mod a {
+    #[allow(extern_outside_corelib)]
     extern fn enum_boxed_match<T>(e: Box<T>) -> Box<felt252> nopanic;
 }
 
 mod b {
+    #[allow(extern_outside_corelib)]
     extern fn enum_boxed_match<T>(e: Box<T>) -> Box<super::A> nopanic;
 }
 
@@ -817,6 +829,7 @@ mod a {
         Value1: Box<felt252>,
         Value2: Box<felt252>,
     }
+    #[allow(extern_outside_corelib)]
     extern fn enum_boxed_match<T>(e: Box<T>) -> A nopanic;
 }
 
@@ -825,6 +838,7 @@ mod b {
         Value1: Box<super::A>,
         Value2: Box<(super::A, felt252, felt252)>,
     }
+    #[allow(extern_outside_corelib)]
     extern fn enum_boxed_match<T>(e: Box<T>) -> B nopanic;
 }
 
@@ -920,6 +934,7 @@ enum BoxedSingle {
     Value: Box<felt252>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedSingle nopanic;
 
 fn add_123(x: felt252) -> felt252 {
@@ -993,6 +1008,7 @@ enum BoxedOption {
     None: Box<()>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedOption nopanic;
 
 fn add_123(x: felt252) -> felt252 {
@@ -1092,6 +1108,7 @@ enum BoxedColor {
     Blue: Box<felt252>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<Color>(e: Box<Color>) -> BoxedColor nopanic;
 
 fn test_blue(x: felt252) -> felt252 {
@@ -1203,6 +1220,7 @@ enum BoxedData {
     Large: Box<(felt252, felt252, felt252)>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<Data>(e: Box<Data>) -> BoxedData nopanic;
 
 fn test_small(x: felt252) -> felt252 {
@@ -1294,6 +1312,7 @@ enum BoxedData {
     Large: Box<(felt252, felt252, felt252)>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<Data>(e: Box<Data>) -> BoxedData nopanic;
 
 fn test_large(x: felt252) -> felt252 {
@@ -1404,6 +1423,7 @@ enum BoxedSingleArray {
     Value: Box<@Array<felt252>>,
 }
 
+#[allow(extern_outside_corelib)]
 extern fn enum_boxed_match<T>(e: Box<T>) -> BoxedSingleArray nopanic;
 
 fn foo(e: Box<@SingleArray>) -> BoxedSingleArray {

--- a/tests/e2e_test_data/libfuncs/enum_snapshot
+++ b/tests/e2e_test_data/libfuncs/enum_snapshot
@@ -258,6 +258,7 @@ test::foo@F0([0]: Snapshot<test::Color>) -> (felt252);
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn enum_snapshot_match<T>(e: @T) -> never nopanic;
 
 fn foo(n: @never) -> never {

--- a/tests/e2e_test_data/libfuncs/felt252_downcast
+++ b/tests/e2e_test_data/libfuncs/felt252_downcast
@@ -4,7 +4,9 @@
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn downcast<T, S>(index: T) -> Option<S> implicits(RangeCheck) nopanic;
 
 fn foo(index: felt252) -> Option<BoundedInt<0, 7>> {
@@ -87,7 +89,9 @@ test::foo@F0([0]: RangeCheck, [1]: felt252) -> (RangeCheck, core::option::Option
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn downcast<T, S>(index: T) -> Option<S> implicits(RangeCheck) nopanic;
 
 fn foo(index: felt252) -> Option<BoundedInt<0, 0>> {
@@ -173,7 +177,9 @@ This tests the upper limit for felt252 to small range casting for K == 2.
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn downcast<T, S>(index: T) -> Option<S> implicits(RangeCheck) nopanic;
 
 fn foo(index: felt252) -> Option<BoundedInt<0, 10633823966279327296825105735305134079>> {
@@ -260,7 +266,9 @@ Range moved to have an upper bound 0.
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn downcast<T, S>(index: T) -> Option<S> implicits(RangeCheck) nopanic;
 
 fn foo(index: felt252) -> Option<BoundedInt<-10633823966279327296825105735305134080, -1>> {
@@ -347,7 +355,9 @@ Range moved to have an upper bound 2**128.
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn downcast<T, S>(index: T) -> Option<S> implicits(RangeCheck) nopanic;
 
 fn foo(
@@ -438,7 +448,9 @@ Validating the basic shrinking of a destination type.
 SmallE2ETestRunner
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern type BoundedInt<const MIN: felt252, const MAX: felt252>;
+#[allow(extern_outside_corelib)]
 extern fn downcast<T, S>(index: T) -> Option<S> implicits(RangeCheck) nopanic;
 
 fn foo(

--- a/tests/e2e_test_data/libfuncs/gas
+++ b/tests/e2e_test_data/libfuncs/gas
@@ -937,6 +937,7 @@ test::foo@F0([0]: RangeCheck, [1]: GasBuiltin, [2]: Bitwise, [3]: Pedersen, [4]:
 SmallE2ETestRunnerSkipAddGas
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn get_unspent_gas() -> u128 implicits(GasBuiltin) nopanic;
 
 fn foo(x: felt252) -> u128 {
@@ -1025,6 +1026,7 @@ test::bar@F1() -> ();
 SmallE2ETestRunnerSkipAddGas
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn get_unspent_gas() -> u128 implicits(GasBuiltin) nopanic;
 
 fn foo(x: felt252) -> u128 {

--- a/tests/e2e_test_data/libfuncs/qm31
+++ b/tests/e2e_test_data/libfuncs/qm31
@@ -102,6 +102,7 @@ SmallE2ETestRunner
 //! > cairo_code
 use core::qm31::qm31;
 
+#[allow(extern_outside_corelib)]
 extern fn qm31_div(a: qm31, b: NonZero<qm31>) -> qm31 nopanic;
 fn foo(a: qm31, b: NonZero<qm31>) -> qm31 {
     qm31_div(a, b)
@@ -170,6 +171,7 @@ SmallE2ETestRunner
 use core::internal::OptionRev;
 use core::qm31::qm31;
 
+#[allow(extern_outside_corelib)]
 extern fn qm31_is_zero(a: qm31) -> OptionRev<NonZero<qm31>> nopanic;
 fn foo(a: qm31) -> OptionRev<NonZero<qm31>> {
     qm31_is_zero(a)

--- a/tests/e2e_test_data/metadata_computation
+++ b/tests/e2e_test_data/metadata_computation
@@ -1883,6 +1883,7 @@ ret;
 SmallE2ETestRunnerMetadataComputation
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn coupon_buy<T>() -> T nopanic;
 impl DropCoupon of Drop<bar::Coupon>;
 
@@ -1968,6 +1969,7 @@ ret;
 SmallE2ETestRunnerMetadataComputation
 
 //! > cairo_code
+#[allow(extern_outside_corelib)]
 extern fn coupon_refund<T>(c: T) nopanic;
 
 fn foo(c0: bar20000::Coupon, c1: bar20000::Coupon, c2: bar20000::Coupon) {


### PR DESCRIPTION
## Summary

Introduces a new `extern_outside_corelib` lint (warning `E2201`) that fires when `extern fn` or `extern type` items are declared outside the core library. The warning message reads: *"Extern types and functions should only be declared in the core library."* It can be suppressed with `#[allow(extern_outside_corelib)]`.

The lint is registered as a known `allow`-able lint in `declared_allows`, and the check is implemented in `report_extern_item_outside_corelib`, which is called from both `extern_function.rs` and `extern_type.rs` during semantic analysis. The constant `EXTERN_OUTSIDE_CORELIB` is added to `cairo-lang-syntax`'s attribute consts.

All existing test fixtures that declare `extern fn` or `extern type` outside the corelib have been updated with `#[allow(extern_outside_corelib)]` to suppress the new warning, and line numbers in expected diagnostics have been adjusted accordingly. New test cases in `diagnostic_test_data/allow` verify that the warning is emitted without the attribute and suppressed with it.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Declaring `extern fn` and `extern type` outside the core library is an advanced, low-level operation that bypasses Cairo's type system guarantees and directly names Sierra libfuncs. Allowing this silently in user code makes it easy to accidentally introduce unsound or non-portable declarations. The lint surfaces this as a warning so developers are aware of the risk, while still allowing it when explicitly opted in.

---

## What was the behavior or documentation before?

`extern fn` and `extern type` could be declared anywhere without any diagnostic.

---

## What is the behavior or documentation after?

Declaring `extern fn` or `extern type` outside the core library emits warning `E2201`. The warning is silenced by annotating the item with `#[allow(extern_outside_corelib)]`.

---

## Related issue or discussion (if any)

---

## Additional context

The error code `E2201` is assigned to this diagnostic. The severity is `Warning`, consistent with other lint-style diagnostics such as `unused_variables` and `unused_imports`.