### PR TITLE
(feat): publish dhat_ls_flow memory benchmark to the dashboard

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,6 +107,24 @@ jobs:
           # this step then reuses. Reordering or removing the timing step will break this one.
           skip-fetch-gh-pages: true
 
+      - name: Run LS-flow heap benchmark
+        run: cargo bench --bench dhat_ls_flow --features dhat
+
+      - name: Store LS-flow heap benchmark results
+        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b
+        with:
+          name: Cairo LS-Flow Memory Benchmarks
+          tool: 'customSmallerIsBetter'
+          output-file-path: target/dhat-bench/dhat-ls-output.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          fail-on-alert: true
+          alert-threshold: '150%'
+          # Like the heap step, reuses the gh-pages worktree fetched by the timing step.
+          skip-fetch-gh-pages: true
+
       - name: Run language-server re-execution benchmark
         run: cargo bench --bench ls_reexec
 


### PR DESCRIPTION
## Summary

Adds a nightly CI benchmark step that runs the `dhat_ls_flow` heap benchmark and stores its results using `github-action-benchmark`. The benchmark tracks Cairo Language Server flow memory usage over time, with a 150% alert threshold, and reuses the gh-pages worktree fetched by the existing timing step.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Without this step, heap memory usage for the LS-flow benchmark was not being tracked or surfaced in the nightly benchmark dashboard, making it impossible to detect regressions in Language Server memory consumption over time.

---

## What was the behavior or documentation before?

The nightly workflow ran the LS re-execution benchmark but had no step to run or record the `dhat_ls_flow` heap benchmark results.

---

## What is the behavior or documentation after?

The nightly workflow now runs `cargo bench --bench dhat_ls_flow --features dhat` and publishes the results to the `gh-pages` branch under the "Cairo LS-Flow Memory Benchmarks" dataset. Alerts are triggered if results exceed 150% of the baseline.

---

## Related issue or discussion (if any)

---

## Additional context

The new step is placed before the existing LS re-execution benchmark and follows the same pattern as the existing heap benchmark step, reusing the gh-pages worktree fetched earlier in the workflow to avoid redundant fetches.