### PR TITLE
fix(semantic): attribute format!/print! bracket errors to the right macro

### DIFF
--- a/crates/cairo-lang-defs/src/plugin_utils.rs
+++ b/crates/cairo-lang-defs/src/plugin_utils.rs
@@ -1,6 +1,7 @@
+use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::helpers::WrappedArgListHelper;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
-use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{SyntaxNode, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::require;
 use itertools::Itertools;
 use salsa::Database;
@@ -58,13 +59,27 @@ impl<'db> PluginResultTrait<'db> for PluginResult<'db> {
     }
 }
 
-/// Returns diagnostics for an unsupported bracket type.
+/// Returns diagnostics for an unsupported bracket type, wrapped in the macro's
+/// [`InlineMacroCall::Result`].
 pub fn unsupported_bracket_diagnostic<'db, CallAst: InlineMacroCall<'db>>(
     db: &'db dyn Database,
     legacy_macro_ast: &CallAst,
     macro_ast: impl Into<SyntaxStablePtrId<'db>>,
 ) -> CallAst::Result {
-    CallAst::Result::diagnostic_only(PluginDiagnostic::error_with_inner_span(
+    CallAst::Result::diagnostic_only(unsupported_bracket_diagnostic_inner(
+        db,
+        legacy_macro_ast,
+        macro_ast,
+    ))
+}
+
+/// Returns diagnostics for an unsupported bracket type.
+fn unsupported_bracket_diagnostic_inner<'db, CallAst: InlineMacroCall<'db>>(
+    db: &'db dyn Database,
+    legacy_macro_ast: &CallAst,
+    macro_ast: impl Into<SyntaxStablePtrId<'db>>,
+) -> PluginDiagnostic<'db> {
+    PluginDiagnostic::error_with_inner_span(
         db,
         macro_ast,
         legacy_macro_ast.arguments(db).left_bracket_syntax_node(db),
@@ -72,9 +87,10 @@ pub fn unsupported_bracket_diagnostic<'db, CallAst: InlineMacroCall<'db>>(
             "Macro `{}` does not support this bracket type.",
             legacy_macro_ast.path(db).as_syntax_node().get_text_without_trivia(db).long(db)
         ),
-    ))
+    )
 }
 
