### PR TITLE
fix(semantic): select a macro repetition's driver placeholder correctly

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1202,6 +1202,12 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     name.long(db)
                 )
             }
+            SemanticDiagnosticKind::MacroRepetitionWithoutDriver => {
+                "Macro expansion repetition block has no placeholder to repeat over. Consider \
+                 using a placeholder declared inside a `$()` repetition in the pattern - only such \
+                 a placeholder can drive one."
+                    .into()
+            }
             SemanticDiagnosticKind::UserDefinedInlineMacrosDisabled => {
                 "User defined inline macros are disabled in the current crate.".into()
             }
@@ -1476,6 +1482,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::UndefinedMacroPlaceholder(_) => error_code!(E2193),
             SemanticDiagnosticKind::MacroPlaceholderRepDepthMismatch { .. } => error_code!(E2198),
             SemanticDiagnosticKind::MacroPlaceholderRepDriverMismatch(_) => error_code!(E2199),
+            SemanticDiagnosticKind::MacroRepetitionWithoutDriver => error_code!(E2202),
             SemanticDiagnosticKind::UserDefinedInlineMacrosDisabled => error_code!(E2194),
             SemanticDiagnosticKind::NonNeverLetElseType => error_code!(E2195),
             SemanticDiagnosticKind::OnlyTypeOrConstParamsInNegImpl => error_code!(E2196),
