### PR TITLE
refactor(starknet): extract replace_self_param helper

### DIFF
--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -215,22 +215,7 @@ pub fn handle_trait<'db>(
                 } else {
                     format!("self: @{GENERIC_CONTRACT_STATE_NAME}")
                 };
-                let stub_decl = {
-                    let mut func_declaration = RewriteNode::from_ast(&declaration);
-                    let params = func_declaration
-                        .modify_child(db, ast::FunctionDeclaration::INDEX_SIGNATURE)
-                        .modify_child(db, ast::FunctionSignature::INDEX_PARAMETERS)
-                        .modify(db)
-                        .children
-                        .as_mut()
-                        .unwrap();
-                    let maybe_comma = if params.len() > 2 { ", " } else { "" };
-                    params.splice(
-                        0..std::cmp::min(2, params.len()),
-                        [RewriteNode::Text(format!("{self_stub_text}{maybe_comma}"))],
-                    );
-                    func_declaration
-                };
+                let stub_decl = replace_self_param(db, &declaration, &self_stub_text);
                 let self_for_class_hash =
                     if self_param.is_ref_param(db) { "@self" } else { "self" };
                 let dispatch_args = sig_params
@@ -600,19 +585,8 @@ fn dispatcher_signature<'db>(
     self_type_name: &str,
     unwrap: bool,
 ) -> RewriteNode<'db> {
-    let mut func_declaration = RewriteNode::from_ast(declaration);
-    let params = func_declaration
-        .modify_child(db, ast::FunctionDeclaration::INDEX_SIGNATURE)
-        .modify_child(db, ast::FunctionSignature::INDEX_PARAMETERS)
-        .modify(db)
-        .children
-        .as_mut()
-        .unwrap();
-    let maybe_comma = if params.len() > 2 { ", " } else { "" };
-    params.splice(
-        0..std::cmp::min(2, params.len()),
-        [RewriteNode::Text(format!("self: {self_type_name}{maybe_comma}"))],
-    );
+    let mut func_declaration =
+        replace_self_param(db, declaration, &format!("self: {self_type_name}"));
     if unwrap {
         return func_declaration;
     }
@@ -636,5 +610,29 @@ fn dispatcher_signature<'db>(
         return_type.splice(1..2, [new_ret_type]);
     };
 
+    func_declaration
+}
+
+/// Replaces the `self` parameter of `declaration` (and the trailing comma, if any) with
+/// `replacement` (e.g. `self: SomeDispatcher`), returning the rewritten declaration for
+/// optional further modification (such as rewriting the return type).
+fn replace_self_param<'db>(
+    db: &'db dyn Database,
+    declaration: &ast::FunctionDeclaration<'db>,
+    replacement: &str,
+) -> RewriteNode<'db> {
+    let mut func_declaration = RewriteNode::from_ast(declaration);
+    let params = func_declaration
+        .modify_child(db, ast::FunctionDeclaration::INDEX_SIGNATURE)
+        .modify_child(db, ast::FunctionSignature::INDEX_PARAMETERS)
+        .modify(db)
+        .children
+        .as_mut()
+        .unwrap();
+    let maybe_comma = if params.len() > 2 { ", " } else { "" };
+    params.splice(
+        0..std::cmp::min(2, params.len()),
+        [RewriteNode::Text(format!("{replacement}{maybe_comma}"))],
+    );
     func_declaration
 }


### PR DESCRIPTION
## What

Prep refactor for the call-builder feature (follow-up PR, stacked on top of this one).

Extracts the duplicated `self`-parameter splicing in the dispatcher codegen into a single `replace_self_param` helper, used by both `dispatcher_signature` and the forward-impl stub declaration.

## Why

The same param-splice block was copied in two places, and the upcoming call-builder needs it a third time. Extracting it first keeps the feature PR focused on the feature.

## Verification

Pure refactor, **no behavior change** — generated output is byte-identical:
- all `#[starknet::interface]` expansion fixtures unchanged (zero fixture drift)
- `cargo test -p cairo-lang-starknet` → **57 passed** without fix mode
- clippy clean

> Build requires `rustc 1.94` (repo `rust-version`); verified with `cargo +1.94`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
