### PR TITLE
(feat): add structural-edit re-execution scenario to ls_reexec

### DIFF
--- a/tests/benches/ls_reexec.rs
+++ b/tests/benches/ls_reexec.rs
@@ -5,28 +5,26 @@
 //! re-lowered, all trait solutions re-solved), so these counts are the regression metric for
 //! incrementality fixes.
 //!
-//! Run with: `cargo bench --bench ls_reexec`. This is a criterion benchmark, so it runs as part of
-//! the normal suite and produces criterion's HTML report + run-to-run regression tracking under
-//! `target/criterion/ls_reexec/`. Rather than timing, it plugs a custom [`Measurement`] into
-//! criterion whose unit is *re-executed queries*: each iteration applies one trivia edit and
-//! rechecks diagnostics, and the measured value is the number of queries salsa re-ran (lower is
-//! better). Criterion records only the headline total, so the per-query breakdown is also printed
-//! to stdout.
+//! Run with: `cargo bench --bench ls_reexec`. Each scenario warms the database, applies one
+//! steady-state edit, counts re-executed queries (lower is better), prints a per-query breakdown,
+//! and writes `target/ls-reexec/ls-reexec-output.json` for the nightly gh-pages dashboard.
+//!
+//! There are also `structural edit (top)` / `(end)` scenarios (inserting one statement at the top
+//! vs the end of a large synthetic body), which the trivia scenarios can't cover since they never
+//! change tree structure.
 
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_compiler::project::setup_project;
-use cairo_lang_filesystem::db::FilesGroup;
-use cairo_lang_filesystem::ids::{CrateInput, FileLongId};
-use cairo_lang_filesystem::override_file_content;
+use cairo_lang_filesystem::db::{CrateConfiguration, FilesGroup};
+use cairo_lang_filesystem::ids::{CrateId, CrateInput, Directory, FileLongId, SmolStrId};
+use cairo_lang_filesystem::{override_file_content, set_crate_config};
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use criterion::Throughput;
-use criterion::measurement::{Measurement, ValueFormatter};
 use salsa::Database;
 
 mod common;
@@ -67,75 +65,6 @@ impl Sink {
     }
 }
 
-/// A criterion [`Measurement`] whose unit is the number of salsa queries re-executed, derived from
-/// the `executing query` tracing events captured into a shared [`Sink`]. `start` discards any
-/// pending events, the benchmark routine triggers the re-execution wave, and `end` counts the
-/// events produced since `start`.
-struct QueryExecutions {
-    sink: Sink,
-}
-
-impl Measurement for QueryExecutions {
-    type Intermediate = ();
-    type Value = u64;
-
-    fn start(&self) -> Self::Intermediate {
-        self.sink.clear();
-    }
-    fn end(&self, _i: Self::Intermediate) -> Self::Value {
-        self.sink.drain_counts().values().sum::<usize>() as u64
-    }
-    fn add(&self, v1: &Self::Value, v2: &Self::Value) -> Self::Value {
-        v1 + v2
-    }
-    fn zero(&self) -> Self::Value {
-        0
-    }
-    fn to_f64(&self, value: &Self::Value) -> f64 {
-        *value as f64
-    }
-    fn formatter(&self) -> &dyn ValueFormatter {
-        &QueryFormatter
-    }
-}
-
-/// Formats [`QueryExecutions`] values, scaling counts to `queries` / `Kqueries` / `Mqueries`.
-struct QueryFormatter;
-
-impl QueryFormatter {
-    fn scale(&self, typical: f64, values: &mut [f64]) -> &'static str {
-        let (factor, unit) = if typical < 1_000.0 {
-            (1.0, "queries")
-        } else if typical < 1_000_000.0 {
-            (1e-3, "Kqueries")
-        } else {
-            (1e-6, "Mqueries")
-        };
-        for v in values {
-            *v *= factor;
-        }
-        unit
-    }
-}
-
-impl ValueFormatter for QueryFormatter {
-    fn scale_values(&self, typical_value: f64, values: &mut [f64]) -> &'static str {
-        self.scale(typical_value, values)
-    }
-    fn scale_throughputs(
-        &self,
-        typical_value: f64,
-        _throughput: &Throughput,
-        values: &mut [f64],
-    ) -> &'static str {
-        // Throughput is not meaningful for this metric; just scale like a plain value.
-        self.scale(typical_value, values)
-    }
-    fn scale_for_machines(&self, _values: &mut [f64]) -> &'static str {
-        "queries"
-    }
-}
-
 fn check_diagnostics(db: &RootDatabase, inputs: &[CrateInput]) {
     DiagnosticsReporter::ignoring().with_crates(inputs).allow_warnings().check(db);
 }
