### PR TITLE
fix(semantic): return the real fullpath for a constant ResolvedGenericItem

### DIFF
--- a/crates/cairo-lang-semantic/src/resolve/item.rs
+++ b/crates/cairo-lang-semantic/src/resolve/item.rs
@@ -67,7 +67,7 @@ impl<'db> ResolvedGenericItem<'db> {
 
     pub fn full_path(&self, db: &dyn Database) -> String {
         match self {
-            ResolvedGenericItem::GenericConstant(_) => "".into(),
+            ResolvedGenericItem::GenericConstant(id) => id.full_path(db),
             ResolvedGenericItem::Module(id) => id.full_path(db),
             ResolvedGenericItem::GenericFunction(id) => id.format(db),
             ResolvedGenericItem::GenericType(id) => id.full_path(db),


### PR DESCRIPTION
## Summary

`ResolvedGenericItem::GenericConstant` now returns the constant's actual full path via `id.full_path(db)` instead of an empty string.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`ResolvedGenericItem::full_path` was returning an empty string for `GenericConstant` variants, while all other variants correctly returned their full path. This caused any tooling or logic relying on `full_path` to silently receive no information for generic constants.

---

## What was the behavior or documentation before?

Calling `full_path` on a `ResolvedGenericItem::GenericConstant` always returned an empty string (`""`), regardless of the actual constant's identity.

---

## What is the behavior or documentation after?

Calling `full_path` on a `ResolvedGenericItem::GenericConstant` now returns the constant's fully qualified path, consistent with how other `ResolvedGenericItem` variants behave.

---

## Related issue or discussion (if any)

---

## Additional context

The fix is a one-line change that mirrors the pattern already used by all other arms of the `match` expression.