### PR TITLE
bugfix(parser): Make `macro` a valid recovery terminal and tree token.

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -1872,6 +1872,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
             SyntaxKind::TerminalImpl => self.take::<TerminalImpl<'_>>().into(),
             SyntaxKind::TerminalImplicits => self.take::<TerminalImplicits<'_>>().into(),
             SyntaxKind::TerminalLet => self.take::<TerminalLet<'_>>().into(),
+            SyntaxKind::TerminalMacro => self.take::<TerminalMacro<'_>>().into(),
             SyntaxKind::TerminalMatch => self.take::<TerminalMatch<'_>>().into(),
             SyntaxKind::TerminalModule => self.take::<TerminalModule<'_>>().into(),
             SyntaxKind::TerminalMut => self.take::<TerminalMut<'_>>().into(),

--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/module_diagnostics
@@ -66,3 +66,37 @@ error[E1029]: Expected either ';' or '{' after module name. Use ';' for an exter
  --> dummy_file.cairo:1:11
 mod my_mod const X: felt252 = 5;
           ^
+
+//! > ==========================================================================
+
+//! > Error recovery stops at a following `macro` declaration.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+const X
+macro m {
+    ($x: expr) => { $x };
+}
+
+//! > expected_diagnostics
+error[E1004]: Unexpected token, expected ':' followed by a type.
+ --> dummy_file.cairo:1:8
+const X
+       ^
+
+error[E1001]: Missing token '='.
+ --> dummy_file.cairo:1:8
+const X
+       ^
+
+error[E1002]: Missing tokens. Expected an expression.
+ --> dummy_file.cairo:1:8
+const X
+       ^
+
+error[E1001]: Missing token ';'.
+ --> dummy_file.cairo:1:8
+const X
+       ^

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/inline_macro
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/inline_macro
@@ -484,3 +484,38 @@ ExprInlineMacro
             │           │       └── leaf (kind: TokenIdentifier): 'x'
             │           └── rparen (kind: TokenRParen): ')'
             └── rparen (kind: TokenRParen): ')'
+
+//! > ==========================================================================
+
+//! > Test inline macro call with the `macro` keyword as a leaf token (regression for #10144 - previously ICEd).
+
+//! > test_runner_name
+test_partial_parser_tree(expect_diagnostics: false)
+
+//! > cairo_code
+fn main() -> u32 {
+    foo!(macro)
+}
+
+//! > top_level_kind
+ExprInlineMacro
+
+//! > ignored_kinds
+
+//! > expected_diagnostics
+
+//! > expected_tree
+└── Top level kind: ExprInlineMacro
+    ├── path (kind: ExprPath)
+    │   ├── dollar (kind: OptionTerminalDollarEmpty) []
+    │   └── segments (kind: ExprPathInner)
+    │       └── item #0 (kind: PathSegmentSimple)
+    │           └── ident (kind: TokenIdentifier): 'foo'
+    ├── bang (kind: TokenNot): '!'
+    └── arguments (kind: TokenTreeNode)
+        └── subtree (kind: ParenthesizedTokenTree)
+            ├── lparen (kind: TokenLParen): '('
+            ├── tokens (kind: TokenList)
+            │   └── child #0 (kind: TokenTreeLeaf)
+            │       └── leaf (kind: TokenMacro): 'macro'
+            └── rparen (kind: TokenRParen): ')'

--- a/crates/cairo-lang-parser/src/recovery.rs
+++ b/crates/cairo-lang-parser/src/recovery.rs
@@ -90,6 +90,7 @@ macro_rules! module_item_kw {
             | SyntaxKind::TerminalExtern
             | SyntaxKind::TerminalFunction
             | SyntaxKind::TerminalImpl
+            | SyntaxKind::TerminalMacro
             | SyntaxKind::TerminalModule
             | SyntaxKind::TerminalStruct
             | SyntaxKind::TerminalTrait


### PR DESCRIPTION
## Summary

Fixes an ICE (Internal Compiler Error) that occurred when the `macro` keyword was used as a token inside an inline macro call (e.g., `foo!(macro)`). The `TerminalMacro` syntax kind was missing from the parser's token-tree leaf handling, causing a panic. Additionally, `TerminalMacro` was not included in the error recovery set of module-level keywords, meaning a `macro` declaration following a malformed item would not correctly stop error recovery.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`TerminalMacro` was absent from the parser's token-tree leaf dispatch in `parser.rs`, so encountering `macro` as a leaf token inside an inline macro invocation caused an ICE. It was also missing from the `module_item_kw!` recovery macro in `recovery.rs`, so error recovery would not stop at a `macro` declaration boundary when recovering from a prior parse error.

---

## What was the behavior or documentation before?

- Using `macro` as an argument to an inline macro call (e.g., `foo!(macro)`) caused an internal compiler error (panic).
- A `macro` declaration following a malformed item (e.g., `const X` with no type or value) would not act as a recovery boundary, potentially producing confusing cascading diagnostics.

---

## What is the behavior or documentation after?

- `foo!(macro)` is parsed correctly without panicking; `macro` is treated as a `TokenTreeLeaf` with kind `TokenMacro`.
- Error recovery now stops at a `macro` keyword at module level, consistent with other module-item keywords like `struct`, `fn`, `impl`, etc.

---

## Related issue or discussion (if any)

Regression fix for #10144.

---

## Additional context

Two new test cases are added: one verifying the inline macro regression no longer ICEs, and one verifying that error recovery halts correctly at a following `macro` declaration.