### PR TITLE
fix(starknet-classes): reject crafted out-of-range type ids instead of panicking

### DIFF
--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class.rs
@@ -442,6 +442,11 @@ impl CasmContractClass {
                 });
             }
         }
+        let program_info = ProgramRegistryInfo::new(&program).map_err(|err| {
+            StarknetSierraCompilationError::CompilationError(Box::new(
+                CompilationError::ProgramRegistryError(err),
+            ))
+        })?;
         let type_resolver = TypeResolver { type_decl: &program.type_declarations };
 
         // Validates the entry point's signature, returning its entry statement, function id and
@@ -533,11 +538,6 @@ impl CasmContractClass {
             skip_non_linear_solver_comparisons: false,
             compute_runtime_costs: false,
         };
-        let program_info = ProgramRegistryInfo::new(&program).map_err(|err| {
-            StarknetSierraCompilationError::CompilationError(Box::new(
-                CompilationError::ProgramRegistryError(err),
-            ))
-        })?;
         let metadata = calc_metadata(&program, &program_info, metadata_computation_config)?;
         let cairo_program = cairo_lang_sierra_to_casm::compiler::compile(
             &program,

--- a/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
+++ b/crates/cairo-lang-starknet-classes/src/casm_contract_class_test.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::io::BufReader;
 
 use cairo_lang_sierra::ids::{ConcreteTypeId, GenericLibfuncId};
+use cairo_lang_sierra::program_registry::ProgramRegistryError;
+use cairo_lang_sierra_to_casm::compiler::CompilationError;
 use cairo_lang_test_utils::compare_contents_or_fix_with_path;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
@@ -105,6 +107,27 @@ fn test_entry_point_mid_list_gas_or_system_rejected() {
             StarknetSierraCompilationError::InvalidBuiltinType(mid_ty),
         );
     }
+}
+
+#[test]
+fn test_entry_point_out_of_range_type_id_rejected() {
+    let contract_class = load_example_contract_class("libfuncs_coverage__libfuncs_coverage");
+    let mut extracted = contract_class.extract_sierra_program(false).unwrap();
+    let program = &mut extracted.program;
+    // An id one past the last declaration is guaranteed undeclared.
+    let out_of_range = ConcreteTypeId::new(program.type_declarations.len() as u64);
+    let func_idx = contract_class.entry_points_by_type.external[0].function_idx;
+    // Point the entry point's input (the `Span<felt252>` calldata param) at the undeclared type id.
+    *program.funcs[func_idx].signature.param_types.last_mut().unwrap() = out_of_range.clone();
+    assert_eq!(
+        CasmContractClass::from_contract_class(contract_class, extracted, false, usize::MAX)
+            .unwrap_err(),
+        StarknetSierraCompilationError::CompilationError(Box::new(
+            CompilationError::ProgramRegistryError(Box::new(ProgramRegistryError::MissingType(
+                out_of_range
+            ))),
+        )),
+    );
 }
 
 /// Tests that the CASM compiled from a contract in the contract_crate is the same as in


### PR DESCRIPTION
## Summary

`ProgramRegistryInfo::new` is now called earlier in `CasmContractClass::from_contract_class`, before entry point signature validation, so that an out-of-range type ID in a function signature is caught and reported as a `ProgramRegistryError` rather than causing a panic or misleading error later. A new test (`test_entry_point_out_of_range_type_id_rejected`) verifies that a contract with an entry point referencing an undeclared type ID is rejected with the correct `CompilationError::ProgramRegistryError(ProgramRegistryError::MissingType(...))` error.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When an entry point's function signature referenced a type ID that was not declared in the program's type declarations, the error was not caught at the registry construction stage. By moving `ProgramRegistryInfo::new` earlier in the compilation pipeline, the missing type is detected immediately and surfaced as a proper `ProgramRegistryError::MissingType` rather than propagating into later stages where it could cause a panic or an opaque failure.

---

## What was the behavior or documentation before?

`ProgramRegistryInfo::new` was called after entry point signature validation. An out-of-range type ID in a function signature could reach later compilation stages without a clear, structured error.

---

## What is the behavior or documentation after?

`ProgramRegistryInfo::new` is called before entry point signature validation. An out-of-range type ID in a function signature is immediately rejected with `StarknetSierraCompilationError::CompilationError(CompilationError::ProgramRegistryError(ProgramRegistryError::MissingType(...)))`.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The new test mutates a known-good contract class by replacing the last parameter type of an external entry point with a `ConcreteTypeId` one past the end of the declared types list, confirming the error path end-to-end.