### PR TITLE
bugfix(semantic): Added diagnostic for use * in statement context.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -7,7 +7,9 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use ast::PathSegment;
-use cairo_lang_defs::db::{DefsGroup, get_all_path_leaves, validate_attributes_flat};
+use cairo_lang_defs::db::{
+    DefsGroup, get_all_path_leaves, get_all_path_stars, validate_attributes_flat,
+};
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::{
     FunctionTitleId, GenericKind, LanguageElementId, LocalVarLongId, LookupItemId, MemberId,
@@ -4868,6 +4870,10 @@ pub fn compute_and_append_statement_semantic<'db>(
                             );
                         }
                         ast::ModuleItem::Use(use_syntax) => {
+                            for star in get_all_path_stars(db, use_syntax) {
+                                ctx.diagnostics
+                                    .report(star.stable_ptr(db), UnsupportedUseItemInStatement);
+                            }
                             for leaf in get_all_path_leaves(db, use_syntax) {
                                 let stable_ptr = leaf.stable_ptr(db);
                                 let resolved_item = ctx.resolver.resolve_use_path(

--- a/crates/cairo-lang-semantic/src/expr/test_data/statements
+++ b/crates/cairo-lang-semantic/src/expr/test_data/statements
@@ -270,3 +270,26 @@ error[E2158]: No matching rule found in inline macro `m`.
  --> lib.cairo:5:5
     m!(1);
     ^^^^^
+
+//! > ==========================================================================
+
+//! > Glob use in statement position is rejected (regression for #10142).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    use core::array::*;
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error[E2075]: Unsupported use item in statement.
+ --> lib.cairo:2:22
+    use core::array::*;
+                     ^


### PR DESCRIPTION
## Summary

Glob (`*`) use statements in statement position (e.g., `use core::array::*;` inside a function body) now produce a proper diagnostic error (`E2075: Unsupported use item in statement`) instead of being silently accepted or causing unexpected behavior.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Glob use items inside statement position were not being caught and rejected. The existing logic only iterated over path leaves when processing `use` statements inside function bodies, but glob (`*`) paths are not leaves — they are star segments. This meant glob imports in statement position slipped through without a diagnostic, leading to incorrect behavior (regression tracked in #10142).

---

## What was the behavior or documentation before?

A glob use statement such as `use core::array::*;` inside a function body was not reported as an error, even though glob use items are unsupported in statement position.

---

## What is the behavior or documentation after?

A glob use statement inside a function body now correctly emits:

```
error[E2075]: Unsupported use item in statement.
 --> lib.cairo:2:22
    use core::array::*;
                     ^
```

---

## Related issue or discussion (if any)

Fixes #10142.

---

## Additional context

The fix introduces a call to `get_all_path_stars` alongside the existing `get_all_path_leaves` call, so that star segments in a use path are also checked and reported before leaf resolution is attempted.