### PR TITLE
Made param not skip the defining fn in its path.

### DIFF
--- a/crates/cairo-lang-defs/src/ids.rs
+++ b/crates/cairo-lang-defs/src/ids.rs
@@ -35,7 +35,7 @@ use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::{Intern, OptionFrom, define_short_id, require};
-use itertools::Itertools;
+use itertools::{Itertools, chain};
 use salsa::Database;
 
 use crate::db::ModuleData;
@@ -1038,8 +1038,39 @@ define_language_element_id_as_enum! {
     }
 }
 
-// TODO(spapini): Override full_path to include parents, for better debug.
-define_top_level_language_element_id!(ParamId, ParamLongId, ast::Param<'db>);
+define_named_language_element_id!(ParamId, ParamLongId, ast::Param<'db>);
+impl<'db> TopLevelLanguageElementId<'db> for ParamId<'db> {
+    fn path_segments(&self, db: &'db dyn Database) -> Vec<SmolStrId<'db>> {
+        let long = self.long(db);
+        let mut closure_segment = None;
+        let node = long.1.lookup(db).as_syntax_node();
+        if let Some(closure) = node.ancestor_of_kind(db, SyntaxKind::ExprClosure) {
+            closure_segment =
+                Some(SmolStrId::from(db, format!("{{closure@{}}}", closure.offset(db).as_u32())));
+        }
+        let mut segments = if let Some(decl) =
+            node.ancestors(db).find_map(|node| match node.kind(db) {
+                SyntaxKind::FunctionDeclaration => Some(node),
+                SyntaxKind::FunctionWithBody => Some(
+                    ast::FunctionWithBody::from_syntax_node(db, node)
+                        .declaration(db)
+                        .as_syntax_node(),
+                ),
+                SyntaxKind::TraitItemFunction => Some(
+                    ast::TraitItemFunction::from_syntax_node(db, node)
+                        .declaration(db)
+                        .as_syntax_node(),
+                ),
+                _ => None,
+            }) {
+            GenericItemId::from_ptr(db, long.0, decl.stable_ptr(db)).path_segments(db)
+        } else {
+            self.parent_module(db).path_segments(db)
+        };
+        segments.extend(chain!(closure_segment, [self.name(db)]));
+        segments
+    }
+}
 define_language_element_id_basic!(GenericParamId, GenericParamLongId, ast::GenericParam<'db>);
 impl<'db> GenericParamLongId<'db> {
     pub fn name(&self, db: &'db dyn Database) -> Option<SmolStrId<'db>> {

--- a/crates/cairo-lang-lowering/src/lower/test_data/merge_block_builders
+++ b/crates/cairo-lang-lowering/src/lower/test_data/merge_block_builders
@@ -15,12 +15,12 @@ x: felt252
 //! > input_blocks
 block_id: blk0
 semantics:
-  Var(ParamId(test::x)): v0
+  Var(ParamId(test::foo::x)): v0
 
 //! > merged_block_builder
 block_id: blk0
 semantics:
-  Var(ParamId(test::x)): v0
+  Var(ParamId(test::foo::x)): v0
 
 //! > lowered
 blk0:
@@ -53,21 +53,21 @@ x: felt252, y: felt252, z: felt252, w: felt252
 //! > input_blocks
 block_id: blk0
 semantics:
-  Var(ParamId(test::x)): v0
-  Var(ParamId(test::y)): v1
-  Var(ParamId(test::z)): v2
+  Var(ParamId(test::foo::x)): v0
+  Var(ParamId(test::foo::y)): v1
+  Var(ParamId(test::foo::z)): v2
 
 block_id: blk1
 semantics:
-  Var(ParamId(test::x)): v0
-  Var(ParamId(test::y)): v3
-  Var(ParamId(test::w)): v4
+  Var(ParamId(test::foo::x)): v0
+  Var(ParamId(test::foo::y)): v3
+  Var(ParamId(test::foo::w)): v4
 
 //! > merged_block_builder
 block_id: blk2
 semantics:
-  Var(ParamId(test::x)): v0
-  Var(ParamId(test::y)): v100
+  Var(ParamId(test::foo::x)): v0
+  Var(ParamId(test::foo::y)): v100
 
 //! > lowered
 blk0:
@@ -129,20 +129,20 @@ struct B {
 //! > merged_block_builder
 block_id: blk3
 semantics:
-  Var(ParamId(test::x)): Scattered(Scattered(v113, v114), v0, v115)
+  Var(ParamId(test::foo::x)): Scattered(Scattered(v113, v114), v0, v115)
 
 //! > input_blocks
 block_id: blk0
 semantics:
-  Var(ParamId(test::x)): Scattered(v3, v0, v1)
+  Var(ParamId(test::foo::x)): Scattered(v3, v0, v1)
 
 block_id: blk1
 semantics:
-  Var(ParamId(test::x)): Scattered(Scattered(v4, v5), v0, v2)
+  Var(ParamId(test::foo::x)): Scattered(Scattered(v4, v5), v0, v2)
 
 block_id: blk2
 semantics:
-  Var(ParamId(test::x)): Scattered(Scattered(v4, v5), v0, v2)
+  Var(ParamId(test::foo::x)): Scattered(Scattered(v4, v5), v0, v2)
 
 //! > lowered
 blk0:
@@ -213,16 +213,16 @@ struct C {
 //! > input_blocks
 block_id: blk0
 semantics:
-  Var(ParamId(test::x)): Scattered(v0, Scattered(v1, v2), Scattered(v4, v7))
+  Var(ParamId(test::foo::x)): Scattered(v0, Scattered(v1, v2), Scattered(v4, v7))
 
 block_id: blk1
 semantics:
-  Var(ParamId(test::x)): Scattered(v0, Scattered(v1, v3), Scattered(Scattered(v5, v6), v7))
+  Var(ParamId(test::foo::x)): Scattered(v0, Scattered(v1, v3), Scattered(Scattered(v5, v6), v7))
 
 //! > merged_block_builder
 block_id: blk2
 semantics:
-  Var(ParamId(test::x)): Scattered(v0, Scattered(v1, v116), Scattered(Scattered(v117, v118), v7))
+  Var(ParamId(test::foo::x)): Scattered(v0, Scattered(v1, v116), Scattered(Scattered(v117, v118), v7))
 
 //! > lowered
 blk0:

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/closure
@@ -21,7 +21,7 @@ ExprClosure(
                             args: [
                                 Value(
                                     Var(
-                                        ParamId(test::a),
+                                        ParamId(test::test_func::{closure@20}::a),
                                     ),
                                 ),
                                 Value(
@@ -43,7 +43,7 @@ ExprClosure(
         ),
         params: [
             Parameter {
-                id: ParamId(test::a),
+                id: ParamId(test::test_func::{closure@20}::a),
                 name: "a",
                 ty: core::felt252,
                 mutability: Immutable,
@@ -96,7 +96,7 @@ Block(
                                                     d,
                                                 ),
                                                 expr: Var(
-                                                    ParamId(test::a),
+                                                    ParamId(test::test_func::{closure@162}::a),
                                                 ),
                                                 else_clause: None,
                                             },
@@ -123,7 +123,7 @@ Block(
                             ),
                             params: [
                                 Parameter {
-                                    id: ParamId(test::a),
+                                    id: ParamId(test::test_func::{closure@162}::a),
                                     name: "a",
                                     ty: core::integer::u8,
                                     mutability: Immutable,

--- a/crates/cairo-lang-semantic/src/expr/test.rs
+++ b/crates/cairo-lang-semantic/src/expr/test.rs
@@ -184,7 +184,7 @@ fn test_tuple_type() {
     let param = &signature.params[0];
     assert_eq!(
         format!("{:?}", param.debug(db)),
-        "Parameter { id: ParamId(test::a), name: \"a\", ty: (core::felt252, (), \
+        "Parameter { id: ParamId(test::foo::a), name: \"a\", ty: (core::felt252, (), \
          (core::felt252,)), mutability: Mutable }"
     );
 }

--- a/crates/cairo-lang-semantic/src/items/imp_test.rs
+++ b/crates/cairo-lang-semantic/src/items/imp_test.rs
@@ -44,9 +44,9 @@ fn test_impl() {
     let signature = db.impl_function_signature(*impl_function_id).unwrap();
     assert_eq!(
         format!("{:?}", signature.debug(db)),
-        "Signature { params: [Parameter { id: ParamId(test::a), name: \"a\", ty: core::felt252, \
-         mutability: Immutable }], return_type: (), implicits: [], panicable: true, is_const: \
-         false }"
+        "Signature { params: [Parameter { id: ParamId(test::Contract::foo::a), name: \"a\", ty: \
+         core::felt252, mutability: Immutable }], return_type: (), implicits: [], panicable: \
+         true, is_const: false }"
     );
 
     db.impl_def_concrete_trait(impl_def_id).unwrap();

--- a/crates/cairo-lang-semantic/src/items/trt_test.rs
+++ b/crates/cairo-lang-semantic/src/items/trt_test.rs
@@ -43,8 +43,8 @@ fn test_trait() {
     let signature = db.trait_function_signature(*trait_function_id).unwrap();
     assert_eq!(
         format!("{:?}", signature.debug(db)),
-        "Signature { params: [Parameter { id: ParamId(test::a), name: \"a\", ty: core::felt252, \
-         mutability: Immutable }], return_type: (), implicits: [], panicable: true, is_const: \
-         false }"
+        "Signature { params: [Parameter { id: ParamId(test::MyContract::foo::a), name: \"a\", ty: \
+         core::felt252, mutability: Immutable }], return_type: (), implicits: [], panicable: \
+         true, is_const: false }"
     );
 }

--- a/crates/cairo-lang-semantic/src/resolve/test.rs
+++ b/crates/cairo-lang-semantic/src/resolve/test.rs
@@ -48,9 +48,9 @@ fn test_resolve_path() {
         format!("{:?}", body.to_option().debug(&expr_formatter)),
         "Some(Block(ExprBlock { statements: [Expr(StatementExpr { expr: \
          FunctionCall(ExprFunctionCall { function: test::bar::<(core::felt252, Q)>, args: \
-         [Value(Var(ParamId(test::value)))], coupon_arg: None, ty: test::S::<()> }) }), \
-         Let(StatementLet { pattern: Variable(_c), expr: Var(ParamId(test::b)), else_clause: None \
-         })], tail: None, ty: () }))"
+         [Value(Var(ParamId(test::foo::value)))], coupon_arg: None, ty: test::S::<()> }) }), \
+         Let(StatementLet { pattern: Variable(_c), expr: Var(ParamId(test::foo::b)), else_clause: \
+         None })], tail: None, ty: () }))"
     );
 }
 

--- a/crates/cairo-lang-semantic/src/usage/test_data/usage
+++ b/crates/cairo-lang-semantic/src/usage/test_data/usage
@@ -34,8 +34,8 @@ struct B {
 
 //! > usage
 Loop 8:4:
-  Usage: LocalVarId(test::c), ParamId(test::b), ParamId(test::a)::b,
-  Changes: ParamId(test::a)::b::c, ParamId(test::b),
+  Usage: LocalVarId(test::c), ParamId(test::foo::b), ParamId(test::foo::a)::b,
+  Changes: ParamId(test::foo::a)::b::c, ParamId(test::foo::b),
   Snapshot_Usage:
 
 //! > ==========================================================================
@@ -69,8 +69,8 @@ struct B {
 
 //! > usage
 While 9:4:
-  Usage: LocalVarId(test::c), ParamId(test::a)::b::c,
-  Changes: ParamId(test::a)::b::c,
+  Usage: LocalVarId(test::c), ParamId(test::foo::a)::b::c,
+  Changes: ParamId(test::foo::a)::b::c,
   Snapshot_Usage: LocalVarId(test::only_used_in_condition),
 
 //! > ==========================================================================
@@ -111,9 +111,9 @@ fn borrow_B(b: @B) {}
 
 //! > usage
 While 11:4:
-  Usage: LocalVarId(test::c), ParamId(test::b),
+  Usage: LocalVarId(test::c), ParamId(test::foo::b),
   Changes:
-  Snapshot_Usage: LocalVarId(test::only_used_in_condition), ParamId(test::a)::b,
+  Snapshot_Usage: LocalVarId(test::only_used_in_condition), ParamId(test::foo::a)::b,
 
 //! > ==========================================================================
 
@@ -136,11 +136,11 @@ foo
 
 //! > usage
 Closure 2:8:
-  Usage: ParamId(test::a), ParamId(test::b),
+  Usage: ParamId(test::foo::a), ParamId(test::foo::{closure@17}::b),
   Changes:
   Snapshot_Usage:
 Closure 1:4:
-  Usage: ParamId(test::a),
+  Usage: ParamId(test::foo::a),
   Changes:
   Snapshot_Usage:
 
@@ -166,7 +166,7 @@ foo
 
 //! > usage
 For 2:4:
-  Usage: LocalVarId(test::in), ParamId(test::a),
+  Usage: LocalVarId(test::in), ParamId(test::foo::a),
   Changes: LocalVarId(test::in),
   Snapshot_Usage:
 


### PR DESCRIPTION
## Summary

`ParamId` now includes the parent function name in its debug path. Previously, `ParamId` used `define_top_level_language_element_id!`, which only included the module path, resulting in paths like `test::x`. It now uses `define_named_language_element_id!` with a custom `TopLevelLanguageElementId` implementation that walks up the AST to find the enclosing `FunctionDeclaration` and uses its `GenericItemId` path segments, producing fully qualified paths like `test::foo::x` or `test::Contract::foo::a`.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

`ParamId` debug output was ambiguous when multiple functions in the same module had parameters with the same name. The path did not include the enclosing function, making it impossible to distinguish `test::foo::x` from `test::bar::x` — both would appear as `test::x`.

---

## What was the behavior or documentation before?

`ParamId` paths only included the module prefix, e.g. `ParamId(test::a)`, regardless of which function the parameter belonged to.

---

## What is the behavior or documentation after?

`ParamId` paths now include the enclosing function (and trait/impl if applicable), e.g. `ParamId(test::foo::a)`, `ParamId(test::Contract::foo::a)`, or `ParamId(test::MyContract::foo::a)`.

---

## Related issue or discussion (if any)

Resolves the TODO comment: `// TODO(spapini): Override full_path to include parents, for better debug.`

---

## Additional context

All affected test expectations have been updated to reflect the new fully qualified `ParamId` paths.