### PR TITLE
(bug fix): complete all nightly benchmark stages even when one alerts on degradation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,10 +88,15 @@ jobs:
           fail-on-alert: true
           alert-threshold: '150%'
 
+      # The remaining suites and the final push run even if an earlier store step failed on a
+      # degradation alert (fail-on-alert), so a single regression doesn't drop the results of the
+      # other benchmarks.
       - name: Run heap benchmarks
+        if: ${{ !cancelled() }}
         run: cargo bench --bench dhat_compile --features dhat
 
       - name: Store heap benchmark results
+        if: ${{ !cancelled() }}
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba
         with:
           name: Cairo Heap Benchmarks
@@ -108,9 +113,11 @@ jobs:
           skip-fetch-gh-pages: true
 
       - name: Run LS-flow heap benchmark
+        if: ${{ !cancelled() }}
         run: cargo bench --bench dhat_ls_flow --features dhat
 
       - name: Store LS-flow heap benchmark results
+        if: ${{ !cancelled() }}
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba
         with:
           name: Cairo LS-Flow Memory Benchmarks
@@ -126,9 +133,11 @@ jobs:
           skip-fetch-gh-pages: true
 
       - name: Run language-server re-execution benchmark
+        if: ${{ !cancelled() }}
         run: cargo bench --bench ls_reexec
 
       - name: Store language-server re-execution benchmark results
+        if: ${{ !cancelled() }}
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba
         with:
           name: Cairo Language Server Re-execution Benchmarks
@@ -144,6 +153,7 @@ jobs:
           skip-fetch-gh-pages: true
 
       - name: Push results to gh-pages
+        if: ${{ !cancelled() }}
         run: git push origin gh-pages
 
   starknet_sierra_validate:


### PR DESCRIPTION
## Summary

Adds `if: ${{ !cancelled() }}` conditions to all benchmark steps after the first `fail-on-alert` store step in the nightly workflow. This ensures that a performance regression detected in one benchmark suite does not prevent the remaining benchmark suites from running and storing their results, and that the final `git push` to `gh-pages` still executes.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When the first benchmark store step triggers a `fail-on-alert` degradation alert, GitHub Actions marks the job as failed and skips all subsequent steps by default. This caused the heap benchmarks, LS-flow heap benchmarks, language-server re-execution benchmarks, and the final `gh-pages` push to be silently dropped whenever a single regression was detected.

---

## What was the behavior or documentation before?

A single benchmark regression would cause all later benchmark suites to be skipped entirely, and their results would never be stored or pushed to `gh-pages`.

---

## What is the behavior or documentation after?

All benchmark suites run and store their results regardless of whether an earlier suite triggered a degradation alert. The `gh-pages` push also runs unconditionally (as long as the job was not explicitly cancelled), so the full set of benchmark results is always recorded.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

The `!cancelled()` condition distinguishes between a step failure (which should not block subsequent steps) and an explicit job cancellation (which should still halt execution).