### PR TITLE
(bug fix): don't orphan non-droppable inputs in variable forwarding

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/test_data/variable_forwarding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/variable_forwarding
@@ -1368,3 +1368,50 @@ blk3:
 Statements:
 End:
   Return(v0)
+
+//! > ==========================================================================
+
+//! > Test destructure of a Copy + non-Drop struct is not removed.
+
+//! > test_runner_name
+test_variable_forwarding
+
+//! > function_code
+#[allow(extern_outside_corelib)]
+extern fn make_copy_only() -> CopyOnly nopanic;
+
+fn foo() {
+    let CopyOnly { x } = make_copy_only();
+    let _ = x;
+}
+
+//! > function_name
+foo
+
+//! > module_code
+#[derive(Copy)]
+struct CopyOnly {
+    x: felt252,
+}
+
+//! > semantic_diagnostics
+
+//! > before
+Parameters:
+blk0 (root):
+Statements:
+  (v0: test::CopyOnly) <- test::make_copy_only()
+  (v1: core::felt252) <- struct_destructure(v0)
+End:
+  Return()
+
+//! > after
+Parameters:
+blk0 (root):
+Statements:
+  (v0: test::CopyOnly) <- test::make_copy_only()
+  (v1: core::felt252) <- struct_destructure(v0)
+End:
+  Return()
+
+//! > lowering_diagnostics

--- a/crates/cairo-lang-lowering/src/optimizations/variable_forwarding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/variable_forwarding.rs
@@ -223,7 +223,7 @@ impl<'a, 'db> ForwardingCtx<'a, 'db> {
         }
         txn.renames.extend(deps);
 
-        // Free inputs and resolve non-copy obligations.
+        // Free inputs and resolve non-copy/non-drop obligations.
         let DefLocation::Statement(stmt_loc) = def else { return true };
         // Free one use per input slot, matching `UseSites`' per-slot multiplicity
         // counts: a statement consuming the same variable in two slots frees two of its
@@ -232,13 +232,15 @@ impl<'a, 'db> ForwardingCtx<'a, 'db> {
             let var_id = var_usage.var_id;
             *txn.freed_delta.entry(var_id).or_default() += 1;
 
-            if self.variables[var_id].info.copyable.is_err()
+            let info = &self.variables[var_id].info;
+            if (info.copyable.is_err() || info.droppable.is_err())
                 && self.effective_use_count(var_id, committed, txn) == 0
             {
-                // Non-copy variable with no remaining consumers — try to remove
-                // the producer so that renames targeting `v` don't create duplicate
-                // consuming uses. If the cascade fails, propagate failure so the
-                // whole transaction is discarded; partial cascade state is left in
+                // A variable with no remaining consumers must not be orphaned: if
+                // non-copy, renames targeting it would create duplicate consuming
+                // uses; if non-drop, leaving it unconsumed is illegal. Either way try
+                // to remove the producer. If the cascade fails, propagate failure so
+                // the whole transaction is discarded; partial cascade state is left in
                 // `txn` and will be dropped together with the rest by the worklist
                 // when this top-level `try_remove` returns false.
                 let Some(producer) = self.definition(var_id) else {


### PR DESCRIPTION
### TL;DR

Fix variable forwarding optimization to correctly handle `Copy`-only (non-`Drop`) structs by preventing them from being orphaned during destructuring.

### What changed?

The variable forwarding optimization's cascade removal logic now checks for both non-copyable **and** non-droppable variables when determining whether a producer should be removed. Previously, only non-copy variables triggered the cascade; non-drop (but copyable) variables could be left unconsumed, which is illegal. A new test case was added to verify that destructuring a `Copy`-but-not-`Drop` struct is not incorrectly eliminated.

### How to test?

Run the variable forwarding optimization tests:

```
cargo test -p cairo-lang-lowering variable_forwarding
```

The new test case `Test destructure of a Copy + non-Drop struct is not removed` verifies that the `struct_destructure` statement is preserved in the lowered output.

### Why make this change?

A `Copy`-only struct (one that is `Copy` but not `Drop`) must still be consumed — it cannot be silently discarded. The previous logic only guarded against duplicate consuming uses for non-copy variables, but missed the case where a non-droppable variable would be left with no consumers, resulting in an illegal orphaned value. Extending the condition to include non-droppable variables ensures such values are always properly consumed.