### PR TITLE
ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration to automatically keep GitHub Actions dependencies up to date on a weekly schedule. All GitHub Actions are grouped together so updates are batched into a single PR.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Without Dependabot, GitHub Actions version pins can become stale, potentially leaving CI workflows on outdated or vulnerable action versions with no automated mechanism to surface updates.

---

## What was the behavior or documentation before?

There was no automated process to detect or propose updates to GitHub Actions versions used in workflows.

---

## What is the behavior or documentation after?

Dependabot will check for GitHub Actions updates weekly and open a single grouped PR with all available updates.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Actions are grouped under a single `github-actions` group using a wildcard pattern, so all updates arrive in one PR rather than one PR per action.