### PR TITLE
feat(starknet): generate a CallBuilder for #[starknet::interface] traits

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -87,6 +87,8 @@ pub fn handle_trait<'db>(
     let mut library_caller_method_impls = vec![];
     let mut safe_contract_caller_method_impls = vec![];
     let mut safe_library_caller_method_impls = vec![];
+    let mut call_builder_signatures = vec![];
+    let mut call_builder_method_impls = vec![];
     let mut forward_method_wrappers = vec![];
     let mut forward_external_fns = vec![];
     let mut forward_impl_method_stubs = vec![];
@@ -101,6 +103,8 @@ pub fn handle_trait<'db>(
     let safe_contract_caller_name = format!("{base_name}SafeDispatcher");
     let library_caller_name = format!("{base_name}LibraryDispatcher");
     let safe_library_caller_name = format!("{base_name}SafeLibraryDispatcher");
+    let call_builder_trait_name = format!("{base_name}CallBuilderTrait");
+    let call_builder_name = format!("{base_name}CallBuilder");
     for item_ast in body.iter_items(db) {
         match item_ast {
             ast::TraitItem::Function(func) => {
@@ -341,6 +345,19 @@ pub fn handle_trait<'db>(
                     ret_decode.clone(),
                     false,
                 ));
+                call_builder_signatures.push(RewriteNode::interpolate_patched(
+                    "\n    #[unstable(feature: \"call_builder\")]\n$func_decl$;",
+                    &[(
+                        "func_decl".to_string(),
+                        call_builder_signature(db, &declaration, "T"),
+                    )]
+                    .into(),
+                ));
+                call_builder_method_impls.push(call_builder_method_impl(
+                    call_builder_signature(db, &declaration, &call_builder_name),
+                    entry_point_selector.clone(),
+                    serialization_code.clone(),
+                ));
                 safe_library_caller_method_impls.push(declaration_method_impl(
                     dispatcher_signature(db, &declaration, &safe_library_caller_name, false),
                     entry_point_selector,
@@ -434,6 +451,21 @@ pub fn handle_trait<'db>(
              {safe_dispatcher_trait_name}<{safe_contract_caller_name}> {{
             $safe_contract_caller_method_impls$
             }}
+
+            {DISPATCHER_DOC_GROUP_ATTR}
+            $visibility$trait {call_builder_trait_name}<T> {{$call_builder_signatures$
+            }}
+
+            {DISPATCHER_DOC_GROUP_ATTR}
+            #[derive(Copy, Drop, {STORE_TRAIT}, Serde)]
+            $visibility$struct {call_builder_name} {{
+                pub contract_address: starknet::ContractAddress,
+            }}
+
+            {DISPATCHER_DOC_GROUP_ATTR}
+            impl {call_builder_name}Impl of {call_builder_trait_name}<{call_builder_name}> {{
+            $call_builder_method_impls$
+            }}
             ",
         ),
         &[
@@ -457,6 +489,14 @@ pub fn handle_trait<'db>(
             (
                 "safe_library_caller_method_impls".to_string(),
                 RewriteNode::new_modified(safe_library_caller_method_impls),
+            ),
+            (
+                "call_builder_signatures".to_string(),
+                RewriteNode::new_modified(call_builder_signatures),
+            ),
+            (
+                "call_builder_method_impls".to_string(),
+                RewriteNode::new_modified(call_builder_method_impls),
             ),
             (
                 "visibility".to_string(),
@@ -591,6 +631,69 @@ fn declaration_method_impl<'db>(
         ]
         .into(),
     )
+}
+
+/// Returns the method implementation for a call builder: serializes the arguments into
+/// `__calldata__` and returns a `starknet::account::Call` targeting `self.contract_address`.
+/// Unlike a dispatcher method, it performs no syscall and never deserializes a return value.
+fn call_builder_method_impl<'db>(
+    func_declaration: RewriteNode<'db>,
+    entry_point_selector: RewriteNode<'db>,
+    serialization_code: Vec<RewriteNode<'db>>,
+) -> RewriteNode<'db> {
+    RewriteNode::interpolate_patched(
+        &formatdoc!(
+            "$func_decl$ {{
+                    let mut {CALLDATA_PARAM_NAME} = core::traits::Default::default();
+            $serialization_code$
+                    starknet::account::Call {{
+                        to: self.contract_address,
+                        selector: $entry_point_selector$,
+                        calldata: core::array::ArrayTrait::span(@{CALLDATA_PARAM_NAME}),
+                    }}
+                }}
+        "
+        ),
+        &[
+            ("func_decl".to_string(), func_declaration),
+            ("entry_point_selector".to_string(), entry_point_selector),
+            ("serialization_code".to_string(), RewriteNode::new_modified(serialization_code)),
+        ]
+        .into(),
+    )
+}
+
+/// Returns the signature for a call-builder method: the declaration's parameters with `self`
+/// replaced by `self_type_name`, and the return type forced to `starknet::account::Call`
+/// (the interface method's own return type is irrelevant when only building a `Call`).
+fn call_builder_signature<'db>(
+    db: &'db dyn Database,
+    declaration: &ast::FunctionDeclaration<'db>,
+    self_type_name: &str,
+) -> RewriteNode<'db> {
+    let mut func_declaration = RewriteNode::from_ast(declaration);
+    let params = func_declaration
+        .modify_child(db, ast::FunctionDeclaration::INDEX_SIGNATURE)
+        .modify_child(db, ast::FunctionSignature::INDEX_PARAMETERS)
+        .modify(db)
+        .children
+        .as_mut()
+        .unwrap();
+    let maybe_comma = if params.len() > 2 { ", " } else { "" };
+    params.splice(
+        0..std::cmp::min(2, params.len()),
+        [RewriteNode::Text(format!("self: {self_type_name}{maybe_comma}"))],
+    );
+    let return_type = func_declaration
+        .modify_child(db, ast::FunctionDeclaration::INDEX_SIGNATURE)
+        .modify_child(db, ast::FunctionSignature::INDEX_RET_TY)
+        .modify(db)
+        .children
+        .as_mut()
+        .unwrap();
+    // Replace the whole return-type clause (empty or not) with `-> Call`.
+    return_type.splice(0..return_type.len(), [RewriteNode::text(" -> starknet::account::Call")]);
+    func_declaration
 }
 
 /// Returns the matching signature for a dispatcher implementation for the given declaration.

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
@@ -385,6 +385,46 @@ impl MyTraitSafeDispatcherImpl of MyTraitSafeDispatcherTrait<MyTraitSafeDispatch
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait MyTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get(self: T, addr: ContractAddress)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set(self: T, addr: ContractAddress, value: u32) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct MyTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderImpl of MyTraitCallBuilderTrait<MyTraitCallBuilder> {
+    fn get(self: MyTraitCallBuilder, addr: ContractAddress)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@addr, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set(self: MyTraitCallBuilder, addr: ContractAddress, value: u32) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@addr, ref __calldata__);
+        core::serde::Serde::<u32>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -951,6 +991,126 @@ lib.cairo:42:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderCopy<> of core::traits::Copy::<MyTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderDrop<> of core::traits::Drop::<MyTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderSerde<> of core::serde::Serde::<MyTraitCallBuilder> {
+    fn serialize(self: @MyTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<MyTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(MyTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:42:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl MyTraitCallBuilderStore<> of starknet::Store::<MyTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<MyTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            MyTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: MyTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let MyTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<MyTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            MyTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: MyTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let MyTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct MyTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<MyTraitCallBuilder> {
+    type SubPointersType = MyTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<MyTraitCallBuilder>) -> MyTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                MyTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct MyTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<MyTraitCallBuilder> {
+    type SubPointersType = MyTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<MyTraitCallBuilder>>) -> MyTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                MyTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:42:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl MyTraitDispatcherSubPointersDrop<> of core::traits::Drop::<MyTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1032,6 +1192,28 @@ impls:
 impl MyTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<MyTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl MyTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<MyTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:42:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<MyTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<MyTraitCallBuilderSubPointers>;
+
+
+lib.cairo:42:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<MyTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<MyTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:6:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/embeddable_as
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/embeddable_as
@@ -151,6 +151,32 @@ impl MyTraitSafeDispatcherImpl of MyTraitSafeDispatcherTrait<MyTraitSafeDispatch
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait MyTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn do_nothing(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct MyTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderImpl of MyTraitCallBuilderTrait<MyTraitCallBuilder> {
+    fn do_nothing(self: MyTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("do_nothing"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -676,6 +702,126 @@ lib.cairo:16:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderCopy<> of core::traits::Copy::<MyTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderDrop<> of core::traits::Drop::<MyTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderSerde<> of core::serde::Serde::<MyTraitCallBuilder> {
+    fn serialize(self: @MyTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<MyTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(MyTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:16:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl MyTraitCallBuilderStore<> of starknet::Store::<MyTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<MyTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            MyTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: MyTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let MyTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<MyTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            MyTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: MyTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let MyTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct MyTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<MyTraitCallBuilder> {
+    type SubPointersType = MyTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<MyTraitCallBuilder>) -> MyTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                MyTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct MyTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<MyTraitCallBuilder> {
+    type SubPointersType = MyTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<MyTraitCallBuilder>>) -> MyTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                MyTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:16:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl MyTraitDispatcherSubPointersDrop<> of core::traits::Drop::<MyTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -757,6 +903,28 @@ impls:
 impl MyTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<MyTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl MyTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<MyTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:16:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<MyTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<MyTraitCallBuilderSubPointers>;
+
+
+lib.cairo:16:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<MyTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<MyTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:1:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -3028,6 +3028,54 @@ impl InterfaceTraitSafeDispatcherImpl of InterfaceTraitSafeDispatcherTrait<Inter
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait InterfaceTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo_external1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo_l1_handler1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo_constructor1(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderImpl of InterfaceTraitCallBuilderTrait<InterfaceTraitCallBuilder> {
+    fn foo_external1(self: InterfaceTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo_external1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo_l1_handler1(self: InterfaceTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo_l1_handler1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo_constructor1(self: InterfaceTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo_constructor1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -3591,6 +3639,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderCopy<> of core::traits::Copy::<InterfaceTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderDrop<> of core::traits::Drop::<InterfaceTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderSerde<> of core::serde::Serde::<InterfaceTraitCallBuilder> {
+    fn serialize(self: @InterfaceTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceTraitCallBuilderStore<> of starknet::Store::<InterfaceTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceTraitCallBuilder> {
+    type SubPointersType = InterfaceTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceTraitCallBuilder>) -> InterfaceTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceTraitCallBuilder> {
+    type SubPointersType = InterfaceTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceTraitCallBuilder>>) -> InterfaceTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceTraitDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -3672,6 +3840,28 @@ impls:
 impl InterfaceTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:8:1
@@ -4546,6 +4736,21 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -5032,6 +5237,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -5113,6 +5438,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -5233,6 +5580,21 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -5719,6 +6081,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -5800,6 +6282,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -5886,6 +6390,21 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -6372,6 +6891,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -6453,6 +7092,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -6546,6 +7207,21 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -7032,6 +7708,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -7113,6 +7909,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -7265,6 +8083,32 @@ impl InterfaceTraitSafeDispatcherImpl of InterfaceTraitSafeDispatcherTrait<Inter
                 'Returned data too short',
             )
         )
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo_with_body(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderImpl of InterfaceTraitCallBuilderTrait<InterfaceTraitCallBuilder> {
+    fn foo_with_body(self: InterfaceTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo_with_body"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -7755,6 +8599,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderCopy<> of core::traits::Copy::<InterfaceTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderDrop<> of core::traits::Drop::<InterfaceTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderSerde<> of core::serde::Serde::<InterfaceTraitCallBuilder> {
+    fn serialize(self: @InterfaceTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceTraitCallBuilderStore<> of starknet::Store::<InterfaceTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceTraitCallBuilder> {
+    type SubPointersType = InterfaceTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceTraitCallBuilder>) -> InterfaceTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceTraitCallBuilder> {
+    type SubPointersType = InterfaceTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceTraitCallBuilder>>) -> InterfaceTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceTraitDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -7836,6 +8800,28 @@ impls:
 impl InterfaceTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceTraitCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -8091,6 +9077,54 @@ impl InterfaceSafeDispatcherImpl of InterfaceSafeDispatcherTrait<InterfaceSafeDi
         );
         let mut __dispatcher_return_data__ = __dispatcher_return_data__?;
         Result::Ok(())
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo2(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo3(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderImpl of InterfaceCallBuilderTrait<InterfaceCallBuilder> {
+    fn foo1(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo2(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo2"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo3(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -8737,6 +9771,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderCopy<> of core::traits::Copy::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderDrop<> of core::traits::Drop::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderSerde<> of core::serde::Serde::<InterfaceCallBuilder> {
+    fn serialize(self: @InterfaceCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceCallBuilderStore<> of starknet::Store::<InterfaceCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceCallBuilder>) -> InterfaceCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceCallBuilder>>) -> InterfaceCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceDispatcherSubPointers>;
 #[doc(hidden)]
@@ -8818,6 +9972,28 @@ impls:
 impl InterfaceSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -9129,6 +10305,54 @@ impl InterfaceSafeDispatcherImpl of InterfaceSafeDispatcherTrait<InterfaceSafeDi
         );
         let mut __dispatcher_return_data__ = __dispatcher_return_data__?;
         Result::Ok(())
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo2(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo3(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderImpl of InterfaceCallBuilderTrait<InterfaceCallBuilder> {
+    fn foo1(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo2(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo2"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo3(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -9695,6 +10919,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderCopy<> of core::traits::Copy::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderDrop<> of core::traits::Drop::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderSerde<> of core::serde::Serde::<InterfaceCallBuilder> {
+    fn serialize(self: @InterfaceCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceCallBuilderStore<> of starknet::Store::<InterfaceCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceCallBuilder>) -> InterfaceCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceCallBuilder>>) -> InterfaceCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceDispatcherSubPointers>;
 #[doc(hidden)]
@@ -9776,6 +11120,28 @@ impls:
 impl InterfaceSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointersMut>;
 
 
 lib.cairo:7:1
@@ -10809,6 +12175,43 @@ impl Comp3TraitSafeDispatcherImpl of Comp3TraitSafeDispatcherTrait<Comp3TraitSaf
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait Comp3TraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo3(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo4(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct Comp3TraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderImpl of Comp3TraitCallBuilderTrait<Comp3TraitCallBuilder> {
+    fn foo3(self: Comp3TraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo4(self: Comp3TraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo4"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -11353,6 +12756,126 @@ lib.cairo:30:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderCopy<> of core::traits::Copy::<Comp3TraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderDrop<> of core::traits::Drop::<Comp3TraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderSerde<> of core::serde::Serde::<Comp3TraitCallBuilder> {
+    fn serialize(self: @Comp3TraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<Comp3TraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(Comp3TraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:30:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl Comp3TraitCallBuilderStore<> of starknet::Store::<Comp3TraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Comp3TraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            Comp3TraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Comp3TraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let Comp3TraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<Comp3TraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            Comp3TraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: Comp3TraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let Comp3TraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Comp3TraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<Comp3TraitCallBuilder> {
+    type SubPointersType = Comp3TraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<Comp3TraitCallBuilder>) -> Comp3TraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Comp3TraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Comp3TraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<Comp3TraitCallBuilder> {
+    type SubPointersType = Comp3TraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<Comp3TraitCallBuilder>>) -> Comp3TraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Comp3TraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:30:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl Comp3TraitDispatcherSubPointersDrop<> of core::traits::Drop::<Comp3TraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -11434,6 +12957,28 @@ impls:
 impl Comp3TraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<Comp3TraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl Comp3TraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<Comp3TraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:30:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersDrop<> of core::traits::Drop::<Comp3TraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersCopy<> of core::traits::Copy::<Comp3TraitCallBuilderSubPointers>;
+
+
+lib.cairo:30:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<Comp3TraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<Comp3TraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:1:1
@@ -12247,6 +13792,32 @@ impl Comp3TraitSafeDispatcherImpl of Comp3TraitSafeDispatcherTrait<Comp3TraitSaf
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait Comp3TraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo3(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct Comp3TraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderImpl of Comp3TraitCallBuilderTrait<Comp3TraitCallBuilder> {
+    fn foo3(self: Comp3TraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -12772,6 +14343,126 @@ lib.cairo:27:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderCopy<> of core::traits::Copy::<Comp3TraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderDrop<> of core::traits::Drop::<Comp3TraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderSerde<> of core::serde::Serde::<Comp3TraitCallBuilder> {
+    fn serialize(self: @Comp3TraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<Comp3TraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(Comp3TraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:27:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl Comp3TraitCallBuilderStore<> of starknet::Store::<Comp3TraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Comp3TraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            Comp3TraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Comp3TraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let Comp3TraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<Comp3TraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            Comp3TraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: Comp3TraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let Comp3TraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Comp3TraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<Comp3TraitCallBuilder> {
+    type SubPointersType = Comp3TraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<Comp3TraitCallBuilder>) -> Comp3TraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Comp3TraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Comp3TraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<Comp3TraitCallBuilder> {
+    type SubPointersType = Comp3TraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<Comp3TraitCallBuilder>>) -> Comp3TraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Comp3TraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:27:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl Comp3TraitDispatcherSubPointersDrop<> of core::traits::Drop::<Comp3TraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -12853,6 +14544,28 @@ impls:
 impl Comp3TraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<Comp3TraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl Comp3TraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<Comp3TraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:27:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersDrop<> of core::traits::Drop::<Comp3TraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersCopy<> of core::traits::Copy::<Comp3TraitCallBuilderSubPointers>;
+
+
+lib.cairo:27:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<Comp3TraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<Comp3TraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:1:1
@@ -13525,6 +15238,32 @@ impl ContractTraitSafeDispatcherImpl of ContractTraitSafeDispatcherTrait<Contrac
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait ContractTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct ContractTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderImpl of ContractTraitCallBuilderTrait<ContractTraitCallBuilder> {
+    fn foo(self: ContractTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -14050,6 +15789,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderCopy<> of core::traits::Copy::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderDrop<> of core::traits::Drop::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderSerde<> of core::serde::Serde::<ContractTraitCallBuilder> {
+    fn serialize(self: @ContractTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ContractTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ContractTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl ContractTraitCallBuilderStore<> of starknet::Store::<ContractTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ContractTraitCallBuilder>) -> ContractTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ContractTraitCallBuilder>>) -> ContractTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl ContractTraitDispatcherSubPointersDrop<> of core::traits::Drop::<ContractTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -14131,6 +15990,28 @@ impls:
 impl ContractTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ContractTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ContractTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ContractTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:6:1
@@ -14522,6 +16403,32 @@ impl ContractTraitSafeDispatcherImpl of ContractTraitSafeDispatcherTrait<Contrac
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait ContractTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct ContractTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderImpl of ContractTraitCallBuilderTrait<ContractTraitCallBuilder> {
+    fn foo(self: ContractTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -15047,6 +16954,126 @@ lib.cairo:9:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderCopy<> of core::traits::Copy::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderDrop<> of core::traits::Drop::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderSerde<> of core::serde::Serde::<ContractTraitCallBuilder> {
+    fn serialize(self: @ContractTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ContractTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ContractTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:9:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl ContractTraitCallBuilderStore<> of starknet::Store::<ContractTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ContractTraitCallBuilder>) -> ContractTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ContractTraitCallBuilder>>) -> ContractTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:9:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl ContractTraitDispatcherSubPointersDrop<> of core::traits::Drop::<ContractTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -15128,6 +17155,28 @@ impls:
 impl ContractTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ContractTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ContractTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ContractTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:9:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointers>;
+
+
+lib.cairo:9:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:1:1
@@ -15761,6 +17810,32 @@ impl ContractTraitSafeDispatcherImpl of ContractTraitSafeDispatcherTrait<Contrac
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait ContractTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct ContractTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderImpl of ContractTraitCallBuilderTrait<ContractTraitCallBuilder> {
+    fn foo(self: ContractTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -16286,6 +18361,126 @@ lib.cairo:43:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderCopy<> of core::traits::Copy::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderDrop<> of core::traits::Drop::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderSerde<> of core::serde::Serde::<ContractTraitCallBuilder> {
+    fn serialize(self: @ContractTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ContractTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ContractTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:43:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl ContractTraitCallBuilderStore<> of starknet::Store::<ContractTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ContractTraitCallBuilder>) -> ContractTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ContractTraitCallBuilder>>) -> ContractTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:43:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl ContractTraitDispatcherSubPointersDrop<> of core::traits::Drop::<ContractTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -16367,6 +18562,28 @@ impls:
 impl ContractTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ContractTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ContractTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ContractTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:43:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointers>;
+
+
+lib.cairo:43:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:48:1
@@ -16750,6 +18967,32 @@ impl InterfaceSafeDispatcherImpl of InterfaceSafeDispatcherTrait<InterfaceSafeDi
         );
         let mut __dispatcher_return_data__ = __dispatcher_return_data__?;
         Result::Ok(())
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn func(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderImpl of InterfaceCallBuilderTrait<InterfaceCallBuilder> {
+    fn func(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("func"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -17278,6 +19521,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderCopy<> of core::traits::Copy::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderDrop<> of core::traits::Drop::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderSerde<> of core::serde::Serde::<InterfaceCallBuilder> {
+    fn serialize(self: @InterfaceCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceCallBuilderStore<> of starknet::Store::<InterfaceCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceCallBuilder>) -> InterfaceCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceCallBuilder>>) -> InterfaceCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceDispatcherSubPointers>;
 #[doc(hidden)]
@@ -17359,6 +19722,28 @@ impls:
 impl InterfaceSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointersMut>;
 
 
 lib.cairo:6:1
@@ -18521,6 +20906,33 @@ impl InterfaceSafeDispatcherImpl of InterfaceSafeDispatcherTrait<InterfaceSafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+pub trait InterfaceCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T, value: u256) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+pub struct InterfaceCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderImpl of InterfaceCallBuilderTrait<InterfaceCallBuilder> {
+    fn foo(self: InterfaceCallBuilder, value: u256) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u256>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -19046,6 +21458,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderCopy<> of core::traits::Copy::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderDrop<> of core::traits::Drop::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderSerde<> of core::serde::Serde::<InterfaceCallBuilder> {
+    fn serialize(self: @InterfaceCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceCallBuilderStore<> of starknet::Store::<InterfaceCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceCallBuilder>) -> InterfaceCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceCallBuilder>>) -> InterfaceCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceDispatcherSubPointers>;
 #[doc(hidden)]
@@ -19127,6 +21659,28 @@ impls:
 impl InterfaceSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointersMut>;
 
 
 lib.cairo:6:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/dispatcher
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/dispatcher
@@ -202,6 +202,47 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_something(self: T, arg: felt252, num: felt252)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+
+    fn empty(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+    fn get_something(self: IContractCallBuilder, arg: felt252, num: felt252)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<felt252>::serialize(@arg, ref __calldata__);
+        core::serde::Serde::<felt252>::serialize(@num, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_something"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+    fn empty(self: IContractCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("empty"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -747,6 +788,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -828,6 +989,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > expected_diagnostics
 
@@ -911,6 +1094,21 @@ struct IContractSafeDispatcher {
 
 #[doc(group: "dispatchers")]
 impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDispatcher> {
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
 
 }
 
@@ -1400,6 +1598,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1481,6 +1799,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > expected_diagnostics
 error[E2200]: Plugin diagnostic: `starknet::interface` functions don't support `ref` parameters other than the first one.
@@ -1647,6 +1987,34 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+
+    fn empty(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+    fn empty(self: IContractCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("empty"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -2133,6 +2501,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -2214,3 +2702,25 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
@@ -252,6 +252,45 @@ impl OutsideTraitSafeDispatcherImpl of OutsideTraitSafeDispatcherTrait<OutsideTr
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn ret_3(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn ret_identity(self: T, from_address: felt252, value: felt252)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct OutsideTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitCallBuilderImpl of OutsideTraitCallBuilderTrait<OutsideTraitCallBuilder> {
+    fn ret_3(self: OutsideTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn ret_identity(self: OutsideTraitCallBuilder, from_address: felt252, value: felt252)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<felt252>::serialize(@from_address, ref __calldata__);
+        core::serde::Serde::<felt252>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_identity"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -866,6 +905,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl OutsideTraitCallBuilderCopy<> of core::traits::Copy::<OutsideTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitCallBuilderDrop<> of core::traits::Drop::<OutsideTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitCallBuilderSerde<> of core::serde::Serde::<OutsideTraitCallBuilder> {
+    fn serialize(self: @OutsideTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<OutsideTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(OutsideTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl OutsideTraitCallBuilderStore<> of starknet::Store::<OutsideTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<OutsideTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: OutsideTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let OutsideTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<OutsideTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: OutsideTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let OutsideTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<OutsideTraitCallBuilder> {
+    type SubPointersType = OutsideTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<OutsideTraitCallBuilder>) -> OutsideTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<OutsideTraitCallBuilder> {
+    type SubPointersType = OutsideTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<OutsideTraitCallBuilder>>) -> OutsideTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl OutsideTraitDispatcherSubPointersDrop<> of core::traits::Drop::<OutsideTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -947,6 +1106,28 @@ impls:
 impl OutsideTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl OutsideTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<OutsideTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<OutsideTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:17:1
@@ -1333,6 +1514,32 @@ impl OutsideTraitWithDestructSafeDispatcherImpl of OutsideTraitWithDestructSafeD
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithDestructCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn ret_3(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct OutsideTraitWithDestructCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructCallBuilderImpl of OutsideTraitWithDestructCallBuilderTrait<OutsideTraitWithDestructCallBuilder> {
+    fn ret_3(self: OutsideTraitWithDestructCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -1533,6 +1740,32 @@ impl OutsideTraitWithPanicDestructSafeDispatcherImpl of OutsideTraitWithPanicDes
                 'Returned data too short',
             )
         )
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithPanicDestructCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn ret_5(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct OutsideTraitWithPanicDestructCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructCallBuilderImpl of OutsideTraitWithPanicDestructCallBuilderTrait<OutsideTraitWithPanicDestructCallBuilder> {
+    fn ret_5(self: OutsideTraitWithPanicDestructCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_5"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -2099,6 +2332,126 @@ impl OutsideTraitWithDestructSafeDispatcherSubPointersMutImpl of starknet::stora
 }
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructCallBuilderCopy<> of core::traits::Copy::<OutsideTraitWithDestructCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructCallBuilderDrop<> of core::traits::Drop::<OutsideTraitWithDestructCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructCallBuilderSerde<> of core::serde::Serde::<OutsideTraitWithDestructCallBuilder> {
+    fn serialize(self: @OutsideTraitWithDestructCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<OutsideTraitWithDestructCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(OutsideTraitWithDestructCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl OutsideTraitWithDestructCallBuilderStore<> of starknet::Store::<OutsideTraitWithDestructCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<OutsideTraitWithDestructCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithDestructCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: OutsideTraitWithDestructCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let OutsideTraitWithDestructCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<OutsideTraitWithDestructCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithDestructCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: OutsideTraitWithDestructCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let OutsideTraitWithDestructCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithDestructCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersImpl of starknet::storage::SubPointers<OutsideTraitWithDestructCallBuilder> {
+    type SubPointersType = OutsideTraitWithDestructCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<OutsideTraitWithDestructCallBuilder>) -> OutsideTraitWithDestructCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithDestructCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithDestructCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<OutsideTraitWithDestructCallBuilder> {
+    type SubPointersType = OutsideTraitWithDestructCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<OutsideTraitWithDestructCallBuilder>>) -> OutsideTraitWithDestructCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithDestructCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:15:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2579,6 +2932,126 @@ impl OutsideTraitWithPanicDestructSafeDispatcherSubPointersMutImpl of starknet::
 }
 
 
+lib.cairo:15:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructCallBuilderCopy<> of core::traits::Copy::<OutsideTraitWithPanicDestructCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructCallBuilderDrop<> of core::traits::Drop::<OutsideTraitWithPanicDestructCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructCallBuilderSerde<> of core::serde::Serde::<OutsideTraitWithPanicDestructCallBuilder> {
+    fn serialize(self: @OutsideTraitWithPanicDestructCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<OutsideTraitWithPanicDestructCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(OutsideTraitWithPanicDestructCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:15:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl OutsideTraitWithPanicDestructCallBuilderStore<> of starknet::Store::<OutsideTraitWithPanicDestructCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<OutsideTraitWithPanicDestructCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithPanicDestructCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: OutsideTraitWithPanicDestructCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let OutsideTraitWithPanicDestructCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<OutsideTraitWithPanicDestructCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithPanicDestructCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: OutsideTraitWithPanicDestructCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let OutsideTraitWithPanicDestructCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithPanicDestructCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersImpl of starknet::storage::SubPointers<OutsideTraitWithPanicDestructCallBuilder> {
+    type SubPointersType = OutsideTraitWithPanicDestructCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<OutsideTraitWithPanicDestructCallBuilder>) -> OutsideTraitWithPanicDestructCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithPanicDestructCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithPanicDestructCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<OutsideTraitWithPanicDestructCallBuilder> {
+    type SubPointersType = OutsideTraitWithPanicDestructCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<OutsideTraitWithPanicDestructCallBuilder>>) -> OutsideTraitWithPanicDestructCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithPanicDestructCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:1:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2667,6 +3140,28 @@ impl OutsideTraitWithDestructSafeDispatcherSubPointersMutDrop<> of core::traits:
 impl OutsideTraitWithDestructSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithDestructSafeDispatcherSubPointersMut>;
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersDrop<> of core::traits::Drop::<OutsideTraitWithDestructCallBuilderSubPointers>;
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersCopy<> of core::traits::Copy::<OutsideTraitWithDestructCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithDestructCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithDestructCallBuilderSubPointersMut>;
+
+
 lib.cairo:15:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2753,6 +3248,28 @@ impls:
 impl OutsideTraitWithPanicDestructSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithPanicDestructSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl OutsideTraitWithPanicDestructSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithPanicDestructSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:15:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersDrop<> of core::traits::Drop::<OutsideTraitWithPanicDestructCallBuilderSubPointers>;
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersCopy<> of core::traits::Copy::<OutsideTraitWithPanicDestructCallBuilderSubPointers>;
+
+
+lib.cairo:15:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithPanicDestructCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithPanicDestructCallBuilderSubPointersMut>;
 
 
 lib.cairo:29:1
@@ -3110,6 +3627,32 @@ impl OutsideTraitWithDropSafeDispatcherImpl of OutsideTraitWithDropSafeDispatche
                 'Returned data too short',
             )
         )
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithDropCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn ret_8(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct OutsideTraitWithDropCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropCallBuilderImpl of OutsideTraitWithDropCallBuilderTrait<OutsideTraitWithDropCallBuilder> {
+    fn ret_8(self: OutsideTraitWithDropCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_8"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -3681,6 +4224,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropCallBuilderCopy<> of core::traits::Copy::<OutsideTraitWithDropCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropCallBuilderDrop<> of core::traits::Drop::<OutsideTraitWithDropCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropCallBuilderSerde<> of core::serde::Serde::<OutsideTraitWithDropCallBuilder> {
+    fn serialize(self: @OutsideTraitWithDropCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<OutsideTraitWithDropCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(OutsideTraitWithDropCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl OutsideTraitWithDropCallBuilderStore<> of starknet::Store::<OutsideTraitWithDropCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<OutsideTraitWithDropCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithDropCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: OutsideTraitWithDropCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let OutsideTraitWithDropCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<OutsideTraitWithDropCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithDropCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: OutsideTraitWithDropCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let OutsideTraitWithDropCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithDropCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersImpl of starknet::storage::SubPointers<OutsideTraitWithDropCallBuilder> {
+    type SubPointersType = OutsideTraitWithDropCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<OutsideTraitWithDropCallBuilder>) -> OutsideTraitWithDropCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithDropCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithDropCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<OutsideTraitWithDropCallBuilder> {
+    type SubPointersType = OutsideTraitWithDropCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<OutsideTraitWithDropCallBuilder>>) -> OutsideTraitWithDropCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithDropCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl OutsideTraitWithDropDispatcherSubPointersDrop<> of core::traits::Drop::<OutsideTraitWithDropDispatcherSubPointers>;
 #[doc(hidden)]
@@ -3762,6 +4425,28 @@ impls:
 impl OutsideTraitWithDropSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithDropSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl OutsideTraitWithDropSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithDropSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersDrop<> of core::traits::Drop::<OutsideTraitWithDropCallBuilderSubPointers>;
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersCopy<> of core::traits::Copy::<OutsideTraitWithDropCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithDropCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithDropCallBuilderSubPointersMut>;
 
 
 lib.cairo:15:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/forward_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/forward_impl
@@ -226,6 +226,44 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_value(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_value(self: T, value: felt252) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+    fn get_value(self: IContractCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_value"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_value(self: IContractCallBuilder, value: felt252) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<felt252>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_value"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -770,6 +808,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -851,6 +1009,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 
 lib.cairo:7:1
@@ -1233,6 +1413,32 @@ impl IForwardedSafeDispatcherImpl of IForwardedSafeDispatcherTrait<IForwardedSaf
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait IForwardedCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn forwarded_fn(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IForwardedCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IForwardedCallBuilderImpl of IForwardedCallBuilderTrait<IForwardedCallBuilder> {
+    fn forwarded_fn(self: IForwardedCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("forwarded_fn"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -1390,6 +1596,32 @@ impl IDirectSafeDispatcherImpl of IDirectSafeDispatcherTrait<IDirectSafeDispatch
                 'Returned data too short',
             )
         )
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait IDirectCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn direct_fn(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IDirectCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IDirectCallBuilderImpl of IDirectCallBuilderTrait<IDirectCallBuilder> {
+    fn direct_fn(self: IDirectCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("direct_fn"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -1956,6 +2188,126 @@ impl IForwardedSafeDispatcherSubPointersMutImpl of starknet::storage::SubPointer
 }
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl IForwardedCallBuilderCopy<> of core::traits::Copy::<IForwardedCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IForwardedCallBuilderDrop<> of core::traits::Drop::<IForwardedCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IForwardedCallBuilderSerde<> of core::serde::Serde::<IForwardedCallBuilder> {
+    fn serialize(self: @IForwardedCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IForwardedCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IForwardedCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IForwardedCallBuilderStore<> of starknet::Store::<IForwardedCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IForwardedCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IForwardedCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IForwardedCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IForwardedCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IForwardedCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IForwardedCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IForwardedCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IForwardedCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IForwardedCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersImpl of starknet::storage::SubPointers<IForwardedCallBuilder> {
+    type SubPointersType = IForwardedCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IForwardedCallBuilder>) -> IForwardedCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IForwardedCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IForwardedCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IForwardedCallBuilder> {
+    type SubPointersType = IForwardedCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IForwardedCallBuilder>>) -> IForwardedCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IForwardedCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:6:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2436,6 +2788,126 @@ impl IDirectSafeDispatcherSubPointersMutImpl of starknet::storage::SubPointersMu
 }
 
 
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl IDirectCallBuilderCopy<> of core::traits::Copy::<IDirectCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IDirectCallBuilderDrop<> of core::traits::Drop::<IDirectCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IDirectCallBuilderSerde<> of core::serde::Serde::<IDirectCallBuilder> {
+    fn serialize(self: @IDirectCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IDirectCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IDirectCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IDirectCallBuilderStore<> of starknet::Store::<IDirectCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IDirectCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IDirectCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IDirectCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IDirectCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IDirectCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IDirectCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IDirectCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IDirectCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IDirectCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersImpl of starknet::storage::SubPointers<IDirectCallBuilder> {
+    type SubPointersType = IDirectCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IDirectCallBuilder>) -> IDirectCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IDirectCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IDirectCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IDirectCallBuilder> {
+    type SubPointersType = IDirectCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IDirectCallBuilder>>) -> IDirectCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IDirectCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:1:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2524,6 +2996,28 @@ impl IForwardedSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IForwa
 impl IForwardedSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IForwardedSafeDispatcherSubPointersMut>;
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersDrop<> of core::traits::Drop::<IForwardedCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersCopy<> of core::traits::Copy::<IForwardedCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IForwardedCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IForwardedCallBuilderSubPointersMut>;
+
+
 lib.cairo:6:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2610,6 +3104,28 @@ impls:
 impl IDirectSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IDirectSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IDirectSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IDirectSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersDrop<> of core::traits::Drop::<IDirectCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersCopy<> of core::traits::Copy::<IDirectCallBuilderSubPointers>;
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IDirectCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IDirectCallBuilderSubPointersMut>;
 
 
 lib.cairo:19:1
@@ -2929,6 +3445,32 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
                 'Returned data too short',
             )
         )
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+pub trait IContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_value(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+pub struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+    fn get_value(self: IContractCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_value"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -3457,6 +3999,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -3538,5 +4200,27 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/hello_starknet
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/hello_starknet
@@ -371,6 +371,48 @@ impl HelloStarknetTraitSafeDispatcherImpl of HelloStarknetTraitSafeDispatcherTra
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait HelloStarknetTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    // Increases the balance by the given amount.
+    fn increase_balance(self: T, amount: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    // Returns the current balance.
+    fn get_balance(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct HelloStarknetTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderImpl of HelloStarknetTraitCallBuilderTrait<HelloStarknetTraitCallBuilder> {
+    // Increases the balance by the given amount.
+    fn increase_balance(self: HelloStarknetTraitCallBuilder, amount: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    // Returns the current balance.
+    fn get_balance(self: HelloStarknetTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -854,6 +896,112 @@ impl HelloStarknetTraitSafeDispatcherSubPointersMutImpl of starknet::storage::Su
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderSerde<> of core::serde::Serde::<HelloStarknetTraitCallBuilder> {
+    fn serialize(self: @HelloStarknetTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<HelloStarknetTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(HelloStarknetTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl HelloStarknetTraitCallBuilderStore<> of starknet::Store::<HelloStarknetTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<HelloStarknetTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            HelloStarknetTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: HelloStarknetTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let HelloStarknetTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<HelloStarknetTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            HelloStarknetTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: HelloStarknetTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let HelloStarknetTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct HelloStarknetTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<HelloStarknetTraitCallBuilder> {
+    type SubPointersType = HelloStarknetTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<HelloStarknetTraitCallBuilder>) -> HelloStarknetTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                HelloStarknetTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct HelloStarknetTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<HelloStarknetTraitCallBuilder> {
+    type SubPointersType = HelloStarknetTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<HelloStarknetTraitCallBuilder>>) -> HelloStarknetTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                HelloStarknetTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl HelloStarknetTraitDispatcherSubPointersDrop<> of core::traits::Drop::<HelloStarknetTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -886,6 +1034,14 @@ impl HelloStarknetTraitSafeDispatcherSubPointersCopy<> of core::traits::Copy::<H
 impl HelloStarknetTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<HelloStarknetTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl HelloStarknetTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<HelloStarknetTraitSafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilderSubPointersMut>;
 
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     #[storage]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
@@ -178,6 +178,32 @@ impl Interface1SafeDispatcherImpl of Interface1SafeDispatcherTrait<Interface1Saf
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait Interface1CallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct Interface1CallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl Interface1CallBuilderImpl of Interface1CallBuilderTrait<Interface1CallBuilder> {
+    fn foo(self: Interface1CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -319,6 +345,32 @@ impl Interface2SafeDispatcherImpl of Interface2SafeDispatcherTrait<Interface2Saf
         );
         let mut __dispatcher_return_data__ = __dispatcher_return_data__?;
         Result::Ok(())
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait Interface2CallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct Interface2CallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl Interface2CallBuilderImpl of Interface2CallBuilderTrait<Interface2CallBuilder> {
+    fn foo(self: Interface2CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
     }
 
 }
@@ -842,6 +894,126 @@ impl Interface1SafeDispatcherSubPointersMutImpl of starknet::storage::SubPointer
 }
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl Interface1CallBuilderCopy<> of core::traits::Copy::<Interface1CallBuilder>;
+#[doc(group: "dispatchers")]
+impl Interface1CallBuilderDrop<> of core::traits::Drop::<Interface1CallBuilder>;
+#[doc(group: "dispatchers")]
+impl Interface1CallBuilderSerde<> of core::serde::Serde::<Interface1CallBuilder> {
+    fn serialize(self: @Interface1CallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<Interface1CallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(Interface1CallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl Interface1CallBuilderStore<> of starknet::Store::<Interface1CallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Interface1CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            Interface1CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Interface1CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let Interface1CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<Interface1CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            Interface1CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: Interface1CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let Interface1CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Interface1CallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersImpl of starknet::storage::SubPointers<Interface1CallBuilder> {
+    type SubPointersType = Interface1CallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<Interface1CallBuilder>) -> Interface1CallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Interface1CallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Interface1CallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<Interface1CallBuilder> {
+    type SubPointersType = Interface1CallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<Interface1CallBuilder>>) -> Interface1CallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Interface1CallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:6:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -1322,6 +1494,126 @@ impl Interface2SafeDispatcherSubPointersMutImpl of starknet::storage::SubPointer
 }
 
 
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl Interface2CallBuilderCopy<> of core::traits::Copy::<Interface2CallBuilder>;
+#[doc(group: "dispatchers")]
+impl Interface2CallBuilderDrop<> of core::traits::Drop::<Interface2CallBuilder>;
+#[doc(group: "dispatchers")]
+impl Interface2CallBuilderSerde<> of core::serde::Serde::<Interface2CallBuilder> {
+    fn serialize(self: @Interface2CallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<Interface2CallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(Interface2CallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl Interface2CallBuilderStore<> of starknet::Store::<Interface2CallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Interface2CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            Interface2CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Interface2CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let Interface2CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<Interface2CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            Interface2CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: Interface2CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let Interface2CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Interface2CallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersImpl of starknet::storage::SubPointers<Interface2CallBuilder> {
+    type SubPointersType = Interface2CallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<Interface2CallBuilder>) -> Interface2CallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Interface2CallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Interface2CallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<Interface2CallBuilder> {
+    type SubPointersType = Interface2CallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<Interface2CallBuilder>>) -> Interface2CallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Interface2CallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:1:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -1410,6 +1702,28 @@ impl Interface1SafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<Interf
 impl Interface1SafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<Interface1SafeDispatcherSubPointersMut>;
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersDrop<> of core::traits::Drop::<Interface1CallBuilderSubPointers>;
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersCopy<> of core::traits::Copy::<Interface1CallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersMutDrop<> of core::traits::Drop::<Interface1CallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersMutCopy<> of core::traits::Copy::<Interface1CallBuilderSubPointersMut>;
+
+
 lib.cairo:6:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -1496,6 +1810,28 @@ impls:
 impl Interface2SafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<Interface2SafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl Interface2SafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<Interface2SafeDispatcherSubPointersMut>;
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersDrop<> of core::traits::Drop::<Interface2CallBuilderSubPointers>;
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersCopy<> of core::traits::Copy::<Interface2CallBuilderSubPointers>;
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersMutDrop<> of core::traits::Drop::<Interface2CallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersMutCopy<> of core::traits::Copy::<Interface2CallBuilderSubPointersMut>;
 
 
 lib.cairo:11:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/mintable
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/mintable
@@ -523,6 +523,32 @@ impl GetSupplySafeDispatcherImpl of GetSupplySafeDispatcherTrait<GetSupplySafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait GetSupplyCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_total_supply_plus_1(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct GetSupplyCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderImpl of GetSupplyCallBuilderTrait<GetSupplyCallBuilder> {
+    fn get_total_supply_plus_1(self: GetSupplyCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_total_supply_plus_1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -985,6 +1011,112 @@ impl GetSupplySafeDispatcherSubPointersMutImpl of starknet::storage::SubPointers
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderCopy<> of core::traits::Copy::<GetSupplyCallBuilder>;
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderDrop<> of core::traits::Drop::<GetSupplyCallBuilder>;
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderSerde<> of core::serde::Serde::<GetSupplyCallBuilder> {
+    fn serialize(self: @GetSupplyCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<GetSupplyCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(GetSupplyCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl GetSupplyCallBuilderStore<> of starknet::Store::<GetSupplyCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<GetSupplyCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            GetSupplyCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: GetSupplyCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let GetSupplyCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<GetSupplyCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            GetSupplyCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: GetSupplyCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let GetSupplyCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct GetSupplyCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersImpl of starknet::storage::SubPointers<GetSupplyCallBuilder> {
+    type SubPointersType = GetSupplyCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<GetSupplyCallBuilder>) -> GetSupplyCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                GetSupplyCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct GetSupplyCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<GetSupplyCallBuilder> {
+    type SubPointersType = GetSupplyCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<GetSupplyCallBuilder>>) -> GetSupplyCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                GetSupplyCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl GetSupplyDispatcherSubPointersDrop<> of core::traits::Drop::<GetSupplyDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1017,6 +1149,14 @@ impl GetSupplySafeDispatcherSubPointersCopy<> of core::traits::Copy::<GetSupplyS
 impl GetSupplySafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<GetSupplySafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl GetSupplySafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<GetSupplySafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersDrop<> of core::traits::Drop::<GetSupplyCallBuilderSubPointers>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersCopy<> of core::traits::Copy::<GetSupplyCallBuilderSubPointers>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutDrop<> of core::traits::Drop::<GetSupplyCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutCopy<> of core::traits::Copy::<GetSupplyCallBuilderSubPointersMut>;
 
     use starknet::ContractAddress;
     use crate::components::erc20::erc20 as erc20_comp;

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/multi_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/multi_component
@@ -580,6 +580,32 @@ impl GetSupplySafeDispatcherImpl of GetSupplySafeDispatcherTrait<GetSupplySafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+pub trait GetSupplyCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_total_supply_plus_1(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+pub struct GetSupplyCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderImpl of GetSupplyCallBuilderTrait<GetSupplyCallBuilder> {
+    fn get_total_supply_plus_1(self: GetSupplyCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_total_supply_plus_1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -1042,6 +1068,112 @@ impl GetSupplySafeDispatcherSubPointersMutImpl of starknet::storage::SubPointers
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderCopy<> of core::traits::Copy::<GetSupplyCallBuilder>;
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderDrop<> of core::traits::Drop::<GetSupplyCallBuilder>;
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderSerde<> of core::serde::Serde::<GetSupplyCallBuilder> {
+    fn serialize(self: @GetSupplyCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<GetSupplyCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(GetSupplyCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl GetSupplyCallBuilderStore<> of starknet::Store::<GetSupplyCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<GetSupplyCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            GetSupplyCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: GetSupplyCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let GetSupplyCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<GetSupplyCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            GetSupplyCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: GetSupplyCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let GetSupplyCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct GetSupplyCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersImpl of starknet::storage::SubPointers<GetSupplyCallBuilder> {
+    type SubPointersType = GetSupplyCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<GetSupplyCallBuilder>) -> GetSupplyCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                GetSupplyCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct GetSupplyCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<GetSupplyCallBuilder> {
+    type SubPointersType = GetSupplyCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<GetSupplyCallBuilder>>) -> GetSupplyCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                GetSupplyCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl GetSupplyDispatcherSubPointersDrop<> of core::traits::Drop::<GetSupplyDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1074,6 +1206,14 @@ impl GetSupplySafeDispatcherSubPointersCopy<> of core::traits::Copy::<GetSupplyS
 impl GetSupplySafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<GetSupplySafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl GetSupplySafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<GetSupplySafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersDrop<> of core::traits::Drop::<GetSupplyCallBuilderSubPointers>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersCopy<> of core::traits::Copy::<GetSupplyCallBuilderSubPointers>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutDrop<> of core::traits::Drop::<GetSupplyCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutCopy<> of core::traits::Copy::<GetSupplyCallBuilderSubPointersMut>;
 
     use starknet::ContractAddress;
     use crate::components::erc20::erc20 as erc20_comp;

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
@@ -1386,6 +1386,222 @@ self: HelloStarknetTraitSafeDispatcher, user_id: usize, subbalance_id: usize,
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait HelloStarknetTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    // Increases the balance by the given amount.
+    fn increase_balance(self: T, amount: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    // Returns the current balance.
+    fn get_balance(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+
+    fn get_user_balance(self: T, user_id: usize)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_user_balance(self: T, user_id: usize, balance: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_legacy_user_balance(self: T, user_id: usize)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_legacy_user_balance(self: T, user_id: usize, balance: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+
+    fn get_user_balance_subbalance(
+self: T, user_id: usize, subbalance_id: usize,
+    )  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_balance_pair_balance1(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_balance_pair_balance2(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_balance_pair_balance1(self: T, value: u256) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_balance_trio_sub_member(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_balance_trio_sub_member(self: T, value: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_third_list_value(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_arr_at(self: T, index: u64)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn append_to_arr(self: T, value: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_queryable_enum(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct HelloStarknetTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderImpl of HelloStarknetTraitCallBuilderTrait<HelloStarknetTraitCallBuilder> {
+    // Increases the balance by the given amount.
+    fn increase_balance(self: HelloStarknetTraitCallBuilder, amount: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    // Returns the current balance.
+    fn get_balance(self: HelloStarknetTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+    fn get_user_balance(self: HelloStarknetTraitCallBuilder, user_id: usize)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_user_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_user_balance(self: HelloStarknetTraitCallBuilder, user_id: usize, balance: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+        core::serde::Serde::<usize>::serialize(@balance, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_user_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_legacy_user_balance(self: HelloStarknetTraitCallBuilder, user_id: usize)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_legacy_user_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_legacy_user_balance(self: HelloStarknetTraitCallBuilder, user_id: usize, balance: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+        core::serde::Serde::<usize>::serialize(@balance, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_legacy_user_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+    fn get_user_balance_subbalance(
+self: HelloStarknetTraitCallBuilder, user_id: usize, subbalance_id: usize,
+    )  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+        core::serde::Serde::<usize>::serialize(@subbalance_id, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_user_balance_subbalance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_balance_pair_balance1(self: HelloStarknetTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance_pair_balance1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_balance_pair_balance2(self: HelloStarknetTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance_pair_balance2"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_balance_pair_balance1(self: HelloStarknetTraitCallBuilder, value: u256) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u256>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_balance_pair_balance1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_balance_trio_sub_member(self: HelloStarknetTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance_trio_sub_member"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_balance_trio_sub_member(self: HelloStarknetTraitCallBuilder, value: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_balance_trio_sub_member"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_third_list_value(self: HelloStarknetTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_third_list_value"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_arr_at(self: HelloStarknetTraitCallBuilder, index: u64)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u64>::serialize(@index, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_arr_at"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn append_to_arr(self: HelloStarknetTraitCallBuilder, value: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("append_to_arr"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_queryable_enum(self: HelloStarknetTraitCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_queryable_enum"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -3174,6 +3390,126 @@ impl HelloStarknetTraitSafeDispatcherSubPointersMutImpl of starknet::storage::Su
 }
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderSerde<> of core::serde::Serde::<HelloStarknetTraitCallBuilder> {
+    fn serialize(self: @HelloStarknetTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<HelloStarknetTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(HelloStarknetTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl HelloStarknetTraitCallBuilderStore<> of starknet::Store::<HelloStarknetTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<HelloStarknetTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            HelloStarknetTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: HelloStarknetTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let HelloStarknetTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<HelloStarknetTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            HelloStarknetTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: HelloStarknetTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let HelloStarknetTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct HelloStarknetTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<HelloStarknetTraitCallBuilder> {
+    type SubPointersType = HelloStarknetTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<HelloStarknetTraitCallBuilder>) -> HelloStarknetTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                HelloStarknetTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct HelloStarknetTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<HelloStarknetTraitCallBuilder> {
+    type SubPointersType = HelloStarknetTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<HelloStarknetTraitCallBuilder>>) -> HelloStarknetTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                HelloStarknetTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:27:1
 #[starknet::storage_node]
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -3506,6 +3842,28 @@ impls:
 impl HelloStarknetTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<HelloStarknetTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl HelloStarknetTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<HelloStarknetTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:78:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/proxy
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/proxy
@@ -401,6 +401,56 @@ impl ICounterContractSafeDispatcherImpl of ICounterContractSafeDispatcherTrait<I
     }
 
 }
+
+#[doc(group: "dispatchers")]
+pub trait ICounterContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn increase_counter(self: T, amount: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn decrease_counter(self: T, amount: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_counter(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+pub struct ICounterContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderImpl of ICounterContractCallBuilderTrait<ICounterContractCallBuilder> {
+    fn increase_counter(self: ICounterContractCallBuilder, amount: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn decrease_counter(self: ICounterContractCallBuilder, amount: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("decrease_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_counter(self: ICounterContractCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -901,6 +951,112 @@ impl ICounterContractSafeDispatcherSubPointersMutImpl of starknet::storage::SubP
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderCopy<> of core::traits::Copy::<ICounterContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderDrop<> of core::traits::Drop::<ICounterContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderSerde<> of core::serde::Serde::<ICounterContractCallBuilder> {
+    fn serialize(self: @ICounterContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ICounterContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ICounterContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl ICounterContractCallBuilderStore<> of starknet::Store::<ICounterContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ICounterContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ICounterContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ICounterContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ICounterContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ICounterContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ICounterContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ICounterContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ICounterContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ICounterContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<ICounterContractCallBuilder> {
+    type SubPointersType = ICounterContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ICounterContractCallBuilder>) -> ICounterContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ICounterContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ICounterContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ICounterContractCallBuilder> {
+    type SubPointersType = ICounterContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ICounterContractCallBuilder>>) -> ICounterContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ICounterContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl ICounterContractDispatcherSubPointersDrop<> of core::traits::Drop::<ICounterContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -933,6 +1089,14 @@ impl ICounterContractSafeDispatcherSubPointersCopy<> of core::traits::Copy::<ICo
 impl ICounterContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ICounterContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ICounterContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ICounterContractSafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersDrop<> of core::traits::Drop::<ICounterContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersCopy<> of core::traits::Copy::<ICounterContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ICounterContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ICounterContractCallBuilderSubPointersMut>;
 
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage_accesses
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage_accesses
@@ -1235,6 +1235,143 @@ self: IERC20SafeDispatcher, spender: ContractAddress, subtracted_value: u256,
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait IERC20CallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_name(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_symbol(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_decimals(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_total_supply(self: T)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn balance_of(self: T, account: ContractAddress)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn allowance(self: T, owner: ContractAddress, spender: ContractAddress)  -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn increase_allowance(self: T, spender: ContractAddress, added_value: u256) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn decrease_allowance(
+self: T, spender: ContractAddress, subtracted_value: u256,
+    ) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn write_info(self: T, user_info: UserInfo) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_info(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IERC20CallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IERC20CallBuilderImpl of IERC20CallBuilderTrait<IERC20CallBuilder> {
+    fn get_name(self: IERC20CallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_name"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_symbol(self: IERC20CallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_symbol"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_decimals(self: IERC20CallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_decimals"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_total_supply(self: IERC20CallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_total_supply"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn balance_of(self: IERC20CallBuilder, account: ContractAddress)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@account, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("balance_of"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn allowance(self: IERC20CallBuilder, owner: ContractAddress, spender: ContractAddress)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@owner, ref __calldata__);
+        core::serde::Serde::<ContractAddress>::serialize(@spender, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("allowance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn increase_allowance(self: IERC20CallBuilder, spender: ContractAddress, added_value: u256) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@spender, ref __calldata__);
+        core::serde::Serde::<u256>::serialize(@added_value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_allowance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn decrease_allowance(
+self: IERC20CallBuilder, spender: ContractAddress, subtracted_value: u256,
+    ) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@spender, ref __calldata__);
+        core::serde::Serde::<u256>::serialize(@subtracted_value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("decrease_allowance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn write_info(self: IERC20CallBuilder, user_info: UserInfo) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<UserInfo>::serialize(@user_info, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("write_info"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_info(self: IERC20CallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_info"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -2153,6 +2290,112 @@ impl IERC20SafeDispatcherSubPointersMutImpl of starknet::storage::SubPointersMut
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl IERC20CallBuilderCopy<> of core::traits::Copy::<IERC20CallBuilder>;
+#[doc(group: "dispatchers")]
+impl IERC20CallBuilderDrop<> of core::traits::Drop::<IERC20CallBuilder>;
+#[doc(group: "dispatchers")]
+impl IERC20CallBuilderSerde<> of core::serde::Serde::<IERC20CallBuilder> {
+    fn serialize(self: @IERC20CallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IERC20CallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IERC20CallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl IERC20CallBuilderStore<> of starknet::Store::<IERC20CallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IERC20CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IERC20CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IERC20CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IERC20CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IERC20CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IERC20CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IERC20CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IERC20CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct IERC20CallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersImpl of starknet::storage::SubPointers<IERC20CallBuilder> {
+    type SubPointersType = IERC20CallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IERC20CallBuilder>) -> IERC20CallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IERC20CallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct IERC20CallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IERC20CallBuilder> {
+    type SubPointersType = IERC20CallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IERC20CallBuilder>>) -> IERC20CallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IERC20CallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl UserInfoSubPointersDrop<> of core::traits::Drop::<UserInfoSubPointers>;
 #[doc(hidden)]
@@ -2209,6 +2452,14 @@ impl IERC20SafeDispatcherSubPointersCopy<> of core::traits::Copy::<IERC20SafeDis
 impl IERC20SafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IERC20SafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IERC20SafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IERC20SafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersDrop<> of core::traits::Drop::<IERC20CallBuilderSubPointers>;
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersCopy<> of core::traits::Copy::<IERC20CallBuilderSubPointers>;
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersMutDrop<> of core::traits::Drop::<IERC20CallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersMutCopy<> of core::traits::Copy::<IERC20CallBuilderSubPointersMut>;
 
     use core::num::traits::Zero;
     use starknet::storage::{

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/upgradable_counter
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/upgradable_counter
@@ -642,6 +642,56 @@ impl ICounterContractSafeDispatcherImpl of ICounterContractSafeDispatcherTrait<I
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait ICounterContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn increase_counter(self: T, amount: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn decrease_counter(self: T, amount: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_counter(self: T)  -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct ICounterContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderImpl of ICounterContractCallBuilderTrait<ICounterContractCallBuilder> {
+    fn increase_counter(self: ICounterContractCallBuilder, amount: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn decrease_counter(self: ICounterContractCallBuilder, amount: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("decrease_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_counter(self: ICounterContractCallBuilder)  -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -1142,6 +1192,112 @@ impl ICounterContractSafeDispatcherSubPointersMutImpl of starknet::storage::SubP
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderCopy<> of core::traits::Copy::<ICounterContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderDrop<> of core::traits::Drop::<ICounterContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderSerde<> of core::serde::Serde::<ICounterContractCallBuilder> {
+    fn serialize(self: @ICounterContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ICounterContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ICounterContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl ICounterContractCallBuilderStore<> of starknet::Store::<ICounterContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ICounterContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ICounterContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ICounterContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ICounterContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ICounterContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ICounterContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ICounterContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ICounterContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct ICounterContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<ICounterContractCallBuilder> {
+    type SubPointersType = ICounterContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ICounterContractCallBuilder>) -> ICounterContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ICounterContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct ICounterContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ICounterContractCallBuilder> {
+    type SubPointersType = ICounterContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ICounterContractCallBuilder>>) -> ICounterContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ICounterContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl ICounterContractDispatcherSubPointersDrop<> of core::traits::Drop::<ICounterContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1174,6 +1330,14 @@ impl ICounterContractSafeDispatcherSubPointersCopy<> of core::traits::Copy::<ICo
 impl ICounterContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ICounterContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ICounterContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ICounterContractSafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersDrop<> of core::traits::Drop::<ICounterContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersCopy<> of core::traits::Copy::<ICounterContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ICounterContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ICounterContractCallBuilderSubPointersMut>;
 
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use crate::components::ownable::ownable as ownable_comp;


### PR DESCRIPTION
## What

Adds a **`CallBuilder`** to the code generated for every `#[starknet::interface]` trait, sitting alongside the existing `Dispatcher` / `LibraryDispatcher` / `SafeDispatcher` family.

A dispatcher method does: serialize args → `selector!` → **syscall** → deserialize return. A call builder is the same method with the syscall/deserialize removed, returning a `starknet::account::Call` instead:

```cairo
#[feature("call_builder")]
fn build_transfer_call(token: ContractAddress, to: ContractAddress, amount: u256) -> Call {
    IERC20CallBuilder { contract_address: token }.transfer(to, amount)
}
```

This removes the hand-rolled boilerplate of building `Call { to, selector, calldata }` (manual `selector!` + manual `Serde`/`u256` splitting) for multicall and account `__execute__` flows.

## Why

Building a `Call` for an interface method today means manually replicating exactly what the dispatcher already generates internally — the selector and the argument serialization — which is verbose and error-prone (e.g. splitting `u256` into `low`/`high` by hand). The "build phase" is literally the first half of an existing dispatcher method, so this reuses the dispatcher's own serialization and `selector!` generation rather than introducing a parallel encoding path.

## What's generated

For `trait IFoo<T> { fn transfer(ref self: T, to: ContractAddress, amount: u256); ... }`:

```cairo
#[doc(group: "dispatchers")]
trait IFooCallBuilderTrait<T> {
    #[unstable(feature: "call_builder")]
    fn transfer(self: T, to: ContractAddress, amount: u256) -> starknet::account::Call;
    // ...one method per interface fn, return type forced to Call
}

#[doc(group: "dispatchers")]
#[derive(Copy, Drop, starknet::Store, Serde)]
struct IFooCallBuilder {
    pub contract_address: starknet::ContractAddress,
}

#[doc(group: "dispatchers")]
impl IFooCallBuilderImpl of IFooCallBuilderTrait<IFooCallBuilder> {
    fn transfer(self: IFooCallBuilder, to: ContractAddress, amount: u256) -> starknet::account::Call {
        let mut __calldata__ = core::traits::Default::default();
        core::serde::Serde::<ContractAddress>::serialize(@to, ref __calldata__);
        core::serde::Serde::<u256>::serialize(@amount, ref __calldata__);
        starknet::account::Call {
            to: self.contract_address,
            selector: selector!("transfer"),
            calldata: core::array::ArrayTrait::span(@__calldata__),
        }
    }
}
```

## Design notes

- **Gated behind `#[unstable(feature: "call_builder")]`** — mirrors the `safe_dispatcher` precedent; lets the API iterate before stabilizing. (Open to shipping it stable instead.)
- **Contract-address only, single builder** — `Call` has no class-hash field, so there is deliberately no Library/Safe matrix; library calls don't map to `Call`.
- **Return type is always `Call`** — the interface method's declared return type is irrelevant when only building a call.

## Does NOT affect the ABI

The contract ABI is generated from the interface trait, not the dispatcher structs (`abi.rs` has zero references to them). This change is purely additive Cairo codegen — no on-chain interface change, nothing for SDKs/indexers/explorers to adapt to. Unused builders are dead-code-eliminated and never reach Sierra.

## Verification

- `cargo test -p cairo-lang-starknet` — **57 passed, 0 failed** (without fix mode; deterministic green).
- The `expand_contract::*` tests run full crate diagnostics (parser + semantic + lowering) with `expect_diagnostics: false`, so the generated Cairo type-checks against corelib (the `starknet::account::Call` path resolves, `Serde`/derives resolve, and implementing the `#[unstable]` trait raises no gate error).
- Regenerated all 14 affected expansion fixtures via `CAIRO_FIX_TESTS=1`. Verified the diff is purely additive: zero pre-existing generated declarations removed and identical `//! >` test-case counts per fixture (the "deletions" in the diff are reordering of derive-generated impls).

> Note: building requires `rustc 1.94` (repo `rust-version`); `cargo +1.94` was used.

## TODO before un-drafting

- [ ] Add a runtime `cairo_level_test` (in `abi_dispatchers_tests.cairo`) asserting `call.to` / `call.selector` / `call.calldata` for a builder-constructed `Call`.
- [ ] corelib doc example + feature note for `call_builder`.
- [ ] Decide stable vs. `#[unstable]` for the initial release.
- [ ] Heads-up to OpenZeppelin Cairo (heaviest interface consumer) re: expansion snapshot tests and the (low) risk of an `I…CallBuilder` name collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
