### PR TITLE
(bug fix): key syntax node child index by kind for stable node ids

### DIFF
--- a/crates/cairo-lang-defs/src/cache/mod.rs
+++ b/crates/cairo-lang-defs/src/cache/mod.rs
@@ -1721,16 +1721,12 @@ enum SyntaxNodeIdCached {
 }
 
 impl SyntaxNodeIdCached {
-    fn new<'db>(
-        ctx: &mut DefCacheSavingContext<'db>,
-        id: &SyntaxNodeId<'db>,
-        syntax_node: SyntaxNode<'db>,
-    ) -> Self {
+    fn new<'db>(ctx: &mut DefCacheSavingContext<'db>, id: &SyntaxNodeId<'db>) -> Self {
         match id {
             SyntaxNodeId::Root(file_id) => Self::Root(FileIdCached::new(*file_id, ctx)),
-            SyntaxNodeId::Child { parent, key_fields, index } => Self::Child {
+            SyntaxNodeId::Child { parent, kind, key_fields, index } => Self::Child {
                 parent: SyntaxNodeCached::new(*parent, ctx),
-                kind: syntax_node.kind(ctx.db),
+                kind: *kind,
                 key_fields: key_fields.into_iter().map(|id| GreenIdCached::new(*id, ctx)).collect(),
                 index: *index,
             },
@@ -1766,7 +1762,7 @@ impl SyntaxNodeCached {
         let green = syntax_node.green_node(db);
         GreenIdCached::new(green.clone().intern(db), ctx);
 
-        let id = SyntaxNodeIdCached::new(ctx, syntax_node.raw_id(db), syntax_node);
+        let id = SyntaxNodeIdCached::new(ctx, syntax_node.raw_id(db));
         let cached_node = SyntaxNodeCached(ctx.syntax_node_lookup.len());
         ctx.syntax_node_lookup.push(id);
         ctx.syntax_nodes.insert(syntax_node, cached_node);
@@ -1797,12 +1793,12 @@ impl SyntaxNodeCached {
                 let children = parent_node.get_children(ctx.db);
                 // For each child, create the cached syntax node ID and insert into syntax_nodes map
                 for child in children {
-                    let SyntaxNodeId::Child { index, key_fields, .. } = child.raw_id(ctx.db) else {
+                    let SyntaxNodeId::Child { kind, index, key_fields, .. } = child.raw_id(ctx.db)
+                    else {
                         panic!("Unexpected SyntaxNodeId type root when creating child");
                     };
-                    let kind = child.kind(ctx.db);
                     let Some(child_id) =
-                        SyntaxNodeIdCached::from_raw(ctx, *parent, kind, *index, key_fields)
+                        SyntaxNodeIdCached::from_raw(ctx, *parent, *kind, *index, key_fields)
                     else {
                         continue;
                     };

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -40,6 +40,9 @@ pub enum SyntaxNodeId<'db> {
     Child {
         /// Parent of this node, either another node or if node is root, its file id.
         parent: SyntaxNode<'db>,
+        /// The kind of this node. Part of the identity, as `index` below counts occurrences
+        /// per `(parent, kind, key_fields)`.
+        kind: SyntaxKind,
         /// Chronological index among all nodes with the same (parent, kind, key_fields).
         index: usize,
         /// Which fields are used is determined by each SyntaxKind.
@@ -348,14 +351,14 @@ impl<'a> SyntaxNode<'a> {
             let key_fields: &'a [GreenId<'a>] = &green.children()[rng];
             let index = key_map
                 .iter_mut()
-                .find(|(k, _v)| *k == key_fields)
+                .find(|(k, _v)| *k == (kind, key_fields))
                 .map(|(_k, v)| {
                     let index = *v;
                     *v += 1;
                     index
                 })
                 .unwrap_or_else(|| {
-                    key_map.push((key_fields, 1));
+                    key_map.push(((kind, key_fields), 1));
                     0
                 });
             // Create the SyntaxNode view for the child.
@@ -363,7 +366,12 @@ impl<'a> SyntaxNode<'a> {
                 db,
                 *green_id,
                 offset,
-                SyntaxNodeId::Child { parent: *self, index, key_fields: Box::from(key_fields) },
+                SyntaxNodeId::Child {
+                    parent: *self,
+                    kind,
+                    index,
+                    key_fields: Box::from(key_fields),
+                },
                 kind,
             ));
 


### PR DESCRIPTION
## Summary

Restores `kind` to both the child-occurrence counter and `SyntaxNodeId::Child`, so a node's stable id no longer shifts when a different-kind sibling is inserted or removed.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`SyntaxNodeId::Child`'s per-sibling index is part of a node's salsa identity. #9555 dropped `kind` from the key used to count child occurrences, so siblings of different kinds sharing (usually empty) `key_fields` were counted together — contradicting the documented per-`(parent, kind, key_fields)` invariant.

As a result, inserting or removing a different-kind sibling shifts an unchanged node's index, churning its stable id and defeating salsa early cutoff. The wasted re-execution scales with list size.

---

## What was the behavior or documentation before?

Child occurrences were counted by `(parent, key_fields)` only. Siblings of different kinds with the same (empty) `key_fields` shared a counter, so an unchanged node's index — and thus its `SyntaxNodeId` — could shift when a different-kind sibling was added or removed, invalidating its salsa cutoff.

---

## What is the behavior or documentation after?

`kind` is part of the occurrence counter and of `SyntaxNodeId::Child` again, matching the documented per-`(parent, kind, key_fields)` invariant. A node's stable id is now unaffected by insertion/removal of different-kind siblings.

---

## Related issue or discussion (if any)

Regression from #9555. Part of a stack with #10189 (regression benchmark) and #10191 (relative offsets, which depends on these stable ids to be effective).

---

## Additional context

Measured on the `ls_reexec` structural-edit scenario added in #10189.
