### PR TITLE
refactor(semantic): Apply full type-based diagnostics to all signature parts.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -95,7 +95,7 @@ use crate::resolve::{
 use crate::semantic::{self, Binding, FunctionId, LocalVariable, TypeId, TypeLongId};
 use crate::substitution::{HasDb, SemanticRewriter};
 use crate::types::{
-    ClosureTypeLongId, ConcreteTypeId, add_type_based_diagnostics, are_coupons_enabled,
+    ClosureTypeLongId, ConcreteTypeId, add_value_type_based_diagnostics, are_coupons_enabled,
     extract_fixed_size_array_size, peel_snapshots, peel_snapshots_ex, resolve_type_ex,
     verify_fixed_size_array_size, wrap_in_snapshots,
 };
@@ -447,6 +447,13 @@ impl<'ctx, 'mt> ComputationContext<'ctx, 'mt> {
     /// Applies inference rewriter to all the rewritable things in the computation context.
     pub fn apply_inference_rewriter(&mut self) {
         let mut analyzed_types = UnorderedHashSet::<_>::default();
+        if let ContextFunction::Function(Ok(function_id)) = self.function_id
+            && let Ok(sig) = self.db.concrete_function_signature(function_id)
+        {
+            analyzed_types.extend(sig.params.iter().map(|p| p.ty));
+            analyzed_types.extend(sig.implicits.iter().copied());
+            analyzed_types.insert(sig.return_type);
+        }
         let inference = &mut self.resolver.inference();
         for (_id, expr) in &mut self.arenas.exprs {
             if let Expr::Literal(literal) = expr {
@@ -456,10 +463,7 @@ impl<'ctx, 'mt> ComputationContext<'ctx, 'mt> {
             }
             // Adding an error only once per type.
             if analyzed_types.insert(expr.ty()) {
-                add_type_based_diagnostics(self.db, self.diagnostics, expr.ty(), &*expr);
-                if expr.ty().is_phantom(self.db) {
-                    self.diagnostics.report(&*expr, InstancesOfPhantomTypes);
-                }
+                add_value_type_based_diagnostics(self.db, self.diagnostics, expr.ty(), &*expr);
             }
         }
         for (_id, pattern) in &mut self.arenas.patterns {
@@ -1605,9 +1609,6 @@ fn compute_expr_function_call_semantic<'db>(
         ResolvedConcreteItem::Variant(variant) => {
             let concrete_enum_type =
                 TypeLongId::Concrete(ConcreteTypeId::Enum(variant.concrete_enum_id)).intern(db);
-            if concrete_enum_type.is_phantom(db) {
-                ctx.diagnostics.report(syntax.stable_ptr(db), InstancesOfPhantomTypes);
-            }
 
             let named_args: Vec<_> = args_syntax
                 .elements(db)
@@ -2462,12 +2463,11 @@ fn compute_expr_closure_semantic<'db>(
             );
         }
         for param in &params {
+            let stable_ptr = param.stable_ptr(ctx.db);
             if param.mutability == Mutability::Reference {
-                new_ctx.diagnostics.report(param.stable_ptr(ctx.db), RefClosureParam);
+                new_ctx.diagnostics.report(stable_ptr, RefClosureParam);
             }
-            if param.ty.is_phantom(ctx.db) {
-                new_ctx.diagnostics.report(param.stable_ptr(ctx.db), InstancesOfPhantomTypes);
-            }
+            add_value_type_based_diagnostics(ctx.db, new_ctx.diagnostics, param.ty, stable_ptr);
         }
 
         new_ctx.variable_tracker.extend_from_environment(&new_ctx.environment);
@@ -2484,10 +2484,9 @@ fn compute_expr_closure_semantic<'db>(
                 new_ctx.resolver.inference().new_type_var(Some(missing.stable_ptr(db).untyped()))
             }
         };
-        if let OptionReturnTypeClause::ReturnTypeClause(ty_syntax) = syntax.ret_ty(db)
-            && return_type.is_phantom(ctx.db)
-        {
-            new_ctx.diagnostics.report(ty_syntax.ty(db).stable_ptr(db), InstancesOfPhantomTypes);
+        if let OptionReturnTypeClause::ReturnTypeClause(ty_syntax) = syntax.ret_ty(db) {
+            let stable_ptr = ty_syntax.ty(db).stable_ptr(db);
+            add_value_type_based_diagnostics(ctx.db, new_ctx.diagnostics, return_type, stable_ptr);
         }
 
         let old_inner_ctx = new_ctx
@@ -3569,10 +3568,6 @@ fn struct_ctor_expr<'db>(
     let concrete_struct_id = *try_extract_matches!(ty.long(ctx.db), TypeLongId::Concrete)
         .and_then(|c| try_extract_matches!(c, ConcreteTypeId::Struct))
         .ok_or_else(|| ctx.diagnostics.report(path.stable_ptr(db), NotAStruct))?;
-
-    if ty.is_phantom(db) {
-        ctx.diagnostics.report(ctor_syntax.stable_ptr(db), InstancesOfPhantomTypes);
-    }
 
     let members = db.concrete_struct_members(concrete_struct_id)?;
     let mut member_exprs: OrderedHashMap<MemberId<'_>, Option<ExprId>> = OrderedHashMap::default();

--- a/crates/cairo-lang-semantic/src/expr/test_data/attributes
+++ b/crates/cairo-lang-semantic/src/expr/test_data/attributes
@@ -84,11 +84,6 @@ error[E2019]: Phantom types cannot be instantiated.
 fn foo(x: Option<Ph>) -> Option<Ph> {
                          ^^^^^^^^^^
 
-error[E2019]: Phantom types cannot be instantiated.
- --> lib.cairo:7:5
-    x
-    ^
-
 //! > ==========================================================================
 
 //! > Phantom struct inside a generic container in a function signature.
@@ -121,11 +116,6 @@ error[E2019]: Phantom types cannot be instantiated.
  --> lib.cairo:6:26
 fn foo(x: Option<Ph>) -> Option<Ph> {
                          ^^^^^^^^^^
-
-error[E2019]: Phantom types cannot be instantiated.
- --> lib.cairo:7:5
-    x
-    ^
 
 //! > ==========================================================================
 
@@ -162,11 +152,6 @@ error[E2019]: Phantom types cannot be instantiated.
  --> lib.cairo:9:27
 fn foo(x: Wrapper<Ph>) -> Wrapper<Ph> {
                           ^^^^^^^^^^^
-
-error[E2019]: Phantom types cannot be instantiated.
- --> lib.cairo:10:5
-    x
-    ^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/items/functions.rs
+++ b/crates/cairo-lang-semantic/src/items/functions.rs
@@ -34,7 +34,7 @@ use crate::items::imp::ImplSemantic;
 use crate::items::trt::TraitSemantic;
 use crate::resolve::{Resolver, ResolverData};
 use crate::substitution::GenericSubstitution;
-use crate::types::resolve_type;
+use crate::types::{add_value_type_based_diagnostics, resolve_type};
 use crate::{
     ConcreteImplId, ConcreteImplLongId, ConcreteTraitLongId, GenericArgumentId, GenericParam,
     SemanticDiagnostic, TypeId, semantic, semantic_object_for_id,
@@ -751,21 +751,15 @@ impl<'db> Signature<'db> {
         );
         let return_type =
             function_signature_return_type(diagnostics, db, resolver, &signature_syntax);
-        // Phantom types (and types transitively containing one through a struct member, enum
-        // variant or tuple/array element, e.g. `Option<Ph>`) have no runtime representation and
-        // cannot be used as values, so they may not appear in a function signature.
         for param in &params {
-            if param.ty.is_phantom(db) {
-                diagnostics
-                    .report(param.stable_ptr(db), SemanticDiagnosticKind::InstancesOfPhantomTypes);
-            }
+            add_value_type_based_diagnostics(db, diagnostics, param.ty, param.stable_ptr(db));
         }
-        if let ast::OptionReturnTypeClause::ReturnTypeClause(syntax) = signature_syntax.ret_ty(db)
-            && return_type.is_phantom(db)
-        {
-            diagnostics.report(
+        if let ast::OptionReturnTypeClause::ReturnTypeClause(syntax) = signature_syntax.ret_ty(db) {
+            add_value_type_based_diagnostics(
+                db,
+                diagnostics,
+                return_type,
                 syntax.ty(db).stable_ptr(db),
-                SemanticDiagnosticKind::InstancesOfPhantomTypes,
             );
         }
         let implicits =
@@ -816,11 +810,7 @@ pub fn function_signature_implicit_parameters<'db>(
         .map(|implicit| {
             let stable_ptr = implicit.stable_ptr(db);
             let ty = resolve_type(db, diagnostics, resolver, &ast::Expr::Path(implicit));
-            // An implicit of a phantom type would be a hidden runtime parameter with no
-            // representation, just like an explicit phantom parameter.
-            if ty.is_phantom(db) {
-                diagnostics.report(stable_ptr, SemanticDiagnosticKind::InstancesOfPhantomTypes);
-            }
+            add_value_type_based_diagnostics(db, diagnostics, ty, stable_ptr);
             ty
         })
         .collect()

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -935,7 +935,29 @@ fn single_value_type_tracked<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> May
     single_value_type(db, ty)
 }
 
-/// Adds diagnostics for a type, post semantic analysis of types.
+/// Adds diagnostics for a type used as a value - in a parameter, return type, or expression.
+///
+/// Like [add_type_based_diagnostics], but additionally rejects a phantom type: a phantom type has
+/// no runtime representation and so cannot be used as a value. Type definitions (e.g. struct
+/// members and enum variants) allow phantom types and so use [add_type_based_diagnostics] directly.
+pub fn add_value_type_based_diagnostics<'db>(
+    db: &'db dyn Database,
+    diagnostics: &mut SemanticDiagnostics<'db>,
+    ty: TypeId<'db>,
+    stable_ptr: impl Into<SyntaxStablePtrId<'db>> + Copy,
+) {
+    if ty.is_phantom(db) {
+        diagnostics.report(stable_ptr, InstancesOfPhantomTypes);
+    } else {
+        add_type_based_diagnostics(db, diagnostics, ty, stable_ptr);
+    }
+}
+
+/// Adds diagnostics based on a type's structure: an infinitely-sized type, or an array of
+/// zero-sized or phantom elements.
+///
+/// This does not reject the type itself being phantom; a value position should use
+/// [add_value_type_based_diagnostics] for that.
 pub fn add_type_based_diagnostics<'db>(
     db: &'db dyn Database,
     diagnostics: &mut SemanticDiagnostics<'db>,

--- a/crates/cairo-lang-sierra-generator/src/function_generator_test_data/generics
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test_data/generics
@@ -57,11 +57,6 @@ fn foo(x: Option<Ph>) -> felt252 {
        ^^^^^^^^^^^^^
 
 error[E2019]: Phantom types cannot be instantiated.
- --> lib.cairo:4:11
-    match x {
-          ^
-
-error[E2019]: Phantom types cannot be instantiated.
  --> lib.cairo:5:34
         Option::Some(p) => match p {},
                                  ^


### PR DESCRIPTION
## Summary

Introduces `add_value_type_based_diagnostics`, a new function that wraps `add_type_based_diagnostics` and additionally rejects phantom types when they appear in value positions (parameters, return types, implicit parameters, closure params, and expressions). The existing `add_type_based_diagnostics` is now reserved for type definition contexts (struct members, enum variants) where phantom types are permitted.

Previously, phantom type checks were scattered across multiple call sites — `compute.rs`, `functions.rs`, and `compute_expr_closure_semantic` — each manually calling `is_phantom` and reporting `InstancesOfPhantomTypes` before or after calling `add_type_based_diagnostics`. This also caused duplicate diagnostics: for example, a phantom type used as a function parameter would be reported both at the signature site and again when the parameter expression was analyzed.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Phantom type diagnostics were being emitted multiple times for the same usage. For instance, using `Option<Ph>` as a parameter type would produce an `E2019` error at the signature and a second one at the expression referencing the parameter. The fix consolidates phantom type checking into `add_value_type_based_diagnostics`, which is called at the canonical location for each value position, eliminating the duplicate reports.

---

## What was the behavior or documentation before?

Using a phantom type in a function parameter, return type, or expression could produce multiple `E2019: Phantom types cannot be instantiated` diagnostics pointing to different locations for the same underlying type usage.

---

## What is the behavior or documentation after?

Each phantom type usage in a value position produces exactly one `E2019` diagnostic, reported at the most specific and relevant source location (the parameter, return type annotation, or expression site). The `analyzed_types` set in `apply_inference_rewriter` is pre-seeded with types from the function signature so that expression-level checks do not re-report errors already covered by the signature.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `add_type_based_diagnostics` function is retained for use in type definition contexts where phantom types are valid. The new `add_value_type_based_diagnostics` function short-circuits to `InstancesOfPhantomTypes` if the type is phantom, and otherwise delegates to `add_type_based_diagnostics` for structural checks (infinite-size types, arrays of zero-sized or phantom elements).