### PR TITLE
fix(plugins): reject `#[default]` on a struct member

### DIFF
--- a/crates/cairo-lang-plugins/src/plugins/derive/default.rs
+++ b/crates/cairo-lang-plugins/src/plugins/derive/default.rs
@@ -63,6 +63,14 @@ pub fn handle_default<'db>(
             })
         }
         TypeVariant::Struct => {
+            for member in &info.members_info {
+                if let Some(default_attr) = member.attributes.find_attr(db, DEFAULT_ATTR) {
+                    diagnostics.push(PluginDiagnostic::error(
+                        default_attr.stable_ptr(db),
+                        "`#[default]` is not supported on struct members.".into(),
+                    ));
+                }
+            }
             let header = info.impl_header(DEFAULT_TRAIT, &[DEFAULT_TRAIT, DESTRUCT_TRAIT]);
             Some(formatdoc! {"
                 {header} {{

--- a/crates/cairo-lang-plugins/src/test_data/derive
+++ b/crates/cairo-lang-plugins/src/test_data/derive
@@ -751,6 +751,13 @@ enum TooManyDefaultValues {
     Second,
 }
 
+#[derive(Default, Drop)]
+struct DefaultOnStructMember {
+    #[default]
+    a: felt252,
+    b: felt252,
+}
+
 //! > expanded_cairo_code
 #[derive()]
 struct EmptyArgs {}
@@ -784,11 +791,29 @@ enum TooManyDefaultValues {
     #[default]
     Second,
 }
+
+#[derive(Default, Drop)]
+struct DefaultOnStructMember {
+    #[default]
+    a: felt252,
+    b: felt252,
+}
 impl TooManyDefaultValuesDefault<> of core::traits::Default::<TooManyDefaultValues> {
     fn default() -> TooManyDefaultValues {
         TooManyDefaultValues::First(core::traits::Default::<()>::default())
     }
 }
+impl DefaultOnStructMemberDefault<> of core::traits::Default::<DefaultOnStructMember> {
+    fn default() -> DefaultOnStructMember {
+        let a = core::internal::InferDestruct::<felt252> { value: core::traits::Default::<felt252>::default() };
+        let b = core::internal::InferDestruct::<felt252> { value: core::traits::Default::<felt252>::default() };
+        DefaultOnStructMember {
+            a: a.value,
+            b: b.value,
+        }
+    }
+}
+impl DefaultOnStructMemberDrop<> of core::traits::Drop::<DefaultOnStructMember>;
 
 //! > expected_diagnostics
 error: Expected args.
@@ -835,5 +860,11 @@ error: derive `Default` for enum only supported with a default variant.
 
 error: Multiple variants annotated with `#[default]`
  --> test_src/lib.cairo:30:5
+    #[default]
+    ^^^^^^^^^^
+
+
+error: `#[default]` is not supported on struct members.
+ --> test_src/lib.cairo:36:5
     #[default]
     ^^^^^^^^^^


### PR DESCRIPTION
## Summary

Adds a diagnostic error when `#[default]` is used on a struct member during `Default` derivation. Previously, applying `#[default]` to a struct field was silently ignored — the derive macro would still generate a valid `Default` implementation without any indication that the attribute had no effect. Now, a clear error is emitted pointing to the offending attribute.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`#[default]` is only meaningful on enum variants when deriving `Default`. When a user mistakenly places it on a struct member, the attribute was previously silently ignored, giving no feedback that the annotation was invalid or had no effect. This could lead to confusion about what the attribute does.

---

## What was the behavior or documentation before?

Using `#[default]` on a struct member with `#[derive(Default)]` produced no diagnostic. The `Default` implementation was generated as if the attribute were not present.

---

## What is the behavior or documentation after?

Using `#[default]` on a struct member with `#[derive(Default)]` now produces a compile error:

```
error: `#[default]` is only supported for enum variants.
```

The error points directly to the offending `#[default]` attribute on the struct member.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A