### PR TITLE
docs(corelib): fix three doc-comment examples

### DIFF
--- a/corelib/src/ops/function.cairo
+++ b/corelib/src/ops/function.cairo
@@ -27,9 +27,9 @@
 /// `FnOnce` is implemented automatically by closures that might consume captured
 /// variables.
 ///
-/// ```
 /// # Examples
 ///
+/// ```
 /// fn consume_with_relish<
 ///     F, O, +Drop<F>, +core::ops::FnOnce<F, ()>[Output: O], +core::fmt::Display<O>, +Drop<O>,
 /// >(
@@ -48,6 +48,7 @@
 ///   let consume_and_return_x = || x;
 ///   consume_with_relish(consume_and_return_x);
 ///   // `consume_and_return_x` can no longer be invoked at this point
+/// ```
 pub trait FnOnce<T, Args> {
     /// The returned type after the call operator is used.
     type Output;

--- a/corelib/src/option.cairo
+++ b/corelib/src/option.cairo
@@ -860,7 +860,7 @@ impl TIntoOption<T> of Into<T, Option<T>> {
     /// # Examples
     ///
     /// ```
-    /// let o: Option<u8> = 67_u8.into()
+    /// let o: Option<u8> = 67_u8.into();
     /// assert_eq!(Some(67), o);
     /// ```
     #[inline]

--- a/corelib/src/zeroable.cairo
+++ b/corelib/src/zeroable.cairo
@@ -19,7 +19,7 @@ pub(crate) trait Zeroable<T> {
     /// # Examples
     ///
     /// ```
-    /// assert!(Zeroable::<i32>::zero() == 0);
+    /// assert!(Zeroable::<u32>::zero() == 0);
     /// ```
     #[must_use]
     fn zero() -> T;


### PR DESCRIPTION
## Summary

Fixes three small documentation bugs in the corelib:

- **`ops/function.cairo`**: Corrects a misplaced code fence in the `FnOnce` doc comment. The opening ` ``` ` was placed before the `# Examples` header instead of after it, and the closing ` ``` ` was missing entirely.
- **`option.cairo`**: Adds a missing semicolon at the end of the `let o: Option<u8> = 67_u8.into()` statement in the `TIntoOption` example.
- **`zeroable.cairo`**: Fixes the type used in the `Zeroable::zero` example from `i32` to `u32`, matching the trait's typical usage with unsigned integers.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `FnOnce` doc comment had a malformed code block that would render incorrectly in generated documentation. The `option.cairo` example had a syntax error (missing semicolon) that would fail if executed. The `zeroable.cairo` example referenced `i32`, which is inconsistent with the unsigned integer context typically associated with `Zeroable`.

---

## What was the behavior or documentation before?

- `FnOnce`: The ` ``` ` opening fence appeared before `# Examples`, and the closing fence was absent, causing the entire example to render as a broken code block.
- `TIntoOption`: The example statement `67_u8.into()` lacked a terminating semicolon.
- `Zeroable::zero`: The example used `Zeroable::<i32>::zero()`.

---

## What is the behavior or documentation after?

- `FnOnce`: The code fence is correctly placed after `# Examples`, and the closing fence is present.
- `TIntoOption`: The example statement is syntactically valid with a semicolon.
- `Zeroable::zero`: The example uses `Zeroable::<u32>::zero()`.

---

## Related issue or discussion (if any)

None.

---

## Additional context

None.