### PR TITLE
fix(defs): reject multiple `#[path(..)]` attributes on a module

### DIFF
--- a/crates/cairo-lang-defs/src/db.rs
+++ b/crates/cairo-lang-defs/src/db.rs
@@ -1346,9 +1346,8 @@ pub fn validate_attributes_flat<'db, Item: QueryAttrs<'db> + TypedSyntaxNode<'db
     }
 
     // Additional semantic validation for `#[path("...")]` attribute.
-    for attr in item.query_attr(db, PATH_ATTR) {
-        let node = item.as_syntax_node();
-        let Some(item_module) = ast::ItemModule::cast(db, node) else {
+    for (idx, attr) in item.query_attr(db, PATH_ATTR).enumerate() {
+        let Some(item_module) = ast::ItemModule::cast(db, item.as_syntax_node()) else {
             plugin_diagnostics.push(PluginDiagnostic::error(
                 attr.stable_ptr(db),
                 "`#[path(..)]` is only allowed on module declarations.".to_string(),
@@ -1370,6 +1369,12 @@ pub fn validate_attributes_flat<'db, Item: QueryAttrs<'db> + TypedSyntaxNode<'db
             plugin_diagnostics.push(PluginDiagnostic::error(
                 args.stable_ptr(db),
                 "`#[path(..)]` expects exactly one string literal argument.".to_string(),
+            ));
+        }
+        if idx > 0 {
+            plugin_diagnostics.push(PluginDiagnostic::error(
+                attr.stable_ptr(db),
+                "Multiple `#[path(..)]` attributes are not allowed on a single module.".to_string(),
             ));
         }
     }

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -1559,6 +1559,9 @@ mod m2;
 #[path(3)]
 mod m3;
 
+#[path("first.cairo")]
+#[path("second.cairo")]
+mod multiple_paths;
 #[path("non_existent_path.cairo")]
 mod non_existing;
 
@@ -1590,6 +1593,11 @@ error[E2200]: Plugin diagnostic: `#[path(..)]` expects exactly one string litera
 #[path(3)]
       ^^^
 
+error[E2200]: Plugin diagnostic: Multiple `#[path(..)]` attributes are not allowed on a single module.
+ --> lib.cairo:17:1
+#[path("second.cairo")]
+^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0005]: Module file not found. Expected path: m1.cairo
  --> lib.cairo:7:1-8:7
   #[path]
@@ -1611,8 +1619,16 @@ error[E0005]: Module file not found. Expected path: m3.cairo
 | mod m3;
 |_______^
 
+error[E0005]: Module file not found. Expected path: first.cairo
+ --> lib.cairo:16:1-18:19
+  #[path("first.cairo")]
+ _^
+| #[path("second.cairo")]
+| mod multiple_paths;
+|___________________^
+
 error[E0005]: Module file not found. Expected path: non_existent_path.cairo
- --> lib.cairo:16:1-17:17
+ --> lib.cairo:19:1-20:17
   #[path("non_existent_path.cairo")]
  _^
 | mod non_existing;


### PR DESCRIPTION
## Summary

Adds a diagnostic error when multiple `#[path(..)]` attributes are applied to a single module declaration. Previously, applying multiple `#[path(..)]` attributes to a module was silently accepted (or only partially validated), with the first path being used. Now, any `#[path(..)]` attribute beyond the first emits an explicit error: `"Multiple #[path(..)] attributes are not allowed on a single module."`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Having multiple `#[path(..)]` attributes on a single module is ambiguous — only one path can be used, and silently ignoring the rest could lead to confusing behavior where a developer believes a second `#[path(..)]` overrides the first, when it does not. This change makes the invalid usage explicit with a clear diagnostic.

---

## What was the behavior or documentation before?

Multiple `#[path(..)]` attributes on a module were not flagged as an error. The compiler would silently use the first valid path and ignore subsequent ones, giving no indication that the extra attributes were invalid.

---

## What is the behavior or documentation after?

Any `#[path(..)]` attribute after the first on a module declaration now produces a plugin diagnostic error pointing to the offending attribute, clearly stating that multiple `#[path(..)]` attributes are not allowed on a single module.

---

## Related issue or discussion (if any)

---

## Additional context

The fix uses `enumerate()` on the iterator over `#[path(..)]` attributes and emits an error for any attribute with index greater than 0. The existing test data has been updated to cover this case and verify the new diagnostic output.