### PR TITLE
ci: skip nightly benchmarks on an already-benchmarked HEAD

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,8 +58,27 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: crate-ci/typos@3bc303c295c081add5df4a4d52a1e117f2fb2dce # master
 
-  benchmark:
+  # Re-running the benchmarks on a HEAD that already has stored results appends duplicate data
+  # points and re-fires stale degradation alerts: the store action compares each result against
+  # the last entry of a *different* commit, so an unchanged HEAD keeps failing against a baseline
+  # from before the last real change, night after night.
+  benchmark-gate:
     if: github.repository == 'starkware-libs/cairo'
+    runs-on: ubuntu-latest
+    outputs:
+      already-benchmarked: ${{ steps.check.outputs.already-benchmarked }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check whether HEAD already has stored benchmark results
+        id: check
+        run: |
+          git fetch --depth=1 origin gh-pages
+          last_benchmarked=$(git log -1 --format=%s FETCH_HEAD | grep -oE '[0-9a-f]{40}$' || true)
+          echo "already-benchmarked=$([ "$last_benchmarked" = "$GITHUB_SHA" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+  benchmark:
+    needs: benchmark-gate
+    if: needs.benchmark-gate.outputs.already-benchmarked != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -69,6 +88,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # Fetched up front so every store step below works standalone: a store must keep committing
+      # its results even if a sibling suite crashed or failed on a degradation alert, so no store
+      # may depend on another store step having fetched the branch.
+      - name: Fetch gh-pages
+        run: git fetch origin gh-pages:gh-pages
 
       - name: Run timing benchmarks
         run: |
@@ -87,6 +112,8 @@ jobs:
           auto-push: false
           fail-on-alert: true
           alert-threshold: '150%'
+          # Reuses the gh-pages branch fetched by the `Fetch gh-pages` step.
+          skip-fetch-gh-pages: true
 
       # The remaining suites and the final push run even if an earlier store step failed on a
       # degradation alert (fail-on-alert), so a single regression doesn't drop the results of the
@@ -108,8 +135,7 @@ jobs:
           auto-push: false
           fail-on-alert: true
           alert-threshold: '150%'
-          # MUST run after `Store timing benchmark results`, which fetches the gh-pages worktree
-          # this step then reuses. Reordering or removing the timing step will break this one.
+          # Reuses the gh-pages branch fetched by the `Fetch gh-pages` step.
           skip-fetch-gh-pages: true
 
       - name: Run LS-flow heap benchmark
@@ -129,7 +155,7 @@ jobs:
           auto-push: false
           fail-on-alert: true
           alert-threshold: '150%'
-          # Like the heap step, reuses the gh-pages worktree fetched by the timing step.
+          # Reuses the gh-pages branch fetched by the `Fetch gh-pages` step.
           skip-fetch-gh-pages: true
 
       - name: Run language-server re-execution benchmark
@@ -149,7 +175,7 @@ jobs:
           auto-push: false
           fail-on-alert: true
           alert-threshold: '150%'
-          # Like the heap step, reuses the gh-pages worktree fetched by the timing step.
+          # Reuses the gh-pages branch fetched by the `Fetch gh-pages` step.
           skip-fetch-gh-pages: true
 
       - name: Push results to gh-pages


### PR DESCRIPTION
## Summary

Two changes to the nightly `benchmark` job so the benchmark baseline actually advances past a degradation instead of re-alerting against a stale value forever:

1. **Gate the job on whether HEAD already has stored results.** A new lightweight `benchmark-gate` job reads the last `gh-pages` benchmark-commit message and skips the whole benchmark job when it already records the current HEAD. `github-action-benchmark` compares each new result against the last entry of a *different* commit, so re-running an unchanged HEAD always skips its own stored entries and re-fails against the pre-regression baseline — night after night, no matter how many times the new value is stored.
2. **Fetch `gh-pages` in a dedicated step** instead of implicitly inside the first store step. Previously, if the timing suite crashed, its store step (the only one with `skip-fetch-gh-pages: false`) was skipped, the local `gh-pages` branch was never created, and every other suite's store + the final push failed too — losing all of that night's results.

---

## Type of change

- [x] Bug fix (fixes incorrect behavior)

---

## Why is this change needed?

The nightly LS-flow heap benchmark regressed on 7/19 (`growth_per_edit_bytes/ls-body-edit`: 5533 → 9322). #10265 correctly made the store/push steps run despite the alert, so the 9322 result *is* stored on `gh-pages` (verified: it's there for both 7/29 and 7/30). But since no new commit landed on `main` after 7/28, every nightly re-benchmarks the same HEAD (`8e2d714`), and the store action's same-commit skip makes each of those runs compare 9322 against the 10-day-old 5533 baseline — producing an identical failure every night (runs [30410676963](https://github.com/starkware-libs/cairo/actions/runs/30410676963) and [30502247291](https://github.com/starkware-libs/cairo/actions/runs/30502247291)) with no way for the alert to ever clear on its own.

---

## What was the behavior or documentation before?

- Nightly re-runs on an unchanged HEAD appended duplicate data points and re-fired the same stale degradation alert indefinitely.
- A crash in the timing suite silently dropped that night's results for **all** suites (heap, LS-flow, ls_reexec), because their store steps depended on the timing store step having fetched the `gh-pages` branch.

## What is the behavior or documentation after?

- If the current HEAD already has stored benchmark results, the benchmark job is skipped entirely (also saving ~1h of runner time on idle nights). A degradation therefore alerts exactly once per offending commit; the next run with a genuinely new HEAD compares against the newest stored value.
- Each store step reuses a `gh-pages` branch fetched up front, independent of every other suite's outcome; the coupling comments ("MUST run after `Store timing benchmark results`…") are gone because the coupling is gone.

---

## Related issue or discussion (if any)

Follow-up to #10265.

---

## Additional context

The gate parses the trailing 40-hex SHA of the last `gh-pages` commit subject (`add <suite> benchmark result for <sha>`, the format the store action itself writes). If the subject doesn't match that format, the gate falls back to running the benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDW1JHcCbDRgiGw8QBiDXE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDW1JHcCbDRgiGw8QBiDXE)_