### PR TITLE
feat(lowering): support tuple element access via `t.0` syntax

### DIFF
--- a/corelib/src/test.cairo
+++ b/corelib/src/test.cairo
@@ -51,5 +51,6 @@ mod language_features {
     mod panics_test;
     mod path_attr_test;
     mod trait_test;
+    mod tuple_test;
     mod while_test;
 }

--- a/corelib/src/test/language_features/tuple_test.cairo
+++ b/corelib/src/test/language_features/tuple_test.cairo
@@ -1,0 +1,55 @@
+#[test]
+fn test_tuple_index_read() {
+    let t = (1_felt252, 2_u8, 3_u16);
+    assert_eq!(t.0, 1);
+    assert_eq!(t.1, 2);
+    assert_eq!(t.2, 3);
+}
+
+#[test]
+fn test_tuple_index_nested_read() {
+    let t = (1_felt252, (2_u8, 3_u16));
+    assert_eq!(t.0, 1);
+    assert_eq!(t.1.0, 2);
+    assert_eq!(t.1.1, 3);
+}
+
+#[test]
+fn test_tuple_index_assignment() {
+    let mut t = (1_felt252, 2_u8);
+    t.0 = 5;
+    t.1 = 7;
+    assert_eq!(t.0, 5);
+    assert_eq!(t.1, 7);
+}
+
+#[test]
+fn test_tuple_index_nested_assignment() {
+    let mut t = (1_felt252, (2_u8, 3_u16));
+    t.1.0 = 20;
+    t.1.1 = 30;
+    assert_eq!(t.0, 1);
+    assert_eq!(t.1.0, 20);
+    assert_eq!(t.1.1, 30);
+}
+
+fn set_to_seven(ref x: felt252) {
+    x = 7;
+}
+
+#[test]
+fn test_tuple_index_ref_argument() {
+    let mut t = (1_felt252, 2_u8);
+    set_to_seven(ref t.0);
+    assert_eq!(t.0, 7);
+    assert_eq!(t.1, 2);
+}
+
+#[test]
+fn test_tuple_index_through_snapshot() {
+    let t = (1_felt252, 2_u8);
+    let s = @t;
+    // In the corelib edition, member access through a snapshot auto-desnaps the element.
+    assert_eq!(s.0, 1);
+    assert_eq!(s.1, 2);
+}

--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -1,21 +1,23 @@
 use cairo_lang_debug::DebugWithDb;
-use cairo_lang_defs::ids::{MemberId, NamedLanguageElementId};
+use cairo_lang_defs::ids::NamedLanguageElementId;
 use cairo_lang_diagnostics::{DiagnosticNote, Maybe};
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::expr::fmt::ExprFormatter;
 use cairo_lang_semantic::items::structure::StructSemantic;
-use cairo_lang_semantic::types::{peel_snapshots, wrap_in_snapshots};
 use cairo_lang_semantic::usage::{MemberPath, Usage};
 use cairo_lang_syntax::node::TypedStablePtr;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{Intern, require};
+use cairo_lang_utils::require;
 use itertools::{Itertools, chain, zip_eq};
-use semantic::{ConcreteTypeId, ExprVarMemberPath, MemberAccessKind, TypeLongId};
+use semantic::{ExprVarMemberPath, MemberAccessKind, TypeLongId};
 
 use super::context::{LoweredExpr, LoweringContext, LoweringFlowError, LoweringResult, VarRequest};
 use super::generators;
 use super::generators::StatementsBuilder;
-use super::refs::{AssembleValueError, MovedVar, SemanticLoweringMapping, merge_semantics};
+use super::refs::{
+    AssembleValueError, MovedVar, SemanticLoweringMapping, aggregate_members,
+    member_access_components, merge_semantics,
+};
 use crate::diagnostic::{LoweringDiagnosticKind, LoweringDiagnosticsBuilder};
 use crate::ids::LocationId;
 use crate::lower::refs::ClosureInfo;
