### PR TITLE
fix(parser): validate param kind for every macro rule param, not just the first

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -865,7 +865,6 @@ impl<'a, 'mt> Parser<'a, 'mt> {
                             }
                             OptionParamKindEmpty::new_green(self.db).into()
                         };
-                        self.macro_parsing_context = MacroParsingContext::None;
                         Ok(MacroParam::new_green(self.db, dollar, ident, param_kind).into())
                     }
                 }

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/macro_declaration
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/macro_declaration
@@ -396,3 +396,66 @@ error[E1031]: Missing macro repetition operator. Expected `?`, `+`, or `*` after
     │       │       └── semicolon (kind: TokenSemicolon): ';'
     │       └── rbrace (kind: TokenRBrace): '}'
     └── eof (kind: TokenEndOfFile).
+
+//! > ==========================================================================
+
+//! > Test macro rule parameter kind validation is not silenced after the first parameter.
+
+//! > test_runner_name
+test_partial_parser_tree(expect_diagnostics: true)
+
+//! > cairo_code
+macro macro_name {
+    ($a:expr $b) => {
+        $a
+    };
+}
+
+//! > top_level_kind
+
+//! > ignored_kinds
+
+//! > expected_diagnostics
+error[E1010]: Macro parameter must have a kind.
+ --> dummy_file.cairo:2:15
+    ($a:expr $b) => {
+              ^
+
+//! > expected_tree
+└── root (kind: SyntaxFile)
+    ├── items (kind: ModuleItemList)
+    │   └── child #0 (kind: ItemMacroDeclaration)
+    │       ├── attributes (kind: AttributeList) []
+    │       ├── visibility (kind: VisibilityDefault) []
+    │       ├── macro_kw (kind: TokenMacro): 'macro'
+    │       ├── name (kind: TokenIdentifier): 'macro_name'
+    │       ├── lbrace (kind: TokenLBrace): '{'
+    │       ├── rules (kind: MacroRulesList)
+    │       │   └── child #0 (kind: MacroRule)
+    │       │       ├── lhs (kind: ParenthesizedMacro)
+    │       │       │   ├── lparen (kind: TokenLParen): '('
+    │       │       │   ├── elements (kind: MacroElements)
+    │       │       │   │   ├── child #0 (kind: MacroParam)
+    │       │       │   │   │   ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │   │   ├── name (kind: TokenIdentifier): 'a'
+    │       │       │   │   │   └── kind (kind: ParamKind)
+    │       │       │   │   │       ├── colon (kind: TokenColon): ':'
+    │       │       │   │   │       └── kind (kind: ParamExpr)
+    │       │       │   │   │           └── expr (kind: TokenIdentifier): 'expr'
+    │       │       │   │   └── child #1 (kind: MacroParam)
+    │       │       │   │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       ├── name (kind: TokenIdentifier): 'b'
+    │       │       │   │       └── kind (kind: OptionParamKindEmpty) []
+    │       │       │   └── rparen (kind: TokenRParen): ')'
+    │       │       ├── fat_arrow (kind: TokenMatchArrow): '=>'
+    │       │       ├── rhs (kind: BracedMacro)
+    │       │       │   ├── lbrace (kind: TokenLBrace): '{'
+    │       │       │   ├── elements (kind: MacroElements)
+    │       │       │   │   └── child #0 (kind: MacroParam)
+    │       │       │   │       ├── dollar (kind: TokenDollar): '$'
+    │       │       │   │       ├── name (kind: TokenIdentifier): 'a'
+    │       │       │   │       └── kind (kind: OptionParamKindEmpty) []
+    │       │       │   └── rbrace (kind: TokenRBrace): '}'
+    │       │       └── semicolon (kind: TokenSemicolon): ';'
+    │       └── rbrace (kind: TokenRBrace): '}'
+    └── eof (kind: TokenEndOfFile).


### PR DESCRIPTION
## Summary

Fixes a bug where the `MacroParsingContext` was being reset to `None` after parsing the first macro parameter, causing parameter kind validation to be silenced for all subsequent parameters in a macro rule.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

After parsing the first macro parameter, `self.macro_parsing_context` was reset to `MacroParsingContext::None`. This meant that any subsequent parameters in the same macro rule would not be validated for a required kind annotation. For example, in `($a:expr $b) => { ... }`, the missing kind on `$b` would not produce a diagnostic.

---

## What was the behavior or documentation before?

Only the first macro parameter in a rule was subject to kind validation. Subsequent parameters with missing kinds (e.g., `$b` without `:expr`) would silently parse without emitting an `E1010` diagnostic.

---

## What is the behavior or documentation after?

All macro parameters in a rule are validated for a kind annotation. In the example `($a:expr $b) => { ... }`, the parser now correctly emits:

```
error[E1010]: Macro parameter must have a kind.
 --> dummy_file.cairo:2:15
    ($a:expr $b) => {
              ^
```

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A new test case was added to `partial_trees/macro_declaration` to cover the scenario where a macro rule has multiple parameters and only the second one is missing a kind annotation.