@@ -147,6 +76,98 @@ fn apply_edit(db: &mut RootDatabase, inputs: &[CrateInput], path: &Path, orig: &
     let file_id = FileLongId::OnDisk(path.to_path_buf()).intern(db_mut);
     override_file_content!(db_mut, file_id, Some(format!("{orig}\n// edit {nonce}\n").into()));
     check_diagnostics(db, inputs);
+}
+
+/// Number of statements in the synthetic body — alternating name-keyed `let` and empty-`key_fields`
+/// expression statements, so it exercises both fixes.
+const STRUCTURAL_BODY_LEN: usize = 400;
+
+/// Overwrites the synthetic crate's file and re-runs diagnostics on it. This is the real analysis
+/// flow (semantic diagnostics walk the body via `get_children`).
+fn edit_and_check(db: &mut RootDatabase, input: &CrateInput, path: &Path, content: &str) {
+    {
+        let db_mut: &mut dyn Database = db;
+        let file_id = FileLongId::OnDisk(path.to_path_buf()).intern(db_mut);
+        override_file_content!(db_mut, file_id, Some(content.to_string().into()));
+    }
+    check_diagnostics(db, std::slice::from_ref(input));
+}
+
+/// Where a structural-edit scenario inserts its statement.
+#[derive(Clone, Copy)]
+enum InsertPos {
+    /// Before every statement: re-keys the following expression statements and shifts every offset.
+    Top,
+    /// After every statement: the control — nothing follows it, so ids and offsets are untouched.
+    End,
+}
+
+/// Synthetic crate + file contents for a structural-edit scenario.
+///
+/// Real project bodies are too small to surface this; diagnostics walks the body via
+/// `get_children`, so this uses the ordinary analysis flow.
+struct StructuralScenario {
+    input: CrateInput,
+    file_path: PathBuf,
+    without: String,
+    with: String,
+}
+
+impl StructuralScenario {
+    fn new(db: &mut RootDatabase, pos: InsertPos) -> Self {
+        let root = PathBuf::from("/ls_reexec_structural_bench");
+        let file_path = root.join("lib.cairo");
+        let body: String = (0..STRUCTURAL_BODY_LEN)
+            .map(|i| {
+                if i % 2 == 0 {
+                    format!("    let _v{i} = {i};\n") // name-keyed StatementLet
+                } else {
+                    format!("    {i} + {i};\n") // empty-key StatementExpr
+                }
+            })
+            .collect();
+        let without = format!("fn body() {{\n{body}}}\n");
+        // A `const` in statement position parses as a `StatementItem` — a *different* kind than
+        // the body's expression statements, with empty `key_fields` (its inner `ItemConstant` is
+        // name-keyed, but that sits below the statement level). Under the child-index bug a `Top`
+        // insert re-keys those exprs (they share the empty-key bucket); the fix keeps their
+        // per-kind index, so it does not.
+        let with = match pos {
+            InsertPos::Top => format!("fn body() {{\n    const _c: felt252 = 1;\n{body}}}\n"),
+            InsertPos::End => format!("fn body() {{\n{body}    const _c: felt252 = 1;\n}}\n"),
+        };
+
+        // Register a standalone single-file crate for the synthetic body. `crate_id` is re-derived
+        // after `set_crate_config` so its (immutable) borrow does not overlap the mutable config
+        // write.
+        let input = {
+            let db_mut: &mut dyn Database = db;
+            let crate_id =
+                CrateId::plain(db_mut, SmolStrId::from(db_mut, "ls_reexec_structural_bench"));
+            set_crate_config!(
+                db_mut,
+                crate_id,
+                Some(CrateConfiguration::default_for_root(Directory::Real(root)))
+            );
+            let crate_id =
+                CrateId::plain(db_mut, SmolStrId::from(db_mut, "ls_reexec_structural_bench"));
+            crate_id.long(db_mut).clone().into_crate_input(db_mut)
+        };
+
+        Self { input, file_path, without, with }
+    }
+
+    /// Warms the scenario, then applies one structural insert and returns the re-execution counts.
+    fn steady_state_edit(
+        &self,
+        db: &mut RootDatabase,
+        sink: &Sink,
+    ) -> OrderedHashMap<String, usize> {
+        edit_and_check(db, &self.input, &self.file_path, &self.without);
+        sink.clear();
+        edit_and_check(db, &self.input, &self.file_path, &self.with);
+        sink.drain_counts()
+    }
 }
 
 /// Number of top re-executed queries to print per scenario.