+/// Returns a diagnostic for a macro call that cannot be parsed as a legacy inline macro.
 pub fn not_legacy_macro_diagnostic(stable_ptr: SyntaxStablePtrId<'_>) -> PluginDiagnostic<'_> {
     PluginDiagnostic::error(
         stable_ptr,
@@ -82,6 +98,21 @@ pub fn not_legacy_macro_diagnostic(stable_ptr: SyntaxStablePtrId<'_>) -> PluginD
          parentheses, brackets, or braces."
             .to_string(),
     )
+}
+
+/// Extracts the parenthesized argument list of a legacy inline macro call. Returns a diagnostic on
+/// a non-legacy-macro call, or on a non-parenthesized bracket.
+pub fn extract_parenthesized_macro<'db>(
+    db: &'db dyn Database,
+    syntax: &ast::ExprInlineMacro<'db>,
+) -> Result<ast::ArgListParenthesized<'db>, PluginDiagnostic<'db>> {
+    let Some(syntax) = syntax.as_legacy_inline_macro(db) else {
+        return Err(not_legacy_macro_diagnostic(syntax.stable_ptr(db).untyped()));
+    };
+    let ast::WrappedArgList::ParenthesizedArgList(args) = syntax.arguments(db) else {
+        return Err(unsupported_bracket_diagnostic_inner(db, &syntax, syntax.stable_ptr(db)));
+    };
+    Ok(args)
 }
 
 /// Extracts a single unnamed argument.

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -691,7 +691,7 @@ test_function_diagnostics(expect_diagnostics: true)
 fn foo() {
     let ba: ByteArray = "hello";
 
-    // Bad brackets. TODO(orizi): Improve diagnostic to not include "write".
+    // Bad brackets.
     format!["{}", ba];
 
     // No params.
@@ -731,15 +731,15 @@ error[E1006]: Missing tokens. Expected an argument list wrapped in either parent
     format!;
            ^
 
-error[E2200]: Plugin diagnostic: Macro `write` does not support this bracket type.
+error[E2200]: Plugin diagnostic: Macro `format` does not support this bracket type.
  --> lib.cairo:5:12
     format!["{}", ba];
            ^
 
 error[E2200]: Plugin diagnostic: Macro expected format string argument.
- --> lib.cairo:8:12
+ --> lib.cairo:8:5
     format!();
-           ^
+    ^^^^^^^^^
 
 error[E2200]: Plugin diagnostic: Format string argument must be a string literal.
  --> lib.cairo:11:13
@@ -792,7 +792,7 @@ test_function_diagnostics(expect_diagnostics: true)
 fn foo() {
     let ba: ByteArray = "hello";
 
-    // Bad brackets. TODO(orizi): Improve diagnostic to not include "write".
+    // Bad brackets.
     print!["{}", ba];
 
     // No params.
@@ -832,15 +832,15 @@ error[E1006]: Missing tokens. Expected an argument list wrapped in either parent
     print!;
           ^
 
-error[E2200]: Plugin diagnostic: Macro `write` does not support this bracket type.
+error[E2200]: Plugin diagnostic: Macro `print` does not support this bracket type.
  --> lib.cairo:5:11
     print!["{}", ba];
           ^
 
 error[E2200]: Plugin diagnostic: Macro expected format string argument.
- --> lib.cairo:8:11
+ --> lib.cairo:8:5
     print!();
-          ^
+    ^^^^^^^^
 
 error[E2200]: Plugin diagnostic: Format string argument must be a string literal.
  --> lib.cairo:11:12
@@ -893,7 +893,7 @@ test_function_diagnostics(expect_diagnostics: true)
 fn foo() {
     let ba: ByteArray = "hello";
 
-    // Bad brackets. TODO(orizi): Improve diagnostic to not include "write".
+    // Bad brackets.
     println!["{}", ba];
 
     // No params.
@@ -933,7 +933,7 @@ error[E1006]: Missing tokens. Expected an argument list wrapped in either parent
     println!;
             ^
 
-error[E2200]: Plugin diagnostic: Macro `writeln` does not support this bracket type.
+error[E2200]: Plugin diagnostic: Macro `println` does not support this bracket type.
  --> lib.cairo:5:13
     println!["{}", ba];
             ^

--- a/crates/cairo-lang-semantic/src/inline_macros/format.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/format.rs
@@ -3,10 +3,8 @@ use cairo_lang_defs::plugin::{
     InlineMacroExprPlugin, InlinePluginResult, MacroPluginMetadata, NamedPlugin,
     PluginGeneratedFile,
 };
-use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
-use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
-use cairo_lang_syntax::node::helpers::WrappedArgListHelper;
-use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
+use cairo_lang_defs::plugin_utils::{PluginResultTrait, extract_parenthesized_macro};
+use cairo_lang_syntax::node::ast;
 use indoc::{formatdoc, indoc};
 use salsa::Database;
 
@@ -23,44 +21,25 @@ impl InlineMacroExprPlugin for FormatMacro {
         syntax: &ast::ExprInlineMacro<'db>,
         _metadata: &MacroPluginMetadata<'_>,
     ) -> InlinePluginResult<'db> {
-        let Some(syntax) = syntax.as_legacy_inline_macro(db) else {
-            return InlinePluginResult::diagnostic_only(not_legacy_macro_diagnostic(
-                syntax.as_syntax_node().stable_ptr(db),
-            ));
+        let args = match extract_parenthesized_macro(db, syntax) {
+            Ok(args) => args,
+            Err(diag) => return InlinePluginResult::diagnostic_only(diag),
         };
-        let arguments = syntax.arguments(db);
-        let mut builder = PatchBuilder::new(db, &syntax);
+        let mut builder = PatchBuilder::new(db, syntax);
         builder.add_modified(RewriteNode::interpolate_patched(
             &formatdoc! {
                 "
                     {{
                         let mut {f}: core::fmt::Formatter = core::traits::Default::default();
                         core::result::ResultTrait::<(), core::fmt::Error>::unwrap(
-                            write!$left_bracket${f}, $args$$right_bracket$
+                            write!({f}, $args$)
                         );
                         {f}.buffer
                     }}
                 ",
                 f = "__formatter_for_format_macro__",
             },
-            &[
-                (
-                    "left_bracket".to_string(),
-                    RewriteNode::new_trimmed(arguments.left_bracket_syntax_node(db)),
-                ),
-                (
-                    "right_bracket".to_string(),
-                    RewriteNode::new_trimmed(arguments.right_bracket_syntax_node(db)),
-                ),
-                (
-                    "args".to_string(),
-                    arguments
-                        .arg_list(db)
-                        .as_ref()
-                        .map_or_else(RewriteNode::empty, RewriteNode::from_ast_trimmed),
-                ),
-            ]
-            .into(),
+            &[("args".to_string(), RewriteNode::from_ast_trimmed(&args.arguments(db)))].into(),
         ));
         let (content, code_mappings) = builder.build();
         InlinePluginResult {

--- a/crates/cairo-lang-semantic/src/inline_macros/print.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/print.rs
@@ -3,10 +3,8 @@ use cairo_lang_defs::plugin::{
     InlineMacroExprPlugin, InlinePluginResult, MacroPluginMetadata, NamedPlugin,
     PluginGeneratedFile,
 };
-use cairo_lang_defs::plugin_utils::{PluginResultTrait, not_legacy_macro_diagnostic};
-use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
-use cairo_lang_syntax::node::helpers::WrappedArgListHelper;
-use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
+use cairo_lang_defs::plugin_utils::{PluginResultTrait, extract_parenthesized_macro};
+use cairo_lang_syntax::node::ast;
 use indoc::{formatdoc, indoc};
 use salsa::Database;
 
@@ -95,20 +93,18 @@ fn generate_code_inner<'db>(
     db: &'db dyn Database,
     with_newline: bool,
 ) -> InlinePluginResult<'db> {
-    let Some(syntax) = syntax.as_legacy_inline_macro(db) else {
-        return InlinePluginResult::diagnostic_only(not_legacy_macro_diagnostic(
-            syntax.as_syntax_node().stable_ptr(db),
-        ));
+    let args = match extract_parenthesized_macro(db, syntax) {
+        Ok(args) => args,
+        Err(diag) => return InlinePluginResult::diagnostic_only(diag),
     };
-    let arguments = syntax.arguments(db);
-    let mut builder = PatchBuilder::new(db, &syntax);
+    let mut builder = PatchBuilder::new(db, syntax);
     builder.add_modified(RewriteNode::interpolate_patched(
         &formatdoc! {
             "
                 {{
                     let mut {f}: core::fmt::Formatter = core::traits::Default::default();
                     core::result::ResultTrait::<(), core::fmt::Error>::unwrap(
-                        {write_func}!$left_bracket${f}, $args$$right_bracket$
+                        {write_func}!({f}, $args$)
                     );
                     core::debug::print_byte_array_as_string(@{f}.buffer);
                 }}
@@ -116,24 +112,7 @@ fn generate_code_inner<'db>(
             f = "__formatter_for_print_macros__",
             write_func = if with_newline { WritelnMacro::NAME } else { WriteMacro::NAME },
         },
-        &[
-            (
-                "left_bracket".to_string(),
-                RewriteNode::new_trimmed(arguments.left_bracket_syntax_node(db)),
-            ),
-            (
-                "right_bracket".to_string(),
-                RewriteNode::new_trimmed(arguments.right_bracket_syntax_node(db)),
-            ),
-            (
-                "args".to_string(),
-                arguments
-                    .arg_list(db)
-                    .as_ref()
-                    .map_or_else(RewriteNode::empty, RewriteNode::from_ast_trimmed),
-            ),
-        ]
-        .into(),
+        &[("args".to_string(), RewriteNode::from_ast_trimmed(&args.arguments(db)))].into(),
     ));
     let (content, code_mappings) = builder.build();
     InlinePluginResult {

--- a/crates/cairo-lang-semantic/src/inline_macros/write.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/write.rs
@@ -5,11 +5,8 @@ use cairo_lang_defs::plugin::{
     InlineMacroExprPlugin, InlinePluginResult, MacroPluginMetadata, NamedPlugin, PluginDiagnostic,
     PluginGeneratedFile,
 };
-use cairo_lang_defs::plugin_utils::{
-    not_legacy_macro_diagnostic, try_extract_unnamed_arg, unsupported_bracket_diagnostic,
-};
+use cairo_lang_defs::plugin_utils::{extract_parenthesized_macro, try_extract_unnamed_arg};
 use cairo_lang_filesystem::span::{TextSpan, TextWidth};
-use cairo_lang_parser::macro_helpers::AsLegacyInlineMacro;
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode, ast};
 use cairo_lang_utils::{OptionHelper, try_extract_matches};
 use indoc::indoc;
@@ -165,21 +162,11 @@ impl<'db> FormattingInfo<'db> {
         syntax: &ast::ExprInlineMacro<'db>,
         with_newline: bool,
     ) -> Result<FormattingInfo<'db>, Vec<PluginDiagnostic<'db>>> {
-        let Some(legacy_inline_macro) = syntax.as_legacy_inline_macro(db) else {
-            return Err(vec![not_legacy_macro_diagnostic(syntax.as_syntax_node().stable_ptr(db))]);
+        let args = match extract_parenthesized_macro(db, syntax) {
+            Ok(args) => args,
+            Err(diag) => return Err(vec![diag]),
         };
-        let ast::WrappedArgList::ParenthesizedArgList(arguments) =
-            legacy_inline_macro.arguments(db)
-        else {
-            return Err(unsupported_bracket_diagnostic(
-                db,
-                &legacy_inline_macro,
-                syntax.stable_ptr(db),
-            )
-            .diagnostics);
-        };
-        let arguments_var = arguments.arguments(db);
-        let mut args_iter = arguments_var.elements(db);
+        let mut args_iter = args.arguments(db).elements(db);
         let error_with_inner_span = |inner_span: SyntaxNode<'_>, message: &str| {
             PluginDiagnostic::error_with_inner_span(
                 db,
@@ -190,7 +177,7 @@ impl<'db> FormattingInfo<'db> {
         };
         let Some(formatter_arg) = args_iter.next() else {
             return Err(vec![error_with_inner_span(
-                arguments.lparen(db).as_syntax_node(),
+                args.lparen(db).as_syntax_node(),
                 "Macro expected formatter argument.",
             )]);
         };
@@ -220,7 +207,7 @@ impl<'db> FormattingInfo<'db> {
                 })
             } else {
                 Err(vec![error_with_inner_span(
-                    arguments.lparen(db).as_syntax_node(),
+                    args.lparen(db).as_syntax_node(),
                     "Macro expected format string argument.",
                 )])
             };


### PR DESCRIPTION
## Summary

The `format!`, `print!`, and `println!` macros now require parentheses as their bracket type. Previously, these macros forwarded whatever bracket type was used (e.g., `format![...]`) directly into the generated `write!`/`writeln!` call, which caused the "unsupported bracket type" diagnostic to incorrectly reference `write` or `writeln` instead of the actual macro being invoked. Now, non-parenthesis brackets are rejected early with a diagnostic naming the correct macro, and the generated code always uses parentheses for the inner `write!`/`writeln!` call.

Additionally, the "no params" diagnostic span for `format!()` and `print!()` was corrected to point at the entire macro invocation rather than just the opening bracket.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a user wrote `format![...]` or `print![...]`, the diagnostic reported that macro `write` does not support this bracket type, which was confusing because the user never invoked `write` directly. The root cause was that the bracket tokens were forwarded verbatim into the generated `write!` expansion, so the error surfaced from the inner macro rather than the outer one.

---

## What was the behavior or documentation before?

Using square brackets with `format!`, `print!`, or `println!` produced:

```
error[E2200]: Plugin diagnostic: Macro `write` does not support this bracket type.
```

And the "no format string argument" diagnostic pointed at the opening bracket position rather than the full macro call.

---

## What is the behavior or documentation after?

Using square brackets now produces a diagnostic that correctly names the invoked macro:

```
error[E2200]: Plugin diagnostic: Macro `format` does not support this bracket type.
```

The "no format string argument" diagnostic now spans the entire macro invocation (e.g., `format!()`).

---

## Related issue or discussion (if any)

Resolves the TODO comments previously left in the test data referencing `orizi`.

---

## Additional context

The bracket-forwarding logic (`left_bracket`/`right_bracket` rewrite nodes) has been removed entirely. The generated code now unconditionally uses `write!(...)` with parentheses, and unsupported bracket types are rejected before code generation via `unsupported_bracket_diagnostic`.