### PR TITLE
fix(semantic): apply feature/visibility gating to glob re-exports of generic items

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -1678,3 +1678,75 @@ error[E2163]: Expected 2 generic arguments, found 3.
  --> lib.cairo:6:18
 P::<felt252, u8, u16> { a: 0, b: 0 }
                  ^^^
+
+//! > ==========================================================================
+
+//! > Test unstable feature gating through a glob re-export.
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: warnings_only)
+
+//! > crate_settings
+edition = "2024_07"
+
+//! > module_code
+mod inner {
+    #[unstable(feature: "testing")]
+    pub fn unstable() {}
+}
+use inner::*;
+
+pub use unstable as renamed;
+
+//! > function_body
+
+//! > expr_code
+{}
+
+//! > expected_semantics
+
+//! > expected_diagnostics
+warning[E2065]: Usage of unstable feature `"testing"` with no `#[feature("testing")]` attribute.
+ --> lib.cairo:7:9
+pub use unstable as renamed;
+        ^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test unstable feature gating through a chain of glob re-exports.
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: warnings_only)
+
+//! > crate_settings
+edition = "2024_07"
+
+//! > module_code
+mod a {
+    #[unstable(feature: "testing")]
+    pub fn unstable() {}
+}
+
+mod b {
+    pub use super::a::*;
+}
+
+mod c {
+    pub use super::b::*;
+}
+use c::*;
+
+pub use unstable as renamed;
+
+//! > function_body
+
+//! > expr_code
+{}
+
+//! > expected_semantics
+
+//! > expected_diagnostics
+warning[E2065]: Usage of unstable feature `"testing"` with no `#[feature("testing")]` attribute.
+ --> lib.cairo:15:9
+pub use unstable as renamed;
+        ^^^^^^^^

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -1841,10 +1841,8 @@ impl<'db, 'a> Resolution<'db, 'a> {
         let db = self.resolver.db;
         let generic_args_syntax = segment.generic_args(db);
         let segment_stable_ptr = segment.stable_ptr(db).untyped();
-        self.validate_module_item_usability(module_id, identifier, &inner_item_info);
-        self.resolver.insert_used_use(inner_item_info.item_id);
         let inner_generic_item =
-            ResolvedGenericItem::from_module_item(db, inner_item_info.item_id)?;
+            self.resolve_module_item_as_generic(module_id, identifier, &inner_item_info)?;
         let mut specialized_item = self.resolver.specialize_generic_module_item(
             self.diagnostics,
             identifier,
@@ -2034,11 +2032,14 @@ impl<'db, 'a> Resolution<'db, 'a> {
                     }
                     ResolvedBase::StatementEnvironment(generic_item) => generic_item,
                     ResolvedBase::FoundThroughGlobalUse {
-                        item_info: inner_module_item, ..
+                        item_info: inner_module_item,
+                        containing_module,
                     } => {
-                        self.resolver.insert_used_use(inner_module_item.item_id);
-                        let generic_item =
-                            ResolvedGenericItem::from_module_item(db, inner_module_item.item_id)?;
+                        let generic_item = self.resolve_module_item_as_generic(
+                            containing_module,
+                            &identifier,
+                            &inner_module_item,
+                        )?;
                         self.resolver.resolved_items.mark_generic(
                             db,
                             &self.segments.next().unwrap(),
@@ -2073,11 +2074,14 @@ impl<'db, 'a> Resolution<'db, 'a> {
                         .resolved_items
                         .mark_generic(db, &self.segments.next().unwrap(), generic_item),
                     ResolvedBase::FoundThroughGlobalUse {
-                        item_info: inner_module_item, ..
+                        item_info: inner_module_item,
+                        containing_module,
                     } => {
-                        self.resolver.insert_used_use(inner_module_item.item_id);
-                        let generic_item =
-                            ResolvedGenericItem::from_module_item(db, inner_module_item.item_id)?;
+                        let generic_item = self.resolve_module_item_as_generic(
+                            containing_module,
+                            &identifier,
+                            &inner_module_item,
+                        )?;
                         self.resolver.resolved_items.mark_generic(
                             db,
                             &self.segments.next().unwrap(),
@@ -2486,9 +2490,7 @@ impl<'db, 'a> Resolution<'db, 'a> {
             ResolvedGenericItem::Module(module_id) => {
                 let inner_item_info = self.module_inner_item(module_id, ident, &identifier)?;
 
-                self.validate_module_item_usability(*module_id, &identifier, &inner_item_info);
-                self.resolver.insert_used_use(inner_item_info.item_id);
-                ResolvedGenericItem::from_module_item(db, inner_item_info.item_id)
+                self.resolve_module_item_as_generic(*module_id, &identifier, &inner_item_info)
             }
             ResolvedGenericItem::GenericType(GenericTypeId::Enum(enum_id)) => {
                 let variants = db.enum_variants(*enum_id)?;
@@ -2594,26 +2596,29 @@ impl<'db, 'a> Resolution<'db, 'a> {
         }
         Ok(ResolvedBase::Module(self.resolver.prelude_submodule_ex(&self.macro_info)))
     }
-    /// Validates that an item is usable from the current module or adds a diagnostic.
-    /// This includes visibility checks and feature checks.
-    fn validate_module_item_usability(
+
+    /// Resolves a module item reached through an import into a [`ResolvedGenericItem`].
+    ///
+    /// Additionally enforces that the item is usable from the current context and records the
+    /// import as used.
+    ///
+    /// Every path that turns an imported item into a generic item — a direct import or one reached
+    /// through a glob `use *` — must go through here, so these checks are never skipped.
+    fn resolve_module_item_as_generic(
         &mut self,
-        containing_module_id: ModuleId<'db>,
+        containing_module: ModuleId<'db>,
         identifier: &ast::TerminalIdentifier<'db>,
         item_info: &ModuleItemInfo<'db>,
-    ) {
-        if !self.resolver.is_item_visible_ex(
-            containing_module_id,
-            item_info,
-            self.resolver.active_module_id(&self.macro_info),
-            &self.macro_info,
-        ) {
-            self.diagnostics.report(
-                identifier.stable_ptr(self.resolver.db),
-                ItemNotVisible(Some(item_info.item_id), vec![]),
-            );
+    ) -> Maybe<ResolvedGenericItem<'db>> {
+        let Self { resolver, diagnostics, macro_info, .. } = self;
+        let active_module = resolver.active_module_id(macro_info);
+        if !resolver.is_item_visible_ex(containing_module, item_info, active_module, macro_info) {
+            let stable_ptr = identifier.stable_ptr(resolver.db);
+            diagnostics.report(stable_ptr, ItemNotVisible(Some(item_info.item_id), vec![]));
         }
 
-        self.resolver.validate_feature_constraints(self.diagnostics, identifier, item_info);
+        resolver.validate_feature_constraints(diagnostics, identifier, item_info);
+        resolver.insert_used_use(item_info.item_id);
+        ResolvedGenericItem::from_module_item(resolver.db, item_info.item_id)
     }
 }


### PR DESCRIPTION
## Summary

Consolidates the three separate call sites that convert an imported module item into a `ResolvedGenericItem` into a single method, `resolve_module_item_as_generic`. This method combines the visibility check (`validate_module_item_usability`), the feature-gate check (`validate_feature_constraints`), the used-import recording (`insert_used_use`), and the conversion (`ResolvedGenericItem::from_module_item`) into one place, ensuring none of these steps can be accidentally omitted.

A new diagnostic test is added covering the case where an unstable item is re-exported through a glob `use *` — previously, the feature-gate warning was not emitted in that path because the `FoundThroughGlobalUse` branches were not calling `validate_feature_constraints`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `FoundThroughGlobalUse` resolution branches were calling `insert_used_use` and `ResolvedGenericItem::from_module_item` directly, bypassing `validate_module_item_usability` (which includes the feature-gate check). This meant that accessing an unstable item via a glob re-export (`use inner::*; pub use unstable as renamed;`) would not produce the expected `#[unstable]` warning.

---

## What was the behavior or documentation before?

Accessing an unstable item through a glob re-export silently skipped the unstable-feature diagnostic. The visibility and feature checks were only reliably applied on the direct-import code path.

---

## What is the behavior or documentation after?

All paths that resolve an imported item — direct imports and glob `use *` — go through `resolve_module_item_as_generic`, which unconditionally applies visibility checks, feature-gate checks, and used-import recording. A new test confirms that the unstable-feature warning is now emitted when an unstable item is re-exported via a glob import.

---

## Related issue or discussion (if any)

---

## Additional context

The refactor is purely mechanical: no logic was changed, only consolidated. The new method is documented with a note that every import-to-generic-item conversion must go through it so these checks are never skipped in the future.