### PR TITLE
bugfix(plugins): Made analyzer plugin properly forward inner spans.

### DIFF
--- a/crates/cairo-lang-semantic/src/db.rs
+++ b/crates/cairo-lang-semantic/src/db.rs
@@ -305,7 +305,15 @@ fn module_semantic_diagnostics<'db>(
         let analyzer_plugin = analyzer_plugin_id.long(db);
 
         for diag in analyzer_plugin.diagnostics(db, module_id) {
-            diagnostics.report(diag.stable_ptr, SemanticDiagnosticKind::PluginDiagnostic(diag));
+            match diag.inner_span {
+                None => diagnostics
+                    .report(diag.stable_ptr, SemanticDiagnosticKind::PluginDiagnostic(diag)),
+                Some(inner_span) => diagnostics.report_with_inner_span(
+                    diag.stable_ptr,
+                    inner_span,
+                    SemanticDiagnosticKind::PluginDiagnostic(diag),
+                ),
+            };
         }
     }
 

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -1,14 +1,16 @@
 use std::sync::Arc;
 
 use cairo_lang_defs::db::{DefsGroup, defs_group_input};
-use cairo_lang_defs::ids::{GenericTypeId, MacroPluginLongId, ModuleId, TopLevelLanguageElementId};
+use cairo_lang_defs::ids::{
+    GenericTypeId, MacroPluginLongId, ModuleId, NamedLanguageElementId, TopLevelLanguageElementId,
+};
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
     MacroPlugin, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
 };
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
-use cairo_lang_syntax::node::{TypedStablePtr, ast};
+use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 use salsa::{Database, Setter};
@@ -247,6 +249,15 @@ impl AnalyzerPlugin for NoU128RenameAnalyzerPlugin {
                     use_id.stable_ptr(db).untyped(),
                     "Use items for u128 disallowed.".to_string(),
                 ));
+                // Adding inner span diag only once per module.
+                if diagnostics.len() < 2 {
+                    diagnostics.push(PluginDiagnostic::error_with_inner_span(
+                        db,
+                        use_id.stable_ptr(db).untyped(),
+                        use_id.name_identifier(db).as_syntax_node(),
+                        "Pointing to name through span.".to_string(),
+                    ));
+                }
             }
         }
         diagnostics
@@ -292,6 +303,11 @@ fn test_analyzer_diagnostics() {
         use core::integer::u128 as long_u128_rename;
                            ^^^^^^^^^^^^^^^^^^^^^^^^
 
+        error[E2200]: Plugin diagnostic: Pointing to name through span.
+         --> lib.cairo:7:28
+        use core::integer::u128 as long_u128_rename;
+                                   ^^^^^^^^^^^^^^^^
+
         error[E2200]: Plugin diagnostic: Use items for u128 disallowed.
          --> lib.cairo:8:5
         use u128 as short_u128_rename;
@@ -306,6 +322,11 @@ fn test_analyzer_diagnostics() {
          --> lib.cairo:2:24
             use core::integer::u128 as long_u128_rename;
                                ^^^^^^^^^^^^^^^^^^^^^^^^
+
+        error[E2200]: Plugin diagnostic: Pointing to name through span.
+         --> lib.cairo:2:32
+            use core::integer::u128 as long_u128_rename;
+                                       ^^^^^^^^^^^^^^^^
 
         error[E2200]: Plugin diagnostic: Use items for u128 disallowed.
          --> lib.cairo:3:9


### PR DESCRIPTION
## Summary

Adds support for `inner_span` in analyzer plugin diagnostics. When a `PluginDiagnostic` has an `inner_span` set, the diagnostic is now reported using `report_with_inner_span` instead of the standard `report`, allowing the diagnostic to point to a more specific sub-span within the broader stable pointer location.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Analyzer plugins previously had no way to emit diagnostics that highlight a precise inner span within a larger syntax node. This made it impossible to point users to, for example, a specific identifier within a `use` item when the diagnostic is anchored to the whole `use` statement.

---

## What was the behavior or documentation before?

All analyzer plugin diagnostics were reported using only the `stable_ptr`, meaning the highlighted span always covered the entire node associated with that pointer, regardless of whether a more specific location was available.

---

## What is the behavior or documentation after?

When a `PluginDiagnostic` carries an `inner_span`, the diagnostic is reported via `report_with_inner_span`, causing the compiler output to underline the narrower inner span. For example, a diagnostic on a `use` alias now highlights just the alias name (`long_u128_rename`) rather than the full `u128 as long_u128_rename` segment.

---

## Related issue or discussion (if any)

---

## Additional context

A test case was added to `NoU128RenameAnalyzerPlugin` that emits an `error_with_inner_span` diagnostic pointing to the alias identifier via `use_id.name_identifier(db).as_syntax_node()`, and the expected diagnostic output was updated to reflect the new, more precise underline.