### PR TITLE
feature(sierra-gen): Added support for injecting constant values externally, via plugins.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "indoc",
  "itertools 0.15.0",
  "log",
+ "num-bigint",
  "num-traits",
  "pretty_assertions",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "indoc",
  "itertools 0.15.0",
  "log",
+ "num-bigint",
  "num-traits",
  "pretty_assertions",
  "rayon",

--- a/crates/cairo-lang-sierra-generator/Cargo.toml
+++ b/crates/cairo-lang-sierra-generator/Cargo.toml
@@ -25,6 +25,7 @@ cairo-lang-test-utils = { path = "../cairo-lang-test-utils", version = "=2.20.0"
 ] }
 cairo-lang-utils = { path = "../cairo-lang-utils", version = "=2.20.0", features = ["tracing"] }
 itertools = { workspace = true, default-features = true }
+num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true }
 rayon.workspace = true
 salsa.workspace = true

--- a/crates/cairo-lang-sierra-generator/Cargo.toml
+++ b/crates/cairo-lang-sierra-generator/Cargo.toml
@@ -38,6 +38,7 @@ cairo-lang-semantic = { path = "../cairo-lang-semantic", features = ["testing"] 
 cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testing"] }
 indoc.workspace = true
 log.workspace = true
+num-bigint = { workspace = true, default-features = true }
 pretty_assertions.workspace = true
 test-case.workspace = true
 tracing.workspace = true

--- a/crates/cairo-lang-sierra-generator/src/block_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/block_generator.rs
@@ -2,11 +2,14 @@
 #[path = "block_generator_test.rs"]
 mod test;
 
+use cairo_lang_debug::DebugWithDb;
+use cairo_lang_defs::ids::ExternFunctionId;
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_lowering as lowering;
 use cairo_lang_lowering::BlockId;
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::ids::LocationId;
+use cairo_lang_semantic::TypeLongId;
 use cairo_lang_sierra as sierra;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use itertools::{chain, enumerate, zip_eq};
@@ -16,7 +19,7 @@ use sierra::extensions::lib_func::SierraApChange;
 use sierra::program;
 
 use crate::block_generator::sierra::ids::ConcreteLibfuncId;
-use crate::db::SierraGenGroup;
+use crate::db::{EXTERNALLY_PROVIDED_CONST, SierraGenGroup};
 use crate::expr_generator_context::{ExprGenerationResult, ExprGeneratorContext};
 use crate::lifetime::{DropLocation, SierraGenVar, UseLocation};
 use crate::local_variables::MIN_SIZE_FOR_LOCAL_INTO_BOX;
@@ -25,11 +28,11 @@ use crate::replace_ids::{DebugReplacer, SierraIdReplacer};
 use crate::utils::{
     branch_align_libfunc_id, const_libfunc_id_by_type, disable_ap_tracking_libfunc_id,
     drop_libfunc_id, dup_libfunc_id, enable_ap_tracking_libfunc_id,
-    enum_from_bounded_int_libfunc_id, enum_init_libfunc_id, get_concrete_libfunc_id,
-    get_libfunc_signature, into_box_libfunc_id, jump_libfunc_id, jump_statement,
-    local_into_box_libfunc_id, match_enum_libfunc_id, rename_libfunc_id, return_statement,
-    simple_basic_statement, snapshot_take_libfunc_id, struct_construct_libfunc_id,
-    struct_deconstruct_libfunc_id, unbox_libfunc_id,
+    enum_from_bounded_int_libfunc_id, enum_init_libfunc_id, externally_provided_const_extern,
+    get_concrete_libfunc_id, get_libfunc_signature, get_match_libfunc_id, into_box_libfunc_id,
+    jump_libfunc_id, jump_statement, local_into_box_libfunc_id, match_enum_libfunc_id,
+    rename_libfunc_id, return_statement, simple_basic_statement, snapshot_take_libfunc_id,
+    struct_construct_libfunc_id, struct_deconstruct_libfunc_id, unbox_libfunc_id,
 };
 
 /// Generates Sierra code for the body of the given [lowering::Block].
@@ -331,15 +334,22 @@ fn generate_statement_call_code<'db>(
     statement: &lowering::StatementCall<'db>,
     statement_location: &StatementLocation,
 ) -> Maybe<()> {
+    let db = context.get_db();
+
+    // Handle the reserved `__externally_provided_const__` extern function: replace the call with a
+    // `const_as_immediate` of the value supplied by the installed `ExternalConstPlugin`s.
+    if let Some(extern_id) = externally_provided_const_extern(db, statement.function) {
+        return generate_externally_provided_const_code(context, statement, extern_id);
+    }
+
     // Check if this is a user defined function or a libfunc.
-    let (body, libfunc_id) =
-        get_concrete_libfunc_id(context.get_db(), statement.function, statement.with_coupon);
+    let (body, libfunc_id) = get_concrete_libfunc_id(db, statement.function, statement.with_coupon);
     // Checks if the call invalidates ap tracking.
-    let libfunc_signature = get_libfunc_signature(context.get_db(), &libfunc_id);
+    let libfunc_signature = get_libfunc_signature(db, &libfunc_id);
     let [branch_signature] = &libfunc_signature.branch_signatures[..] else {
         panic!(
             "Unexpected branches in '{}'.",
-            DebugReplacer { db: context.get_db() }.replace_libfunc_id(&libfunc_id)
+            DebugReplacer { db }.replace_libfunc_id(&libfunc_id)
         );
     };
     if matches!(branch_signature.ap_change, SierraApChange::Unknown) {
@@ -390,6 +400,51 @@ fn generate_statement_call_code<'db>(
         );
         context.push_statement(stmt);
     }
+    Ok(())
+}
+
+/// Generates Sierra code for a call to the reserved `__externally_provided_const__` extern
+/// function, replacing it with a `const_as_immediate`.
+///
+/// The value is supplied by the installed [`crate::db::ExternalConstPlugin`]s - see
+/// [`SierraGenGroup::externally_provided_const`].
+fn generate_externally_provided_const_code<'db>(
+    context: &mut ExprGeneratorContext<'db, '_>,
+    statement: &lowering::StatementCall<'db>,
+    extern_id: ExternFunctionId<'db>,
+) -> Maybe<()> {
+    let db = context.get_db();
+    let location = statement.location.long(db).stable_location;
+    // The concrete return type of the call - substituted for a generic declaration, and the shape
+    // the call's outputs were expanded from. A tuple - including the unit type - is expanded into
+    // an output per member, which no single constant can fill.
+    let return_type = statement.function.signature(db)?.return_type;
+    assert!(
+        !matches!(return_type.long(db), TypeLongId::Tuple(_)),
+        "`{EXTERNALLY_PROVIDED_CONST}` must not return a tuple: {:?}",
+        location.span_in_file(db).user_location(db).debug(db)
+    );
+    let [output] = statement.outputs[..] else {
+        panic!(
+            "`{EXTERNALLY_PROVIDED_CONST}` must have exactly one output: {:?}",
+            location.span_in_file(db).user_location(db).debug(db)
+        );
+    };
+    // Nothing is consumed here, so an argument would be neither used nor dropped in the generated
+    // code.
+    assert!(
+        statement.inputs.is_empty() && !statement.with_coupon,
+        "`{EXTERNALLY_PROVIDED_CONST}` must be called with no arguments: {:?}",
+        location.span_in_file(db).user_location(db).debug(db)
+    );
+    let value = db.externally_provided_const(extern_id, return_type)?;
+
+    let output_var = context.get_sierra_variable(output);
+    context.push_statement(simple_basic_statement(
+        const_libfunc_id_by_type(db, value, false),
+        &[],
+        &[output_var],
+    ));
     Ok(())
 }
 
@@ -453,8 +508,7 @@ fn generate_match_extern_code<'db>(
     // Prepare the Sierra input variables.
     let args = maybe_add_dup_statements(context, statement_location, &match_info.inputs)?;
     // Get the [ConcreteLibfuncId].
