### PR TITLE
(refactor): move crate_modules_including_generated out of the cache module

### DIFF
--- a/crates/cairo-lang-lowering/src/cache/mod.rs
+++ b/crates/cairo-lang-lowering/src/cache/mod.rs
@@ -22,13 +22,14 @@ use cairo_lang_semantic::cache::{
     ConcreteEnumCached, ConcreteVariantCached, ConstValueIdCached, ExprVarMemberPathCached,
     ImplIdCached, MatchArmSelectorCached, SEMANTIC_CACHE_SECTION, SemanticCacheLoadingData,
     SemanticCacheSavingContext, SemanticCacheSavingData, SemanticConcreteFunctionWithBodyCached,
-    SemanticFunctionIdCached, TypeIdCached, all_crate_modules_for_cache, generate_crate_def_cache,
+    SemanticFunctionIdCached, TypeIdCached, generate_crate_def_cache,
     generate_crate_semantic_cache,
 };
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::expr::inference::InferenceError;
 use cairo_lang_semantic::items::function_with_body::FunctionWithBodySemantic;
 use cairo_lang_semantic::items::imp::ImplSemantic;
+use cairo_lang_semantic::items::macro_call::crate_modules_including_generated;
 use cairo_lang_semantic::items::trt::TraitSemantic;
 use cairo_lang_semantic::types::TypeInfo;
 use cairo_lang_syntax::node::TypedStablePtr;
@@ -113,7 +114,7 @@ pub fn generate_crate_cache<'db>(
     crate_id: CrateId<'db>,
 ) -> Result<Vec<u8>, CrateCacheError> {
     let mut function_ids = Vec::new();
-    for module_id in all_crate_modules_for_cache(db, crate_id) {
+    for module_id in crate_modules_including_generated(db, crate_id) {
         for free_func in db.module_free_functions_ids(module_id)?.iter() {
             function_ids.push(FunctionWithBodyId::Free(*free_func));
         }

--- a/crates/cairo-lang-semantic/src/cache/mod.rs
+++ b/crates/cairo-lang-semantic/src/cache/mod.rs
@@ -12,7 +12,7 @@ use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::diagnostic_utils::StableLocation;
 use cairo_lang_defs::ids::{
     EnumLongId, ExternFunctionLongId, ExternTypeLongId, FreeFunctionLongId, ImplFunctionLongId,
-    LocalVarId, LocalVarLongId, MemberLongId, ModuleId, ParamId, ParamLongId, StatementConstLongId,
+    LocalVarId, LocalVarLongId, MemberLongId, ParamId, ParamLongId, StatementConstLongId,
     StatementItemId, StatementUseLongId, StructLongId, TraitConstantId, TraitConstantLongId,
     TraitFunctionLongId, TraitImplId, TraitImplLongId, TraitLongId, TraitTypeId, TraitTypeLongId,
     VarId, VariantLongId,
@@ -47,7 +47,7 @@ use crate::items::imp::{
     NegativeImplId, NegativeImplLongId,
 };
 use crate::items::impl_alias::ImplAliasSemantic;
-use crate::items::macro_call::MacroCallSemantic;
+use crate::items::macro_call::crate_modules_including_generated;
 use crate::items::module::{ModuleItemInfo, ModuleSemantic, ModuleSemanticData};
 use crate::items::trt::ConcreteTraitGenericFunctionLongId;
 use crate::items::visibility::Visibility;
@@ -116,7 +116,7 @@ pub fn generate_crate_def_cache<'db>(
     ctx: &mut DefCacheSavingContext<'db>,
 ) -> Maybe<CrateDefCache<'db>> {
     Ok(CrateDefCache::new(
-        all_crate_modules_for_cache(db, crate_id)
+        crate_modules_including_generated(db, crate_id)
             .into_iter()
             .map(|module_id| {
                 Ok((
@@ -142,7 +142,7 @@ pub fn generate_crate_semantic_cache<'db>(
     crate_id: CrateId<'db>,
     ctx: &mut SemanticCacheSavingContext<'db>,
 ) -> Maybe<CrateSemanticCache> {
-    let all_modules = all_crate_modules_for_cache(ctx.db, crate_id);
+    let all_modules = crate_modules_including_generated(ctx.db, crate_id);
 
     let modules_data = all_modules
         .iter()
@@ -1981,24 +1981,4 @@ impl ConcreteTraitCached {
         };
         long_id.intern(db)
     }
-}
-
-/// Returns all modules reachable from the crate root, following both submodule and macro call
-/// edges. This ensures that submodules nested inside MacroCall modules are included.
-pub fn all_crate_modules_for_cache<'db>(
-    db: &'db dyn Database,
-    crate_id: CrateId<'db>,
-) -> Vec<ModuleId<'db>> {
-    let mut result = vec![ModuleId::CrateRoot(crate_id)];
-    let mut unprocessed = 0;
-    while let Some(module_id) = result.get(unprocessed).copied() {
-        unprocessed += 1;
-        if let Ok(submodule_ids) = db.module_submodules_ids(module_id) {
-            result.extend(submodule_ids.iter().map(|id| ModuleId::Submodule(*id)));
-        }
-        if let Ok(macro_calls) = db.module_macro_calls_ids(module_id) {
-            result.extend(macro_calls.iter().flat_map(|id| db.macro_call_module_id(*id)));
-        }
-    }
-    result
 }

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -4,7 +4,7 @@ use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{LanguageElementId, MacroCallId, ModuleId};
 use cairo_lang_diagnostics::{Diagnostics, Maybe, skip_diagnostic};
 use cairo_lang_filesystem::ids::{
-    CodeMapping, CodeOrigin, FileKind, FileLongId, SmolStrId, VirtualFile,
+    CodeMapping, CodeOrigin, CrateId, FileKind, FileLongId, SmolStrId, VirtualFile,
 };
 use cairo_lang_filesystem::span::{TextOffset, TextSpan};
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
@@ -329,6 +329,26 @@ pub fn module_macro_modules<'db>(
         }
     }
     modules
+}
+
+/// Returns all modules reachable from the crate root, following both submodule and macro call
+/// edges. This ensures that submodules nested inside MacroCall modules are included.
+pub fn crate_modules_including_generated<'db>(
+    db: &'db dyn Database,
+    crate_id: CrateId<'db>,
+) -> Vec<ModuleId<'db>> {
+    let mut result = vec![ModuleId::CrateRoot(crate_id)];
+    let mut unprocessed = 0;
+    while let Some(module_id) = result.get(unprocessed).copied() {
+        unprocessed += 1;
+        if let Ok(submodule_ids) = db.module_submodules_ids(module_id) {
+            result.extend(submodule_ids.iter().map(|id| ModuleId::Submodule(*id)));
+        }
+        if let Ok(macro_calls) = db.module_macro_calls_ids(module_id) {
+            result.extend(macro_calls.iter().flat_map(|id| db.macro_call_module_id(*id)));
+        }
+    }
+    result
 }
 
 /// Trait for macro call-related semantic queries.

