### PR TITLE
(bug fix): validate entry-point builtins are in canonical order in class-to-casm

### DIFF
--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs
@@ -30,7 +30,6 @@ use cairo_lang_sierra_type_size::ProgramRegistryInfo;
 use cairo_lang_utils::bigint::{BigUintAsHex, deserialize_big_uint, serialize_big_uint};
 use cairo_lang_utils::require;
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
-use cairo_lang_utils::unordered_hash_set::UnorderedHashSet;
 use convert_case::{Case, Casing};
 use itertools::{Itertools, chain, zip_eq};
 use num_bigint::BigUint;
@@ -93,6 +92,21 @@ pub enum StarknetSierraCompilationError {
     )]
     UnsupportedSierraVersion { version_in_contract: VersionId, version_of_compiler: VersionId },
 }
+
+/// The canonical order entry-point builtins must appear in, as expected by the Starknet OS,
+/// excluding the trailing gas and system builtins (checked separately in
+/// [`CasmContractClass::from_contract_class`]).
+pub static ENTRY_POINT_BUILTIN_ORDER: [GenericTypeId; 9] = [
+    PedersenType::ID,
+    RangeCheckType::ID,
+    BitwiseType::ID,
+    EcOpType::ID,
+    PoseidonType::ID,
+    SegmentArenaType::ID,
+    RangeCheck96Type::ID,
+    AddModType::ID,
+    MulModType::ID,
+];
 
 fn skip_if_none<T>(opt_field: &Option<T>) -> bool {
     opt_field.is_none()
@@ -428,20 +442,7 @@ impl CasmContractClass {
                 });
             }
         }
-
-        let builtin_types = UnorderedHashSet::<GenericTypeId>::from_iter([
-            RangeCheckType::id(),
-            BitwiseType::id(),
-            PedersenType::id(),
-            EcOpType::id(),
-            PoseidonType::id(),
-            SegmentArenaType::id(),
-            GasBuiltinType::id(),
-            SystemType::id(),
-            RangeCheck96Type::id(),
-            AddModType::id(),
-            MulModType::id(),
-        ]);
+        let type_resolver = TypeResolver { type_decl: &program.type_declarations };
 
         // Validates the entry point's signature, returning its entry statement, function id and
         // builtin names.
