### PR TITLE
bugfix(semantic): Detect non-instantiable array elements nested in a type.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/attributes
+++ b/crates/cairo-lang-semantic/src/expr/test_data/attributes
@@ -314,3 +314,137 @@ error[E2019]: Phantom types cannot be instantiated.
  --> lib.cairo:7:5
     x: Array<Ph>,
     ^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Phantom type nested in an array inside a Span.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(x: Span<Ph>) -> Span<Ph> {
+    x
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[phantom]
+enum Ph {
+    A: felt252,
+}
+
+//! > expected_diagnostics
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:5:8
+fn foo(x: Span<Ph>) -> Span<Ph> {
+       ^^^^^^^^^^^
+
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:5:24
+fn foo(x: Span<Ph>) -> Span<Ph> {
+                       ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Zero-sized type nested in an array inside a Span.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(x: Span<()>) -> Span<()> {
+    x
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics
+error[E2053]: Cannot have array of type "()" that is zero sized.
+ --> lib.cairo:1:8
+fn foo(x: Span<()>) -> Span<()> {
+       ^^^^^^^^^^^
+
+error[E2053]: Cannot have array of type "()" that is zero sized.
+ --> lib.cairo:1:24
+fn foo(x: Span<()>) -> Span<()> {
+                       ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Phantom array reached through a cycle of array-recursive types.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(x: B, y: A) {}
+
+//! > function_name
+foo
+
+//! > module_code
+#[phantom]
+enum Ph {
+    A: felt252,
+}
+
+struct A {
+    b: Array<B>,
+}
+
+struct B {
+    a: Array<A>,
+    bad: Array<Ph>,
+}
+
+//! > expected_diagnostics
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:7:5
+    b: Array<B>,
+    ^^^^^^^^^^^
+
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:11:5
+    a: Array<A>,
+    ^^^^^^^^^^^
+
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:12:5
+    bad: Array<Ph>,
+    ^^^^^^^^^^^^^^
+
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:14:8
+fn foo(x: B, y: A) {}
+       ^^^^
+
+error[E2019]: Phantom types cannot be instantiated.
+ --> lib.cairo:14:14
+fn foo(x: B, y: A) {}
+             ^^^^
+
+//! > ==========================================================================
+
+//! > Type recursive through an array with no bad element is fine (cycle terminates).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > function_code
+fn foo(x: A) {}
+
+//! > function_name
+foo
+
+//! > module_code
+struct A {
+    a: Array<A>,
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -25,7 +25,7 @@ use crate::corelib::{
     CorelibSemantic, concrete_copy_trait, concrete_destruct_trait, concrete_drop_trait,
     concrete_panic_destruct_trait, core_box_ty, get_usize_ty, unit_ty,
 };
-use crate::diagnostic::SemanticDiagnosticKind::*;
+use crate::diagnostic::SemanticDiagnosticKind::{self, *};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::compute::{ComputationContext, compute_expr_semantic};
 use crate::expr::inference::canonic::{CanonicalTrait, ResultNoErrEx};
@@ -953,8 +953,8 @@ pub fn add_value_type_based_diagnostics<'db>(
     }
 }
 
-/// Adds diagnostics based on a type's structure: an infinitely-sized type, or an array of
-/// zero-sized or phantom elements.
+/// Adds diagnostics based on a type's structure: an infinitely-sized type, or a (possibly nested)
+/// array of zero-sized or phantom elements.
 ///
 /// This does not reject the type itself being phantom; a value position should use
 /// [add_value_type_based_diagnostics] for that.
@@ -967,17 +967,120 @@ pub fn add_type_based_diagnostics<'db>(
     if db.type_size_info(ty) == Ok(TypeSizeInformation::Infinite) {
         diagnostics.report(stable_ptr, InfiniteSizeType(ty));
     }
-    if let TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) = ty.long(db) {
-        let long_id = extrn.long(db);
-        if long_id.extern_type_id.name(db).long(db) == "Array"
-            && let [GenericArgumentId::Type(arg_ty)] = &long_id.generic_args[..]
-        {
-            if arg_ty.is_phantom(db) {
-                diagnostics.report(stable_ptr, InstancesOfPhantomTypes);
-            } else if db.type_size_info(*arg_ty) == Ok(TypeSizeInformation::ZeroSized) {
-                diagnostics.report(stable_ptr, ArrayOfZeroSizedElements(*arg_ty));
+    if let Some(violation) = array_element_violation(db, ty) {
+        diagnostics.report(stable_ptr, violation.to_kind());
+    }
+}
+
+/// A reason a type cannot be used as a value: it (transitively) contains an array whose element
+/// type cannot be instantiated.
+#[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
+enum ArrayElementViolation<'db> {
+    /// An array of a phantom element.
+    Phantom,
+    /// An array of a zero-sized element (carries the element type, for the diagnostic).
+    ZeroSized(TypeId<'db>),
+}
+impl<'db> ArrayElementViolation<'db> {
+    /// The diagnostic kind reported for this violation.
+    fn to_kind(&self) -> SemanticDiagnosticKind<'db> {
+        match self {
+            Self::Phantom => InstancesOfPhantomTypes,
+            Self::ZeroSized(ty) => ArrayOfZeroSizedElements(*ty),
+        }
+    }
+}
+
+/// Whether `ty` (transitively) contains an array whose element type cannot be instantiated - a
+/// phantom or zero-sized element - and so cannot be used as a value, e.g. `Span<Ph>` or
+/// `Span<[(); 0]>` (which nest `Array<...>`). Memoized.
+///
+/// A phantom type is reported on its own (see [add_value_type_based_diagnostics] for a value, or
+/// the `NonPhantomTypeContainingPhantomType` check for a definition), so it is not descended into.
+/// Only concrete types are searched; a generic parameter is assumed instantiable, so a generic
+/// `Array<T>` is only diagnosed once `T` is concretely disallowed.
+#[salsa::tracked(cycle_result=array_element_violation_cycle)]
+fn array_element_violation<'db>(
+    db: &'db dyn Database,
+    ty: TypeId<'db>,
+) -> Option<ArrayElementViolation<'db>> {
+    if ty.is_phantom(db) {
+        return None;
+    }
+    array_element_deps_or_issue(db, ty, |dep| array_element_violation(db, dep))
+}
+
+/// Cycle handling for [array_element_violation], hit when a type is recursive through an array
+/// element (e.g. `Array<Self>`).
+///
+/// Implements the same logic as [array_element_violation], but iteratively over an explicit
+/// work-stack with a visited set so it never re-enters the query. Recursing back into the query
+/// mid-cycle would let salsa cache a false negative for whichever participant is computed first -
+/// its violation may be reachable only through the rest of the cycle.
+fn array_element_violation_cycle<'db>(
+    db: &'db dyn Database,
+    _id: salsa::Id,
+    ty: TypeId<'db>,
+) -> Option<ArrayElementViolation<'db>> {
+    let mut visited: OrderedHashSet<TypeId<'db>> = OrderedHashSet::default();
+    let mut stack = vec![ty];
+    while let Some(ty) = stack.pop() {
+        if ty.is_phantom(db) || !visited.insert(ty) {
+            continue;
+        }
+        if let Some(violation) = array_element_deps_or_issue(db, ty, |dep| {
+            stack.push(dep);
+            None
+        }) {
+            return Some(violation);
+        }
+    }
+    None
+}
+
+/// Searches `ty` for a bad array element. An array's element is checked directly (phantom or
+/// zero-sized); every component to search recursively - struct members, enum variants, tuple /
+/// snapshot / fixed-size-array / closure-capture components, the type wrapped by a `Box` /
+/// `Nullable`, and an array's (otherwise valid) element - is passed to `on_dep`. Returns the first
+/// violation found.
+fn array_element_deps_or_issue<'db>(
+    db: &'db dyn Database,
+    ty: TypeId<'db>,
+    mut on_dep: impl FnMut(TypeId<'db>) -> Option<ArrayElementViolation<'db>>,
+) -> Option<ArrayElementViolation<'db>> {
+    match ty.long(db) {
+        TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
+            let ConcreteExternTypeLongId { extern_type_id, generic_args } = extrn.long(db);
+            match (extern_type_id.name(db).long(db).as_str(), &generic_args[..]) {
+                ("Array", [GenericArgumentId::Type(arg_ty)]) => {
+                    if arg_ty.is_phantom(db) {
+                        Some(ArrayElementViolation::Phantom)
+                    } else if db.type_size_info(*arg_ty) == Ok(TypeSizeInformation::ZeroSized) {
+                        Some(ArrayElementViolation::ZeroSized(*arg_ty))
+                    } else {
+                        on_dep(*arg_ty)
+                    }
+                }
+                ("Box" | "Nullable", [GenericArgumentId::Type(arg_ty)]) => on_dep(*arg_ty),
+                _ => None,
             }
         }
+        TypeLongId::Concrete(ConcreteTypeId::Struct(id)) => {
+            db.concrete_struct_members(*id).ok()?.iter().find_map(|(_, member)| on_dep(member.ty))
+        }
+        TypeLongId::Concrete(ConcreteTypeId::Enum(id)) => {
+            db.concrete_enum_variants(*id).ok()?.iter().find_map(|variant| on_dep(variant.ty))
+        }
+        TypeLongId::Tuple(types) => types.iter().find_map(|ty| on_dep(*ty)),
+        TypeLongId::Snapshot(inner) => on_dep(*inner),
+        TypeLongId::FixedSizeArray { type_id, .. } => on_dep(*type_id),
+        TypeLongId::Closure(closure) => closure.captured_types.iter().find_map(|ty| on_dep(*ty)),
+        TypeLongId::GenericParameter(_)
+        | TypeLongId::Var(_)
+        | TypeLongId::NumericLiteral(_)
+        | TypeLongId::Coupon(_)
+        | TypeLongId::ImplType(_)
+        | TypeLongId::Missing(_) => None,
     }
 }
 


