### PR TITLE
WIP: example class hash forward.

### DIFF
--- a/crates/cairo-lang-starknet/src/compile_test.rs
+++ b/crates/cairo-lang-starknet/src/compile_test.rs
@@ -76,3 +76,24 @@ fn class_hash_injection_compiles() {
     // The injected class hash is deterministic, so recompilation yields an identical program.
     assert_eq!(contract.sierra_program, compile().sierra_program);
 }
+
+/// Tests STATIC interface forwarding via the compile-time class-hash feature: `static_proxy`
+/// forwards `ICounterContract` to `counter_contract`'s class using the generated
+/// `counter_contract::__class_hash__::ForwardingClassHashImpl` (no stored class hash, no
+/// constructor). Verifies the proxy compiles to a class exposing the forwarded entry points; the
+/// forwarded class hash is injected by the two-pass in `compile_path`.
+#[test]
+fn static_forwarding_compiles() {
+    let path = get_example_file_path("static_forwarding_contract.cairo");
+    let contract = compile_path(
+        &path,
+        Some("static_forwarding_contract::static_forwarding_contract::static_proxy"),
+        CompilerConfig { replace_ids: true, ..Default::default() },
+        InliningStrategy::default(),
+    )
+    .unwrap();
+
+    // The two `ICounterContract` methods are forwarded as external entry points on the proxy.
+    assert_eq!(contract.entry_points_by_type.external.len(), 2);
+    contract.sanity_check();
+}

--- a/crates/cairo-lang-starknet/test_data/static_forwarding_contract.cairo
+++ b/crates/cairo-lang-starknet/test_data/static_forwarding_contract.cairo
@@ -1,0 +1,49 @@
+// Demonstrates STATIC interface forwarding via the compile-time class-hash feature: `static_proxy`
+// forwards the `ICounterContract` interface to `counter_contract`'s class using the generated
+// `counter_contract::__class_hash__::ForwardingClassHashImpl` (the contract's own class hash,
+// injected at Sierra generation). Unlike the dynamic `proxy` contract, it stores no class hash and
+// needs no constructor. Exercised by `compile_test::static_forwarding_compiles`.
+#[starknet::interface]
+pub trait ICounterContract<TContractState> {
+    fn increase_counter(ref self: TContractState, amount: u128);
+    fn get_counter(self: @TContractState) -> u128;
+}
+
+/// The implementation contract whose class is forwarded to.
+#[starknet::contract]
+pub mod counter_contract {
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        counter: u128,
+    }
+
+    #[abi(embed_v0)]
+    impl ICounterImpl of super::ICounterContract<ContractState> {
+        fn increase_counter(ref self: ContractState, amount: u128) {
+            self.counter.write(self.counter.read() + amount);
+        }
+
+        fn get_counter(self: @ContractState) -> u128 {
+            self.counter.read()
+        }
+    }
+}
+
+/// A static proxy that forwards every `ICounterContract` call as a library call to
+/// `counter_contract`'s class, using its compile-time-injected class hash. No storage, no
+/// constructor.
+#[starknet::contract]
+#[feature("forward-impl")]
+pub mod static_proxy {
+    #[storage]
+    struct Storage {}
+
+    // Statically point the forwarding impl at `counter_contract`'s class.
+    impl CounterClassHash =
+        super::counter_contract::__class_hash__::ForwardingClassHashImpl<ContractState>;
+
+    #[abi(embed_v0)]
+    impl ForwardedImpl = super::ICounterContractForwardImpl<ContractState>;
+}


### PR DESCRIPTION
## Summary

Adds a test and accompanying test data for **static interface forwarding** via the compile-time class-hash feature. A new `static_forwarding_contract.cairo` example demonstrates a `static_proxy` contract that forwards all `ICounterContract` calls as library calls to `counter_contract`'s class using the compile-time-injected `ForwardingClassHashImpl` — requiring no stored class hash and no constructor. The new `static_forwarding_compiles` test verifies that the proxy compiles successfully and exposes exactly the two forwarded external entry points.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The compile-time class-hash / `forward-impl` feature lacked test coverage for the static forwarding pattern. Without a test, regressions in the two-pass Sierra injection or the `ForwardingClassHashImpl` generation could go undetected.

---

## What was the behavior or documentation before?

There was no test exercising static proxy forwarding using `counter_contract::__class_hash__::ForwardingClassHashImpl`. Only the dynamic proxy pattern (with a stored class hash and constructor) was covered.

---

## What is the behavior or documentation after?

A `static_forwarding_compiles` test compiles the `static_proxy` contract and asserts that:
- Compilation succeeds (no panics or errors).
- Exactly two external entry points are exposed (matching the two methods of `ICounterContract`).
- The compiled contract passes `sanity_check()`.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `static_proxy` contract uses the `#[feature("forward-impl")]` attribute and delegates to `counter_contract`'s class hash, which is injected by the two-pass compilation in `compile_path`. This is distinct from the existing `class_hash_injection_compiles` test, which only verifies deterministic recompilation of the injected hash, not the forwarding behavior itself.