### PR TITLE
fix(starknet): clearer error for a non-`ref self` constructor

### DIFF
--- a/crates/cairo-lang-starknet/src/abi.rs
+++ b/crates/cairo-lang-starknet/src/abi.rs
@@ -458,8 +458,9 @@ impl<'db> AbiBuilder<'db> {
 
         let (inputs, state_mutability) =
             self.get_function_signature_inputs_and_mutability(signature, storage_type)?;
+        require(state_mutability == StateMutability::External)
+            .ok_or(ABIError::ConstructorNotExternal(source))?;
         self.ctor = Some(EntryPointInfo { source, inputs: inputs.clone() });
-        require(state_mutability == StateMutability::External).ok_or(ABIError::UnexpectedType)?;
 
         let constructor_item = Item::Constructor(Constructor { name, inputs });
         self.add_abi_item(constructor_item, true, source)?;
@@ -891,6 +892,8 @@ pub enum ABIError<'db> {
     ExpectedOneGenericParam(Source<'db>),
     #[error("Contracts must have only one constructor.")]
     MultipleConstructors(Source<'db>),
+    #[error("A contract constructor must take `ref self`, not `@self`.")]
+    ConstructorNotExternal(Source<'db>),
     #[error("Contracts must have a Storage struct.")]
     NoStorage,
     #[error("Contracts must have only one Storage struct.")]
@@ -943,6 +946,7 @@ impl<'db> ABIError<'db> {
             | ABIError::EventWithGenericParams(source)
             | ABIError::ExpectedOneGenericParam(source)
             | ABIError::MultipleConstructors(source)
+            | ABIError::ConstructorNotExternal(source)
             | ABIError::MultipleStorages(source)
             | ABIError::EmbeddedImplMustBeInterface(source)
             | ABIError::EmbeddedImplNotEmbeddable(source)

--- a/crates/cairo-lang-starknet/src/test_data/abi_failures
+++ b/crates/cairo-lang-starknet/src/test_data/abi_failures
@@ -258,3 +258,31 @@ warning[E2200]: Plugin diagnostic: Failed to generate ABI: `__validate_deploy__`
 | ...
 |         ) {}
 |____________^
+
+//! > ==========================================================================
+
+//! > Test constructor taking `@self` (view) instead of `ref self`.
+
+//! > test_runner_name
+test_abi_failure(expect_diagnostics: warnings_only)
+
+//! > cairo_code
+#[starknet::contract]
+mod contract {
+    #[storage]
+    struct Storage {}
+
+    #[constructor]
+    fn constructor(self: @ContractState) {}
+}
+
+//! > expected_error
+A contract constructor must take `ref self`, not `@self`.
+
+//! > expected_diagnostics
+warning[E2200]: Plugin diagnostic: Failed to generate ABI: A contract constructor must take `ref self`, not `@self`.
+ --> lib.cairo:6:5-7:43
+      #[constructor]
+ _____^
+|     fn constructor(self: @ContractState) {}
+|___________________________________________^


### PR DESCRIPTION
## Summary

Adds a dedicated `ConstructorNotExternal` ABI error for the case where a contract constructor is declared with `self: @ContractState` (view/snapshot) instead of `ref self: ContractState` (external). Previously, this case fell through to a generic `UnexpectedType` error, which gave no useful diagnostic information. The new error message explicitly states: `"A contract constructor must take 'ref self', not '@self'."` and correctly points to the constructor's source location in the diagnostic output.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a constructor was written with `self: @ContractState` instead of `ref self: ContractState`, the compiler emitted a generic `UnexpectedType` error with no indication of what was actually wrong or how to fix it. This made it difficult for developers to diagnose the issue.

---

## What was the behavior or documentation before?

A constructor declared with `self: @ContractState` would fail ABI generation with the unhelpful error `UnexpectedType`, and the source location was not attached to the error.

---

## What is the behavior or documentation after?

ABI generation now fails with the specific error:

```
A contract constructor must take `ref self`, not `@self`.
```

The diagnostic correctly points to the constructor definition in the source file.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A new test case (`Test constructor taking '@self' (view) instead of 'ref self'`) has been added to `abi_failures` to cover this scenario.