@@ -1902,6 +1909,7 @@ pub enum SemanticDiagnosticKind<'db> {
         actual: usize,
     },
     MacroPlaceholderRepDriverMismatch(SmolStrId<'db>),
+    MacroRepetitionWithoutDriver,
     UserDefinedInlineMacrosDisabled,
     NonNeverLetElseType,
     OnlyTypeOrConstParamsInNegImpl,

--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -822,9 +822,11 @@ fn expand_inline_macro<'db>(
     );
     if let Ok(ResolvedGenericItem::Macro(macro_declaration_id)) = user_defined_macro {
         let macro_rules = ctx.db.macro_declaration_rules(macro_declaration_id)?;
-        let Some((rule, (captures, placeholder_to_rep_id))) = macro_rules.iter().find_map(|rule| {
-            is_macro_rule_match(ctx.db, rule, &syntax.arguments(db)).map(|res| (rule, res))
-        }) else {
+        let Some((rule, (captures, placeholder_to_rep_id, rep_depths))) =
+            macro_rules.iter().find_map(|rule| {
+                is_macro_rule_match(ctx.db, rule, &syntax.arguments(db)).map(|res| (rule, res))
+            })
+        else {
             return Err(ctx.diagnostics.report(
                 syntax.stable_ptr(ctx.db),
                 InlineMacroNoMatchingRule(macro_path.identifier(db)),
@@ -834,7 +836,7 @@ fn expand_inline_macro<'db>(
         // rules.
         rule.err?;
         let mut matcher_ctx =
-            MatcherContext { captures, placeholder_to_rep_id, ..Default::default() };
+            MatcherContext { captures, placeholder_to_rep_id, rep_depths, ..Default::default() };
         let expanded_code = expand_macro_rule(ctx.db, rule, &mut matcher_ctx)?;
 
         let macro_defsite_resolver_data =

--- a/crates/cairo-lang-semantic/src/expr/expansion_test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/expansion_test_data/inline_macros
@@ -289,3 +289,303 @@ error[E1001]: Missing token ']'.
  --> lib.cairo:2:12
 array![1, 2
            ^
+
+//! > ==========================================================================
+
+//! > Test a repetition block is driven by its repeated placeholder, not by the first one textually.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro sum_with_base {
+    ($x:expr, $($y:expr),*) => { $($x + $y +)* 0 };
+}
+
+//! > expr_code
+sum_with_base!(100, 1, 2, 3)
+
+//! > expanded_code
+100+ 1+100+ 2+100+ 3+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test the driving placeholder is found regardless of its position inside the block.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro sum_with_base {
+    ($x:expr, $($y:expr),*) => { $($y + $x +)* 0 };
+}
+
+//! > expr_code
+sum_with_base!(100, 1, 2, 3)
+
+//! > expanded_code
+1+ 100+2+ 100+3+ 100+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test `$defsite` at the start of a repetition block does not suppress the repetition.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+fn triple(v: felt252) -> felt252 {
+    v * 3
+}
+macro sum_tripled {
+    ($($y:expr),*) => { $($defsite::triple($y) +)* 0 };
+}
+
+//! > expr_code
+sum_tripled!(3, 4, 5)
+
+//! > expanded_code
+$defsite::triple(3) +$defsite::triple(4) +$defsite::triple(5) +0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a repetition matching zero times expands to nothing.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+fn triple(v: felt252) -> felt252 {
+    v * 3
+}
+macro sum_tripled {
+    ($($y:expr),*) => { $($defsite::triple($y) +)* 0 };
+}
+
+//! > expr_code
+sum_tripled!()
+
+//! > expanded_code
+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a repetition whose separator is inside the block is driven by its placeholder.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro sum_with_base {
+    ($x:expr $(, $y:expr)*) => { $($x + $y +)* 0 };
+}
+
+//! > expr_code
+sum_with_base!(100, 1, 2, 3)
+
+//! > expanded_code
+100+ 1+100+ 2+100+ 3+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a repetition whose separator is inside the block, matching zero times.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro sum_with_base {
+    ($x:expr $(, $y:expr)*) => { $($x + $y +)* 0 };
+}
+
+//! > expr_code
+sum_with_base!(100)
+
+//! > expanded_code
+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a nested repetition matching zero times expands to nothing.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro sum_groups {
+    ($([$($x:expr),*]),*) => { $($($x +)*)* 0 };
+}
+
+//! > expr_code
+sum_groups!()
+
+//! > expanded_code
+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test nested repetitions with different drivers, neither of them first in its block.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro nested_drivers {
+    ($n:expr; $($a:expr => [$($b:expr),*]),*) => { $($n + $($n + $b +)* $a +)* 0 };
+}
+
+//! > expr_code
+nested_drivers!(100; 10 => [1, 2])
+
+//! > expanded_code
+100+ 100+ 1+100+ 2+10 +0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a repetition block driven by a placeholder written before a nested block.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro nested_drivers {
+    ($($a:expr => [$($b:expr),*]),*) => { $($a + $($b +)*)* 0 };
+}
+
+//! > expr_code
+nested_drivers!(10 => [1, 2])
+
+//! > expanded_code
+10 + 1+2+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a repetition block driven at all levels.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro nested_drivers {
+    ($n:expr; $($a:expr => [$($b:expr),*]),*) => { $n $( + $n + $a $( + $n + $a + $b)*)* };
+}
+
+//! > expr_code
+nested_drivers!(100; 10 => [1, 2])
+
+//! > expanded_code
+100+ 100+ 10 + 100+ 10 + 1+ 100+ 10 + 2
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test three nested repetition levels, each driven by its own placeholder.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro three_levels {
+    ($($a:expr => [$($b:expr => ($($c:expr),*)),*]),*) => { $($a + $($b + $($c +)*)*)* 0 };
+}
+
+//! > expr_code
+three_levels!(1 => [2 => (3, 4)])
+
+//! > expanded_code
+1 + 2 + 3+4+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test two sibling repetition blocks driven by the same placeholder.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro sibling_blocks {
+    ($($a:expr),*) => { $($a +)* $($a +)* 0 };
+}
+
+//! > expr_code
+sibling_blocks!(1, 2)
+
+//! > expanded_code
+1+2+1+2+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test an outer block whose only driver sits inside its nested block.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro outer_driver_nested {
+    ($($a:expr => [$($b:expr),*]),*) => { $(100 + $($b + $a +)*)* 0 };
+}
+
+//! > expr_code
+outer_driver_nested!(1 => [7, 8])
+
+//! > expanded_code
+100 + 7+ 1 +8+ 1 +0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a block whose only placeholder is bound to a deeper repetition.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro deeper_only {
+    ($([$($x:expr),*]),*) => { $($($x +)*)* 0 };
+}
+
+//! > expr_code
+deeper_only!([1])
+
+//! > expanded_code
+1+0
+
+//! > diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -2730,7 +2730,7 @@ test_function_diagnostics(expect_diagnostics: false)
 
 //! > function_code
 fn foo() {
-    m!(1 + 2, 3, 4);
+    let _a = m!(1 + 2, 3, 4);
 }
 
 //! > function_name
@@ -2738,14 +2738,14 @@ foo
 
 //! > module_code
 macro m {
-    ($x:expr, $($y:expr),*) => { $($x + $y),* };
+    ($x:expr, $($y:expr),*) => { [$($x + $y),*] };
 }
 
 //! > expected_diagnostics
 
 //! > ==========================================================================
 
-//! > Test cross-repetition placeholder mixing in expansion (E2199).
+//! > Test cross-repetition placeholder mixing in expansion.
 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
@@ -2790,6 +2790,82 @@ error[E2199]: Macro placeholder 'y' is from a different repetition than the one 
  --> lib.cairo:2:54
     ($($x:expr),* ; $($($y:expr),*),*) => { $($($x + $y),*),* };
                                                      ^^
+
+//! > ==========================================================================
+
+//! > Test expansion repetition block with no placeholder at all.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($($x:expr),*) => { $(1 +)* 0 };
+}
+
+//! > expected_diagnostics
+error[E2202]: Macro expansion repetition block has no placeholder to repeat over. Consider using a placeholder declared inside a `$()` repetition in the pattern - only such a placeholder can drive one.
+ --> lib.cairo:2:25
+    ($($x:expr),*) => { $(1 +)* 0 };
+                        ^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test expansion repetition block driven only by `$defsite`.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+fn bar() -> felt252 {
+    1
+}
+
+macro m {
+    ($($x:expr),*) => { $($defsite::bar() +)* 0 };
+}
+
+//! > expected_diagnostics
+error[E2202]: Macro expansion repetition block has no placeholder to repeat over. Consider using a placeholder declared inside a `$()` repetition in the pattern - only such a placeholder can drive one.
+ --> lib.cairo:6:25
+    ($($x:expr),*) => { $($defsite::bar() +)* 0 };
+                        ^^^^^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test expansion repetition block whose only placeholder is depth-0.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($x:expr) => { $($x +)* 0 };
+}
+
+//! > expected_diagnostics
+error[E2202]: Macro expansion repetition block has no placeholder to repeat over. Consider using a placeholder declared inside a `$()` repetition in the pattern - only such a placeholder can drive one.
+ --> lib.cairo:2:20
+    ($x:expr) => { $($x +)* 0 };
+                   ^^^^^^^^
 
 //! > ==========================================================================
 
@@ -3066,3 +3142,29 @@ error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::mak
  --> lib.cairo:18:14
     MyTrait::foo();
              ^^^
+
+//! > ==========================================================================
+
+//! > Test expansion repetition block whose only placeholder drives an enclosing block.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo() {
+    m!(1 =>[2]);
+}
+
+//! > function_name
+foo
+
+//! > module_code
+macro m {
+    ($($a:expr => [$($b:expr),*]),*) => { $($a + $($a +)*)* 0 };
+}
+
+//! > expected_diagnostics
+error[E2202]: Macro expansion repetition block has no placeholder to repeat over. Consider using a placeholder declared inside a `$()` repetition in the pattern - only such a placeholder can drive one.
+ --> lib.cairo:2:50
+    ($($a:expr => [$($b:expr),*]),*) => { $($a + $($a +)*)* 0 };
+                                                 ^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -123,9 +123,11 @@ fn priv_macro_call_data<'db>(
             });
         }
     };
