### PR TITLE
Made calling meta_tx_v0 not crashl cairo test.

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -863,7 +863,7 @@ impl CairoHintProcessor<'_> {
                 self.get_class_hash_at(gas_counter, system_buffer.next_felt252()?.into_owned())
             }),
             "MetaTxV0" => execute_handle_helper(&mut |_system_buffer, _gas_counter| {
-                panic!("Meta transaction is not supported.")
+                fail_syscall!(b"Meta tx is not supported.")
             }),
             _ => panic!("Unknown selector for system call!"),
         }


### PR DESCRIPTION
## Summary

Replace `panic!` with `fail_syscall!` for the `MetaTxV0` syscall handler, so that unsupported meta transactions result in a graceful syscall failure rather than a hard process panic.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Using `panic!` in a syscall handler causes the entire runner process to abort when a `MetaTxV0` syscall is encountered. This is overly aggressive — the error should be surfaced as a syscall-level failure that the caller can handle, rather than crashing the process.

---

## What was the behavior or documentation before?

Calling the `MetaTxV0` syscall caused an immediate process panic with the message `"Meta transaction is not supported."`.

---

## What is the behavior or documentation after?

Calling the `MetaTxV0` syscall now returns a syscall failure with the message `b"Meta transaction is not supported."`, allowing the error to be handled gracefully by the caller.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A