### PR TITLE
docs(semantic): drop copy-pasted `assert!` examples from `panic!` doc.

### DIFF
--- a/crates/cairo-lang-semantic/src/inline_macros/panic.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/panic.rs
@@ -145,10 +145,6 @@ impl InlineMacroExprPlugin for PanicMacro {
                 panic!("Math is broken: {} + {} != 30", x, y);
                 // Panics with "Math is broken: 10 + 20 != 30".
             }
-            let x = -1;
-            assert!(x >= 0, "Invalid value: x = {}", x);
-            assert!(x >= 0, "Invalid value: x = {x}");
-            // Panics with "Invalid value: x = -1."
             ```
 
             # Notes


### PR DESCRIPTION
## Summary

Removes the `assert!` macro examples from the `panic!` macro documentation.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `panic!` macro documentation included example usages of the `assert!` macro, which is a separate macro and does not belong in the `panic!` documentation. This is misleading, as it implies `assert!` is part of `panic!`'s behavior or usage.

---

## What was the behavior or documentation before?

The `panic!` macro docs contained example code demonstrating `assert!` macro calls, including `assert!(x >= 0, "Invalid value: x = {}", x)` and `assert!(x >= 0, "Invalid value: x = {x}")`.

---

## What is the behavior or documentation after?

The `panic!` macro documentation no longer includes `assert!` examples, keeping the docs focused solely on `panic!` usage.

---

## Related issue or discussion (if any)

---

## Additional context

The `assert!` macro has its own documentation and examples; its usage should not appear in the `panic!` macro docs.