### PR TITLE
feature(starknet): Adding injected class-hash values into code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "indent",
  "indoc",
  "itertools 0.14.0",
+ "num-bigint",
  "pretty_assertions",
  "rayon",
  "salsa",

--- a/crates/cairo-lang-starknet-classes/src/contract_class.rs
+++ b/crates/cairo-lang-starknet-classes/src/contract_class.rs
@@ -5,6 +5,7 @@ use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use starknet_types_core::felt::Felt as Felt252;
+use starknet_types_core::hash::{Poseidon, StarkHash};
 use thiserror::Error;
 
 use crate::abi::Contract;
@@ -13,6 +14,7 @@ use crate::compiler_version::{VersionId, current_compiler_version_id, current_si
 use crate::felt252_serde::{
     Felt252SerdeError, sierra_from_felt252s, sierra_to_felt252s, version_id_from_felt252s,
 };
+use crate::keccak::starknet_keccak;
 
 #[cfg(test)]
 #[path = "contract_class_test.rs"]
@@ -79,6 +81,42 @@ impl ContractClass {
         Ok(ExtractedSierraProgram { program, sierra_version, compiler_version })
     }
 
+    /// Computes the Starknet class hash of this (Sierra) contract class.
+    ///
+    /// Mirrors the algorithm used downstream (the sequencer / `starknet_api`): a Poseidon hash
+    /// over the contract-class version marker, the three entry-point groups, the ABI hash, and the
+    /// Sierra program hash.
+    ///
+    /// NOTE: this duplicates security-sensitive logic that normally lives outside the compiler. In
+    /// particular, the ABI is hashed via its canonical [`Contract::json`] string representation;
+    /// the exact serialization affects the resulting hash, so this implementation must be validated
+    /// against known class-hash reference vectors before being relied upon.
+    pub fn class_hash(&self) -> Felt252 {
+        let entry_points_hash = |entry_points: &[ContractEntryPoint]| {
+            let mut elements = vec![];
+            for entry_point in entry_points {
+                elements.push(Felt252::from(&entry_point.selector));
+                elements.push(Felt252::from(entry_point.function_idx));
+            }
+            Poseidon::hash_array(&elements)
+        };
+        let abi_hash = self
+            .abi
+            .as_ref()
+            .map_or(Felt252::ZERO, |abi| Felt252::from(&starknet_keccak(abi.json().as_bytes())));
+        let sierra_program_hash = Poseidon::hash_array(
+            &self.sierra_program.iter().map(|felt| Felt252::from(&felt.value)).collect::<Vec<_>>(),
+        );
+        Poseidon::hash_array(&[
+            Felt252::from_bytes_be_slice(CONTRACT_CLASS_VERSION_MARKER),
+            entry_points_hash(&self.entry_points_by_type.external),
+            entry_points_hash(&self.entry_points_by_type.l1_handler),
+            entry_points_hash(&self.entry_points_by_type.constructor),
+            abi_hash,
+            sierra_program_hash,
+        ])
+    }
+
     /// Sanity checks the contract class.
     /// Currently only checks that if ABI exists, its counts match the entry points counts.
     pub fn sanity_check(&self) {
@@ -134,6 +172,10 @@ impl ExtractedSierraProgram {
 }
 
 const DEFAULT_CONTRACT_CLASS_VERSION: &str = "0.1.0";
+
+/// The version marker hashed into the Sierra contract class hash (see
+/// [`ContractClass::class_hash`]).
+const CONTRACT_CLASS_VERSION_MARKER: &[u8] = b"CONTRACT_CLASS_V0.1.0";
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContractEntryPoints {

--- a/crates/cairo-lang-starknet-classes/src/contract_class_test.rs
+++ b/crates/cairo-lang-starknet-classes/src/contract_class_test.rs
@@ -3,6 +3,7 @@ use std::io::BufReader;
 use indoc::indoc;
 use num_bigint::BigUint;
 use pretty_assertions::assert_eq;
+use starknet_types_core::felt::Felt as Felt252;
 use test_case::test_case;
 
 use crate::contract_class::{
@@ -51,6 +52,26 @@ fn test_serialization() {
     );
 
     assert_eq!(contract, serde_json::from_str(&serialized).unwrap())
+}
+
+#[test]
+fn test_class_hash_is_deterministic_and_sensitive() {
+    let contract_path = get_example_file_path("hello_starknet__hello_starknet.contract_class.json");
+    let contract: ContractClass =
+        serde_json::from_reader(BufReader::new(std::fs::File::open(contract_path).unwrap()))
+            .unwrap();
+
+    let class_hash = contract.class_hash();
+    // Deterministic.
+    assert_eq!(class_hash, contract.class_hash());
+    // Non-trivial.
+    assert_ne!(class_hash, Felt252::ZERO);
+
+    // Sensitive to the entry points: flipping an external entry point's function index changes the
+    // hash.
+    let mut modified = contract.clone();
+    modified.entry_points_by_type.external[0].function_idx += 1;
+    assert_ne!(modified.class_hash(), class_hash);
 }
 
 // Tests the serialization and deserialization of a contract.

--- a/crates/cairo-lang-starknet/Cargo.toml
+++ b/crates/cairo-lang-starknet/Cargo.toml
@@ -25,6 +25,7 @@ const_format.workspace = true
 indent.workspace = true
 indoc.workspace = true
 itertools = { workspace = true, default-features = true }
+num-bigint = { workspace = true, default-features = true }
 rayon.workspace = true
 salsa.workspace = true
 serde = { workspace = true, default-features = true }

--- a/crates/cairo-lang-starknet/src/compile.rs
+++ b/crates/cairo-lang-starknet/src/compile.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::setup_project;
 use cairo_lang_compiler::{CompilerConfig, ensure_diagnostics};
 use cairo_lang_defs::ids::TopLevelLanguageElementId;
@@ -10,6 +12,7 @@ use cairo_lang_filesystem::ids::{CrateId, CrateInput};
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
 use cairo_lang_lowering::optimizations::config::Optimizations;
 use cairo_lang_lowering::utils::InliningStrategy;
+use cairo_lang_semantic::items::constant::ConstValueId;
 use cairo_lang_sierra::debug_info::Annotations;
 use cairo_lang_sierra_generator::canonical_id_replacer::CanonicalReplacer;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
@@ -22,8 +25,10 @@ use cairo_lang_starknet_classes::contract_class::{
 };
 use cairo_lang_utils::CloneableDatabase;
 use itertools::{Itertools, chain};
+use num_bigint::BigInt;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use salsa::Database;
+use starknet_types_core::felt::Felt as Felt252;
 
 use crate::abi::AbiBuilder;
 use crate::aliased::Aliased;
@@ -57,8 +62,45 @@ pub fn compile_path(
     let main_crate_inputs = setup_project(&mut db, path)?;
     compiler_config.diagnostics_reporter =
         compiler_config.diagnostics_reporter.with_crates(&main_crate_inputs);
+
+    // The generated `class_hash()` accessor injects the contract's own class hash at the Sierra
+    // generation stage via the reserved `__externally_provided_const__` extern. Since the hash is
+    // derived from the compiled program, we compute it in two passes: first with the extern stubbed
+    // to zero (to obtain the class hash), then with that hash injected. Embedding the hash changes
+    // the bytecode, so the final class's true hash differs from the injected value (a deliberate,
+    // documented approximation).
+    //
+    // `main_crate_ids` are re-derived after each provider change, as the crate ids are bound to the
+    // database and cannot be held across a mutation.
+    set_class_hash_provider(&mut db, Felt252::ZERO);
+    let stub_main_crate_ids = CrateInput::into_crate_ids(&db, main_crate_inputs.clone());
+    let stub_class = compile_contract_in_prepared_db(
+        &db,
+        contract_path,
+        stub_main_crate_ids,
+        CompilerConfig {
+            // Scope to the main crate (like the final pass) and stay silent: the real diagnostics
+            // are reported by the second pass.
+            diagnostics_reporter: DiagnosticsReporter::ignoring()
+                .with_crates(&main_crate_inputs)
+                .allow_warnings(),
+            ..Default::default()
+        },
+    )?;
+    set_class_hash_provider(&mut db, stub_class.class_hash());
+
     let main_crate_ids = CrateInput::into_crate_ids(&db, main_crate_inputs);
     compile_contract_in_prepared_db(&db, contract_path, main_crate_ids, compiler_config)
+}
+
+/// Installs an [`cairo_lang_sierra_generator::db::ExternalConstProvider`] that resolves every call
+/// to the reserved `__externally_provided_const__` extern function (used by the generated
+/// `class_hash()` accessor) to `value`, as a constant of the call's declared return type.
+fn set_class_hash_provider(db: &mut RootDatabase, value: Felt252) {
+    let value = BigInt::from(value.to_biguint());
+    db.set_external_const_provider(Some(Arc::new(move |db, _full_path, ty| {
+        Ok(ConstValueId::from_int(db, ty, &value))
+    })));
 }
 
 /// Runs Starknet contract compiler on the specified contract.

--- a/crates/cairo-lang-starknet/src/compile_test.rs
+++ b/crates/cairo-lang-starknet/src/compile_test.rs
@@ -1,7 +1,10 @@
+use cairo_lang_compiler::CompilerConfig;
+use cairo_lang_lowering::utils::InliningStrategy;
 use cairo_lang_starknet_classes::allowed_libfuncs::ListSelector;
 use cairo_lang_test_utils::compare_contents_or_fix_with_path;
 use test_case::test_case;
 
+use crate::compile::compile_path;
 use crate::test_utils::{get_example_file_path, get_test_contract};
 
 /// Tests that the Sierra compiled from a contract in the contracts crate is the same as in
@@ -46,4 +49,30 @@ fn test_compile_path_from_contracts_crate(example_contract_path: &str) {
         &get_example_file_path(format!("{example_file_name}.sierra").as_str()),
         extracted.program.to_string(),
     );
+}
+
+/// Tests the two-pass class-hash injection: the contract's external `get_class_hash` calls the
+/// generated `__class_hash__::class_hash()`, making the reserved `__externally_provided_const__`
+/// extern reachable. Compilation succeeds only because `compile_path` installs a provider for it
+/// (computing the contract's own class hash); otherwise Sierra generation would fail. The result
+/// is also deterministic across runs.
+#[test]
+fn class_hash_injection_compiles() {
+    let path = get_example_file_path("class_hash_test_contract.cairo");
+    let compile = || {
+        compile_path(
+            &path,
+            None,
+            CompilerConfig { replace_ids: true, ..Default::default() },
+            InliningStrategy::default(),
+        )
+        .unwrap()
+    };
+
+    let contract = compile();
+    assert_eq!(contract.entry_points_by_type.external.len(), 1);
+    contract.sanity_check();
+
+    // The injected class hash is deterministic, so recompilation yields an identical program.
+    assert_eq!(contract.sierra_program, compile().sierra_program);
 }

--- a/crates/cairo-lang-starknet/src/plugin/consts.rs
+++ b/crates/cairo-lang-starknet/src/plugin/consts.rs
@@ -4,6 +4,8 @@ use const_format::formatcp;
 pub const EXTERNAL_MODULE: &str = "__external";
 pub const L1_HANDLER_MODULE: &str = "__l1_handler";
 pub const CONSTRUCTOR_MODULE: &str = "__constructor";
+/// The hidden inner module holding the contract's own class hash accessor (`class_hash()`).
+pub const CLASS_HASH_MODULE: &str = "__class_hash__";
 pub const WRAPPER_PREFIX: &str = "__wrapper__";
 pub const STORAGE_STRUCT_NAME: &str = "Storage";
 pub const EVENT_TYPE_NAME: &str = "Event";

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/contract
@@ -181,6 +181,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x512a6d7124a897370409ddf4a36e94192a8e84b6eb12aa805962db55776618.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__get_something(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -567,6 +581,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x19e877991b74c1b921fadcea48b83b3d8a5a0e86737a0ad2db0c95d8768eaea.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 
 #[doc(hidden)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -107,6 +107,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x198f4bc6efa8417922f8041d6e73821af41c6bbf15f1c93084da188702456b.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {
@@ -328,6 +342,20 @@ pub fn deploy_for_test(
 }
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__invalid_constructor_name(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -544,6 +572,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x547f368ac55821b57d7da42588a2985edb69dd87af9e9c16e740d6e14b2420.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -820,6 +862,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x16fce813e4d7f676441c2cffa36b5101b7e75cb787a8aec7259094fdbacb80e.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__foo(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -1033,6 +1089,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2c31752790f50b7f25195fc7cc9dcc1234d7af736c5ed771c69ddc8bb9fd8d4.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__foo(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -1242,6 +1312,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2bcbd7e08add1bbb62c174729940be27dbe922f83afd842f02af5355af726a1.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -1483,6 +1567,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x51e947dc07c2918ff505d4f848310fd40dc215c7a78b8e0ec19a8c6ab47ce3.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__foo(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -1711,6 +1809,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x291a42fae50c99636dc1d6bc0c4e28fdb0e21f47c26aa0d5e22c21d993823d8.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -2042,6 +2154,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0xe6da8c1c7f4f4eacbcd1e253492a549cdbe26d925524eeed0c44aaaf75d668.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {
@@ -2275,6 +2401,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x271c051b9d25373bc88ddfddfb1c29cc601d7014c5343fe167b82768570a896.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 
 #[doc(hidden)]
@@ -2546,6 +2686,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1f35904b8fc9bed6ac08457ded74e522aa254844ebb1d7da8eaff06532a8b4d.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 
 #[doc(hidden)]
@@ -3751,6 +3905,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0xb2b80f78cee80a1a53222a998e318822f6d9d701bdc8037948c5964158503c.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__Impl2__foo_external1(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -4066,6 +4234,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x820d41c225755fd6813443e1db69b44d323763bb1bdc6c58da9d8011855f0b.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {
@@ -4260,6 +4442,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1786cd1474db7f1bf61efa820fedb6cc8a9892313c56a8ab854a488db0d2879.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 
 #[doc(hidden)]
@@ -10103,6 +10299,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x291a893aaae68e6364fac8003da0089f1c976946ebe457ce78ed62b5e680be2.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateMyEmbeddableImpl of
     super::component::UnsafeNewContractStateTraitForMyEmbeddableImpl<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -10372,6 +10582,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x7bfb361123ab6c75c9b1db29acd3b69ea425da0db94322a959835a160c41da.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 
 #[doc(hidden)]
@@ -14217,6 +14441,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x3232c860888b3e1c54dda19284c63d6667fbbdebe403a54921a6dfbbe3134c9.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__ContractInterfaceImpl__foo(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -15360,6 +15598,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x29df08f1d7a448905745936c947da165c96a5e2fdbd90ffd2bdabbc7a7e0b1d.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__ContractInterfaceImpl__foo(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -16451,6 +16703,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0xc5af418eb5eed4ff51ca2888dc884ade488de0dea59772fe757c6cfc2d73f3.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -17636,6 +17902,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x3168f720317a98a00e5727dec4873607cd97bfa1e65fef0524f5661f2b767ed.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateMyImpl of
     super::component::UnsafeNewContractStateTraitForMyImpl<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -18003,6 +18283,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x3140ea2161c9eba12d890be5ea892f4f2b985bb300febf93c7b28573ece4148.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__foo_v0(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -18250,6 +18544,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1f8613d56d66d984da05cc17f5069dd7c5f35d3a46672cb071c8687a93d643e.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -19204,6 +19512,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2e3d710211a1db4f11c437acdeb9f49e98b109fc39b2ff41ee561e832266625.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
@@ -1032,6 +1032,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x24989c51cc02d16815c925171e8167063fde5b6487bb15a58d126a7bc4f3591.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateOutsideImpl of
     super::UnsafeNewContractStateTraitForOutsideImpl<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -2831,6 +2845,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2f3505035216cb9786b44e88c45f03e355e52c775f1b6ee6be27556e20667b.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateOutsideImplWithDestruct of
     super::UnsafeNewContractStateTraitForOutsideImplWithDestruct<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -3839,6 +3867,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x7abed9c637e9d7ff4d836f1e5e23fa64efc1ba2169cc22aa5d822ad70fed47.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateOutsideImplWithDrop of
     super::UnsafeNewContractStateTraitForOutsideImplWithDrop<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/external_event
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/external_event
@@ -236,6 +236,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x32ff02b6abf104297a08971d16f6970b6530be8e49a83bde923ea117b47a37e.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/forward_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/forward_impl
@@ -936,6 +936,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x20c8dcb117f9363167927bfabb7c2d09f58f71bedf05e8fac0a9e604ed10a85.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateIContractForwardImpl of
     super::UnsafeNewContractStateTraitForIContractForwardImpl<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -2694,6 +2708,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x16a68a84419b4469ecb3dd73d3fccf12f5d26792e1630b0450ea6ab6d2c11ff.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateDirectImpl of
     super::UnsafeNewContractStateTraitForDirectImpl<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/hello_starknet
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/hello_starknet
@@ -100,6 +100,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__HelloStarknetImpl__increase_balance(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -968,6 +982,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
@@ -1879,6 +1879,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x22aa9f2c832fb18ac0ec19b508b86f5fc9d78a62b4d7a72ee2a8c7c11a786b5.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateI1I1 of
     super::comp::UnsafeNewContractStateTraitForI1I1<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/l1_handler
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/l1_handler
@@ -108,6 +108,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x32a1956d182625bfe7f9834635d01441624366b326c190ecbf557e699f94b76.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__good_l1_handler(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/mintable
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/mintable
@@ -164,6 +164,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateIERC20 of
     erc20_comp::UnsafeNewContractStateTraitForIERC20<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -1167,6 +1181,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateIERC20 of
     erc20_comp::UnsafeNewContractStateTraitForIERC20<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/multi_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/multi_component
@@ -182,6 +182,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateIERC20 of
     erc20_comp::UnsafeNewContractStateTraitForIERC20<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -1242,6 +1256,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateIERC20 of
     erc20_comp::UnsafeNewContractStateTraitForIERC20<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
@@ -3648,6 +3648,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x3656be188a3ea1c67b67e871882de0a1f2e3b4fd7c5a974b585ef6f64cfb9d9.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__HelloStarknetImpl__increase_balance(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/ownable_erc20
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/ownable_erc20
@@ -134,6 +134,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateIERC20 of
     erc20_comp::UnsafeNewContractStateTraitForIERC20<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -444,6 +458,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateIERC20 of
     erc20_comp::UnsafeNewContractStateTraitForIERC20<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/proxy
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/proxy
@@ -105,6 +105,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__constructor(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -1020,6 +1034,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/raw_output
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/raw_output
@@ -120,6 +120,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0xd3e4aedceb9023ffd093c5d4d4605354999ba4a10776d97d533a048d33898.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__test_raw_output(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/shadowed_prelude_types
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/shadowed_prelude_types
@@ -116,6 +116,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2462d52c48bf7ed89c3a104e46620bb2516623714234b78744bf64278c9366d.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__get_value(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage
@@ -389,6 +389,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x25c680547752cece853ea35e00dbd269ee33545db32a2d900eb20e872e0d255.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage_accesses
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage_accesses
@@ -232,6 +232,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__constructor(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -2398,6 +2412,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/upgradable_counter
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/upgradable_counter
@@ -161,6 +161,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__constructor(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -1318,6 +1332,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/user_defined_types
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/user_defined_types
@@ -203,6 +203,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x175e3ea08fbd92b73ad06ddc3822cc0689ed2771dc573e3f7bd095442d98491.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component
@@ -313,6 +313,20 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x13b620794e5b3dc7cc2033d0b9381b35d5d10d1f0a43fe1f5e1d495f793ebab.try_into().unwrap();
 
 #[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
+#[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
 fn __wrapper__get_data(mut data: core::array::Span::<felt252>) -> core::array::Span::<felt252> {
     core::internal::require_implicit::<System>();
@@ -926,6 +940,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x20768e618c747c9e742de0446492553ae65eafb837da660ed6516e1ed6b52fc.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -1584,6 +1612,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x20768e618c747c9e742de0446492553ae65eafb837da660ed6516e1ed6b52fc.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_component_diagnostics
@@ -271,6 +271,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x2943e6b272892c78655f823e0abb3da425a1ac0c3f9bdd70869a3f37bc54797.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {
@@ -669,6 +683,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0xe61d99740f46b06b2ccd91d014bc9f9acc438fec59d79dd30fd0d852e5210.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {
@@ -1054,6 +1082,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x14aaf6de6aff44d64b4c3609768860615e979fdd851d125bbdfc10597a50a1d.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 
 #[doc(hidden)]
@@ -1453,6 +1495,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x121a1470e2769fd2e9f4441ff7ab7e2ae96e0f4e0446116a0f29d76df75b33.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 
 #[doc(hidden)]
@@ -1896,6 +1952,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x13a81b6876baa1445c90fd69add3e928a4f6c6807e5227544ac6f6698c463b2.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {
@@ -2311,6 +2381,20 @@ use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1092f63083af07b77ee426fd76d9695c3747a2e42571a914cee1dd17960254f.try_into().unwrap();
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 
 #[doc(hidden)]
 pub mod __external {
@@ -2697,6 +2781,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x8618264598f52601eed9355f5b7c0fc7c8912d966e620eb0a2914ed8cb5c10.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 
 #[doc(hidden)]
@@ -3093,6 +3191,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x8f9d2a9bd3a3fe28e42c16030ed25a2756a86a13d4297597e43683c3df9a02.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -3550,6 +3662,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x1c59c1f2e69fc61b0f9162b5cdb7fd6a0828ffb8f03548b02c3c52f2ef1c284.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]
@@ -4118,6 +4244,20 @@ pub fn contract_state_for_testing() -> ContractState {
 use starknet::storage::Map as LegacyMap;
 #[cfg(target: 'test')]
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0xa09b926ceb282d29edce76bb84e4aeb97f1a82ce15099322f1c2869a49b549.try_into().unwrap();
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 #[doc(hidden)]
 #[implicit_precedence(core::pedersen::Pedersen, core::RangeCheck, core::integer::Bitwise, core::ec::EcOp, core::poseidon::Poseidon, core::SegmentArena, core::circuit::RangeCheck96, core::circuit::AddMod, core::circuit::MulMod, core::gas::GasBuiltin, System)]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_erc20
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_erc20
@@ -112,6 +112,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateIERC20 of
     erc20_comp::UnsafeNewContractStateTraitForIERC20<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -356,6 +370,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateIERC20 of
     erc20_comp::UnsafeNewContractStateTraitForIERC20<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_erc20_mini
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_erc20_mini
@@ -121,6 +121,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateERC20Impl of
     erc20_mini::UnsafeNewContractStateTraitForERC20Impl<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -354,6 +368,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateERC20Impl of
     erc20_mini::UnsafeNewContractStateTraitForERC20Impl<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_ownable
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_ownable
@@ -123,6 +123,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateTransfer of
     ownable_comp::UnsafeNewContractStateTraitForTransfer<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -405,6 +419,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateTransfer of
     ownable_comp::UnsafeNewContractStateTraitForTransfer<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_ownable_mini
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/with_ownable_mini
@@ -131,6 +131,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
 
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
+
 impl ContractStateTransferImpl of
     ownable_mini::UnsafeNewContractStateTraitForTransferImpl<ContractState> {
     fn unsafe_new_contract_state() -> ContractState {
@@ -387,6 +401,20 @@ pub fn unsafe_new_contract_state() -> ContractState {
 )]
 #[allow(unused_imports)]
 use starknet::storage::Map as LegacyMap;
+
+#[doc(hidden)]
+pub mod __class_hash__ {
+    extern fn __externally_provided_const__() -> starknet::ClassHash nopanic;
+    pub fn class_hash() -> starknet::ClassHash {
+        __externally_provided_const__()
+    }
+    #[feature("forward-impl")]
+    pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {
+        fn class_hash(self: @T) -> starknet::ClassHash {
+            class_hash()
+        }
+    }
+}
 
 impl ContractStateTransferImpl of
     ownable_mini::UnsafeNewContractStateTraitForTransferImpl<ContractState> {

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
@@ -5,6 +5,7 @@ use cairo_lang_filesystem::cfg::CfgSet;
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_plugins::plugins::HasItemsInCfgEx;
+use cairo_lang_sierra_generator::db::EXTERNALLY_PROVIDED_CONST;
 use cairo_lang_starknet_classes::keccak::starknet_keccak;
 use cairo_lang_syntax::node::ast::{Attribute, OptionTypeClause};
 use cairo_lang_syntax::node::helpers::{
@@ -21,9 +22,9 @@ use salsa::Database;
 use super::generation_data::{ContractGenerationData, StarknetModuleCommonGenerationData};
 use super::{StarknetModuleKind, grand_grand_parent_starknet_module};
 use crate::plugin::consts::{
-    ABI_ATTR, ABI_ATTR_EMBED_V0_ARG, ABI_ATTR_PER_ITEM_ARG, COMPONENT_INLINE_MACRO,
-    CONCRETE_COMPONENT_STATE_NAME, CONTRACT_STATE_NAME, EVENT_TRAIT, EVENT_TYPE_NAME,
-    EXTERNAL_ATTR, HAS_COMPONENT_TRAIT, STORAGE_STRUCT_NAME, SUBSTORAGE_ATTR,
+    ABI_ATTR, ABI_ATTR_EMBED_V0_ARG, ABI_ATTR_PER_ITEM_ARG, CLASS_HASH_MODULE,
+    COMPONENT_INLINE_MACRO, CONCRETE_COMPONENT_STATE_NAME, CONTRACT_STATE_NAME, EVENT_TRAIT,
+    EVENT_TYPE_NAME, EXTERNAL_ATTR, HAS_COMPONENT_TRAIT, STORAGE_STRUCT_NAME, SUBSTORAGE_ATTR,
 };
 use crate::plugin::entry_point::{
     EntryPointGenerationParams, EntryPointKind, EntryPointsGenerationData, GetEntryPointKind,
@@ -36,6 +37,7 @@ use crate::plugin::utils::{find_v0_attribute_ex, forbid_attributes_in_impl};
 #[derive(Default)]
 pub struct ContractSpecificGenerationData<'db> {
     test_config: RewriteNode<'db>,
+    class_hash_code: RewriteNode<'db>,
     entry_points_code: EntryPointsGenerationData<'db>,
     components_data: ComponentsGenerationData<'db>,
 }
@@ -222,11 +224,13 @@ impl<'db> ContractSpecificGenerationData<'db> {
                 #[allow(unused_imports)]
                 use starknet::storage::Map as LegacyMap;
                 $test_config$
+                $class_hash_code$
                 $entry_points_code$
                 {EVENT_EMITTER_CODE}
                 $components_code$"},
             &[
                 ("test_config".to_string(), self.test_config),
+                ("class_hash_code".to_string(), self.class_hash_code),
                 ("entry_points_code".to_string(), self.entry_points_code.into_rewrite_node()),
                 (
                     "components_code".to_string(),
@@ -339,7 +343,41 @@ pub(super) fn generate_contract_specific_code<'db, 'a>(
     generation_data.specific.test_config =
         RewriteNode::new_modified(vec![test_class_hash_node, deploy_function_node]);
 
+    generation_data.specific.class_hash_code = generate_class_hash_code();
+
     generation_data.into_rewrite_node(db, diagnostics)
+}
+
+/// Generates a hidden inner module exposing the contract's own class hash as a compile-time
+/// constant.
+///
+/// `class_hash()` returns the value injected for the reserved `__externally_provided_const__`
+/// extern at the Sierra generation stage (the contract's own class hash, computed via
+/// stub-then-hash). It is placed in a hidden inner module so it is not directly in the contract's
+/// namespace.
+///
+/// The module also exposes `ForwardingClassHashImpl`, a generic implementation of
+/// `starknet::ForwardingClassHash<T>` returning this contract's class hash. It is generic over the
+/// contract state `T` (rather than this contract's own `ContractState`) so a *forwarding* contract
+/// can import it and use it as the forwarding impl that statically points at this contract's class.
+fn generate_class_hash_code<'db>() -> RewriteNode<'db> {
+    RewriteNode::Text(formatdoc!(
+        "
+            #[doc(hidden)]
+            pub mod {CLASS_HASH_MODULE} {{
+                extern fn {EXTERNALLY_PROVIDED_CONST}() -> starknet::ClassHash nopanic;
+                pub fn class_hash() -> starknet::ClassHash {{
+                    {EXTERNALLY_PROVIDED_CONST}()
+                }}
+                #[feature(\"forward-impl\")]
+                pub impl ForwardingClassHashImpl<T> of starknet::ForwardingClassHash<T> {{
+                    fn class_hash(self: @T) -> starknet::ClassHash {{
+                        class_hash()
+                    }}
+                }}
+            }}
+        "
+    ))
 }
 
 /// Generates the contract class hash for deploying contracts using cairo-test.

--- a/crates/cairo-lang-starknet/test_data/class_hash_test_contract.cairo
+++ b/crates/cairo-lang-starknet/test_data/class_hash_test_contract.cairo
@@ -1,0 +1,13 @@
+// A minimal contract whose external entry point returns the contract's own class hash via the
+// generated `__class_hash__::class_hash()` accessor. Used to exercise the two-pass class-hash
+// injection (see `compile_test::class_hash_injection_compiles`).
+#[starknet::contract]
+mod class_hash_test_contract {
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    fn get_class_hash(self: @ContractState) -> starknet::ClassHash {
+        __class_hash__::class_hash()
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `ContractClass::class_hash()` method that computes the Starknet Sierra class hash using Poseidon over the contract class version marker, entry-point groups, ABI keccak hash, and Sierra program hash. Integrates this into `compile_path` via a two-pass compilation strategy: a first pass compiles with the class hash stubbed to zero, computes the resulting class hash, then a second pass re-compiles with that hash injected via the reserved `__externally_provided_const__` extern. The Starknet plugin now generates a hidden `__class_hash__` module in every contract, exposing a `class_hash()` function and a generic `ForwardingClassHashImpl` that delegates to it.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

Contracts previously had no way to statically reference their own class hash at compile time. The `TEST_CLASS_HASH` constant existed only under `#[cfg(target: 'test')]`. This change makes the class hash available at runtime via a generated accessor backed by a compiler-injected constant, enabling patterns like forwarding contracts that need to statically embed their own class hash.

---

## What was the behavior or documentation before?

Contracts could not call their own class hash from within Cairo code outside of test targets. Sierra generation would fail if `__externally_provided_const__` was referenced without a registered provider.

---

## What is the behavior or documentation after?

Every `#[starknet::contract]` module now contains a generated `__class_hash__` submodule with:
- `class_hash() -> starknet::ClassHash` — returns the contract's own class hash as a compile-time constant injected during Sierra generation.
- `ForwardingClassHashImpl<T>` — a generic impl of `starknet::ForwardingClassHash<T>` that returns this contract's class hash, usable by forwarding contracts.

`compile_path` performs two compilation passes: the first compiles with the hash stubbed to zero to obtain the Sierra output, computes its class hash via `ContractClass::class_hash()`, then re-compiles with that hash injected. The injected value is an approximation because embedding the hash changes the bytecode, but the result is deterministic across runs.

---

## Related issue or discussion (if any)

---

## Additional context

The `ContractClass::class_hash()` implementation mirrors the algorithm used by the sequencer (`starknet_api`): a Poseidon hash over `CONTRACT_CLASS_V0.1.0`, the three entry-point group hashes, the ABI keccak hash, and the Sierra program hash. The ABI is hashed via its canonical JSON string representation, so the exact serialization affects the result. A test (`test_class_hash_is_deterministic_and_sensitive`) verifies determinism and sensitivity to entry-point mutations. An end-to-end compilation test (`class_hash_injection_compiles`) verifies that a contract calling `__class_hash__::class_hash()` compiles successfully and produces a deterministic Sierra program.