### PR TITLE
Changed `u128_to_u32_guarantees` input to be guarantee as well.

### DIFF
--- a/corelib/src/internal/bounded_int.cairo
+++ b/corelib/src/internal/bounded_int.cairo
@@ -251,6 +251,14 @@ extern const fn bounded_int_is_zero<T>(
     value: T,
 ) -> crate::zeroable::IsZeroResult<T> implicits() nopanic;
 
+extern fn bounded_int_to_guarantee<const MIN: felt252, const MAX: felt252>(
+    value: BoundedInt<MIN, MAX>,
+) -> BoundedIntGuarantee<MIN, MAX> implicits() nopanic;
+
+extern fn bounded_int_guarantee_content<const MIN: felt252, const MAX: felt252>(
+    ref value: BoundedIntGuarantee<MIN, MAX>,
+) -> BoundedInt<MIN, MAX> implicits() nopanic;
+
 /// Returns the negation of the given `felt252` value.
 trait NegFelt252<const NUM: felt252> {
     /// The negation of the given `felt252` value.
@@ -343,6 +351,7 @@ impl NonZeroMulMinusOneNegateHelper<
 
 pub use {
     bounded_int_add as add, bounded_int_constrain as constrain, bounded_int_div_rem as div_rem,
-    bounded_int_is_zero as is_zero, bounded_int_mul as mul, bounded_int_sub as sub,
+    bounded_int_guarantee_content as guarantee_content, bounded_int_is_zero as is_zero,
+    bounded_int_mul as mul, bounded_int_sub as sub, bounded_int_to_guarantee as to_guarantee,
     bounded_int_trim_max as trim_max, bounded_int_trim_min as trim_min,
 };

--- a/corelib/src/test/hash_test.cairo
+++ b/corelib/src/test/hash_test.cairo
@@ -173,19 +173,20 @@ fn to_u256(value: Box<[u32; 8]>) -> u256 {
 
 mod msg {
     #[feature("bounded-int-utils")]
-    type U32Guarantee =
-        core::internal::bounded_int::BoundedIntGuarantee<0, 0xffffffff>;
-    pub extern fn u128_to_u32_guarantees(
-        value: u128,
+    use core::internal::bounded_int::{BoundedIntGuarantee, to_guarantee, upcast};
+    type U32Guarantee = BoundedIntGuarantee<0, 0xffffffff>;
+    type U128Guarantee = BoundedIntGuarantee<0, 0xffffffffffffffffffffffffffffffff>;
+    extern fn u128_to_u32_guarantees(
+        value: U128Guarantee,
     ) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) nopanic;
 
     pub fn from_felt252s(a: felt252, b: felt252) -> Box<[U32Guarantee; 16]> {
         let a: u256 = a.into();
         let b: u256 = b.into();
-        let (a_w0, a_w1, a_w2, a_w3) = u128_to_u32_guarantees(a.low);
-        let (a_w4, a_w5, a_w6, a_w7) = u128_to_u32_guarantees(a.high);
-        let (b_w0, b_w1, b_w2, b_w3) = u128_to_u32_guarantees(b.low);
-        let (b_w4, b_w5, b_w6, b_w7) = u128_to_u32_guarantees(b.high);
+        let (a_w0, a_w1, a_w2, a_w3) = u128_to_u32_guarantees(to_guarantee(upcast(a.low)));
+        let (a_w4, a_w5, a_w6, a_w7) = u128_to_u32_guarantees(to_guarantee(upcast(a.high)));
+        let (b_w0, b_w1, b_w2, b_w3) = u128_to_u32_guarantees(to_guarantee(upcast(b.low)));
+        let (b_w4, b_w5, b_w6, b_w7) = u128_to_u32_guarantees(to_guarantee(upcast(b.high)));
         BoxTrait::new(
             [
                 a_w0, a_w1, a_w2, a_w3, a_w4, a_w5, a_w6, a_w7, b_w0, b_w1, b_w2, b_w3, b_w4, b_w5,

--- a/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/bounded_int.rs
@@ -6,7 +6,6 @@ use num_bigint::{BigInt, ToBigInt};
 use num_traits::{One, Signed, ToPrimitive, Zero};
 use starknet_types_core::felt::Felt as Felt252;
 
-use super::int::unsigned128::Uint128Type;
 use super::non_zero::{NonZeroType, nonzero_ty};
 use super::range_check::RangeCheckType;
 use super::utils::{Range, reinterpret_cast_signature};
@@ -711,12 +710,13 @@ impl NoGenericArgsGenericLibfunc for U128ToU32GuaranteesLibfunc {
         &self,
         context: &dyn SignatureSpecializationContext,
     ) -> Result<LibfuncSignature, SpecializationError> {
-        let u128_ty = context.get_concrete_type(Uint128Type::id(), &[])?;
+        let u128_guarantee_ty =
+            bounded_int_guarantee_ty(context, BigInt::ZERO, BigInt::from(u128::MAX))?;
         let u32_guarantee_ty =
             bounded_int_guarantee_ty(context, BigInt::ZERO, BigInt::from(u32::MAX))?;
 
         Ok(LibfuncSignature::new_non_branch(
-            vec![u128_ty],
+            vec![u128_guarantee_ty],
             vec![
                 OutputVarInfo {
                     ty: u32_guarantee_ty.clone(),

--- a/tests/e2e_test_data/libfuncs/blake
+++ b/tests/e2e_test_data/libfuncs/blake
@@ -185,25 +185,25 @@ SmallE2ETestRunner(future_sierra: true)
 
 //! > cairo_code
 use core::blake::{Blake2sInputGuarantee, Blake2sState, blake2s_finalize_guarantees};
-
 #[feature("bounded-int-utils")]
-type U32Guarantee =
-    core::internal::bounded_int::BoundedIntGuarantee<0, 0xffffffff>;
+use core::internal::bounded_int::{BoundedIntGuarantee, to_guarantee, upcast};
+type U32Guarantee = BoundedIntGuarantee<0, 0xffffffff>;
+type U128Guarantee = BoundedIntGuarantee<0, 0xffffffffffffffffffffffffffffffff>;
 extern fn u128_to_u32_guarantees(
-    value: u128,
+    value: U128Guarantee,
 ) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) nopanic;
 
 fn hash_two_felt252s(state: Blake2sState, a: felt252, b: felt252) -> Blake2sState {
     let a: u256 = a.into();
     let b: u256 = b.into();
-    let (a_low_w0, a_low_w1, a_low_w2, a_low_w3) = u128_to_u32_guarantees(a.low);
-    let (a_high_w0, a_high_w1, a_high_w2, a_high_w3) = u128_to_u32_guarantees(a.high);
-    let (b_low_w0, b_low_w1, b_low_w2, b_low_w3) = u128_to_u32_guarantees(b.low);
-    let (b_high_w0, b_high_w1, b_high_w2, b_high_w3) = u128_to_u32_guarantees(b.high);
+    let (a_w0, a_w1, a_w2, a_w3) = u128_to_u32_guarantees(to_guarantee(upcast(a.low)));
+    let (a_w4, a_w5, a_w6, a_w7) = u128_to_u32_guarantees(to_guarantee(upcast(a.high)));
+    let (b_w0, b_w1, b_w2, b_w3) = u128_to_u32_guarantees(to_guarantee(upcast(b.low)));
+    let (b_w4, b_w5, b_w6, b_w7) = u128_to_u32_guarantees(to_guarantee(upcast(b.high)));
     let msg: Blake2sInputGuarantee = BoxTrait::new(
         [
-            a_low_w0, a_low_w1, a_low_w2, a_low_w3, a_high_w0, a_high_w1, a_high_w2, a_high_w3,
-            b_low_w0, b_low_w1, b_low_w2, b_low_w3, b_high_w0, b_high_w1, b_high_w2, b_high_w3,
+            a_w0, a_w1, a_w2, a_w3, a_w4, a_w5, a_w6, a_w7, b_w0, b_w1, b_w2, b_w3, b_w4, b_w5,
+            b_w6, b_w7,
         ],
     );
     blake2s_finalize_guarantees(state, 64, msg)
@@ -341,6 +341,8 @@ type Const<u32, 64> = Const<u32, 64> [storable: false, drop: false, dup: false, 
 type u32 = u32 [storable: true, drop: true, dup: true, zero_sized: false];
 type Tuple<u32, u32, u32, u32, u32, u32, u32, u32> = Struct<ut@Tuple, u32, u32, u32, u32, u32, u32, u32, u32> [storable: true, drop: true, dup: true, zero_sized: false];
 type Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> [storable: true, drop: false, dup: false, zero_sized: false];
+type BoundedIntGuarantee<0, 340282366920938463463374607431768211455> = BoundedIntGuarantee<0, 340282366920938463463374607431768211455> [storable: true, drop: false, dup: false, zero_sized: false];
+type BoundedInt<0, 340282366920938463463374607431768211455> = BoundedInt<0, 340282366920938463463374607431768211455> [storable: true, drop: true, dup: true, zero_sized: false];
 type Const<u128, 0> = Const<u128, 0> [storable: false, drop: false, dup: false, zero_sized: false];
 type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
 type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
@@ -354,6 +356,8 @@ libfunc const_as_immediate<Const<u128, 0>> = const_as_immediate<Const<u128, 0>>;
 libfunc store_temp<RangeCheck> = store_temp<RangeCheck>;
 libfunc store_temp<u128> = store_temp<u128>;
 libfunc jump = jump;
+libfunc upcast<u128, BoundedInt<0, 340282366920938463463374607431768211455>> = upcast<u128, BoundedInt<0, 340282366920938463463374607431768211455>>;
+libfunc bounded_int_to_guarantee<0, 340282366920938463463374607431768211455> = bounded_int_to_guarantee<0, 340282366920938463463374607431768211455>;
 libfunc u128_to_u32_guarantees = u128_to_u32_guarantees;
 libfunc struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>;
 libfunc store_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>> = store_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>;
@@ -393,19 +397,27 @@ store_temp<RangeCheck>([17]) -> ([21]);
 store_temp<u128>([19]) -> ([22]);
 store_temp<u128>([18]) -> ([23]);
 F0_B3:
-u128_to_u32_guarantees([13]) -> ([24], [25], [26], [27]);
-u128_to_u32_guarantees([14]) -> ([28], [29], [30], [31]);
-u128_to_u32_guarantees([22]) -> ([32], [33], [34], [35]);
-u128_to_u32_guarantees([23]) -> ([36], [37], [38], [39]);
-struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([24], [25], [26], [27], [28], [29], [30], [31], [32], [33], [34], [35], [36], [37], [38], [39]) -> ([4]);
+upcast<u128, BoundedInt<0, 340282366920938463463374607431768211455>>([13]) -> ([24]);
+bounded_int_to_guarantee<0, 340282366920938463463374607431768211455>([24]) -> ([25]);
+u128_to_u32_guarantees([25]) -> ([26], [27], [28], [29]);
+upcast<u128, BoundedInt<0, 340282366920938463463374607431768211455>>([14]) -> ([30]);
+bounded_int_to_guarantee<0, 340282366920938463463374607431768211455>([30]) -> ([31]);
+u128_to_u32_guarantees([31]) -> ([32], [33], [34], [35]);
+upcast<u128, BoundedInt<0, 340282366920938463463374607431768211455>>([22]) -> ([36]);
+bounded_int_to_guarantee<0, 340282366920938463463374607431768211455>([36]) -> ([37]);
+u128_to_u32_guarantees([37]) -> ([38], [39], [40], [41]);
+upcast<u128, BoundedInt<0, 340282366920938463463374607431768211455>>([23]) -> ([42]);
+bounded_int_to_guarantee<0, 340282366920938463463374607431768211455>([42]) -> ([43]);
+u128_to_u32_guarantees([43]) -> ([44], [45], [46], [47]);
+struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([26], [27], [28], [29], [32], [33], [34], [35], [38], [39], [40], [41], [44], [45], [46], [47]) -> ([4]);
 store_local<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([5], [4]) -> ([4]);
-local_into_box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([4]) -> ([40]);
-const_as_immediate<Const<u32, 64>>() -> ([41]);
-store_temp<u32>([41]) -> ([41]);
-store_temp<Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>>([40]) -> ([40]);
-blake2s_finalize_guarantees([1], [41], [40]) -> ([42]);
+local_into_box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([4]) -> ([48]);
+const_as_immediate<Const<u32, 64>>() -> ([49]);
+store_temp<u32>([49]) -> ([49]);
+store_temp<Box<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>>([48]) -> ([48]);
+blake2s_finalize_guarantees([1], [49], [48]) -> ([50]);
 store_temp<RangeCheck>([21]) -> ([21]);
-store_temp<Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>>([42]) -> ([42]);
-return([21], [42]);
+store_temp<Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>>([50]) -> ([50]);
+return([21], [50]);
 
 test::hash_two_felt252s@F0([0]: RangeCheck, [1]: Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>, [2]: felt252, [3]: felt252) -> (RangeCheck, Box<Tuple<u32, u32, u32, u32, u32, u32, u32, u32>>);

--- a/tests/e2e_test_data/libfuncs/bounded_int
+++ b/tests/e2e_test_data/libfuncs/bounded_int
@@ -1346,12 +1346,13 @@ SmallE2ETestRunner
 //! > cairo_code
 extern type BoundedIntGuarantee<const MIN: felt252, const MAX: felt252>;
 type U32Guarantee = BoundedIntGuarantee<0, 0xffffffff>;
+type U128Guarantee = BoundedIntGuarantee<0, 0xffffffffffffffffffffffffffffffff>;
 
 extern fn u128_to_u32_guarantees(
-    value: u128,
+    value: U128Guarantee,
 ) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) nopanic;
 
-fn foo(value: u128) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) {
+fn foo(value: U128Guarantee) -> (U32Guarantee, U32Guarantee, U32Guarantee, U32Guarantee) {
     u128_to_u32_guarantees(value)
 }
 
@@ -1376,7 +1377,7 @@ ret;
 test::foo: SmallOrderedMap({Const: 1100})
 
 //! > sierra_code
-type u128 = u128 [storable: true, drop: true, dup: true, zero_sized: false];
+type BoundedIntGuarantee<0, 340282366920938463463374607431768211455> = BoundedIntGuarantee<0, 340282366920938463463374607431768211455> [storable: true, drop: false, dup: false, zero_sized: false];
 type BoundedIntGuarantee<0, 4294967295> = BoundedIntGuarantee<0, 4294967295> [storable: true, drop: false, dup: false, zero_sized: false];
 type Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>> = Struct<ut@Tuple, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>> [storable: true, drop: false, dup: false, zero_sized: false];
 
@@ -1390,4 +1391,4 @@ struct_construct<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0
 store_temp<Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>>([5]) -> ([5]);
 return([5]);
 
-test::foo@F0([0]: u128) -> (Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>);
+test::foo@F0([0]: BoundedIntGuarantee<0, 340282366920938463463374607431768211455>) -> (Tuple<BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>, BoundedIntGuarantee<0, 4294967295>>);


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR does.
Focus on *what changed*, not just that something was "improved".
-->

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

<!--
Explain the concrete problem this PR addresses.

Good answers:
- Something was incorrect, misleading, or outdated
- A behavior was undocumented or unclear in a way that caused real confusion
- An example was missing for a non-obvious use case

Weak answers (often lead to closure):
- "Improves clarity"
- "Fixes wording"
- "Makes this read better"
-->

---

## What was the behavior or documentation before?

<!-- Optional but encouraged, especially for docs-only changes -->

---

## What is the behavior or documentation after?

<!-- Optional but encouraged -->

---

## Related issue or discussion (if any)

<!--
Link to an existing issue or discussion if applicable.
Docs-only PRs without a linked issue are less likely to be accepted.
-->

---

## Additional context

<!--
Anything else reviewers should know.
If this is a documentation PR, explain why this change is important for users.
-->

