### PR TITLE
bugfix(parser): Fix location of missing before EOF diags.

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -3583,7 +3583,8 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     /// current trivia as skipped, and continuing the compilation as if it wasn't there.
     fn skip_token(&mut self, diagnostic_kind: ParserDiagnosticKind) {
         if self.peek().kind == SyntaxKind::TerminalEndOfFile {
-            self.add_diagnostic(diagnostic_kind, TextSpan::cursor(self.offset));
+            let next_offset = self.offset.add_width(self.current_width - self.last_trivia_length);
+            self.add_diagnostic(diagnostic_kind, TextSpan::cursor(next_offset));
             return;
         }
         let terminal = self.take_raw();

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees/for
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees/for
@@ -112,9 +112,9 @@ fn f() { for
             ^
 
 error[E1000]: Skipped tokens. Expected: 'in'.
- --> dummy_file.cairo:1:10
+ --> dummy_file.cairo:1:13
 fn f() { for
-         ^
+            ^
 
 error[E1002]: Missing tokens. Expected an expression.
  --> dummy_file.cairo:1:13


### PR DESCRIPTION
## Summary

Fixes the diagnostic span reported when a skipped token is encountered at end-of-file. Previously, the diagnostic pointed to `self.offset` (the start of the current token, before its content), but it now correctly points to the position after the token's non-trivia content by computing `self.offset + current_width - last_trivia_length`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When the parser encountered an unexpected token at end-of-file and emitted a "Skipped tokens" diagnostic, the reported source location was pointing to the beginning of the current offset rather than the actual position of the offending token. This caused misleading error arrows in diagnostics.

---

## What was the behavior or documentation before?

For input like `fn f() { for`, the "Skipped tokens. Expected: 'in'." diagnostic incorrectly pointed to column 10 (the `f` of `for`):

```
error[E1000]: Skipped tokens. Expected: 'in'.
 --> dummy_file.cairo:1:10
fn f() { for
         ^
```

---

## What is the behavior or documentation after?

The diagnostic now correctly points to column 13 (the end of `for`, after its content):

```
error[E1000]: Skipped tokens. Expected: 'in'.
 --> dummy_file.cairo:1:13
fn f() { for
            ^
```

---

## Related issue or discussion (if any)

---

## Additional context

The fix accounts for trailing trivia (e.g., whitespace/comments) by subtracting `last_trivia_length` from `current_width`, ensuring the caret lands on the token itself rather than any trailing trivia or the raw start offset.