### PR TITLE
fix(semantic): report an unresolved trait in a negative impl bound

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
+++ b/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
@@ -392,3 +392,77 @@ error[E2313]: Negative impl has an unsupported generic argument GenericParamCons
  --> lib.cairo:10:5
     bar::<[u32; N]>();
     ^^^
+
+//! > ==========================================================================
+
+//! > Negative impl with an unresolved trait.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() -> felt252 {
+    MyTrait::<felt252>::f()
+}
+
+//! > function_name
+foo
+
+//! > module_code
+trait MyTrait<T> {
+    fn f() -> felt252;
+}
+
+impl BlanketNonCopy<T, -MissomgTrait<T>> of MyTrait<T> {
+    fn f() -> felt252 {
+        7
+    }
+}
+
+//! > expected_diagnostics
+error[E0006]: Trait not found.
+ --> lib.cairo:5:25
+impl BlanketNonCopy<T, -MissomgTrait<T>> of MyTrait<T> {
+                        ^^^^^^^^^^^^
+
+error[E2311]: Trait has no implementation in context: test::MyTrait::<core::felt252>.
+ --> lib.cairo:11:25
+    MyTrait::<felt252>::f()
+                        ^
+
+//! > ==========================================================================
+
+//! > Positive impl parameter with an unresolved trait.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() -> felt252 {
+    MyTrait::<felt252>::f()
+}
+
+//! > function_name
+foo
+
+//! > module_code
+trait MyTrait<T> {
+    fn f() -> felt252;
+}
+
+impl BlanketNonCopy<T, +MissingTrait<T>> of MyTrait<T> {
+    fn f() -> felt252 {
+        7
+    }
+}
+
+//! > expected_diagnostics
+error[E0006]: Trait not found.
+ --> lib.cairo:5:25
+impl BlanketNonCopy<T, +MissingTrait<T>> of MyTrait<T> {
+                        ^^^^^^^^^^^^
+
+error[E2311]: Trait has no implementation in context: test::MyTrait::<core::felt252>.
+ --> lib.cairo:11:25
+    MyTrait::<felt252>::f()
+                        ^

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -679,14 +679,21 @@ fn semantic_from_generic_param_ast<'db>(
 
             let neg_impl =
                 impl_generic_param_semantic(db, resolver, diagnostics, &path_syntax, None, id);
-            for param in db.trait_generic_params(neg_impl.concrete_trait?.trait_id(db))? {
-                if matches!(param, GenericParam::Type(_) | GenericParam::Const(_)) {
-                    continue;
+            // Note: the trait params are only inspected if the trait was resolved successfully.
+            // On failure the param is still returned (as in the positive impl param arms), so that
+            // the resolution diagnostic is not lost.
+            if let Ok(concrete_trait) = neg_impl.concrete_trait
+                && let Ok(trait_params) = db.trait_generic_params(concrete_trait.trait_id(db))
+            {
+                for param in trait_params {
+                    if matches!(param, GenericParam::Type(_) | GenericParam::Const(_)) {
+                        continue;
+                    }
+                    diagnostics.report(
+                        param.stable_ptr(db),
+                        SemanticDiagnosticKind::OnlyTypeOrConstParamsInNegImpl,
+                    );
                 }
-                diagnostics.report(
-                    param.stable_ptr(db),
-                    SemanticDiagnosticKind::OnlyTypeOrConstParamsInNegImpl,
-                );
             }
 
             GenericParam::NegImpl(neg_impl)


### PR DESCRIPTION
## Summary

When a negative impl parameter references an unresolved trait (e.g., a typo like `-MissingTrait<T>`), the compiler was silently swallowing the "Trait not found" diagnostic. This happened because the code used `?` to propagate the `Err` from `neg_impl.concrete_trait`, causing an early return before the diagnostic could be emitted.

The fix wraps the trait param inspection in an `if let Ok(...)` guard, so that the unresolved-trait diagnostic is preserved and surfaced to the user, while the invalid-param-kind check is only performed when the trait resolved successfully.

Two new test cases are added: one for a negative impl with an unresolved trait, and one for the equivalent positive impl parameter (as a control case), both confirming that `E0006: Trait not found` and the resulting `E2311: Trait has no implementation` diagnostics are correctly reported.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a negative impl generic parameter contained a misspelled or otherwise unresolved trait, the `?` operator caused an early return from the function, discarding the "Trait not found" diagnostic that had already been recorded. Users would see no actionable error pointing to the typo in the negative impl constraint.

---

## What was the behavior or documentation before?

A negative impl with an unresolved trait (e.g., `impl Foo<T, -MissingTrait<T>>`) would silently fail to emit the `E0006: Trait not found` diagnostic, leaving the user without a clear indication of what went wrong.

---

## What is the behavior or documentation after?

The `E0006: Trait not found` diagnostic is now correctly emitted when a negative impl parameter references an unresolved trait, consistent with how positive impl parameters (`+MissingTrait<T>`) already behave.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The behavior for positive impl parameters (`+Trait`) was already correct; this fix brings negative impl parameters (`-Trait`) in line with that behavior.