-    let Some((rule, (captures, placeholder_to_rep_id))) = macro_rules.iter().find_map(|rule| {
-        is_macro_rule_match(db, rule, &macro_call_syntax.arguments(db)).map(|res| (rule, res))
-    }) else {
+    let Some((rule, (captures, placeholder_to_rep_id, rep_depths))) =
+        macro_rules.iter().find_map(|rule| {
+            is_macro_rule_match(db, rule, &macro_call_syntax.arguments(db)).map(|res| (rule, res))
+        })
+    else {
         let diag_added = diagnostics.report(
             macro_call_syntax.stable_ptr(db),
             SemanticDiagnosticKind::InlineMacroNoMatchingRule(macro_name),
@@ -150,7 +152,8 @@ fn priv_macro_call_data<'db>(
             parent_macro_call_data,
         });
     }
-    let mut matcher_ctx = MatcherContext { captures, placeholder_to_rep_id, ..Default::default() };
+    let mut matcher_ctx =
+        MatcherContext { captures, placeholder_to_rep_id, rep_depths, ..Default::default() };
     let expanded_code = expand_macro_rule(db, rule, &mut matcher_ctx).unwrap();
     let generated_file_id = FileLongId::Virtual(VirtualFile {
         parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -32,6 +32,14 @@ pub struct RepetitionId(usize);
 /// Each macro parameter name maps to a flat list of matched strings.
 type Captures<'db> = OrderedHashMap<SmolStrId<'db>, Vec<CapturedValue<'db>>>;
 
+/// What a successful macro rule match hands to the expansion: the captured values, the repetition
+/// each placeholder is bound to, and the pattern nesting depth of each repetition.
+type MacroMatch<'db> = (
+    Captures<'db>,
+    OrderedHashMap<SmolStrId<'db>, RepetitionId>,
+    OrderedHashMap<RepetitionId, usize>,
+);
+
 /// Context used during macro pattern matching and expansion.
 /// Tracks captured values, active repetition scopes, and repetition ownership per placeholder.
 #[derive(Default, Clone, Debug)]
@@ -50,6 +58,10 @@ pub struct MatcherContext<'db> {
 
     /// Counter for generating unique `RepetitionId`s.
     pub next_repetition_id: usize,
+
+    /// The nesting depth of each repetition within the pattern, starting at 1. Used to pick the
+    /// driver of an expansion block: the outermost repetition still available drives it.
+    pub rep_depths: OrderedHashMap<RepetitionId, usize>,
 
     /// Tracks the current index for each active repetition during expansion.
     pub repetition_indices: OrderedHashMap<RepetitionId, usize>,
@@ -242,11 +254,11 @@ struct ExpansionCheckCtx<'db, 'a> {
     /// Maps each placeholder name to its pattern path: the sequence of repetition IDs
     /// (outermost to innermost) of the `$()` blocks it is nested in within the pattern.
     placeholder_paths: &'a OrderedHashMap<SmolStrId<'db>, Vec<usize>>,
-    /// Number of `$()` expansion blocks currently entered. Used for E2198 depth checks
-    /// and to trim `known_path` when exiting a block.
+    /// Number of `$()` expansion blocks currently entered.
     curr_rep_depth: usize,
     /// The deepest placeholder path seen so far within the current expansion scope.
-    /// New placeholders at the same depth are validated against this prefix (E2199).
+    /// New placeholders at the same depth are validated against this prefix, to catch a
+    /// placeholder from a different repetition than the driving one.
     /// Invariant: `known_path.len() <= curr_rep_depth`.
     /// Trimmed to `curr_rep_depth` on `$()` exit so sibling blocks start fresh.
     known_path: &'a [usize],
@@ -256,64 +268,76 @@ struct ExpansionCheckCtx<'db, 'a> {
 }
 
 impl<'db> ExpansionCheckCtx<'db, '_> {
-    /// Validates placeholder usage by recursively traversing `node`.
+    /// Validates placeholder usage by recursively traversing `node`, reporting undefined
+    /// placeholders, repetition depth and driver mismatches, and blocks with no driver.
     ///
-    /// Two kinds of errors are reported:
-    /// * Depth mismatch (E2198): placeholder used at fewer expansion levels than its pattern depth.
-    /// * Context mismatch (E2199): placeholder from a different repetition than the driving one.
-    fn check_node(&mut self, node: SyntaxNode<'db>) {
+    /// Returns the deepest pattern nesting that a placeholder in `node`'s subtree is bound to -
+    /// the depth up to which that subtree can drive an enclosing `$()` block. A block whose
+    /// subtree stays below its own depth has nothing to iterate over.
+    fn check_node(&mut self, node: SyntaxNode<'db>) -> usize {
         let db = self.db;
         if let Some(param) = MacroParam::cast(db, node) {
-            if let Some(name) = extract_placeholder(db, &param) {
-                let ptr = param.stable_ptr(db).untyped();
-                match self.placeholder_paths.get(&name) {
-                    None => {
-                        self.rule_err = Err(self
-                            .diagnostics
-                            .report(ptr, SemanticDiagnosticKind::UndefinedMacroPlaceholder(name)));
-                    }
-                    Some(path) => {
-                        if path.len() > self.curr_rep_depth {
-                            self.rule_err = Err(self.diagnostics.report(
-                                ptr,
-                                SemanticDiagnosticKind::MacroPlaceholderRepDepthMismatch {
-                                    name,
-                                    required: path.len(),
-                                    actual: self.curr_rep_depth,
-                                },
-                            ));
-                        } else {
-                            let cmp_size = path.len().min(self.known_path.len());
-                            if path[..cmp_size] != self.known_path[..cmp_size] {
-                                self.rule_err = Err(self.diagnostics.report(
-                                    ptr,
-                                    SemanticDiagnosticKind::MacroPlaceholderRepDriverMismatch(name),
-                                ));
-                            } else if path.len() > self.known_path.len() {
-                                self.known_path = path;
-                            }
-                        }
-                    }
+            let Some(name) = extract_placeholder(db, &param) else { return 0 };
+            let ptr = param.stable_ptr(db).untyped();
+            let Some(path) = self.placeholder_paths.get(&name) else {
+                self.rule_err = Err(self
+                    .diagnostics
+                    .report(ptr, SemanticDiagnosticKind::UndefinedMacroPlaceholder(name)));
+                // The placeholder's depth is unknown - assume it could have driven the enclosing
+                // block, so that a second diagnostic is not piled on top of this one.
+                return self.curr_rep_depth;
+            };
+            if path.len() > self.curr_rep_depth {
+                self.rule_err = Err(self.diagnostics.report(
+                    ptr,
+                    SemanticDiagnosticKind::MacroPlaceholderRepDepthMismatch {
+                        name,
+                        required: path.len(),
+                        actual: self.curr_rep_depth,
+                    },
+                ));
+            } else {
+                let cmp_size = path.len().min(self.known_path.len());
+                if path[..cmp_size] != self.known_path[..cmp_size] {
+                    self.rule_err = Err(self.diagnostics.report(
+                        ptr,
+                        SemanticDiagnosticKind::MacroPlaceholderRepDriverMismatch(name),
+                    ));
+                } else if path.len() > self.known_path.len() {
+                    self.known_path = path;
                 }
             }
-            return;
+            // Reported or not, the placeholder is still one the enclosing block could repeat over,
+            // so it does not also collect a diagnostic for having no driver.
+            return path.len();
         }
 
         if let Some(repetition) = ast::MacroRepetition::cast(db, node) {
             self.curr_rep_depth += 1;
-            for element in repetition.elements(db).elements(db) {
-                self.check_node(element.as_syntax_node());
+            let max_drivable_depth_in_block = repetition
+                .elements(db)
+                .elements(db)
+                .map(|element| self.check_node(element.as_syntax_node()))
+                .max()
+                .unwrap_or(0);
+            if max_drivable_depth_in_block < self.curr_rep_depth {
+                self.rule_err = Err(self.diagnostics.report(
+                    repetition.stable_ptr(db).untyped(),
+                    SemanticDiagnosticKind::MacroRepetitionWithoutDriver,
+                ));
             }
             self.curr_rep_depth -= 1;
             if self.curr_rep_depth < self.known_path.len() {
                 // Trimming `self.known_path` so it won't leak between different repetitions.
                 self.known_path = &self.known_path[..self.curr_rep_depth];
             }
-        } else if !node.kind(db).is_terminal() {
-            for child in node.get_children(db).iter() {
-                self.check_node(*child);
-            }
+            return max_drivable_depth_in_block;
         }
+
+        if node.kind(db).is_terminal() {
+            return 0;
+        }
+        node.get_children(db).iter().map(|child| self.check_node(*child)).max().unwrap_or(0)
     }
 }
 
@@ -323,7 +347,7 @@ pub fn is_macro_rule_match<'db>(
     db: &'db dyn Database,
     rule: &MacroRuleData<'db>,
     input: &ast::TokenTreeNode<'db>,
-) -> Option<(Captures<'db>, OrderedHashMap<SmolStrId<'db>, RepetitionId>)> {
+) -> Option<MacroMatch<'db>> {
     let mut ctx = MatcherContext::default();
 
     let matcher_elements = get_macro_elements(db, rule.pattern.clone());
@@ -339,7 +363,7 @@ pub fn is_macro_rule_match<'db>(
     if !validate_repetition_operator_constraints(&ctx) {
         return None;
     }
-    Some((ctx.captures, ctx.placeholder_to_rep_id))
+    Some((ctx.captures, ctx.placeholder_to_rep_id, ctx.rep_depths))
 }
 
 /// Helper function for [expand_macro_rule].
@@ -474,7 +498,12 @@ fn is_macro_rule_match_ex<'db>(
                 let rep_id = RepetitionId(ctx.next_repetition_id);
                 ctx.next_repetition_id += 1;
                 ctx.current_repetition_stack.push(rep_id);
+                ctx.rep_depths.insert(rep_id, ctx.current_repetition_stack.len());
                 let elements = repetition.elements(db);
+                // Bind the placeholders owned by this repetition to it up front, so that the
+                // binding exists even if the repetition ends up matching zero times. Without it,
+                // the expansion could not tell "repeat zero times" from "unknown placeholder".
+                register_repetition_placeholders(db, elements.elements(db), rep_id, ctx);
                 let operator = repetition.operator(db);
                 let separator_token = repetition.separator(db);
                 let expected_separator = match separator_token {
@@ -515,10 +544,6 @@ fn is_macro_rule_match_ex<'db>(
                 }
                 ctx.repetition_match_counts.insert(rep_id, match_count);
                 ctx.repetition_operators.insert(rep_id, operator.clone());
-                for placeholder_name in ctx.captures.keys() {
-                    ctx.placeholder_to_rep_id.insert(*placeholder_name, rep_id);
-                }
-
                 for i in 0..match_count {
                     ctx.repetition_indices.insert(rep_id, i);
                 }
@@ -611,15 +636,10 @@ fn expand_macro_rule_ex(
         SyntaxKind::MacroRepetition => {
             let repetition = ast::MacroRepetition::from_syntax_node(db, node);
             let elements = repetition.elements(db);
-            let first_param = find_first_repetition_param(db, elements.elements(db))
-                .ok_or_else(skip_diagnostic)?;
-            let placeholder_name = first_param.name(db).text(db);
-            // If the placeholder isn't mapped to any repetition, it means it doesn't belong to any
-            // consumed repetition.
-            let Some(rep_id) = matcher_ctx.placeholder_to_rep_id.get(&placeholder_name).copied()
-            else {
-                return Ok(());
-            };
+            // A block with no driver is rejected at declaration time.
+            let (placeholder_name, rep_id) =
+                find_repetition_driver(db, elements.elements(db), matcher_ctx)
+                    .ok_or_else(skip_diagnostic)?;
             let repetition_len =
                 matcher_ctx.captures.get(&placeholder_name).map(|v| v.len()).unwrap_or(0);
             for i in 0..repetition_len {
@@ -666,30 +686,83 @@ fn expand_macro_rule_ex(
     Ok(())
 }
 
-/// Returns the first param within the given macro elements.
-fn find_first_repetition_param<'db>(
+/// Binds every placeholder in a pattern repetition block to `rep_id`, including the placeholders
+/// of nested repetitions.
+///
+/// The nested ones are bound here, rather than by their own repetition, because that repetition is
+/// only entered while matching its body: when this block matches zero times it never is, leaving
+/// its placeholders with no binding at all - which the expansion cannot tell apart from an unknown
+/// placeholder. A nested repetition that *is* entered rebinds its own placeholders back in
+/// [`is_macro_rule_match_ex`], so a non-empty match ends up with the innermost binding.
+fn register_repetition_placeholders<'db>(
     db: &'db dyn Database,
     elements: impl IntoIterator<Item = MacroElement<'db>>,
-) -> Option<MacroParam<'db>> {
+    rep_id: RepetitionId,
+    ctx: &mut MatcherContext<'db>,
+) {
     for element in elements {
-        match element {
-            ast::MacroElement::Param(param) => return Some(param),
-            ast::MacroElement::Subtree(subtree) => {
-                let inner_elements = get_macro_elements(db, subtree.subtree(db)).elements(db);
-                if let Some(param) = find_first_repetition_param(db, inner_elements) {
-                    return Some(param);
+        let inner_elements = match element {
+            ast::MacroElement::Param(param) => {
+                if let Some(name) = extract_placeholder(db, &param) {
+                    ctx.placeholder_to_rep_id.insert(name, rep_id);
                 }
+                continue;
             }
+            ast::MacroElement::Token(_) => continue,
+            ast::MacroElement::Subtree(subtree) => get_macro_elements(db, subtree.subtree(db)),
+            ast::MacroElement::Repetition(repetition) => repetition.elements(db),
+        };
+        register_repetition_placeholders(db, inner_elements.elements(db), rep_id, ctx);
+    }
+}
+
+/// Returns the placeholder driving the given expansion repetition block, and the repetition it is
+/// bound to.
+///
+/// A placeholder carries the iteration count of the repetition it is bound to. Candidates are
+/// ranked by `(already iterated by an enclosing block, pattern depth)`, lowest first, so the block
+/// takes the outermost repetition no enclosing block is iterating. One already being iterated is a
+/// last resort: the pattern binds nothing at this level, and the same values repeat.
+fn find_repetition_driver<'db>(
+    db: &'db dyn Database,
+    elements: impl IntoIterator<Item = MacroElement<'db>>,
+    matcher_ctx: &MatcherContext<'_>,
+) -> Option<(SmolStrId<'db>, RepetitionId)> {
+    let mut best = None;
+    for element in elements {
+        let found = match element {
+            // A placeholder captured outside any repetition has a single value, repeated as-is in
+            // every iteration, so it carries no iteration count and cannot drive a block.
+            ast::MacroElement::Param(param) => extract_placeholder(db, &param).and_then(|name| {
+                matcher_ctx.placeholder_to_rep_id.get(&name).map(|&rep_id| (name, rep_id))
+            }),
+            ast::MacroElement::Token(_) => None,
+            ast::MacroElement::Subtree(subtree) => find_repetition_driver(
+                db,
+                get_macro_elements(db, subtree.subtree(db)).elements(db),
+                matcher_ctx,
+            ),
             ast::MacroElement::Repetition(repetition) => {
-                let inner_elements = repetition.elements(db).elements(db);
-                if let Some(param) = find_first_repetition_param(db, inner_elements) {
-                    return Some(param);
-                }
+                find_repetition_driver(db, repetition.elements(db).elements(db), matcher_ctx)
             }
-            ast::MacroElement::Token(_) => {}
+        };
+        let Some((name, rep_id)) = found else { continue };
+        const BEST_DRIVER_RANK: (bool, usize) = (false, 1);
+        let rank = {
+            let depth = *matcher_ctx
+                .rep_depths
+                .get(&rep_id)
+                .expect("Every repetition records its depth when its id is created.");
+            (matcher_ctx.repetition_indices.contains_key(&rep_id), depth)
+        };
+        if rank == BEST_DRIVER_RANK {
+            return Some((name, rep_id));
+        }
+        if best.is_none_or(|(_, best_rank)| rank < best_rank) {
+            best = Some(((name, rep_id), rank));
         }
     }
-    None
+    Some(best?.0)
 }
 
 /// Implementation of [MacroDeclarationSemantic::macro_declaration_diagnostics].


### PR DESCRIPTION
## Summary

Adds a new semantic diagnostic **E2202** (`MacroRepetitionWithoutDriver`) that is emitted when a macro expansion repetition block `$(...)` contains no placeholder that can drive the iteration — i.e., no placeholder bound to a pattern repetition at the required depth.

Previously, `find_first_repetition_param` would locate the first `MacroParam` node in a repetition block and use it as the driver, regardless of whether that placeholder was actually bound to a pattern repetition. This meant blocks containing only plain tokens, `$defsite`/`$callsite`, or depth-0 placeholders would silently misbehave. Now, `find_repetition_driver` skips non-driving elements and returns the first placeholder that is actually bound to a pattern repetition, and the declaration-time check (`ExpansionCheckCtx`) reports E2202 if no such placeholder exists.

Additionally, `register_repetition_placeholders` is introduced to pre-bind all placeholders in a pattern repetition block (including those in nested blocks) to their `rep_id` before matching begins. This ensures that when an outer repetition matches zero times, inner placeholders are still bound and the expansion correctly produces zero iterations rather than failing to find a driver.

The `max_path_len_in_block` field is added to `ExpansionCheckCtx` to track the deepest placeholder path seen within the current expansion block. A block whose maximum path length stays below `curr_rep_depth` triggers E2202. The value merges upward into the parent block on exit, so a depth-2 placeholder also satisfies the enclosing depth-1 block.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Macro expansion repetition blocks with no repeating placeholder would previously either silently expand incorrectly or fail in an opaque way at expansion time. There was no compile-time diagnostic to catch patterns like `$(1 +)* 0` or `$($defsite::bar() +)* 0` where the block has nothing to iterate over.

---

## What was the behavior or documentation before?

A repetition block in a macro expansion template that contained no placeholder bound to a pattern repetition would not be caught at declaration time. The expander would attempt to use the first `MacroParam` it found as the driver, which could be a non-repeating placeholder, `$defsite`, or nothing at all, leading to silent incorrect expansion.

---

## What is the behavior or documentation after?

At macro declaration time, any expansion repetition block that contains no placeholder bound to a pattern repetition at the required depth is rejected with:

```
error[E2202]: Macro expansion repetition block has no placeholder to repeat over.
```

Repetition blocks that are driven by a non-first placeholder (e.g., `$($x + $y +)*` where `$x` is depth-0 and `$y` is the repeating one) now correctly identify `$y` as the driver. Repetitions matching zero times now correctly expand to nothing rather than failing to find a driver.

---

## Related issue or discussion (if any)

---

## Additional context

The existing test for `$($x + $y),*` was adjusted to wrap the expansion in an array `[$($x + $y),*]` so the comma-separated result is syntactically valid as an expression.