### PR TITLE
bugfix(semantic): Reject arrays of phantom elements.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/attributes
+++ b/crates/cairo-lang-semantic/src/expr/test_data/attributes
@@ -223,3 +223,94 @@ error[E2019]: Phantom types cannot be instantiated.
  --> lib.cairo:4:15
     let _f = |_x: Option<Ph>| {};
               ^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Array of a phantom type.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(x: Array<Ph>) -> Array<Ph> {
+    x
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[phantom]
+enum Ph {
+    A: felt252,
+}
+
+//! > expected_diagnostics
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:5:8
+fn foo(x: Array<Ph>) -> Array<Ph> {
+       ^^^^^^^^^^^^
+
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:5:25
+fn foo(x: Array<Ph>) -> Array<Ph> {
+                        ^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Array of an empty phantom struct is reported as phantom, not zero-sized.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(x: Array<Ph>) -> Array<Ph> {
+    x
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[phantom]
+struct Ph {}
+
+//! > expected_diagnostics
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:3:8
+fn foo(x: Array<Ph>) -> Array<Ph> {
+       ^^^^^^^^^^^^
+
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:3:25
+fn foo(x: Array<Ph>) -> Array<Ph> {
+                        ^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Array of a phantom type as a struct member.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+#[phantom]
+enum Ph {
+    A: felt252,
+}
+
+struct S {
+    x: Array<Ph>,
+}
+
+//! > expected_diagnostics
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:7:5
+    x: Array<Ph>,
+    ^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -971,9 +971,12 @@ pub fn add_type_based_diagnostics<'db>(
         let long_id = extrn.long(db);
         if long_id.extern_type_id.name(db).long(db) == "Array"
             && let [GenericArgumentId::Type(arg_ty)] = &long_id.generic_args[..]
-            && db.type_size_info(*arg_ty) == Ok(TypeSizeInformation::ZeroSized)
         {
-            diagnostics.report(stable_ptr, ArrayOfZeroSizedElements(*arg_ty));
+            if arg_ty.is_phantom(db) {
+                diagnostics.report(stable_ptr, InstancesOfPhantomTypes);
+            } else if db.type_size_info(*arg_ty) == Ok(TypeSizeInformation::ZeroSized) {
+                diagnostics.report(stable_ptr, ArrayOfZeroSizedElements(*arg_ty));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

When an `Array` contains a phantom type, the compiler now emits `InstancesOfPhantomTypes` (E2019) instead of `ArrayOfZeroSizedElements`. Previously, phantom types that happened to be zero-sized (e.g., empty phantom structs) would incorrectly trigger the zero-sized array diagnostic rather than the phantom type diagnostic. The check now explicitly tests for phantom types first, falling back to the zero-sized check only for non-phantom types.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`Array<Ph>` where `Ph` is a phantom type was either not diagnosed correctly or diagnosed with the wrong error. Phantom types should always produce E2019 (`InstancesOfPhantomTypes`) when used as array element types, regardless of whether they are also zero-sized. An empty phantom struct (`#[phantom] struct Ph {}`) would previously fall through to the zero-sized diagnostic, masking the real issue.

---

## What was the behavior or documentation before?

- `Array<Ph>` where `Ph` is a non-zero-sized phantom type produced no diagnostic from the array check path.
- `Array<Ph>` where `Ph` is an empty (zero-sized) phantom struct produced `ArrayOfZeroSizedElements` instead of `InstancesOfPhantomTypes`.

---

## What is the behavior or documentation after?

- `Array<Ph>` for any phantom type consistently produces `error[E2019]: Phantom types cannot be instantiated.`
- The `ArrayOfZeroSizedElements` diagnostic is only emitted for zero-sized types that are not phantom types.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Three new test cases were added covering: phantom enums as array element types, empty phantom structs as array element types, and phantom types used as array element types inside struct members.