### PR TITLE
docs(corelib): fix cmp and Iterator::any/all examples that don't compile

### DIFF
--- a/corelib/src/cmp.cairo
+++ b/corelib/src/cmp.cairo
@@ -6,11 +6,11 @@
 //! ```
 //! use core::cmp::{min, max, minmax};
 //!
-//! assert!(min(10, 20) == 10);
-//! assert!(max(10, 20) == 20);
+//! assert!(min(10, 20) == 10_u8);
+//! assert!(max(10, 20) == 20_u8);
 //!
-//! assert!(minmax(20, 10) == (10, 20));
-//! assert!(minmax(10, 20) == (10, 20));
+//! assert!(minmax(20, 10) == (10, 20_u8));
+//! assert!(minmax(10, 20) == (10, 20_u8));
 //! ```
 
 /// Takes two comparable values `a` and `b` and returns
@@ -21,7 +21,7 @@
 /// ```
 /// use core::cmp::min;
 ///
-/// assert!(min(0, 1) == 0);
+/// assert!(min(0, 1) == 0_u8);
 /// ```
 #[must_use]
 pub fn min<T, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> T {
@@ -40,7 +40,7 @@ pub fn min<T, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> T {
 /// ```
 /// use core::cmp::max;
 ///
-/// assert!(max(0, 1) == 1);
+/// assert!(max(0, 1) == 1_u8);
 /// ```
 #[must_use]
 pub fn max<T, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> T {
@@ -59,8 +59,8 @@ pub fn max<T, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> T {
 /// ```
 /// use core::cmp::minmax;
 ///
-/// assert!(minmax(0, 1) == (0, 1));
-/// assert!(minmax(1, 0) == (0, 1));
+/// assert!(minmax(0, 1) == (0, 1_u8));
+/// assert!(minmax(1, 0) == (0, 1_u8));
 /// ```
 #[must_use]
 pub fn minmax<T, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> (T, T) {

--- a/corelib/src/iter/traits/iterator.cairo
+++ b/corelib/src/iter/traits/iterator.cairo
@@ -401,7 +401,7 @@ pub trait Iterator<T> {
     /// ```
     /// assert!(array![1, 2, 3].into_iter().any(|x| x == 2));
     ///
-    /// assert!(!array![1, 2, 3].into_iter().any(|x| x > 5));
+    /// assert!(!array![1, 2, 3].into_iter().any(|x| x > 5_u8));
     /// ```
     fn any<
         P,
@@ -434,9 +434,9 @@ pub trait Iterator<T> {
     /// Basic usage:
     ///
     /// ```
-    /// assert!(array![1, 2, 3].into_iter().all(|x| x > 0));
+    /// assert!(array![1, 2, 3].into_iter().all(|x| x > 0_u8));
     ///
-    /// assert!(!array![1, 2, 3].into_iter().all(|x| x > 2));
+    /// assert!(!array![1, 2, 3].into_iter().all(|x| x > 2_u8));
     /// ```
     fn all<
         P,


### PR DESCRIPTION
## Summary

Doc examples in `cmp` and `iter` modules now use explicit type suffixes (e.g., `0_u8`, `1_u8`, `20_u8`) on integer literals in comparison expressions to ensure the types are unambiguous.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Without explicit type suffixes on integer literals in doc examples, the compiler must infer the type from context. Adding `_u8` suffixes makes the intended type explicit, avoiding potential ambiguity and ensuring the examples compile cleanly without relying on type inference.

---

## What was the behavior or documentation before?

Doc examples used bare integer literals such as `0`, `1`, `10`, `20` in comparisons, leaving the concrete integer type implicit.

---

## What is the behavior or documentation after?

Doc examples use explicitly typed literals such as `0_u8`, `1_u8`, `10_u8`, `20_u8`, making the integer type unambiguous in all comparison expressions.

---

## Related issue or discussion (if any)

---

## Additional context

Affected examples are in `corelib/src/cmp.cairo` (`min`, `max`, `minmax`) and `corelib/src/iter/traits/iterator.cairo` (`any`, `all`).