### PR TITLE
docs(corelib): Made bytes31 example compile.

### DIFF
--- a/corelib/src/bytes_31.cairo
+++ b/corelib/src/bytes_31.cairo
@@ -4,13 +4,11 @@
 //!
 //! # Examples
 //!
-//! Creating a `bytes31` from a `felt252`:
 //! ```
+//! // Creating a `bytes31` from a `felt252`:
 //! let value: bytes31 = 0xaabb.try_into().unwrap();
-//! ```
 //!
-//! Accessing a byte by index:
-//! ```
+//! // Accessing a byte by index:
 //! assert!(value[0] == 0xbb);
 //! ```
 


### PR DESCRIPTION
## Summary

Consolidates the two separate code blocks in the `bytes31` module documentation into a single code block, converting the section headers from standalone text into inline comments within the example.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The `bytes31` module had two separate fenced code blocks for what is effectively one continuous example — creating a `bytes31` value and then accessing a byte by index. Splitting them into two blocks broke the logical flow, since the second block references `value` defined in the first. Combining them into a single block makes the example self-contained and easier to read.

---

## What was the behavior or documentation before?

Two separate fenced code blocks with prose headers between them, where the second block depended on a variable declared in the first.

---

## What is the behavior or documentation after?

A single fenced code block containing both the construction and the index access, with the former prose headers converted to inline comments.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A