### PR TITLE
feat(starknet): add deploy_v2 syscall (compiler support)

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/contract_address.rs
+++ b/crates/cairo-lang-runner/src/casm_run/contract_address.rs
@@ -1,11 +1,24 @@
 use starknet_types_core::felt::{Felt as Felt252, NonZeroFelt as NonZeroFelt252};
-use starknet_types_core::hash::{Pedersen, StarkHash};
+use starknet_types_core::hash::{Blake2Felt252, Pedersen, StarkHash};
 
 /// 2 ** 251 - 256
-const ADDR_BOUND: NonZeroFelt252 =
-    NonZeroFelt252::from_felt_unchecked(Felt252::from_hex_unchecked(
-        "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00",
-    ));
+const ADDR_BOUND_FELT: Felt252 = Felt252::from_hex_unchecked(
+    "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00",
+);
+
+/// 2 ** 251 - 256
+const ADDR_BOUND: NonZeroFelt252 = NonZeroFelt252::from_felt_unchecked(ADDR_BOUND_FELT);
+
+/// The field prime minus [`ADDR_BOUND_FELT`]. Addresses below this bound have a second lift into
+/// the field: both `address` and `address + ADDR_BOUND_FELT` are below the prime.
+const SECOND_LIFT_BOUND: Felt252 =
+    Felt252::from_hex_unchecked("0x11000000000000000000000000000000000000000000000101");
+
+/// The STARK curve is `y^2 = x^3 + ALPHA * x + BETA`.
+const STARK_CURVE_ALPHA: Felt252 = Felt252::ONE;
+const STARK_CURVE_BETA: Felt252 = Felt252::from_hex_unchecked(
+    "0x6f21413efbe40de150e596d72f7a8c5609ad26c15c915c1f4cdfcb99cee9e89",
+);
 
 /// Cairo string of "STARKNET_CONTRACT_ADDRESS".
 const CONTRACT_ADDRESS_PREFIX: Felt252 =
@@ -28,4 +41,66 @@ pub fn calculate_contract_address(
         constructor_calldata_hash,
     ])
     .mod_floor(&ADDR_BOUND)
+}
+
+/// Calculates the address of a Starknet contract with the Blake-escaped derivation used by the
+/// `deploy_v2` syscall (and `deploy_account` v4).
+///
+/// The raw address is the BLAKE2s felt-array hash of the same preimage `deploy` hashes with
+/// Pedersen, reduced modulo [`ADDR_BOUND_FELT`]. It is then incremented (wrapping, skipping the
+/// reserved `0x0`/`0x1`) until it is provably unreachable by any Pedersen derivation, so the two
+/// schemes' address spaces are disjoint. This must match the sequencer's
+/// `starknet_api::core::calculate_contract_address` for the `Blake2` arm.
+pub fn calculate_contract_address_blake_escaped(
+    salt: &Felt252,
+    class_hash: &Felt252,
+    constructor_calldata: &[Felt252],
+    deployer_address: &Felt252,
+) -> Felt252 {
+    let constructor_calldata_hash =
+        Blake2Felt252::encode_felt252_data_and_calc_blake_hash(constructor_calldata);
+    let raw_address = Blake2Felt252::encode_felt252_data_and_calc_blake_hash(&[
+        CONTRACT_ADDRESS_PREFIX,
+        *deployer_address,
+        *salt,
+        *class_hash,
+        constructor_calldata_hash,
+    ])
+    .mod_floor(&ADDR_BOUND);
+    escape_pedersen_image(raw_address)
+}
+
+/// Returns `value^3 + STARK_CURVE_ALPHA * value + STARK_CURVE_BETA` — a square in the field iff
+/// `value` is the x-coordinate of a STARK curve point.
+fn stark_curve_cubic(value: &Felt252) -> Felt252 {
+    value * value * value + STARK_CURVE_ALPHA * value + STARK_CURVE_BETA
+}
+
+/// Returns whether `value` is the x-coordinate of a STARK curve point (`stark_curve_cubic(value)`
+/// is a quadratic residue, i.e. `t == 0` or `legendre(t) == 1`).
+fn is_stark_curve_x_coordinate(value: &Felt252) -> bool {
+    stark_curve_cubic(value).sqrt().is_some()
+}
+
+/// Returns whether some Pedersen hash output reduces (mod [`ADDR_BOUND_FELT`]) to `address`. A
+/// Pedersen output is the x-coordinate of a STARK curve point, so `address` is reachable iff one of
+/// its lifts into the field is a curve x-coordinate.
+pub fn is_pedersen_reachable_address(address: &Felt252) -> bool {
+    is_stark_curve_x_coordinate(address)
+        || (*address < SECOND_LIFT_BOUND
+            && is_stark_curve_x_coordinate(&(address + ADDR_BOUND_FELT)))
+}
+
+/// Increments `raw_address` (wrapping mod [`ADDR_BOUND_FELT`], skipping the reserved `0x0`/`0x1`)
+/// until no Pedersen derivation can reach it. Expected ~1 increment; each step costs one
+/// residuosity check, never a re-hash.
+fn escape_pedersen_image(raw_address: Felt252) -> Felt252 {
+    let mut address = raw_address;
+    while address < Felt252::TWO || is_pedersen_reachable_address(&address) {
+        address += Felt252::ONE;
+        if address == ADDR_BOUND_FELT {
+            address = Felt252::ZERO;
+        }
+    }
+    address
 }

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -46,7 +46,9 @@ use num_traits::{Signed, ToPrimitive, Zero};
 use rand::RngExt;
 use starknet_types_core::felt::{Felt as Felt252, NonZeroFelt};
 