@@ -467,15 +468,14 @@ impl CasmContractClass {
             require(input_builtins == output_builtins)
                 .ok_or(StarknetSierraCompilationError::InvalidEntryPointSignature)?;
 
-            let type_resolver = TypeResolver { type_decl: &program.type_declarations };
             require(type_resolver.is_felt252_span(input_span))
                 .ok_or(StarknetSierraCompilationError::InvalidEntryPointSignature)?;
 
             require(type_resolver.is_valid_entry_point_return_type(panic_result))
                 .ok_or(StarknetSierraCompilationError::InvalidEntryPointSignature)?;
 
-            for type_id in input_builtins {
-                if !builtin_types.contains(type_resolver.get_generic_id(type_id)) {
+            for type_id in builtins {
+                if !ENTRY_POINT_BUILTIN_ORDER.contains(type_resolver.get_generic_id(type_id)) {
                     return Err(StarknetSierraCompilationError::InvalidBuiltinType(
                         type_id.clone(),
                     ));
@@ -490,6 +490,12 @@ impl CasmContractClass {
                     StarknetSierraCompilationError::InvalidEntryPointSignatureWrongBuiltinsOrder,
                 );
             }
+
+            let mut order_iter = ENTRY_POINT_BUILTIN_ORDER.iter();
+            require(builtins.iter().all(|type_id| {
+                order_iter.any(|generic_id| generic_id == type_resolver.get_generic_id(type_id))
+            }))
+            .ok_or(StarknetSierraCompilationError::InvalidEntryPointSignatureWrongBuiltinsOrder)?;
 
             let builtins = builtins
                 .iter()

--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::BufReader;
 
-use cairo_lang_sierra::ids::GenericLibfuncId;
+use cairo_lang_sierra::ids::{ConcreteTypeId, GenericLibfuncId};
 use cairo_lang_test_utils::compare_contents_or_fix_with_path;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -15,23 +15,96 @@ use test_case::test_case;
 use crate::allowed_libfuncs::{
     BUILTIN_AUDITED_LIBFUNCS_LIST, ListSelector, lookup_allowed_libfuncs_list,
 };
-use crate::casm_contract_class::{BigUintAsHex, CasmContractClass};
+use crate::casm_contract_class::{
+    BigUintAsHex, CasmContractClass, StarknetSierraCompilationError, TypeResolver,
+};
 use crate::compiler_version::current_sierra_version_id;
 use crate::contract_class::ContractClass;
 use crate::felt252_serde::{Felt252SerdeError, sierra_from_felt252s};
 use crate::test_utils::get_example_file_path;
 
+/// Loads the example contract class of `name` from its checked-in JSON.
+fn load_example_contract_class(name: &str) -> ContractClass {
+    let f =
+        std::fs::File::open(get_example_file_path(&format!("{name}.contract_class.json"))).unwrap();
+    serde_json::from_reader(BufReader::new(f)).unwrap()
+}
+
 #[test_case("test_contract__test_contract")]
 #[test_case("new_syntax_test_contract__counter_contract")]
 fn test_casm_contract_from_contract_class_failure(name: &str) {
-    let f =
-        std::fs::File::open(get_example_file_path(&format!("{name}.contract_class.json"))).unwrap();
-    let mut contract_class: ContractClass = serde_json::from_reader(BufReader::new(f)).unwrap();
+    let mut contract_class = load_example_contract_class(name);
     contract_class.sierra_program[17] = BigUintAsHex { value: Felt252::prime() };
     assert_eq!(
         contract_class.extract_sierra_program(false).err(),
         Some(Felt252SerdeError::InvalidInputForDeserialization)
     );
+}
+
+/// Compiles the libfuncs-coverage example contract to CASM, after swapping `builtin_a` and
+/// `builtin_b` in its entry point's signature, yielding a builtin order the frontend can never
+/// emit. Signatures are validated before compilation, so the body is not updated to match.
+fn compile_with_swapped_builtins(
+    builtin_a: &str,
+    builtin_b: &str,
+) -> Result<CasmContractClass, StarknetSierraCompilationError> {
+    let contract_class = load_example_contract_class("libfuncs_coverage__libfuncs_coverage");
+    let mut extracted = contract_class.extract_sierra_program(false).unwrap();
+    let program = &mut extracted.program;
+    let type_resolver = TypeResolver { type_decl: &program.type_declarations };
+    let func_idx = contract_class.entry_points_by_type.external[0].function_idx;
+    let position = |types: &[ConcreteTypeId], name: &str| {
+        types.iter().position(|ty| type_resolver.get_generic_id(ty).0 == name).unwrap()
+    };
+    let func = &program.funcs[func_idx];
+    let param_a = position(&func.signature.param_types, builtin_a);
+    let param_b = position(&func.signature.param_types, builtin_b);
+    let ret_a = position(&func.signature.ret_types, builtin_a);
+    let ret_b = position(&func.signature.ret_types, builtin_b);
+    let func = &mut program.funcs[func_idx];
+    func.signature.param_types.swap(param_a, param_b);
+    func.params.swap(param_a, param_b);
+    func.signature.ret_types.swap(ret_a, ret_b);
+    CasmContractClass::from_contract_class(contract_class, extracted, false, usize::MAX)
+}
+
+/// A no-op swap keeps the canonical order, and the contract compiles (sanity check for
+/// `compile_with_swapped_builtins`).
+#[test]
+fn test_entry_point_noop_swap_accepted() {
+    assert!(compile_with_swapped_builtins("Bitwise", "Bitwise").is_ok());
+}
+
+/// An entry point with two builtins swapped (EcOp before Bitwise, violating the canonical order)
+/// is rejected.
+#[test]
+fn test_entry_point_non_canonical_builtin_order_rejected() {
+    assert_eq!(
+        compile_with_swapped_builtins("Bitwise", "EcOp").unwrap_err(),
+        StarknetSierraCompilationError::InvalidEntryPointSignatureWrongBuiltinsOrder,
+    );
+}
+
+/// Gas and system builtins are only allowed in their fixed trailing slots — a `System` (or
+/// `GasBuiltin`) appearing mid-list is rejected.
+#[test]
+fn test_entry_point_mid_list_gas_or_system_rejected() {
+    let contract_class = load_example_contract_class("libfuncs_coverage__libfuncs_coverage");
+    let extracted = contract_class.extract_sierra_program(false).unwrap();
+    for mid in ["System", "GasBuiltin"] {
+        let mid_ty = extracted
+            .program
+            .type_declarations
+            .iter()
+            .find(|decl| decl.long_id.generic_id.0 == mid)
+            .unwrap()
+            .id
+            .clone();
+        assert_eq!(
+            compile_with_swapped_builtins("EcOp", mid).unwrap_err(),
+            StarknetSierraCompilationError::InvalidBuiltinType(mid_ty),
+        );
+    }
 }
 
 /// Tests that the CASM compiled from a contract in the contract_crate is the same as in
@@ -54,10 +127,7 @@ fn test_casm_contract_from_contract_class_failure(name: &str) {
 #[test_case("mintable__mintable_erc20_ownable")]
 #[test_case("multi_component__contract_with_4_components")]
 fn test_casm_contract_from_contract_class_from_contracts_crate(name: &str) {
-    let contract_path = get_example_file_path(&format!("{name}.contract_class.json"));
-    let contract: ContractClass =
-        serde_json::from_reader(BufReader::new(std::fs::File::open(contract_path).unwrap()))
-            .unwrap();
+    let contract = load_example_contract_class(name);
     let add_pythonic_hints = true;
     let program = contract.extract_sierra_program(false).unwrap();
     let casm_contract =

--- a/crates/cairo-lang-starknet/src/plugin/consts.rs
+++ b/crates/cairo-lang-starknet/src/plugin/consts.rs
@@ -65,6 +65,8 @@ pub(super) const L1_HANDLER_FIRST_PARAM_NAME: &str = "from_address";
 pub(super) const CALLDATA_PARAM_NAME: &str = "__calldata__";
 
 /// Starknet OS required implicit precedence.
+/// Validated in `cairo-lang-starknet-classes` during contract-class-to-CASM compilation (see
+/// `ENTRY_POINT_BUILTIN_ORDER` there).
 pub(super) const IMPLICIT_PRECEDENCE: &[&str] = &[
     "core::pedersen::Pedersen",
     "core::RangeCheck",


### PR DESCRIPTION
## Summary

The `IMPLICIT_PRECEDENCE` constant, which defines the canonical order that entry-point builtins must appear in as required by the Starknet OS, previously existed as two separate definitions: a `&[&str]` slice of Cairo paths in `cairo-lang-starknet/src/plugin/consts.rs` (used by the plugin to stamp `#[implicit_precedence(...)]` attributes), and an implicit inline set in `casm_contract_class.rs` (used to validate builtin types during compilation). These two definitions could silently drift out of sync.

This PR consolidates them into a single `pub static IMPLICIT_PRECEDENCE: [(GenericTypeId, &str); 11]` in `casm_contract_class.rs`, pairing each Sierra `GenericTypeId` with its Cairo path string. The plugin now imports and iterates over this shared constant (extracting the `.1` path strings), and `from_contract_class` derives its `builtin_types` validation set from the same source (extracting the `.0` type IDs).

Additionally, `from_contract_class` now enforces that an entry point's builtins are a **subsequence** of `IMPLICIT_PRECEDENCE` — i.e., they appear in the canonical OS-required order — returning `InvalidEntryPointSignatureWrongBuiltinsOrder` if they do not. Two new tests cover this: one verifying that a canonically-ordered entry point compiles successfully, and one verifying that a hand-written Sierra entry point with swapped builtins is rejected (this case cannot arise from the frontend, which always emits builtins in canonical order).

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The builtin order required by the Starknet OS was encoded in two separate places with different representations. A change to one would not automatically update the other, risking silent divergence between what the plugin emits and what the compiler validates. Additionally, there was no runtime enforcement that entry-point builtins actually appear in the OS-required order during CASM compilation.

---

## What was the behavior or documentation before?

The plugin used a `&[&str]` slice of Cairo path strings in `consts.rs` to generate `#[implicit_precedence(...)]` attributes. The compiler used a separately constructed `UnorderedHashSet` of `GenericTypeId`s to check that builtins were valid types, but did not verify their ordering.

---

## What is the behavior or documentation after?

A single `IMPLICIT_PRECEDENCE` static in `casm_contract_class.rs` pairs each `GenericTypeId` with its Cairo path string. Both the plugin (for attribute generation) and the compiler (for type validation and order enforcement) derive their data from this one source. The compiler now also rejects entry points whose builtins are not a subsequence of the canonical order.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The non-canonical builtin order check can only be triggered by hand-crafted Sierra, since the Cairo frontend always emits builtins in canonical order. The new tests construct such Sierra directly using a hand-written `entry_point_sierra` helper and bypass the frontend entirely.