### PR TITLE
docs: update adoc for tuple index access and glob use restriction

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/item-statement.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/item-statement.adoc
@@ -58,7 +58,8 @@ documentation.
   and may be used where a compile-time constant is required.
 - `use` item statements make the imported names available only within the
   block where they are declared (and any nested blocks), without affecting
-  the surrounding module.
+  the surrounding module. Glob imports (`use path::*`) are not supported in
+  statement position and will produce a compiler error.
 - `type` alias item statements introduce a local alias for a type; the alias
   is not visible outside the enclosing block.
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/member-access-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/member-access-expressions.adoc
@@ -37,15 +37,24 @@ struct Point {
     y: felt252,
 }
 
+struct Line {
+    start: Point,
+    end: Point,
+}
+
 fn example() -> felt252 {
     let p = Point { x: 10, y: 20 };
     let sum = p.x + p.y;
+
+    // Nested struct member access
+    let line = Line { start: Point { x: 0, y: 0 }, end: Point { x: 10, y: 10 } };
+    let end_x: felt252 = line.end.x;
 
     let t: (felt252, u8) = (1, 2_u8);
     let first: felt252 = t.0;
     let second: u8 = t.1;
 
-    sum
+    sum + end_x
 }
 ----
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/member-access-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/member-access-expressions.adoc
@@ -46,15 +46,17 @@ fn example() -> felt252 {
     let p = Point { x: 10, y: 20 };
     let sum = p.x + p.y;
 
-    // Nested struct member access
-    let line = Line { start: Point { x: 0, y: 0 }, end: Point { x: 10, y: 10 } };
+    let line = Line {
+        start: Point { x: 0, y: 0 },
+        end: Point { x: 10, y: 10 },
+    };
     let end_x: felt252 = line.end.x;
 
     let t: (felt252, u8) = (1, 2_u8);
     let first: felt252 = t.0;
     let second: u8 = t.1;
 
-    sum + end_x
+    sum
 }
 ----
 

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/member-access-expressions.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/member-access-expressions.adoc
@@ -1,31 +1,34 @@
 = Member access expressions
 
-A member access expression is an expression that accesses a member (field) of a xref:structs.adoc[struct].
-Additionally, if a type implements the `Deref` trait, member access expressions can access members of the `Deref::Target` type.
+A member access expression accesses a field of a xref:structs.adoc[struct] or an element of a
+xref:tuple-types.adoc[tuple].
+Additionally, if a type implements the `Deref` trait, member access expressions can access members
+of the `Deref::Target` type.
 
 == Syntax
 
-The syntax for member access expressions is:
+For structs, `member_name` is a field name:
 
 [source,cairo]
 ----
 expression.member_name
 ----
 
-where `member_name` is an identifier corresponding to a field name in the struct type.
+For tuples, the index is a plain decimal integer literal (no type suffix, no leading zeros,
+no hex prefix):
+
+[source,cairo]
+----
+expression.0
+expression.1
+----
 
 == Semantics
 
-A member access expression is evaluated by:
-
-1. First evaluating the primary expression (left side of the dot)
-2. Then accessing the specified member from the resulting value
-
-The type of the member access expression is the type of the accessed member.
+The expression on the left is evaluated first, then the specified member or element is accessed.
+The type of the result is the type of the accessed field or tuple element.
 
 == Examples
-
-Valid examples:
 
 [source,cairo]
 ----
@@ -34,42 +37,29 @@ struct Point {
     y: felt252,
 }
 
-struct Line {
-    start: Point,
-    end: Point,
-}
-
 fn example() -> felt252 {
     let p = Point { x: 10, y: 20 };
+    let sum = p.x + p.y;
 
-    // Basic member access
-    let x_val: felt252 = p.x;
-
-    // Member access in expressions
-    let sum: felt252 = p.x + p.y;
-
-    // Nested struct member access
-    let line = Line {
-        start: Point { x: 0, y: 0 },
-        end: Point { x: 10, y: 10 }
-    };
-    let end_x: felt252 = line.end.x;
+    let t: (felt252, u8) = (1, 2_u8);
+    let first: felt252 = t.0;
+    let second: u8 = t.1;
 
     sum
 }
 ----
 
-Invalid examples (illustrative):
+Assignment to a mutable tuple element is also supported:
 
-- Accessing non-existent member: `p.z` when `Point` only has `x` and `y`
-- Missing dot operator: `px` instead of `p.x`
-- Accessing member on non-struct type: `5.field`
-
-NOTE: Tuples in Cairo currently do not support member access syntax. To access tuple
-elements, use pattern matching with `let` destructuring: `let (first, second, third) = tuple;`
+[source,cairo]
+----
+fn mutate(mut t: (felt252, u8)) {
+    t.0 = 5;
+}
+----
 
 == Related
 
 - xref:structs.adoc[Structs]
-- xref:tuple-types.adoc[Tuple types] (note: tuples use destructuring, not member access)
+- xref:tuple-types.adoc[Tuple types]
 - xref:method-calls.adoc[Method calls]

--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/tuple-types.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/tuple-types.adoc
@@ -17,4 +17,6 @@ Examples:
 ---
 
 Values of this type are constructed using xref:tuple-expressions.adoc[tuple expressions].
-Tuples can be deconstructed using xref:patterns.adoc[patterns].
+Tuple elements can be accessed by index using xref:member-access-expressions.adoc[member access]
+syntax (e.g. `t.0`, `t.1`).
+Tuples can also be deconstructed using xref:patterns.adoc[patterns].


### PR DESCRIPTION
Update docs to reflect two changes landed this week:

**Tuple element access via `t.0` syntax** (feat #10111, #10153):
- `member-access-expressions.adoc`: document numeric index access for tuples (`t.0`, `t.1`), including the restriction that only plain decimal integers are accepted (no type suffix, no hex, no leading zeros). Remove the stale NOTE claiming tuples don't support member access.
- `tuple-types.adoc`: mention element-by-index access alongside pattern destructuring.

**Glob use rejected in statement position** (bugfix #10148):
- `item-statement.adoc`: note that `use path::*` is not supported in statement position and produces a compiler error.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133f5aSdHrhx2GHNLGKDc2X)_