### PR TITLE
Bumped nightly version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
-          toolchain: nightly-2026-05-17
+          toolchain: nightly-2026-07-27
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: |
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           components: rustfmt
-          toolchain: nightly-2026-05-17
+          toolchain: nightly-2026-07-27
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --profile=ci-dev -p cairo-lang-syntax-codegen
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           components: rustfmt
-          toolchain: nightly-2026-05-17
+          toolchain: nightly-2026-07-27
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: scripts/rust_fmt.sh --check
 
@@ -169,7 +169,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           components: clippy
-          toolchain: nightly-2026-05-17
+          toolchain: nightly-2026-07-27
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: >
           scripts/clippy.sh
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
-          toolchain: nightly-2026-05-17
+          toolchain: nightly-2026-07-27
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: >
           scripts/docs.sh

--- a/crates/cairo-lang-lowering/src/lower/mod.rs
+++ b/crates/cairo-lang-lowering/src/lower/mod.rs
@@ -1056,8 +1056,7 @@ fn add_chunks_to_data_array<'db, 'r>(
 ) -> &'r [u8] {
     let expr_stable_ptr = expr.stable_ptr.untyped();
 
-    let chunks = expr.value.as_bytes().chunks_exact(31);
-    let remainder = chunks.remainder();
+    let (chunks, remainder) = expr.value.as_bytes().as_chunks::<31>();
     for chunk in chunks {
         let chunk_usage = generators::Const {
             value: ConstValue::Int(BigInt::from_bytes_be(Sign::Plus, chunk), bytes31_ty)

--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -49,7 +49,7 @@ pub fn reformat_rust_code(text: String) -> String {
 }
 pub fn reformat_rust_code_inner(text: String) -> String {
     let sh = Shell::new().unwrap();
-    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-05-17");
+    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-07-27");
     let cmd_with_args = cmd.arg("--config-path").arg(project_root().join("rustfmt.toml"));
     let mut stdout = cmd_with_args.stdin(text).read().unwrap();
     if !stdout.ends_with('\n') {

--- a/crates/cairo-lang-test-plugin/src/test_config.rs
+++ b/crates/cairo-lang-test-plugin/src/test_config.rs
@@ -220,11 +220,10 @@ fn extract_string_panic_bytes(
     db: &dyn Database,
 ) -> Vec<Felt252> {
     let panic_string = panic_string.string_value(db).unwrap();
-    let chunks = panic_string.as_bytes().chunks_exact(BYTES_IN_WORD);
+    let (chunks, remainder) = panic_string.as_bytes().as_chunks::<BYTES_IN_WORD>();
     let num_full_words = chunks.len().into();
-    let remainder = chunks.remainder();
     let pending_word_len = remainder.len().into();
-    let full_words = chunks.map(|chunk| BigInt::from_bytes_be(Sign::Plus, chunk).into());
+    let full_words = chunks.iter().map(|chunk| BigInt::from_bytes_be(Sign::Plus, chunk).into());
     let pending_word = BigInt::from_bytes_be(Sign::Plus, remainder).into();
 
     chain!(

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The `rustfmt` configuration used by Cairo requires a nightly version of Rust.
 You can install the nightly version by running:
 
 ```sh
-rustup install nightly-2026-05-17
+rustup install nightly-2026-07-27
 ```
 
 ## Running Tests

--- a/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
@@ -35,5 +35,5 @@ You can install the nightly version by running:
 
 [source,bash]
 ----
-rustup install nightly-2026-05-17
+rustup install nightly-2026-07-27
 ----

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,11 +23,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2026-05-17",
+#         "nightly-2026-07-27",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2024",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2026-05-17".
+# and run "rustup toolchain install nightly-2026-07-27".

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-05-17}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-07-27}"
 
 cargo clippy "$@" --all-targets --all-features -- -D warnings -D future-incompatible \
     -D nonstandard-style -D rust-2018-idioms -D unused

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-05-17}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-07-27}"
 
 RUSTDOCFLAGS="-Dwarnings" cargo doc --document-private-items --no-deps --all-features

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-05-17}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-07-27}"
 
 cargo fmt --all -- "$@"


### PR DESCRIPTION
## Summary

Bumps the Rust nightly toolchain from `nightly-2026-05-17` to `nightly-2026-07-27` across CI workflows, scripts, documentation, and code that relies on nightly-only APIs. Also migrates two uses of `chunks_exact` + `remainder()` to the stabilized `as_chunks` API introduced in the newer nightly.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

The pinned nightly toolchain was outdated. Updating it keeps the project on a more recent nightly, picks up compiler improvements and bug fixes, and allows use of `as_chunks` which provides a cleaner and more idiomatic API than `chunks_exact` + `.remainder()`.

---

## What was the behavior or documentation before?

The project used `nightly-2026-05-17` for formatting, linting, doc generation, and CI builds. Byte-slice chunking used `chunks_exact` with a separate `.remainder()` call.

---

## What is the behavior or documentation after?

The project uses `nightly-2026-07-27`. Byte-slice chunking now uses `as_chunks::<N>()`, which returns the chunks and remainder as a tuple in a single call.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `as_chunks` API is a nightly feature that returns `(&[[T; N]], &[T])` directly, eliminating the need for the separate `.remainder()` call that `chunks_exact` required.