### PR TITLE
fix(parser): Fixes doc regarding type expressions in parser.

### DIFF
--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -1736,8 +1736,11 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         }
     }
 
-    /// Returns a GreenId of a node with an ExprPath|ExprParenthesized|ExprTuple kind, or
-    /// TryParseFailure if such an expression can't be parsed.
+    /// Returns a GreenId of a node with an
+    /// ExprUnderscore|ExprUnary|ExprPath|ExprTuple|ExprFixedSizeArray kind, or TryParseFailure if
+    /// such an expression can't be parsed.
+    /// Note that unlike in value position, `(<type_expr>)` is not a grouping construct - it is
+    /// parsed as a tuple, with a diagnostic.
     fn try_parse_type_expr(&mut self) -> TryParseResult<ExprGreen<'a>> {
         // TODO(yuval): support paths starting with "::".
         match self.peek().kind {
@@ -1765,8 +1768,9 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         }
     }
 
-    /// Returns a GreenId of a node with an ExprPath|ExprParenthesized|ExprTuple kind, or
-    /// ExprMissing if such an expression can't be parsed.
+    /// Returns a GreenId of a node with an
+    /// ExprUnderscore|ExprUnary|ExprPath|ExprTuple|ExprFixedSizeArray kind, or ExprMissing if such
+    /// an expression can't be parsed.
     fn parse_type_expr(&mut self) -> ExprGreen<'a> {
         match self.try_parse_type_expr() {
             Ok(expr) => expr,


### PR DESCRIPTION
## Summary

Updates the doc comments for `try_parse_type_expr` and `parse_type_expr` to accurately reflect the full set of expression kinds these functions can return. Previously, the comments only listed `ExprPath|ExprParenthesized|ExprTuple`, but the functions also handle `ExprUnderscore`, `ExprUnary`, and `ExprFixedSizeArray`. Additionally, a note is added clarifying that `(<type_expr>)` in type position is not a grouping construct — it is parsed as a tuple and emits a diagnostic.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The existing comments were incomplete and misleading — they omitted several expression kinds that `try_parse_type_expr` and `parse_type_expr` actually handle, and they incorrectly implied that parenthesized expressions behave as a grouping construct in type position (as they do in value position). This distinction is important for understanding parser behavior and avoiding incorrect assumptions when working with type expressions.

---

## What was the behavior or documentation before?

The comments stated that these functions returned nodes of kind `ExprPath|ExprParenthesized|ExprTuple`, with no mention of `ExprUnderscore`, `ExprUnary`, or `ExprFixedSizeArray`, and no note about the semantics of parenthesized type expressions.

---

## What is the behavior or documentation after?

The comments now list all handled expression kinds: `ExprUnderscore|ExprUnary|ExprPath|ExprTuple|ExprFixedSizeArray`. They also include an explicit note that `(<type_expr>)` in type position is parsed as a tuple (not a grouping construct) and produces a diagnostic.

---

## Related issue or discussion (if any)

None.

---

## Additional context

None.