### PR TITLE
bugfix(plugins): emit derive member bounds for associated-type-path members.

### DIFF
--- a/crates/cairo-lang-syntax/src/node/helpers.rs
+++ b/crates/cairo-lang-syntax/src/node/helpers.rs
@@ -730,8 +730,10 @@ impl<'a> UsePathLeaf<'a> {
 pub trait IsDependentType<'db> {
     /// Returns true if `self` is dependent on `identifier` in an internal type.
     /// For example given identifier `T` will return true for:
-    /// `T`, `Array<T>`, `Array<Array<T>>`, `(T, felt252)`.
-    /// Does not resolve paths, type aliases or named generics.
+    /// `T`, `Array<T>`, `Array<Array<T>>`, `(T, felt252)`, `T::AssocType`.
+    /// Does not resolve type aliases or named generics. A multi-segment path is considered
+    /// dependent when its head segment is one of the identifiers (e.g. the associated type
+    /// `T::AssocType`), which is a purely syntactic check (no path resolution).
     fn is_dependent_type(&self, db: &'db dyn Database, identifiers: &[SmolStrId<'db>]) -> bool;
 }
 
@@ -743,18 +745,24 @@ impl<'a> IsDependentType<'a> for ast::ExprPath<'a> {
             Some(ast::PathSegment::Simple(simple)) if segments.len() == 0 => {
                 identifiers.contains(&simple.identifier(db))
             }
-            Some(first) => chain!([first], segments).any(|segment| {
-                let ast::PathSegment::WithGenericArgs(with_generics) = segment else {
-                    return false;
-                };
-                with_generics.generic_args(db).generic_args(db).elements(db).any(|arg| {
-                    match arg {
-                        ast::GenericArg::Named(named) => named.value(db),
-                        ast::GenericArg::Unnamed(unnamed) => unnamed.value(db),
-                    }
-                    .is_dependent_type(db, identifiers)
-                })
-            }),
+            Some(first) => {
+                // A path whose head segment is one of the identifiers (e.g. the associated type
+                // `T::AssocType`) depends on that identifier. Only the head segment can be a
+                // generic param; a later segment with the same name is an associated-item name.
+                identifiers.contains(&first.identifier(db))
+                    || chain!([first], segments).any(|segment| {
+                        let ast::PathSegment::WithGenericArgs(with_generics) = segment else {
+                            return false;
+                        };
+                        with_generics.generic_args(db).generic_args(db).elements(db).any(|arg| {
+                            match arg {
+                                ast::GenericArg::Named(named) => named.value(db),
+                                ast::GenericArg::Unnamed(unnamed) => unnamed.value(db),
+                            }
+                            .is_dependent_type(db, identifiers)
+                        })
+                    })
+            }
         }
     }
 }

--- a/tests/bug_samples/derive_associated_type_member.cairo
+++ b/tests/bug_samples/derive_associated_type_member.cairo
@@ -1,0 +1,24 @@
+//! Regression: deriving a trait on a struct member whose type is an associated-type path through
+//! a generic/impl param (e.g. `S::Corners`) must emit that member's trait bound. The member used
+//! to be misclassified as non-generics-dependent, so the bound was omitted and the derived impl
+//! failed to type-check (E2111 for Drop, E2311 for Clone).
+
+trait Shape<T> {
+    type Corners;
+}
+
+impl U8Shape of Shape<u8> {
+    type Corners = felt252;
+}
+
+#[derive(Drop, Clone)]
+struct Poly<T, impl S: Shape<T>> {
+    corners: S::Corners,
+}
+
+#[test]
+fn test_derive_on_associated_type_member() {
+    let poly = Poly::<u8, U8Shape> { corners: 7 };
+    let cloned = poly.clone();
+    assert!(cloned.corners == 7);
+}

--- a/tests/bug_samples/lib.cairo
+++ b/tests/bug_samples/lib.cairo
@@ -1,4 +1,5 @@
 mod builtin_usage_before_unreachable;
+mod derive_associated_type_member;
 mod ecdsa_completeness;
 mod generic_cycles;
 mod inconsistent_gas;


### PR DESCRIPTION
## Summary

`IsDependentType` now recognises multi-segment paths whose head segment is a generic/impl parameter as being dependent on that parameter. For example, `S::Corners` (an associated type accessed through an impl param `S`) is now correctly treated as dependent on `S`. Previously, only single-segment paths (e.g. bare `T`) or paths containing generic arguments (e.g. `Array<T>`) were considered dependent, so a struct member typed as `S::Corners` was misclassified as non-generics-dependent. This caused `#[derive(Drop, Clone)]` to omit the required trait bounds for such members, producing type-check errors (E2111 for `Drop`, E2311 for `Clone`).

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When deriving a trait on a struct that has a member whose type is an associated-type path (e.g. `S::Corners` where `S: Shape<T>` is an impl parameter), the derive macro must emit a trait bound for that member. Because `is_dependent_type` did not check whether the head segment of a multi-segment path matched a known generic/impl identifier, it returned `false` for `S::Corners`, and the bound was silently dropped, making the derived impl fail to type-check.

---

## What was the behavior or documentation before?

`is_dependent_type` only returned `true` for a multi-segment path if one of its segments carried generic arguments that were themselves dependent (e.g. `Array<T>`). A plain associated-type path like `S::Corners` returned `false`, so `#[derive(Drop, Clone)]` on a struct containing such a member produced compilation errors.

---

## What is the behavior or documentation after?

`is_dependent_type` additionally checks whether the head segment of a multi-segment path is one of the tracked identifiers. This is a purely syntactic check (no path resolution). `S::Corners` is now correctly identified as dependent on `S`, and `#[derive(Drop, Clone)]` emits the necessary bounds, allowing the derived impl to type-check successfully.

---

## Related issue or discussion (if any)

Regression test added in `tests/bug_samples/derive_associated_type_member.cairo`.

---

## Additional context

The fix is confined to `ExprPath::is_dependent_type`. Only the head segment is checked for a bare identifier match, since a later segment with the same name would be an associated-item name rather than a generic parameter reference.