### PR TITLE
fix(parser): stop colored_printer panicking on valid tokens

### DIFF
--- a/crates/cairo-lang-parser/src/colored_printer.rs
+++ b/crates/cairo-lang-parser/src/colored_printer.rs
@@ -71,6 +71,9 @@ fn set_color(text: &str, kind: SyntaxKind) -> ColoredString {
         | SyntaxKind::TokenEnum
         | SyntaxKind::TokenStruct
         | SyntaxKind::TokenTrait
+        | SyntaxKind::TokenMacro
+        | SyntaxKind::TokenConst
+        | SyntaxKind::TokenPub
         | SyntaxKind::TokenImpl => text.bright_blue(),
         SyntaxKind::TokenOf
         | SyntaxKind::TokenLet
@@ -78,7 +81,13 @@ fn set_color(text: &str, kind: SyntaxKind) -> ColoredString {
         | SyntaxKind::TokenMatch
         | SyntaxKind::TokenIf
         | SyntaxKind::TokenElse
+        | SyntaxKind::TokenWhile
+        | SyntaxKind::TokenFor
+        | SyntaxKind::TokenLoop
+        | SyntaxKind::TokenContinue
+        | SyntaxKind::TokenBreak
         | SyntaxKind::TokenUse
+        | SyntaxKind::TokenAs
         | SyntaxKind::TokenImplicits
         | SyntaxKind::TokenRef
         | SyntaxKind::TokenMut
@@ -98,6 +107,9 @@ fn set_color(text: &str, kind: SyntaxKind) -> ColoredString {
         | SyntaxKind::TokenNot
         | SyntaxKind::TokenQuestionMark
         | SyntaxKind::TokenUnderscore
+        | SyntaxKind::TokenAt
+        | SyntaxKind::TokenBitNot
+        | SyntaxKind::TokenDollar
         | SyntaxKind::TokenHash => text.truecolor(255, 180, 255), // Pink
         SyntaxKind::TokenEq
         | SyntaxKind::TokenEqEq
@@ -105,6 +117,11 @@ fn set_color(text: &str, kind: SyntaxKind) -> ColoredString {
         | SyntaxKind::TokenGT
         | SyntaxKind::TokenLE
         | SyntaxKind::TokenLT
+        | SyntaxKind::TokenPlusEq
+        | SyntaxKind::TokenMinusEq
+        | SyntaxKind::TokenMulEq
+        | SyntaxKind::TokenDivEq
+        | SyntaxKind::TokenModEq
         | SyntaxKind::TokenNeq => {
             text.truecolor(255, 165, 0) // Orange
         }
@@ -120,11 +137,13 @@ fn set_color(text: &str, kind: SyntaxKind) -> ColoredString {
         SyntaxKind::TokenMissing => text.clear(),
         SyntaxKind::TokenSkipped => text.on_red(), // red background
         SyntaxKind::TokenSingleLineComment
+        | SyntaxKind::TokenSingleLineDocComment
+        | SyntaxKind::TokenSingleLineInnerComment
         | SyntaxKind::TokenWhitespace
         | SyntaxKind::TokenNewline
         | SyntaxKind::TokenEmpty => text.clear(),
-        // TODO(yuval): Can this be made exhaustive?
-        _ => panic!("Unexpected syntax kind: {kind:?}"),
+        // TODO(orizi): Make exhaustive.
+        _ => text.clear(),
     }
 }
 


### PR DESCRIPTION
## Summary

Extends the colored printer to handle additional `SyntaxKind` tokens that were previously falling through to a panic. Adds color assignments for:
- Keywords: `macro`, `const`, `pub`, `while`, `for`, `loop`, `continue`, `break`, `as`
- Operators/symbols: `@`, `~` (BitNot), `$`, `+=`, `-=`, `*=`, `/=`, `%=`
- Comment types: single-line doc comments and single-line inner comments

Also changes the fallback behavior from panicking on unexpected syntax kinds to returning cleared (unstyled) text.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The colored printer would panic when encountering valid syntax tokens that were not explicitly handled in the `set_color` function. Tokens such as `macro`, `const`, `pub`, control flow keywords (`while`, `for`, `loop`, `continue`, `break`), compound assignment operators (`+=`, `-=`, etc.), and doc comment tokens had no color mapping, causing crashes during printing.

---

## What was the behavior or documentation before?

Any unrecognized `SyntaxKind` token caused a panic with the message `"Unexpected syntax kind: {kind:?}"`.

---

## What is the behavior or documentation after?

Previously unhandled tokens are now assigned appropriate colors matching their token category. Any remaining unrecognized tokens fall back to unstyled (cleared) text instead of panicking.

---

## Related issue or discussion (if any)

None.

---

## Additional context

The TODO comment has been updated from `yuval` to `orizi` to reflect the current owner of the task to make the match exhaustive.