@@ -224,28 +226,12 @@ impl<'db> BlockBuilder<'db> {
         let ExprVarMemberPath::Member { parent, kind, .. } = member_path else {
             return None;
         };
-        // TODO(TomerStarkware): Support lowering of tuple index access (`t.0`).
-        let MemberAccessKind::Struct { concrete_struct_id, member_id } = kind else {
-            return None;
-        };
         let parent_var = self.get_snap_ref(ctx, parent)?;
-        let members = ctx.db.concrete_struct_members(*concrete_struct_id).ok()?;
-        let (parent_number_of_snapshots, _) =
-            peel_snapshots(ctx.db, ctx.variables[parent_var.var_id].ty);
-        let member_idx = members.iter().position(|(_, member)| member.id == *member_id)?;
+        let (member_tys, member_idx) =
+            member_access_components(ctx, ctx.variables[parent_var.var_id].ty, kind)?;
         Some(
-            generators::StructMemberAccess {
-                input: parent_var,
-                member_tys: members
-                    .iter()
-                    .map(|(_, member)| {
-                        wrap_in_snapshots(ctx.db, member.ty, parent_number_of_snapshots)
-                    })
-                    .collect(),
-                member_idx,
-                location,
-            }
-            .add(ctx, &mut self.statements),
+            generators::StructMemberAccess { input: parent_var, member_tys, member_idx, location }
+                .add(ctx, &mut self.statements),
         )
     }
 
@@ -428,9 +414,11 @@ fn get_ty<'db>(
                     [&member_id.name(ctx.db)]
                     .ty
             }
-            // TODO(TomerStarkware): Support lowering of tuple index access (`t.0`).
-            MemberAccessKind::Index { .. } => {
-                unreachable!("Tuple index access is not supported in lowering.")
+            MemberAccessKind::Index { tuple_ty, index } => {
+                let TypeLongId::Tuple(tys) = tuple_ty.long(ctx.db) else {
+                    unreachable!("Tuple index access on a non-tuple type.");
+                };
+                tys[*index]
             }
         },
     }
@@ -491,21 +479,18 @@ pub type SealedBlockBuilder<'db> = Option<SealedGotoCallsite<'db>>;
 pub struct BlockStructRecomposer<'a, 'b, 'db> {
     statements: &'a mut StatementsBuilder<'db>,
     pub ctx: &'a mut LoweringContext<'db, 'b>,
-    pub(crate) location: LocationId<'db>,
+    location: LocationId<'db>,
 }
 impl<'db> BlockStructRecomposer<'_, '_, 'db> {
     pub fn deconstruct(
         &mut self,
-        concrete_struct_id: semantic::ConcreteStructId<'db>,
+        ty: semantic::TypeId<'db>,
         value: VariableId,
-    ) -> OrderedHashMap<MemberId<'db>, VariableId> {
-        let members = self.ctx.db.concrete_struct_members(concrete_struct_id).unwrap();
-        let members = members.values().collect_vec();
-        let member_ids = members.iter().map(|m| m.id);
-
+    ) -> OrderedHashMap<MemberAccessKind<'db>, VariableId> {
+        let members = aggregate_members(self.ctx.db, ty);
         let member_values =
