### PR TITLE
bugfix(formatter): Made formatter merge in `use` more consistent.

### DIFF
--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -1284,13 +1284,8 @@ fn compare_use_paths<'a>(a: &UsePath<'a>, b: &UsePath<'a>, db: &dyn Database) ->
     match (a, b) {
         // Case for multi vs multi.
         (UsePath::Multi(a_multi), UsePath::Multi(b_multi)) => {
-            let empty_string = "".into();
             let get_min_child = |multi: &ast::UsePathMulti<'a>| {
-                multi.use_paths(db).elements(db).min_by_key(|child| match child {
-                    UsePath::Leaf(leaf) => leaf.extract_ident(db),
-                    UsePath::Single(single) => single.extract_ident(db),
-                    _ => &empty_string,
-                })
+                multi.use_paths(db).elements(db).min_by(|a, b| compare_use_paths(a, b, db))
             };
             match (get_min_child(a_multi), get_min_child(b_multi)) {
                 (Some(a_min), Some(b_min)) => compare_use_paths(&a_min, &b_min, db),

--- a/crates/cairo-lang-formatter/test_data/cairo_files/sort_inner_use.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/sort_inner_use.cairo
@@ -18,3 +18,5 @@ use a::{{d}, e, ab, c};
 
 use a::{a, a::{c, {a}}, a::{b}, a::{{a},b}};
 use a::{c, d::{a, *}, r, t::{*, c::a}};
+
+use x::{{self, m}, {a, m}};

--- a/crates/cairo-lang-formatter/test_data/expected_results/sort_inner_use.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/sort_inner_use.cairo
@@ -4,17 +4,19 @@ use a::{a, b, c, d};
 
 use a::{a, b as aee, b as bee, c as cee, d};
 
-use a::{a, a::{b}, a::{c, {a}}, a::{b, {a}}};
+use a::{a, a::{b}, a::{b, {a}}, a::{c, {a}}};
 use a::{a as ab, a as bc};
+
+use a::{ab, c, e, {d}};
 use a::{b, d};
 use a::{b, d};
 
 use a::{c, d};
 use a::{c, d::{*, a}, r, t::{*, c::a}};
-
-use a::{ab, c, e, {d}};
 use aba;
 use b::{a, b, c, d};
 use c::{*, a, b, c, d};
 use std::collections::HashMap;
+
+use x::{{self, m}, {a, m}};
 use crate::utils::{a, b, c, d};


### PR DESCRIPTION
## Summary

Fixes incorrect sorting of nested `use` path groups containing `Multi` variants.

The `compare_use_paths` function previously fell back to an empty string when comparing `Multi` use path variants, causing incorrect sort ordering for groups like `{self, m}` and `{a, m}`. The comparison now recurses via `compare_use_paths` itself to find the minimum child path, producing a correct and stable ordering.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When sorting nested `use` import groups, the `Multi` variant was assigned an empty string as its sort key instead of being compared recursively. This caused `use x::{{self, m}, {a, m}};` and similar patterns to be ordered incorrectly.

---

## What was the behavior or documentation before?

Nested `use` path groups with `Multi` variants were compared using an empty string fallback, so their relative ordering was undefined and incorrect. For example, `{self, m}` and `{a, m}` were not sorted by their actual minimum child paths.

---

## What is the behavior or documentation after?

Nested `use` path groups are sorted by recursively comparing their minimum child paths using `compare_use_paths`, producing a correct and stable ordering. The expected sort order for several existing test cases is also corrected as a result.

---

## Related issue or discussion (if any)

None.

---

## Additional context

A new test case `use x::{{self, m}, {a, m}};` is added to `sort_inner_use.cairo` to cover the previously broken multi-group comparison. The `get_min_child` closure is simplified by replacing the manual key extraction with a direct call to `compare_use_paths`, removing the need for the `empty_string` fallback variable.