### PR TITLE
Stabilize ids in debug replacer

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/replace_ids.rs
+++ b/crates/cairo-lang-sierra-generator/src/replace_ids.rs
@@ -108,7 +108,12 @@ impl SierraIdReplacer for DebugReplacer<'_> {
     ) -> cairo_lang_sierra::ids::ConcreteTypeId {
         match self.db.lookup_concrete_type(id) {
             SierraGeneratorTypeLongId::Phantom(ty)
-            | SierraGeneratorTypeLongId::CycleBreaker(ty) => ty.format(self.db).into(),
+            | SierraGeneratorTypeLongId::CycleBreaker(ty) => {
+                cairo_lang_sierra::ids::ConcreteTypeId {
+                    id: id.id,
+                    debug_name: Some(ty.format(self.db).into()),
+                }
+            }
             SierraGeneratorTypeLongId::Regular(long_id) => {
                 let mut long_id = long_id.as_ref().clone();
                 self.replace_generic_args(&mut long_id.generic_args);


### PR DESCRIPTION
Before it generated id equal to a hash from name. It interfered with `SerializableTypeNamesDebugInfo::extract_type_names` (which was being called after debug replacing) which called `db.lookup_concrete_type` with id from `Program.type_declarations` causing a panic