### PR TITLE
fix(semantic): don't ICE on a deref chain whose downstream impl has the wrong assoc-type count

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/deref
+++ b/crates/cairo-lang-semantic/src/expr/test_data/deref
@@ -292,3 +292,91 @@ Candidate `core::dict::Felt252DictTrait::get` inference failed with: Type mismat
  --> lib.cairo:15:7
     b.get();
       ^^^
+
+//! > ==========================================================================
+
+//! > Deref chain where a downstream impl is missing its associated type.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+struct A {}
+
+#[derive(Drop)]
+struct B {}
+
+#[derive(Drop)]
+struct C {}
+
+impl ADeref of core::ops::Deref<A> {
+    type Target = B;
+    fn deref(self: A) -> B {
+        B {}
+    }
+}
+
+// `type Target` is missing on the second hop of the deref chain.
+impl BDeref of core::ops::Deref<B> {
+    fn deref(self: B) -> C {
+        C {}
+    }
+}
+
+//! > expected_diagnostics
+error[E0004]: Not all trait items are implemented. Missing: 'Target'.
+ --> lib.cairo:18:6
+impl BDeref of core::ops::Deref<B> {
+     ^^^^^^
+
+//! > ==========================================================================
+
+//! > Deref chain where a downstream impl has more than one associated type.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Drop)]
+struct A {}
+
+#[derive(Drop)]
+struct B {}
+
+#[derive(Drop)]
+struct C {}
+
+impl ADeref of core::ops::Deref<A> {
+    type Target = B;
+    fn deref(self: A) -> B {
+        B {}
+    }
+}
+
+// An extra associated type on the second hop of the deref chain.
+impl BDeref of core::ops::Deref<B> {
+    type Target = C;
+    type Extra = C;
+    fn deref(self: B) -> C {
+        C {}
+    }
+}
+
+//! > expected_diagnostics
+error[E2014]: Impl item type `BDeref::Extra` is not a member of trait `Deref`.
+ --> lib.cairo:20:5
+    type Extra = C;
+    ^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -1137,15 +1137,15 @@ fn deref_impl_diagnostics<'db>(
     }
 
     loop {
-        let Ok(impl_id) = get_impl_based_on_single_impl_type(db, impl_def_id, |ty| {
+        let Some(impl_id) = get_impl_based_on_single_impl_type(db, impl_def_id, |ty| {
             ConcreteTraitLongId {
                 trait_id: deref_trait_id,
                 generic_args: vec![GenericArgumentId::Type(ty)],
             }
             .intern(db)
         }) else {
-            // Inference errors are handled when the impl is in actual use. In here we only check
-            // for cycles.
+            // Invalid impls and inference errors are reported by the impl validation queries. In
+            // here we only check for cycles.
             return;
         };
 
@@ -1170,31 +1170,24 @@ fn deref_impl_diagnostics<'db>(
     }
 }
 
-/// Assuming that an impl has a single impl type, extracts the type, and then infers another impl
-/// based on it. If the inference fails, returns the inference error and the impl type definition
-/// for diagnostics.
+/// Extracts the single impl type of the given impl, and then infers another impl based on it.
+/// Returns `None` if the impl does not have exactly one impl type, or if the inference fails - such
+/// impls are reported on by the impl validation queries.
 fn get_impl_based_on_single_impl_type<'db>(
     db: &'db dyn Database,
     impl_def_id: ImplDefId<'db>,
     concrete_trait_id: impl FnOnce(TypeId<'db>) -> ConcreteTraitId<'db>,
-) -> Result<ImplId<'db>, (InferenceError<'db>, ImplTypeDefId<'db>)> {
-    let data = impl_definition_data(db, impl_def_id).clone().unwrap();
-    let mut types_iter = data.item_type_asts.iter();
-    let (impl_item_type_id, _) = types_iter.next().unwrap();
-    if types_iter.next().is_some() {
-        panic!(
-            "get_impl_based_on_single_impl_type called with an impl that has more than one type"
-        );
-    }
-    let ty = db.impl_type_def_resolved_type(*impl_item_type_id).unwrap();
+) -> Option<ImplId<'db>> {
+    let data = impl_definition_data(db, impl_def_id).maybe_as_ref().ok()?;
+    let (impl_item_type_id, _) = data.item_type_asts.iter().exactly_one().ok()?;
+    let ty = db.impl_type_def_resolved_type(*impl_item_type_id).ok()?;
 
     let module_id = impl_def_id.parent_module(db);
-    let generic_params = db.impl_def_generic_params(impl_def_id).unwrap();
+    let generic_params = db.impl_def_generic_params(impl_def_id).ok()?;
     let generic_params_ids =
         generic_params.iter().map(|generic_param| generic_param.id()).collect();
     let lookup_context = ImplLookupContext::new(module_id, generic_params_ids, db);
-    get_impl_at_context(db, lookup_context.intern(db), concrete_trait_id(ty), None)
-        .map_err(|err| (err, *impl_item_type_id))
+    get_impl_at_context(db, lookup_context.intern(db), concrete_trait_id(ty), None).ok()
 }
 
 /// Query implementation of [ImplSemantic::impl_functions].


### PR DESCRIPTION
## Summary

`get_impl_based_on_single_impl_type` previously panicked if the impl had more than one associated type or was missing its associated type entirely. It now returns `None` in those cases, delegating diagnostic reporting to the existing impl validation queries. The `deref_impl_diagnostics` loop is updated to match, treating a `None` result as a signal to stop traversal rather than an error to surface directly.

Two new test cases are added to `deref` test data covering a deref chain where a downstream impl is missing its `Target` associated type, and one where it declares an extra associated type not defined by the `Deref` trait.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When traversing a deref chain, if a downstream impl had zero or more than one associated type, the code would panic rather than gracefully handling the malformed impl. These cases should instead be caught and reported by the standard impl validation diagnostics, not cause a compiler crash.

---

## What was the behavior or documentation before?

`get_impl_based_on_single_impl_type` would `unwrap()` or `panic!()` if the impl had no associated type or more than one, causing a compiler crash when such impls appeared in a deref chain.

---

## What is the behavior or documentation after?

`get_impl_based_on_single_impl_type` returns `None` for impls with zero or more than one associated type, or when any intermediate query fails. The deref chain traversal stops cleanly, and the appropriate diagnostics (e.g., `Missing: 'Target'` or `Impl item type is not a member of trait`) are emitted by the impl validation queries instead.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

N/A