### PR TITLE
feat(corelib): add deploy_v2_syscall to syscalls.cairo

### DIFF
--- a/corelib/src/starknet.cairo
+++ b/corelib/src/starknet.cairo
@@ -37,9 +37,10 @@ use storage_access::{
 pub mod syscalls;
 #[allow(unused_imports)]
 use syscalls::{
-    call_contract_syscall, deploy_syscall, emit_event_syscall, get_block_hash_syscall,
-    get_class_hash_at_syscall, get_execution_info_syscall, keccak_syscall, library_call_syscall,
-    replace_class_syscall, send_message_to_l1_syscall, storage_read_syscall, storage_write_syscall,
+    call_contract_syscall, deploy_syscall, deploy_v2_syscall, emit_event_syscall,
+    get_block_hash_syscall, get_class_hash_at_syscall, get_execution_info_syscall, keccak_syscall,
+    library_call_syscall, replace_class_syscall, send_message_to_l1_syscall, storage_read_syscall,
+    storage_write_syscall,
 };
 
 pub mod contract_address;

--- a/corelib/src/starknet/syscalls.cairo
+++ b/corelib/src/starknet/syscalls.cairo
@@ -47,6 +47,34 @@ pub extern fn deploy_syscall(
     deploy_from_zero: bool,
 ) -> SyscallResult<(ContractAddress, Span<felt252>)> implicits(GasBuiltin, System) nopanic;
 
+/// Deploys a new instance of a previously declared class, deriving the deployed contract's address
+/// with the BLAKE2s-based derivation instead of Pedersen.
+///
+/// The request and response are identical to [`deploy_syscall`]; the only difference is how the
+/// deployed contract's address is computed. The address is the BLAKE2s felt-array hash of the same
+/// preimage `deploy_syscall` hashes with Pedersen, incremented until it is provably unreachable by
+/// any Pedersen derivation, so the Blake and Pedersen address spaces are disjoint. `deploy_syscall`
+/// itself remains Pedersen-based and is unchanged.
+///
+/// # Arguments
+///
+/// * `class_hash` - The class hash of the contract to be deployed.
+/// * `contract_address_salt` - The salt, an arbitrary value provided by the deployer, used in the
+///  computation of the contract's address.
+/// * `calldata` - Call arguments for the constructor.
+/// * `deploy_from_zero` - Deploy the contract from the zero address.
+///
+/// # Returns
+///
+/// * The address of the deployed contract.
+/// * The serialized return value of the constructor.
+pub extern fn deploy_v2_syscall(
+    class_hash: ClassHash,
+    contract_address_salt: felt252,
+    calldata: Span<felt252>,
+    deploy_from_zero: bool,
+) -> SyscallResult<(ContractAddress, Span<felt252>)> implicits(GasBuiltin, System) nopanic;
+
 /// Emits an event.
 ///
 /// # Arguments

--- a/tests/e2e_test_data/libfuncs/starknet/syscalls
+++ b/tests/e2e_test_data/libfuncs/starknet/syscalls
@@ -1238,23 +1238,15 @@ test::foo@F0([0]: GasBuiltin, [1]: System, [2]: ContractAddress, [3]: felt252, [
 SmallE2ETestRunner
 
 //! > cairo_code
-use starknet::{ClassHash, ContractAddress, SyscallResult};
-
-#[allow(extern_outside_corelib)]
-pub extern fn deploy_v2_syscall(
-    class_hash: ClassHash,
-    contract_address_salt: felt252,
-    calldata: Span<felt252>,
-    deploy_from_zero: bool,
-) -> SyscallResult<(ContractAddress, Span<felt252>)> implicits(GasBuiltin, System) nopanic;
-
 fn foo(
     class_hash: starknet::ClassHash,
     contract_address_salt: felt252,
     calldata: Span<felt252>,
     deploy_from_zero: bool,
 ) -> starknet::SyscallResult<(starknet::ContractAddress, Span::<felt252>)> {
-    deploy_v2_syscall(class_hash, contract_address_salt, calldata, deploy_from_zero)
+    starknet::syscalls::deploy_v2_syscall(
+        class_hash, contract_address_salt, calldata, deploy_from_zero,
+    )
 }
 
 //! > casm


### PR DESCRIPTION
**Stack — part 2 of 3** (base: `ron/deploy-v2/compiler`).

Exposes the `deploy_v2` syscall to Cairo contracts:
- `deploy_v2_syscall` extern declaration in `corelib/src/starknet/syscalls.cairo` (identical request/response layout to `deploy_syscall`; Blake-escaped address derivation).
- Re-export next to `deploy_syscall` in `starknet.cairo`.
- Doc comment stating the Blake-escaped derivation and that `deploy_syscall` itself stays Pedersen.
- The e2e libfunc golden's `deploy_v2` block now calls the corelib function (casm/sierra output unchanged from PR 1).

**Cross-repo contract:** selector `b"DeployV2"` (felt `0x4465706c6f795632`); corelib fn `deploy_v2_syscall`; Sierra id `deploy_v2_syscall`; `deploy_from_zero` semantics unchanged; `deploy_syscall` stays Pedersen forever. The five frozen derivation vectors (0/1/2/3/7 escape steps) and the `pedersen_reachable` truth table are the same ones the sequencer (`ron/contract-address/*`, PRs #14811–#14819 + #14839), the Cairo OS and cairo-native pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