-    let (_function_long_id, libfunc_id) =
-        get_concrete_libfunc_id(context.get_db(), match_info.function, false);
+    let libfunc_id = get_match_libfunc_id(context.get_db(), match_info.function);
 
     generate_match_code(context, block_gen_stack, libfunc_id, args, &match_info.arms)
 }

--- a/crates/cairo-lang-sierra-generator/src/block_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/block_generator.rs
@@ -16,7 +16,7 @@ use sierra::extensions::lib_func::SierraApChange;
 use sierra::program;
 
 use crate::block_generator::sierra::ids::ConcreteLibfuncId;
-use crate::db::SierraGenGroup;
+use crate::db::{EXTERNALLY_PROVIDED_CONST, SierraGenGroup};
 use crate::expr_generator_context::{ExprGenerationResult, ExprGeneratorContext};
 use crate::lifetime::{DropLocation, SierraGenVar, UseLocation};
 use crate::local_variables::MIN_SIZE_FOR_LOCAL_INTO_BOX;
@@ -26,10 +26,10 @@ use crate::utils::{
     branch_align_libfunc_id, const_libfunc_id_by_type, disable_ap_tracking_libfunc_id,
     drop_libfunc_id, dup_libfunc_id, enable_ap_tracking_libfunc_id,
     enum_from_bounded_int_libfunc_id, enum_init_libfunc_id, get_concrete_libfunc_id,
-    get_libfunc_signature, into_box_libfunc_id, jump_libfunc_id, jump_statement,
-    local_into_box_libfunc_id, match_enum_libfunc_id, rename_libfunc_id, return_statement,
-    simple_basic_statement, snapshot_take_libfunc_id, struct_construct_libfunc_id,
-    struct_deconstruct_libfunc_id, unbox_libfunc_id,
+    get_libfunc_signature, get_match_libfunc_id, into_box_libfunc_id, is_externally_provided_const,
+    jump_libfunc_id, jump_statement, local_into_box_libfunc_id, match_enum_libfunc_id,
+    rename_libfunc_id, return_statement, simple_basic_statement, snapshot_take_libfunc_id,
+    struct_construct_libfunc_id, struct_deconstruct_libfunc_id, unbox_libfunc_id,
 };
 
 /// Generates Sierra code for the body of the given [lowering::Block].
@@ -331,15 +331,22 @@ fn generate_statement_call_code<'db>(
     statement: &lowering::StatementCall<'db>,
     statement_location: &StatementLocation,
 ) -> Maybe<()> {
+    let db = context.get_db();
+
+    // Handle the reserved `__externally_provided_const__` extern function: replace the call with a
+    // `const_as_immediate` of the value supplied by the installed `ExternalConstPlugin`s.
+    if is_externally_provided_const(db, statement.function) {
+        return generate_externally_provided_const_code(context, statement);
+    }
+
     // Check if this is a user defined function or a libfunc.
-    let (body, libfunc_id) =
-        get_concrete_libfunc_id(context.get_db(), statement.function, statement.with_coupon);
+    let (body, libfunc_id) = get_concrete_libfunc_id(db, statement.function, statement.with_coupon);
     // Checks if the call invalidates ap tracking.
-    let libfunc_signature = get_libfunc_signature(context.get_db(), &libfunc_id);
+    let libfunc_signature = get_libfunc_signature(db, &libfunc_id);
     let [branch_signature] = &libfunc_signature.branch_signatures[..] else {
         panic!(
             "Unexpected branches in '{}'.",
-            DebugReplacer { db: context.get_db() }.replace_libfunc_id(&libfunc_id)
+            DebugReplacer { db }.replace_libfunc_id(&libfunc_id)
         );
     };
     if matches!(branch_signature.ap_change, SierraApChange::Unknown) {
@@ -390,6 +397,38 @@ fn generate_statement_call_code<'db>(
         );
         context.push_statement(stmt);
     }
+    Ok(())
+}
+
+/// Generates Sierra code for a call to the reserved `__externally_provided_const__` extern
+/// function, replacing it with a `const_as_immediate`.
+///
+/// The value is supplied by the installed [`crate::db::ExternalConstPlugin`]s - see
+/// [`SierraGenGroup::externally_provided_const`].
+fn generate_externally_provided_const_code<'db>(
+    context: &mut ExprGeneratorContext<'db, '_>,
+    statement: &lowering::StatementCall<'db>,
+) -> Maybe<()> {
+    let db = context.get_db();
+    let [output] = statement.outputs[..] else {
+        panic!("`{EXTERNALLY_PROVIDED_CONST}` must have exactly one output.");
+    };
+    // Nothing is consumed here, so an argument would be neither used nor dropped in the generated
+    // code.
+    assert!(
+        statement.inputs.is_empty() && !statement.with_coupon,
+        "`{EXTERNALLY_PROVIDED_CONST}` must be called with no arguments."
+    );
+    let (extern_id, _) = statement.function.get_extern(db).unwrap();
+    // The lowered variable's type is the extern's declared return type.
+    let value = db.externally_provided_const(extern_id, context.get_lowered_variable(output).ty)?;
+
+    let output_var = context.get_sierra_variable(output);
+    context.push_statement(simple_basic_statement(
+        const_libfunc_id_by_type(db, value, false),
+        &[],
+        &[output_var],
+    ));
     Ok(())
 }
 
@@ -453,8 +492,7 @@ fn generate_match_extern_code<'db>(
     // Prepare the Sierra input variables.
     let args = maybe_add_dup_statements(context, statement_location, &match_info.inputs)?;
     // Get the [ConcreteLibfuncId].
-    let (_function_long_id, libfunc_id) =
-        get_concrete_libfunc_id(context.get_db(), match_info.function, false);
+    let libfunc_id = get_match_libfunc_id(context.get_db(), match_info.function);
 
     generate_match_code(context, block_gen_stack, libfunc_id, args, &match_info.arms)
 }

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test.rs
@@ -28,6 +28,7 @@ cairo_lang_test_utils::test_file_test!(
         serialization: "serialization",
         early_return: "early_return",
         panic: "panic",
+        externally_provided_const: "externally_provided_const",
     },
     block_generator_test
 );

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test.rs
@@ -1,8 +1,13 @@
+use std::sync::Arc;
+
 use cairo_lang_debug::DebugWithDb;
+use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::flag::{Flag, FlagsGroup};
 use cairo_lang_filesystem::ids::FlagLongId;
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::{self as lowering, LoweringStage, ids};
+use cairo_lang_semantic::TypeId;
+use cairo_lang_semantic::items::constant::ConstValueId;
 use cairo_lang_semantic::test_utils::setup_test_function;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::Intern;
@@ -10,8 +15,11 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use lowering::fmt::LoweredFormatter;
 use lowering::ids::ConcreteFunctionWithBodyId;
+use num_bigint::BigInt;
+use salsa::Database;
 
 use super::generate_function_result;
+use crate::db::{ExternalConstPlugin, SierraGenGroup};
 use crate::expr_generator_context::ExprGeneratorContext;
 use crate::lifetime::find_variable_lifetime;
 use crate::replace_ids::replace_sierra_ids;
@@ -28,9 +36,30 @@ cairo_lang_test_utils::test_file_test!(
         serialization: "serialization",
         early_return: "early_return",
         panic: "panic",
+        externally_provided_const: "externally_provided_const",
     },
     block_generator_test
 );