--- a/crates/cairo-lang-sierra-generator/src/executables.rs
+++ b/crates/cairo-lang-sierra-generator/src/executables.rs
@@ -3,7 +3,7 @@ use cairo_lang_defs::plugin::MacroPlugin;
 use cairo_lang_diagnostics::ToOption;
 use cairo_lang_filesystem::ids::{CrateId, SmolStrId};
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
-use cairo_lang_semantic::cache::all_crate_modules_for_cache;
+use cairo_lang_semantic::items::macro_call::crate_modules_including_generated;
 use cairo_lang_sierra::ids::FunctionId;
 use cairo_lang_sierra::program::Program;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
@@ -41,7 +41,7 @@ pub fn find_executable_function_ids<'db>(
             continue;
         }
 
-        for module in all_crate_modules_for_cache(db, crate_id) {
+        for module in crate_modules_including_generated(db, crate_id) {
             if let Some(free_functions) =
                 module.module_data(db).map(|data| data.free_functions(db)).to_option()
             {


### PR DESCRIPTION
## Summary

Moves `all_crate_modules_for_cache` from `cairo-lang-semantic/src/cache/mod.rs` to `cairo-lang-semantic/src/items/macro_call.rs`, renaming it to `crate_modules_including_generated`. All call sites in the cache modules and the Sierra generator's executable finder are updated to import and use the function from its new location.

---

## Type of change

Please check **one**:

- [x] New feature
- [ ] Bug fix (fixes incorrect behavior)
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The function that traverses all modules reachable from a crate root (including those generated by macro calls) was previously defined in the cache module, making it inaccessible to non-cache consumers without pulling in cache-related dependencies. The Sierra generator's `find_executable_function_ids` also needed this traversal, but was importing it from the cache module — a conceptually incorrect dependency. Placing the function in `macro_call.rs` alongside the macro call semantics it relies on makes the ownership clearer and allows broader reuse.

---

## What was the behavior or documentation before?

`all_crate_modules_for_cache` was defined in `cairo-lang-semantic::cache` and exported from there. The Sierra generator imported it from that location.

---

## What is the behavior or documentation after?

The function is now named `crate_modules_including_generated` and lives in `cairo-lang-semantic::items::macro_call`. All consumers — the def cache, semantic cache, lowering cache, and Sierra generator — import it from its new location.

---

## Related issue or discussion (if any)

---

## Additional context

The rename from `all_crate_modules_for_cache` to `crate_modules_including_generated` better reflects the function's purpose: it is not specific to caching, but rather returns all modules reachable from a crate root including those generated by macro calls.