### PR TITLE
bugfix(formatter): Made cairofmt::skip work properly for additional items.

### DIFF
--- a/crates/cairo-lang-formatter/test_data/cairo_files/fmt_skip.cairo
+++ b/crates/cairo-lang-formatter/test_data/cairo_files/fmt_skip.cairo
@@ -36,3 +36,19 @@ a: i32, b: i32,
 mod mod1 {
 fn foo() {let x=1   ;}
 }
+
+// Skip the formatting of trait items.
+trait MyTrait {
+    #[cairofmt::skip]
+    const   FOO:   i32;
+    #[cairofmt::skip]
+    type   Bar;
+    #[cairofmt::skip]
+    impl   Baz:   MyTrait;
+}
+
+// Skip the formatting of a macro declaration.
+#[cairofmt::skip]
+macro   my_macro   {
+    ($x:expr) => {$x};
+}

--- a/crates/cairo-lang-formatter/test_data/expected_results/fmt_skip.cairo
+++ b/crates/cairo-lang-formatter/test_data/expected_results/fmt_skip.cairo
@@ -81,3 +81,18 @@ a: i32, b: i32,
 mod mod1 {
 fn foo() {let x=1   ;}
 }
+
+// Skip the formatting of trait items.
+trait MyTrait {
+    #[cairofmt::skip]
+    const   FOO:   i32;
+    #[cairofmt::skip]
+    type   Bar;
+    #[cairofmt::skip]
+    impl   Baz:   MyTrait;
+}
+// Skip the formatting of a macro declaration.
+#[cairofmt::skip]
+macro   my_macro   {
+    ($x:expr) => {$x};
+}

--- a/crates/cairo-lang-syntax/src/node/helpers.rs
+++ b/crates/cairo-lang-syntax/src/node/helpers.rs
@@ -537,6 +537,18 @@ impl<'a> QueryAttrs<'a> for SyntaxNode<'a> {
             SyntaxKind::TraitItemFunction => {
                 Some(ast::TraitItemFunction::from_syntax_node(db, *self).attributes(db))
             }
+            SyntaxKind::TraitItemType => {
+                Some(ast::TraitItemType::from_syntax_node(db, *self).attributes(db))
+            }
+            SyntaxKind::TraitItemConstant => {
+                Some(ast::TraitItemConstant::from_syntax_node(db, *self).attributes(db))
+            }
+            SyntaxKind::TraitItemImpl => {
+                Some(ast::TraitItemImpl::from_syntax_node(db, *self).attributes(db))
+            }
+            SyntaxKind::ItemMacroDeclaration => {
+                Some(ast::ItemMacroDeclaration::from_syntax_node(db, *self).attributes(db))
+            }
             SyntaxKind::ItemInlineMacro => {
                 Some(ast::ItemInlineMacro::from_syntax_node(db, *self).attributes(db))
             }


### PR DESCRIPTION
## Summary

Extends `#[cairofmt::skip]` support to `TraitItemType`, `TraitItemConstant`, `TraitItemImpl`, and `ItemMacroDeclaration` nodes. Previously, applying `#[cairofmt::skip]` to trait associated types, constants, or impls, as well as macro declarations, had no effect because these syntax kinds were not handled in `QueryAttrs`. The attribute lookup now returns their attributes correctly, allowing the formatter to respect the skip directive.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`#[cairofmt::skip]` was silently ignored when placed on trait associated types (`type Bar`), trait associated constants (`const FOO: i32`), trait associated impls (`impl Baz: MyTrait`), and macro declarations (`macro my_macro { ... }`). This was because the `QueryAttrs` implementation for `SyntaxNode` did not include match arms for these syntax kinds, so their attributes were never surfaced to the formatter.

---

## What was the behavior or documentation before?

Applying `#[cairofmt::skip]` to trait item types, constants, impls, or macro declarations had no effect — the formatter would reformat those items regardless of the attribute.

---

## What is the behavior or documentation after?

`#[cairofmt::skip]` is now respected for `TraitItemType`, `TraitItemConstant`, `TraitItemImpl`, and `ItemMacroDeclaration`, preserving their original formatting as written.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Test cases covering all four newly supported node kinds have been added to `fmt_skip.cairo` and its corresponding expected output file.