### PR TITLE
fix(semantic): report every invalid associated-item constraint, not just the first

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/generics
+++ b/crates/cairo-lang-semantic/src/expr/test_data/generics
@@ -754,3 +754,41 @@ error[E2038]: Generic parameter kind of impl function `FooImpl::bar` is incompat
  --> lib.cairo:5:12
     fn bar<+Drop<felt252>>(self: felt252) {}
            ^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Multiple invalid associated-item constraints are each reported (not just the first).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+trait MyTrait<T> {
+    type Real;
+}
+
+fn bar<T, +MyTrait<T>[Bogus1: u8, Bogus2: u16]>() {}
+
+//! > crate_settings
+edition = "2024_07"
+
+[experimental_features]
+negative_impls = false
+associated_item_constraints = true
+
+//! > expected_diagnostics
+error[E2189]: associated type `Bogus1` not found for `MyTrait`
+ --> lib.cairo:5:23
+fn bar<T, +MyTrait<T>[Bogus1: u8, Bogus2: u16]>() {}
+                      ^^^^^^^^^^
+
+error[E2189]: associated type `Bogus2` not found for `MyTrait`
+ --> lib.cairo:5:35
+fn bar<T, +MyTrait<T>[Bogus1: u8, Bogus2: u16]>() {}
+                                  ^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -713,7 +713,7 @@ fn impl_generic_param_semantic<'db>(
                             concrete_trait_id,
                         },
                     );
-                    return map;
+                    continue;
                 };
 
                 let concrete_trait_type_id =


### PR DESCRIPTION
## Summary

When processing associated-item constraints on a generic parameter, a `return` statement caused the loop to exit early after encountering the first invalid associated type, silently dropping any subsequent constraint errors. Replacing `return map` with `continue` allows the loop to keep processing remaining constraints and emit a diagnostic for each invalid one.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a generic bound included multiple invalid associated-item constraints (e.g., `+MyTrait<T>[Bogus1: u8, Bogus2: u16]`), only the first unknown associated type was reported. The early `return` prevented the remaining constraints from being validated, leaving subsequent errors silently ignored.

---

## What was the behavior or documentation before?

Only the first invalid associated type in a constraint list would produce a diagnostic. Any further invalid constraints in the same bound were silently skipped.

---

## What is the behavior or documentation after?

Every invalid associated type in a constraint list produces its own diagnostic. For example, both `Bogus1` and `Bogus2` in `+MyTrait<T>[Bogus1: u8, Bogus2: u16]` are now reported as unknown associated types.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A new test case was added to `generics` test data to verify that all invalid associated-item constraints are reported independently rather than stopping at the first failure.