### PR TITLE
fix(semantic): don't leak a closure's early-return into the enclosing loop

### DIFF
--- a/crates/cairo-lang-lowering/src/lower/test_data/closure
+++ b/crates/cairo-lang-lowering/src/lower/test_data/closure
@@ -808,6 +808,247 @@ End:
 
 //! > ==========================================================================
 
+//! > Test closure with `return` inside a loop does not add loop early-return machinery.
+
+//! > test_runner_name
+test_generated_function
+
+//! > function_code
+fn foo(n: felt252) -> felt252 {
+    let mut i = n;
+    loop {
+        let f = || -> felt252 {
+            return 7;
+        };
+        i = i + f();
+        if i == 100 {
+            break i;
+        };
+    }
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > lowering
+Main:
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+  (v2: core::felt252, v1: core::felt252) <- test::foo[51-208](v0)
+End:
+  Return(v1)
+
+
+Final lowering:
+Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::felt252
+blk0 (root):
+Statements:
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[51-208](v0, v1, v2)
+End:
+  Match(match_enum(v5) {
+    PanicResult::Ok(v6) => blk1,
+    PanicResult::Err(v7) => blk2,
+  })
+
+blk1:
+Statements:
+  (v8: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
+  (v9: core::felt252, v10: core::felt252) <- struct_destructure(v6)
+  (v11: (core::felt252,)) <- struct_construct(v10)
+  (v12: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Ok(v11)
+End:
+  Return(v3, v8, v12)
+
+blk2:
+Statements:
+  (v13: core::panics::PanicResult::<(core::felt252,)>) <- PanicResult::Err(v7)
+End:
+  Return(v3, v4, v13)
+
+
+Generated core::traits::Destruct::destruct lowering for source location:
+        let f = || -> felt252 {
+                ^^
+
+Parameters: v0: {closure@lib.cairo:4:17: 4:19}
+blk0 (root):
+Statements:
+  () <- struct_destructure(v0)
+  (v1: ()) <- struct_construct()
+End:
+  Return(v1)
+
+
+Final lowering:
+Parameters: v0: {closure@lib.cairo:4:17: 4:19}
+blk0 (root):
+Statements:
+End:
+  Return()
+
+
+Generated core::ops::function::Fn::call lowering for source location:
+        let f = || -> felt252 {
+                ^^
+
+Parameters: v0: @{closure@lib.cairo:4:17: 4:19}, v2: ()
+blk0 (root):
+Statements:
+  (v1: {closure@lib.cairo:4:17: 4:19}) <- desnap(v0)
+  () <- struct_destructure(v1)
+  () <- struct_destructure(v2)
+  (v3: core::felt252) <- 7
+End:
+  Return(v3)
+
+
+Final lowering:
+Parameters: v0: @{closure@lib.cairo:4:17: 4:19}, v1: ()
+blk0 (root):
+Statements:
+  (v2: core::felt252) <- 7
+End:
+  Return(v2)
+
+
+Generated loop lowering for source location:
+      loop {
+ _____^
+| ...
+|     }
+|_____^
+
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+  (v1: {closure@lib.cairo:4:17: 4:19}) <- struct_construct()
+  (v2: {closure@lib.cairo:4:17: 4:19}, v3: @{closure@lib.cairo:4:17: 4:19}) <- snapshot(v1)
+  (v4: ()) <- struct_construct()
+  (v5: core::felt252) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:4:17: 4:19}(v3, v4)
+  (v6: core::felt252) <- core::Felt252Add::add(v0, v5)
+  (v7: core::felt252, v8: @core::felt252) <- snapshot(v6)
+  (v9: core::felt252) <- 100
+  (v10: core::felt252, v11: @core::felt252) <- snapshot(v9)
+  (v12: core::bool) <- core::Felt252PartialEq::eq(v8, v11)
+End:
+  Match(match_enum(v12) {
+    bool::False(v14) => blk2,
+    bool::True(v13) => blk1,
+  })
+
+blk1:
+Statements:
+End:
+  Return(v7, v7)
+
+blk2:
+Statements:
+End:
+  Goto(blk3, {})
+
+blk3:
+Statements:
+  (v16: core::felt252, v15: core::felt252) <- test::foo[51-208](v7)
+End:
+  Return(v16, v15)
+
+
+Final lowering:
+Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::felt252
+blk0 (root):
+Statements:
+End:
+  Match(match core::gas::withdraw_gas(v0, v1) {
+    Option::Some(v3, v4) => blk1,
+    Option::None(v5, v6) => blk4,
+  })
+
+blk1:
+Statements:
+  (v7: core::felt252) <- 7
+  (v8: core::felt252) <- core::felt252_add(v2, v7)
+  (v9: core::felt252) <- 100
+  (v10: core::felt252) <- core::felt252_sub(v8, v9)
+End:
+  Match(match core::felt252_is_zero(v10) {
+    IsZeroResult::Zero => blk2,
+    IsZeroResult::NonZero(v11) => blk3,
+  })
+
+blk2:
+Statements:
+  (v12: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
+  (v13: (core::felt252, core::felt252)) <- struct_construct(v8, v8)
+  (v14: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- PanicResult::Ok(v13)
+End:
+  Return(v3, v12, v14)
+
+blk3:
+Statements:
+  (v15: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
+  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[51-208](v3, v15, v8)
+End:
+  Return(v16, v17, v18)
+
+blk4:
+Statements:
+  (v19: (core::panics::Panic, core::array::Array::<core::felt252>)) <- core::panic_with_const_felt252::<375233589013918064796019>()
+  (v20: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- PanicResult::Err(v19)
+End:
+  Return(v5, v6, v20)
+
+
+Final lowering of specialized call "test::foo[51-208]":
+Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::felt252
+blk0 (root):
+Statements:
+End:
+  Match(match core::gas::withdraw_gas(v0, v1) {
+    Option::Some(v3, v4) => blk1,
+    Option::None(v5, v6) => blk4,
+  })
+
+blk1:
+Statements:
+  (v7: core::felt252) <- 7
+  (v8: core::felt252) <- core::felt252_add(v2, v7)
+  (v9: core::felt252) <- 100
+  (v10: core::felt252) <- core::felt252_sub(v8, v9)
+End:
+  Match(match core::felt252_is_zero(v10) {
+    IsZeroResult::Zero => blk2,
+    IsZeroResult::NonZero(v11) => blk3,
+  })
+
+blk2:
+Statements:
+  (v12: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
+  (v13: (core::felt252, core::felt252)) <- struct_construct(v8, v8)
+  (v14: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- PanicResult::Ok(v13)
+End:
+  Return(v3, v12, v14)
+
+blk3:
+Statements:
+  (v15: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
+  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[51-208](v3, v15, v8)
+End:
+  Return(v16, v17, v18)
+
+blk4:
+Statements:
+  (v19: (core::panics::Panic, core::array::Array::<core::felt252>)) <- core::panic_with_const_felt252::<375233589013918064796019>()
+  (v20: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- PanicResult::Err(v19)
+End:
+  Return(v5, v6, v20)
+
+//! > ==========================================================================
+
 //! > Test closure desnapping a snapshot-only captured variable.
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/usage/mod.rs
+++ b/crates/cairo-lang-semantic/src/usage/mod.rs
@@ -185,6 +185,8 @@ impl<'db> Usages<'db> {
         usage.introductions.extend(param_ids.iter().map(|param| VarId::Param(param.id)));
         self.handle_expr(arenas, body, &mut usage);
         usage.finalize_as_scope();
+        // Closure is a different function - no early return is relevant for outer scope.
+        usage.has_early_return = false;
         usage
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where a `return` statement inside a closure that is defined within a `loop` incorrectly triggered the loop's early-return machinery. After processing a closure body's usages, `has_early_return` is now reset to `false`, since a closure represents a separate function scope and its `return` statements are not early returns from the enclosing loop.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a closure containing a `return` statement was defined inside a `loop`, the usage analysis was propagating `has_early_return = true` from the closure's body back into the enclosing loop scope. This caused the loop lowering to unnecessarily generate early-return machinery, producing incorrect or bloated lowered IR.

---

## What was the behavior or documentation before?

A closure with a `return` inside a loop (e.g., `let f = || -> felt252 { return 7; };`) caused the loop's lowering to include early-return handling, as if the `return` could exit the loop directly.

---

## What is the behavior or documentation after?

After processing a closure's usage scope, `has_early_return` is reset to `false`. The `return` inside the closure is correctly treated as belonging only to the closure's own function scope, and the enclosing loop no longer generates spurious early-return machinery. A new test case confirms the correct lowered output for this pattern.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The fix is a single line added in `crates/cairo-lang-semantic/src/usage/mod.rs` after `usage.finalize_as_scope()`, clearing `has_early_return` before the closure's usage is returned to the outer scope analysis.