-            self.deconstruct_by_types(value, members.iter().map(|member| member.ty));
-        OrderedHashMap::from_iter(zip_eq(member_ids, member_values))
+            self.deconstruct_by_types(value, members.iter().map(|(_, member_ty)| *member_ty));
+        OrderedHashMap::from_iter(zip_eq(members.into_iter().map(|(kind, _)| kind), member_values))
     }
 
     pub fn deconstruct_by_types(
@@ -527,12 +512,10 @@ impl<'db> BlockStructRecomposer<'_, '_, 'db> {
 
     pub fn reconstruct(
         &mut self,
-        concrete_struct_id: semantic::ConcreteStructId<'db>,
+        ty: semantic::TypeId<'db>,
         members: Vec<VariableId>,
         location: LocationId<'db>,
     ) -> VariableId {
-        let ty =
-            TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)).intern(self.ctx.db);
         generators::StructConstruct {
             inputs: members
                 .into_iter()

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -35,7 +35,7 @@ use flow_control::lower_graph::lower_graph;
 use itertools::{Itertools, chain, izip, zip_eq};
 use num_bigint::{BigInt, Sign};
 use num_traits::ToPrimitive;
-use refs::ClosureInfo;
+use refs::{ClosureInfo, member_access_components};
 use salsa::Database;
 use semantic::corelib::{
     core_submodule, get_core_function_id, get_core_ty_by_name, get_function_id, never_ty, unit_ty,
@@ -1802,12 +1802,6 @@ fn lower_expr_member_access<'db>(
     builder: &mut BlockBuilder<'db>,
 ) -> LoweringResult<'db, LoweredExpr<'db>> {
     log::trace!("Lowering a member-access expression: {:?}", expr.debug(&ctx.expr_formatter));
-    // TODO(TomerStarkware): Support lowering of tuple index access (`t.0`).
-    let MemberAccessKind::Struct { concrete_struct_id, member_id } = expr.kind else {
-        return Err(LoweringFlowError::Failed(
-            ctx.diagnostics.report(expr.stable_ptr.untyped(), Unsupported),
-        ));
-    };
     if let Some(member_path) = &expr.member_path {
         return Ok(LoweredExpr::MemberPath(
             member_path.clone(),
@@ -1815,25 +1809,18 @@ fn lower_expr_member_access<'db>(
         ));
     }
     let location = ctx.get_location(expr.stable_ptr.untyped());
-    let members =
-        ctx.db.concrete_struct_members(concrete_struct_id).map_err(LoweringFlowError::Failed)?;
-    let member_idx =
-        members.iter().position(|(_, member)| member.id == member_id).ok_or_else(|| {
-            LoweringFlowError::Failed(
-                ctx.diagnostics.report(expr.stable_ptr.untyped(), UnexpectedError),
-            )
-        })?;
+    let input = lower_expr_to_var_usage(ctx, builder, expr.expr)?;
+    let (member_tys, member_idx) =
+        member_access_components(ctx, ctx.variables[input.var_id].ty, &expr.kind).ok_or_else(
+            || {
+                LoweringFlowError::Failed(
+                    ctx.diagnostics.report(expr.stable_ptr.untyped(), UnexpectedError),
+                )
+            },
+        )?;
     Ok(LoweredExpr::AtVariable(
-        generators::StructMemberAccess {
-            input: lower_expr_to_var_usage(ctx, builder, expr.expr)?,
-            member_tys: members
-                .iter()
-                .map(|(_, member)| wrap_in_snapshots(ctx.db, member.ty, expr.n_snapshots))
-                .collect(),
-            member_idx,
-            location,
-        }
-        .add(ctx, &mut builder.statements),
+        generators::StructMemberAccess { input, member_tys, member_idx, location }
+            .add(ctx, &mut builder.statements),
     ))
 }
 

--- a/crates/cairo-lang-lowering/src/lower/refs.rs
+++ b/crates/cairo-lang-lowering/src/lower/refs.rs
@@ -1,18 +1,18 @@
-use cairo_lang_defs::ids::{LanguageElementId, MemberId};
+use cairo_lang_defs::ids::LanguageElementId;
 use cairo_lang_proc_macros::DebugWithDb;
 use cairo_lang_semantic::expr::fmt::ExprFormatter;
 use cairo_lang_semantic::expr::inference::InferenceError;
 use cairo_lang_semantic::items::structure::StructSemantic;
+use cairo_lang_semantic::types::{peel_snapshots, wrap_in_snapshots};
 use cairo_lang_semantic::usage::MemberPath;
-use cairo_lang_semantic::{self as semantic, MemberAccessKind};
+use cairo_lang_semantic::{self as semantic, ConcreteTypeId, MemberAccessKind, TypeLongId};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use cairo_lang_utils::{extract_matches, try_extract_matches};
+use cairo_lang_utils::{Intern, extract_matches, try_extract_matches};
 use itertools::{Itertools, chain};
 
 use super::block_builder::BlockStructRecomposer;
-use super::context::VarRequest;
+use super::context::{LoweringContext, VarRequest};
 use crate::VariableId;
-use crate::diagnostic::{LoweringDiagnosticKind, LoweringDiagnosticsBuilder};
 use crate::ids::LocationId;
 
 /// Information about members captured by the closure and their types.
@@ -130,6 +130,7 @@ impl<'db> SemanticLoweringMapping<'db> {
             Value::Var(var) => Ok(*var),
             Value::MovedVar(moved) => Err(moved.clone()),
             Value::Scattered(scattered) => {
+                let ty = scattered.ty;
                 let mut moved_var = None;
                 let members = scattered
                     .members
@@ -143,7 +144,7 @@ impl<'db> SemanticLoweringMapping<'db> {
                         }
                     })
                     .collect_vec();
-                let var = ctx.reconstruct(scattered.concrete_struct_id, members, location);
+                let var = ctx.reconstruct(ty, members, location);
                 *value = Value::Var(var);
                 if let Some(MovedVar { var_id: _, inference_error, last_use_location }) = moved_var
                 {
@@ -167,44 +168,41 @@ impl<'db> SemanticLoweringMapping<'db> {
         let MemberPath::Member { parent, kind } = path else {
             return None;
         };
-        // TODO(TomerStarkware): Support lowering of tuple index access (`t.0`).
-        let &MemberAccessKind::Struct { member_id, concrete_struct_id } = kind else {
-            ctx.ctx.diagnostics.report_by_location(
-                ctx.location.long(ctx.ctx.db).clone(),
-                LoweringDiagnosticKind::Unsupported,
-            );
-            return None;
-        };
 
+        // The type of the parent aggregate, taken from the member's [MemberAccessKind] (the
+        // authoritative semantic type).
+        let ty = aggregate_ty(ctx.ctx.db, kind);
         let parent_value = self.break_into_value(ctx, parent)?;
         match parent_value {
             Value::Var(var) => {
-                let members = ctx.deconstruct(concrete_struct_id, *var);
+                let members = ctx.deconstruct(ty, *var);
                 let members = OrderedHashMap::from_iter(
-                    members.into_iter().map(|(member_id, var)| (member_id, Value::Var(var))),
+                    members.into_iter().map(|(kind, var)| (kind, Value::Var(var))),
                 );
-                let scattered = Scattered { concrete_struct_id, members };
+                let scattered = Scattered { ty, members };
                 *parent_value = Value::Scattered(Box::new(scattered));
             }
             &mut Value::MovedVar(MovedVar { var_id, ref inference_error, last_use_location }) => {
-                let member_map = ctx.ctx.db.concrete_struct_members(concrete_struct_id).unwrap();
                 let location = ctx.ctx.variables[var_id].location;
-                let members = OrderedHashMap::from_iter(member_map.values().map(|member| {
-                    (
-                        member.id,
-                        Value::MovedVar(MovedVar {
-                            var_id: ctx.ctx.new_var(VarRequest { ty: member.ty, location }),
-                            inference_error: inference_error.clone(),
-                            last_use_location,
-                        }),
-                    )
-                }));
-                let scattered = Scattered { concrete_struct_id, members };
+                let inference_error = inference_error.clone();
+                let members = OrderedHashMap::from_iter(
+                    aggregate_members(ctx.ctx.db, ty).into_iter().map(|(kind, member_ty)| {
+                        (
+                            kind,
+                            Value::MovedVar(MovedVar {
+                                var_id: ctx.ctx.new_var(VarRequest { ty: member_ty, location }),
+                                inference_error: inference_error.clone(),
+                                last_use_location,
+                            }),
+                        )
+                    }),
+                );
+                let scattered = Scattered { ty, members };
                 *parent_value = Value::Scattered(Box::new(scattered));
             }
             Value::Scattered(..) => {}
         };
-        extract_matches!(parent_value, Value::Scattered).members.get_mut(&member_id)
+        extract_matches!(parent_value, Value::Scattered).members.get_mut(kind)
     }
 }
 
@@ -334,23 +332,21 @@ fn compute_remapped_variables<'db>(
     // If we encountered a [Value::Var], we need to remap all the [Value::Scattered] values.
     let require_remapping = require_remapping || only_scattered.len() < values.len();
 
-    let concrete_struct_id = only_scattered[0].concrete_struct_id;
+    let ty = only_scattered[0].ty;
     let members = only_scattered[0]
         .members
         .keys()
-        .map(|member_id| {
-            let member_path = MemberPath::Member {
-                parent: parent_path.clone().into(),
-                kind: MemberAccessKind::Struct { concrete_struct_id, member_id: *member_id },
-            };
+        .map(|kind| {
+            let member_path =
+                MemberPath::Member { parent: parent_path.clone().into(), kind: kind.clone() };
             // Call `compute_remapped_variables` recursively on the scattered values.
             // If there is a [Value::Var], `require_remapping` will be set to `true` to account
             // for it.
             let member_values =
-                only_scattered.iter().map(|scattered| &scattered.members[member_id]).collect_vec();
+                only_scattered.iter().map(|scattered| &scattered.members[kind]).collect_vec();
 
             (
-                *member_id,
+                kind.clone(),
                 compute_remapped_variables(
                     &member_values,
                     require_remapping,
@@ -361,7 +357,7 @@ fn compute_remapped_variables<'db>(
         })
         .collect();
 
-    Value::Scattered(Box::new(Scattered { concrete_struct_id, members }))
+    Value::Scattered(Box::new(Scattered { ty, members }))
 }
 
 /// Returns an iterator to all the [MemberPath]s that appear in both mappings and have different
@@ -425,6 +421,81 @@ impl<'db> std::fmt::Display for Value<'db> {
 #[derive(Clone, Debug, DebugWithDb, Eq, PartialEq)]
 #[debug_db(ExprFormatter<'db>)]
 struct Scattered<'db> {
-    concrete_struct_id: semantic::ConcreteStructId<'db>,
-    members: OrderedHashMap<MemberId<'db>, Value<'db>>,
+    /// The type of the scattered aggregate (a struct or a tuple), used to reconstruct it.
+    ty: semantic::TypeId<'db>,
+    members: OrderedHashMap<MemberAccessKind<'db>, Value<'db>>,
+}
+
+/// Returns the type of the aggregate (a struct or a tuple) that a [MemberAccessKind] accesses a
+/// member of.
+fn aggregate_ty<'db>(
+    db: &'db dyn salsa::Database,
+    kind: &MemberAccessKind<'db>,
+) -> semantic::TypeId<'db> {
+    match kind {
+        MemberAccessKind::Struct { concrete_struct_id, .. } => {
+            TypeLongId::Concrete(ConcreteTypeId::Struct(*concrete_struct_id)).intern(db)
+        }
+        MemberAccessKind::Index { tuple_ty, .. } => *tuple_ty,
+    }
+}
+
+/// Returns the ordered members of an aggregate type (struct or tuple), as pairs of
+/// [MemberAccessKind] and the member type.
+pub(crate) fn aggregate_members<'db>(
+    db: &'db dyn salsa::Database,
+    ty: semantic::TypeId<'db>,
+) -> Vec<(MemberAccessKind<'db>, semantic::TypeId<'db>)> {
+    match ty.long(db) {
+        TypeLongId::Concrete(ConcreteTypeId::Struct(concrete_struct_id)) => db
+            .concrete_struct_members(*concrete_struct_id)
+            .unwrap()
+            .iter()
+            .map(|(_, member)| {
+                (
+                    MemberAccessKind::Struct {
+                        concrete_struct_id: *concrete_struct_id,
+                        member_id: member.id,
+                    },
+                    member.ty,
+                )
+            })
+            .collect(),
+        TypeLongId::Tuple(tys) => tys
+            .iter()
+            .enumerate()
+            .map(|(index, member_ty)| (MemberAccessKind::Index { tuple_ty: ty, index }, *member_ty))
+            .collect(),
+        _ => unreachable!("Tried to scatter a non-aggregate type."),
+    }
+}
+
+/// Returns the snapshot-wrapped lowered types of the members of the aggregate `aggregate_ty`,
+/// along with the index of the member selected by `kind`. Returns `None` if `aggregate_ty` does
+/// not match `kind` (e.g. a tuple index on a non-tuple type).
+pub(crate) fn member_access_components<'db>(
+    ctx: &LoweringContext<'db, '_>,
+    aggregate_ty: semantic::TypeId<'db>,
+    kind: &MemberAccessKind<'db>,
+) -> Option<(Vec<semantic::TypeId<'db>>, usize)> {
+    let (n_snapshots, long_ty) = peel_snapshots(ctx.db, aggregate_ty);
+    match kind {
+        MemberAccessKind::Struct { concrete_struct_id, member_id } => {
+            let members = ctx.db.concrete_struct_members(*concrete_struct_id).ok()?;
+            let member_idx = members.iter().position(|(_, member)| member.id == *member_id)?;
+            let member_tys = members
+                .iter()
+                .map(|(_, member)| wrap_in_snapshots(ctx.db, member.ty, n_snapshots))
+                .collect();
+            Some((member_tys, member_idx))
+        }
+        MemberAccessKind::Index { index, .. } => {
+            let TypeLongId::Tuple(tys) = long_ty else {
+                return None;
+            };
+            let member_tys =
+                tys.iter().map(|ty| wrap_in_snapshots(ctx.db, *ty, n_snapshots)).collect();
+            Some((member_tys, *index))
+        }
+    }
 }

--- a/crates/cairo-lang-lowering/src/test_data/tuple
+++ b/crates/cairo-lang-lowering/src/test_data/tuple
@@ -34,3 +34,231 @@ Statements:
   (v4: (core::felt252, core::felt252)) <- test::immovable::<(core::felt252, core::felt252)>(v2)
 End:
   Return()
+
+//! > ==========================================================================
+
+//! > Test tuple index access - read.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function_code
+fn foo(t: (felt252, u8)) -> u8 {
+    t.1
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: (core::felt252, core::integer::u8)
+blk0 (root):
+Statements:
+  (v1: core::felt252, v2: core::integer::u8) <- struct_destructure(v0)
+End:
+  Return(v2)
+
+//! > ==========================================================================
+
+//! > Test tuple index access - nested read.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function_code
+fn foo(t: (felt252, (u8, u16))) -> u16 {
+    t.1.1
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: (core::felt252, (core::integer::u8, core::integer::u16))
+blk0 (root):
+Statements:
+  (v1: core::felt252, v2: (core::integer::u8, core::integer::u16)) <- struct_destructure(v0)
+  (v3: core::integer::u8, v4: core::integer::u16) <- struct_destructure(v2)
+End:
+  Return(v4)
+
+//! > ==========================================================================
+
+//! > Test tuple index access - assignment to element.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function_code
+fn foo(mut t: (felt252, u8)) -> (felt252, u8) {
+    t.0 = 5;
+    t
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: (core::felt252, core::integer::u8)
+blk0 (root):
+Statements:
+  (v1: core::felt252) <- 5
+  (v2: core::felt252, v3: core::integer::u8) <- struct_destructure(v0)
+  (v4: (core::felt252, core::integer::u8)) <- struct_construct(v1, v3)
+End:
+  Return(v4)
+
+//! > ==========================================================================
+
+//! > Test tuple index access - ref argument.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function_code
+fn foo(mut t: (felt252, u8)) -> (felt252, u8) {
+    bar(ref t.0);
+    t
+}
+
+//! > function_name
+foo
+
+//! > module_code
+fn bar(ref x: felt252) {
+    x = 7;
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: (core::felt252, core::integer::u8)
+blk0 (root):
+Statements:
+  (v1: core::felt252, v2: core::integer::u8) <- struct_destructure(v0)
+  (v3: core::felt252) <- 7
+  (v4: (core::felt252, core::integer::u8)) <- struct_construct(v3, v2)
+End:
+  Return(v4)
+
+//! > ==========================================================================
+
+//! > Test tuple index access - ref tuple argument.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function_code
+fn foo(mut t: ((felt252, u8), u16)) -> ((felt252, u8), u16) {
+    bar(ref t.0);
+    t
+}
+
+//! > function_name
+foo
+
+//! > module_code
+fn bar(ref x: (felt252, u8)) {
+    x.1 = 7;
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: ((core::felt252, core::integer::u8), core::integer::u16)
+blk0 (root):
+Statements:
+  (v1: (core::felt252, core::integer::u8), v2: core::integer::u16) <- struct_destructure(v0)
+  (v3: core::integer::u8) <- 7
+  (v4: core::felt252, v5: core::integer::u8) <- struct_destructure(v1)
+  (v6: (core::felt252, core::integer::u8)) <- struct_construct(v4, v3)
+  (v7: ((core::felt252, core::integer::u8), core::integer::u16)) <- struct_construct(v6, v2)
+End:
+  Return(v7)
+
+//! > ==========================================================================
+
+//! > Test tuple index access - through a snapshot.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function_code
+fn foo(t: (felt252, u8)) -> @u8 {
+    let s = @t;
+    s.1
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: (core::felt252, core::integer::u8)
+blk0 (root):
+Statements:
+  (v1: (core::felt252, core::integer::u8), v2: @(core::felt252, core::integer::u8)) <- snapshot(v0)
+  (v3: @core::felt252, v4: @core::integer::u8) <- struct_destructure(v2)
+End:
+  Return(v4)
+
+//! > ==========================================================================
+
+//! > Test tuple index access - on a snapshot tuple held in a struct member.
+
+//! > test_runner_name
+test_function_lowering(expect_diagnostics: false)
+
+//! > function_code
+fn foo(w: Wrapper) -> @u8 {
+    w.inner.1
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop, Copy)]
+struct Wrapper {
+    inner: @(felt252, u8),
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering_flat
+Parameters: v0: test::Wrapper
+blk0 (root):
+Statements:
+  (v1: @(core::felt252, core::integer::u8)) <- struct_destructure(v0)
+  (v2: @core::felt252, v3: @core::integer::u8) <- struct_destructure(v1)
+End:
+  Return(v3)


### PR DESCRIPTION
Implements the lowering half of `t.0` tuple-index member access, stacked on top of #10111 (the semantic half).

## What

Generalizes the member-access lowering machinery from struct-only to any aggregate (struct or tuple):

- Replace the `concrete_struct_id`-keyed `Scattered` with a `TypeId`-keyed one, keyed by `MemberAccessKind` instead of `MemberId`.
- Add helpers in `refs.rs` that handle both structs and tuples uniformly:
  - `aggregate_ty` — the type an access reads a member of.
  - `aggregate_members` — ordered `(MemberAccessKind, member_ty)` pairs of an aggregate.
  - `member_access_components` — snapshot-wrapped member types + selected index.
- Handle `MemberAccessKind::Index` in member-access lowering, ref-binding, and struct deconstruct/reconstruct (previously `unreachable!`/`Unsupported`).

## Tests

- Lowering `test_data/tuple` cases.
- Corelib `tuple_test.cairo`: index read, nested access, assignment, nested assignment, `ref` arguments, and access through snapshots.

> [!NOTE]
> Stacked on #10111 — review/merge that first. The base will need to be retargeted to `main` once #10111 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)