+
+/// A test [`ExternalConstPlugin`], supplying `value` for the externs whose full path contains
+/// `module`.
+#[derive(Debug)]
+struct TestConstPlugin {
+    module: &'static str,
+    value: i64,
+}
+impl ExternalConstPlugin for TestConstPlugin {
+    fn provide<'db>(
+        &self,
+        db: &'db dyn Database,
+        full_path: &str,
+        ty: TypeId<'db>,
+    ) -> Option<Maybe<ConstValueId<'db>>> {
+        full_path
+            .contains(self.module)
+            .then(|| Ok(ConstValueId::from_int(db, ty, &BigInt::from(self.value))))
+    }
+}
 
 fn block_generator_test(
     inputs: &OrderedHashMap<String, String>,
@@ -42,6 +71,11 @@ fn block_generator_test(
     // unnecessary complication to them.
     let add_withdraw_gas_flag_id = FlagLongId(Flag::ADD_WITHDRAW_GAS.into());
     db.set_flag(add_withdraw_gas_flag_id, Some(Flag::AddWithdrawGas(false)));
+
+    // Install test plugins for the `__externally_provided_const__` extern function. They are inert
+    // unless that extern is actually called, and each resolves only the calls in its own module.
+    db.set_external_const_plugins(vec![Arc::new(TestConstPlugin { module: "seven", value: 7777 })]);
+    db.add_external_const_plugin(Arc::new(TestConstPlugin { module: "eight", value: 8888 }));
 
     // Parse code and create semantic model.
     let (test_function, semantic_diagnostics) = setup_test_function(db, inputs).split();

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test_data/externally_provided_const
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test_data/externally_provided_const
@@ -1,0 +1,84 @@
+//! > Test that a call to `__externally_provided_const__` becomes a const_as_immediate.
+
+//! > test_runner_name
+block_generator_test
+
+//! > function_code
+mod seven {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> felt252 nopanic;
+}
+
+fn foo() -> felt252 {
+    seven::__externally_provided_const__()
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_gen_diagnostics
+
+//! > sierra_code
+const_as_immediate<Const<felt252, 7777>>() -> ([0])
+PushValues([0]: felt252) -> ([0])
+return([0])
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- test::seven::__externally_provided_const__()
+End:
+  Return(v0)
+
+//! > ==========================================================================
+
+//! > Test that each of the installed plugins provides the const of its own extern.
+
+//! > test_runner_name
+block_generator_test
+
+//! > function_code
+mod seven {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> felt252 nopanic;
+}
+
+mod eight {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> felt252 nopanic;
+}
+
+fn foo() -> (felt252, felt252) {
+    (seven::__externally_provided_const__(), eight::__externally_provided_const__())
+}
+
+//! > function_name
+foo
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_gen_diagnostics
+
+//! > sierra_code
+const_as_immediate<Const<felt252, 7777>>() -> ([0])
+const_as_immediate<Const<felt252, 8888>>() -> ([1])
+struct_construct<Tuple<felt252, felt252>>([0], [1]) -> ([2])
+PushValues([2]: Tuple<felt252, felt252>) -> ([2])
+return([2])
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- test::seven::__externally_provided_const__()
+  (v1: core::felt252) <- test::eight::__externally_provided_const__()
+  (v2: (core::felt252, core::felt252)) <- struct_construct(v0, v1)
+End:
+  Return(v2)

--- a/crates/cairo-lang-sierra-generator/src/block_generator_test_data/externally_provided_const
+++ b/crates/cairo-lang-sierra-generator/src/block_generator_test_data/externally_provided_const
@@ -1,0 +1,215 @@
+//! > Test that a call to `__externally_provided_const__` becomes a const_as_immediate.
+
+//! > test_runner_name
+block_generator_test
+
+//! > cairo_code
+mod seven {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> felt252 nopanic;
+}
+
+#[target_function]
+fn foo() -> felt252 {
+    seven::__externally_provided_const__()
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_code
+const_as_immediate<Const<felt252, 7777>>() -> ([0])
+PushValues([0]: felt252) -> ([0])
+return([0])
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- test::seven::__externally_provided_const__()
+End:
+  Return(v0)
+
+//! > ==========================================================================
+
+//! > Test that each of the installed plugins provides the const of its own extern.
+
+//! > test_runner_name
+block_generator_test
+
+//! > cairo_code
+mod seven {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> felt252 nopanic;
+}
+
+mod eight {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> felt252 nopanic;
+}
+
+#[target_function]
+fn foo() -> (felt252, felt252) {
+    (seven::__externally_provided_const__(), eight::__externally_provided_const__())
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_code
+const_as_immediate<Const<felt252, 7777>>() -> ([0])
+const_as_immediate<Const<felt252, 8888>>() -> ([1])
+struct_construct<Tuple<felt252, felt252>>([0], [1]) -> ([2])
+PushValues([2]: Tuple<felt252, felt252>) -> ([2])
+return([2])
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::felt252) <- test::seven::__externally_provided_const__()
+  (v1: core::felt252) <- test::eight::__externally_provided_const__()
+  (v2: (core::felt252, core::felt252)) <- struct_construct(v0, v1)
+End:
+  Return(v2)
+
+//! > ==========================================================================
+
+//! > Test differently sized externally provided consts, used across an ap revoking call.
+
+//! > test_runner_name
+block_generator_test
+
+//! > cairo_code
+mod seven {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> u16 nopanic;
+}
+
+mod eight {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> u256 nopanic;
+}
+
+#[target_function]
+fn foo(n: felt252) -> (u16, u256) {
+    let single_slot = seven::__externally_provided_const__();
+    let multi_slot = eight::__externally_provided_const__();
+    // The recursive call revokes ap, so both consts are used across a revocation.
+    if n != 0 {
+        foo(n - 1);
+    }
+    (single_slot, multi_slot)
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_code
+const_as_immediate<Const<u16, 7777>>() -> ([0])
+const_as_immediate<Const<core::integer::u256, Const<u128, 8888>, Const<u128, 0>>>() -> ([1])
+dup<felt252>([2]) -> ([2], [3])
+felt252_is_zero([3]) { fallthrough() label_test::foo::0([4]) }
+branch_align() -> ()
+drop<felt252>([2]) -> ()
+struct_construct<Unit>() -> ([5])
+enum_init<core::bool, 1>([5]) -> ([6])
+bool_not_impl([6]) -> ([7])
+drop<core::bool>([7]) -> ()
+struct_construct<Tuple<u16, core::integer::u256>>([0], [1]) -> ([8])
+PushValues([8]: Tuple<u16, core::integer::u256>) -> ([8])
+return([8])
+label_test::foo::0:
+branch_align() -> ()
+drop<NonZero<felt252>>([4]) -> ()
+struct_construct<Unit>() -> ([9])
+enum_init<core::bool, 0>([9]) -> ([10])
+bool_not_impl([10]) -> ([11])
+drop<core::bool>([11]) -> ()
+const_as_immediate<Const<felt252, 1>>() -> ([12])
+felt252_sub([2], [12]) -> ([13])
+PushValues([13]: felt252) -> ([13])
+function_call<user@test::foo>([13]) -> ([14])
+drop<Tuple<u16, core::integer::u256>>([14]) -> ()
+struct_construct<Tuple<u16, core::integer::u256>>([0], [1]) -> ([15])
+PushValues([15]: Tuple<u16, core::integer::u256>) -> ([15])
+return([15])
+label_test::foo::1:
+
+//! > lowering_flat
+Parameters: v0: core::felt252
+blk0 (root):
+Statements:
+  (v1: core::integer::u16) <- test::seven::__externally_provided_const__()
+  (v2: core::integer::u256) <- test::eight::__externally_provided_const__()
+End:
+  Match(match core::felt252_is_zero(v0) {
+    IsZeroResult::Zero => blk1,
+    IsZeroResult::NonZero(v3) => blk2,
+  })
+
+blk1:
+Statements:
+  (v4: ()) <- struct_construct()
+  (v5: core::bool) <- bool::True(v4)
+  (v6: core::bool) <- core::bool_not_impl(v5)
+  (v7: (core::integer::u16, core::integer::u256)) <- struct_construct(v1, v2)
+End:
+  Return(v7)
+
+blk2:
+Statements:
+  (v8: ()) <- struct_construct()
+  (v9: core::bool) <- bool::False(v8)
+  (v10: core::bool) <- core::bool_not_impl(v9)
+  (v11: core::felt252) <- 1
+  (v12: core::felt252) <- core::felt252_sub(v0, v11)
+  (v13: (core::integer::u16, core::integer::u256)) <- test::foo(v12)
+  (v14: (core::integer::u16, core::integer::u256)) <- struct_construct(v1, v2)
+End:
+  Return(v14)
+
+//! > ==========================================================================
+
+//! > Test a generic externally provided const, instantiated at two types.
+
+//! > test_runner_name
+block_generator_test
+
+//! > cairo_code
+mod seven {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__<T>() -> T nopanic;
+}
+
+#[target_function]
+fn foo() -> (u16, felt252) {
+    (
+        seven::__externally_provided_const__::<u16>(),
+        seven::__externally_provided_const__::<felt252>(),
+    )
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_code
+const_as_immediate<Const<u16, 7777>>() -> ([0])
+const_as_immediate<Const<felt252, 7777>>() -> ([1])
+struct_construct<Tuple<u16, felt252>>([0], [1]) -> ([2])
+PushValues([2]: Tuple<u16, felt252>) -> ([2])
+return([2])
+
+//! > lowering_flat
+Parameters:
+blk0 (root):
+Statements:
+  (v0: core::integer::u16) <- test::seven::__externally_provided_const__::<core::integer::u16>()
+  (v1: core::felt252) <- test::seven::__externally_provided_const__::<core::felt252>()
+  (v2: (core::integer::u16, core::felt252)) <- struct_construct(v0, v1)
+End:
+  Return(v2)

--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use cairo_lang_defs::ids::{ExternFunctionId, TopLevelLanguageElementId};
 use cairo_lang_diagnostics::{Maybe, MaybeAsRef};
 use cairo_lang_filesystem::flag::FlagsGroup;
 use cairo_lang_filesystem::ids::{CrateId, Tracked};
@@ -7,12 +8,13 @@ use cairo_lang_lowering as lowering;
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::panic::PanicSignatureInfo;
 use cairo_lang_semantic as semantic;
+use cairo_lang_semantic::items::constant::ConstValueId;
 use cairo_lang_sierra::extensions::lib_func::SierraApChange;
 use cairo_lang_sierra::extensions::{ConcreteType, GenericTypeEx};
 use cairo_lang_sierra::ids::ConcreteTypeId;
 use lowering::ids::ConcreteFunctionWithBodyId;
 use salsa::plumbing::FromId;
-use salsa::{Database, Id};
+use salsa::{Database, Id, Setter};
 
 use crate::program_generator::{self, SierraProgramWithDebug};
 use crate::replace_ids::SierraIdReplacer;
@@ -31,6 +33,88 @@ pub enum SierraGeneratorTypeLongId<'db> {
     /// This is a long id of a phantom type.
     /// Phantom types have a one to one mapping from the semantic type to the Sierra type.
     Phantom(semantic::TypeId<'db>),
+}
+
+/// The reserved name of the extern function whose calls are replaced, at the Sierra generation
+/// stage, by a constant value supplied by one of the installed [`ExternalConstPlugin`]s. It may be
+/// declared anywhere; it is recognized solely by this name and never reaches Sierra.
+pub const EXTERNALLY_PROVIDED_CONST: &str = "__externally_provided_const__";
+
+/// A plugin supplying constant values for calls to the reserved `__externally_provided_const__`
+/// extern function.
+///
+/// Any number of plugins may be installed on the database (see
+/// [`SierraGenGroup::set_external_const_plugins`]), allowing independent flows - e.g. class hash
+/// injection and build configuration values - to each supply their own constants.
+pub trait ExternalConstPlugin: std::fmt::Debug + Send + Sync {
+    /// Returns the [`ConstValueId`] the call should be replaced with, or `None` if this plugin does
+    /// not supply a value for it, in which case the following plugins are queried.
+    ///
+    /// Given the full path of the (concrete) extern function being called, so that distinct
+    /// declarations resolve independently, and its declared return type, which the returned value
+    /// is validated against by the caller. Returning an error fails Sierra generation, as does a
+    /// call none of the installed plugins supplies a value for.
+    ///
+    /// Called from within [`externally_provided_const`], so the answer must be stable per
+    /// declaration and type - a plugin changing its answers must be reinstalled through
+    /// [`SierraGenGroup::set_external_const_plugins`].
+    fn provide<'db>(
+        &self,
+        db: &'db dyn Database,
+        full_path: &str,
+        ty: semantic::TypeId<'db>,
+    ) -> Option<Maybe<ConstValueId<'db>>>;
+}
+
+/// See [`SierraGenGroup::externally_provided_const`] for documentation.
+#[salsa::tracked(returns(copy), cycle_result = externally_provided_const_cycle)]
+pub fn externally_provided_const<'db>(
+    db: &'db dyn Database,
+    extern_id: ExternFunctionId<'db>,
+    ty: semantic::TypeId<'db>,
+) -> Maybe<ConstValueId<'db>> {
+    let full_path = extern_id.full_path(db);
+    let Some(value) =
+        db.external_const_plugins().iter().find_map(|plugin| plugin.provide(db, &full_path, ty))
+    else {
+        panic!("No `{EXTERNALLY_PROVIDED_CONST}` plugin provided a value for `{full_path}`.");
+    };
+    let value = value?;
+    // The plugins return a value of an arbitrary type; ensure it matches the declared one, as a
+    // mismatch would produce a type-incorrect Sierra program.
+    if value.ty(db)? != ty {
+        panic!(
+            "`{EXTERNALLY_PROVIDED_CONST}` plugin returned a value whose type does not match the \
+             declared return type of `{full_path}`."
+        );
+    }
+    Ok(value)
+}
+
+/// A plugin supplied a value depending on the value itself, which has no fixed point.
+fn externally_provided_const_cycle<'db>(
+    db: &'db dyn Database,
+    _id: salsa::Id,
+    extern_id: ExternFunctionId<'db>,
+    _ty: semantic::TypeId<'db>,
+) -> Maybe<ConstValueId<'db>> {
+    panic!(
+        "`{EXTERNALLY_PROVIDED_CONST}` value of `{}` depends on itself.",
+        extern_id.full_path(db)
+    );
+}
+
+#[salsa::input]
+pub struct SierraGenGroupInput {
+    #[returns(ref)]
+    pub external_const_plugins: Option<Vec<Arc<dyn ExternalConstPlugin>>>,
+}
+
+/// Returns a reference to the inputs of [`SierraGenGroup`].
+/// The reference is also used to set the inputs to new values.
+#[salsa::tracked]
+pub fn sierra_gen_group_input(db: &dyn Database) -> SierraGenGroupInput {
+    SierraGenGroupInput::new(db, None)
 }
 
 /// Wrapper for the concrete libfunc long id, providing a unique id for each libfunc.
@@ -271,6 +355,51 @@ pub trait SierraGenGroup: Database {
     ) -> Maybe<&'db SierraProgramWithDebug<'db>> {
         program_generator::get_sierra_program(self.as_dyn_database(), (), requested_crate_ids)
             .maybe_as_ref()
+    }
+
+    /// Returns the constant value supplied for the reserved `__externally_provided_const__` extern
+    /// function declared by `extern_id` and returning `ty`.
+    ///
+    /// The installed [`ExternalConstPlugin`]s are queried in order, keyed by the full path of the
+    /// declaration, and the first supplied value wins, after being validated against `ty`. There is
+    /// no default value - a declaration none of the plugins supplies a value for fails Sierra
+    /// generation.
+    ///
+    /// Resolution is a query, so a plugin computing its value through the database - e.g. by
+    /// compiling another crate - has that work memoized per declaration instead of repeated per
+    /// call site, and a value transitively depending on itself is reported as a cycle rather than
+    /// recursing endlessly.
+    fn externally_provided_const<'db>(
+        &'db self,
+        extern_id: ExternFunctionId<'db>,
+        ty: semantic::TypeId<'db>,
+    ) -> Maybe<ConstValueId<'db>> {
+        externally_provided_const(self.as_dyn_database(), extern_id, ty)
+    }
+
+    /// Returns the installed [`ExternalConstPlugin`]s, in the order they are queried in.
+    fn external_const_plugins(&self) -> &[Arc<dyn ExternalConstPlugin>] {
+        sierra_gen_group_input(self.as_dyn_database())
+            .external_const_plugins(self)
+            .as_deref()
+            .unwrap_or_default()
+    }
+
+    /// Sets the [`ExternalConstPlugin`]s used to resolve calls to the reserved
+    /// `__externally_provided_const__` extern function, replacing the previously installed ones.
+    ///
+    /// The plugins are queried in order, and the first one supplying a value for a call resolves
+    /// it.
+    fn set_external_const_plugins(&mut self, plugins: Vec<Arc<dyn ExternalConstPlugin>>) {
+        let input = sierra_gen_group_input(self.as_dyn_database());
+        input.set_external_const_plugins(self).to(Some(plugins));
+    }
+
+    /// Adds an [`ExternalConstPlugin`], to be queried after the already installed ones.
+    fn add_external_const_plugin(&mut self, plugin: Arc<dyn ExternalConstPlugin>) {
+        let mut plugins = self.external_const_plugins().to_vec();
+        plugins.push(plugin);
+        self.set_external_const_plugins(plugins);
     }
 }
 impl<T: Database + ?Sized> SierraGenGroup for T {}

