### PR TITLE
fix(parser): stop block recovery at a following control-flow statement

### DIFF
--- a/crates/cairo-lang-parser/src/parser_test_data/diagnostics/if
+++ b/crates/cairo-lang-parser/src/parser_test_data/diagnostics/if
@@ -40,10 +40,15 @@ error[E1002]: Missing tokens. Expected an expression.
     if 0 == if x {1} else {2} {
            ^
 
-error[E1000]: Skipped tokens. Expected: '{'.
- --> dummy_file.cairo:2:13
+error[E1001]: Missing token '{'.
+ --> dummy_file.cairo:2:12
     if 0 == if x {1} else {2} {
-            ^^^^
+           ^
+
+error[E1001]: Missing token '}'.
+ --> dummy_file.cairo:4:2
+}
+ ^
 
 //! > ==========================================================================
 
@@ -315,3 +320,57 @@ error[E1000]: Skipped tokens. Expected: statement.
  --> dummy_file.cairo:7:44
     if x += 3 && let x = 10 || false < > { += }
                                            ^^
+
+//! > ==========================================================================
+
+//! > Test broken if header does not swallow a following control-flow statement
+
+//! > test_comments
+// Recovering the broken `if` block must stop at the following `while`, leaving it
+// as its own statement rather than consuming its `{ ... }` as the `if` body.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+fn f(a: felt252, b: bool) {
+    if a ==
+    while b { let _x = 1; }
+    let _y = 2;
+}
+
+//! > expected_diagnostics
+error[E1002]: Missing tokens. Expected an expression.
+ --> dummy_file.cairo:2:12
+    if a ==
+           ^
+
+error[E1001]: Missing token '{'.
+ --> dummy_file.cairo:2:12
+    if a ==
+           ^
+
+error[E1001]: Missing token '}'.
+ --> dummy_file.cairo:5:2
+}
+ ^
+
+//! > ==========================================================================
+
+//! > Test bad if condition with well-formed braces keeps the inner statement.
+
+//! > test_runner_name
+get_diagnostics
+
+//! > cairo_code
+fn f(b: bool) {
+    if {
+        while b {}
+    }
+}
+
+//! > expected_diagnostics
+error[E1002]: Missing tokens. Expected an expression.
+ --> dummy_file.cairo:2:7
+    if {
+      ^

--- a/crates/cairo-lang-parser/src/recovery.rs
+++ b/crates/cairo-lang-parser/src/recovery.rs
@@ -102,7 +102,15 @@ pub(crate) use module_item_kw;
 
 macro_rules! block {
     () => {
-        SyntaxKind::TerminalLet | SyntaxKind::TerminalMatch | SyntaxKind::TerminalReturn
+        SyntaxKind::TerminalLet
+            | SyntaxKind::TerminalMatch
+            | SyntaxKind::TerminalReturn
+            | SyntaxKind::TerminalBreak
+            | SyntaxKind::TerminalContinue
+            | SyntaxKind::TerminalIf
+            | SyntaxKind::TerminalWhile
+            | SyntaxKind::TerminalLoop
+            | SyntaxKind::TerminalFor
     };
 }
 pub(crate) use block;


### PR DESCRIPTION
### TL;DR

Improved parser error recovery for broken `if` statement headers to prevent consuming subsequent control-flow statements as part of the `if` body.

### What changed?

The `block!` recovery macro now includes `if`, `while`, `loop`, and `for` as recovery stop tokens, in addition to the existing `let`, `match`, and `return`. This ensures that when the parser encounters a malformed `if` header (e.g., `if a ==` with a missing right-hand expression), it stops recovery at the next control-flow keyword rather than consuming it as part of the broken `if` block.

Additionally, the diagnostic reported for a missing `{` after a broken `if` header was changed from a "Skipped tokens" error to a more precise "Missing token '{'" error, with a corresponding "Missing token '}'" error to close the implicit block.

### How to test?

The existing parser diagnostic test suite covers this behavior. A new test case was added verifying that a broken `if` header followed by a `while` statement correctly produces missing-token diagnostics without swallowing the `while` as the `if` body:

```cairo
fn f(a: felt252, b: bool) {
    if a ==
    while b { let _x = 1; }
    let _y = 2;
}
```

### Why make this change?

Previously, a malformed `if` header would cause the parser to greedily consume the `{ ... }` block of a subsequent control-flow statement (e.g., `while`, `loop`, `for`) as the body of the broken `if`. This led to confusing diagnostics and incorrect AST structure. By treating control-flow keywords as recovery boundaries, the parser now handles these cases more gracefully and produces cleaner, more accurate error messages.