-use self::contract_address::calculate_contract_address;
+use self::contract_address::{
+    calculate_contract_address, calculate_contract_address_blake_escaped,
+};
 use self::dict_manager::DictSquashExecScope;
 use crate::short_string::{as_cairo_short_string, as_cairo_short_string_ex};
 use crate::{Arg, RunResultValue, SierraCasmRunner, StarknetExecutionResources, args_size};
@@ -355,6 +357,8 @@ mod gas_costs {
     // compiler).
     pub const CALL_CONTRACT: usize = 10 * STEP + ENTRY_POINT;
     pub const DEPLOY: usize = 200 * STEP + ENTRY_POINT;
+    // Provisional: same profile as `DEPLOY` until a measured one lands (sequencer-side).
+    pub const DEPLOY_V2: usize = 200 * STEP + ENTRY_POINT;
     pub const EMIT_EVENT: usize = 10 * STEP;
     pub const GET_BLOCK_HASH: usize = 50 * STEP;
     pub const GET_EXECUTION_INFO: usize = 10 * STEP;
@@ -838,6 +842,16 @@ impl CairoHintProcessor<'_> {
                     system_buffer,
                 )
             }),
+            "DeployV2" => execute_handle_helper(&mut |system_buffer, gas_counter| {
+                self.deploy_v2(
+                    gas_counter,
+                    system_buffer.next_felt252()?.into_owned(),
+                    system_buffer.next_felt252()?.into_owned(),
+                    system_buffer.next_arr()?,
+                    system_buffer.next_bool()?,
+                    system_buffer,
+                )
+            }),
             "CallContract" => execute_handle_helper(&mut |system_buffer, gas_counter| {
                 self.call_contract(
                     gas_counter,
@@ -1036,6 +1050,81 @@ impl CairoHintProcessor<'_> {
             self.starknet_state.exec_info.contract_address
         };
         let deployed_contract_address = calculate_contract_address(
+            &_contract_address_salt,
+            &class_hash,
+            &calldata,
+            &deployer_address,
+        );
+
+        // Prepare runner for running the constructor.
+        let runner = self.runner.expect("Runner is needed for starknet.");
+        let Some(contract_info) = runner.starknet_contracts_info.get(&class_hash) else {
+            fail_syscall!(b"CLASS_HASH_NOT_FOUND");
+        };
+
+        // Set the class hash of the deployed contract before executing the constructor,
+        // as the constructor could make an external call to this address.
+        if self
+            .starknet_state
+            .deployed_contracts
+            .insert(deployed_contract_address, class_hash)
+            .is_some()
+        {
+            fail_syscall!(b"CONTRACT_ALREADY_DEPLOYED");
+        }
+
+        // Call constructor if it exists.
+        let (res_data_start, res_data_end) = if let Some(constructor) = &contract_info.constructor {
+            let old_addrs = self
+                .starknet_state
+                .open_caller_context((deployed_contract_address, deployer_address));
+            let res = self.call_entry_point(gas_counter, runner, constructor, calldata, vm);
+            self.starknet_state.close_caller_context(old_addrs);
+            match res {
+                Ok(value) => value,
+                Err(mut revert_reason) => {
+                    self.starknet_state.deployed_contracts.remove(&deployed_contract_address);
+                    fail_syscall!(revert_reason, b"CONSTRUCTOR_FAILED");
+                }
+            }
+        } else if calldata.is_empty() {
+            (Relocatable::from((0, 0)), Relocatable::from((0, 0)))
+        } else {
+            // Remove the contract from the deployed contracts,
+            // since it failed to deploy.
+            self.starknet_state.deployed_contracts.remove(&deployed_contract_address);
+            fail_syscall!(b"INVALID_CALLDATA_LEN");
+        };
+
+        Ok(SyscallResult::Success(vec![
+            deployed_contract_address.into(),
+            res_data_start.into(),
+            res_data_end.into(),
+        ]))
+    }
+
+    /// Executes the `deploy_v2_syscall` syscall.
+    ///
+    /// Identical to [`Self::deploy`] except the deployed address is derived with the Blake-escaped
+    /// derivation ([`calculate_contract_address_blake_escaped`]) instead of Pedersen.
+    fn deploy_v2(
+        &mut self,
+        gas_counter: &mut usize,
+        class_hash: Felt252,
+        _contract_address_salt: Felt252,
+        calldata: Vec<Felt252>,
+        deploy_from_zero: bool,
+        vm: &mut dyn VMWrapper,
+    ) -> Result<SyscallResult, HintError> {
+        deduct_gas!(gas_counter, DEPLOY_V2);
+
+        // Assign the Starknet address of the contract.
+        let deployer_address = if deploy_from_zero {
+            Felt252::zero()
+        } else {
+            self.starknet_state.exec_info.contract_address
+        };
+        let deployed_contract_address = calculate_contract_address_blake_escaped(
             &_contract_address_salt,
             &class_hash,
             &calldata,

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -51,7 +51,9 @@ use num_traits::{Signed, ToPrimitive, Zero};
 use rand::RngExt;
 use starknet_types_core::felt::{Felt as Felt252, NonZeroFelt};
 
-use self::contract_address::calculate_contract_address;
+use self::contract_address::{
+    calculate_contract_address, calculate_contract_address_blake_escaped,
+};
 use self::dict_manager::DictSquashExecScope;
 use crate::short_string::{as_cairo_short_string, as_cairo_short_string_ex};
 use crate::{Arg, RunResultValue, SierraCasmRunner, StarknetExecutionResources, args_size};
@@ -344,6 +346,8 @@ mod gas_costs {
     // compiler).
     pub const CALL_CONTRACT: usize = 10 * STEP + ENTRY_POINT;
     pub const DEPLOY: usize = 200 * STEP + ENTRY_POINT;
+    // Provisional: same profile as `DEPLOY` until a measured one lands (sequencer-side).
+    pub const DEPLOY_V2: usize = 200 * STEP + ENTRY_POINT;
     pub const EMIT_EVENT: usize = 10 * STEP;
     pub const GET_BLOCK_HASH: usize = 50 * STEP;
     pub const GET_EXECUTION_INFO: usize = 10 * STEP;
@@ -829,6 +833,16 @@ impl CairoHintProcessor<'_> {
                     system_buffer,
                 )
             }),
+            "DeployV2" => execute_handle_helper(&mut |system_buffer, gas_counter| {
+                self.deploy_v2(
+                    gas_counter,
+                    system_buffer.next_felt252()?.into_owned(),
+                    system_buffer.next_felt252()?.into_owned(),
+                    system_buffer.next_arr()?,
+                    system_buffer.next_bool()?,
+                    system_buffer,
+                )
+            }),
             "CallContract" => execute_handle_helper(&mut |system_buffer, gas_counter| {
                 self.call_contract(
                     gas_counter,
@@ -1029,6 +1043,47 @@ impl CairoHintProcessor<'_> {
             &if deploy_from_zero { Felt252::zero() } else { caller_address },
         );
 
+        self.deploy_at(gas_counter, class_hash, calldata, deployed_address, caller_address, vm)
+    }
+
+    /// Executes the `deploy_v2_syscall` syscall.
+    ///
+    /// Identical to [`Self::deploy`] except the deployed address is derived with the Blake-escaped
+    /// derivation ([`calculate_contract_address_blake_escaped`]) instead of Pedersen.
+    fn deploy_v2(
+        &mut self,
+        gas_counter: &mut usize,
+        class_hash: Felt252,
+        contract_address_salt: Felt252,
+        calldata: Vec<Felt252>,
+        deploy_from_zero: bool,
+        vm: &mut dyn VMWrapper,
+    ) -> Result<SyscallResult, HintError> {
+        deduct_gas!(gas_counter, DEPLOY_V2);
+
+        let caller_address = self.starknet_state.exec_info.call_info.contract_address;
+        // Assign the Starknet address of the contract.
+        let deployed_address = calculate_contract_address_blake_escaped(
+            &contract_address_salt,
+            &class_hash,
+            &calldata,
+            &if deploy_from_zero { Felt252::zero() } else { caller_address },
+        );
+
+        self.deploy_at(gas_counter, class_hash, calldata, deployed_address, caller_address, vm)
+    }
+
+    /// Deploys `class_hash` at `deployed_address` and runs its constructor. Shared by the `deploy`
+    /// and `deploy_v2` syscalls, which differ only in how they derive the address.
+    fn deploy_at(
+        &mut self,
+        gas_counter: &mut usize,
+        class_hash: Felt252,
+        calldata: Vec<Felt252>,
+        deployed_address: Felt252,
+        caller_address: Felt252,
+        vm: &mut dyn VMWrapper,
+    ) -> Result<SyscallResult, HintError> {
         // Prepare runner for running the constructor.
         let runner = self.runner.expect("Runner is needed for starknet.");
         let Some(contract_info) = runner.starknet_contracts_info.get(&class_hash) else {

--- a/crates/cairo-lang-runner/src/casm_run/test.rs
+++ b/crates/cairo-lang-runner/src/casm_run/test.rs
@@ -11,7 +11,10 @@ use starknet_types_core::felt::Felt as Felt252;
 use test_case::test_case;
 
 use super::format_for_debug;
-use crate::casm_run::contract_address::calculate_contract_address;
+use crate::casm_run::contract_address::{
+    calculate_contract_address, calculate_contract_address_blake_escaped,
+    is_pedersen_reachable_address,
+};
 use crate::casm_run::{RunFunctionResult, run_function};
 use crate::short_string::{as_cairo_short_string, as_cairo_short_string_ex};
 use crate::{CairoHintProcessor, StarknetState, build_hints_dict};
@@ -484,4 +487,55 @@ fn test_calculate_contract_address() {
         .unwrap(),
         deployed_contract_address
     );
+}
+
+/// The five frozen Blake-escaped derivation vectors (0/1/2/3/7 escape steps), shared with the
+/// sequencer and `cairo_native`. `deploy_from_zero = true` (deployer = 0), `class_hash = 0x4242`,
+/// `calldata = [42, 2 ** 63, 1337]`.
+#[test]
+fn test_calculate_contract_address_blake_escaped() {
+    let deployer_address = Felt252::ZERO;
+    let class_hash = Felt252::from(0x4242);
+    let calldata = vec![Felt252::from(42), Felt252::TWO.pow(63_u32), Felt252::from(1337)];
+
+    for (salt, expected) in [
+        (777, "0x781e95f4b806dfe5b550756620c77a108d974a5b5d1198b1d45901ac1f89e9f"),
+        (771, "0x566c3e328f3fd5a311267250cadc3c1c4de799db54180fcf862fe90b622571d"),
+        (776, "0x1cd7f5c31ef1b147b816048b025a6cc345e7e023aa8ed97222a883e31dc8435"),
+        (775, "0x4f7ba32369d7f68c42a7619242a52a5be9e803459f5afae1772d9377b161c4c"),
+        (774, "0x47d0c1ff356a1d540cd9f2efa122b60168b1007ef0603af0857bc6100e4b8e8"),
+    ] {
+        let salt = Felt252::from(salt);
+        assert_eq!(
+            calculate_contract_address_blake_escaped(
+                &salt,
+                &class_hash,
+                &calldata,
+                &deployer_address,
+            ),
+            Felt252::from_hex(expected).unwrap(),
+            "wrong Blake-escaped address for salt {salt}",
+        );
+        // Negative check: the Pedersen path must give a different address, guarding against
+        // accidentally wiring `deploy_v2` to the old derivation.
+        assert_ne!(
+            calculate_contract_address(&salt, &class_hash, &calldata, &deployer_address),
+            Felt252::from_hex(expected).unwrap(),
+            "Pedersen derivation unexpectedly matched the Blake-escaped address for salt {salt}",
+        );
+    }
+}
+
+/// The frozen `pedersen_reachable` truth table, shared with the sequencer and `cairo_native`.
+#[test]
+fn test_is_pedersen_reachable_address() {
+    for (address, expected) in
+        [(0x1_u64, true), (0x2_u64, true), (0x5_u64, false), (0x1234567890abcdef_u64, true)]
+    {
+        assert_eq!(
+            is_pedersen_reachable_address(&Felt252::from(address)),
+            expected,
+            "wrong pedersen_reachable for {address:#x}",
+        );
+    }
 }

--- a/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
+++ b/crates/cairo-lang-sierra-ap-change/src/core_libfunc_ap_change.rs
@@ -357,6 +357,7 @@ pub fn core_libfunc_ap_change<InfoProvider: InvocationApChangeInfoProvider>(
             | StarknetConcreteLibfunc::GetExecutionInfoV2(_)
             | StarknetConcreteLibfunc::GetExecutionInfoV3(_)
             | StarknetConcreteLibfunc::Deploy(_)
+            | StarknetConcreteLibfunc::DeployV2(_)
             | StarknetConcreteLibfunc::Keccak(_)
             | StarknetConcreteLibfunc::Sha256ProcessBlock(_)
             | StarknetConcreteLibfunc::Sha512ProcessBlock(_)

--- a/crates/cairo-lang-sierra-gas/src/starknet_libfunc_cost_base.rs
+++ b/crates/cairo-lang-sierra-gas/src/starknet_libfunc_cost_base.rs
@@ -43,6 +43,8 @@ pub fn starknet_libfunc_cost_base(libfunc: &StarknetConcreteLibfunc) -> Vec<Cons
         | StarknetConcreteLibfunc::GetExecutionInfoV2(_)
         | StarknetConcreteLibfunc::GetExecutionInfoV3(_) => syscall_cost(0),
         StarknetConcreteLibfunc::Deploy(_) => syscall_cost(5),
+        // Provisional: same bucket as `Deploy` until a measured profile lands (sequencer-side).
+        StarknetConcreteLibfunc::DeployV2(_) => syscall_cost(5),
         StarknetConcreteLibfunc::Keccak(_) => syscall_cost(2),
         StarknetConcreteLibfunc::Sha256ProcessBlock(_) => syscall_cost(2),
         StarknetConcreteLibfunc::Sha256StateHandleInit(_) => vec![steps(0)],

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/starknet/mod.rs
@@ -67,6 +67,9 @@ pub fn build(
         StarknetConcreteLibfunc::Deploy(_) => {
             build_syscalls(builder, "Deploy", [1, 1, 2, 1], [1, 2])
         }
+        StarknetConcreteLibfunc::DeployV2(_) => {
+            build_syscalls(builder, "DeployV2", [1, 1, 2, 1], [1, 2])
+        }
         StarknetConcreteLibfunc::Keccak(_) => build_syscalls(builder, "Keccak", [2], [2]),
         StarknetConcreteLibfunc::Sha256ProcessBlock(_) => {
             build_syscalls(builder, "Sha256ProcessBlock", [1, 1], [1])

--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/interoperability.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/interoperability.rs
@@ -170,6 +170,41 @@ impl SyscallGenericLibfunc for DeployLibfunc {
     }
 }
 
+/// Libfunc for deploying a declared class system call, deriving the deployed contract's address
+/// with the Blake-escaped derivation instead of Pedersen.
+///
+/// Identical request/response layout to [`DeployLibfunc`]; the only difference is the on-chain
+/// address derivation (see the `deploy_v2_syscall` corelib doc).
+#[derive(Default)]
+pub struct DeployV2Libfunc {}
+impl SyscallGenericLibfunc for DeployV2Libfunc {
+    const STR_ID: &'static str = "deploy_v2_syscall";
+
+    fn input_tys(
+        context: &dyn SignatureSpecializationContext,
+    ) -> Result<Vec<crate::ids::ConcreteTypeId>, SpecializationError> {
+        Ok(vec![
+            // Class hash
+            context.get_concrete_type(ClassHashType::id(), &[])?,
+            // Contract address salt
+            context.get_concrete_type(Felt252Type::id(), &[])?,
+            // Constructor call data
+            felt252_span_ty(context)?,
+            // Deploy from zero
+            get_bool_type(context)?,
+        ])
+    }
+
+    fn success_output_tys(
+        context: &dyn SignatureSpecializationContext,
+    ) -> Result<Vec<crate::ids::ConcreteTypeId>, SpecializationError> {
+        Ok(vec![
+            context.get_concrete_type(ContractAddressType::id(), &[])?,
+            felt252_span_ty(context)?,
+        ])
+    }
+}
+
 /// Libfunc for a library call system call.
 #[derive(Default)]
 pub struct LibraryCallLibfunc {}

--- a/crates/cairo-lang-sierra/src/extensions/modules/starknet/mod.rs
+++ b/crates/cairo-lang-sierra/src/extensions/modules/starknet/mod.rs
@@ -35,7 +35,7 @@ use self::getter::{GetExecutionInfoTrait, GetExecutionInfoV2Trait, GetterLibfunc
 use self::interoperability::{
     ClassHashConstLibfunc, ClassHashToFelt252Libfunc, ClassHashTryFromFelt252Trait, ClassHashType,
     ContractAddressToFelt252Libfunc, ContractAddressTryFromFelt252Libfunc, DeployLibfunc,
-    LibraryCallLibfunc, SendMessageToL1Libfunc,
+    DeployV2Libfunc, LibraryCallLibfunc, SendMessageToL1Libfunc,
 };
 use self::storage::{
     StorageAddressFromBaseAndOffsetLibfunc, StorageAddressFromBaseLibfunc,
@@ -90,6 +90,7 @@ define_libfunc_hierarchy! {
          GetExecutionInfoV2(GetterLibfunc<GetExecutionInfoV2Trait>),
          GetExecutionInfoV3(GetterLibfunc<GetExecutionInfoV3Trait>),
          Deploy(DeployLibfunc),
+         DeployV2(DeployV2Libfunc),
          Keccak(KeccakLibfunc),
          Sha256ProcessBlock(Sha256ProcessBlockLibfunc),
          Sha256StateHandleInit(Sha256StateHandleInitLibfunc),

--- a/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
+++ b/crates/cairo-lang-starknet-classes/src/allowed_libfuncs_lists/all.json
@@ -53,6 +53,7 @@
         "coupon_call",
         "coupon_refund",
         "deploy_syscall",
+        "deploy_v2_syscall",
         "disable_ap_tracking",
         "downcast",
         "drop",

--- a/tests/e2e_test_data/libfuncs/starknet/syscalls
+++ b/tests/e2e_test_data/libfuncs/starknet/syscalls
@@ -1227,3 +1227,111 @@ store_temp<core::result::Result::<core::array::Span::<core::felt252>, core::arra
 return([14], [10], [15]);
 
 test::foo@F0([0]: GasBuiltin, [1]: System, [2]: ContractAddress, [3]: felt252, [4]: core::array::Span::<core::felt252>, [5]: core::array::Span::<core::felt252>) -> (GasBuiltin, System, core::result::Result::<core::array::Span::<core::felt252>, core::array::Array::<core::felt252>>);
+
+//! > ==========================================================================
+
+//! > deploy_v2_syscall libfunc
+
+//! > test_comments
+
+//! > test_runner_name
+SmallE2ETestRunner
+
+//! > cairo_code
+use starknet::{ClassHash, ContractAddress, SyscallResult};
+
+#[allow(extern_outside_corelib)]
+pub extern fn deploy_v2_syscall(
+    class_hash: ClassHash,
+    contract_address_salt: felt252,
+    calldata: Span<felt252>,
+    deploy_from_zero: bool,
+) -> SyscallResult<(ContractAddress, Span<felt252>)> implicits(GasBuiltin, System) nopanic;
+
+fn foo(
+    class_hash: starknet::ClassHash,
+    contract_address_salt: felt252,
+    calldata: Span<felt252>,
+    deploy_from_zero: bool,
+) -> starknet::SyscallResult<(starknet::ContractAddress, Span::<felt252>)> {
+    deploy_v2_syscall(class_hash, contract_address_salt, calldata, deploy_from_zero)
+}
+
+//! > casm
+[ap + 0] = 4928468978255877682, ap++;
+[ap + -1] = [[fp + -8] + 0];
+[fp + -9] = [[fp + -8] + 1];
+[fp + -7] = [[fp + -8] + 2];
+[fp + -6] = [[fp + -8] + 3];
+[fp + -5] = [[fp + -8] + 4];
+[fp + -4] = [[fp + -8] + 5];
+[fp + -3] = [[fp + -8] + 6];
+%{ syscall_handler.syscall(syscall_ptr=memory[fp + -8]) %}
+[ap + 0] = [[fp + -8] + 8], ap++;
+jmp rel 12 if [ap + -1] != 0;
+[ap + 0] = [[fp + -8] + 7], ap++;
+[ap + 0] = [ap + -1], ap++;
+[ap + 0] = [fp + -8] + 12, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = [[fp + -8] + 9], ap++;
+[ap + 0] = [[fp + -8] + 10], ap++;
+[ap + 0] = [[fp + -8] + 11], ap++;
+ret;
+[ap + 0] = [[fp + -8] + 7], ap++;
+[ap + 0] = [ap + -1], ap++;
+[ap + 0] = [fp + -8] + 11, ap++;
+[ap + 0] = 1, ap++;
+[ap + 0] = 0, ap++;
+[ap + 0] = [[fp + -8] + 9], ap++;
+[ap + 0] = [[fp + -8] + 10], ap++;
+ret;
+
+//! > function_costs
+test::foo: SmallOrderedMap({Const: 11700})
+
+//! > sierra_code
+type GasBuiltin = GasBuiltin [storable: true, drop: false, dup: false, zero_sized: false];
+type ContractAddress = ContractAddress [storable: true, drop: true, dup: true, zero_sized: false];
+type Array<felt252> = Array<felt252> [storable: true, drop: true, dup: false, zero_sized: false];
+type Snapshot<Array<felt252>> = Snapshot<Array<felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::array::Span::<core::felt252> = Struct<ut@core::array::Span::<core::felt252>, Snapshot<Array<felt252>>> [storable: true, drop: true, dup: true, zero_sized: false];
+type Tuple<ContractAddress, core::array::Span::<core::felt252>> = Struct<ut@Tuple, ContractAddress, core::array::Span::<core::felt252>> [storable: true, drop: true, dup: true, zero_sized: false];
+type core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>> = Enum<ut@core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, Tuple<ContractAddress, core::array::Span::<core::felt252>>, Array<felt252>> [storable: true, drop: true, dup: false, zero_sized: false];
+type Unit = Struct<ut@Tuple> [storable: true, drop: true, dup: true, zero_sized: true];
+type core::bool = Enum<ut@core::bool, Unit, Unit> [storable: true, drop: true, dup: true, zero_sized: false];
+type felt252 = felt252 [storable: true, drop: true, dup: true, zero_sized: false];
+type ClassHash = ClassHash [storable: true, drop: true, dup: true, zero_sized: false];
+type System = System [storable: true, drop: false, dup: false, zero_sized: false];
+
+libfunc deploy_v2_syscall = deploy_v2_syscall;
+libfunc branch_align = branch_align;
+libfunc store_temp<GasBuiltin> = store_temp<GasBuiltin>;
+libfunc redeposit_gas = redeposit_gas;
+libfunc struct_construct<Tuple<ContractAddress, core::array::Span::<core::felt252>>> = struct_construct<Tuple<ContractAddress, core::array::Span::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 0> = enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 0>;
+libfunc store_temp<System> = store_temp<System>;
+libfunc store_temp<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>> = store_temp<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>>;
+libfunc enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 1> = enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 1>;
+
+F0:
+deploy_v2_syscall([0], [1], [2], [3], [4], [5]) { fallthrough([6], [7], [8], [9]) F0_B0([10], [11], [12]) };
+branch_align() -> ();
+store_temp<GasBuiltin>([6]) -> ([6]);
+redeposit_gas([6]) -> ([13]);
+struct_construct<Tuple<ContractAddress, core::array::Span::<core::felt252>>>([8], [9]) -> ([14]);
+enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 0>([14]) -> ([15]);
+store_temp<GasBuiltin>([13]) -> ([13]);
+store_temp<System>([7]) -> ([7]);
+store_temp<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>>([15]) -> ([15]);
+return([13], [7], [15]);
+F0_B0:
+branch_align() -> ();
+store_temp<GasBuiltin>([10]) -> ([10]);
+redeposit_gas([10]) -> ([16]);
+enum_init<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>, 1>([12]) -> ([17]);
+store_temp<GasBuiltin>([16]) -> ([16]);
+store_temp<System>([11]) -> ([11]);
+store_temp<core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>>([17]) -> ([17]);
+return([16], [11], [17]);
+
+test::foo@F0([0]: GasBuiltin, [1]: System, [2]: ClassHash, [3]: felt252, [4]: core::array::Span::<core::felt252>, [5]: core::bool) -> (GasBuiltin, System, core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>);


### PR DESCRIPTION
**Stack (cairo side of the `deploy_v2` syscall):**
1. **▸ this PR** — compiler support
2. `ron/deploy-v2/corelib` — corelib `deploy_v2_syscall`
3. `ron/deploy-v2/make-usable` — `audited.json` + coverage (held for the release/measured-gas decision)

Adds the **`deploy_v2`** system call: identical request/response layout to `deploy`, but the deployed contract's address is derived with the BLAKE2s-with-Pedersen-image-escape derivation instead of Pedersen (Starknet's new contract-address scheme; `deploy` stays Pedersen, byte-for-byte).

This PR (compiler side):
- Sierra libfunc `DeployV2Libfunc` (`STR_ID = "deploy_v2_syscall"`) + enum registration.
- sierra→casm `build_syscalls(builder, "DeployV2", [1, 1, 2, 1], [1, 2])` — the `"DeployV2"` string is the on-chain selector (the felt whose big-endian bytes are `b"DeployV2"`).
- Provisional gas (`syscall_cost(5)`, `Deploy`-equal) + ap-change.
- Runner `deploy_v2` handler + `calculate_contract_address_blake_escaped` (`Blake2Felt252` + the Pedersen-image escape), mirroring the sequencer's `starknet_api::core::calculate_contract_address` `Blake2` arm. The existing Pedersen `calculate_contract_address` is untouched.
- `deploy_v2_syscall` added to the `all.json` dev allowed-libfuncs list only (`audited.json` is PR 3).

`sierra-updated-check` reads the commit body, so the `SIERRA_UPDATE_MINOR_CHANGE_TAG` (purely additive — previously compilable code stays compilable) lives in the commit message.

**Cross-repo contract:** selector `b"DeployV2"`; corelib fn `deploy_v2_syscall`; Sierra id `deploy_v2_syscall`; `deploy_from_zero` semantics unchanged. The five frozen derivation vectors (0/1/2/3/7 escape steps) + the `pedersen_reachable` truth table are asserted in the runner unit tests and are the same vectors the sequencer pins. Sequencer stack: `ron/contract-address/*` (PRs #14811–#14819).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