--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use cairo_lang_debug::DebugWithDb;
+use cairo_lang_defs::ids::{ExternFunctionId, LanguageElementId, TopLevelLanguageElementId};
 use cairo_lang_diagnostics::{Maybe, MaybeAsRef};
 use cairo_lang_filesystem::flag::FlagsGroup;
 use cairo_lang_filesystem::ids::{CrateId, Tracked};
@@ -7,12 +9,13 @@ use cairo_lang_lowering as lowering;
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::panic::PanicSignatureInfo;
 use cairo_lang_semantic as semantic;
+use cairo_lang_semantic::items::constant::ConstValueId;
 use cairo_lang_sierra::extensions::lib_func::SierraApChange;
 use cairo_lang_sierra::extensions::{ConcreteType, GenericTypeEx};
 use cairo_lang_sierra::ids::ConcreteTypeId;
 use lowering::ids::ConcreteFunctionWithBodyId;
 use salsa::plumbing::FromId;
-use salsa::{Database, Id};
+use salsa::{Database, Id, Setter};
 
 use crate::program_generator::{self, SierraProgramWithDebug};
 use crate::replace_ids::SierraIdReplacer;
@@ -31,6 +34,45 @@ pub enum SierraGeneratorTypeLongId<'db> {
     /// This is a long id of a phantom type.
     /// Phantom types have a one to one mapping from the semantic type to the Sierra type.
     Phantom(semantic::TypeId<'db>),
+}
+
+/// The reserved name of the extern function whose calls are replaced by a constant supplied by an
+/// installed [`ExternalConstPlugin`]. Recognized solely by this name, and never reaches Sierra.
+pub const EXTERNALLY_PROVIDED_CONST: &str = "__externally_provided_const__";
+
+/// A plugin supplying constant values for calls to the reserved `__externally_provided_const__`
+/// extern function.
+///
+/// Any number of plugins may be installed on the database (see
+/// [`SierraGenGroup::set_external_const_plugins`]), so that independent flows - e.g. class hash
+/// injection and build configuration values - may each supply their own constants.
+pub trait ExternalConstPlugin: std::fmt::Debug + Send + Sync {
+    /// Returns the value for the declaration `extern_id` returning `ty`, or `None` to leave it to
+    /// the following plugins. Validated against `ty` by the caller.
+    ///
+    /// Memoized per declaration, so the answer must be stable - a plugin changing its answers must
+    /// be reinstalled through [`SierraGenGroup::set_external_const_plugins`].
+    fn provide<'db>(
+        &self,
+        db: &'db dyn Database,
+        extern_id: ExternFunctionId<'db>,
+        ty: semantic::TypeId<'db>,
+    ) -> Option<Maybe<ConstValueId<'db>>>;
+}
+
+/// The inputs of [`SierraGenGroup`], set through its `set_*` methods.
+#[salsa::input]
+pub struct SierraGenGroupInput {
+    /// The plugins supplying the values of the externally provided constants.
+    #[returns(ref)]
+    pub external_const_plugins: Option<Vec<Arc<dyn ExternalConstPlugin>>>,
+}
+
+/// Returns a reference to the inputs of [`SierraGenGroup`].
+/// The reference is also used to set the inputs to new values.
+#[salsa::tracked]
+pub fn sierra_gen_group_input(db: &dyn Database) -> SierraGenGroupInput {
+    SierraGenGroupInput::new(db, None)
 }
 
 /// Wrapper for the concrete libfunc long id, providing a unique id for each libfunc.
