### PR TITLE
ci: retry rate-limited crate publishes during release

### DIFF
--- a/scripts/release_crates.sh
+++ b/scripts/release_crates.sh
@@ -11,16 +11,27 @@ fi
 
 source "$(dirname "$0")/crates_list.sh"
 
+RETRY_COUNT=2
+RATELIMIT_SLEEP=60
+
 # Publish the crates.
 for CRATE in "${CRATES[@]:$SKIP_FIRST}"; do
-    output=$(cargo publish --package "$CRATE" 2>&1)
-    exit_code=$?
-    if [ $exit_code -ne 0 ]; then
+    for ((attempt = 0; attempt <= RETRY_COUNT; attempt++)); do
+        output=$(cargo publish --package "$CRATE" 2>&1)
+        if [ $? -eq 0 ]; then
+            echo "Published $CRATE successfully."
+            break
+        fi
         if echo "$output" | grep -qi "already exists\|already uploaded"; then
             echo "Skipping $CRATE (already published)."
-        else
-            echo "$output" >&2
-            exit 1
+            break
         fi
-    fi
+        echo "$output" >&2
+        if echo "$output" | grep -qi "Please try again after" && [ $attempt -lt $RETRY_COUNT ]; then
+            echo "Rate limited; retrying $CRATE in ${RATELIMIT_SLEEP}s (attempt $attempt)..." >&2
+            sleep $RATELIMIT_SLEEP
+            continue
+        fi
+        exit 1
+    done
 done


### PR DESCRIPTION
## Summary

The crate release script now retries publishing when crates.io returns a rate limit response, sleeping for 60 seconds between attempts (up to 2 retries). It also explicitly logs a success message when a crate publishes successfully.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When publishing many crates in sequence, crates.io can respond with a rate limit error ("Please try again after ..."). Previously, the script would treat this as a fatal error and exit immediately, requiring a manual restart of the release process.

---

## What was the behavior or documentation before?

Any non-zero exit code from `cargo publish` that wasn't an "already exists" error caused the script to print the error and exit with code 1, including transient rate limit responses from crates.io.

---

## What is the behavior or documentation after?

When a rate limit response is detected, the script waits 60 seconds and retries the publish up to 2 times before giving up. All other errors still cause an immediate exit. Successfully published crates now log a confirmation message.

---

## Related issue or discussion (if any)

---

## Additional context

`RETRY_COUNT` and `RATELIMIT_SLEEP` are defined as constants at the top of the script for easy adjustment.