### PR DESCRIPTION
## Summary

Extends the phantom-type and zero-sized-array diagnostic checks to cover types that **transitively** contain a bad `Array` element, rather than only catching a direct `Array<Ph>` or `Array<()>`. For example, `Span<Ph>` (which wraps `Array<Ph>`) and mutually-recursive struct chains that eventually reach a phantom array element are now diagnosed correctly.

The core change introduces a new `array_element_violation` salsa-tracked query that walks the full type structure — structs, enums, tuples, snapshots, fixed-size arrays, closures, `Box`/`Nullable` wrappers — looking for an `Array` whose element is phantom or zero-sized. A dedicated cycle handler (`array_element_violation_cycle`) is added to handle types that are recursive through an array element (e.g. `struct A { a: Array<A> }`), using an explicit work-stack with a visited set to avoid salsa caching false negatives mid-cycle.

New test cases cover: `Span<Ph>`, `Span<()>`, a phantom array reachable through a cycle of array-recursive structs, and a self-recursive array type with no bad element (which must not produce a diagnostic).

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Previously, the diagnostic for phantom or zero-sized array elements was only triggered when the `Array<...>` appeared directly as the type being checked. Wrapping the array in another type — most commonly `Span<Ph>`, which is `{base: Array<Ph>, len: usize}` — silently bypassed the check, allowing invalid types to pass semantic validation without an error.

---

## What was the behavior or documentation before?

`Span<Ph>` and similar types that nest a bad `Array` inside a struct or other wrapper were accepted without any diagnostic.

---

## What is the behavior or documentation after?

Any type that transitively contains an `Array` whose element is phantom or zero-sized is rejected with the appropriate `E2019` or `E2053` diagnostic, regardless of how deeply the array is nested. Self-recursive array types with no bad element continue to be accepted.

---

## Related issue or discussion (if any)

---

## Additional context

The cycle handler is necessary because salsa's default cycle recovery would cache a `None` (no violation) for the first type encountered in a cycle, even if a violation is reachable only after traversing the rest of the cycle. The iterative stack-based fallback avoids re-entering the query during cycle resolution.