### PR TITLE
fix(runner): return the correct entrypoint selector.

### DIFF
--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -153,22 +153,25 @@ impl StarknetState {
     /// Replaces the addresses in the context.
     pub fn open_caller_context(
         &mut self,
-        (new_contract_address, new_caller_address): (Felt252, Felt252),
-    ) -> (Felt252, Felt252) {
+        [new_contract_address, new_caller_address, new_selector]: [Felt252; 3],
+    ) -> [Felt252; 3] {
         let old_contract_address =
             std::mem::replace(&mut self.exec_info.contract_address, new_contract_address);
         let old_caller_address =
             std::mem::replace(&mut self.exec_info.caller_address, new_caller_address);
-        (old_contract_address, old_caller_address)
+        let old_selector =
+            std::mem::replace(&mut self.exec_info.entry_point_selector, new_selector);
+        [old_contract_address, old_caller_address, old_selector]
     }
 
     /// Restores the addresses in the context.
     pub fn close_caller_context(
         &mut self,
-        (old_contract_address, old_caller_address): (Felt252, Felt252),
+        [old_contract_address, old_caller_address, old_selector]: [Felt252; 3],
     ) {
         self.exec_info.contract_address = old_contract_address;
         self.exec_info.caller_address = old_caller_address;
+        self.exec_info.entry_point_selector = old_selector;
     }
 }
 
@@ -1061,9 +1064,13 @@ impl CairoHintProcessor<'_> {
 
         // Call constructor if it exists.
         let (res_data_start, res_data_end) = if let Some(constructor) = &contract_info.constructor {
-            let old_addrs = self
-                .starknet_state
-                .open_caller_context((deployed_contract_address, deployer_address));
+            let old_addrs = self.starknet_state.open_caller_context([
+                deployed_contract_address,
+                deployer_address,
+                Felt252::from_hex_unchecked(
+                    "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+                ),
+            ]);
             let res = self.call_entry_point(gas_counter, runner, constructor, calldata, vm);
             self.starknet_state.close_caller_context(old_addrs);
             match res {
@@ -1117,10 +1124,9 @@ impl CairoHintProcessor<'_> {
             fail_syscall!([b"ENTRYPOINT_NOT_FOUND", b"ENTRYPOINT_FAILED"]);
         };
 
-        let old_addrs = self.starknet_state.open_caller_context((
-            contract_address,
-            self.starknet_state.exec_info.contract_address,
-        ));
+        let new_caller = self.starknet_state.exec_info.contract_address;
+        let old_addrs =
+            self.starknet_state.open_caller_context([contract_address, new_caller, selector]);
         let res = self.call_entry_point(gas_counter, runner, entry_point, calldata, vm);
         self.starknet_state.close_caller_context(old_addrs);
 
@@ -1154,7 +1160,14 @@ impl CairoHintProcessor<'_> {
         let Some(entry_point) = contract_info.externals.get(&selector) else {
             fail_syscall!([b"ENTRYPOINT_NOT_FOUND", b"ENTRYPOINT_FAILED"]);
         };
-        match self.call_entry_point(gas_counter, runner, entry_point, calldata, vm) {
+        // A library call runs in the caller's context; only the entry point selector changes.
+        let contract_address = self.starknet_state.exec_info.contract_address;
+        let caller_address = self.starknet_state.exec_info.caller_address;
+        let old_addrs =
+            self.starknet_state.open_caller_context([contract_address, caller_address, selector]);
+        let res = self.call_entry_point(gas_counter, runner, entry_point, calldata, vm);
+        self.starknet_state.close_caller_context(old_addrs);
+        match res {
             Ok((res_data_start, res_data_end)) => {
                 Ok(SyscallResult::Success(vec![res_data_start.into(), res_data_end.into()]))
             }

--- a/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo
+++ b/crates/cairo-lang-starknet/cairo_level_tests/interoperability.cairo
@@ -163,3 +163,42 @@ fn test_entrypoint_failed() {
 fn test_get_block_hash() {
     get_block_hash_syscall(0).unwrap_syscall();
 }
+
+#[starknet::interface]
+trait ISelector<T> {
+    fn selector1(self: @T) -> felt252;
+    fn selector2(self: @T) -> felt252;
+}
+
+#[starknet::contract]
+mod selectors {
+    #[storage]
+    struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState) -> felt252 {
+        starknet::get_execution_info().unbox().entry_point_selector
+    }
+
+    #[external(v0)]
+    fn selector1(self: @ContractState) -> felt252 {
+        starknet::get_execution_info().unbox().entry_point_selector
+    }
+
+    #[external(v0)]
+    fn selector2(self: @ContractState) -> felt252 {
+        starknet::get_execution_info().unbox().entry_point_selector
+    }
+}
+
+#[test]
+fn test_entry_point_selector_is_set() {
+    let (address, data) = deploy_syscall(selectors::TEST_CLASS_HASH, 0, [].span(), false).unwrap();
+    assert_eq!(data, [selector!("constructor")].span());
+    let contract = ISelectorDispatcher { contract_address: address };
+    assert_eq!(contract.selector1(), selector!("selector1"));
+    assert_eq!(contract.selector2(), selector!("selector2"));
+    let library = ISelectorLibraryDispatcher { class_hash: selectors::TEST_CLASS_HASH };
+    assert_eq!(library.selector1(), selector!("selector1"));
+    assert_eq!(library.selector2(), selector!("selector2"));
+}


### PR DESCRIPTION
## Summary

The `entry_point_selector` field in `exec_info` is now tracked and updated when entering and exiting caller contexts. Previously, `open_caller_context` and `close_caller_context` only saved and restored `contract_address` and `caller_address`. Now they also save and restore `entry_point_selector`, passing it as a third element in a fixed-size array `[Felt252; 3]`.

- Constructor calls now set the selector to the known constructor selector (`0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194`).
- Regular contract calls set the selector to the dispatched entry point's selector.
- Library calls, which run in the caller's context, now also update the selector to the called entry point's selector while preserving the existing `contract_address` and `caller_address`.

A new test (`test_entry_point_selector_is_set`) verifies that `get_execution_info().entry_point_selector` returns the correct selector for constructors, external calls, and library calls.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`entry_point_selector` in `exec_info` was never updated when entering a new call context, meaning `starknet::get_execution_info().entry_point_selector` always returned a stale or default value regardless of which entry point was actually being executed. This made the selector field unreliable for contracts that inspect it at runtime.

---

## What was the behavior or documentation before?

`open_caller_context` and `close_caller_context` only managed `contract_address` and `caller_address`. The `entry_point_selector` in `exec_info` was never set to reflect the currently executing entry point, so any contract reading it via `get_execution_info()` would receive an incorrect value.

---

## What is the behavior or documentation after?

`entry_point_selector` is correctly set to the active entry point's selector for every call type — constructors, external calls, and library calls — and is restored to its previous value when the context is closed.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

Library calls intentionally preserve `contract_address` and `caller_address` from the caller's context (as per Starknet semantics), but now correctly update `entry_point_selector` to reflect the library entry point being invoked.