### PR TITLE
fix(semantic): don't ICE when an impl provides an associated item of the wrong kind

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/impl
+++ b/crates/cairo-lang-semantic/src/expr/test_data/impl
@@ -47,3 +47,68 @@ error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with
  --> lib.cairo:7:28
     fn foo(x: T, y: u8, z: u16) -> T {}
                            ^^^
+
+//! > ==========================================================================
+
+//! > Impl provides associated type/const/impl items each with the wrong kind (cross-kind collision).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() -> MyImpl::AsType {
+    let _c = MyImpl::AsConst;
+    MyImpl::AsImpl::method(0)
+}
+
+//! > function_name
+foo
+
+//! > module_code
+trait OtherTrait<T> {
+    fn method(x: T) -> T;
+}
+
+impl OtherImpl of OtherTrait<felt252> {
+    fn method(x: felt252) -> felt252 {
+        x
+    }
+}
+
+trait MyTrait {
+    type AsType;
+    const AsConst: felt252;
+    impl AsImpl: OtherTrait<felt252>;
+}
+
+impl MyImpl of MyTrait {
+    const AsType: felt252 = 5;
+    type AsConst = felt252;
+    type AsImpl = felt252;
+}
+
+//! > expected_diagnostics
+error[E2014]: Impl item type `MyImpl::AsConst` is not a member of trait `MyTrait`.
+ --> lib.cairo:19:5
+    type AsConst = felt252;
+    ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2014]: Impl item type `MyImpl::AsImpl` is not a member of trait `MyTrait`.
+ --> lib.cairo:20:5
+    type AsImpl = felt252;
+    ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2014]: Impl item const `MyImpl::AsType` is not a member of trait `MyTrait`.
+ --> lib.cairo:18:5
+    const AsType: felt252 = 5;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2311]: Trait has no implementation in context: test::MyTrait.
+ --> lib.cairo:22:1
+fn foo() -> MyImpl::AsType {
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2042]: Unexpected return type. Expected: "test::MyImpl::AsType", found: "core::felt252".
+ --> lib.cairo:24:5
+    MyImpl::AsImpl::method(0)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -28,7 +28,7 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
-use cairo_lang_utils::{Intern, define_short_id, extract_matches};
+use cairo_lang_utils::{Intern, define_short_id, extract_matches, try_extract_matches};
 use itertools::{Itertools, chain, izip};
 use salsa::Database;
 use syntax::attribute::structured::{Attribute, AttributeListStructurize};
@@ -1288,13 +1288,10 @@ fn impl_type_by_trait_type<'db>(
              trait"
         )
     }
-
-    let name = trait_type_id.name(db);
     // If the trait type's name is not found, then a missing item diagnostic is reported.
-    db.impl_item_by_name(impl_def_id, name).and_then(|maybe_item_id| match maybe_item_id {
-        Some(item_id) => Ok(extract_matches!(item_id, ImplItemId::Type)),
-        None => Err(skip_diagnostic()),
-    })
+    db.impl_item_by_name(impl_def_id, trait_type_id.name(db))?
+        .and_then(|item_id| try_extract_matches!(item_id, ImplItemId::Type))
+        .ok_or_else(skip_diagnostic)
 }
 
 /// Query implementation of [ImplSemantic::impl_type_by_trait_type].
@@ -1320,13 +1317,10 @@ fn impl_constant_by_trait_constant<'db>(
              the impl's trait"
         )
     }
-
-    let name = trait_constant_id.name(db);
     // If the trait constant's name is not found, then a missing item diagnostic is reported.
-    db.impl_item_by_name(impl_def_id, name).and_then(|maybe_item_id| match maybe_item_id {
-        Some(item_id) => Ok(extract_matches!(item_id, ImplItemId::Constant)),
-        None => Err(skip_diagnostic()),
-    })
+    db.impl_item_by_name(impl_def_id, trait_constant_id.name(db))?
+        .and_then(|item_id| try_extract_matches!(item_id, ImplItemId::Constant))
+        .ok_or_else(skip_diagnostic)
 }
 
 /// Query implementation of [PrivImplSemantic::impl_impl_by_id].
@@ -1352,13 +1346,10 @@ fn impl_impl_by_trait_impl<'db>(
              trait"
         )
     }
-
-    let name = trait_impl_id.name(db);
     // If the trait impl's name is not found, then a missing item diagnostic is reported.
-    db.impl_item_by_name(impl_def_id, name).and_then(|maybe_item_id| match maybe_item_id {
-        Some(item_id) => Ok(extract_matches!(item_id, ImplItemId::Impl)),
-        None => Err(skip_diagnostic()),
-    })
+    db.impl_item_by_name(impl_def_id, trait_impl_id.name(db))?
+        .and_then(|item_id| try_extract_matches!(item_id, ImplItemId::Impl))
+        .ok_or_else(skip_diagnostic)
 }
 
 /// Query implementation of [PrivImplSemantic::is_implicit_impl_impl].


### PR DESCRIPTION
## Summary

When an impl provides an associated item with the wrong kind (e.g., a `const` where a `type` is expected, or a `type` where an `impl` is expected), the compiler previously panicked via `extract_matches!` instead of emitting a proper diagnostic. This PR replaces those panicking `extract_matches!` calls with `try_extract_matches!` in `impl_type_by_trait_type`, `impl_constant_by_trait_constant`, and `impl_impl_by_trait_impl`, so that a mismatched-kind item is treated as "not found" and a graceful `skip_diagnostic` error is returned instead.

A new test case is added covering cross-kind collisions where `MyImpl` provides a `const AsType`, `type AsConst`, and `type AsImpl` against a trait expecting a `type AsType`, `const AsConst`, and `impl AsImpl`, verifying that appropriate `E2014` diagnostics are emitted for each mismatched item.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When an impl supplies an associated item under the correct name but the wrong kind (e.g., a `const` instead of a `type`), the lookup functions assumed the item would always match the expected `ImplItemId` variant and called `extract_matches!`, which panics on a mismatch. This caused a compiler crash rather than a user-facing diagnostic.

---

## What was the behavior or documentation before?

The compiler panicked when an impl item's name matched a trait item but the kinds differed (e.g., `const Foo` provided where `type Foo` was expected).

---

## What is the behavior or documentation after?

The compiler now emits an `E2014` diagnostic ("Impl item `<kind>` `<name>` is not a member of trait `<trait>`") for each cross-kind collision and continues compilation without crashing.

---

## Related issue or discussion (if any)

None.

---

## Additional context

The refactor also simplifies the lookup logic by chaining `?`, `and_then`, and `ok_or_else` instead of nested `match` blocks.