### PR TITLE
bugfix(starknet-plugin): Fixed test deployment hygiene issues.

### DIFF
--- a/crates/cairo-lang-starknet/cairo_level_tests/deployment.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/deployment.cairo
@@ -51,6 +51,40 @@ pub mod advanced {
     ) {}
 }
 
+/// Contract whose constructor parameters are named exactly like the bindings that
+/// `deploy_for_test` generates for itself (`class_hash` / `deployment_params` /
+/// `calldata`). These must neither collide with those bindings (compile error) nor
+/// shadow them (silently dropping the user's `calldata` argument).
+#[starknet::contract]
+pub mod reserved_ctor_arg_names {
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    #[storage]
+    struct Storage {
+        value: felt252,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        class_hash: felt252,
+        deployment_params: felt252,
+        calldata: Array<felt252>,
+    ) {
+        self.value.write(class_hash + deployment_params + calldata.len().into());
+    }
+
+    #[abi(embed_v0)]
+    impl ValueImpl of super::IValue<ContractState> {
+        fn get_value(self: @ContractState) -> felt252 {
+            self.value.read()
+        }
+
+        fn set_value(ref self: ContractState, value: felt252) {
+            self.value.write(value);
+        }
+    }
+}
+
 #[test]
 fn test_deploy_in_construct() {
     let (contract_address, _) = deploy_syscall(self_caller::TEST_CLASS_HASH, 0, [].span(), false)
@@ -121,4 +155,17 @@ fn test_typed_deploy_default_with_complex_args() {
             advanced::TEST_CLASS_HASH, 0, calldata.span(), false,
         ) == Err(array!['CONTRACT_ALREADY_DEPLOYED']),
     );
+}
+
+#[test]
+fn test_deploy_for_test_reserved_ctor_arg_names() {
+    // The constructor args named `class_hash` / `deployment_params` / `calldata` must be passed
+    // through correctly. Pre-fix this failed to compile (E2054, parameter redefinition) and the
+    // `calldata` arg was silently dropped.
+    let (contract_address, _) = reserved_ctor_arg_names::deploy_for_test(
+        reserved_ctor_arg_names::TEST_CLASS_HASH, Default::default(), 10, 20, array![1, 2, 3],
+    )
+        .expect('deployment failed');
+    // 10 + 20 + len([1, 2, 3]) == 33; a dropped `calldata` arg would change the sum.
+    assert!(IValueDispatcher { contract_address }.get_value() == 33);
 }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -311,19 +311,19 @@ use starknet::storage::Map as LegacyMap;
 pub const TEST_CLASS_HASH: starknet::ClassHash = 0x3bd690d1a73da0d8c43f46ecc3a006978d8343a075e91a1c7a24529e7d244a.try_into().unwrap();
 #[cfg(target: 'test')]
 pub fn deploy_for_test(
-    class_hash: starknet::ClassHash,
-    deployment_params: starknet::deployment::DeploymentParams,
+    __deploy_class_hash__: starknet::ClassHash,
+    __deploy_params__: starknet::deployment::DeploymentParams,
     
 ) -> starknet::SyscallResult<(starknet::ContractAddress, core::array::Span<felt252>)> {
-    let mut calldata: core::array::Array<felt252> = core::array::ArrayTrait::new();
+    let mut __deploy_calldata__: core::array::Array<felt252> = core::array::ArrayTrait::new();
 
     
 
     starknet::syscalls::deploy_syscall(
-        class_hash,
-        deployment_params.salt,
-        core::array::ArrayTrait::span(@calldata),
-        deployment_params.deploy_from_zero,
+        __deploy_class_hash__,
+        __deploy_params__.salt,
+        core::array::ArrayTrait::span(@__deploy_calldata__),
+        __deploy_params__.deploy_from_zero,
     )
 }
 

--- a/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
+++ b/crates/cairo-lang-starknet/src/plugin/starknet_module/contract.rs
@@ -406,8 +406,9 @@ fn generate_deploy_function<'db>(
         let type_text = ty.as_syntax_node().get_text_without_trivia(db).long(db);
 
         param_declarations.push(format!("{name}: {type_text}"));
-        calldata_serialization
-            .push(format!("core::serde::Serde::<{type_text}>::serialize(@{name}, ref calldata);",));
+        calldata_serialization.push(format!(
+            "core::serde::Serde::<{type_text}>::serialize(@{name}, ref __deploy_calldata__);",
+        ));
     }
 
     let param_declarations_str = param_declarations.join(",\n");
@@ -417,19 +418,20 @@ fn generate_deploy_function<'db>(
         "
         #[cfg(target: 'test')]
         pub fn deploy_for_test(
-            class_hash: starknet::ClassHash,
-            deployment_params: starknet::deployment::DeploymentParams,
+            __deploy_class_hash__: starknet::ClassHash,
+            __deploy_params__: starknet::deployment::DeploymentParams,
             {param_declarations_str}
         ) -> starknet::SyscallResult<(starknet::ContractAddress, core::array::Span<felt252>)> {{
-            let mut calldata: core::array::Array<felt252> = core::array::ArrayTrait::new();
+            let mut __deploy_calldata__: core::array::Array<felt252> = \
+         core::array::ArrayTrait::new();
 
             {calldata_serialization_str}
 
             starknet::syscalls::deploy_syscall(
-                class_hash,
-                deployment_params.salt,
-                core::array::ArrayTrait::span(@calldata),
-                deployment_params.deploy_from_zero,
+                __deploy_class_hash__,
+                __deploy_params__.salt,
+                core::array::ArrayTrait::span(@__deploy_calldata__),
+                __deploy_params__.deploy_from_zero,
             )
         }}
     "


### PR DESCRIPTION
## Summary

The internal bindings generated by `deploy_for_test` (`class_hash`, `deployment_params`, `calldata`) are renamed to `__deploy_class_hash__`, `__deploy_params__`, and `__deploy_calldata__` to avoid collisions with constructor parameter names that happen to share those identifiers.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a contract's constructor declared parameters named `class_hash`, `deployment_params`, or `calldata`, the generated `deploy_for_test` function would either fail to compile with a parameter redefinition error (E2054) or silently drop the user's argument (e.g. the `calldata` array was overwritten by the internally declared `let mut calldata` binding, causing serialization to operate on an empty array instead of the user-supplied one).

---

## What was the behavior or documentation before?

A constructor with parameters named `class_hash`, `deployment_params`, or `calldata` caused the generated `deploy_for_test` to either produce a compile error due to duplicate parameter names, or silently ignore the user-supplied `calldata` argument because the internal `let mut calldata` binding shadowed it.

---

## What is the behavior or documentation after?

The generated `deploy_for_test` uses mangled names (`__deploy_class_hash__`, `__deploy_params__`, `__deploy_calldata__`) for its internal bindings, so constructor parameters with any of those names are passed through correctly without collision or shadowing. A new test contract (`reserved_ctor_arg_names`) and accompanying test (`test_deploy_for_test_reserved_ctor_arg_names`) verify this behavior end-to-end.

---

## Related issue or discussion (if any)

---

## Additional context

The fix is purely in the code generation template inside `generate_deploy_function`. The double-underscore prefix/suffix convention is chosen to minimize the chance of a real constructor parameter ever colliding with the generated names.