### PR TITLE
fix(semantic): don't ICE on a wrong generic-argument count through a local use alias

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -1651,3 +1651,30 @@ error[E2099]: Item is not visible in this context through any of the modules: `t
  --> lib.cairo:11:1
 AMBIGUOUS
 ^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Local use alias with a wrong generic-argument count is diagnosed, not an ICE.
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: true)
+
+//! > module_code
+struct Pair<S, T> {
+    a: S,
+    b: T,
+}
+
+//! > function_body
+use Pair as P;
+
+//! > expr_code
+P::<felt252, u8, u16> { a: 0, b: 0 }
+
+//! > expected_semantics
+
+//! > expected_diagnostics
+error[E2163]: Expected 2 generic arguments, found 3.
+ --> lib.cairo:6:18
+P::<felt252, u8, u16> { a: 0, b: 0 }
+                 ^^^

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -1560,23 +1560,21 @@ impl<'db> Resolver<'db> {
         identifier: &ast::TerminalIdentifier<'db>,
         inner_generic_item: ResolvedGenericItem<'db>,
         generic_args_syntax: Option<Vec<ast::GenericArg<'db>>>,
-    ) -> ResolvedConcreteItem<'db> {
+    ) -> Maybe<ResolvedConcreteItem<'db>> {
         let segment_stable_ptr = segment.stable_ptr(self.db).untyped();
-        let mut specialized_item = self
-            .specialize_generic_module_item(
-                diagnostics,
-                identifier,
-                inner_generic_item,
-                generic_args_syntax.clone(),
-            )
-            .unwrap();
+        let mut specialized_item = self.specialize_generic_module_item(
+            diagnostics,
+            identifier,
+            inner_generic_item,
+            generic_args_syntax.clone(),
+        )?;
         self.handle_same_impl_trait(
             diagnostics,
             &mut specialized_item,
             &generic_args_syntax.unwrap_or_default(),
             segment_stable_ptr,
         );
-        specialized_item
+        Ok(specialized_item)
     }
 }
 
@@ -1899,7 +1897,7 @@ impl<'db, 'a> Resolution<'db, 'a> {
                             &identifier,
                             generic_item,
                             segment.generic_args(db),
-                        );
+                        )?;
                         self.resolver.resolved_items.mark_concrete(db, &segment, concrete_item)
                     }
                     ResolvedBase::FoundThroughGlobalUse {
@@ -1974,7 +1972,7 @@ impl<'db, 'a> Resolution<'db, 'a> {
                                 &identifier,
                                 generic_item,
                                 segment.generic_args(db),
-                            );
+                            )?;
                             self.resolver.resolved_items.mark_concrete(db, &segment, concrete_item)
                         }
                         ResolvedBase::FoundThroughGlobalUse {


### PR DESCRIPTION
## Summary

Propagates errors from `specialize_generic_module_item` in `specialize_generic_inner_item` by changing the return type from `ResolvedConcreteItem` to `Maybe<ResolvedConcreteItem>` and using `?` instead of `.unwrap()`. Call sites are updated to propagate the error with `?`. A regression test is added covering the case where a local `use` alias is instantiated with the wrong number of generic arguments (e.g., `use Pair as P; P::<felt252, u8, u16> { ... }`).

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a local `use` alias was instantiated with the wrong number of generic arguments, `specialize_generic_module_item` returned an `Err`, but the call in `specialize_generic_inner_item` called `.unwrap()` on that result, causing an ICE (internal compiler error) instead of a proper diagnostic.

---

## What was the behavior or documentation before?

Providing the wrong number of generic arguments to a type accessed through a local `use` alias (e.g., `use Pair as P; P::<felt252, u8, u16> { ... }`) triggered an ICE rather than emitting a diagnostic error.

---

## What is the behavior or documentation after?

The compiler now correctly emits a diagnostic error (`E2163: Expected 2 generic arguments, found 3.`) and no longer panics in this case.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The fix is minimal: replacing `.unwrap()` with `?` and adjusting the return type of `specialize_generic_inner_item` accordingly.