### PR TITLE
fix(semantic): recover from a salsa cycle in enum_definition_data instead of panicking

### DIFF
--- a/crates/cairo-lang-semantic/src/items/enm.rs
+++ b/crates/cairo-lang-semantic/src/items/enm.rs
@@ -145,7 +145,7 @@ pub enum MatchArmSelector<'db> {
 }
 
 /// Returns the definition data of an enum.
-#[salsa::tracked(returns(ref))]
+#[salsa::tracked(returns(ref), cycle_fn=enum_definition_data_cycle, cycle_initial=enum_definition_data_initial)]
 fn enum_definition_data<'db>(
     db: &'db dyn Database,
     enum_id: EnumId<'db>,
@@ -213,6 +213,26 @@ fn enum_definition_data<'db>(
         variant_semantic,
         resolver_data,
     })
+}
+
+/// Cycle handling for [enum_definition_data].
+fn enum_definition_data_cycle<'db>(
+    _db: &'db dyn Database,
+    _cycle: &salsa::Cycle<'_>,
+    _last_provisional_value: &Maybe<EnumDefinitionData<'db>>,
+    value: Maybe<EnumDefinitionData<'db>>,
+    _enum_id: EnumId<'db>,
+) -> Maybe<EnumDefinitionData<'db>> {
+    value
+}
+
+/// Cycle handling for [enum_definition_data].
+fn enum_definition_data_initial<'db>(
+    _db: &'db dyn Database,
+    _id: salsa::Id,
+    _enum_id: EnumId<'db>,
+) -> Maybe<EnumDefinitionData<'db>> {
+    Err(skip_diagnostic())
 }
 
 /// Query implementation of [EnumSemantic::enum_definition_diagnostics].

--- a/crates/cairo-lang-semantic/src/items/tests/enum
+++ b/crates/cairo-lang-semantic/src/items/tests/enum
@@ -193,3 +193,39 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
  --> lib.cairo:9:9
     let E = A::E(());
         ^
+
+//! > ==========================================================================
+
+//! > Test no ICE when a malformed module-level macro call re-enters the enum definition. The unresolved variant type's error must survive the cycle recovery.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+enum MyEnum {
+    A: P,
+}
+MyEnum::A(());
+
+//! > expected_diagnostics
+error[E1012]: Expected a '!' after the identifier 'A' to start an inline macro.
+Did you mean to write `A!(...)'?
+ --> lib.cairo:4:9
+MyEnum::A(());
+        ^
+
+error[E0006]: Type not found.
+ --> lib.cairo:2:8
+    A: P,
+       ^
+
+error[E2156]: Inline macro `MyEnum::A` not found.
+ --> lib.cairo:4:1
+MyEnum::A(());
+^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Adds cycle recovery handlers (`enum_definition_data_cycle` and `enum_definition_data_initial`) to the `enum_definition_data` Salsa query so that re-entrant calls caused by malformed module-level macro expressions (e.g., `MyEnum::A(());` at module scope) return a graceful `Err` instead of triggering an ICE.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a malformed module-level expression like `MyEnum::A(());` is parsed, the compiler attempts to resolve it as a macro call. This re-enters the `enum_definition_data` query for `MyEnum` while it is still being computed, creating a Salsa cycle. Without cycle recovery, this caused an internal compiler error (ICE) rather than a user-facing diagnostic.

---

## What was the behavior or documentation before?

A malformed module-level macro call that referenced an enum variant (e.g., `MyEnum::A(());`) would cause an ICE due to an unhandled Salsa cycle in `enum_definition_data`.

---

## What is the behavior or documentation after?

The cycle is now recovered gracefully. The compiler emits the expected user-facing diagnostics — an "Expected a '!' after the identifier" error, a "Type not found" error for the unresolved variant type, and an "Inline macro not found" error — without crashing.

---

## Related issue or discussion (if any)

N/A

---

## Additional context

A regression test has been added to the enum semantic test suite covering the exact scenario: an enum with an unresolved variant type followed by a module-level expression that re-enters the enum definition query.