### PR TITLE
doc(lowering): Fixed doc regarding the meaning of small types.

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/create_graph/patterns.rs
@@ -934,7 +934,7 @@ fn optimized_value_match_size<'db>(
 
 /// Returns the threshold for the number of arms for optimizing numeric match expressions, by using
 /// a jump table instead of an if-else construct.
-/// `is_small_type` means the matched type has < 2**128 possible values.
+/// `is_small_type` means the matched type has <= 2**128 possible values.
 pub fn numeric_match_optimization_threshold<'db>(
     ctx: &LoweringContext<'db, '_>,
     is_small_type: bool,


### PR DESCRIPTION
## Summary

Fixes an off-by-one error in the doc comment for `numeric_match_optimization_threshold`. The `is_small_type` parameter was described as the matched type having `< 2**128` possible values, but the correct condition is `<= 2**128`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The comment describing the `is_small_type` flag used a strict less-than (`< 2**128`), which incorrectly excluded types with exactly `2**128` possible values. The actual intended boundary is inclusive (`<= 2**128`), so the comment was misleading about which types qualify as "small."

---

## What was the behavior or documentation before?

The comment stated: `is_small_type` means the matched type has `< 2**128` possible values.

---

## What is the behavior or documentation after?

The comment now correctly states: `is_small_type` means the matched type has `<= 2**128` possible values.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A