@@ -271,6 +313,98 @@ pub trait SierraGenGroup: Database {
     ) -> Maybe<&'db SierraProgramWithDebug<'db>> {
         program_generator::get_sierra_program(self.as_dyn_database(), (), requested_crate_ids)
             .maybe_as_ref()
+    }
+
+    /// Returns the constant value supplied for the reserved `__externally_provided_const__` extern
+    /// function declared by `extern_id` and returning `ty`.
+    ///
+    /// The installed [`ExternalConstPlugin`]s are queried in order with the declaration, and the
+    /// first supplied value wins, after being validated against `ty`. There is no default value - a
+    /// declaration none of the plugins supplies a value for fails Sierra generation.
+    ///
+    /// Resolution is a query, so a plugin computing its value through the database - e.g. by
+    /// compiling another crate - has that work memoized per declaration instead of repeated per
+    /// call site, and a value transitively depending on itself is reported as a cycle rather than
+    /// recursing endlessly.
+    fn externally_provided_const<'db>(
+        &'db self,
+        extern_id: ExternFunctionId<'db>,
+        ty: semantic::TypeId<'db>,
+    ) -> Maybe<ConstValueId<'db>> {
+        #[salsa::tracked(returns(copy), cycle_result = externally_provided_const_cycle)]
+        fn externally_provided_const_tracked<'db>(
+            db: &'db dyn Database,
+            extern_id: ExternFunctionId<'db>,
+            ty: semantic::TypeId<'db>,
+        ) -> Maybe<ConstValueId<'db>> {
+            let declaration = || {
+                format!(
+                    "`{}` at {:?}",
+                    extern_id.full_path(db),
+                    extern_id.stable_location(db).span_in_file(db).user_location(db).debug(db)
+                )
+            };
+            let Some(value) = db
+                .external_const_plugins()
+                .iter()
+                .find_map(|plugin| plugin.provide(db, extern_id, ty))
+            else {
+                panic!(
+                    "No `{EXTERNALLY_PROVIDED_CONST}` plugin provided a value for {}.",
+                    declaration()
+                );
+            };
+            let value = value?;
+            // The plugins return a value of an arbitrary type; ensure it matches the declared one,
+            // as a mismatch would produce a type-incorrect Sierra program.
+            if value.ty(db)? != ty {
+                panic!(
+                    "`{EXTERNALLY_PROVIDED_CONST}` plugin returned a value whose type does not \
+                     match the declared return type of {}.",
+                    declaration()
+                );
+            }
+            Ok(value)
+        }
+        /// A plugin supplied a value depending on the value itself, which has no fixed point.
+        fn externally_provided_const_cycle<'db>(
+            db: &'db dyn Database,
+            _id: salsa::Id,
+            extern_id: ExternFunctionId<'db>,
+            _ty: semantic::TypeId<'db>,
+        ) -> Maybe<ConstValueId<'db>> {
+            panic!(
+                "`{EXTERNALLY_PROVIDED_CONST}` value of `{}` at {:?} depends on itself.",
+                extern_id.full_path(db),
+                extern_id.stable_location(db).span_in_file(db).user_location(db).debug(db)
+            );
+        }
+        externally_provided_const_tracked(self.as_dyn_database(), extern_id, ty)
+    }
+
+    /// Returns the installed [`ExternalConstPlugin`]s, in the order they are queried in.
+    fn external_const_plugins(&self) -> &[Arc<dyn ExternalConstPlugin>] {
+        sierra_gen_group_input(self.as_dyn_database())
+            .external_const_plugins(self)
+            .as_deref()
+            .unwrap_or_default()
+    }
+
+    /// Sets the [`ExternalConstPlugin`]s used to resolve calls to the reserved
+    /// `__externally_provided_const__` extern function, replacing the previously installed ones.
+    ///
+    /// The plugins are queried in order, and the first one supplying a value for a call resolves
+    /// it.
+    fn set_external_const_plugins(&mut self, plugins: Vec<Arc<dyn ExternalConstPlugin>>) {
+        let input = sierra_gen_group_input(self.as_dyn_database());
+        input.set_external_const_plugins(self).to(Some(plugins));
+    }
+
+    /// Adds an [`ExternalConstPlugin`], to be queried after the already installed ones.
+    fn add_external_const_plugin(&mut self, plugin: Arc<dyn ExternalConstPlugin>) {
+        let mut plugins = self.external_const_plugins().to_vec();
+        plugins.push(plugin);
+        self.set_external_const_plugins(plugins);
     }
 }
 impl<T: Database + ?Sized> SierraGenGroup for T {}

