### PR TITLE
bugfix(doc): Made inline links with markup point to the url.

### DIFF
--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -264,6 +264,7 @@ pub fn parse_documentation_comment(documentation_comment: &str) -> Vec<Documenta
                             .as_ref()
                             .and_then(|label_range| {
                                 location_from_link_fields(
+                                    documentation_comment,
                                     link.link_type,
                                     &link.destination,
                                     label_range,
@@ -370,24 +371,22 @@ fn span_from_relative_range(content: &str, range: Range<usize>) -> TextSpan {
 
 /// Extracts a location link span and normalized destination text for the given link fields.
 fn location_from_link_fields(
+    content: &str,
     link_type: LinkType,
     destination: &str,
     label_range: &Range<usize>,
 ) -> Option<(Range<usize>, String)> {
     let (destination_normalized, backticked) = normalize_location_text(destination)?;
 
-    match link_type {
-        LinkType::Inline => {
-            let range = find_inline_destination_range(label_range.end, destination);
-            Some((range, destination_normalized))
-        }
+    let range = match link_type {
+        LinkType::Inline => find_inline_destination_range(content, label_range.end, destination),
         LinkType::Collapsed
         | LinkType::CollapsedUnknown
         | LinkType::Shortcut
-        | LinkType::ShortcutUnknown => Some((label_range.clone(), destination_normalized)),
-        _ => None,
-    }
-    .map(|(range, text)| (trim_backtick_range(range.clone(), backticked), text))
+        | LinkType::ShortcutUnknown => label_range.clone(),
+        _ => return None,
+    };
+    Some((trim_backtick_range(range, backticked), destination_normalized))
 }
 
 /// Returns true when the string looks like a location path (letters, digits, '_' or ':').
@@ -417,10 +416,17 @@ fn trim_backtick_range(range: Range<usize>, backticked: bool) -> Range<usize> {
 }
 
 /// Computes the range for an inline destination that follows a label.
-fn find_inline_destination_range(label_last_end: usize, destination: &str) -> Range<usize> {
-    let destination_start = label_last_end + 2;
-    let destination_end = destination_start + destination.len();
-    destination_start..destination_end
+fn find_inline_destination_range(
+    content: &str,
+    label_last_end: usize,
+    destination: &str,
+) -> Range<usize> {
+    // Finds the actual `](` boundary after the label, or uses the label's end if not found.
+    // This handles cases where the label ends in markup (e.g. `[**bold**](path)`),
+    // so the `](` that opens the destination is not necessarily adjacent to it.
+    let destination_start =
+        label_last_end + content[label_last_end..].find("](").unwrap_or_default() + 2;
+    destination_start..(destination_start + destination.len())
 }
 
 /// Maps `HeadingLevel` to the correct markdown marker.

--- a/crates/cairo-lang-doc/src/tests/test-data/documentation_comment_parser_links.txt
+++ b/crates/cairo-lang-doc/src/tests/test-data/documentation_comment_parser_links.txt
@@ -393,3 +393,88 @@ MarkdownLink {
     dest_span: None,
     dest_text: None,
 }
+
+//! > ==========================================================================
+
+//! > Inline link whose label ends in bare emphasis markers.
+
+//! > test_runner_name
+documentation_comment_parser_links_runner
+
+//! > cairo_project.toml
+[crate_roots]
+hello = "src"
+
+//! > cairo_code
+/// See [**bold**](path) and [*em*](path2).
+
+fn foo() {}
+
+//! > expected_diagnostics
+
+//! > Doc comment #1
+/// See [**bold**](path) and [*em*](path2).
+
+//! > Doc comment #1 links
+MarkdownLink {
+    link_span: TextSpan {
+        start: TextOffset(
+            TextWidth(
+                8,
+            ),
+        ),
+        end: TextOffset(
+            TextWidth(
+                24,
+            ),
+        ),
+    },
+    dest_span: Some(
+        TextSpan {
+            start: TextOffset(
+                TextWidth(
+                    19,
+                ),
+            ),
+            end: TextOffset(
+                TextWidth(
+                    23,
+                ),
+            ),
+        },
+    ),
+    dest_text: Some(
+        "path",
+    ),
+}
+MarkdownLink {
+    link_span: TextSpan {
+        start: TextOffset(
+            TextWidth(
+                29,
+            ),
+        ),
+        end: TextOffset(
+            TextWidth(
+                42,
+            ),
+        ),
+    },
+    dest_span: Some(
+        TextSpan {
+            start: TextOffset(
+                TextWidth(
+                    36,
+                ),
+            ),
+            end: TextOffset(
+                TextWidth(
+                    41,
+                ),
+            ),
+        },
+    ),
+    dest_text: Some(
+        "path2",
+    ),
+}


### PR DESCRIPTION
## Summary

Fixes incorrect destination span computation for inline Markdown links whose labels contain markup (e.g. `[**bold**](path)`). The `](` boundary separating the label from the destination was assumed to be immediately adjacent to the label's end offset, but when the label contains emphasis or other inline markup, the parser-reported label end does not point directly at `](`. The fix searches forward in the raw content string from the label's end to locate the actual `](` before computing the destination range. The `content` string is now threaded through `location_from_link_fields` and `find_inline_destination_range` to enable this lookup.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a doc comment link label contained bold or italic markers such as `[**bold**](path)`, the computed `dest_span` pointed to the wrong byte range in the source text. This caused incorrect go-to-definition or hover behavior for those links because the destination text offset was shifted by the length of the markup characters inside the label.

---

## What was the behavior or documentation before?

`find_inline_destination_range` assumed the destination started exactly 2 bytes after the label's end offset (i.e., immediately after `](`). For plain labels this is correct, but for labels with inline markup the Markdown parser reports the label end at the closing `**` or `*`, not at `]`, so the computed destination range was wrong.

---

## What is the behavior or documentation after?

`find_inline_destination_range` now scans forward in the raw comment string from the label's end to find the `](` token, then computes the destination range relative to that position. Links like `[**bold**](path)` and `[*em*](path2)` now produce correct `dest_span` values, as verified by the new test cases.

---

## Related issue or discussion (if any)

---

## Additional context

A new test case covering `[**bold**](path)` and `[*em*](path2)` in the same doc comment is added to `documentation_comment_parser_links.txt` to prevent regressions.