### PR TITLE
docs(corelib): close the unterminated code fence in storage_node module docs

### DIFF
--- a/corelib/src/starknet/storage/storage_node.cairo
+++ b/corelib/src/starknet/storage/storage_node.cairo
@@ -67,6 +67,7 @@
 //!     my_struct: MyStruct,
 //!     a: felt252,
 //! }
+//! ```
 //!
 //! We can access the members of the storage node as follows:
 //!


### PR DESCRIPTION
## Summary

Adds a missing closing code fence (` ``` `) to the `storage_node` module documentation, fixing a broken Markdown code block.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The code block in the `storage_node` module documentation was missing its closing ` ``` ` fence, causing the Markdown to render incorrectly — the subsequent prose and code examples would be treated as part of the code block rather than normal documentation text.

---

## What was the behavior or documentation before?

The code block demonstrating the `MyStruct` storage definition was not properly closed, causing all following content to be rendered as part of the code block.

---

## What is the behavior or documentation after?

The code block is properly closed, and the following explanation ("We can access the members of the storage node as follows:") renders correctly as prose.

---

## Related issue or discussion (if any)

None.

---

## Additional context

None.