### PR TITLE
docs(reference): fix the mutable tuple-pattern example; mut is per-binding

### DIFF
--- a/docs/reference/src/components/cairo/modules/language_constructs/pages/patterns.adoc
+++ b/docs/reference/src/components/cairo/modules/language_constructs/pages/patterns.adoc
@@ -328,14 +328,15 @@ match result {
 
 == Mutability in Patterns
 
-Patterns in `let mut` statements bind mutable variables:
+The `mut` keyword applies to an individual binding, not to the pattern as a whole.
+To bind several mutable variables, mark each binding with `mut`:
 
 [source,cairo]
 ----
 let mut x = 5;
 x = 10;  // OK: x is mutable
 
-let mut (a, b) = (1, 2);
+let (mut a, mut b) = (1, 2);
 a = 10;  // OK: a is mutable
 b = 20;  // OK: b is mutable
 ----


### PR DESCRIPTION
## Summary

Corrects the documentation for mutability in patterns to reflect that `mut` must be applied to each individual binding rather than to the pattern as a whole. The example is updated from `let mut (a, b) = (1, 2)` to `let (mut a, mut b) = (1, 2)`, and the accompanying explanation is revised accordingly.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The previous documentation showed `let mut (a, b) = (1, 2)` as valid syntax for binding multiple mutable variables in a tuple pattern. This is incorrect — `mut` must annotate each binding individually. The old example could mislead users into writing invalid Cairo code.

---

## What was the behavior or documentation before?

The docs stated that `let mut` on a pattern statement binds mutable variables, and showed `let mut (a, b) = (1, 2)` as the correct form.

---

## What is the behavior or documentation after?

The docs now clarify that `mut` applies to an individual binding, not the pattern as a whole, and show the correct syntax: `let (mut a, mut b) = (1, 2)`.

---

## Related issue or discussion (if any)

None provided.

---

## Additional context

This is a correctness fix for a code example that demonstrated invalid syntax, which could cause direct compilation errors if users followed it.