### PR TITLE
feat(starknet): generate a CallBuilder for #[starknet::interface] traits

### DIFF
--- a/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo
@@ -1,5 +1,6 @@
-use starknet::SyscallResultTrait;
 use starknet::syscalls::{deploy_syscall, get_block_hash_syscall};
+use starknet::{ContractAddress, SyscallResultTrait};
+use super::utils::serialized;
 
 #[starknet::interface]
 trait IContract<T> {
@@ -76,6 +77,39 @@ fn test_flow_safe_dispatcher() {
     // Library calls.
     let mut library = IContractSafeLibraryDispatcher { class_hash: contract_a::TEST_CLASS_HASH };
     assert_eq!(library.foo(300), Ok(0));
+}
+
+#[starknet::interface]
+trait ICallTarget<T> {
+    fn transfer(self: @T, recipient: ContractAddress, amount: u256);
+    fn poke(self: @T);
+}
+
+// Verifies that the generated call builder produces a `Call` with the right `to`, `selector`, and
+// (Serde-encoded) `calldata`, both standalone and via the dispatcher's `.builder()` accessor.
+#[test]
+#[feature("call_builder")]
+fn test_call_builder() {
+    let token: ContractAddress = 0x1234.try_into().unwrap();
+    let recipient: ContractAddress = 0x5678.try_into().unwrap();
+    let amount = 0x42_u256;
+
+    let call = ICallTargetCallBuilder { contract_address: token }.transfer(recipient, amount);
+    assert_eq!(call.to, token);
+    assert_eq!(call.selector, selector!("transfer"));
+    // calldata = serialize(recipient) ++ serialize(amount) = [recipient, amount.low, amount.high].
+    assert_eq!(call.calldata, [0x5678, 0x42, 0x0].span());
+
+    // A method with no arguments yields empty calldata.
+    let poke = ICallTargetCallBuilder { contract_address: token }.poke();
+    assert_eq!(poke.selector, selector!("poke"));
+    assert_eq!(poke.calldata.len(), 0);
+
+    // The dispatcher's `.builder()` accessor produces the same `Call`.
+    let via_dispatcher = ICallTargetDispatcher { contract_address: token }
+        .builder()
+        .transfer(recipient, amount);
+    assert_eq!(serialized(via_dispatcher), serialized(call));
 }
 
 // If the test is failing due to gas usage changes, update the gas limit by taking `test_flow` test

--- a/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
+++ b/crates/cairo-lang-starknet/src/plugin/dispatcher.rs
@@ -87,6 +87,8 @@ pub fn handle_trait<'db>(
     let mut library_caller_method_impls = vec![];
     let mut safe_contract_caller_method_impls = vec![];
     let mut safe_library_caller_method_impls = vec![];
+    let mut call_builder_signatures = vec![];
+    let mut call_builder_method_impls = vec![];
     let mut forward_method_wrappers = vec![];
     let mut forward_external_fns = vec![];
     let mut forward_impl_method_stubs = vec![];
@@ -101,6 +103,8 @@ pub fn handle_trait<'db>(
     let safe_contract_caller_name = format!("{base_name}SafeDispatcher");
     let library_caller_name = format!("{base_name}LibraryDispatcher");
     let safe_library_caller_name = format!("{base_name}SafeLibraryDispatcher");
+    let call_builder_trait_name = format!("{base_name}CallBuilderTrait");
+    let call_builder_name = format!("{base_name}CallBuilder");
     for item_ast in body.iter_items(db) {
         match item_ast {
             ast::TraitItem::Function(func) => {
@@ -287,20 +291,28 @@ pub fn handle_trait<'db>(
                 };
                 dispatcher_signatures.push(RewriteNode::interpolate_patched(
                     "\n$func_decl$;",
-                    &[("func_decl".to_string(), dispatcher_signature(db, &declaration, "T", true))]
-                        .into(),
+                    &[(
+                        "func_decl".to_string(),
+                        dispatcher_signature(db, &declaration, "T", DispatcherKind::Panicking),
+                    )]
+                    .into(),
                 ));
                 safe_dispatcher_signatures.push(RewriteNode::interpolate_patched(
                     "\n    #[unstable(feature: \"safe_dispatcher\")]\n$func_decl$;",
                     &[(
                         "func_decl".to_string(),
-                        dispatcher_signature(db, &declaration, "T", false),
+                        dispatcher_signature(db, &declaration, "T", DispatcherKind::Safe),
                     )]
                     .into(),
                 ));
                 let entry_point_selector = RewriteNode::Text(format!("selector!(\"{fn_name}\")"));
                 contract_caller_method_impls.push(declaration_method_impl(
-                    dispatcher_signature(db, &declaration, &contract_caller_name, true),
+                    dispatcher_signature(
+                        db,
+                        &declaration,
+                        &contract_caller_name,
+                        DispatcherKind::Panicking,
+                    ),
                     entry_point_selector.clone(),
                     "contract_address",
                     "syscalls::call_contract_syscall",
@@ -309,7 +321,12 @@ pub fn handle_trait<'db>(
                     true,
                 ));
                 library_caller_method_impls.push(declaration_method_impl(
-                    dispatcher_signature(db, &declaration, &library_caller_name, true),
+                    dispatcher_signature(
+                        db,
+                        &declaration,
+                        &library_caller_name,
+                        DispatcherKind::Panicking,
+                    ),
                     entry_point_selector.clone(),
                     "class_hash",
                     "syscalls::library_call_syscall",
@@ -318,7 +335,12 @@ pub fn handle_trait<'db>(
                     true,
                 ));
                 safe_contract_caller_method_impls.push(declaration_method_impl(
-                    dispatcher_signature(db, &declaration, &safe_contract_caller_name, false),
+                    dispatcher_signature(
+                        db,
+                        &declaration,
+                        &safe_contract_caller_name,
+                        DispatcherKind::Safe,
+                    ),
                     entry_point_selector.clone(),
                     "contract_address",
                     "syscalls::call_contract_syscall",
@@ -326,8 +348,31 @@ pub fn handle_trait<'db>(
                     ret_decode.clone(),
                     false,
                 ));
+                call_builder_signatures.push(RewriteNode::interpolate_patched(
+                    "\n    #[unstable(feature: \"call_builder\")]\n$func_decl$;",
+                    &[(
+                        "func_decl".to_string(),
+                        dispatcher_signature(db, &declaration, "T", DispatcherKind::Builder),
+                    )]
+                    .into(),
+                ));
+                call_builder_method_impls.push(call_builder_method_impl(
+                    dispatcher_signature(
+                        db,
+                        &declaration,
+                        &call_builder_name,
+                        DispatcherKind::Builder,
+                    ),
+                    entry_point_selector.clone(),
+                    serialization_code.clone(),
+                ));
                 safe_library_caller_method_impls.push(declaration_method_impl(
-                    dispatcher_signature(db, &declaration, &safe_library_caller_name, false),
+                    dispatcher_signature(
+                        db,
+                        &declaration,
+                        &safe_library_caller_name,
+                        DispatcherKind::Safe,
+                    ),
                     entry_point_selector,
                     "class_hash",
                     "syscalls::library_call_syscall",
@@ -419,6 +464,35 @@ pub fn handle_trait<'db>(
              {safe_dispatcher_trait_name}<{safe_contract_caller_name}> {{
             $safe_contract_caller_method_impls$
             }}
+
+            {DISPATCHER_DOC_GROUP_ATTR}
+            $visibility$trait {call_builder_trait_name}<T> {{$call_builder_signatures$
+            }}
+
+            {DISPATCHER_DOC_GROUP_ATTR}
+            #[derive(Copy, Drop, {STORE_TRAIT}, Serde)]
+            $visibility$struct {call_builder_name} {{
+                pub contract_address: starknet::ContractAddress,
+            }}
+
+            {DISPATCHER_DOC_GROUP_ATTR}
+            impl {call_builder_name}Impl of {call_builder_trait_name}<{call_builder_name}> {{
+            $call_builder_method_impls$
+            }}
+
+            {DISPATCHER_DOC_GROUP_ATTR}
+            $visibility$trait {contract_caller_name}BuilderTrait<T> {{
+                #[unstable(feature: \"call_builder\")]
+                fn builder(self: T) -> {call_builder_name};
+            }}
+
+            {DISPATCHER_DOC_GROUP_ATTR}
+            impl {contract_caller_name}BuilderImpl of \
+             {contract_caller_name}BuilderTrait<{contract_caller_name}> {{
+                fn builder(self: {contract_caller_name}) -> {call_builder_name} {{
+                    {call_builder_name} {{ contract_address: self.contract_address }}
+                }}
+            }}
             ",
         ),
         &[
@@ -442,6 +516,14 @@ pub fn handle_trait<'db>(
             (
                 "safe_library_caller_method_impls".to_string(),
                 RewriteNode::new_modified(safe_library_caller_method_impls),
+            ),
+            (
+                "call_builder_signatures".to_string(),
+                RewriteNode::new_modified(call_builder_signatures),
+            ),
+            (
+                "call_builder_method_impls".to_string(),
+                RewriteNode::new_modified(call_builder_method_impls),
             ),
             (
                 "visibility".to_string(),
@@ -578,16 +660,59 @@ fn declaration_method_impl<'db>(
     )
 }
 
-/// Returns the matching signature for a dispatcher implementation for the given declaration.
+/// Returns the method implementation for a call builder: serializes the arguments into
+/// `__calldata__` and returns a `starknet::account::Call` targeting `self.contract_address`.
+/// Unlike a dispatcher method, it performs no syscall and never deserializes a return value.
+fn call_builder_method_impl<'db>(
+    func_declaration: RewriteNode<'db>,
+    entry_point_selector: RewriteNode<'db>,
+    serialization_code: Vec<RewriteNode<'db>>,
+) -> RewriteNode<'db> {
+    RewriteNode::interpolate_patched(
+        &formatdoc!(
+            "$func_decl$ {{
+                    let mut {CALLDATA_PARAM_NAME} = core::traits::Default::default();
+            $serialization_code$
+                    starknet::account::Call {{
+                        to: self.contract_address,
+                        selector: $entry_point_selector$,
+                        calldata: core::array::ArrayTrait::span(@{CALLDATA_PARAM_NAME}),
+                    }}
+                }}
+        "
+        ),
+        &[
+            ("func_decl".to_string(), func_declaration),
+            ("entry_point_selector".to_string(), entry_point_selector),
+            ("serialization_code".to_string(), RewriteNode::new_modified(serialization_code)),
+        ]
+        .into(),
+    )
+}
+
+/// Which member of the dispatcher family a generated method signature belongs to, which
+/// determines how the interface method's return type is rewritten.
+enum DispatcherKind {
+    /// Standard dispatcher: keeps the declared return type, unwrapping the syscall (panics on
+    /// failure).
+    Panicking,
+    /// Safe dispatcher: wraps the declared return type in `starknet::SyscallResult<...>`.
+    Safe,
+    /// Call builder: replaces the declared return type with `starknet::account::Call`.
+    Builder,
+}
+
+/// Returns the signature for a dispatcher-family method: `declaration` with its `self`
+/// parameter replaced by `self_type_name`, and its return type rewritten per `kind`.
 fn dispatcher_signature<'db>(
     db: &'db dyn Database,
     declaration: &ast::FunctionDeclaration<'db>,
     self_type_name: &str,
