### PR TITLE
fix(semantic): report a glob name collision of non-visible items as not-visible, not ambiguous

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -707,9 +707,14 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 "`super` used in macro call top level.".into()
             }
             SemanticDiagnosticKind::ItemNotVisible(item_id, containing_modules) => {
+                // Several distinct items may share the name when reached through global uses; in
+                // that case no single item can be pointed at, so it is reported without a name.
+                let item = match item_id {
+                    Some(item_id) => format!("Item `{}`", item_id.full_path(db)),
+                    None => "Item".to_string(),
+                };
                 format!(
-                    "Item `{}` is not visible in this context{}.",
-                    item_id.full_path(db),
+                    "{item} is not visible in this context{}.",
                     if containing_modules.is_empty() {
                         "".to_string()
                     } else if let [module_id] = &containing_modules[..] {
@@ -1737,7 +1742,7 @@ pub enum SemanticDiagnosticKind<'db> {
     ImplItemForbiddenInTheImpl,
     SuperUsedInRootModule,
     SuperUsedInMacroCallTopLevel,
-    ItemNotVisible(ModuleItemId<'db>, Vec<ModuleId<'db>>),
+    ItemNotVisible(Option<ModuleItemId<'db>>, Vec<ModuleId<'db>>),
     UnusedImport(UseId<'db>),
     RedundantModifier {
         current_modifier: SmolStrId<'db>,

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -1617,3 +1617,37 @@ error[E0005]: Module file not found. Expected path: non_existent_path.cairo
  _^
 | mod non_existing;
 |_________________^
+
+//! > ==========================================================================
+
+//! > Testing use star with only invisible candidates.
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: true)
+
+//! > crate_settings
+edition = "2024_07"
+
+//! > module_code
+mod a {
+    const AMBIGUOUS: u8 = 1;
+}
+
+mod b {
+    const AMBIGUOUS: u8 = 4;
+}
+use a::*;
+use b::*;
+
+//! > function_body
+
+//! > expr_code
+AMBIGUOUS
+
+//! > expected_semantics
+
+//! > expected_diagnostics
+error[E2099]: Item is not visible in this context through any of the modules: `test::a`, `test::b`.
+ --> lib.cairo:11:1
+AMBIGUOUS
+^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -367,7 +367,7 @@ enum UseStarResult<'db> {
     /// The path was not found, considering only the `use *` imports.
     PathNotFound,
     /// Item is not visible in the current module, considering only the `use *` imports.
-    ItemNotVisible(ModuleItemId<'db>, Vec<ModuleId<'db>>),
+    ItemNotVisible(Option<ModuleItemId<'db>>, Vec<ModuleId<'db>>),
 }
 
 /// A trait for things that can be interpreted as a path of segments.
@@ -775,7 +775,9 @@ impl<'db> Resolver<'db> {
     ) -> UseStarResult<'db> {
         let mut item_info = None;
         let mut module_items_found: OrderedHashSet<ModuleItemId<'_>> = OrderedHashSet::default();
-        let mut other_containing_modules = vec![];
+        let mut non_pub_module_items_found: OrderedHashSet<ModuleItemId<'_>> =
+            OrderedHashSet::default();
+        let mut non_pub_containing_modules = vec![];
         for (item_module_id, info) in self.db.module_imported_modules((), module_id).iter() {
             // Not checking the main module to prevent cycles.
             if *item_module_id == module_id {
@@ -790,34 +792,21 @@ impl<'db> Resolver<'db> {
                     item_info = Some(inner_item_info.clone());
                     module_items_found.insert(inner_item_info.item_id);
                 } else {
-                    other_containing_modules.push(*item_module_id);
+                    non_pub_containing_modules.push(*item_module_id);
+                    non_pub_module_items_found.insert(inner_item_info.item_id);
                 }
             }
         }
         if module_items_found.len() > 1 {
-            return UseStarResult::AmbiguousPath(module_items_found.iter().cloned().collect());
+            return UseStarResult::AmbiguousPath(module_items_found.into_iter().collect());
         }
         match item_info {
             Some(item_info) => UseStarResult::UniquePathFound(item_info),
-            None => {
-                for item_module_id in &other_containing_modules {
-                    if let Some(inner_item_info) =
-                        self.resolve_item_in_module_or_expanded_macro(*item_module_id, ident)
-                    {
-                        item_info = Some(inner_item_info.clone());
-                        module_items_found.insert(inner_item_info.item_id);
-                    }
-                }
-                if let Some(item_info) = item_info {
-                    if module_items_found.len() > 1 {
-                        UseStarResult::AmbiguousPath(module_items_found.iter().cloned().collect())
-                    } else {
-                        UseStarResult::ItemNotVisible(item_info.item_id, other_containing_modules)
-                    }
-                } else {
-                    UseStarResult::PathNotFound
-                }
-            }
+            None => match non_pub_module_items_found.into_iter().exactly_one() {
+                Ok(item) => UseStarResult::ItemNotVisible(Some(item), non_pub_containing_modules),
+                Err(err) if err.len() == 0 => UseStarResult::PathNotFound,
+                Err(_) => UseStarResult::ItemNotVisible(None, non_pub_containing_modules),
+            },
         }
     }
 
@@ -1699,7 +1688,7 @@ enum ResolvedBase<'db> {
     /// The base module is ambiguous.
     Ambiguous(Vec<ModuleItemId<'db>>),
     /// The base module is inaccessible.
-    ItemNotVisible(ModuleItemId<'db>, Vec<ModuleId<'db>>),
+    ItemNotVisible(Option<ModuleItemId<'db>>, Vec<ModuleId<'db>>),
 }
 
 /// The callbacks to be used by `resolve_path_inner`.
@@ -2623,7 +2612,7 @@ impl<'db, 'a> Resolution<'db, 'a> {
         ) {
             self.diagnostics.report(
                 identifier.stable_ptr(self.resolver.db),
-                ItemNotVisible(item_info.item_id, vec![]),
+                ItemNotVisible(Some(item_info.item_id), vec![]),
             );
         }
 


### PR DESCRIPTION
## Summary

When resolving identifiers through `use *` (glob) imports, multiple distinct items from different modules can share the same name. Previously, the `ItemNotVisible` diagnostic variant required a concrete `ModuleItemId`, which forced the resolver to pick a single item even when multiple non-visible candidates existed. This PR changes `ItemNotVisible` to hold `Option<ModuleItemId>` so that ambiguous invisible candidates can be reported without pointing to a specific item.

The resolver now tracks non-visible candidates separately (`non_pub_module_items_found`) and uses `exactly_one()` to determine whether a single invisible item or multiple invisible items were found. When exactly one non-visible item exists, it is reported by name. When multiple non-visible items share the name, the diagnostic omits the item name and reports `"Item is not visible in this context through any of the modules: ..."` instead of `"Item \`...\` is not visible..."`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When two glob imports (`use a::*; use b::*;`) both bring in a name that is not publicly visible, the old code would attempt to resolve the item in each non-visible module sequentially and report whichever it found first. This could produce a misleading diagnostic naming one specific item when in fact multiple invisible candidates existed. The fix correctly handles the ambiguous-invisible case.

---

## What was the behavior or documentation before?

When multiple non-visible items shared the same name via glob imports, the diagnostic would arbitrarily name one of them: `Item \`some::path\` is not visible in this context...`.

---

## What is the behavior or documentation after?

When multiple non-visible items share the same name via glob imports, the diagnostic now reads: `Item is not visible in this context through any of the modules: \`test::a\`, \`test::b\`.` — omitting the specific item path since no single item can be unambiguously identified.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A new test case (`Testing use star with only invisible candidates`) was added to `diagnostic_test_data/tests` to cover the scenario where all glob-imported candidates for a name are non-visible.