### PR TITLE
docs(semantic): make the assert! doc example compile

### DIFF
--- a/crates/cairo-lang-semantic/src/inline_macros/assert.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/assert.rs
@@ -145,10 +145,10 @@ impl InlineMacroExprPlugin for AssertMacro {
             ```cairo
             assert!(2 + 2 == 4); // Passes, does nothing.
             assert!(2 + 2 == 5); // Panics with "assertion failed: `2 + 2 == 5`."
-            let age = 18;
+            let age: i32 = 18;
             assert!(age >= 21, "Age must be at least 21, found {}", age);
             // Panics with "Age must be at least 21, found 18."
-            let x = -1;
+            let x: i32 = -1;
             assert!(x >= 0, "Invalid value: x = {}", x);
             assert!(x >= 0, "Invalid value: x = {x}");
             // Panics with "Invalid value: x = -1."


### PR DESCRIPTION
## Summary

Add explicit type annotations to variables in the `assert!` macro documentation examples, changing `let age = 18` to `let age: i32 = 18` and `let x = -1` to `let x: i32 = -1`.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

> ⚠️ Note:
> To keep maintainer workload sustainable, we generally do **not** accept PRs that
> are only minor wording, grammar, formatting, or style changes.
> Such PRs may be closed without detailed review.

---

## Why is this change needed?

The example variables `age` and `x` in the `assert!` macro docs lacked explicit type annotations. Without them, readers may be unclear about the intended types, and the examples may fail to compile if Cairo's type inference cannot resolve the integer literals to a concrete type in that context.

---

## What was the behavior or documentation before?

The variables were declared without type annotations:
```cairo
let age = 18;
let x = -1;
```

---

## What is the behavior or documentation after?

The variables are declared with explicit `i32` type annotations:
```cairo
let age: i32 = 18;
let x: i32 = -1;
```

---

## Related issue or discussion (if any)

None.

---

## Additional context

This ensures the documentation examples are unambiguous and compile correctly without relying on type inference.