### PR TITLE
fix(semantic): evaluate const `!`, `&`, `|`, `^` on bool operands

### DIFF
--- a/corelib/src/test/language_features/const_test.cairo
+++ b/corelib/src/test/language_features/const_test.cairo
@@ -159,6 +159,16 @@ fn test_complex_consts() {
     assert_eq!(IF_CONST_FALSE, 7);
 }
 
+#[test]
+fn test_const_bool_bitwise() {
+    const AND: bool = true & false;
+    const OR: bool = true | false;
+    const XOR: bool = true ^ false;
+    assert!(!AND);
+    assert!(OR);
+    assert!(XOR);
+}
+
 #[derive(Copy, Drop, PartialEq, Debug)]
 struct Pair<T> {
     a: T,

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -922,8 +922,17 @@ impl<'a, 'r, 'mt> ConstantEvaluateContext<'a, 'r, 'mt> {
             return bool_value(self.const_values_eq(args[0], args[1]));
         } else if imp.function == self.ne_fn {
             return bool_value(!self.const_values_eq(args[0], args[1]));
-        } else if imp.function == self.not_fn {
-            return bool_value(args[0] == self.false_const);
+        } else if args.iter().all(|arg| [self.false_const, self.true_const].contains(arg)) {
+            let as_bool = |v| v == self.true_const;
+            if imp.function == self.not_fn {
+                return bool_value(!as_bool(args[0]));
+            } else if imp.function == self.bitand_fn {
+                return bool_value(as_bool(args[0]) & as_bool(args[1]));
+            } else if imp.function == self.bitor_fn {
+                return bool_value(as_bool(args[0]) | as_bool(args[1]));
+            } else if imp.function == self.bitxor_fn {
+                return bool_value(as_bool(args[0]) ^ as_bool(args[1]));
+            }
         }
 
         let args = match args


### PR DESCRIPTION
## Summary

Adds support for evaluating `bool` bitwise operations (`&`, `|`, `^`) at compile time in constant expressions. The `not_fn` handling is also refactored to sit alongside the new bitwise operations under a shared guard that ensures all arguments are valid boolean constants.

---

## Type of change

Please check **one**:

- [x] New feature

---

## Why is this change needed?

Previously, constant expressions involving boolean bitwise operations (`&`, `|`, `^`) were not evaluated at compile time, causing them to fail or be rejected in `const` contexts. Only `!` (not), `==`, and `!=` were handled.

---

## What was the behavior or documentation before?

Boolean bitwise operations such as `true & false`, `true | false`, and `true ^ false` could not be used in `const` declarations.

---

## What is the behavior or documentation after?

`const` declarations can now use boolean bitwise operations. For example:

```cairo
const AND: bool = true & false;
const OR: bool = true | false;
const XOR: bool = true ^ false;
```

These are correctly evaluated at compile time to `false`, `true`, and `true` respectively.

---

## Related issue or discussion (if any)

---

## Additional context

A new test `test_const_bool_bitwise` is added to `const_test.cairo` to verify the correct compile-time evaluation of all three boolean bitwise operations.