--- a/crates/cairo-lang-sierra-generator/src/function_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test.rs
@@ -13,6 +13,7 @@ cairo_lang_test_utils::test_file_test!(
         stack_tracking: "stack_tracking",
         literals: "literals",
         generics: "generics",
+        externally_provided_const: "externally_provided_const",
 
     },
     test_function_generator,

--- a/crates/cairo-lang-sierra-generator/src/function_generator_test_data/externally_provided_const
+++ b/crates/cairo-lang-sierra-generator/src/function_generator_test_data/externally_provided_const
@@ -1,0 +1,65 @@
+//! > Test differently sized externally provided consts, used across an ap revoking call.
+
+//! > test_runner_name
+test_function_generator
+
+//! > cairo_code
+#[target_function]
+fn foo(n: felt252) -> (u16, u256) {
+    let single_slot = seven::__externally_provided_const__();
+    let multi_slot = eight::__externally_provided_const__();
+    // The recursive call revokes ap, so both consts are used across a revocation.
+    if n != 0 {
+        foo(n - 1);
+    }
+    (single_slot, multi_slot)
+}
+
+mod seven {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> u16 nopanic;
+}
+
+mod eight {
+    #[allow(extern_outside_corelib)]
+    pub extern fn __externally_provided_const__() -> u256 nopanic;
+}
+
+//! > semantic_diagnostics
+
+//! > lowering_diagnostics
+
+//! > sierra_code
+label_test::foo::0:
+disable_ap_tracking() -> ()
+const_as_immediate<Const<u16, 7777>>() -> ([1])
+const_as_immediate<Const<core::integer::u256, Const<u128, 8888>, Const<u128, 0>>>() -> ([2])
+dup<felt252>([0]) -> ([0], [3])
+felt252_is_zero([3]) { fallthrough() label_test::foo::1([4]) }
+branch_align() -> ()
+drop<felt252>([0]) -> ()
+struct_construct<Unit>() -> ([5])
+enum_init<core::bool, 1>([5]) -> ([6])
+store_temp<core::bool>([6]) -> ([6])
+bool_not_impl([6]) -> ([7])
+drop<core::bool>([7]) -> ()
+struct_construct<Tuple<u16, core::integer::u256>>([1], [2]) -> ([8])
+store_temp<Tuple<u16, core::integer::u256>>([8]) -> ([8])
+return([8])
+label_test::foo::1:
+branch_align() -> ()
+drop<NonZero<felt252>>([4]) -> ()
+struct_construct<Unit>() -> ([9])
+enum_init<core::bool, 0>([9]) -> ([10])
+store_temp<core::bool>([10]) -> ([10])
+bool_not_impl([10]) -> ([11])
+drop<core::bool>([11]) -> ()
+const_as_immediate<Const<felt252, 1>>() -> ([12])
+felt252_sub([0], [12]) -> ([13])
+store_temp<felt252>([13]) -> ([13])
+function_call<user@test::foo>([13]) -> ([14])
+drop<Tuple<u16, core::integer::u256>>([14]) -> ()
+struct_construct<Tuple<u16, core::integer::u256>>([1], [2]) -> ([15])
+store_temp<Tuple<u16, core::integer::u256>>([15]) -> ([15])
+return([15])
+label_test::foo::2:

--- a/crates/cairo-lang-sierra-generator/src/local_variables.rs
+++ b/crates/cairo-lang-sierra-generator/src/local_variables.rs
@@ -26,7 +26,8 @@ use crate::ap_tracking::{ApTrackingConfiguration, get_ap_tracking_configuration}
 use crate::db::SierraGenGroup;
 use crate::replace_ids::{DebugReplacer, SierraIdReplacer};
 use crate::utils::{
-    enum_init_libfunc_id, get_concrete_libfunc_id, get_libfunc_signature, match_enum_libfunc_id,
+    enum_init_libfunc_id, externally_provided_const_extern, get_concrete_libfunc_id,
+    get_libfunc_signature, get_match_libfunc_id, match_enum_libfunc_id,
     struct_construct_libfunc_id, struct_deconstruct_libfunc_id,
 };
 
