### PR TITLE
bugfix(semantic): don't ICE on a Deref impl with the wrong number of associated types.

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/deref
+++ b/crates/cairo-lang-semantic/src/expr/test_data/deref
@@ -248,3 +248,47 @@ struct A {
 }
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Deref impl missing its associated type reports the trait-item mismatch instead of an ICE.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    let b = MyBox {};
+    b.get();
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+struct Inner {}
+
+#[derive(Drop)]
+struct MyBox {}
+
+// `type Target` is missing: resolving a method through the deref chain used to ICE.
+impl MyDeref of core::ops::Deref<MyBox> {
+    fn deref(self: MyBox) -> Inner {
+        Inner {}
+    }
+}
+
+//! > expected_diagnostics
+error[E0004]: Not all trait items are implemented. Missing: 'Target'.
+ --> lib.cairo:8:6
+impl MyDeref of core::ops::Deref<MyBox> {
+     ^^^^^^^
+
+error[E0002]: Method `get` could not be called on type `test::MyBox`.
+Candidate `core::array::ArrayTrait::get` inference failed with: Type mismatch: `test::MyBox` and `@core::array::Array::<?0>`.
+Candidate `core::array::SpanTrait::get` inference failed with: Type mismatch: `test::MyBox` and `core::array::Span::<?0>`.
+Candidate `core::dict::Felt252DictTrait::get` inference failed with: Type mismatch: `test::MyBox` and `core::dict::Felt252Dict::<?0>`.
+ --> lib.cairo:15:7
+    b.get();
+      ^^^

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -1092,17 +1092,13 @@ fn try_get_deref_func_and_target<'db>(
     }
     .intern(db);
 
-    let data = impl_definition_data(db, concrete_impl_id.impl_def_id(db)).clone().unwrap();
-    let mut types_iter = data.item_type_asts.iter();
-    let (impl_item_type_id, _) = types_iter.next().unwrap();
-    if types_iter.next().is_some() {
-        panic!(
-            "get_impl_based_on_single_impl_type called with an impl that has more than one type"
-        );
-    }
-    let ty = db.impl_type_def_resolved_type(*impl_item_type_id).unwrap();
+    let data = impl_definition_data(db, concrete_impl_id.impl_def_id(db)).maybe_as_ref()?;
+    let Ok((impl_item_type_id, _)) = data.item_type_asts.iter().exactly_one() else {
+        return Ok(None);
+    };
+    let ty = db.impl_type_def_resolved_type(*impl_item_type_id)?;
     let substitution: GenericSubstitution<'db> = concrete_impl_id.substitution(db)?;
-    let ty: TypeId<'db> = substitution.substitute(db, ty).unwrap();
+    let ty: TypeId<'db> = substitution.substitute(db, ty)?;
 
     Ok(Some((function_id, ty)))
 }


### PR DESCRIPTION
## Summary

When resolving method calls that walk the deref chain, `try_get_deref_func_and_target` previously used `unwrap()` calls that would panic (ICE) if a `Deref` impl was missing its associated `Target` type. The function now uses `?`-based error propagation and gracefully returns `None` when the impl definition data is unavailable or the associated type list does not contain exactly one entry.

A test case was added covering the scenario where a `Deref` impl omits `type Target`, verifying that the compiler emits a proper diagnostic (`Not all trait items are implemented. Missing: 'Target'.`) rather than crashing.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a `Deref` impl was written without the required `type Target` associated type, the compiler would ICE (internal compiler error / panic) instead of reporting a user-facing diagnostic. This made it impossible to get actionable feedback from the compiler in this situation.

---

## What was the behavior or documentation before?

Calling a method on a type whose `Deref` impl was missing `type Target` caused the compiler to panic with an unwrap failure inside `try_get_deref_func_and_target` while walking the deref chain.

---

## What is the behavior or documentation after?

The compiler now emits a proper `E0004` diagnostic (`Not all trait items are implemented. Missing: 'Target'.`) and continues to report method resolution failures normally, without crashing.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The fix replaces `unwrap()` calls with `?`-based propagation and uses `exactly_one()` to guard against unexpected numbers of associated types, returning `Ok(None)` in error cases so the caller can handle the missing deref target gracefully.