@@ -170,21 +191,30 @@ fn write_metrics_json(results: &[(&str, u64)]) {
     eprintln!("ls_reexec: wrote {}", path.display());
 }
 
-/// Prints the top re-executed queries for a scenario to stdout. Criterion records only the total,
-/// so this preserves the diagnostic detail: which queries dominate the re-execution wave.
+/// Prints the top re-executed queries for a scenario to stdout.
 fn print_breakdown(label: &str, counts: &OrderedHashMap<String, usize>) {
     let mut sorted: Vec<_> = counts.iter().collect();
     sorted.sort_by_key(|(_, c)| std::cmp::Reverse(**c));
     let total: usize = counts.values().sum();
     println!("\n== {label}: {total} query executions, {} distinct queries", counts.len());
-    println!(
-        "   (this total is the value recorded to the gh-pages dashboard: the first steady-state \
-         edit. Criterion's median below runs slightly lower, as it samples later, fully-warmed \
-         edits.)"
-    );
     for (name, c) in sorted.into_iter().take(TOP_QUERIES) {
         println!("{c:8}  {name}");
     }
+}
+
+fn run_trivia_scenario(
+    db: &mut RootDatabase,
+    sink: &Sink,
+    inputs: &[CrateInput],
+    path: &Path,
+) -> OrderedHashMap<String, usize> {
+    let orig = std::fs::read_to_string(path).unwrap();
+    // The first edit on a fresh DB pays one-time new-revision costs; the second reflects steady
+    // state.
+    apply_edit(db, inputs, path, &orig, 0);
+    sink.clear();
+    apply_edit(db, inputs, path, &orig, 1);
+    sink.drain_counts()
 }
 
 fn main() {
@@ -203,50 +233,35 @@ fn main() {
     check_diagnostics(&db, &inputs);
     sink.clear(); // Discard the one-time full-analysis events.
 
-    let scenarios = [
+    let mut results: Vec<(&str, u64)> = Vec::new();
+
+    for (label, pos) in
+        [("structural edit (top)", InsertPos::Top), ("structural edit (end)", InsertPos::End)]
+    {
+        let scenario = StructuralScenario::new(&mut db, pos);
+        let counts = scenario.steady_state_edit(&mut db, &sink);
+        let total: usize = counts.values().sum();
+        assert!(
+            total > 0,
+            "no `executing query` events for {label:?}; salsa tracing capture is broken"
+        );
+        results.push((label, total as u64));
+        print_breakdown(label, &counts);
+    }
+
+    for (label, path) in [
         ("contract trivia edit", config.path.join("contracts/hello_starknet.cairo")),
         ("plain trivia edit", config.path.join("utils.cairo")),
-    ];
-
-    let mut criterion = criterion::Criterion::default()
-        .with_measurement(QueryExecutions { sink: sink.clone() })
-        .configure_from_args();
-    let mut group = criterion.benchmark_group("ls_reexec");
-    group.sample_size(10);
-    let mut results: Vec<(&str, u64)> = Vec::new();
-    for (label, path) in &scenarios {
-        let orig = std::fs::read_to_string(path).unwrap();
-        let mut nonce: u64 = 0;
-        // The first edit on a fresh DB pays one-time new-revision costs; the second reflects steady
-        // state. Warm up with one edit (discarded), then capture the steady-state breakdown once.
-        apply_edit(&mut db, &inputs, path, &orig, nonce);
-        nonce += 1;
-        sink.clear();
-        apply_edit(&mut db, &inputs, path, &orig, nonce);
-        nonce += 1;
-        let steady = sink.drain_counts();
-        let total: usize = steady.values().sum();
-        // A content-changing edit always re-runs at least the parse/file queries, so an empty
-        // capture means the salsa tracing pipeline broke (e.g. event format or level drift). Fail
-        // loudly rather than recording 0, which criterion would silently drop from the report.
+    ] {
+        let counts = run_trivia_scenario(&mut db, &sink, &inputs, &path);
+        let total: usize = counts.values().sum();
         assert!(
             total > 0,
             "no `executing query` events captured for {label:?}; salsa tracing capture is broken"
         );
-        results.push((*label, total as u64));
-        print_breakdown(label, &steady);
-
-        // Each iteration applies one steady-state edit; the measurement counts the queries it
-        // re-executes. Criterion paces iterations by its own wall-clock, so the per-edit cost is
-        // bounded even though the recorded metric is a query count.
-        group.bench_function(*label, |b| {
-            b.iter(|| {
-                apply_edit(&mut db, &inputs, path, &orig, nonce);
-                nonce += 1;
-            });
-        });
+        results.push((label, total as u64));
+        print_breakdown(label, &counts);
     }
-    group.finish();
-    criterion.final_summary();
+
     write_metrics_json(&results);
 }


### PR DESCRIPTION
## Summary

Adds a structural-edit re-execution scenario to the `ls_reexec` benchmark, and simplifies the bench to one-shot steady-state measurements (dropping criterion).

Previously `ls_reexec` only exercised trivia keystrokes, which never change tree structure. This adds scenarios that insert one `const` statement at the top vs. the end of a large synthetic body and measure the syntax-query re-execution such an edit forces. A `const` is used (rather than e.g. `return;`) so the insert does not change the reachability of the rest of the body, keeping the two variants semantically comparable; in statement position it is a `StatementItem` — empty `key_fields`, a different kind than the body's expression statements.

These scenarios are the regression metric for the child-index and relative-offset fixes stacked on top of this PR (#10190, #10191).

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The existing `ls_reexec` bench only measured trivia keystrokes, which never change tree structure, so it could not observe re-execution caused by structural edits. Without a structural-edit metric, the child-index and relative-offset fixes (#10190, #10191) have no benchmark to demonstrate their effect or to guard against regression.

The top insert is currently dominated by offset-driven re-execution: `get_children` reads a node's offset, so it re-executes for the whole tail regardless of node-id stability (4139 executions vs. 1920 for the end-insert control).

---

## What was the behavior or documentation before?

`ls_reexec` exercised only trivia keystrokes and used criterion for repeated sampling, adding minutes of runtime. The recorded metric (queries re-executed per steady-state edit) was already the one-shot count, so criterion's repeated sampling added nothing to what the dashboard records.

---

## What is the behavior or documentation after?

New top-insert and end-insert `const`-statement scenarios measure syntax-query re-execution per structural edit. The bench is simplified to one-shot steady-state measurements: each scenario warms once, measures one edit, prints its per-query breakdown, and writes the same dashboard JSON — without criterion.

---

## Related issue or discussion (if any)

Part of a stack with #10190 (child-index-by-kind fix) and #10191 (relative offsets).

---

## Additional context

The top-insert scenario is the regression metric for the two fixes stacked above it.