@@ -390,13 +391,23 @@ impl<'db, 'a> FindLocalsContext<'db, 'a> {
                 BranchInfo { known_ap_change: true }
             }
             lowering::Statement::Call(statement_call) => {
-                let (_, concrete_function_id) = get_concrete_libfunc_id(
-                    self.db,
-                    statement_call.function,
-                    statement_call.with_coupon,
-                );
+                // The reserved `__externally_provided_const__` extern is replaced by a
+                // `const_as_immediate` at code generation, so treat it as a constant here (known
+                // ap-change, constant output) rather than resolving a (non-existent) libfunc.
+                if externally_provided_const_extern(self.db, statement_call.function).is_some() {
+                    if let [output] = statement_call.outputs[..] {
+                        self.constants.insert(output);
+                    }
+                    BranchInfo { known_ap_change: true }
+                } else {
+                    let (_, concrete_function_id) = get_concrete_libfunc_id(
+                        self.db,
+                        statement_call.function,
+                        statement_call.with_coupon,
+                    );
 
-                self.analyze_call(concrete_function_id, inputs, outputs)
+                    self.analyze_call(concrete_function_id, inputs, outputs)
+                }
             }
             lowering::Statement::StructConstruct(statement_struct_construct) => {
                 let ty = self.db.get_concrete_type_id(
@@ -463,7 +474,7 @@ impl<'db, 'a> FindLocalsContext<'db, 'a> {
     ) -> Maybe<&'db LibfuncSignature> {
         let db = self.db;
         let concrete_libfunc_id = match match_info {
-            MatchInfo::Extern(s) => get_concrete_libfunc_id(db, s.function, false).1,
+            MatchInfo::Extern(s) => get_match_libfunc_id(db, s.function),
             MatchInfo::Enum(s) => {
                 let enum_ty =
                     db.get_concrete_type_id(self.lowered_function.variables[s.input.var_id].ty)?;

--- a/crates/cairo-lang-sierra-generator/src/local_variables.rs
+++ b/crates/cairo-lang-sierra-generator/src/local_variables.rs
@@ -26,8 +26,9 @@ use crate::ap_tracking::{ApTrackingConfiguration, get_ap_tracking_configuration}
 use crate::db::SierraGenGroup;
 use crate::replace_ids::{DebugReplacer, SierraIdReplacer};
 use crate::utils::{
-    enum_init_libfunc_id, get_concrete_libfunc_id, get_libfunc_signature, match_enum_libfunc_id,
-    struct_construct_libfunc_id, struct_deconstruct_libfunc_id,
+    enum_init_libfunc_id, get_concrete_libfunc_id, get_libfunc_signature, get_match_libfunc_id,
+    is_externally_provided_const, match_enum_libfunc_id, struct_construct_libfunc_id,
+    struct_deconstruct_libfunc_id,
 };
 
 /// Minimum type size for which `local_into_box` is more efficient than `into_box`.
@@ -390,13 +391,23 @@ impl<'db, 'a> FindLocalsContext<'db, 'a> {
                 BranchInfo { known_ap_change: true }
             }
             lowering::Statement::Call(statement_call) => {
-                let (_, concrete_function_id) = get_concrete_libfunc_id(
-                    self.db,
-                    statement_call.function,
-                    statement_call.with_coupon,
-                );
+                // The reserved `__externally_provided_const__` extern is replaced by a
+                // `const_as_immediate` at code generation, so treat it as a constant here (known
+                // ap-change, constant output) rather than resolving a (non-existent) libfunc.
+                if is_externally_provided_const(self.db, statement_call.function) {
+                    if let [output] = statement_call.outputs[..] {
+                        self.constants.insert(output);
+                    }
+                    BranchInfo { known_ap_change: true }
+                } else {
+                    let (_, concrete_function_id) = get_concrete_libfunc_id(
+                        self.db,
+                        statement_call.function,
+                        statement_call.with_coupon,
+                    );
 
-                self.analyze_call(concrete_function_id, inputs, outputs)
+                    self.analyze_call(concrete_function_id, inputs, outputs)
+                }
             }
             lowering::Statement::StructConstruct(statement_struct_construct) => {
                 let ty = self.db.get_concrete_type_id(
@@ -463,7 +474,7 @@ impl<'db, 'a> FindLocalsContext<'db, 'a> {
     ) -> Maybe<&'db LibfuncSignature> {
         let db = self.db;
         let concrete_libfunc_id = match match_info {
-            MatchInfo::Extern(s) => get_concrete_libfunc_id(db, s.function, false).1,
+            MatchInfo::Extern(s) => get_match_libfunc_id(db, s.function),
             MatchInfo::Enum(s) => {
                 let enum_ty =
                     db.get_concrete_type_id(self.lowered_function.variables[s.input.var_id].ty)?;

--- a/crates/cairo-lang-sierra-generator/src/program_generator_test.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator_test.rs
@@ -1,8 +1,13 @@
+use std::sync::Arc;
+
 use cairo_lang_defs::db::DefsGroup;
-use cairo_lang_defs::ids::ModuleItemId;
+use cairo_lang_defs::ids::{ExternFunctionId, ModuleItemId, TopLevelLanguageElementId};
+use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
+use cairo_lang_semantic::TypeId;
+use cairo_lang_semantic::items::constant::ConstValueId;
 use cairo_lang_semantic::items::module::ModuleSemantic;
 use cairo_lang_semantic::test_utils::setup_test_function;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
@@ -11,10 +16,11 @@ use cairo_lang_utils::try_extract_matches;
 use indoc::indoc;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
+use salsa::Database;
 use test_case::test_case;
 
 use super::get_dummy_program_for_size_estimation;
-use crate::db::SierraGenGroup;
+use crate::db::{ExternalConstPlugin, SierraGenGroup};
 use crate::program_generator::SierraProgramWithDebug;
 use crate::replace_ids::replace_sierra_ids_in_program;
 use crate::test_utils::{
@@ -125,4 +131,58 @@ fn test_only_include_dependencies(func_name: &str, sierra_used_funcs: &[&str]) {
             .collect_vec(),
         sierra_used_funcs
     );
+}
+
+/// A test [`ExternalConstPlugin`] defining its value in terms of itself.
+#[derive(Debug)]
+struct CyclicConstPlugin;
+impl ExternalConstPlugin for CyclicConstPlugin {
+    fn provide<'db>(
+        &self,
+        db: &'db dyn Database,
+        extern_id: ExternFunctionId<'db>,
+        ty: TypeId<'db>,
+    ) -> Option<Maybe<ConstValueId<'db>>> {
+        extern_id
+            .full_path(db)
+            .contains("cyclic")
+            .then(|| db.externally_provided_const(extern_id, ty))
+    }
+}
+
+#[test]
+#[should_panic(expected = "depends on itself")]
+fn test_externally_provided_const_cycle() {
+    let mut db = SierraGenDatabaseForTesting::new_empty();
+    db.add_external_const_plugin(Arc::new(CyclicConstPlugin));
+    let crate_id = setup_db_and_get_crate_id(
+        &db,
+        indoc! {"
+            mod cyclic {
+                #[allow(extern_outside_corelib)]
+                pub extern fn __externally_provided_const__() -> felt252 nopanic;
+            }
+
+            fn user() -> felt252 { cyclic::__externally_provided_const__() }
+        "},
+    );
+    db.get_sierra_program(vec![crate_id]).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "must not return a tuple")]
+fn test_externally_provided_const_tuple() {
+    let db = SierraGenDatabaseForTesting::new_empty();
+    let crate_id = setup_db_and_get_crate_id(
+        &db,
+        indoc! {"
+            mod seven {
+                #[allow(extern_outside_corelib)]
+                pub extern fn __externally_provided_const__() -> (felt252, felt252) nopanic;
+            }
+
+            fn user() -> (felt252, felt252) { seven::__externally_provided_const__() }
+        "},
+    );
+    db.get_sierra_program(vec![crate_id]).unwrap();
 }

--- a/crates/cairo-lang-sierra-generator/src/test_utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/test_utils.rs
@@ -1,8 +1,9 @@
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use cairo_lang_defs as defs;
 use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
-use cairo_lang_defs::ids::ModuleId;
+use cairo_lang_defs::ids::{ExternFunctionId, ModuleId, TopLevelLanguageElementId};
+use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::db::{init_dev_corelib, init_files_group};
 use cairo_lang_filesystem::detect::detect_corelib;
 use cairo_lang_filesystem::flag::{Flag, FlagsGroup};
@@ -12,6 +13,7 @@ use cairo_lang_lowering::db::{LoweringGroup, lowering_group_input};
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::corelib::CorelibSemantic;
 use cairo_lang_semantic::db::{PluginSuiteInput, SemanticGroup, init_semantic_group};
+use cairo_lang_semantic::items::constant::ConstValueId;
 use cairo_lang_semantic::test_utils::{setup_test_crate, with_target_function_plugin};
 use cairo_lang_sierra::ids::{ConcreteLibfuncId, GenericLibfuncId};
 use cairo_lang_sierra::program;
@@ -19,14 +21,36 @@ use cairo_lang_utils::{CloneableDatabase, Intern};
 use defs::ids::FreeFunctionId;
 use lowering::ids::ConcreteFunctionWithBodyLongId;
 use lowering::optimizations::config::Optimizations;
+use num_bigint::BigInt;
 use salsa::{Database, Setter};
 use semantic::inline_macros::get_default_plugin_suite;
 
-use crate::db::SierraGenGroup;
+use crate::db::{ExternalConstPlugin, SierraGenGroup};
 use crate::pre_sierra::{self, LabelLongId};
 use crate::program_generator::SierraProgramWithDebug;
 use crate::replace_ids::replace_sierra_ids_in_program;
 use crate::utils::{jump_statement, return_statement, simple_statement};
+
+/// A test [`ExternalConstPlugin`], supplying `value` for the externs whose full path contains
+/// `module`.
+#[derive(Debug)]
+struct TestConstPlugin {
+    module: &'static str,
+    value: i64,
+}
+impl ExternalConstPlugin for TestConstPlugin {
+    fn provide<'db>(
+        &self,
+        db: &'db dyn Database,
+        extern_id: ExternFunctionId<'db>,
+        ty: semantic::TypeId<'db>,
+    ) -> Option<Maybe<ConstValueId<'db>>> {
+        extern_id
+            .full_path(db)
+            .contains(self.module)
+            .then(|| Ok(ConstValueId::from_int(db, ty, &BigInt::from(self.value))))
+    }
+}
 
 #[salsa::db]
 #[derive(Clone)]
@@ -72,6 +96,14 @@ impl SierraGenDatabaseForTesting {
         lowering_group_input(&res)
             .set_optimizations(&mut res)
             .to(Some(Optimizations::enabled_with_minimal_movable_functions()));
+
+        // Test plugins for the `__externally_provided_const__` extern function. They are inert
+        // unless that extern is actually called, and each resolves only the calls in its own
+        // module.
+        res.set_external_const_plugins(vec![
+            Arc::new(TestConstPlugin { module: "seven", value: 7777 }),
+            Arc::new(TestConstPlugin { module: "eight", value: 8888 }),
+        ]);
 
         let corelib_path = detect_corelib().expect("Corelib not found in default location.");
         init_dev_corelib(&mut res, corelib_path);

--- a/crates/cairo-lang-sierra-generator/src/utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/utils.rs
@@ -1,6 +1,6 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs as defs;
-use cairo_lang_defs::ids::NamedLanguageElementId;
+use cairo_lang_defs::ids::{LanguageElementId, NamedLanguageElementId};
 use cairo_lang_diagnostics::Maybe;
 use cairo_lang_filesystem::ids::Tracked;
 use cairo_lang_lowering as lowering;
@@ -24,7 +24,7 @@ use semantic::items::constant::ConstValue;
 use semantic::items::functions::GenericFunctionId;
 use smol_str::SmolStr;
 
-use crate::db::{SierraGenGroup, SierraGeneratorTypeLongId};
+use crate::db::{EXTERNALLY_PROVIDED_CONST, SierraGenGroup, SierraGeneratorTypeLongId};
 use crate::pre_sierra;
 use crate::replace_ids::{DebugReplacer, SierraIdReplacer};
 use crate::specialization_context::SierraSignatureSpecializationContext;
@@ -408,6 +408,34 @@ pub fn generic_libfunc_id(
         generic_id: GenericLibfuncId::from_string(extern_id.name(db).long(db).clone()),
         generic_args,
     })
+}
+
+/// Returns the declaration of the given function if it is the reserved
+/// `__externally_provided_const__` extern function, whose calls are replaced by an externally
+/// provided constant.
+pub fn externally_provided_const_extern<'db>(
+    db: &'db dyn Database,
+    function: lowering::ids::FunctionId<'db>,
+) -> Option<defs::ids::ExternFunctionId<'db>> {
+    function
+        .get_extern(db)
+        .map(|(extern_id, _)| extern_id)
+        .filter(|extern_id| extern_id.name(db).long(db) == EXTERNALLY_PROVIDED_CONST)
+}
+
+/// Returns the [ConcreteLibfuncId] used for a match on the given extern function.
+pub fn get_match_libfunc_id<'db>(
+    db: &'db dyn Database,
+    function: lowering::ids::FunctionId<'db>,
+) -> ConcreteLibfuncId {
+    // An extern returning an enum is lowered as a match, which no constant can replace.
+    if let Some(extern_id) = externally_provided_const_extern(db, function) {
+        panic!(
+            "`{EXTERNALLY_PROVIDED_CONST}` must not return an enum: {:?}",
+            extern_id.stable_location(db).span_in_file(db).user_location(db).debug(db)
+        );
+    }
+    get_concrete_libfunc_id(db, function, false).1
 }
 
 /// Returns the [ConcreteLibfuncId] used for calling a function (either user-defined or libfunc).

--- a/crates/cairo-lang-sierra-generator/src/utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/utils.rs
@@ -24,7 +24,7 @@ use semantic::items::constant::ConstValue;
 use semantic::items::functions::GenericFunctionId;
 use smol_str::SmolStr;
 
-use crate::db::{SierraGenGroup, SierraGeneratorTypeLongId};
+use crate::db::{EXTERNALLY_PROVIDED_CONST, SierraGenGroup, SierraGeneratorTypeLongId};
 use crate::pre_sierra;
 use crate::replace_ids::{DebugReplacer, SierraIdReplacer};
 use crate::specialization_context::SierraSignatureSpecializationContext;
@@ -408,6 +408,30 @@ pub fn generic_libfunc_id(
         generic_id: GenericLibfuncId::from_string(extern_id.name(db).long(db).clone()),
         generic_args,
     })
