### PR TITLE
bugfix(formatter): don't glue a comment to `{` in an empty block.

### DIFF
--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -1048,6 +1048,16 @@ impl<'a> FormatterImpl<'a> {
         // Format each child node, inserting breaks where specified.
         for (i, child) in children.iter().enumerate() {
             if child.width(self.db) == TextWidth::default() {
+                if child.kind(self.db) == SyntaxKind::StatementList
+                    && let Some(rbrace) = children.get(i + 1)
+                    && !self.has_only_whitespace_trivia(
+                        &ast::TerminalRBrace::from_syntax_node(self.db, *rbrace)
+                            .leading_trivia(self.db)
+                            .as_syntax_node(),
+                    )
+                {
+                    self.line_state.line_buffer.push_space();
+                }
                 continue;
             }
 

--- a/crates/cairo-lang-formatter/src/test.rs
+++ b/crates/cairo-lang-formatter/src/test.rs
@@ -17,6 +17,15 @@ use crate::{FormatterConfig, get_formatted_file};
     false
 )]
 #[test_case(
+    "test_data/cairo_files/empty_block_comment.cairo",
+    "test_data/expected_results/empty_block_comment.cairo",
+    false,
+    false,
+    false,
+    false,
+    false
+)]
+#[test_case(
     "test_data/cairo_files/linebreaking.cairo",
     "test_data/expected_results/linebreaking.cairo",
     false,
@@ -182,8 +191,14 @@ fn format_and_compare_file(
         .merge_use_items(Some(merge_use_statements))
         .allow_duplicate_uses(Some(allow_duplicate_uses));
 
-    let formatted_file = get_formatted_file(db, &syntax_root, config);
+    let formatted_file = get_formatted_file(db, &syntax_root, config.clone());
     let expected_file =
         fs::read_to_string(expected_filename).expect("Expected file does not exist.");
     assert_eq!(formatted_file, expected_file);
+
+    // Reformatting the formatted file should be a no-op.
+    let formatted_root =
+        db.parse_virtual(&formatted_file).expect("The formatted file failed parsing.");
+    let reformatted_file = get_formatted_file(db, &formatted_root, config);
+    assert_eq!(reformatted_file, formatted_file, "Formatting is not idempotent.");
 }

--- a/crates/cairo-lang-formatter/test_data/cairo_files/empty_block_comment.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/empty_block_comment.cairo
@@ -1,0 +1,14 @@
+fn empty_body() {
+    // just a comment
+}
+
+fn glued_in_input() {// no leading space in input
+}
+
+fn nested_in_loop() {
+    loop {
+        // comment in loop
+    }
+}
+
+fn comment_after_block() {} // comment after the block, not inside it.

--- a/crates/cairo-lang-formatter/test_data/expected_results/empty_block_comment.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/empty_block_comment.cairo
@@ -1,0 +1,12 @@
+fn empty_body() { // just a comment
+}
+
+fn glued_in_input() { // no leading space in input
+}
+
+fn nested_in_loop() {
+    loop { // comment in loop
+    }
+}
+
+fn comment_after_block() {} // comment after the block, not inside it.


### PR DESCRIPTION
## Summary

When an empty `StatementList` block body has a comment attached to the closing brace, the formatter was omitting the space between `{` and the comment, producing `{// comment` instead of `{ // comment`. A space is now inserted before the closing brace's trivia in this case, ensuring idempotent formatting.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

When a block body is empty (zero-width `StatementList`) and the closing `}` carries a leading comment in its trivia, the formatter skipped the empty node without inserting any space. This caused the comment to be glued directly to the opening brace (`{// comment`), which is both visually incorrect and non-idempotent — re-running the formatter on its own output would produce a different result.

---

## What was the behavior or documentation before?

An empty block with a comment on the closing brace was formatted as:

```cairo
fn glued_in_input() {// no leading space in input
}
```

---

## What is the behavior or documentation after?

The formatter now inserts a space before the comment, producing:

```cairo
fn glued_in_input() { // no leading space in input
}
```

This applies to all empty block bodies, including nested constructs like `loop { // comment in loop }`.

---

## Related issue or discussion (if any)

---

## Additional context

A new test case (`empty_block_comment.cairo`) covers three scenarios: a top-level empty function body with a comment, input that already lacks the leading space, and a nested `loop` block with a comment.