### PR TITLE
doc(corelib): Made byte-array example compile.

### DIFF
--- a/corelib/src/byte_array.cairo
+++ b/corelib/src/byte_array.cairo
@@ -38,7 +38,7 @@
 //!
 //! ```
 //! let mut ba: ByteArray = "ABC";
-//! let first_byte = ba[0]
+//! let first_byte = ba[0];
 //! assert!(first_byte == 0x41);
 //! ```
 


### PR DESCRIPTION
## Summary

Adds a missing semicolon at the end of the `let first_byte = ba[0]` statement in the `ByteArray` documentation example.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The code example in the `byte_array` module documentation was missing a semicolon, making it syntactically invalid Cairo code. This could confuse readers trying to use the example as a reference.

---

## What was the behavior or documentation before?

The example contained `let first_byte = ba[0]` without a trailing semicolon, which is not valid Cairo syntax.

---

## What is the behavior or documentation after?

The example now reads `let first_byte = ba[0];`, which is syntactically correct Cairo code.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A