+}
+
+/// Returns whether the given function is the reserved `__externally_provided_const__` extern
+/// function, whose calls are replaced by an externally provided constant.
+pub fn is_externally_provided_const<'db>(
+    db: &'db dyn Database,
+    function: lowering::ids::FunctionId<'db>,
+) -> bool {
+    function
+        .get_extern(db)
+        .is_some_and(|(extern_id, _)| extern_id.name(db).long(db) == EXTERNALLY_PROVIDED_CONST)
+}
+
+/// Returns the [ConcreteLibfuncId] used for a match on the given extern function.
+pub fn get_match_libfunc_id<'db>(
+    db: &'db dyn Database,
+    function: lowering::ids::FunctionId<'db>,
+) -> ConcreteLibfuncId {
+    // An extern returning an enum is lowered as a match, which no constant can replace.
+    assert!(
+        !is_externally_provided_const(db, function),
+        "`{EXTERNALLY_PROVIDED_CONST}` must not return an enum."
+    );
+    get_concrete_libfunc_id(db, function, false).1
 }
 
 /// Returns the [ConcreteLibfuncId] used for calling a function (either user-defined or libfunc).


### PR DESCRIPTION
## Summary

Introduces a reserved extern function `__externally_provided_const__` that, when called in Cairo code, is intercepted during Sierra generation and replaced with a `const_as_immediate` instruction whose value is supplied by externally installed plugins.

Any number of `ExternalConstPlugin`s may be installed on the database (`set_external_const_plugins` / `add_external_const_plugin` / `external_const_plugins` on `SierraGenGroup`, backed by a new `SierraGenGroupInput` Salsa input). Resolution goes through the tracked `externally_provided_const` query, keyed by the declaration and its return type: the plugins are queried in order with the declaration's full path, each either returning the `ConstValueId` to substitute or `None` to let the following plugins handle it, and the first supplied value wins after being validated against the declared return type. There is no default value: a declaration none of the installed plugins supplies a value for fails Sierra generation, as does a plugin returning an error.

Resolving through a query rather than inline in code generation means a plugin computing its value through the database - e.g. by compiling another crate to hash it - has that work memoized per declaration instead of repeated per call site, and a value that transitively depends on itself is reported by the query's `cycle_result` (naming the extern) instead of recursing endlessly or surfacing as a cycle in some unrelated function's code generation.

The mechanism is wired into both the code generator (`block_generator.rs`) and the local-variables analysis (`local_variables.rs`), where calls to this extern are treated as constants with known AP change rather than resolved as real libfuncs. The extern is recognized solely by its name (`utils::is_externally_provided_const`), may be declared anywhere, and never reaches the Sierra output.

Two test plugins are installed in the test harness - one resolving the externs whose path contains `seven` to `7777`, one resolving those containing `eight` to `8888` - and a new test file (`externally_provided_const`) verifies that a call becomes a `const_as_immediate`, and that each plugin resolves its own extern.

---

## Type of change

Please check **one**:

- [ ] Bug fix (fixes incorrect behavior)
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

There was no mechanism for build drivers or tooling to inject a compile-time constant into a Cairo program without modifying source code. This is needed when the value of a constant is only known at build time (e.g. a contract address, a configuration value, or a version hash) and must be embedded into the compiled Sierra output without requiring the Cairo source to hard-code it.

Several such injectors may need to coexist in a single compilation (e.g. class hash injection alongside build configuration values), so the value is supplied by a list of plugins rather than by a single installed provider callback - each plugin claims only the extern declarations it recognizes, by full path.

---

## What was the behavior or documentation before?

There was no way to externally supply a constant value during Sierra generation. Any constant had to be written directly in Cairo source.

---

## What is the behavior or documentation after?

A Cairo program may declare `extern fn __externally_provided_const__() -> T nopanic;` and call it. During Sierra generation the call is replaced with a `const_as_immediate` of the value returned by the first installed plugin that provides one for that declaration's full path. If no plugin provides one, Sierra generation fails - an unfulfilled externally provided const is an error, not a defaulted value. A const whose value transitively depends on itself fails as a cycle, naming the extern.

---

## Related issue or discussion (if any)

Equivalent to #10159, with the single `ExternalConstProvider` callback replaced by an ordered list of `ExternalConstPlugin`s, so that independent flows can each inject their own constants.

---

## Additional context

Since resolution is memoized per declaration, a plugin's answer must be stable per declaration and type within a revision; changing values means reinstalling the plugins through `set_external_const_plugins`, which bumps the input revision and invalidates the memos. `cargo test -p cairo-lang-sierra-generator` and `cargo test -p cairo-lang-runner` (whose profiling goldens are sensitive to any statement-index shift) pass unchanged, and `./scripts/clippy.sh` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWdxtvPQtiT25VSiDj9oTK)_