-    unwrap: bool,
+    kind: DispatcherKind,
 ) -> RewriteNode<'db> {
     let mut func_declaration =
         replace_self_param(db, declaration, &format!("self: {self_type_name}"));
-    if unwrap {
+    if matches!(kind, DispatcherKind::Panicking) {
         return func_declaration;
     }
     let return_type = func_declaration
@@ -597,20 +722,41 @@ fn dispatcher_signature<'db>(
         .children
         .as_mut()
         .unwrap();
-
-    if return_type.is_empty() {
-        let new_ret_type = RewriteNode::text(" -> starknet::SyscallResult<()>");
-        return_type.splice(0..0, [new_ret_type]);
-    } else {
-        let previous_ret_type = RewriteNode::new_modified(return_type[1..2].into());
-        let new_ret_type = RewriteNode::interpolate_patched(
-            "starknet::SyscallResult<$ret_type$>",
-            &[("ret_type".to_string(), previous_ret_type)].into(),
-        );
-        return_type.splice(1..2, [new_ret_type]);
-    };
-
+    match kind {
+        // The interface method's own return type is irrelevant when only building a `Call`.
+        DispatcherKind::Builder => {
+            set_return_type(return_type, RewriteNode::text("starknet::account::Call"));
+        }
+        DispatcherKind::Safe => {
+            let inner = if return_type.is_empty() {
+                RewriteNode::text("()")
+            } else {
+                RewriteNode::new_modified(return_type[1..2].into())
+            };
+            set_return_type(
+                return_type,
+                RewriteNode::interpolate_patched(
+                    "starknet::SyscallResult<$ret_type$>",
+                    &[("ret_type".to_string(), inner)].into(),
+                ),
+            );
+        }
+        DispatcherKind::Panicking => {
+            unreachable!("`Panicking` returns early before touching the return type")
+        }
+    }
     func_declaration
+}
+
+/// Rewrites a return-type clause's children to `-> new_type`: inserts a ` -> ` arrow when the
+/// method had no return type, or replaces just the type (keeping the existing arrow and its
+/// spacing) otherwise.
+fn set_return_type<'db>(return_type: &mut Vec<RewriteNode<'db>>, new_type: RewriteNode<'db>) {
+    if return_type.is_empty() {
+        return_type.splice(0..0, [RewriteNode::text(" -> "), new_type]);
+    } else {
+        return_type.splice(1..2, [new_type]);
+    }
 }
 
 /// Replaces the `self` parameter of `declaration` (and the trailing comma, if any) with

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/component
@@ -385,6 +385,59 @@ impl MyTraitSafeDispatcherImpl of MyTraitSafeDispatcherTrait<MyTraitSafeDispatch
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait MyTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get(self: T, addr: ContractAddress) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set(self: T, addr: ContractAddress, value: u32) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct MyTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderImpl of MyTraitCallBuilderTrait<MyTraitCallBuilder> {
+    fn get(self: MyTraitCallBuilder, addr: ContractAddress) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@addr, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set(self: MyTraitCallBuilder, addr: ContractAddress, value: u32) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@addr, ref __calldata__);
+        core::serde::Serde::<u32>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait MyTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> MyTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl MyTraitDispatcherBuilderImpl of MyTraitDispatcherBuilderTrait<MyTraitDispatcher> {
+    fn builder(self: MyTraitDispatcher) -> MyTraitCallBuilder {
+        MyTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -951,6 +1004,126 @@ lib.cairo:42:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderCopy<> of core::traits::Copy::<MyTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderDrop<> of core::traits::Drop::<MyTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderSerde<> of core::serde::Serde::<MyTraitCallBuilder> {
+    fn serialize(self: @MyTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<MyTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(MyTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:42:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl MyTraitCallBuilderStore<> of starknet::Store::<MyTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<MyTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            MyTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: MyTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let MyTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<MyTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            MyTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: MyTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let MyTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct MyTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<MyTraitCallBuilder> {
+    type SubPointersType = MyTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<MyTraitCallBuilder>) -> MyTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                MyTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct MyTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<MyTraitCallBuilder> {
+    type SubPointersType = MyTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<MyTraitCallBuilder>>) -> MyTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                MyTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:42:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl MyTraitDispatcherSubPointersDrop<> of core::traits::Drop::<MyTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1032,6 +1205,28 @@ impls:
 impl MyTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<MyTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl MyTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<MyTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:42:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<MyTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<MyTraitCallBuilderSubPointers>;
+
+
+lib.cairo:42:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<MyTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<MyTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:6:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/embeddable_as
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/components/embeddable_as
@@ -151,6 +151,45 @@ impl MyTraitSafeDispatcherImpl of MyTraitSafeDispatcherTrait<MyTraitSafeDispatch
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait MyTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn do_nothing(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct MyTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderImpl of MyTraitCallBuilderTrait<MyTraitCallBuilder> {
+    fn do_nothing(self: MyTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("do_nothing"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait MyTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> MyTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl MyTraitDispatcherBuilderImpl of MyTraitDispatcherBuilderTrait<MyTraitDispatcher> {
+    fn builder(self: MyTraitDispatcher) -> MyTraitCallBuilder {
+        MyTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -676,6 +715,126 @@ lib.cairo:16:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderCopy<> of core::traits::Copy::<MyTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderDrop<> of core::traits::Drop::<MyTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl MyTraitCallBuilderSerde<> of core::serde::Serde::<MyTraitCallBuilder> {
+    fn serialize(self: @MyTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<MyTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(MyTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:16:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl MyTraitCallBuilderStore<> of starknet::Store::<MyTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<MyTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            MyTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: MyTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let MyTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<MyTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            MyTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: MyTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let MyTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct MyTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<MyTraitCallBuilder> {
+    type SubPointersType = MyTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<MyTraitCallBuilder>) -> MyTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                MyTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct MyTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<MyTraitCallBuilder> {
+    type SubPointersType = MyTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<MyTraitCallBuilder>>) -> MyTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                MyTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:16:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl MyTraitDispatcherSubPointersDrop<> of core::traits::Drop::<MyTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -757,6 +916,28 @@ impls:
 impl MyTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<MyTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl MyTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<MyTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:16:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<MyTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<MyTraitCallBuilderSubPointers>;
+
+
+lib.cairo:16:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<MyTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl MyTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<MyTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:1:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -3028,6 +3028,67 @@ impl InterfaceTraitSafeDispatcherImpl of InterfaceTraitSafeDispatcherTrait<Inter
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait InterfaceTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo_external1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo_l1_handler1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo_constructor1(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderImpl of InterfaceTraitCallBuilderTrait<InterfaceTraitCallBuilder> {
+    fn foo_external1(self: InterfaceTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo_external1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo_l1_handler1(self: InterfaceTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo_l1_handler1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo_constructor1(self: InterfaceTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo_constructor1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> InterfaceTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceTraitDispatcherBuilderImpl of InterfaceTraitDispatcherBuilderTrait<InterfaceTraitDispatcher> {
+    fn builder(self: InterfaceTraitDispatcher) -> InterfaceTraitCallBuilder {
+        InterfaceTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -3591,6 +3652,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderCopy<> of core::traits::Copy::<InterfaceTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderDrop<> of core::traits::Drop::<InterfaceTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderSerde<> of core::serde::Serde::<InterfaceTraitCallBuilder> {
+    fn serialize(self: @InterfaceTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceTraitCallBuilderStore<> of starknet::Store::<InterfaceTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceTraitCallBuilder> {
+    type SubPointersType = InterfaceTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceTraitCallBuilder>) -> InterfaceTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceTraitCallBuilder> {
+    type SubPointersType = InterfaceTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceTraitCallBuilder>>) -> InterfaceTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceTraitDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -3672,6 +3853,28 @@ impls:
 impl InterfaceTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:8:1
@@ -4546,6 +4749,34 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -5032,6 +5263,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -5113,6 +5464,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -5233,6 +5606,34 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -5719,6 +6120,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -5800,6 +6321,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -5886,6 +6429,34 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -6372,6 +6943,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -6453,6 +7144,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -6546,6 +7259,34 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -7032,6 +7773,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -7113,6 +7974,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -7267,6 +8150,45 @@ impl InterfaceTraitSafeDispatcherImpl of InterfaceTraitSafeDispatcherTrait<Inter
         )
     }
 
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo_with_body(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderImpl of InterfaceTraitCallBuilderTrait<InterfaceTraitCallBuilder> {
+    fn foo_with_body(self: InterfaceTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo_with_body"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> InterfaceTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceTraitDispatcherBuilderImpl of InterfaceTraitDispatcherBuilderTrait<InterfaceTraitDispatcher> {
+    fn builder(self: InterfaceTraitDispatcher) -> InterfaceTraitCallBuilder {
+        InterfaceTraitCallBuilder { contract_address: self.contract_address }
+    }
 }
 
 
@@ -7755,6 +8677,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderCopy<> of core::traits::Copy::<InterfaceTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderDrop<> of core::traits::Drop::<InterfaceTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceTraitCallBuilderSerde<> of core::serde::Serde::<InterfaceTraitCallBuilder> {
+    fn serialize(self: @InterfaceTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceTraitCallBuilderStore<> of starknet::Store::<InterfaceTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceTraitCallBuilder> {
+    type SubPointersType = InterfaceTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceTraitCallBuilder>) -> InterfaceTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceTraitCallBuilder> {
+    type SubPointersType = InterfaceTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceTraitCallBuilder>>) -> InterfaceTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceTraitDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -7836,6 +8878,28 @@ impls:
 impl InterfaceTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceTraitCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -8093,6 +9157,67 @@ impl InterfaceSafeDispatcherImpl of InterfaceSafeDispatcherTrait<InterfaceSafeDi
         Result::Ok(())
     }
 
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo2(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo3(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderImpl of InterfaceCallBuilderTrait<InterfaceCallBuilder> {
+    fn foo1(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo2(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo2"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo3(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> InterfaceCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceDispatcherBuilderImpl of InterfaceDispatcherBuilderTrait<InterfaceDispatcher> {
+    fn builder(self: InterfaceDispatcher) -> InterfaceCallBuilder {
+        InterfaceCallBuilder { contract_address: self.contract_address }
+    }
 }
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
@@ -8737,6 +9862,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderCopy<> of core::traits::Copy::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderDrop<> of core::traits::Drop::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderSerde<> of core::serde::Serde::<InterfaceCallBuilder> {
+    fn serialize(self: @InterfaceCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceCallBuilderStore<> of starknet::Store::<InterfaceCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceCallBuilder>) -> InterfaceCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceCallBuilder>>) -> InterfaceCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceDispatcherSubPointers>;
 #[doc(hidden)]
@@ -8818,6 +10063,28 @@ impls:
 impl InterfaceSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointersMut>;
 
 //! > ==========================================================================
 
@@ -9131,6 +10398,67 @@ impl InterfaceSafeDispatcherImpl of InterfaceSafeDispatcherTrait<InterfaceSafeDi
         Result::Ok(())
     }
 
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo2(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo3(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderImpl of InterfaceCallBuilderTrait<InterfaceCallBuilder> {
+    fn foo1(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo2(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo2"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo3(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> InterfaceCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceDispatcherBuilderImpl of InterfaceDispatcherBuilderTrait<InterfaceDispatcher> {
+    fn builder(self: InterfaceDispatcher) -> InterfaceCallBuilder {
+        InterfaceCallBuilder { contract_address: self.contract_address }
+    }
 }
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
@@ -9695,6 +11023,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderCopy<> of core::traits::Copy::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderDrop<> of core::traits::Drop::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderSerde<> of core::serde::Serde::<InterfaceCallBuilder> {
+    fn serialize(self: @InterfaceCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceCallBuilderStore<> of starknet::Store::<InterfaceCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceCallBuilder>) -> InterfaceCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceCallBuilder>>) -> InterfaceCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceDispatcherSubPointers>;
 #[doc(hidden)]
@@ -9776,6 +11224,28 @@ impls:
 impl InterfaceSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointersMut>;
 
 
 lib.cairo:7:1
@@ -10809,6 +12279,56 @@ impl Comp3TraitSafeDispatcherImpl of Comp3TraitSafeDispatcherTrait<Comp3TraitSaf
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait Comp3TraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo3(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn foo4(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct Comp3TraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderImpl of Comp3TraitCallBuilderTrait<Comp3TraitCallBuilder> {
+    fn foo3(self: Comp3TraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn foo4(self: Comp3TraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo4"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait Comp3TraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> Comp3TraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl Comp3TraitDispatcherBuilderImpl of Comp3TraitDispatcherBuilderTrait<Comp3TraitDispatcher> {
+    fn builder(self: Comp3TraitDispatcher) -> Comp3TraitCallBuilder {
+        Comp3TraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -11353,6 +12873,126 @@ lib.cairo:30:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderCopy<> of core::traits::Copy::<Comp3TraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderDrop<> of core::traits::Drop::<Comp3TraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderSerde<> of core::serde::Serde::<Comp3TraitCallBuilder> {
+    fn serialize(self: @Comp3TraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<Comp3TraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(Comp3TraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:30:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl Comp3TraitCallBuilderStore<> of starknet::Store::<Comp3TraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Comp3TraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            Comp3TraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Comp3TraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let Comp3TraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<Comp3TraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            Comp3TraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: Comp3TraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let Comp3TraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Comp3TraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<Comp3TraitCallBuilder> {
+    type SubPointersType = Comp3TraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<Comp3TraitCallBuilder>) -> Comp3TraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Comp3TraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Comp3TraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<Comp3TraitCallBuilder> {
+    type SubPointersType = Comp3TraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<Comp3TraitCallBuilder>>) -> Comp3TraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Comp3TraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:30:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl Comp3TraitDispatcherSubPointersDrop<> of core::traits::Drop::<Comp3TraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -11434,6 +13074,28 @@ impls:
 impl Comp3TraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<Comp3TraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl Comp3TraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<Comp3TraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:30:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersDrop<> of core::traits::Drop::<Comp3TraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersCopy<> of core::traits::Copy::<Comp3TraitCallBuilderSubPointers>;
+
+
+lib.cairo:30:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<Comp3TraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<Comp3TraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:1:1
@@ -12247,6 +13909,45 @@ impl Comp3TraitSafeDispatcherImpl of Comp3TraitSafeDispatcherTrait<Comp3TraitSaf
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait Comp3TraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo3(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct Comp3TraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderImpl of Comp3TraitCallBuilderTrait<Comp3TraitCallBuilder> {
+    fn foo3(self: Comp3TraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait Comp3TraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> Comp3TraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl Comp3TraitDispatcherBuilderImpl of Comp3TraitDispatcherBuilderTrait<Comp3TraitDispatcher> {
+    fn builder(self: Comp3TraitDispatcher) -> Comp3TraitCallBuilder {
+        Comp3TraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -12772,6 +14473,126 @@ lib.cairo:27:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderCopy<> of core::traits::Copy::<Comp3TraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderDrop<> of core::traits::Drop::<Comp3TraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl Comp3TraitCallBuilderSerde<> of core::serde::Serde::<Comp3TraitCallBuilder> {
+    fn serialize(self: @Comp3TraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<Comp3TraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(Comp3TraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:27:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl Comp3TraitCallBuilderStore<> of starknet::Store::<Comp3TraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Comp3TraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            Comp3TraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Comp3TraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let Comp3TraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<Comp3TraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            Comp3TraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: Comp3TraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let Comp3TraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Comp3TraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<Comp3TraitCallBuilder> {
+    type SubPointersType = Comp3TraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<Comp3TraitCallBuilder>) -> Comp3TraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Comp3TraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Comp3TraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<Comp3TraitCallBuilder> {
+    type SubPointersType = Comp3TraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<Comp3TraitCallBuilder>>) -> Comp3TraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Comp3TraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:27:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl Comp3TraitDispatcherSubPointersDrop<> of core::traits::Drop::<Comp3TraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -12853,6 +14674,28 @@ impls:
 impl Comp3TraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<Comp3TraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl Comp3TraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<Comp3TraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:27:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersDrop<> of core::traits::Drop::<Comp3TraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersCopy<> of core::traits::Copy::<Comp3TraitCallBuilderSubPointers>;
+
+
+lib.cairo:27:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<Comp3TraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl Comp3TraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<Comp3TraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:1:1
@@ -13525,6 +15368,45 @@ impl ContractTraitSafeDispatcherImpl of ContractTraitSafeDispatcherTrait<Contrac
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait ContractTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct ContractTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderImpl of ContractTraitCallBuilderTrait<ContractTraitCallBuilder> {
+    fn foo(self: ContractTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait ContractTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> ContractTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitDispatcherBuilderImpl of ContractTraitDispatcherBuilderTrait<ContractTraitDispatcher> {
+    fn builder(self: ContractTraitDispatcher) -> ContractTraitCallBuilder {
+        ContractTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -14050,6 +15932,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderCopy<> of core::traits::Copy::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderDrop<> of core::traits::Drop::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderSerde<> of core::serde::Serde::<ContractTraitCallBuilder> {
+    fn serialize(self: @ContractTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ContractTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ContractTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl ContractTraitCallBuilderStore<> of starknet::Store::<ContractTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ContractTraitCallBuilder>) -> ContractTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ContractTraitCallBuilder>>) -> ContractTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl ContractTraitDispatcherSubPointersDrop<> of core::traits::Drop::<ContractTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -14131,6 +16133,28 @@ impls:
 impl ContractTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ContractTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ContractTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ContractTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:6:1
@@ -14522,6 +16546,45 @@ impl ContractTraitSafeDispatcherImpl of ContractTraitSafeDispatcherTrait<Contrac
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait ContractTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct ContractTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderImpl of ContractTraitCallBuilderTrait<ContractTraitCallBuilder> {
+    fn foo(self: ContractTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait ContractTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> ContractTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitDispatcherBuilderImpl of ContractTraitDispatcherBuilderTrait<ContractTraitDispatcher> {
+    fn builder(self: ContractTraitDispatcher) -> ContractTraitCallBuilder {
+        ContractTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -15047,6 +17110,126 @@ lib.cairo:9:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderCopy<> of core::traits::Copy::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderDrop<> of core::traits::Drop::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderSerde<> of core::serde::Serde::<ContractTraitCallBuilder> {
+    fn serialize(self: @ContractTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ContractTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ContractTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:9:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl ContractTraitCallBuilderStore<> of starknet::Store::<ContractTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ContractTraitCallBuilder>) -> ContractTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ContractTraitCallBuilder>>) -> ContractTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:9:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl ContractTraitDispatcherSubPointersDrop<> of core::traits::Drop::<ContractTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -15128,6 +17311,28 @@ impls:
 impl ContractTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ContractTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ContractTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ContractTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:9:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointers>;
+
+
+lib.cairo:9:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:1:1
@@ -15761,6 +17966,45 @@ impl ContractTraitSafeDispatcherImpl of ContractTraitSafeDispatcherTrait<Contrac
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait ContractTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct ContractTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderImpl of ContractTraitCallBuilderTrait<ContractTraitCallBuilder> {
+    fn foo(self: ContractTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait ContractTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> ContractTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl ContractTraitDispatcherBuilderImpl of ContractTraitDispatcherBuilderTrait<ContractTraitDispatcher> {
+    fn builder(self: ContractTraitDispatcher) -> ContractTraitCallBuilder {
+        ContractTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -16286,6 +18530,126 @@ lib.cairo:43:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderCopy<> of core::traits::Copy::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderDrop<> of core::traits::Drop::<ContractTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ContractTraitCallBuilderSerde<> of core::serde::Serde::<ContractTraitCallBuilder> {
+    fn serialize(self: @ContractTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ContractTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ContractTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:43:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl ContractTraitCallBuilderStore<> of starknet::Store::<ContractTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ContractTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ContractTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ContractTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ContractTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ContractTraitCallBuilder>) -> ContractTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ContractTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ContractTraitCallBuilder> {
+    type SubPointersType = ContractTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ContractTraitCallBuilder>>) -> ContractTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ContractTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:43:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl ContractTraitDispatcherSubPointersDrop<> of core::traits::Drop::<ContractTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -16367,6 +18731,28 @@ impls:
 impl ContractTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ContractTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ContractTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ContractTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:43:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointers>;
+
+
+lib.cairo:43:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ContractTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ContractTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ContractTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:48:1
@@ -16752,6 +19138,45 @@ impl InterfaceSafeDispatcherImpl of InterfaceSafeDispatcherTrait<InterfaceSafeDi
         Result::Ok(())
     }
 
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn func(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct InterfaceCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderImpl of InterfaceCallBuilderTrait<InterfaceCallBuilder> {
+    fn func(self: InterfaceCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("func"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait InterfaceDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> InterfaceCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceDispatcherBuilderImpl of InterfaceDispatcherBuilderTrait<InterfaceDispatcher> {
+    fn builder(self: InterfaceDispatcher) -> InterfaceCallBuilder {
+        InterfaceCallBuilder { contract_address: self.contract_address }
+    }
 }
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
@@ -17278,6 +19703,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderCopy<> of core::traits::Copy::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderDrop<> of core::traits::Drop::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderSerde<> of core::serde::Serde::<InterfaceCallBuilder> {
+    fn serialize(self: @InterfaceCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceCallBuilderStore<> of starknet::Store::<InterfaceCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceCallBuilder>) -> InterfaceCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceCallBuilder>>) -> InterfaceCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceDispatcherSubPointers>;
 #[doc(hidden)]
@@ -17359,6 +19904,28 @@ impls:
 impl InterfaceSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointersMut>;
 
 
 lib.cairo:6:1
@@ -18521,6 +21088,46 @@ impl InterfaceSafeDispatcherImpl of InterfaceSafeDispatcherTrait<InterfaceSafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+pub trait InterfaceCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T, value: u256) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+pub struct InterfaceCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderImpl of InterfaceCallBuilderTrait<InterfaceCallBuilder> {
+    fn foo(self: InterfaceCallBuilder, value: u256) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u256>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+pub trait InterfaceDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> InterfaceCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl InterfaceDispatcherBuilderImpl of InterfaceDispatcherBuilderTrait<InterfaceDispatcher> {
+    fn builder(self: InterfaceDispatcher) -> InterfaceCallBuilder {
+        InterfaceCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -19046,6 +21653,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderCopy<> of core::traits::Copy::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderDrop<> of core::traits::Drop::<InterfaceCallBuilder>;
+#[doc(group: "dispatchers")]
+impl InterfaceCallBuilderSerde<> of core::serde::Serde::<InterfaceCallBuilder> {
+    fn serialize(self: @InterfaceCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<InterfaceCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(InterfaceCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl InterfaceCallBuilderStore<> of starknet::Store::<InterfaceCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<InterfaceCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            InterfaceCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: InterfaceCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let InterfaceCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersImpl of starknet::storage::SubPointers<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<InterfaceCallBuilder>) -> InterfaceCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct InterfaceCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<InterfaceCallBuilder> {
+    type SubPointersType = InterfaceCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<InterfaceCallBuilder>>) -> InterfaceCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                InterfaceCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl InterfaceDispatcherSubPointersDrop<> of core::traits::Drop::<InterfaceDispatcherSubPointers>;
 #[doc(hidden)]
@@ -19127,6 +21854,28 @@ impls:
 impl InterfaceSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<InterfaceSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl InterfaceSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<InterfaceSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointers>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutDrop<> of core::traits::Drop::<InterfaceCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl InterfaceCallBuilderSubPointersMutCopy<> of core::traits::Copy::<InterfaceCallBuilderSubPointersMut>;
 
 
 lib.cairo:6:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/dispatcher
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/dispatcher
@@ -202,6 +202,60 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_something(self: T, arg: felt252, num: felt252) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+
+    fn empty(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+    fn get_something(self: IContractCallBuilder, arg: felt252, num: felt252) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<felt252>::serialize(@arg, ref __calldata__);
+        core::serde::Serde::<felt252>::serialize(@num, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_something"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+    fn empty(self: IContractCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("empty"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -747,6 +801,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -828,6 +1002,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > expected_diagnostics
 
@@ -912,6 +1108,34 @@ struct IContractSafeDispatcher {
 #[doc(group: "dispatchers")]
 impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDispatcher> {
 
+}
+
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
 }
 
 
@@ -1400,6 +1624,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1481,6 +1825,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > expected_diagnostics
 error[E2200]: Plugin diagnostic: `starknet::interface` functions don't support `ref` parameters other than the first one.
@@ -1647,6 +2013,47 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
 
 }
 
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+
+    fn empty(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+
+    fn empty(self: IContractCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("empty"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
+}
+
 
 lib.cairo:1:1
 #[starknet::interface]
@@ -2133,6 +2540,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -2214,3 +2741,25 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/embedded_impl
@@ -252,6 +252,58 @@ impl OutsideTraitSafeDispatcherImpl of OutsideTraitSafeDispatcherTrait<OutsideTr
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn ret_3(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn ret_identity(self: T, from_address: felt252, value: felt252) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct OutsideTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitCallBuilderImpl of OutsideTraitCallBuilderTrait<OutsideTraitCallBuilder> {
+    fn ret_3(self: OutsideTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn ret_identity(self: OutsideTraitCallBuilder, from_address: felt252, value: felt252) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<felt252>::serialize(@from_address, ref __calldata__);
+        core::serde::Serde::<felt252>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_identity"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> OutsideTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitDispatcherBuilderImpl of OutsideTraitDispatcherBuilderTrait<OutsideTraitDispatcher> {
+    fn builder(self: OutsideTraitDispatcher) -> OutsideTraitCallBuilder {
+        OutsideTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -866,6 +918,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl OutsideTraitCallBuilderCopy<> of core::traits::Copy::<OutsideTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitCallBuilderDrop<> of core::traits::Drop::<OutsideTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitCallBuilderSerde<> of core::serde::Serde::<OutsideTraitCallBuilder> {
+    fn serialize(self: @OutsideTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<OutsideTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(OutsideTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl OutsideTraitCallBuilderStore<> of starknet::Store::<OutsideTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<OutsideTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: OutsideTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let OutsideTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<OutsideTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: OutsideTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let OutsideTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<OutsideTraitCallBuilder> {
+    type SubPointersType = OutsideTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<OutsideTraitCallBuilder>) -> OutsideTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<OutsideTraitCallBuilder> {
+    type SubPointersType = OutsideTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<OutsideTraitCallBuilder>>) -> OutsideTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl OutsideTraitDispatcherSubPointersDrop<> of core::traits::Drop::<OutsideTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -947,6 +1119,28 @@ impls:
 impl OutsideTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl OutsideTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<OutsideTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<OutsideTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl OutsideTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:17:1
@@ -1333,6 +1527,45 @@ impl OutsideTraitWithDestructSafeDispatcherImpl of OutsideTraitWithDestructSafeD
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithDestructCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn ret_3(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct OutsideTraitWithDestructCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructCallBuilderImpl of OutsideTraitWithDestructCallBuilderTrait<OutsideTraitWithDestructCallBuilder> {
+    fn ret_3(self: OutsideTraitWithDestructCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_3"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithDestructDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> OutsideTraitWithDestructCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructDispatcherBuilderImpl of OutsideTraitWithDestructDispatcherBuilderTrait<OutsideTraitWithDestructDispatcher> {
+    fn builder(self: OutsideTraitWithDestructDispatcher) -> OutsideTraitWithDestructCallBuilder {
+        OutsideTraitWithDestructCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -1535,6 +1768,45 @@ impl OutsideTraitWithPanicDestructSafeDispatcherImpl of OutsideTraitWithPanicDes
         )
     }
 
+}
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithPanicDestructCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn ret_5(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct OutsideTraitWithPanicDestructCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructCallBuilderImpl of OutsideTraitWithPanicDestructCallBuilderTrait<OutsideTraitWithPanicDestructCallBuilder> {
+    fn ret_5(self: OutsideTraitWithPanicDestructCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_5"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithPanicDestructDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> OutsideTraitWithPanicDestructCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructDispatcherBuilderImpl of OutsideTraitWithPanicDestructDispatcherBuilderTrait<OutsideTraitWithPanicDestructDispatcher> {
+    fn builder(self: OutsideTraitWithPanicDestructDispatcher) -> OutsideTraitWithPanicDestructCallBuilder {
+        OutsideTraitWithPanicDestructCallBuilder { contract_address: self.contract_address }
+    }
 }
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
@@ -2099,6 +2371,126 @@ impl OutsideTraitWithDestructSafeDispatcherSubPointersMutImpl of starknet::stora
 }
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructCallBuilderCopy<> of core::traits::Copy::<OutsideTraitWithDestructCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructCallBuilderDrop<> of core::traits::Drop::<OutsideTraitWithDestructCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDestructCallBuilderSerde<> of core::serde::Serde::<OutsideTraitWithDestructCallBuilder> {
+    fn serialize(self: @OutsideTraitWithDestructCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<OutsideTraitWithDestructCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(OutsideTraitWithDestructCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl OutsideTraitWithDestructCallBuilderStore<> of starknet::Store::<OutsideTraitWithDestructCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<OutsideTraitWithDestructCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithDestructCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: OutsideTraitWithDestructCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let OutsideTraitWithDestructCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<OutsideTraitWithDestructCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithDestructCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: OutsideTraitWithDestructCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let OutsideTraitWithDestructCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithDestructCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersImpl of starknet::storage::SubPointers<OutsideTraitWithDestructCallBuilder> {
+    type SubPointersType = OutsideTraitWithDestructCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<OutsideTraitWithDestructCallBuilder>) -> OutsideTraitWithDestructCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithDestructCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithDestructCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<OutsideTraitWithDestructCallBuilder> {
+    type SubPointersType = OutsideTraitWithDestructCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<OutsideTraitWithDestructCallBuilder>>) -> OutsideTraitWithDestructCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithDestructCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:15:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2579,6 +2971,126 @@ impl OutsideTraitWithPanicDestructSafeDispatcherSubPointersMutImpl of starknet::
 }
 
 
+lib.cairo:15:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructCallBuilderCopy<> of core::traits::Copy::<OutsideTraitWithPanicDestructCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructCallBuilderDrop<> of core::traits::Drop::<OutsideTraitWithPanicDestructCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithPanicDestructCallBuilderSerde<> of core::serde::Serde::<OutsideTraitWithPanicDestructCallBuilder> {
+    fn serialize(self: @OutsideTraitWithPanicDestructCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<OutsideTraitWithPanicDestructCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(OutsideTraitWithPanicDestructCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:15:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl OutsideTraitWithPanicDestructCallBuilderStore<> of starknet::Store::<OutsideTraitWithPanicDestructCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<OutsideTraitWithPanicDestructCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithPanicDestructCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: OutsideTraitWithPanicDestructCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let OutsideTraitWithPanicDestructCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<OutsideTraitWithPanicDestructCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithPanicDestructCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: OutsideTraitWithPanicDestructCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let OutsideTraitWithPanicDestructCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithPanicDestructCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersImpl of starknet::storage::SubPointers<OutsideTraitWithPanicDestructCallBuilder> {
+    type SubPointersType = OutsideTraitWithPanicDestructCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<OutsideTraitWithPanicDestructCallBuilder>) -> OutsideTraitWithPanicDestructCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithPanicDestructCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithPanicDestructCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<OutsideTraitWithPanicDestructCallBuilder> {
+    type SubPointersType = OutsideTraitWithPanicDestructCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<OutsideTraitWithPanicDestructCallBuilder>>) -> OutsideTraitWithPanicDestructCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithPanicDestructCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:1:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2667,6 +3179,28 @@ impl OutsideTraitWithDestructSafeDispatcherSubPointersMutDrop<> of core::traits:
 impl OutsideTraitWithDestructSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithDestructSafeDispatcherSubPointersMut>;
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersDrop<> of core::traits::Drop::<OutsideTraitWithDestructCallBuilderSubPointers>;
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersCopy<> of core::traits::Copy::<OutsideTraitWithDestructCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithDestructCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl OutsideTraitWithDestructCallBuilderSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithDestructCallBuilderSubPointersMut>;
+
+
 lib.cairo:15:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2753,6 +3287,28 @@ impls:
 impl OutsideTraitWithPanicDestructSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithPanicDestructSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl OutsideTraitWithPanicDestructSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithPanicDestructSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:15:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersDrop<> of core::traits::Drop::<OutsideTraitWithPanicDestructCallBuilderSubPointers>;
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersCopy<> of core::traits::Copy::<OutsideTraitWithPanicDestructCallBuilderSubPointers>;
+
+
+lib.cairo:15:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithPanicDestructCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl OutsideTraitWithPanicDestructCallBuilderSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithPanicDestructCallBuilderSubPointersMut>;
 
 
 lib.cairo:29:1
@@ -3112,6 +3668,45 @@ impl OutsideTraitWithDropSafeDispatcherImpl of OutsideTraitWithDropSafeDispatche
         )
     }
 
+}
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithDropCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn ret_8(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct OutsideTraitWithDropCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropCallBuilderImpl of OutsideTraitWithDropCallBuilderTrait<OutsideTraitWithDropCallBuilder> {
+    fn ret_8(self: OutsideTraitWithDropCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("ret_8"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait OutsideTraitWithDropDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> OutsideTraitWithDropCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropDispatcherBuilderImpl of OutsideTraitWithDropDispatcherBuilderTrait<OutsideTraitWithDropDispatcher> {
+    fn builder(self: OutsideTraitWithDropDispatcher) -> OutsideTraitWithDropCallBuilder {
+        OutsideTraitWithDropCallBuilder { contract_address: self.contract_address }
+    }
 }
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
@@ -3681,6 +4276,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropCallBuilderCopy<> of core::traits::Copy::<OutsideTraitWithDropCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropCallBuilderDrop<> of core::traits::Drop::<OutsideTraitWithDropCallBuilder>;
+#[doc(group: "dispatchers")]
+impl OutsideTraitWithDropCallBuilderSerde<> of core::serde::Serde::<OutsideTraitWithDropCallBuilder> {
+    fn serialize(self: @OutsideTraitWithDropCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<OutsideTraitWithDropCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(OutsideTraitWithDropCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl OutsideTraitWithDropCallBuilderStore<> of starknet::Store::<OutsideTraitWithDropCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<OutsideTraitWithDropCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithDropCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: OutsideTraitWithDropCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let OutsideTraitWithDropCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<OutsideTraitWithDropCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            OutsideTraitWithDropCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: OutsideTraitWithDropCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let OutsideTraitWithDropCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithDropCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersImpl of starknet::storage::SubPointers<OutsideTraitWithDropCallBuilder> {
+    type SubPointersType = OutsideTraitWithDropCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<OutsideTraitWithDropCallBuilder>) -> OutsideTraitWithDropCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithDropCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct OutsideTraitWithDropCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<OutsideTraitWithDropCallBuilder> {
+    type SubPointersType = OutsideTraitWithDropCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<OutsideTraitWithDropCallBuilder>>) -> OutsideTraitWithDropCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                OutsideTraitWithDropCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl OutsideTraitWithDropDispatcherSubPointersDrop<> of core::traits::Drop::<OutsideTraitWithDropDispatcherSubPointers>;
 #[doc(hidden)]
@@ -3762,6 +4477,28 @@ impls:
 impl OutsideTraitWithDropSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithDropSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl OutsideTraitWithDropSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithDropSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersDrop<> of core::traits::Drop::<OutsideTraitWithDropCallBuilderSubPointers>;
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersCopy<> of core::traits::Copy::<OutsideTraitWithDropCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersMutDrop<> of core::traits::Drop::<OutsideTraitWithDropCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl OutsideTraitWithDropCallBuilderSubPointersMutCopy<> of core::traits::Copy::<OutsideTraitWithDropCallBuilderSubPointersMut>;
 
 
 lib.cairo:15:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/forward_impl
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/forward_impl
@@ -226,6 +226,57 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait IContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_value(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_value(self: T, value: felt252) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+    fn get_value(self: IContractCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_value"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_value(self: IContractCallBuilder, value: felt252) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<felt252>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_value"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -770,6 +821,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -851,6 +1022,28 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 
 lib.cairo:7:1
@@ -1233,6 +1426,45 @@ impl IForwardedSafeDispatcherImpl of IForwardedSafeDispatcherTrait<IForwardedSaf
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait IForwardedCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn forwarded_fn(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IForwardedCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IForwardedCallBuilderImpl of IForwardedCallBuilderTrait<IForwardedCallBuilder> {
+    fn forwarded_fn(self: IForwardedCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("forwarded_fn"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait IForwardedDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IForwardedCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IForwardedDispatcherBuilderImpl of IForwardedDispatcherBuilderTrait<IForwardedDispatcher> {
+    fn builder(self: IForwardedDispatcher) -> IForwardedCallBuilder {
+        IForwardedCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -1392,6 +1624,45 @@ impl IDirectSafeDispatcherImpl of IDirectSafeDispatcherTrait<IDirectSafeDispatch
         )
     }
 
+}
+
+#[doc(group: "dispatchers")]
+trait IDirectCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn direct_fn(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IDirectCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IDirectCallBuilderImpl of IDirectCallBuilderTrait<IDirectCallBuilder> {
+    fn direct_fn(self: IDirectCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("direct_fn"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait IDirectDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IDirectCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IDirectDispatcherBuilderImpl of IDirectDispatcherBuilderTrait<IDirectDispatcher> {
+    fn builder(self: IDirectDispatcher) -> IDirectCallBuilder {
+        IDirectCallBuilder { contract_address: self.contract_address }
+    }
 }
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
@@ -1956,6 +2227,126 @@ impl IForwardedSafeDispatcherSubPointersMutImpl of starknet::storage::SubPointer
 }
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl IForwardedCallBuilderCopy<> of core::traits::Copy::<IForwardedCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IForwardedCallBuilderDrop<> of core::traits::Drop::<IForwardedCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IForwardedCallBuilderSerde<> of core::serde::Serde::<IForwardedCallBuilder> {
+    fn serialize(self: @IForwardedCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IForwardedCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IForwardedCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IForwardedCallBuilderStore<> of starknet::Store::<IForwardedCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IForwardedCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IForwardedCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IForwardedCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IForwardedCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IForwardedCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IForwardedCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IForwardedCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IForwardedCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IForwardedCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersImpl of starknet::storage::SubPointers<IForwardedCallBuilder> {
+    type SubPointersType = IForwardedCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IForwardedCallBuilder>) -> IForwardedCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IForwardedCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IForwardedCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IForwardedCallBuilder> {
+    type SubPointersType = IForwardedCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IForwardedCallBuilder>>) -> IForwardedCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IForwardedCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:6:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2436,6 +2827,126 @@ impl IDirectSafeDispatcherSubPointersMutImpl of starknet::storage::SubPointersMu
 }
 
 
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl IDirectCallBuilderCopy<> of core::traits::Copy::<IDirectCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IDirectCallBuilderDrop<> of core::traits::Drop::<IDirectCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IDirectCallBuilderSerde<> of core::serde::Serde::<IDirectCallBuilder> {
+    fn serialize(self: @IDirectCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IDirectCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IDirectCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IDirectCallBuilderStore<> of starknet::Store::<IDirectCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IDirectCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IDirectCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IDirectCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IDirectCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IDirectCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IDirectCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IDirectCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IDirectCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IDirectCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersImpl of starknet::storage::SubPointers<IDirectCallBuilder> {
+    type SubPointersType = IDirectCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IDirectCallBuilder>) -> IDirectCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IDirectCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IDirectCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IDirectCallBuilder> {
+    type SubPointersType = IDirectCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IDirectCallBuilder>>) -> IDirectCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IDirectCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:1:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2524,6 +3035,28 @@ impl IForwardedSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IForwa
 impl IForwardedSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IForwardedSafeDispatcherSubPointersMut>;
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersDrop<> of core::traits::Drop::<IForwardedCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersCopy<> of core::traits::Copy::<IForwardedCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IForwardedCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IForwardedCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IForwardedCallBuilderSubPointersMut>;
+
+
 lib.cairo:6:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -2610,6 +3143,28 @@ impls:
 impl IDirectSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IDirectSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IDirectSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IDirectSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersDrop<> of core::traits::Drop::<IDirectCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersCopy<> of core::traits::Copy::<IDirectCallBuilderSubPointers>;
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IDirectCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IDirectCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IDirectCallBuilderSubPointersMut>;
 
 
 lib.cairo:19:1
@@ -2931,6 +3486,45 @@ impl IContractSafeDispatcherImpl of IContractSafeDispatcherTrait<IContractSafeDi
         )
     }
 
+}
+
+#[doc(group: "dispatchers")]
+pub trait IContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_value(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+pub struct IContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderImpl of IContractCallBuilderTrait<IContractCallBuilder> {
+    fn get_value(self: IContractCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_value"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+pub trait IContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IContractDispatcherBuilderImpl of IContractDispatcherBuilderTrait<IContractDispatcher> {
+    fn builder(self: IContractDispatcher) -> IContractCallBuilder {
+        IContractCallBuilder { contract_address: self.contract_address }
+    }
 }
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
@@ -3457,6 +4051,126 @@ lib.cairo:1:1
 ^^^^^^^^^^^^^^^^^^^^^^
 impls:
 
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderCopy<> of core::traits::Copy::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderDrop<> of core::traits::Drop::<IContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl IContractCallBuilderSerde<> of core::serde::Serde::<IContractCallBuilder> {
+    fn serialize(self: @IContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl IContractCallBuilderStore<> of starknet::Store::<IContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IContractCallBuilder>) -> IContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct IContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IContractCallBuilder> {
+    type SubPointersType = IContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IContractCallBuilder>>) -> IContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
 #[doc(hidden)]
 impl IContractDispatcherSubPointersDrop<> of core::traits::Drop::<IContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -3538,5 +4252,27 @@ impls:
 impl IContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IContractSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersDrop<> of core::traits::Drop::<IContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersCopy<> of core::traits::Copy::<IContractCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<IContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<IContractCallBuilderSubPointersMut>;
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/hello_starknet
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/hello_starknet
@@ -371,6 +371,61 @@ impl HelloStarknetTraitSafeDispatcherImpl of HelloStarknetTraitSafeDispatcherTra
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait HelloStarknetTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    // Increases the balance by the given amount.
+    fn increase_balance(self: T, amount: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    // Returns the current balance.
+    fn get_balance(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct HelloStarknetTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderImpl of HelloStarknetTraitCallBuilderTrait<HelloStarknetTraitCallBuilder> {
+    // Increases the balance by the given amount.
+    fn increase_balance(self: HelloStarknetTraitCallBuilder, amount: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    // Returns the current balance.
+    fn get_balance(self: HelloStarknetTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait HelloStarknetTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> HelloStarknetTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitDispatcherBuilderImpl of HelloStarknetTraitDispatcherBuilderTrait<HelloStarknetTraitDispatcher> {
+    fn builder(self: HelloStarknetTraitDispatcher) -> HelloStarknetTraitCallBuilder {
+        HelloStarknetTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -854,6 +909,112 @@ impl HelloStarknetTraitSafeDispatcherSubPointersMutImpl of starknet::storage::Su
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderSerde<> of core::serde::Serde::<HelloStarknetTraitCallBuilder> {
+    fn serialize(self: @HelloStarknetTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<HelloStarknetTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(HelloStarknetTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl HelloStarknetTraitCallBuilderStore<> of starknet::Store::<HelloStarknetTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<HelloStarknetTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            HelloStarknetTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: HelloStarknetTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let HelloStarknetTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<HelloStarknetTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            HelloStarknetTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: HelloStarknetTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let HelloStarknetTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct HelloStarknetTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<HelloStarknetTraitCallBuilder> {
+    type SubPointersType = HelloStarknetTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<HelloStarknetTraitCallBuilder>) -> HelloStarknetTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                HelloStarknetTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct HelloStarknetTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<HelloStarknetTraitCallBuilder> {
+    type SubPointersType = HelloStarknetTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<HelloStarknetTraitCallBuilder>>) -> HelloStarknetTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                HelloStarknetTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl HelloStarknetTraitDispatcherSubPointersDrop<> of core::traits::Drop::<HelloStarknetTraitDispatcherSubPointers>;
 #[doc(hidden)]
@@ -886,6 +1047,14 @@ impl HelloStarknetTraitSafeDispatcherSubPointersCopy<> of core::traits::Copy::<H
 impl HelloStarknetTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<HelloStarknetTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl HelloStarknetTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<HelloStarknetTraitSafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilderSubPointersMut>;
 
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     #[storage]

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/interfaces
@@ -178,6 +178,45 @@ impl Interface1SafeDispatcherImpl of Interface1SafeDispatcherTrait<Interface1Saf
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait Interface1CallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct Interface1CallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl Interface1CallBuilderImpl of Interface1CallBuilderTrait<Interface1CallBuilder> {
+    fn foo(self: Interface1CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait Interface1DispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> Interface1CallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl Interface1DispatcherBuilderImpl of Interface1DispatcherBuilderTrait<Interface1Dispatcher> {
+    fn builder(self: Interface1Dispatcher) -> Interface1CallBuilder {
+        Interface1CallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -321,6 +360,45 @@ impl Interface2SafeDispatcherImpl of Interface2SafeDispatcherTrait<Interface2Saf
         Result::Ok(())
     }
 
+}
+
+#[doc(group: "dispatchers")]
+trait Interface2CallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn foo(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct Interface2CallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl Interface2CallBuilderImpl of Interface2CallBuilderTrait<Interface2CallBuilder> {
+    fn foo(self: Interface2CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("foo"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait Interface2DispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> Interface2CallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl Interface2DispatcherBuilderImpl of Interface2DispatcherBuilderTrait<Interface2Dispatcher> {
+    fn builder(self: Interface2Dispatcher) -> Interface2CallBuilder {
+        Interface2CallBuilder { contract_address: self.contract_address }
+    }
 }
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
@@ -842,6 +920,126 @@ impl Interface1SafeDispatcherSubPointersMutImpl of starknet::storage::SubPointer
 }
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl Interface1CallBuilderCopy<> of core::traits::Copy::<Interface1CallBuilder>;
+#[doc(group: "dispatchers")]
+impl Interface1CallBuilderDrop<> of core::traits::Drop::<Interface1CallBuilder>;
+#[doc(group: "dispatchers")]
+impl Interface1CallBuilderSerde<> of core::serde::Serde::<Interface1CallBuilder> {
+    fn serialize(self: @Interface1CallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<Interface1CallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(Interface1CallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl Interface1CallBuilderStore<> of starknet::Store::<Interface1CallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Interface1CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            Interface1CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Interface1CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let Interface1CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<Interface1CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            Interface1CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: Interface1CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let Interface1CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Interface1CallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersImpl of starknet::storage::SubPointers<Interface1CallBuilder> {
+    type SubPointersType = Interface1CallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<Interface1CallBuilder>) -> Interface1CallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Interface1CallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Interface1CallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<Interface1CallBuilder> {
+    type SubPointersType = Interface1CallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<Interface1CallBuilder>>) -> Interface1CallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Interface1CallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:6:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -1322,6 +1520,126 @@ impl Interface2SafeDispatcherSubPointersMutImpl of starknet::storage::SubPointer
 }
 
 
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl Interface2CallBuilderCopy<> of core::traits::Copy::<Interface2CallBuilder>;
+#[doc(group: "dispatchers")]
+impl Interface2CallBuilderDrop<> of core::traits::Drop::<Interface2CallBuilder>;
+#[doc(group: "dispatchers")]
+impl Interface2CallBuilderSerde<> of core::serde::Serde::<Interface2CallBuilder> {
+    fn serialize(self: @Interface2CallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<Interface2CallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(Interface2CallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl Interface2CallBuilderStore<> of starknet::Store::<Interface2CallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Interface2CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            Interface2CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Interface2CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let Interface2CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<Interface2CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            Interface2CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: Interface2CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let Interface2CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Interface2CallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersImpl of starknet::storage::SubPointers<Interface2CallBuilder> {
+    type SubPointersType = Interface2CallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<Interface2CallBuilder>) -> Interface2CallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Interface2CallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct Interface2CallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<Interface2CallBuilder> {
+    type SubPointersType = Interface2CallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<Interface2CallBuilder>>) -> Interface2CallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                Interface2CallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:1:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -1410,6 +1728,28 @@ impl Interface1SafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<Interf
 impl Interface1SafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<Interface1SafeDispatcherSubPointersMut>;
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersDrop<> of core::traits::Drop::<Interface1CallBuilderSubPointers>;
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersCopy<> of core::traits::Copy::<Interface1CallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersMutDrop<> of core::traits::Drop::<Interface1CallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl Interface1CallBuilderSubPointersMutCopy<> of core::traits::Copy::<Interface1CallBuilderSubPointersMut>;
+
+
 lib.cairo:6:1
 #[starknet::interface]
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -1496,6 +1836,28 @@ impls:
 impl Interface2SafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<Interface2SafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl Interface2SafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<Interface2SafeDispatcherSubPointersMut>;
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersDrop<> of core::traits::Drop::<Interface2CallBuilderSubPointers>;
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersCopy<> of core::traits::Copy::<Interface2CallBuilderSubPointers>;
+
+
+lib.cairo:6:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersMutDrop<> of core::traits::Drop::<Interface2CallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl Interface2CallBuilderSubPointersMutCopy<> of core::traits::Copy::<Interface2CallBuilderSubPointersMut>;
 
 
 lib.cairo:11:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/mintable
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/mintable
@@ -523,6 +523,45 @@ impl GetSupplySafeDispatcherImpl of GetSupplySafeDispatcherTrait<GetSupplySafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait GetSupplyCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_total_supply_plus_1(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct GetSupplyCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderImpl of GetSupplyCallBuilderTrait<GetSupplyCallBuilder> {
+    fn get_total_supply_plus_1(self: GetSupplyCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_total_supply_plus_1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait GetSupplyDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> GetSupplyCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl GetSupplyDispatcherBuilderImpl of GetSupplyDispatcherBuilderTrait<GetSupplyDispatcher> {
+    fn builder(self: GetSupplyDispatcher) -> GetSupplyCallBuilder {
+        GetSupplyCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -985,6 +1024,112 @@ impl GetSupplySafeDispatcherSubPointersMutImpl of starknet::storage::SubPointers
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderCopy<> of core::traits::Copy::<GetSupplyCallBuilder>;
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderDrop<> of core::traits::Drop::<GetSupplyCallBuilder>;
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderSerde<> of core::serde::Serde::<GetSupplyCallBuilder> {
+    fn serialize(self: @GetSupplyCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<GetSupplyCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(GetSupplyCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl GetSupplyCallBuilderStore<> of starknet::Store::<GetSupplyCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<GetSupplyCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            GetSupplyCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: GetSupplyCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let GetSupplyCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<GetSupplyCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            GetSupplyCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: GetSupplyCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let GetSupplyCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct GetSupplyCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersImpl of starknet::storage::SubPointers<GetSupplyCallBuilder> {
+    type SubPointersType = GetSupplyCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<GetSupplyCallBuilder>) -> GetSupplyCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                GetSupplyCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct GetSupplyCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<GetSupplyCallBuilder> {
+    type SubPointersType = GetSupplyCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<GetSupplyCallBuilder>>) -> GetSupplyCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                GetSupplyCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl GetSupplyDispatcherSubPointersDrop<> of core::traits::Drop::<GetSupplyDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1017,6 +1162,14 @@ impl GetSupplySafeDispatcherSubPointersCopy<> of core::traits::Copy::<GetSupplyS
 impl GetSupplySafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<GetSupplySafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl GetSupplySafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<GetSupplySafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersDrop<> of core::traits::Drop::<GetSupplyCallBuilderSubPointers>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersCopy<> of core::traits::Copy::<GetSupplyCallBuilderSubPointers>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutDrop<> of core::traits::Drop::<GetSupplyCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutCopy<> of core::traits::Copy::<GetSupplyCallBuilderSubPointersMut>;
 
     use starknet::ContractAddress;
     use crate::components::erc20::erc20 as erc20_comp;

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/multi_component
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/multi_component
@@ -580,6 +580,45 @@ impl GetSupplySafeDispatcherImpl of GetSupplySafeDispatcherTrait<GetSupplySafeDi
     }
 
 }
+
+#[doc(group: "dispatchers")]
+pub trait GetSupplyCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_total_supply_plus_1(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+pub struct GetSupplyCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderImpl of GetSupplyCallBuilderTrait<GetSupplyCallBuilder> {
+    fn get_total_supply_plus_1(self: GetSupplyCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_total_supply_plus_1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+pub trait GetSupplyDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> GetSupplyCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl GetSupplyDispatcherBuilderImpl of GetSupplyDispatcherBuilderTrait<GetSupplyDispatcher> {
+    fn builder(self: GetSupplyDispatcher) -> GetSupplyCallBuilder {
+        GetSupplyCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -1042,6 +1081,112 @@ impl GetSupplySafeDispatcherSubPointersMutImpl of starknet::storage::SubPointers
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderCopy<> of core::traits::Copy::<GetSupplyCallBuilder>;
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderDrop<> of core::traits::Drop::<GetSupplyCallBuilder>;
+#[doc(group: "dispatchers")]
+impl GetSupplyCallBuilderSerde<> of core::serde::Serde::<GetSupplyCallBuilder> {
+    fn serialize(self: @GetSupplyCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<GetSupplyCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(GetSupplyCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl GetSupplyCallBuilderStore<> of starknet::Store::<GetSupplyCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<GetSupplyCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            GetSupplyCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: GetSupplyCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let GetSupplyCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<GetSupplyCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            GetSupplyCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: GetSupplyCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let GetSupplyCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct GetSupplyCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersImpl of starknet::storage::SubPointers<GetSupplyCallBuilder> {
+    type SubPointersType = GetSupplyCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<GetSupplyCallBuilder>) -> GetSupplyCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                GetSupplyCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct GetSupplyCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<GetSupplyCallBuilder> {
+    type SubPointersType = GetSupplyCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<GetSupplyCallBuilder>>) -> GetSupplyCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                GetSupplyCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl GetSupplyDispatcherSubPointersDrop<> of core::traits::Drop::<GetSupplyDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1074,6 +1219,14 @@ impl GetSupplySafeDispatcherSubPointersCopy<> of core::traits::Copy::<GetSupplyS
 impl GetSupplySafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<GetSupplySafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl GetSupplySafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<GetSupplySafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersDrop<> of core::traits::Drop::<GetSupplyCallBuilderSubPointers>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersCopy<> of core::traits::Copy::<GetSupplyCallBuilderSubPointers>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutDrop<> of core::traits::Drop::<GetSupplyCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl GetSupplyCallBuilderSubPointersMutCopy<> of core::traits::Copy::<GetSupplyCallBuilderSubPointersMut>;
 
     use starknet::ContractAddress;
     use crate::components::erc20::erc20 as erc20_comp;

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
@@ -1386,6 +1386,235 @@ self: HelloStarknetTraitSafeDispatcher, user_id: usize, subbalance_id: usize,
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait HelloStarknetTraitCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    // Increases the balance by the given amount.
+    fn increase_balance(self: T, amount: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    // Returns the current balance.
+    fn get_balance(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+
+    fn get_user_balance(self: T, user_id: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_user_balance(self: T, user_id: usize, balance: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_legacy_user_balance(self: T, user_id: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_legacy_user_balance(self: T, user_id: usize, balance: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+
+    fn get_user_balance_subbalance(
+self: T, user_id: usize, subbalance_id: usize,
+    ) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_balance_pair_balance1(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_balance_pair_balance2(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_balance_pair_balance1(self: T, value: u256) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_balance_trio_sub_member(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn set_balance_trio_sub_member(self: T, value: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_third_list_value(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_arr_at(self: T, index: u64) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn append_to_arr(self: T, value: usize) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_queryable_enum(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct HelloStarknetTraitCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderImpl of HelloStarknetTraitCallBuilderTrait<HelloStarknetTraitCallBuilder> {
+    // Increases the balance by the given amount.
+    fn increase_balance(self: HelloStarknetTraitCallBuilder, amount: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    // Returns the current balance.
+    fn get_balance(self: HelloStarknetTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+    fn get_user_balance(self: HelloStarknetTraitCallBuilder, user_id: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_user_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_user_balance(self: HelloStarknetTraitCallBuilder, user_id: usize, balance: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+        core::serde::Serde::<usize>::serialize(@balance, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_user_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_legacy_user_balance(self: HelloStarknetTraitCallBuilder, user_id: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_legacy_user_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_legacy_user_balance(self: HelloStarknetTraitCallBuilder, user_id: usize, balance: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+        core::serde::Serde::<usize>::serialize(@balance, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_legacy_user_balance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+    fn get_user_balance_subbalance(
+self: HelloStarknetTraitCallBuilder, user_id: usize, subbalance_id: usize,
+    ) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@user_id, ref __calldata__);
+        core::serde::Serde::<usize>::serialize(@subbalance_id, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_user_balance_subbalance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_balance_pair_balance1(self: HelloStarknetTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance_pair_balance1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_balance_pair_balance2(self: HelloStarknetTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance_pair_balance2"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_balance_pair_balance1(self: HelloStarknetTraitCallBuilder, value: u256) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u256>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_balance_pair_balance1"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_balance_trio_sub_member(self: HelloStarknetTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_balance_trio_sub_member"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn set_balance_trio_sub_member(self: HelloStarknetTraitCallBuilder, value: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("set_balance_trio_sub_member"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_third_list_value(self: HelloStarknetTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_third_list_value"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_arr_at(self: HelloStarknetTraitCallBuilder, index: u64) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u64>::serialize(@index, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_arr_at"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn append_to_arr(self: HelloStarknetTraitCallBuilder, value: usize) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<usize>::serialize(@value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("append_to_arr"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_queryable_enum(self: HelloStarknetTraitCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_queryable_enum"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait HelloStarknetTraitDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> HelloStarknetTraitCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitDispatcherBuilderImpl of HelloStarknetTraitDispatcherBuilderTrait<HelloStarknetTraitDispatcher> {
+    fn builder(self: HelloStarknetTraitDispatcher) -> HelloStarknetTraitCallBuilder {
+        HelloStarknetTraitCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -3174,6 +3403,126 @@ impl HelloStarknetTraitSafeDispatcherSubPointersMutImpl of starknet::storage::Su
 }
 
 
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilder>;
+#[doc(group: "dispatchers")]
+impl HelloStarknetTraitCallBuilderSerde<> of core::serde::Serde::<HelloStarknetTraitCallBuilder> {
+    fn serialize(self: @HelloStarknetTraitCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<HelloStarknetTraitCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(HelloStarknetTraitCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+starknet_derive:
+
+impl HelloStarknetTraitCallBuilderStore<> of starknet::Store::<HelloStarknetTraitCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<HelloStarknetTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            HelloStarknetTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: HelloStarknetTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let HelloStarknetTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<HelloStarknetTraitCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            HelloStarknetTraitCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: HelloStarknetTraitCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let HelloStarknetTraitCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct HelloStarknetTraitCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersImpl of starknet::storage::SubPointers<HelloStarknetTraitCallBuilder> {
+    type SubPointersType = HelloStarknetTraitCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<HelloStarknetTraitCallBuilder>) -> HelloStarknetTraitCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                HelloStarknetTraitCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct HelloStarknetTraitCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<HelloStarknetTraitCallBuilder> {
+    type SubPointersType = HelloStarknetTraitCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<HelloStarknetTraitCallBuilder>>) -> HelloStarknetTraitCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                HelloStarknetTraitCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+
+
 lib.cairo:27:1
 #[starknet::storage_node]
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -3506,6 +3855,28 @@ impls:
 impl HelloStarknetTraitSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<HelloStarknetTraitSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl HelloStarknetTraitSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<HelloStarknetTraitSafeDispatcherSubPointersMut>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilderSubPointers>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilderSubPointers>;
+
+
+lib.cairo:1:1
+#[starknet::interface]
+^^^^^^^^^^^^^^^^^^^^^^
+impls:
+
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutDrop<> of core::traits::Drop::<HelloStarknetTraitCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl HelloStarknetTraitCallBuilderSubPointersMutCopy<> of core::traits::Copy::<HelloStarknetTraitCallBuilderSubPointersMut>;
 
 
 lib.cairo:78:1

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/proxy
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/proxy
@@ -401,6 +401,69 @@ impl ICounterContractSafeDispatcherImpl of ICounterContractSafeDispatcherTrait<I
     }
 
 }
+
+#[doc(group: "dispatchers")]
+pub trait ICounterContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn increase_counter(self: T, amount: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn decrease_counter(self: T, amount: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_counter(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+pub struct ICounterContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderImpl of ICounterContractCallBuilderTrait<ICounterContractCallBuilder> {
+    fn increase_counter(self: ICounterContractCallBuilder, amount: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn decrease_counter(self: ICounterContractCallBuilder, amount: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("decrease_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_counter(self: ICounterContractCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+pub trait ICounterContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> ICounterContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl ICounterContractDispatcherBuilderImpl of ICounterContractDispatcherBuilderTrait<ICounterContractDispatcher> {
+    fn builder(self: ICounterContractDispatcher) -> ICounterContractCallBuilder {
+        ICounterContractCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -901,6 +964,112 @@ impl ICounterContractSafeDispatcherSubPointersMutImpl of starknet::storage::SubP
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderCopy<> of core::traits::Copy::<ICounterContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderDrop<> of core::traits::Drop::<ICounterContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderSerde<> of core::serde::Serde::<ICounterContractCallBuilder> {
+    fn serialize(self: @ICounterContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ICounterContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ICounterContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl ICounterContractCallBuilderStore<> of starknet::Store::<ICounterContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ICounterContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ICounterContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ICounterContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ICounterContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ICounterContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ICounterContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ICounterContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ICounterContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ICounterContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<ICounterContractCallBuilder> {
+    type SubPointersType = ICounterContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ICounterContractCallBuilder>) -> ICounterContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ICounterContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+pub struct ICounterContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ICounterContractCallBuilder> {
+    type SubPointersType = ICounterContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ICounterContractCallBuilder>>) -> ICounterContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ICounterContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl ICounterContractDispatcherSubPointersDrop<> of core::traits::Drop::<ICounterContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -933,6 +1102,14 @@ impl ICounterContractSafeDispatcherSubPointersCopy<> of core::traits::Copy::<ICo
 impl ICounterContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ICounterContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ICounterContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ICounterContractSafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersDrop<> of core::traits::Drop::<ICounterContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersCopy<> of core::traits::Copy::<ICounterContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ICounterContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ICounterContractCallBuilderSubPointersMut>;
 
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage_accesses
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/storage_accesses
@@ -1235,6 +1235,156 @@ self: IERC20SafeDispatcher, spender: ContractAddress, subtracted_value: u256,
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait IERC20CallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn get_name(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_symbol(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_decimals(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_total_supply(self: T) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn balance_of(self: T, account: ContractAddress) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn allowance(self: T, owner: ContractAddress, spender: ContractAddress) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn increase_allowance(self: T, spender: ContractAddress, added_value: u256) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn decrease_allowance(
+self: T, spender: ContractAddress, subtracted_value: u256,
+    ) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn write_info(self: T, user_info: UserInfo) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_info(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct IERC20CallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl IERC20CallBuilderImpl of IERC20CallBuilderTrait<IERC20CallBuilder> {
+    fn get_name(self: IERC20CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_name"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_symbol(self: IERC20CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_symbol"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_decimals(self: IERC20CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_decimals"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_total_supply(self: IERC20CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_total_supply"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn balance_of(self: IERC20CallBuilder, account: ContractAddress) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@account, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("balance_of"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn allowance(self: IERC20CallBuilder, owner: ContractAddress, spender: ContractAddress) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@owner, ref __calldata__);
+        core::serde::Serde::<ContractAddress>::serialize(@spender, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("allowance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn increase_allowance(self: IERC20CallBuilder, spender: ContractAddress, added_value: u256) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@spender, ref __calldata__);
+        core::serde::Serde::<u256>::serialize(@added_value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_allowance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn decrease_allowance(
+self: IERC20CallBuilder, spender: ContractAddress, subtracted_value: u256,
+    ) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<ContractAddress>::serialize(@spender, ref __calldata__);
+        core::serde::Serde::<u256>::serialize(@subtracted_value, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("decrease_allowance"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn write_info(self: IERC20CallBuilder, user_info: UserInfo) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<UserInfo>::serialize(@user_info, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("write_info"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_info(self: IERC20CallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_info"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait IERC20DispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> IERC20CallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl IERC20DispatcherBuilderImpl of IERC20DispatcherBuilderTrait<IERC20Dispatcher> {
+    fn builder(self: IERC20Dispatcher) -> IERC20CallBuilder {
+        IERC20CallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -2153,6 +2303,112 @@ impl IERC20SafeDispatcherSubPointersMutImpl of starknet::storage::SubPointersMut
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl IERC20CallBuilderCopy<> of core::traits::Copy::<IERC20CallBuilder>;
+#[doc(group: "dispatchers")]
+impl IERC20CallBuilderDrop<> of core::traits::Drop::<IERC20CallBuilder>;
+#[doc(group: "dispatchers")]
+impl IERC20CallBuilderSerde<> of core::serde::Serde::<IERC20CallBuilder> {
+    fn serialize(self: @IERC20CallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<IERC20CallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(IERC20CallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl IERC20CallBuilderStore<> of starknet::Store::<IERC20CallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<IERC20CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            IERC20CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: IERC20CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let IERC20CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<IERC20CallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            IERC20CallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: IERC20CallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let IERC20CallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct IERC20CallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersImpl of starknet::storage::SubPointers<IERC20CallBuilder> {
+    type SubPointersType = IERC20CallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<IERC20CallBuilder>) -> IERC20CallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IERC20CallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct IERC20CallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<IERC20CallBuilder> {
+    type SubPointersType = IERC20CallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<IERC20CallBuilder>>) -> IERC20CallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                IERC20CallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl UserInfoSubPointersDrop<> of core::traits::Drop::<UserInfoSubPointers>;
 #[doc(hidden)]
@@ -2209,6 +2465,14 @@ impl IERC20SafeDispatcherSubPointersCopy<> of core::traits::Copy::<IERC20SafeDis
 impl IERC20SafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<IERC20SafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl IERC20SafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<IERC20SafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersDrop<> of core::traits::Drop::<IERC20CallBuilderSubPointers>;
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersCopy<> of core::traits::Copy::<IERC20CallBuilderSubPointers>;
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersMutDrop<> of core::traits::Drop::<IERC20CallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl IERC20CallBuilderSubPointersMutCopy<> of core::traits::Copy::<IERC20CallBuilderSubPointersMut>;
 
     use core::num::traits::Zero;
     use starknet::storage::{

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/upgradable_counter
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/upgradable_counter
@@ -642,6 +642,69 @@ impl ICounterContractSafeDispatcherImpl of ICounterContractSafeDispatcherTrait<I
     }
 
 }
+
+#[doc(group: "dispatchers")]
+trait ICounterContractCallBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn increase_counter(self: T, amount: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn decrease_counter(self: T, amount: u128) -> starknet::account::Call;
+    #[unstable(feature: "call_builder")]
+    fn get_counter(self: T) -> starknet::account::Call;
+}
+
+#[doc(group: "dispatchers")]
+#[derive(Copy, Drop, starknet::Store, Serde)]
+struct ICounterContractCallBuilder {
+    pub contract_address: starknet::ContractAddress,
+}
+
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderImpl of ICounterContractCallBuilderTrait<ICounterContractCallBuilder> {
+    fn increase_counter(self: ICounterContractCallBuilder, amount: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("increase_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn decrease_counter(self: ICounterContractCallBuilder, amount: u128) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+        core::serde::Serde::<u128>::serialize(@amount, ref __calldata__);
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("decrease_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+    fn get_counter(self: ICounterContractCallBuilder) -> starknet::account::Call {
+        let mut __calldata__ = core::traits::Default::default();
+
+        starknet::account::Call {
+            to: self.contract_address,
+            selector: selector!("get_counter"),
+            calldata: core::array::ArrayTrait::span(@__calldata__),
+        }
+    }
+
+}
+
+#[doc(group: "dispatchers")]
+trait ICounterContractDispatcherBuilderTrait<T> {
+    #[unstable(feature: "call_builder")]
+    fn builder(self: T) -> ICounterContractCallBuilder;
+}
+
+#[doc(group: "dispatchers")]
+impl ICounterContractDispatcherBuilderImpl of ICounterContractDispatcherBuilderTrait<ICounterContractDispatcher> {
+    fn builder(self: ICounterContractDispatcher) -> ICounterContractCallBuilder {
+        ICounterContractCallBuilder { contract_address: self.contract_address }
+    }
+}
 #[feature("forward-impl")]
 #[unstable(feature: "forward-impl")]
 #[starknet::forward_impl]
@@ -1142,6 +1205,112 @@ impl ICounterContractSafeDispatcherSubPointersMutImpl of starknet::storage::SubP
         }
     }
 }
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderCopy<> of core::traits::Copy::<ICounterContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderDrop<> of core::traits::Drop::<ICounterContractCallBuilder>;
+#[doc(group: "dispatchers")]
+impl ICounterContractCallBuilderSerde<> of core::serde::Serde::<ICounterContractCallBuilder> {
+    fn serialize(self: @ICounterContractCallBuilder, ref output: core::array::Array<felt252>) {
+        core::serde::Serde::<starknet::ContractAddress>::serialize(self.contract_address, ref output)
+    }
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<ICounterContractCallBuilder> {
+        let __serde_member_contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: core::serde::Serde::<starknet::ContractAddress>::deserialize(ref serialized)? };
+        core::option::Option::Some(ICounterContractCallBuilder {
+            contract_address: __serde_member_contract_address.value,
+        })
+    }
+}
+impl ICounterContractCallBuilderStore<> of starknet::Store::<ICounterContractCallBuilder> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<ICounterContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read(__store_derive_address_domain__, __store_derive_base__)? };
+        starknet::SyscallResult::Ok(
+            ICounterContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    fn write(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: ICounterContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let ICounterContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write(__store_derive_address_domain__, __store_derive_base__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    fn read_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8) -> starknet::SyscallResult<ICounterContractCallBuilder> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: starknet::Store::<starknet::ContractAddress>::read_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__)? };
+        starknet::SyscallResult::Ok(
+            ICounterContractCallBuilder {
+                contract_address: contract_address.value,
+            }
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(address_domain: u32, base: starknet::storage_access::StorageBaseAddress, offset: u8, value: ICounterContractCallBuilder) -> starknet::SyscallResult<()> {
+        let __store_derive_address_domain__ = address_domain;
+        let __store_derive_base__ = base;
+        let __store_derive_offset__ = offset;
+        let ICounterContractCallBuilder {
+            contract_address,
+        } = value;
+        let contract_address = core::internal::InferDestruct::<starknet::ContractAddress> { value: contract_address };
+        starknet::Store::<starknet::ContractAddress>::write_at_offset(__store_derive_address_domain__, __store_derive_base__, __store_derive_offset__, contract_address.value)?;
+        starknet::SyscallResult::Ok(())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        starknet::Store::<starknet::ContractAddress>::size()
+    }
+}
+
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct ICounterContractCallBuilderSubPointers {
+    pub contract_address: starknet::storage::StoragePointer<starknet::ContractAddress>,
+}
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersImpl of starknet::storage::SubPointers<ICounterContractCallBuilder> {
+    type SubPointersType = ICounterContractCallBuilderSubPointers;
+    fn sub_pointers(self: starknet::storage::StoragePointer<ICounterContractCallBuilder>) -> ICounterContractCallBuilderSubPointers {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ICounterContractCallBuilderSubPointers {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
+#[derive(Drop, Copy)]
+#[doc(hidden)]
+struct ICounterContractCallBuilderSubPointersMut {
+    pub contract_address: starknet::storage::StoragePointer<starknet::storage::Mutable::<starknet::ContractAddress>>,
+}
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutImpl of starknet::storage::SubPointersMut<ICounterContractCallBuilder> {
+    type SubPointersType = ICounterContractCallBuilderSubPointersMut;
+    fn sub_pointers_mut(self: starknet::storage::StoragePointer<starknet::storage::Mutable::<ICounterContractCallBuilder>>) -> ICounterContractCallBuilderSubPointersMut {
+        let base_address = self.__storage_pointer_address__;
+        let mut current_offset = self.__storage_pointer_offset__;
+        let __contract_address_value__ = starknet::storage::StoragePointer {
+            __storage_pointer_address__: base_address,
+            __storage_pointer_offset__: current_offset,
+        };
+                ICounterContractCallBuilderSubPointersMut {
+           contract_address: __contract_address_value__,
+        }
+    }
+}
 #[doc(hidden)]
 impl ICounterContractDispatcherSubPointersDrop<> of core::traits::Drop::<ICounterContractDispatcherSubPointers>;
 #[doc(hidden)]
@@ -1174,6 +1343,14 @@ impl ICounterContractSafeDispatcherSubPointersCopy<> of core::traits::Copy::<ICo
 impl ICounterContractSafeDispatcherSubPointersMutDrop<> of core::traits::Drop::<ICounterContractSafeDispatcherSubPointersMut>;
 #[doc(hidden)]
 impl ICounterContractSafeDispatcherSubPointersMutCopy<> of core::traits::Copy::<ICounterContractSafeDispatcherSubPointersMut>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersDrop<> of core::traits::Drop::<ICounterContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersCopy<> of core::traits::Copy::<ICounterContractCallBuilderSubPointers>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutDrop<> of core::traits::Drop::<ICounterContractCallBuilderSubPointersMut>;
+#[doc(hidden)]
+impl ICounterContractCallBuilderSubPointersMutCopy<> of core::traits::Copy::<ICounterContractCallBuilderSubPointersMut>;
 
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use crate::components::ownable::ownable as ownable_comp;


### PR DESCRIPTION
> ⚠️ **Stacked on #10165** (prep refactor). Review/merge that first; this PR's diff is against that branch.

## What

Generates a **`CallBuilder`** for every `#[starknet::interface]` trait, alongside the existing Dispatcher family, plus a **`.builder()`** accessor on the contract dispatcher. Its methods serialize their arguments and return a `starknet::account::Call` targeting the contract address — no syscall, no return deserialization.

```cairo
#[feature("call_builder")]
fn build(token: ContractAddress, to: ContractAddress, amount: u256) -> Call {
    // from a dispatcher you already hold:
    IERC20Dispatcher { contract_address: token }.builder().transfer(to, amount)
    // ...or standalone:
    // IERC20CallBuilder { contract_address: token }.transfer(to, amount)
}
```

## Why

Building a `Call` for an interface method today means manually replicating what the dispatcher already generates — the selector and the argument serialization (e.g. splitting `u256` into `low`/`high` by hand). The builder reuses the dispatcher's own serialization and `selector!` generation via the shared `dispatcher_signature` (extended from a `bool` to a `ReturnStyle::{Raw, SyscallResult, Call}` enum).

## Generated code

```cairo
#[derive(Copy, Drop, starknet::Store, Serde)]
struct IFooCallBuilder { pub contract_address: starknet::ContractAddress }

impl IFooCallBuilderImpl of IFooCallBuilderTrait<IFooCallBuilder> {
    fn transfer(self: IFooCallBuilder, to: ContractAddress, amount: u256) -> starknet::account::Call {
        let mut __calldata__ = Default::default();
        Serde::serialize(@to, ref __calldata__);
        Serde::serialize(@amount, ref __calldata__);
        starknet::account::Call { to: self.contract_address, selector: selector!("transfer"), calldata: __calldata__.span() }
    }
}
// + accessor on the dispatcher:
impl IFooDispatcherBuilderImpl of IFooDispatcherBuilderTrait<IFooDispatcher> {
    fn builder(self: IFooDispatcher) -> IFooCallBuilder { IFooCallBuilder { contract_address: self.contract_address } }
}
```

## Design notes

- Gated behind `#[unstable(feature: "call_builder")]` (mirrors `safe_dispatcher`).
- Contract-address only — `Call` has no class-hash field, so there is no Library/Safe variant; the accessor lives on the contract dispatcher only (not the shared `DispatcherTrait`, which the library dispatcher also implements).
- Collision surface is minimal: builder method names are identical to the interface (no suffixes); the only invented method name is `builder`.

## Does NOT affect the ABI

The ABI is generated from the interface trait, not the dispatcher structs — purely additive Cairo codegen. Unused builders are dead-code-eliminated and never reach Sierra.

## Verification

- `cargo test -p cairo-lang-starknet` → **57 passed** without fix mode (the `expand_contract::*` tests run full diagnostics with `expect_diagnostics: false`, so the generated code type-checks against corelib).
- All 14 expansion fixtures regenerated via `CAIRO_FIX_TESTS=1`; clippy clean.

## TODO before un-drafting

- [ ] Runtime `cairo_level_test` asserting `call.to` / `call.selector` / `call.calldata`.
- [ ] corelib doc example + feature note for `call_builder`.
- [ ] Decide stable vs. `#[unstable]` for the initial release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
