### PR TITLE
fix(semantic): use a trivia-free origin span for the consteval_int! code mapping

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -210,6 +210,33 @@ const mod_negative: felt252 = consteval_int!(-7 % 3);
 
 //! > ==========================================================================
 
+//! > Test consteval_int! remapped diagnostic span skips leading trivia
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() -> u8 {
+    // A comment before the macro.
+    consteval_int!(120 + 160)
+}
+
+//! > function_name
+foo
+
+//! > expected_diagnostics
+warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
+ --> lib.cairo:3:5
+    consteval_int!(120 + 160)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2008]: The value does not fit within the range of type core::integer::u8.
+ --> lib.cairo:3:5
+    consteval_int!(120 + 160)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
 //! > Test bad array! macros
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
+++ b/crates/cairo-lang-semantic/src/inline_macros/consteval_int.rs
@@ -60,7 +60,7 @@ impl InlineMacroExprPlugin for ConstevalIntMacro {
                     content,
                     code_mappings: vec![CodeMapping {
                         span,
-                        origin: CodeOrigin::Span(syntax.as_syntax_node().span(db)),
+                        origin: CodeOrigin::Span(syntax.as_syntax_node().span_without_trivia(db)),
                     }],
                     aux_data: None,
                     diagnostics_note: Default::default(),


### PR DESCRIPTION
## Summary

Fix the `consteval_int!` macro's code mapping to use `span_without_trivia` instead of `span`, so that diagnostic spans correctly point to the macro call itself rather than including any leading trivia (e.g., comments or whitespace) that precedes it.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a `consteval_int!` macro call was preceded by a comment or other leading trivia, the remapped diagnostic span included that trivia. This caused diagnostics (such as deprecation warnings or out-of-range value errors) to point to an incorrect or misleading source location.

---

## What was the behavior or documentation before?

Diagnostics emitted for `consteval_int!` would have their spans remapped using the full syntax node span, which includes leading trivia. If a comment appeared before the macro call, the reported span would start at the comment rather than at the macro itself.

---

## What is the behavior or documentation after?

Diagnostics now use `span_without_trivia`, so the reported span starts precisely at the `consteval_int!(...)` token, regardless of any preceding comments or whitespace. A new test case verifies this behavior when a comment precedes the macro call.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A regression test was added to `inline_macros` test data to confirm that both the deprecation warning and the out-of-range error correctly point to the macro call on line 3, column 5, even when a comment appears on the preceding line.