### PR TITLE
(bug fix): close ']' in FixedSizeArray type short_name

### DIFF
--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -1210,7 +1210,7 @@ pub fn priv_type_short_name(db: &dyn Database, ty: TypeId<'_>) -> String {
             format!("@{}", ty.short_name(db))
         }
         TypeLongId::FixedSizeArray { type_id, size } => {
-            format!("[{}; {:?}", type_id.short_name(db), size.debug(db))
+            format!("[{}; {:?}]", type_id.short_name(db), size.debug(db))
         }
         TypeLongId::NumericLiteral(_) => "{numeric}".to_string(),
         other => other.format(db),


### PR DESCRIPTION
## Summary

Fixes the `FixedSizeArray` type short name formatting by adding the missing closing bracket `]`. The format string was `"[{}; {:?}"`, which produced malformed output like `[u8; 3` instead of the correct `[u8; 3]`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `priv_type_short_name` function was producing an unclosed bracket when formatting `FixedSizeArray` types, resulting in invalid/misleading type name strings.

---

## What was the behavior or documentation before?

`FixedSizeArray` short names were formatted as `[<type>; <size>` (missing the closing `]`).

---

## What is the behavior or documentation after?

`FixedSizeArray` short names are now correctly formatted as `[<type>; <size>]`.

---

## Related issue or discussion (if any)

None.

---

## Additional context

None.