### PR TITLE
fix(lowering): normalize storage_base_address_from_felt252 const folding

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -658,8 +658,16 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
             if let Some(const_value) = self.as_const(input_var)
                 && let ConstValue::Int(val, ty) = const_value.long(db)
             {
+                const ADDR_BOUND: Felt252 = Felt252::from_hex_unchecked(
+                    "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00",
+                );
+                let as_felt252 = Felt252::from(val);
+                let normalized =
+                    if as_felt252 >= ADDR_BOUND { as_felt252 - ADDR_BOUND } else { as_felt252 };
                 stmt.inputs.clear();
-                let arg = GenericArgumentId::Constant(ConstValue::Int(val.clone(), *ty).intern(db));
+                let arg = GenericArgumentId::Constant(
+                    ConstValue::Int(normalized.to_bigint(), *ty).intern(db),
+                );
                 stmt.function =
                     self.storage_base_address_const.concretize(db, vec![arg]).lowered(db);
             }

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
@@ -1407,6 +1407,78 @@ End:
 
 //! > ==========================================================================
 
+//! > StorageBaseAddress const normalization.
+
+//! > test_runner_name
+test_match_optimizer
+
+//! > function_code
+fn foo() -> [StorageBaseAddress; 6] {
+    [
+        storage_base_address_from_felt252(1), storage_base_address_from_felt252(2),
+        storage_base_address_from_felt252(
+            0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+        ),
+        storage_base_address_from_felt252(
+            0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeff,
+        ),
+        storage_base_address_from_felt252(-1), storage_base_address_from_felt252(-2),
+    ]
+}
+
+//! > module_code
+use starknet::StorageBaseAddress;
+use starknet::storage_access::storage_base_address_from_felt252;
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 1
+  (v1: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_from_felt252(v0)
+  (v2: core::felt252) <- 2
+  (v3: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_from_felt252(v2)
+  (v4: core::felt252) <- 3618502788666131106986593281521497120414687020801267626233049500247285301247
+  (v5: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_from_felt252(v4)
+  (v6: core::felt252) <- 3618502788666131106986593281521497120414687020801267626233049500247285300991
+  (v7: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_from_felt252(v6)
+  (v8: core::felt252) <- -1
+  (v9: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_from_felt252(v8)
+  (v10: core::felt252) <- -2
+  (v11: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_from_felt252(v10)
+  (v12: [core::starknet::storage_access::StorageBaseAddress; 6]) <- struct_construct(v1, v3, v5, v7, v9, v11)
+End:
+  Return(v12)
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- 1
+  (v1: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_const::<1>()
+  (v2: core::felt252) <- 2
+  (v3: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_const::<2>()
+  (v4: core::felt252) <- 3618502788666131106986593281521497120414687020801267626233049500247285301247
+  (v5: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_const::<255>()
+  (v6: core::felt252) <- 3618502788666131106986593281521497120414687020801267626233049500247285300991
+  (v7: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_const::<3618502788666131106986593281521497120414687020801267626233049500247285300991>()
+  (v8: core::felt252) <- -1
+  (v9: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_const::<106710729501573572985208420194530329073740042555888586719488>()
+  (v10: core::felt252) <- -2
+  (v11: core::starknet::storage_access::StorageBaseAddress) <- core::starknet::storage_access::storage_base_address_const::<106710729501573572985208420194530329073740042555888586719487>()
+  (v12: [core::starknet::storage_access::StorageBaseAddress; 6]) <- struct_construct(v1, v3, v5, v7, v9, v11)
+End:
+  Return(v12)
+
+//! > lowering_diagnostics
+
+//! > ==========================================================================
+
 //! > complex StorageBaseAddress const.
 
 //! > test_runner_name


### PR DESCRIPTION
## Summary

During const folding of `storage_base_address_from_felt252`, the input `felt252` value is now normalized before being embedded as a `storage_base_address_const` generic argument. Values at or above `0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00` are reduced by that bound, matching the runtime behavior of `storage_base_address_from_felt252`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`storage_base_address_from_felt252` clamps its input at runtime: values in the high range (≥ `ADDR_BOUND`) are wrapped by subtracting `ADDR_BOUND`. The const folding optimization was previously passing the raw `felt252` value directly into `storage_base_address_const` without applying this normalization, producing a different constant than what the runtime would compute. For example, `-1` as a `felt252` would fold to an incorrect address instead of the expected normalized value.

---

## What was the behavior or documentation before?

When `storage_base_address_from_felt252` was called with a constant `felt252` value ≥ `ADDR_BOUND` (including negative values like `-1` and `-2`), the const folding pass emitted `storage_base_address_const` with the raw, un-normalized value, diverging from the runtime result.

---

## What is the behavior or documentation after?

The const folding pass now applies the same normalization as the runtime: if the `felt252` value is ≥ `ADDR_BOUND`, it subtracts `ADDR_BOUND` before constructing the constant. For example, `-1` now correctly folds to `storage_base_address_const::<106710729501573572985208420194530329073740042555888586719488>()`.

---

## Related issue or discussion (if any)

---

## Additional context

A new test case (`StorageBaseAddress const normalization`) covers the six cases: small positive values (unchanged), a value just below `ADDR_BOUND` (unchanged), a value at `ADDR_BOUND` (normalized to `255`), a value just below `ADDR_BOUND` that is not normalized, and `-1`/`-2` (normalized to their correct addresses).