### PR TITLE
Remove in_cycle parameter from semantic data functions

### DIFF
--- a/crates/cairo-lang-lowering/src/graph_algorithms/cycles.rs
+++ b/crates/cairo-lang-lowering/src/graph_algorithms/cycles.rs
@@ -62,7 +62,7 @@ pub fn final_contains_call_cycle<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn final_contains_call_cycle<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         function_id: ConcreteFunctionWithBodyId<'db>,
     ) -> Maybe<bool> {
@@ -79,7 +79,7 @@ pub fn final_contains_call_cycle<'db>(
 
         Ok(false)
     }
-    final_contains_call_cycle(db, function_id)
+    query(db, function_id)
 }
 
 /// Query implementation of [LoweringGroup::in_cycle].

--- a/crates/cairo-lang-lowering/src/graph_algorithms/cycles.rs
+++ b/crates/cairo-lang-lowering/src/graph_algorithms/cycles.rs
@@ -48,32 +48,38 @@ pub fn function_with_body_direct_function_with_body_callees<'db>(
 }
 
 /// Query implementation of [LoweringGroup::final_contains_call_cycle].
-#[salsa::tracked(returns(copy), cycle_result=final_contains_call_cycle_handle_cycle)]
 pub fn final_contains_call_cycle<'db>(
     db: &'db dyn Database,
     function_id: ConcreteFunctionWithBodyId<'db>,
 ) -> Maybe<bool> {
-    let direct_callees = db.lowered_direct_callees_with_body(
-        function_id,
-        DependencyType::Call,
-        LoweringStage::Final,
-    )?;
-    for callee in direct_callees {
-        if db.final_contains_call_cycle(*callee)? {
-            return Ok(true);
-        }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        _db: &'db dyn Database,
+        _id: salsa::Id,
+        _function_id: ConcreteFunctionWithBodyId<'db>,
+    ) -> Maybe<bool> {
+        Ok(true)
     }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn final_contains_call_cycle<'db>(
+        db: &'db dyn Database,
+        function_id: ConcreteFunctionWithBodyId<'db>,
+    ) -> Maybe<bool> {
+        let direct_callees = db.lowered_direct_callees_with_body(
+            function_id,
+            DependencyType::Call,
+            LoweringStage::Final,
+        )?;
+        for callee in direct_callees {
+            if db.final_contains_call_cycle(*callee)? {
+                return Ok(true);
+            }
+        }
 
-    Ok(false)
-}
-
-/// Cycle handling for [LoweringGroup::final_contains_call_cycle].
-pub fn final_contains_call_cycle_handle_cycle<'db>(
-    _db: &'db dyn Database,
-    _id: salsa::Id,
-    _function_id: ConcreteFunctionWithBodyId<'db>,
-) -> Maybe<bool> {
-    Ok(true)
+        Ok(false)
+    }
+    final_contains_call_cycle(db, function_id)
 }
 
 /// Query implementation of [LoweringGroup::in_cycle].

--- a/crates/cairo-lang-semantic/src/expr/inference/solver.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/solver.rs
@@ -86,7 +86,7 @@ impl<'db> Ambiguity<'db> {
     }
 }
 
-/// Implementation of [SemanticSolver::canonic_trait_solutions].
+/// Query implementation of [SemanticSolver::canonic_trait_solutions].
 /// Assumes the lookup context is already enriched by [enrich_lookup_context].
 pub fn canonic_trait_solutions<'db>(
     db: &'db dyn Database,
@@ -94,52 +94,54 @@ pub fn canonic_trait_solutions<'db>(
     lookup_context: ImplLookupContextId<'db>,
     impl_type_bounds: BTreeMap<ImplTypeById<'db>, TypeId<'db>>,
 ) -> Result<SolutionSet<'db, CanonicalImpl<'db>>, InferenceError<'db>> {
-    let mut concrete_trait_id = canonical_trait.id;
-    let impl_type_bounds = Arc::new(impl_type_bounds);
-    // If the trait is not fully concrete, we might be able to use the trait's items to find a
-    // more concrete trait.
-    if !concrete_trait_id.is_fully_concrete(db) && !canonical_trait.mappings.is_empty() {
-        match solve_canonical_trait(db, canonical_trait, lookup_context, impl_type_bounds.clone()) {
-            SolutionSet::None => {}
-            SolutionSet::Unique(imp) => {
-                concrete_trait_id =
-                    imp.0.concrete_trait(db).expect("A solved impl must have a concrete trait");
-            }
-            SolutionSet::Ambiguous(ambiguity) => {
-                return Ok(SolutionSet::Ambiguous(ambiguity));
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        _db: &dyn Database,
+        _id: salsa::Id,
+        _canonical_trait: CanonicalTrait<'db>,
+        _lookup_context: ImplLookupContextId<'db>,
+        _impl_type_bounds: BTreeMap<ImplTypeById<'db>, TypeId<'db>>,
+    ) -> Result<SolutionSet<'db, CanonicalImpl<'db>>, InferenceError<'db>> {
+        Err(InferenceError::Cycle(InferenceVar::Impl(LocalImplVarId(0))))
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(clone), cycle_result=cycle)]
+    fn canonic_trait_solutions<'db>(
+        db: &'db dyn Database,
+        canonical_trait: CanonicalTrait<'db>,
+        lookup_context: ImplLookupContextId<'db>,
+        impl_type_bounds: BTreeMap<ImplTypeById<'db>, TypeId<'db>>,
+    ) -> Result<SolutionSet<'db, CanonicalImpl<'db>>, InferenceError<'db>> {
+        let mut concrete_trait_id = canonical_trait.id;
+        let impl_type_bounds = Arc::new(impl_type_bounds);
+        // If the trait is not fully concrete, we might be able to use the trait's items to find a
+        // more concrete trait.
+        if !concrete_trait_id.is_fully_concrete(db) && !canonical_trait.mappings.is_empty() {
+            match solve_canonical_trait(
+                db,
+                canonical_trait,
+                lookup_context,
+                impl_type_bounds.clone(),
+            ) {
+                SolutionSet::None => {}
+                SolutionSet::Unique(imp) => {
+                    concrete_trait_id =
+                        imp.0.concrete_trait(db).expect("A solved impl must have a concrete trait");
+                }
+                SolutionSet::Ambiguous(ambiguity) => {
+                    return Ok(SolutionSet::Ambiguous(ambiguity));
+                }
             }
         }
+        // Solve the trait without the trait items, so we'd be able to find conflicting impls.
+        Ok(solve_canonical_trait(
+            db,
+            CanonicalTrait { id: concrete_trait_id, mappings: ImplVarTraitItemMappings::default() },
+            lookup_context,
+            impl_type_bounds,
+        ))
     }
-    // Solve the trait without the trait items, so we'd be able to find conflicting impls.
-    Ok(solve_canonical_trait(
-        db,
-        CanonicalTrait { id: concrete_trait_id, mappings: ImplVarTraitItemMappings::default() },
-        lookup_context,
-        impl_type_bounds,
-    ))
-}
-
-/// Query implementation of [SemanticSolver::canonic_trait_solutions].
-/// Assumes the lookup context is already enriched by [enrich_lookup_context].
-#[salsa::tracked(returns(clone), cycle_result=canonic_trait_solutions_cycle)]
-pub fn canonic_trait_solutions_tracked<'db>(
-    db: &'db dyn Database,
-    canonical_trait: CanonicalTrait<'db>,
-    lookup_context: ImplLookupContextId<'db>,
-    impl_type_bounds: BTreeMap<ImplTypeById<'db>, TypeId<'db>>,
-) -> Result<SolutionSet<'db, CanonicalImpl<'db>>, InferenceError<'db>> {
     canonic_trait_solutions(db, canonical_trait, lookup_context, impl_type_bounds)
-}
-
-/// Cycle handling for [canonic_trait_solutions].
-pub fn canonic_trait_solutions_cycle<'db>(
-    _db: &dyn Database,
-    _id: salsa::Id,
-    _canonical_trait: CanonicalTrait<'db>,
-    _lookup_context: ImplLookupContextId<'db>,
-    _impl_type_bounds: BTreeMap<ImplTypeById<'db>, TypeId<'db>>,
-) -> Result<SolutionSet<'db, CanonicalImpl<'db>>, InferenceError<'db>> {
-    Err(InferenceError::Cycle(InferenceVar::Impl(LocalImplVarId(0))))
 }
 
 /// Adds the defining module of the trait and the generic arguments to the lookup context.
@@ -879,7 +881,7 @@ pub trait SemanticSolver<'db>: Database {
         lookup_context: ImplLookupContextId<'db>,
         impl_type_bounds: BTreeMap<ImplTypeById<'db>, TypeId<'db>>,
     ) -> Result<SolutionSet<'db, CanonicalImpl<'db>>, InferenceError<'db>> {
-        canonic_trait_solutions_tracked(
+        canonic_trait_solutions(
             self.as_dyn_database(),
             canonical_trait,
             lookup_context,

--- a/crates/cairo-lang-semantic/src/expr/inference/solver.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/solver.rs
@@ -106,7 +106,7 @@ pub fn canonic_trait_solutions<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(clone), cycle_result=cycle)]
-    fn canonic_trait_solutions<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         canonical_trait: CanonicalTrait<'db>,
         lookup_context: ImplLookupContextId<'db>,
@@ -141,7 +141,7 @@ pub fn canonic_trait_solutions<'db>(
             impl_type_bounds,
         ))
     }
-    canonic_trait_solutions(db, canonical_trait, lookup_context, impl_type_bounds)
+    query(db, canonical_trait, lookup_context, impl_type_bounds)
 }
 
 /// Adds the defining module of the trait and the generic arguments to the lookup context.

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -304,14 +304,7 @@ fn constant_semantic_data<'db>(
     db: &'db dyn Database,
     const_id: ConstantId<'db>,
 ) -> Maybe<ConstantData<'db>> {
-    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Constant(const_id));
-    constant_semantic_data_helper(
-        db,
-        &db.module_constant_by_id(const_id)?,
-        lookup_item_id,
-        None,
-        &const_id,
-    )
+    constant_semantic_data_inner(db, const_id, false)
 }
 
 /// Cycle handling for [ConstantSemantic::constant_semantic_data].
@@ -320,14 +313,35 @@ fn constant_semantic_data_cycle<'db>(
     _id: salsa::Id,
     const_id: ConstantId<'db>,
 ) -> Maybe<ConstantData<'db>> {
+    constant_semantic_data_inner(db, const_id, true)
+}
+
+/// Shared code for the query and cycle handling of
+/// [ConstantSemantic::constant_semantic_data].
+/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+fn constant_semantic_data_inner<'db>(
+    db: &'db dyn Database,
+    const_id: ConstantId<'db>,
+    in_cycle: bool,
+) -> Maybe<ConstantData<'db>> {
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Constant(const_id));
-    constant_semantic_data_cycle_helper(
-        db,
-        &db.module_constant_by_id(const_id)?,
-        lookup_item_id,
-        None,
-        &const_id,
-    )
+    if in_cycle {
+        constant_semantic_data_cycle_helper(
+            db,
+            &db.module_constant_by_id(const_id)?,
+            lookup_item_id,
+            None,
+            &const_id,
+        )
+    } else {
+        constant_semantic_data_helper(
+            db,
+            &db.module_constant_by_id(const_id)?,
+            lookup_item_id,
+            None,
+            &const_id,
+        )
+    }
 }
 
 /// Returns constant semantic data for the given ItemConstant.

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -299,49 +299,53 @@ impl<'db> DebugWithDb<'db> for ImplConstantId<'db> {
 }
 
 /// Returns the semantic data of a constant.
-#[salsa::tracked(returns(ref), cycle_result=constant_semantic_data_cycle)]
 fn constant_semantic_data<'db>(
     db: &'db dyn Database,
     const_id: ConstantId<'db>,
-) -> Maybe<ConstantData<'db>> {
-    constant_semantic_data_inner(db, const_id, false)
-}
-
-/// Cycle handling for [ConstantSemantic::constant_semantic_data].
-fn constant_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    const_id: ConstantId<'db>,
-) -> Maybe<ConstantData<'db>> {
-    constant_semantic_data_inner(db, const_id, true)
-}
-
-/// Shared code for the query and cycle handling of
-/// [ConstantSemantic::constant_semantic_data].
-/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
-fn constant_semantic_data_inner<'db>(
-    db: &'db dyn Database,
-    const_id: ConstantId<'db>,
-    in_cycle: bool,
-) -> Maybe<ConstantData<'db>> {
-    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Constant(const_id));
-    if in_cycle {
-        constant_semantic_data_cycle_helper(
-            db,
-            &db.module_constant_by_id(const_id)?,
-            lookup_item_id,
-            None,
-            &const_id,
-        )
-    } else {
-        constant_semantic_data_helper(
-            db,
-            &db.module_constant_by_id(const_id)?,
-            lookup_item_id,
-            None,
-            &const_id,
-        )
+) -> &'db Maybe<ConstantData<'db>> {
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        const_id: ConstantId<'db>,
+        in_cycle: bool,
+    ) -> Maybe<ConstantData<'db>> {
+        let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Constant(const_id));
+        if in_cycle {
+            constant_semantic_data_cycle_helper(
+                db,
+                &db.module_constant_by_id(const_id)?,
+                lookup_item_id,
+                None,
+                &const_id,
+            )
+        } else {
+            constant_semantic_data_helper(
+                db,
+                &db.module_constant_by_id(const_id)?,
+                lookup_item_id,
+                None,
+                &const_id,
+            )
+        }
     }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        const_id: ConstantId<'db>,
+    ) -> Maybe<ConstantData<'db>> {
+        calc(db, const_id, true)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(ref), cycle_result=cycle)]
+    fn constant_semantic_data<'db>(
+        db: &'db dyn Database,
+        const_id: ConstantId<'db>,
+    ) -> Maybe<ConstantData<'db>> {
+        calc(db, const_id, false)
+    }
+    constant_semantic_data(db, const_id)
 }
 
 /// Returns constant semantic data for the given ItemConstant.

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -339,13 +339,10 @@ fn constant_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(ref), cycle_result=cycle)]
-    fn constant_semantic_data<'db>(
-        db: &'db dyn Database,
-        const_id: ConstantId<'db>,
-    ) -> Maybe<ConstantData<'db>> {
+    fn query<'db>(db: &'db dyn Database, const_id: ConstantId<'db>) -> Maybe<ConstantData<'db>> {
         calc(db, const_id, false)
     }
-    constant_semantic_data(db, const_id)
+    query(db, const_id)
 }
 
 /// Returns constant semantic data for the given ItemConstant.

--- a/crates/cairo-lang-semantic/src/items/constant.rs
+++ b/crates/cairo-lang-semantic/src/items/constant.rs
@@ -303,26 +303,15 @@ impl<'db> DebugWithDb<'db> for ImplConstantId<'db> {
 fn constant_semantic_data<'db>(
     db: &'db dyn Database,
     const_id: ConstantId<'db>,
-    in_cycle: bool,
 ) -> Maybe<ConstantData<'db>> {
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Constant(const_id));
-    if in_cycle {
-        constant_semantic_data_cycle_helper(
-            db,
-            &db.module_constant_by_id(const_id)?,
-            lookup_item_id,
-            None,
-            &const_id,
-        )
-    } else {
-        constant_semantic_data_helper(
-            db,
-            &db.module_constant_by_id(const_id)?,
-            lookup_item_id,
-            None,
-            &const_id,
-        )
-    }
+    constant_semantic_data_helper(
+        db,
+        &db.module_constant_by_id(const_id)?,
+        lookup_item_id,
+        None,
+        &const_id,
+    )
 }
 
 /// Cycle handling for [ConstantSemantic::constant_semantic_data].
@@ -330,7 +319,6 @@ fn constant_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     const_id: ConstantId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<ConstantData<'db>> {
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Constant(const_id));
     constant_semantic_data_cycle_helper(
@@ -1478,7 +1466,7 @@ pub trait ConstantSemantic<'db>: Database {
         const_id: ConstantId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
         let db = self.as_dyn_database();
-        constant_semantic_data(db, const_id, false)
+        constant_semantic_data(db, const_id)
             .as_ref()
             .map(|data| data.diagnostics.clone())
             .unwrap_or_default()
@@ -1486,17 +1474,17 @@ pub trait ConstantSemantic<'db>: Database {
     /// Returns the semantic data of a constant definition.
     fn constant_semantic_data(&'db self, use_id: ConstantId<'db>) -> Maybe<Constant<'db>> {
         let db = self.as_dyn_database();
-        constant_semantic_data(db, use_id, false).maybe_as_ref()?.constant.clone()
+        constant_semantic_data(db, use_id).maybe_as_ref()?.constant.clone()
     }
     /// Returns the resolver data of a constant definition.
     fn constant_resolver_data(&'db self, use_id: ConstantId<'db>) -> Maybe<Arc<ResolverData<'db>>> {
         let db = self.as_dyn_database();
-        Ok(constant_semantic_data(db, use_id, false).maybe_as_ref()?.resolver_data.clone())
+        Ok(constant_semantic_data(db, use_id).maybe_as_ref()?.resolver_data.clone())
     }
     /// Returns the const value of a constant definition.
     fn constant_const_value(&'db self, const_id: ConstantId<'db>) -> Maybe<ConstValueId<'db>> {
         let db = self.as_dyn_database();
-        Ok(constant_semantic_data(db, const_id, false).maybe_as_ref()?.const_value)
+        Ok(constant_semantic_data(db, const_id).maybe_as_ref()?.const_value)
     }
     /// Returns information required for const calculations.
     fn const_calc_info(&'db self) -> Arc<ConstCalcInfo<'db>> {

--- a/crates/cairo-lang-semantic/src/items/enm.rs
+++ b/crates/cairo-lang-semantic/src/items/enm.rs
@@ -169,10 +169,7 @@ fn enum_definition_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(ref), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
-    fn enum_definition_data<'db>(
-        db: &'db dyn Database,
-        enum_id: EnumId<'db>,
-    ) -> Maybe<EnumDefinitionData<'db>> {
+    fn query<'db>(db: &'db dyn Database, enum_id: EnumId<'db>) -> Maybe<EnumDefinitionData<'db>> {
         let module_id = enum_id.parent_module(db);
         let crate_id = module_id.owning_crate(db);
         let mut diagnostics = SemanticDiagnostics::new(module_id);
@@ -238,7 +235,7 @@ fn enum_definition_data<'db>(
             resolver_data,
         })
     }
-    enum_definition_data(db, enum_id)
+    query(db, enum_id)
 }
 
 /// Query implementation of [EnumSemantic::enum_definition_diagnostics].

--- a/crates/cairo-lang-semantic/src/items/enm.rs
+++ b/crates/cairo-lang-semantic/src/items/enm.rs
@@ -145,94 +145,100 @@ pub enum MatchArmSelector<'db> {
 }
 
 /// Returns the definition data of an enum.
-#[salsa::tracked(returns(ref), cycle_fn=enum_definition_data_cycle, cycle_initial=enum_definition_data_initial)]
 fn enum_definition_data<'db>(
     db: &'db dyn Database,
     enum_id: EnumId<'db>,
-) -> Maybe<EnumDefinitionData<'db>> {
-    let module_id = enum_id.parent_module(db);
-    let crate_id = module_id.owning_crate(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
-    // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
-    // the item instead of all the module data.
-    let enum_ast = db.module_enum_by_id(enum_id)?;
+) -> &'db Maybe<EnumDefinitionData<'db>> {
+    /// The initial value for the cycle handling of the query.
+    fn cycle_initial<'db>(
+        _db: &'db dyn Database,
+        _id: salsa::Id,
+        _enum_id: EnumId<'db>,
+    ) -> Maybe<EnumDefinitionData<'db>> {
+        Err(skip_diagnostic())
+    }
+    /// The update function for the cycle handling of the query.
+    fn cycle_update<'db>(
+        _db: &'db dyn Database,
+        _cycle: &salsa::Cycle<'_>,
+        _last_provisional_value: &Maybe<EnumDefinitionData<'db>>,
+        value: Maybe<EnumDefinitionData<'db>>,
+        _enum_id: EnumId<'db>,
+    ) -> Maybe<EnumDefinitionData<'db>> {
+        value
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(ref), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
+    fn enum_definition_data<'db>(
+        db: &'db dyn Database,
+        enum_id: EnumId<'db>,
+    ) -> Maybe<EnumDefinitionData<'db>> {
+        let module_id = enum_id.parent_module(db);
+        let crate_id = module_id.owning_crate(db);
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        // TODO(spapini): when code changes in a file, all the AST items change (as they contain a
+        // path to the green root that changes. Once ASTs are rooted on items, use a
+        // selector that picks only the item instead of all the module data.
+        let enum_ast = db.module_enum_by_id(enum_id)?;
 
-    // Generic params.
-    let generic_params_data = enum_generic_params_data(db, enum_id).maybe_as_ref()?;
-    let inference_id =
-        InferenceId::LookupItemDefinition(LookupItemId::ModuleItem(ModuleItemId::Enum(enum_id)));
-    let mut resolver = Resolver::with_data(
-        db,
-        (*generic_params_data.resolver_data).clone_with_inference_id(db, inference_id),
-    );
-    diagnostics.extend(generic_params_data.diagnostics.clone());
+        // Generic params.
+        let generic_params_data = enum_generic_params_data(db, enum_id).maybe_as_ref()?;
+        let inference_id = InferenceId::LookupItemDefinition(LookupItemId::ModuleItem(
+            ModuleItemId::Enum(enum_id),
+        ));
+        let mut resolver = Resolver::with_data(
+            db,
+            (*generic_params_data.resolver_data).clone_with_inference_id(db, inference_id),
+        );
+        diagnostics.extend(generic_params_data.diagnostics.clone());
 
-    // Variants.
-    let mut variants = OrderedHashMap::default();
-    let mut variant_semantic = OrderedHashMap::default();
-    for variant in enum_ast.variants(db).elements(db) {
-        let feature_restore =
-            resolver.extend_feature_config_from_item(db, crate_id, &mut diagnostics, &variant);
-        let id = VariantLongId(module_id, variant.stable_ptr(db)).intern(db);
-        let ty = match variant.type_clause(db) {
-            ast::OptionTypeClause::Empty(_) => unit_ty(db),
-            ast::OptionTypeClause::TypeClause(type_clause) => {
-                resolve_type(db, &mut diagnostics, &mut resolver, &type_clause.ty(db))
+        // Variants.
+        let mut variants = OrderedHashMap::default();
+        let mut variant_semantic = OrderedHashMap::default();
+        for variant in enum_ast.variants(db).elements(db) {
+            let feature_restore =
+                resolver.extend_feature_config_from_item(db, crate_id, &mut diagnostics, &variant);
+            let id = VariantLongId(module_id, variant.stable_ptr(db)).intern(db);
+            let ty = match variant.type_clause(db) {
+                ast::OptionTypeClause::Empty(_) => unit_ty(db),
+                ast::OptionTypeClause::TypeClause(type_clause) => {
+                    resolve_type(db, &mut diagnostics, &mut resolver, &type_clause.ty(db))
+                }
+            };
+            let variant_name = variant.name(db).text(db);
+            match variants.entry(variant_name) {
+                Entry::Vacant(e) => {
+                    e.insert(id);
+                    let idx = variant_semantic.len();
+                    variant_semantic.insert(id, Variant { enum_id, id, ty, idx });
+                }
+                Entry::Occupied(_) => {
+                    diagnostics.report(
+                        variant.stable_ptr(db),
+                        EnumVariantRedefinition { enum_id, variant_name },
+                    );
+                }
             }
-        };
-        let variant_name = variant.name(db).text(db);
-        match variants.entry(variant_name) {
-            Entry::Vacant(e) => {
-                e.insert(id);
-                let idx = variant_semantic.len();
-                variant_semantic.insert(id, Variant { enum_id, id, ty, idx });
-            }
-            Entry::Occupied(_) => {
-                diagnostics.report(
-                    variant.stable_ptr(db),
-                    EnumVariantRedefinition { enum_id, variant_name },
-                );
-            }
+            resolver.restore_feature_config(feature_restore);
         }
-        resolver.restore_feature_config(feature_restore);
+
+        // Check fully resolved.
+        let inference = &mut resolver.inference();
+        inference.finalize(&mut diagnostics, enum_ast.stable_ptr(db).untyped());
+
+        for (_, variant) in variant_semantic.iter_mut() {
+            variant.ty = inference.rewrite(variant.ty).no_err();
+        }
+
+        let resolver_data = Arc::new(resolver.data);
+        Ok(EnumDefinitionData {
+            diagnostics: diagnostics.build(),
+            variants,
+            variant_semantic,
+            resolver_data,
+        })
     }
-
-    // Check fully resolved.
-    let inference = &mut resolver.inference();
-    inference.finalize(&mut diagnostics, enum_ast.stable_ptr(db).untyped());
-
-    for (_, variant) in variant_semantic.iter_mut() {
-        variant.ty = inference.rewrite(variant.ty).no_err();
-    }
-
-    let resolver_data = Arc::new(resolver.data);
-    Ok(EnumDefinitionData {
-        diagnostics: diagnostics.build(),
-        variants,
-        variant_semantic,
-        resolver_data,
-    })
-}
-
-/// Cycle handling for [enum_definition_data].
-fn enum_definition_data_cycle<'db>(
-    _db: &'db dyn Database,
-    _cycle: &salsa::Cycle<'_>,
-    _last_provisional_value: &Maybe<EnumDefinitionData<'db>>,
-    value: Maybe<EnumDefinitionData<'db>>,
-    _enum_id: EnumId<'db>,
-) -> Maybe<EnumDefinitionData<'db>> {
-    value
-}
-
-/// Cycle handling for [enum_definition_data].
-fn enum_definition_data_initial<'db>(
-    _db: &'db dyn Database,
-    _id: salsa::Id,
-    _enum_id: EnumId<'db>,
-) -> Maybe<EnumDefinitionData<'db>> {
-    Err(skip_diagnostic())
+    enum_definition_data(db, enum_id)
 }
 
 /// Query implementation of [EnumSemantic::enum_definition_diagnostics].

--- a/crates/cairo-lang-semantic/src/items/free_function.rs
+++ b/crates/cairo-lang-semantic/src/items/free_function.rs
@@ -148,7 +148,7 @@ fn priv_free_function_body_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(ref), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
-    fn priv_free_function_body_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         free_function_id: FreeFunctionId<'db>,
     ) -> Maybe<FunctionBodyData<'db>> {
@@ -200,7 +200,7 @@ fn priv_free_function_body_data<'db>(
             body: FunctionBody { arenas, body_expr },
         })
     }
-    priv_free_function_body_data(db, free_function_id)
+    query(db, free_function_id)
 }
 
 /// Trait for free function-related semantic queries.

--- a/crates/cairo-lang-semantic/src/items/free_function.rs
+++ b/crates/cairo-lang-semantic/src/items/free_function.rs
@@ -124,76 +124,83 @@ fn free_function_declaration_data<'db>(
 }
 
 /// Query implementation of [FreeFunctionSemantic::priv_free_function_body_data].
-#[salsa::tracked(returns(ref), cycle_fn=priv_free_function_body_data_cycle, cycle_initial=priv_free_function_body_data_initial)]
 fn priv_free_function_body_data<'db>(
     db: &'db dyn Database,
     free_function_id: FreeFunctionId<'db>,
-) -> Maybe<FunctionBodyData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::new(free_function_id.parent_module(db));
-    let free_function_syntax = db.module_free_function_by_id(free_function_id)?;
-    // Compute declaration semantic.
-    let declaration = free_function_declaration_data(db, free_function_id).maybe_as_ref()?;
+) -> &'db Maybe<FunctionBodyData<'db>> {
+    /// The initial value for the cycle handling of the query.
+    fn cycle_initial<'db>(
+        _db: &'db dyn Database,
+        _id: salsa::Id,
+        _free_function_id: FreeFunctionId<'db>,
+    ) -> Maybe<FunctionBodyData<'db>> {
+        Err(skip_diagnostic())
+    }
+    /// The update function for the cycle handling of the query.
+    fn cycle_update<'db>(
+        _db: &'db dyn Database,
+        _cycle: &salsa::Cycle<'_>,
+        last_provisional_value: &Maybe<FunctionBodyData<'db>>,
+        _value: Maybe<FunctionBodyData<'db>>,
+        _free_function_id: FreeFunctionId<'db>,
+    ) -> Maybe<FunctionBodyData<'db>> {
+        last_provisional_value.clone()
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(ref), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
+    fn priv_free_function_body_data<'db>(
+        db: &'db dyn Database,
+        free_function_id: FreeFunctionId<'db>,
+    ) -> Maybe<FunctionBodyData<'db>> {
+        let mut diagnostics = SemanticDiagnostics::new(free_function_id.parent_module(db));
+        let free_function_syntax = db.module_free_function_by_id(free_function_id)?;
+        // Compute declaration semantic.
+        let declaration = free_function_declaration_data(db, free_function_id).maybe_as_ref()?;
 
-    // Generic params.
-    let parent_resolver_data = db.free_function_declaration_resolver_data(free_function_id)?;
-    let inference_id = InferenceId::LookupItemDefinition(LookupItemId::ModuleItem(
-        ModuleItemId::FreeFunction(free_function_id),
-    ));
-    let mut resolver =
-        Resolver::with_data(db, (*parent_resolver_data).clone_with_inference_id(db, inference_id));
+        // Generic params.
+        let parent_resolver_data = db.free_function_declaration_resolver_data(free_function_id)?;
+        let inference_id = InferenceId::LookupItemDefinition(LookupItemId::ModuleItem(
+            ModuleItemId::FreeFunction(free_function_id),
+        ));
+        let mut resolver = Resolver::with_data(
+            db,
+            (*parent_resolver_data).clone_with_inference_id(db, inference_id),
+        );
 
-    let environment = declaration.environment.clone();
-    let function_id = (|| {
-        let generic_function = GenericFunctionId::Free(free_function_id);
+        let environment = declaration.environment.clone();
+        let function_id = (|| {
+            let generic_function = GenericFunctionId::Free(free_function_id);
 
-        Ok(FunctionLongId::from_generic(db, generic_function)?.intern(db))
-    })();
-    // Compute body semantic expr.
-    let mut ctx = ComputationContext::new(
-        db,
-        &mut diagnostics,
-        &mut resolver,
-        Some(&declaration.signature),
-        environment,
-        ContextFunction::Function(function_id),
-    );
-    let function_body = free_function_syntax.body(db);
-    let return_type = declaration.signature.return_type;
-    let body_expr = compute_root_expr(&mut ctx, &function_body, return_type)?;
-    let ComputationContext { arenas, .. } = ctx;
+            Ok(FunctionLongId::from_generic(db, generic_function)?.intern(db))
+        })();
+        // Compute body semantic expr.
+        let mut ctx = ComputationContext::new(
+            db,
+            &mut diagnostics,
+            &mut resolver,
+            Some(&declaration.signature),
+            environment,
+            ContextFunction::Function(function_id),
+        );
+        let function_body = free_function_syntax.body(db);
+        let return_type = declaration.signature.return_type;
+        let body_expr = compute_root_expr(&mut ctx, &function_body, return_type)?;
+        let ComputationContext { arenas, .. } = ctx;
 
-    let expr_lookup: UnorderedHashMap<_, _> =
-        arenas.exprs.iter().map(|(id, expr)| (expr.stable_ptr(), id)).collect();
-    let pattern_lookup: UnorderedHashMap<_, _> =
-        arenas.patterns.iter().map(|(id, pattern)| (pattern.stable_ptr(), id)).collect();
-    let resolver_data = Arc::new(resolver.data);
-    Ok(FunctionBodyData {
-        diagnostics: diagnostics.build(),
-        expr_lookup,
-        pattern_lookup,
-        resolver_data,
-        body: FunctionBody { arenas, body_expr },
-    })
-}
-
-/// Cycle handling for [FreeFunctionSemantic::priv_free_function_body_data].
-fn priv_free_function_body_data_cycle<'db>(
-    _db: &'db dyn Database,
-    _cycle: &salsa::Cycle<'_>,
-    last_provisional_value: &Maybe<FunctionBodyData<'db>>,
-    _value: Maybe<FunctionBodyData<'db>>,
-    _free_function_id: FreeFunctionId<'db>,
-) -> Maybe<FunctionBodyData<'db>> {
-    last_provisional_value.clone()
-}
-
-/// Cycle handling for [FreeFunctionSemantic::priv_free_function_body_data].
-fn priv_free_function_body_data_initial<'db>(
-    _db: &'db dyn Database,
-    _id: salsa::Id,
-    _free_function_id: FreeFunctionId<'db>,
-) -> Maybe<FunctionBodyData<'db>> {
-    Err(skip_diagnostic())
+        let expr_lookup: UnorderedHashMap<_, _> =
+            arenas.exprs.iter().map(|(id, expr)| (expr.stable_ptr(), id)).collect();
+        let pattern_lookup: UnorderedHashMap<_, _> =
+            arenas.patterns.iter().map(|(id, pattern)| (pattern.stable_ptr(), id)).collect();
+        let resolver_data = Arc::new(resolver.data);
+        Ok(FunctionBodyData {
+            diagnostics: diagnostics.build(),
+            expr_lookup,
+            pattern_lookup,
+            resolver_data,
+            body: FunctionBody { arenas, body_expr },
+        })
+    }
+    priv_free_function_body_data(db, free_function_id)
 }
 
 /// Trait for free function-related semantic queries.

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -427,23 +427,8 @@ fn generic_impl_param_shallow_trait_generic_args<'db>(
 fn generic_param_data<'db>(
     db: &'db dyn Database,
     generic_param_id: GenericParamId<'db>,
-    in_cycle: bool,
 ) -> Maybe<GenericParamData<'db>> {
     let module_id = generic_param_id.parent_module(db);
-    if in_cycle {
-        let mut diagnostics = SemanticDiagnostics::new(module_id);
-        return Ok(GenericParamData {
-            generic_param: Err(diagnostics.report(
-                generic_param_id.stable_ptr(db).untyped(),
-                SemanticDiagnosticKind::ImplRequirementCycle,
-            )),
-            diagnostics: diagnostics.build(),
-            resolver_data: Arc::new(ResolverData::new(
-                generic_param_id.parent_module(db),
-                InferenceId::GenericParam(generic_param_id),
-            )),
-        });
-    }
     let mut diagnostics = SemanticDiagnostics::new(module_id);
     let parent_item_id = generic_param_id.generic_item(db);
     let lookup_item: LookupItemId<'_> = parent_item_id.into();
@@ -498,9 +483,20 @@ fn generic_param_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     generic_param_id: GenericParamId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<GenericParamData<'db>> {
-    generic_param_data(db, generic_param_id, true).clone()
+    let module_id = generic_param_id.parent_module(db);
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
+    Ok(GenericParamData {
+        generic_param: Err(diagnostics.report(
+            generic_param_id.stable_ptr(db).untyped(),
+            SemanticDiagnosticKind::ImplRequirementCycle,
+        )),
+        diagnostics: diagnostics.build(),
+        resolver_data: Arc::new(ResolverData::new(
+            module_id,
+            InferenceId::GenericParam(generic_param_id),
+        )),
+    })
 }
 
 /// Query implementation of [GenericsSemantic::generic_params_type_constraints].
@@ -564,17 +560,6 @@ pub fn semantic_generic_params<'db>(
     module_id: ModuleId<'db>,
     generic_params: &ast::OptionWrappedGenericParamList<'db>,
 ) -> Vec<GenericParam<'db>> {
-    semantic_generic_params_ex(db, diagnostics, resolver, module_id, generic_params, false)
-}
-
-pub fn semantic_generic_params_ex<'db>(
-    db: &'db dyn Database,
-    diagnostics: &mut SemanticDiagnostics<'db>,
-    resolver: &mut Resolver<'db>,
-    module_id: ModuleId<'db>,
-    generic_params: &ast::OptionWrappedGenericParamList<'db>,
-    in_cycle: bool,
-) -> Vec<GenericParam<'db>> {
     match generic_params {
         syntax::node::ast::OptionWrappedGenericParamList::Empty(_) => vec![],
         syntax::node::ast::OptionWrappedGenericParamList::WrappedGenericParamList(syntax) => syntax
@@ -583,7 +568,7 @@ pub fn semantic_generic_params_ex<'db>(
             .filter_map(|param_syntax| {
                 let generic_param_id =
                     GenericParamLongId(module_id, param_syntax.stable_ptr(db)).intern(db);
-                let data = generic_param_data(db, generic_param_id, in_cycle).as_ref().ok()?;
+                let data = generic_param_data(db, generic_param_id).as_ref().ok()?;
                 let generic_param = data.generic_param.clone();
                 diagnostics.extend(data.diagnostics.clone());
                 resolver.add_generic_param(generic_param_id);
@@ -841,7 +826,7 @@ pub trait GenericParamSemantic<'db>: Database {
         &'db self,
         generic_param: GenericParamId<'db>,
     ) -> Maybe<GenericParam<'db>> {
-        generic_param_data(self.as_dyn_database(), generic_param, false)
+        generic_param_data(self.as_dyn_database(), generic_param)
             .maybe_as_ref()?
             .generic_param
             .clone()
@@ -851,7 +836,7 @@ pub trait GenericParamSemantic<'db>: Database {
         &'db self,
         generic_param: GenericParamId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-        generic_param_data(self.as_dyn_database(), generic_param, false)
+        generic_param_data(self.as_dyn_database(), generic_param)
             .as_ref()
             .map(|data| data.diagnostics.clone())
             .unwrap_or_default()
@@ -861,7 +846,7 @@ pub trait GenericParamSemantic<'db>: Database {
         &'db self,
         generic_param: GenericParamId<'db>,
     ) -> Maybe<Arc<ResolverData<'db>>> {
-        Ok(generic_param_data(self.as_dyn_database(), generic_param, false)
+        Ok(generic_param_data(self.as_dyn_database(), generic_param)
             .maybe_as_ref()?
             .resolver_data
             .clone())

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -437,7 +437,7 @@ fn generic_param_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn generic_param_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         generic_param_id: GenericParamId<'db>,
     ) -> Maybe<GenericParamData<'db>> {
@@ -492,7 +492,7 @@ fn generic_param_data<'db>(
             resolver_data,
         })
     }
-    generic_param_data(db, generic_param_id)
+    query(db, generic_param_id)
 }
 
 /// Computes the data of a generic param when it is in a cycle.

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -423,68 +423,76 @@ fn generic_impl_param_shallow_trait_generic_args<'db>(
 }
 
 /// Returns data about a generic param.
-#[salsa::tracked(cycle_result=generic_param_data_cycle, returns(ref))]
 fn generic_param_data<'db>(
     db: &'db dyn Database,
     generic_param_id: GenericParamId<'db>,
-) -> Maybe<GenericParamData<'db>> {
-    let module_id = generic_param_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let parent_item_id = generic_param_id.generic_item(db);
-    let lookup_item: LookupItemId<'_> = parent_item_id.into();
-    let context_resolver_data = lookup_item.resolver_context(db)?;
-    let inference_id = InferenceId::GenericParam(generic_param_id);
-    let mut resolver =
-        Resolver::with_data(db, (*context_resolver_data).clone_with_inference_id(db, inference_id));
-    resolver.set_feature_config(
-        &lookup_item,
-        &lookup_item.untyped_stable_ptr(db).lookup(db),
-        &mut diagnostics,
-    );
-    let generic_params_syntax = extract_matches!(
-        generic_param_generic_params_list(db, generic_param_id)?,
-        ast::OptionWrappedGenericParamList::WrappedGenericParamList
-    );
-
-    let mut opt_generic_param_syntax = None;
-    for param_syntax in generic_params_syntax.generic_params(db).elements(db) {
-        let cur_generic_param_id =
-            GenericParamLongId(module_id, param_syntax.stable_ptr(db)).intern(db);
-        resolver.add_generic_param(cur_generic_param_id);
-
-        if cur_generic_param_id == generic_param_id {
-            opt_generic_param_syntax = Some(param_syntax);
-        }
+) -> &'db Maybe<GenericParamData<'db>> {
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        generic_param_id: GenericParamId<'db>,
+    ) -> Maybe<GenericParamData<'db>> {
+        generic_param_data_cycle_helper(db, generic_param_id)
     }
-    let generic_param_syntax =
-        opt_generic_param_syntax.expect("Query called on a non existing generic param.");
-    let param_semantic = semantic_from_generic_param_ast(
-        db,
-        &mut resolver,
-        &mut diagnostics,
-        module_id,
-        &generic_param_syntax,
-        parent_item_id,
-    )?;
-    let inference = &mut resolver.inference();
-    inference.finalize(&mut diagnostics, generic_param_syntax.stable_ptr(db).untyped());
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn generic_param_data<'db>(
+        db: &'db dyn Database,
+        generic_param_id: GenericParamId<'db>,
+    ) -> Maybe<GenericParamData<'db>> {
+        let module_id = generic_param_id.parent_module(db);
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        let parent_item_id = generic_param_id.generic_item(db);
+        let lookup_item: LookupItemId<'_> = parent_item_id.into();
+        let context_resolver_data = lookup_item.resolver_context(db)?;
+        let inference_id = InferenceId::GenericParam(generic_param_id);
+        let mut resolver = Resolver::with_data(
+            db,
+            (*context_resolver_data).clone_with_inference_id(db, inference_id),
+        );
+        resolver.set_feature_config(
+            &lookup_item,
+            &lookup_item.untyped_stable_ptr(db).lookup(db),
+            &mut diagnostics,
+        );
+        let generic_params_syntax = extract_matches!(
+            generic_param_generic_params_list(db, generic_param_id)?,
+            ast::OptionWrappedGenericParamList::WrappedGenericParamList
+        );
 
-    let param_semantic = inference.rewrite(param_semantic).no_err();
-    let resolver_data = Arc::new(resolver.data);
-    Ok(GenericParamData {
-        generic_param: Ok(param_semantic),
-        diagnostics: diagnostics.build(),
-        resolver_data,
-    })
-}
+        let mut opt_generic_param_syntax = None;
+        for param_syntax in generic_params_syntax.generic_params(db).elements(db) {
+            let cur_generic_param_id =
+                GenericParamLongId(module_id, param_syntax.stable_ptr(db)).intern(db);
+            resolver.add_generic_param(cur_generic_param_id);
 
-/// Cycle handling for [generic_param_data].
-fn generic_param_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    generic_param_id: GenericParamId<'db>,
-) -> Maybe<GenericParamData<'db>> {
-    generic_param_data_cycle_helper(db, generic_param_id)
+            if cur_generic_param_id == generic_param_id {
+                opt_generic_param_syntax = Some(param_syntax);
+            }
+        }
+        let generic_param_syntax =
+            opt_generic_param_syntax.expect("Query called on a non existing generic param.");
+        let param_semantic = semantic_from_generic_param_ast(
+            db,
+            &mut resolver,
+            &mut diagnostics,
+            module_id,
+            &generic_param_syntax,
+            parent_item_id,
+        )?;
+        let inference = &mut resolver.inference();
+        inference.finalize(&mut diagnostics, generic_param_syntax.stable_ptr(db).untyped());
+
+        let param_semantic = inference.rewrite(param_semantic).no_err();
+        let resolver_data = Arc::new(resolver.data);
+        Ok(GenericParamData {
+            generic_param: Ok(param_semantic),
+            diagnostics: diagnostics.build(),
+            resolver_data,
+        })
+    }
+    generic_param_data(db, generic_param_id)
 }
 
 /// Computes the data of a generic param when it is in a cycle.

--- a/crates/cairo-lang-semantic/src/items/generics.rs
+++ b/crates/cairo-lang-semantic/src/items/generics.rs
@@ -484,6 +484,14 @@ fn generic_param_data_cycle<'db>(
     _id: salsa::Id,
     generic_param_id: GenericParamId<'db>,
 ) -> Maybe<GenericParamData<'db>> {
+    generic_param_data_cycle_helper(db, generic_param_id)
+}
+
+/// Computes the data of a generic param when it is in a cycle.
+fn generic_param_data_cycle_helper<'db>(
+    db: &'db dyn Database,
+    generic_param_id: GenericParamId<'db>,
+) -> Maybe<GenericParamData<'db>> {
     let module_id = generic_param_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::new(module_id);
     Ok(GenericParamData {
@@ -560,6 +568,17 @@ pub fn semantic_generic_params<'db>(
     module_id: ModuleId<'db>,
     generic_params: &ast::OptionWrappedGenericParamList<'db>,
 ) -> Vec<GenericParam<'db>> {
+    semantic_generic_params_ex(db, diagnostics, resolver, module_id, generic_params, false)
+}
+
+pub fn semantic_generic_params_ex<'db>(
+    db: &'db dyn Database,
+    diagnostics: &mut SemanticDiagnostics<'db>,
+    resolver: &mut Resolver<'db>,
+    module_id: ModuleId<'db>,
+    generic_params: &ast::OptionWrappedGenericParamList<'db>,
+    in_cycle: bool,
+) -> Vec<GenericParam<'db>> {
     match generic_params {
         syntax::node::ast::OptionWrappedGenericParamList::Empty(_) => vec![],
         syntax::node::ast::OptionWrappedGenericParamList::WrappedGenericParamList(syntax) => syntax
@@ -568,7 +587,15 @@ pub fn semantic_generic_params<'db>(
             .filter_map(|param_syntax| {
                 let generic_param_id =
                     GenericParamLongId(module_id, param_syntax.stable_ptr(db)).intern(db);
-                let data = generic_param_data(db, generic_param_id).as_ref().ok()?;
+                let cycle_data;
+                let data = if in_cycle {
+                    cycle_data = generic_param_data_cycle_helper(db, generic_param_id);
+                    &cycle_data
+                } else {
+                    generic_param_data(db, generic_param_id)
+                }
+                .as_ref()
+                .ok()?;
                 let generic_param = data.generic_param.clone();
                 diagnostics.extend(data.diagnostics.clone());
                 resolver.add_generic_param(generic_param_id);

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -883,13 +883,13 @@ fn impl_declaration_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn impl_declaration_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         impl_def_id: ImplDefId<'db>,
     ) -> Maybe<ImplDeclarationData<'db>> {
         calc(db, impl_def_id, true)
     }
-    impl_declaration_data(db, impl_def_id)
+    query(db, impl_def_id)
 }
 
 // === Impl Definition ===
@@ -1034,7 +1034,7 @@ fn deref_chain<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn deref_chain<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         ty: TypeId<'db>,
         crate_id: CrateId<'db>,
@@ -1067,7 +1067,7 @@ fn deref_chain<'db>(
             ),
         })
     }
-    deref_chain(db, ty, crate_id, try_deref_mut)
+    query(db, ty, crate_id, try_deref_mut)
 }
 
 /// Tries to find the deref function and the target type for a given type and deref trait.
@@ -2514,13 +2514,13 @@ fn impl_type_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn impl_type_semantic_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         impl_type_def_id: ImplTypeDefId<'db>,
     ) -> Maybe<ImplItemTypeData<'db>> {
         calc(db, impl_type_def_id, false)
     }
-    impl_type_semantic_data(db, impl_type_def_id)
+    query(db, impl_type_def_id)
 }
 
 /// Returns the generic parameters data of an impl type definition.
@@ -2622,14 +2622,14 @@ fn impl_type_concrete_implized<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn impl_type_concrete_implized<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         _tracked: Tracked,
         impl_type_id: ImplTypeId<'db>,
     ) -> Maybe<TypeId<'db>> {
         calc(db, impl_type_id)
     }
-    impl_type_concrete_implized(db, (), impl_type_id)
+    query(db, (), impl_type_id)
 }
 
 // === Impl Item Constant definition ===
@@ -2709,13 +2709,13 @@ fn impl_constant_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn impl_constant_semantic_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         impl_constant_def_id: ImplConstantDefId<'db>,
     ) -> Maybe<ImplItemConstantData<'db>> {
         calc(db, impl_constant_def_id, false)
     }
-    impl_constant_semantic_data(db, impl_constant_def_id)
+    query(db, impl_constant_def_id)
 }
 
 /// Validates the impl item constant, and returns the matching trait constant id.
@@ -2798,14 +2798,14 @@ fn impl_constant_implized_by_context<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn impl_constant_implized_by_context<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         impl_constant_id: ImplConstantId<'db>,
         impl_def_id: ImplDefId<'db>,
     ) -> Maybe<ConstValueId<'db>> {
         calc(db, impl_constant_id, impl_def_id)
     }
-    impl_constant_implized_by_context(db, impl_constant_id, impl_def_id)
+    query(db, impl_constant_id, impl_def_id)
 }
 
 /// Query implementation of [ImplSemantic::impl_constant_concrete_implized_value].
@@ -2842,14 +2842,14 @@ fn impl_constant_concrete_implized_value<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn impl_constant_concrete_implized_value<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         _tracked: Tracked,
         impl_constant_id: ImplConstantId<'db>,
     ) -> Maybe<ConstValueId<'db>> {
         calc(db, impl_constant_id)
     }
-    impl_constant_concrete_implized_value(db, (), impl_constant_id)
+    query(db, (), impl_constant_id)
 }
 
 /// Query implementation of [ImplSemantic::impl_constant_concrete_implized_type].
@@ -2899,14 +2899,14 @@ fn impl_constant_concrete_implized_type<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn impl_constant_concrete_implized_type<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         _tracked: Tracked,
         impl_constant_id: ImplConstantId<'db>,
     ) -> Maybe<TypeId<'db>> {
         calc(db, impl_constant_id)
     }
-    impl_constant_concrete_implized_type(db, (), impl_constant_id)
+    query(db, (), impl_constant_id)
 }
 
 // === Impl Item Impl definition ===
@@ -2984,13 +2984,13 @@ fn impl_impl_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn impl_impl_semantic_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         impl_impl_def_id: ImplImplDefId<'db>,
     ) -> Maybe<ImplItemImplData<'db>> {
         calc(db, impl_impl_def_id, false)
     }
-    impl_impl_semantic_data(db, impl_impl_def_id)
+    query(db, impl_impl_def_id)
 }
 
 /// Returns the generic parameters data of an impl impl definition.
@@ -3105,7 +3105,7 @@ fn implicit_impl_impl_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn implicit_impl_impl_semantic_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         impl_def_id: ImplDefId<'db>,
         trait_impl_id: TraitImplId<'db>,
@@ -3154,7 +3154,7 @@ fn implicit_impl_impl_semantic_data<'db>(
 
         Ok(ImplicitImplImplData { resolved_impl, trait_impl_id, diagnostics: diagnostics.build() })
     }
-    implicit_impl_impl_semantic_data(db, impl_def_id, trait_impl_id)
+    query(db, impl_def_id, trait_impl_id)
 }
 
 // === Impl Impl ===
@@ -3178,7 +3178,7 @@ fn impl_impl_implized_by_context<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn impl_impl_implized_by_context<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         impl_impl_id: ImplImplId<'db>,
         impl_def_id: ImplDefId<'db>,
@@ -3192,7 +3192,7 @@ fn impl_impl_implized_by_context<'db>(
 
         db.impl_impl_def_impl(impl_impl_def_id)
     }
-    impl_impl_implized_by_context(db, impl_impl_id, impl_def_id)
+    query(db, impl_impl_id, impl_def_id)
 }
 
 /// Query implementation of [ImplSemantic::impl_impl_concrete_implized].
@@ -3234,14 +3234,14 @@ fn impl_impl_concrete_implized<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn impl_impl_concrete_implized<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         _tracked: Tracked,
         impl_impl_id: ImplImplId<'db>,
     ) -> Maybe<ImplId<'db>> {
         calc(db, impl_impl_id, false)
     }
-    impl_impl_concrete_implized(db, (), impl_impl_id)
+    query(db, (), impl_impl_id)
 }
 
 /// Implementation of [PrivImplSemantic::impl_impl_concrete_trait].

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -2440,7 +2440,6 @@ struct ImplItemTypeData<'db> {
 fn impl_type_semantic_data<'db>(
     db: &'db dyn Database,
     impl_type_def_id: ImplTypeDefId<'db>,
-    in_cycle: bool,
 ) -> Maybe<ImplItemTypeData<'db>> {
     let mut diagnostics =
         SemanticDiagnostics::new(impl_type_def_id.impl_def_id(db).parent_module(db));
@@ -2452,42 +2451,47 @@ fn impl_type_semantic_data<'db>(
     let trait_type_id =
         validate_impl_item_type(db, &mut diagnostics, impl_type_def_id, &impl_type_def_ast);
 
-    if in_cycle {
-        Ok(ImplItemTypeData {
-            type_alias_data: type_alias_semantic_data_cycle_helper(
-                db,
-                &mut diagnostics,
-                &impl_type_def_ast,
-                lookup_item_id,
-                generic_params_data,
-            )?,
-            trait_type_id,
-            diagnostics: diagnostics.build(),
-        })
-    } else {
-        // TODO(yuval): resolve type aliases later, like in module type aliases, to avoid cycles in
-        // non-cyclic chains.
-        Ok(ImplItemTypeData {
-            type_alias_data: type_alias_semantic_data_helper(
-                db,
-                &mut diagnostics,
-                &impl_type_def_ast,
-                lookup_item_id,
-                generic_params_data,
-            )?,
-            trait_type_id,
-            diagnostics: diagnostics.build(),
-        })
-    }
+    // TODO(yuval): resolve type aliases later, like in module type aliases, to avoid cycles in
+    // non-cyclic chains.
+    Ok(ImplItemTypeData {
+        type_alias_data: type_alias_semantic_data_helper(
+            db,
+            &mut diagnostics,
+            &impl_type_def_ast,
+            lookup_item_id,
+            generic_params_data,
+        )?,
+        trait_type_id,
+        diagnostics: diagnostics.build(),
+    })
 }
 
 fn impl_type_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     impl_type_def_id: ImplTypeDefId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<ImplItemTypeData<'db>> {
-    impl_type_semantic_data(db, impl_type_def_id, true).clone()
+    let mut diagnostics =
+        SemanticDiagnostics::new(impl_type_def_id.impl_def_id(db).parent_module(db));
+    let impl_type_def_ast = db.impl_type_by_id(impl_type_def_id)?;
+    let generic_params_data =
+        impl_type_def_generic_params_data(db, impl_type_def_id).maybe_as_ref()?.clone();
+    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Type(impl_type_def_id));
+
+    let trait_type_id =
+        validate_impl_item_type(db, &mut diagnostics, impl_type_def_id, &impl_type_def_ast);
+
+    Ok(ImplItemTypeData {
+        type_alias_data: type_alias_semantic_data_cycle_helper(
+            db,
+            &mut diagnostics,
+            &impl_type_def_ast,
+            lookup_item_id,
+            generic_params_data,
+        )?,
+        trait_type_id,
+        diagnostics: diagnostics.build(),
+    })
 }
 
 /// Returns the generic parameters data of an impl type definition.
@@ -2620,7 +2624,6 @@ struct ImplItemConstantData<'db> {
 fn impl_constant_semantic_data<'db>(
     db: &'db dyn Database,
     impl_constant_def_id: ImplConstantDefId<'db>,
-    in_cycle: bool,
 ) -> Maybe<ImplItemConstantData<'db>> {
     let impl_def_id = impl_constant_def_id.impl_def_id(db);
     let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
@@ -2642,23 +2645,13 @@ fn impl_constant_semantic_data<'db>(
         impl_constant_def_ast,
         &mut resolver,
     );
-    let mut constant_data = if in_cycle {
-        constant_semantic_data_cycle_helper(
-            db,
-            impl_constant_def_ast,
-            lookup_item_id,
-            Some(Arc::new(resolver.data)),
-            &impl_def_id,
-        )?
-    } else {
-        constant_semantic_data_helper(
-            db,
-            impl_constant_def_ast,
-            lookup_item_id,
-            Some(Arc::new(resolver.data)),
-            &impl_def_id,
-        )?
-    };
+    let mut constant_data = constant_semantic_data_helper(
+        db,
+        impl_constant_def_ast,
+        lookup_item_id,
+        Some(Arc::new(resolver.data)),
+        &impl_def_id,
+    )?;
     diagnostics.extend(mem::take(&mut constant_data.diagnostics));
     Ok(ImplItemConstantData { constant_data, trait_constant_id, diagnostics: diagnostics.build() })
 }
@@ -2667,9 +2660,36 @@ fn impl_constant_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     impl_constant_def_id: ImplConstantDefId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<ImplItemConstantData<'db>> {
-    impl_constant_semantic_data(db, impl_constant_def_id, true).clone()
+    let impl_def_id = impl_constant_def_id.impl_def_id(db);
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
+    let impl_constant_defs = db.impl_constants(impl_def_id)?;
+    let impl_constant_def_ast = impl_constant_defs.get(&impl_constant_def_id).to_maybe()?;
+    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Constant(impl_constant_def_id));
+
+    let inference_id = InferenceId::LookupItemGenerics(LookupItemId::ImplItem(
+        ImplItemId::Constant(impl_constant_def_id),
+    ));
+    let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
+    let mut resolver =
+        Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
+
+    let trait_constant_id = validate_impl_item_constant(
+        db,
+        &mut diagnostics,
+        impl_constant_def_id,
+        impl_constant_def_ast,
+        &mut resolver,
+    );
+    let mut constant_data = constant_semantic_data_cycle_helper(
+        db,
+        impl_constant_def_ast,
+        lookup_item_id,
+        Some(Arc::new(resolver.data)),
+        &impl_def_id,
+    )?;
+    diagnostics.extend(mem::take(&mut constant_data.diagnostics));
+    Ok(ImplItemConstantData { constant_data, trait_constant_id, diagnostics: diagnostics.build() })
 }
 
 /// Validates the impl item constant, and returns the matching trait constant id.
@@ -2878,7 +2898,6 @@ struct ImplItemImplData<'db> {
 fn impl_impl_semantic_data<'db>(
     db: &'db dyn Database,
     impl_impl_def_id: ImplImplDefId<'db>,
-    in_cycle: bool,
 ) -> Maybe<ImplItemImplData<'db>> {
     let impl_def_id = impl_impl_def_id.impl_def_id(db);
     let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
@@ -2893,16 +2912,12 @@ fn impl_impl_semantic_data<'db>(
     let mut resolver =
         Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
 
-    let mut impl_data = if in_cycle {
-        impl_alias_semantic_data_cycle_helper(
-            db,
-            impl_impl_def_ast,
-            lookup_item_id,
-            generic_params_data,
-        )?
-    } else {
-        impl_alias_semantic_data_helper(db, impl_impl_def_ast, lookup_item_id, generic_params_data)?
-    };
+    let mut impl_data = impl_alias_semantic_data_helper(
+        db,
+        impl_impl_def_ast,
+        lookup_item_id,
+        generic_params_data,
+    )?;
 
     diagnostics.extend(mem::take(&mut impl_data.diagnostics));
 
@@ -2922,9 +2937,39 @@ fn impl_impl_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     impl_impl_def_id: ImplImplDefId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<ImplItemImplData<'db>> {
-    impl_impl_semantic_data(db, impl_impl_def_id, true).clone()
+    let impl_def_id = impl_impl_def_id.impl_def_id(db);
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
+    let impl_impl_defs = db.impl_impls(impl_def_id)?;
+    let impl_impl_def_ast = impl_impl_defs.get(&impl_impl_def_id).to_maybe()?;
+    let generic_params_data =
+        impl_impl_def_generic_params_data(db, impl_impl_def_id).maybe_as_ref()?.clone();
+    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Impl(impl_impl_def_id));
+
+    let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
+    let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
+    let mut resolver =
+        Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
+
+    let mut impl_data = impl_alias_semantic_data_cycle_helper(
+        db,
+        impl_impl_def_ast,
+        lookup_item_id,
+        generic_params_data,
+    )?;
+
+    diagnostics.extend(mem::take(&mut impl_data.diagnostics));
+
+    let trait_impl_id = validate_impl_item_impl(
+        db,
+        &mut diagnostics,
+        impl_impl_def_id,
+        impl_impl_def_ast,
+        &impl_data,
+        &mut resolver,
+    );
+
+    Ok(ImplItemImplData { impl_data, trait_impl_id, diagnostics: diagnostics.build() })
 }
 
 /// Returns the generic parameters data of an impl impl definition.
@@ -3017,21 +3062,13 @@ struct ImplicitImplImplData<'db> {
 }
 
 /// Computes implicit impl semantic data with cycle handling.
-fn implicit_impl_impl_semantic_data<'db>(
+#[salsa::tracked(cycle_result=implicit_impl_impl_semantic_data_cycle, returns(ref))]
+fn implicit_impl_impl_semantic_data_tracked<'db>(
     db: &'db dyn Database,
     impl_def_id: ImplDefId<'db>,
     trait_impl_id: TraitImplId<'db>,
-    in_cycle: bool,
 ) -> Maybe<ImplicitImplImplData<'db>> {
     let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
-    if in_cycle {
-        let err = Err(diagnostics.report(impl_def_id.stable_ptr(db).untyped(), ImplAliasCycle));
-        return Ok(ImplicitImplImplData {
-            resolved_impl: err,
-            trait_impl_id,
-            diagnostics: diagnostics.build(),
-        });
-    }
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Impl(impl_def_id));
 
     let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
@@ -3075,68 +3112,46 @@ fn implicit_impl_impl_semantic_data<'db>(
     Ok(ImplicitImplImplData { resolved_impl, trait_impl_id, diagnostics: diagnostics.build() })
 }
 
-/// Computes implicit impl semantic data with cycle handling.
-#[salsa::tracked(cycle_result=implicit_impl_impl_semantic_data_cycle, returns(ref))]
-fn implicit_impl_impl_semantic_data_tracked<'db>(
-    db: &'db dyn Database,
-    impl_def_id: ImplDefId<'db>,
-    trait_impl_id: TraitImplId<'db>,
-    in_cycle: bool,
-) -> Maybe<ImplicitImplImplData<'db>> {
-    implicit_impl_impl_semantic_data(db, impl_def_id, trait_impl_id, in_cycle)
-}
-
 /// Cycle handling for implicit impl semantic data computation.
 fn implicit_impl_impl_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     impl_def_id: ImplDefId<'db>,
     trait_impl_id: TraitImplId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<ImplicitImplImplData<'db>> {
-    // Forwarding cycle handling to `implicit_impl_impl_semantic_data` handler.
-    implicit_impl_impl_semantic_data(db, impl_def_id, trait_impl_id, true)
+    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
+    let err = Err(diagnostics.report(impl_def_id.stable_ptr(db).untyped(), ImplAliasCycle));
+    Ok(ImplicitImplImplData { resolved_impl: err, trait_impl_id, diagnostics: diagnostics.build() })
 }
 
 // === Impl Impl ===
 
 /// Query implementation of [PrivImplSemantic::impl_impl_implized_by_context].
-fn impl_impl_implized_by_context<'db>(
-    db: &'db dyn Database,
-    impl_impl_id: ImplImplId<'db>,
-    impl_def_id: ImplDefId<'db>,
-    in_cycle: bool,
-) -> Maybe<ImplId<'db>> {
-    if db.is_implicit_impl_impl(impl_def_id, impl_impl_id.trait_impl_id())? {
-        return db.implicit_impl_impl_impl(impl_def_id, impl_impl_id.trait_impl_id(), in_cycle);
-    }
-
-    let impl_impl_def_id = db.impl_impl_by_trait_impl(impl_def_id, impl_impl_id.trait_impl_id())?;
-
-    db.impl_impl_def_impl(impl_impl_def_id, in_cycle)
-}
-
-/// Query implementation of [ImplSemantic::impl_impl_implized_by_context].
 #[salsa::tracked(returns(copy), cycle_result=impl_impl_implized_by_context_cycle)]
 fn impl_impl_implized_by_context_tracked<'db>(
     db: &'db dyn Database,
     impl_impl_id: ImplImplId<'db>,
     impl_def_id: ImplDefId<'db>,
-    in_cycle: bool,
 ) -> Maybe<ImplId<'db>> {
-    impl_impl_implized_by_context(db, impl_impl_id, impl_def_id, in_cycle)
+    if db.is_implicit_impl_impl(impl_def_id, impl_impl_id.trait_impl_id())? {
+        return db.implicit_impl_impl_impl(impl_def_id, impl_impl_id.trait_impl_id());
+    }
+
+    let impl_impl_def_id = db.impl_impl_by_trait_impl(impl_def_id, impl_impl_id.trait_impl_id())?;
+
+    db.impl_impl_def_impl(impl_impl_def_id)
 }
 
 /// Cycle handling for [PrivImplSemantic::impl_impl_implized_by_context].
 fn impl_impl_implized_by_context_cycle<'db>(
-    db: &'db dyn Database,
+    _db: &dyn Database,
     _id: salsa::Id,
-    impl_impl_id: ImplImplId<'db>,
-    impl_def_id: ImplDefId<'db>,
-    _in_cycle: bool,
+    _impl_impl_id: ImplImplId<'db>,
+    _impl_def_id: ImplDefId<'db>,
 ) -> Maybe<ImplId<'db>> {
-    // Forwarding cycle handling to `impl_impl_semantic_data` handler.
-    impl_impl_implized_by_context(db, impl_impl_id, impl_def_id, true)
+    // The relevant impl item is in a cycle, and the cycle diagnostic is reported by the cycle
+    // handlers of `impl_impl_semantic_data`/`implicit_impl_impl_semantic_data_tracked`.
+    Err(skip_diagnostic())
 }
 
 /// Implementation of [ImplSemantic::impl_impl_concrete_implized].
@@ -3144,7 +3159,16 @@ fn impl_impl_concrete_implized<'db>(
     db: &'db dyn Database,
     impl_impl_id: ImplImplId<'db>,
 ) -> Maybe<ImplId<'db>> {
-    impl_impl_concrete_implized_ex(db, impl_impl_id, false)
+    if let ImplLongId::Concrete(concrete_impl) = impl_impl_id.impl_id().long(db) {
+        let impl_def_id = concrete_impl.impl_def_id(db);
+        let imp = db.impl_impl_implized_by_context(impl_impl_id, impl_def_id)?;
+        return concrete_impl.substitution(db)?.substitute(db, imp);
+    }
+
+    Ok(ImplLongId::ImplImpl(
+        GenericSubstitution::from_impl(impl_impl_id.impl_id()).substitute(db, impl_impl_id)?,
+    )
+    .intern(db))
 }
 
 /// Query implementation of [ImplSemantic::impl_impl_concrete_implized].
@@ -3171,18 +3195,10 @@ fn impl_impl_concrete_implized_cycle<'db>(
     _tracked: Tracked,
     impl_impl_id: ImplImplId<'db>,
 ) -> Maybe<ImplId<'db>> {
-    impl_impl_concrete_implized_ex(db, impl_impl_id, true)
-}
-
-fn impl_impl_concrete_implized_ex<'db>(
-    db: &'db dyn Database,
-    impl_impl_id: ImplImplId<'db>,
-    in_cycle: bool,
-) -> Maybe<ImplId<'db>> {
-    if let ImplLongId::Concrete(concrete_impl) = impl_impl_id.impl_id().long(db) {
-        let impl_def_id = concrete_impl.impl_def_id(db);
-        let imp = db.impl_impl_implized_by_context(impl_impl_id, impl_def_id, in_cycle)?;
-        return concrete_impl.substitution(db)?.substitute(db, imp);
+    if let ImplLongId::Concrete(_) = impl_impl_id.impl_id().long(db) {
+        // The relevant impl item is in a cycle, and the cycle diagnostic is reported by the cycle
+        // handlers of the underlying queries.
+        return Err(skip_diagnostic());
     }
 
     Ok(ImplLongId::ImplImpl(
@@ -4160,7 +4176,7 @@ pub trait ImplSemantic<'db>: Database {
     // ================
     /// Returns the resolved type of an impl item type.
     fn impl_type_def_resolved_type(&'db self, id: ImplTypeDefId<'db>) -> Maybe<TypeId<'db>> {
-        impl_type_semantic_data(self.as_dyn_database(), id, false)
+        impl_type_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .type_alias_data
             .resolved_type
@@ -4177,7 +4193,7 @@ pub trait ImplSemantic<'db>: Database {
     }
     /// Returns the attributes of an impl type.
     fn impl_type_def_attributes(&'db self, id: ImplTypeDefId<'db>) -> Maybe<&'db [Attribute<'db>]> {
-        Ok(&impl_type_semantic_data(self.as_dyn_database(), id, false)
+        Ok(&impl_type_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .type_alias_data
             .attributes)
@@ -4187,7 +4203,7 @@ pub trait ImplSemantic<'db>: Database {
         &'db self,
         id: ImplTypeDefId<'db>,
     ) -> Maybe<Arc<ResolverData<'db>>> {
-        Ok(impl_type_semantic_data(self.as_dyn_database(), id, false)
+        Ok(impl_type_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .type_alias_data
             .resolver_data
@@ -4219,7 +4235,7 @@ pub trait ImplSemantic<'db>: Database {
     // ================
     /// Returns the resolved constant value of an impl item constant.
     fn impl_constant_def_value(&'db self, id: ImplConstantDefId<'db>) -> Maybe<ConstValueId<'db>> {
-        Ok(impl_constant_semantic_data(self.as_dyn_database(), id, false)
+        Ok(impl_constant_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .constant_data
             .const_value)
@@ -4229,7 +4245,7 @@ pub trait ImplSemantic<'db>: Database {
         &'db self,
         id: ImplConstantDefId<'db>,
     ) -> Maybe<Arc<ResolverData<'db>>> {
-        Ok(impl_constant_semantic_data(self.as_dyn_database(), id, false)
+        Ok(impl_constant_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .constant_data
             .resolver_data
@@ -4262,7 +4278,7 @@ pub trait ImplSemantic<'db>: Database {
         &'db self,
         id: ImplImplDefId<'db>,
     ) -> Maybe<Arc<ResolverData<'db>>> {
-        Ok(impl_impl_semantic_data(self.as_dyn_database(), id, false)
+        Ok(impl_impl_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .impl_data
             .resolver_data
@@ -4500,7 +4516,7 @@ trait PrivImplSemantic<'db>: Database {
         &'db self,
         id: ImplTypeDefId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-        impl_type_semantic_data(self.as_dyn_database(), id, false)
+        impl_type_semantic_data(self.as_dyn_database(), id)
             .as_ref()
             .map(|data| data.diagnostics.clone())
             .unwrap_or_default()
@@ -4510,7 +4526,7 @@ trait PrivImplSemantic<'db>: Database {
         &'db self,
         id: ImplConstantDefId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-        impl_constant_semantic_data(self.as_dyn_database(), id, false)
+        impl_constant_semantic_data(self.as_dyn_database(), id)
             .as_ref()
             .map(|data| data.diagnostics.clone())
             .unwrap_or_default()
@@ -4532,18 +4548,14 @@ trait PrivImplSemantic<'db>: Database {
         &'db self,
         id: ImplImplDefId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-        impl_impl_semantic_data(self.as_dyn_database(), id, false)
+        impl_impl_semantic_data(self.as_dyn_database(), id)
             .as_ref()
             .map(|data| data.diagnostics.clone())
             .unwrap_or_default()
     }
     /// Returns the resolved impl of an impl item impl.
-    fn impl_impl_def_impl(
-        &'db self,
-        impl_impl_def_id: ImplImplDefId<'db>,
-        in_cycle: bool,
-    ) -> Maybe<ImplId<'db>> {
-        impl_impl_semantic_data(self.as_dyn_database(), impl_impl_def_id, in_cycle)
+    fn impl_impl_def_impl(&'db self, impl_impl_def_id: ImplImplDefId<'db>) -> Maybe<ImplId<'db>> {
+        impl_impl_semantic_data(self.as_dyn_database(), impl_impl_def_id)
             .maybe_as_ref()?
             .impl_data
             .resolved_impl
@@ -4554,45 +4566,28 @@ trait PrivImplSemantic<'db>: Database {
         impl_def_id: ImplDefId<'db>,
         trait_impl_id: TraitImplId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-        implicit_impl_impl_semantic_data_tracked(
-            self.as_dyn_database(),
-            impl_def_id,
-            trait_impl_id,
-            false,
-        )
-        .as_ref()
-        .map(|data| data.diagnostics.clone())
-        .unwrap_or_default()
+        implicit_impl_impl_semantic_data_tracked(self.as_dyn_database(), impl_def_id, trait_impl_id)
+            .as_ref()
+            .map(|data| data.diagnostics.clone())
+            .unwrap_or_default()
     }
     /// Returns the resolved impl of an implicit impl.
     fn implicit_impl_impl_impl(
         &'db self,
         impl_def_id: ImplDefId<'db>,
         trait_impl_id: TraitImplId<'db>,
-        in_cycle: bool,
     ) -> Maybe<ImplId<'db>> {
-        implicit_impl_impl_semantic_data_tracked(
-            self.as_dyn_database(),
-            impl_def_id,
-            trait_impl_id,
-            in_cycle,
-        )
-        .maybe_as_ref()?
-        .resolved_impl
+        implicit_impl_impl_semantic_data_tracked(self.as_dyn_database(), impl_def_id, trait_impl_id)
+            .maybe_as_ref()?
+            .resolved_impl
     }
     /// Returns the implized impl impl if the impl is concrete.
     fn impl_impl_implized_by_context(
         &'db self,
         impl_impl_id: ImplImplId<'db>,
         impl_def_id: ImplDefId<'db>,
-        in_cycle: bool,
     ) -> Maybe<ImplId<'db>> {
-        impl_impl_implized_by_context_tracked(
-            self.as_dyn_database(),
-            impl_impl_id,
-            impl_def_id,
-            in_cycle,
-        )
+        impl_impl_implized_by_context_tracked(self.as_dyn_database(), impl_impl_id, impl_def_id)
     }
     /// Returns the concrete trait of an impl impl.
     fn impl_impl_concrete_trait(

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -2441,35 +2441,23 @@ fn impl_type_semantic_data<'db>(
     db: &'db dyn Database,
     impl_type_def_id: ImplTypeDefId<'db>,
 ) -> Maybe<ImplItemTypeData<'db>> {
-    let mut diagnostics =
-        SemanticDiagnostics::new(impl_type_def_id.impl_def_id(db).parent_module(db));
-    let impl_type_def_ast = db.impl_type_by_id(impl_type_def_id)?;
-    let generic_params_data =
-        impl_type_def_generic_params_data(db, impl_type_def_id).maybe_as_ref()?.clone();
-    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Type(impl_type_def_id));
-
-    let trait_type_id =
-        validate_impl_item_type(db, &mut diagnostics, impl_type_def_id, &impl_type_def_ast);
-
-    // TODO(yuval): resolve type aliases later, like in module type aliases, to avoid cycles in
-    // non-cyclic chains.
-    Ok(ImplItemTypeData {
-        type_alias_data: type_alias_semantic_data_helper(
-            db,
-            &mut diagnostics,
-            &impl_type_def_ast,
-            lookup_item_id,
-            generic_params_data,
-        )?,
-        trait_type_id,
-        diagnostics: diagnostics.build(),
-    })
+    impl_type_semantic_data_inner(db, impl_type_def_id, false)
 }
 
 fn impl_type_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     impl_type_def_id: ImplTypeDefId<'db>,
+) -> Maybe<ImplItemTypeData<'db>> {
+    impl_type_semantic_data_inner(db, impl_type_def_id, true)
+}
+
+/// Shared code for the query and cycle handling of [impl_type_semantic_data].
+/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+fn impl_type_semantic_data_inner<'db>(
+    db: &'db dyn Database,
+    impl_type_def_id: ImplTypeDefId<'db>,
+    in_cycle: bool,
 ) -> Maybe<ImplItemTypeData<'db>> {
     let mut diagnostics =
         SemanticDiagnostics::new(impl_type_def_id.impl_def_id(db).parent_module(db));
@@ -2481,17 +2469,33 @@ fn impl_type_semantic_data_cycle<'db>(
     let trait_type_id =
         validate_impl_item_type(db, &mut diagnostics, impl_type_def_id, &impl_type_def_ast);
 
-    Ok(ImplItemTypeData {
-        type_alias_data: type_alias_semantic_data_cycle_helper(
-            db,
-            &mut diagnostics,
-            &impl_type_def_ast,
-            lookup_item_id,
-            generic_params_data,
-        )?,
-        trait_type_id,
-        diagnostics: diagnostics.build(),
-    })
+    if in_cycle {
+        Ok(ImplItemTypeData {
+            type_alias_data: type_alias_semantic_data_cycle_helper(
+                db,
+                &mut diagnostics,
+                &impl_type_def_ast,
+                lookup_item_id,
+                generic_params_data,
+            )?,
+            trait_type_id,
+            diagnostics: diagnostics.build(),
+        })
+    } else {
+        // TODO(yuval): resolve type aliases later, like in module type aliases, to avoid cycles in
+        // non-cyclic chains.
+        Ok(ImplItemTypeData {
+            type_alias_data: type_alias_semantic_data_helper(
+                db,
+                &mut diagnostics,
+                &impl_type_def_ast,
+                lookup_item_id,
+                generic_params_data,
+            )?,
+            trait_type_id,
+            diagnostics: diagnostics.build(),
+        })
+    }
 }
 
 /// Returns the generic parameters data of an impl type definition.
@@ -2625,41 +2629,23 @@ fn impl_constant_semantic_data<'db>(
     db: &'db dyn Database,
     impl_constant_def_id: ImplConstantDefId<'db>,
 ) -> Maybe<ImplItemConstantData<'db>> {
-    let impl_def_id = impl_constant_def_id.impl_def_id(db);
-    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
-    let impl_constant_defs = db.impl_constants(impl_def_id)?;
-    let impl_constant_def_ast = impl_constant_defs.get(&impl_constant_def_id).to_maybe()?;
-    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Constant(impl_constant_def_id));
-
-    let inference_id = InferenceId::LookupItemGenerics(LookupItemId::ImplItem(
-        ImplItemId::Constant(impl_constant_def_id),
-    ));
-    let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
-    let mut resolver =
-        Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
-
-    let trait_constant_id = validate_impl_item_constant(
-        db,
-        &mut diagnostics,
-        impl_constant_def_id,
-        impl_constant_def_ast,
-        &mut resolver,
-    );
-    let mut constant_data = constant_semantic_data_helper(
-        db,
-        impl_constant_def_ast,
-        lookup_item_id,
-        Some(Arc::new(resolver.data)),
-        &impl_def_id,
-    )?;
-    diagnostics.extend(mem::take(&mut constant_data.diagnostics));
-    Ok(ImplItemConstantData { constant_data, trait_constant_id, diagnostics: diagnostics.build() })
+    impl_constant_semantic_data_inner(db, impl_constant_def_id, false)
 }
 
 fn impl_constant_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     impl_constant_def_id: ImplConstantDefId<'db>,
+) -> Maybe<ImplItemConstantData<'db>> {
+    impl_constant_semantic_data_inner(db, impl_constant_def_id, true)
+}
+
+/// Shared code for the query and cycle handling of [impl_constant_semantic_data].
+/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+fn impl_constant_semantic_data_inner<'db>(
+    db: &'db dyn Database,
+    impl_constant_def_id: ImplConstantDefId<'db>,
+    in_cycle: bool,
 ) -> Maybe<ImplItemConstantData<'db>> {
     let impl_def_id = impl_constant_def_id.impl_def_id(db);
     let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
@@ -2681,13 +2667,23 @@ fn impl_constant_semantic_data_cycle<'db>(
         impl_constant_def_ast,
         &mut resolver,
     );
-    let mut constant_data = constant_semantic_data_cycle_helper(
-        db,
-        impl_constant_def_ast,
-        lookup_item_id,
-        Some(Arc::new(resolver.data)),
-        &impl_def_id,
-    )?;
+    let mut constant_data = if in_cycle {
+        constant_semantic_data_cycle_helper(
+            db,
+            impl_constant_def_ast,
+            lookup_item_id,
+            Some(Arc::new(resolver.data)),
+            &impl_def_id,
+        )?
+    } else {
+        constant_semantic_data_helper(
+            db,
+            impl_constant_def_ast,
+            lookup_item_id,
+            Some(Arc::new(resolver.data)),
+            &impl_def_id,
+        )?
+    };
     diagnostics.extend(mem::take(&mut constant_data.diagnostics));
     Ok(ImplItemConstantData { constant_data, trait_constant_id, diagnostics: diagnostics.build() })
 }
@@ -2899,44 +2895,23 @@ fn impl_impl_semantic_data<'db>(
     db: &'db dyn Database,
     impl_impl_def_id: ImplImplDefId<'db>,
 ) -> Maybe<ImplItemImplData<'db>> {
-    let impl_def_id = impl_impl_def_id.impl_def_id(db);
-    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
-    let impl_impl_defs = db.impl_impls(impl_def_id)?;
-    let impl_impl_def_ast = impl_impl_defs.get(&impl_impl_def_id).to_maybe()?;
-    let generic_params_data =
-        impl_impl_def_generic_params_data(db, impl_impl_def_id).maybe_as_ref()?.clone();
-    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Impl(impl_impl_def_id));
-
-    let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
-    let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
-    let mut resolver =
-        Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
-
-    let mut impl_data = impl_alias_semantic_data_helper(
-        db,
-        impl_impl_def_ast,
-        lookup_item_id,
-        generic_params_data,
-    )?;
-
-    diagnostics.extend(mem::take(&mut impl_data.diagnostics));
-
-    let trait_impl_id = validate_impl_item_impl(
-        db,
-        &mut diagnostics,
-        impl_impl_def_id,
-        impl_impl_def_ast,
-        &impl_data,
-        &mut resolver,
-    );
-
-    Ok(ImplItemImplData { impl_data, trait_impl_id, diagnostics: diagnostics.build() })
+    impl_impl_semantic_data_inner(db, impl_impl_def_id, false)
 }
 
 fn impl_impl_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     impl_impl_def_id: ImplImplDefId<'db>,
+) -> Maybe<ImplItemImplData<'db>> {
+    impl_impl_semantic_data_inner(db, impl_impl_def_id, true)
+}
+
+/// Shared code for the query and cycle handling of [impl_impl_semantic_data].
+/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+fn impl_impl_semantic_data_inner<'db>(
+    db: &'db dyn Database,
+    impl_impl_def_id: ImplImplDefId<'db>,
+    in_cycle: bool,
 ) -> Maybe<ImplItemImplData<'db>> {
     let impl_def_id = impl_impl_def_id.impl_def_id(db);
     let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
@@ -2951,12 +2926,16 @@ fn impl_impl_semantic_data_cycle<'db>(
     let mut resolver =
         Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
 
-    let mut impl_data = impl_alias_semantic_data_cycle_helper(
-        db,
-        impl_impl_def_ast,
-        lookup_item_id,
-        generic_params_data,
-    )?;
+    let mut impl_data = if in_cycle {
+        impl_alias_semantic_data_cycle_helper(
+            db,
+            impl_impl_def_ast,
+            lookup_item_id,
+            generic_params_data,
+        )?
+    } else {
+        impl_alias_semantic_data_helper(db, impl_impl_def_ast, lookup_item_id, generic_params_data)?
+    };
 
     diagnostics.extend(mem::take(&mut impl_data.diagnostics));
 
@@ -3159,16 +3138,7 @@ fn impl_impl_concrete_implized<'db>(
     db: &'db dyn Database,
     impl_impl_id: ImplImplId<'db>,
 ) -> Maybe<ImplId<'db>> {
-    if let ImplLongId::Concrete(concrete_impl) = impl_impl_id.impl_id().long(db) {
-        let impl_def_id = concrete_impl.impl_def_id(db);
-        let imp = db.impl_impl_implized_by_context(impl_impl_id, impl_def_id)?;
-        return concrete_impl.substitution(db)?.substitute(db, imp);
-    }
-
-    Ok(ImplLongId::ImplImpl(
-        GenericSubstitution::from_impl(impl_impl_id.impl_id()).substitute(db, impl_impl_id)?,
-    )
-    .intern(db))
+    impl_impl_concrete_implized_ex(db, impl_impl_id, false)
 }
 
 /// Query implementation of [ImplSemantic::impl_impl_concrete_implized].
@@ -3195,10 +3165,26 @@ fn impl_impl_concrete_implized_cycle<'db>(
     _tracked: Tracked,
     impl_impl_id: ImplImplId<'db>,
 ) -> Maybe<ImplId<'db>> {
-    if let ImplLongId::Concrete(_) = impl_impl_id.impl_id().long(db) {
-        // The relevant impl item is in a cycle, and the cycle diagnostic is reported by the cycle
-        // handlers of the underlying queries.
-        return Err(skip_diagnostic());
+    impl_impl_concrete_implized_ex(db, impl_impl_id, true)
+}
+
+/// Shared code for the query and cycle handling of
+/// [ImplSemantic::impl_impl_concrete_implized].
+/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+fn impl_impl_concrete_implized_ex<'db>(
+    db: &'db dyn Database,
+    impl_impl_id: ImplImplId<'db>,
+    in_cycle: bool,
+) -> Maybe<ImplId<'db>> {
+    if let ImplLongId::Concrete(concrete_impl) = impl_impl_id.impl_id().long(db) {
+        if in_cycle {
+            // The relevant impl item is in a cycle, and the cycle diagnostic is reported by the
+            // cycle handlers of the underlying queries.
+            return Err(skip_diagnostic());
+        }
+        let impl_def_id = concrete_impl.impl_def_id(db);
+        let imp = db.impl_impl_implized_by_context(impl_impl_id, impl_def_id)?;
+        return concrete_impl.substitution(db)?.substitute(db, imp);
     }
 
     Ok(ImplLongId::ImplImpl(

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -785,100 +785,111 @@ fn impl_concrete_trait_tracked<'db>(
 
 // --- Computation ---
 
-/// Cycle handling for [impl_declaration_data].
-fn impl_declaration_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    impl_def_id: ImplDefId<'db>,
-) -> Maybe<ImplDeclarationData<'db>> {
-    impl_declaration_data_inner(db, impl_def_id, false)
-}
-
 /// Computes impl declaration data.
-#[salsa::tracked(cycle_result=impl_declaration_data_cycle, returns(ref))]
 fn impl_declaration_data<'db>(
     db: &'db dyn Database,
     impl_def_id: ImplDefId<'db>,
-) -> Maybe<ImplDeclarationData<'db>> {
-    impl_declaration_data_inner(db, impl_def_id, true)
-}
+) -> &'db Maybe<ImplDeclarationData<'db>> {
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass resolve_trait=false to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_def_id: ImplDefId<'db>,
+        resolve_trait: bool,
+    ) -> Maybe<ImplDeclarationData<'db>> {
+        let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
 
-/// Shared code for the query and cycle handling.
-/// The cycle handling logic needs to pass resolve_trait=false to prevent the cycle.
-fn impl_declaration_data_inner<'db>(
-    db: &'db dyn Database,
-    impl_def_id: ImplDefId<'db>,
-    resolve_trait: bool,
-) -> Maybe<ImplDeclarationData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
+        // TODO(spapini): when code changes in a file, all the AST items change (as they contain a
+        // path to the green root that changes. Once ASTs are rooted on items, use a selector
+        // that picks only the item instead of all the module data.
+        let impl_ast = db.module_impl_by_id(impl_def_id)?;
+        let inference_id = InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(
+            ModuleItemId::Impl(impl_def_id),
+        ));
 
-    // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
-    // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
-    // the item instead of all the module data.
-    let impl_ast = db.module_impl_by_id(impl_def_id)?;
-    let inference_id = InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(
-        ModuleItemId::Impl(impl_def_id),
-    ));
-
-    // Generic params.
-    let generic_params_data = impl_def_generic_params_data(db, impl_def_id).maybe_as_ref()?;
-    let mut resolver = Resolver::with_data(
-        db,
-        (*generic_params_data.resolver_data).clone_with_inference_id(db, inference_id),
-    );
-    resolver.set_feature_config(&impl_def_id, &impl_ast, &mut diagnostics);
-    diagnostics.extend(generic_params_data.diagnostics.clone());
-    let trait_path_syntax = impl_ast.trait_path(db);
-
-    let concrete_trait = if resolve_trait {
-        resolver
-            .resolve_concrete_path(&mut diagnostics, &trait_path_syntax, NotFoundItemType::Trait)
-            .and_then(|resolved_item| match resolved_item {
-                ResolvedConcreteItem::Trait(id) | ResolvedConcreteItem::SelfTrait(id) => Ok(id),
-                _ => Err(diagnostics
-                    .report(trait_path_syntax.stable_ptr(db), SemanticDiagnosticKind::NotATrait)),
-            })
-    } else {
-        Err(diagnostics.report(trait_path_syntax.stable_ptr(db), ImplRequirementCycle))
-    };
-
-    let info = db.core_info();
-
-    // Check for reimplementation of compilers' Traits.
-    if let Ok(concrete_trait) = concrete_trait
-        && [
-            info.type_eq_trt,
-            info.fn_trt,
-            info.fn_once_trt,
-            info.felt252_dict_value_trt,
-            info.numeric_literal_trt,
-            info.string_literal_trt,
-        ]
-        .contains(&concrete_trait.trait_id(db))
-        && impl_def_id.parent_module(db).owning_crate(db) != core_crate(db)
-    {
-        diagnostics.report(
-            trait_path_syntax.stable_ptr(db),
-            CompilerTraitReImplementation { trait_id: concrete_trait.trait_id(db) },
+        // Generic params.
+        let generic_params_data = impl_def_generic_params_data(db, impl_def_id).maybe_as_ref()?;
+        let mut resolver = Resolver::with_data(
+            db,
+            (*generic_params_data.resolver_data).clone_with_inference_id(db, inference_id),
         );
+        resolver.set_feature_config(&impl_def_id, &impl_ast, &mut diagnostics);
+        diagnostics.extend(generic_params_data.diagnostics.clone());
+        let trait_path_syntax = impl_ast.trait_path(db);
+
+        let concrete_trait = if resolve_trait {
+            resolver
+                .resolve_concrete_path(
+                    &mut diagnostics,
+                    &trait_path_syntax,
+                    NotFoundItemType::Trait,
+                )
+                .and_then(|resolved_item| match resolved_item {
+                    ResolvedConcreteItem::Trait(id) | ResolvedConcreteItem::SelfTrait(id) => Ok(id),
+                    _ => Err(diagnostics.report(
+                        trait_path_syntax.stable_ptr(db),
+                        SemanticDiagnosticKind::NotATrait,
+                    )),
+                })
+        } else {
+            Err(diagnostics.report(trait_path_syntax.stable_ptr(db), ImplRequirementCycle))
+        };
+
+        let info = db.core_info();
+
+        // Check for reimplementation of compilers' Traits.
+        if let Ok(concrete_trait) = concrete_trait
+            && [
+                info.type_eq_trt,
+                info.fn_trt,
+                info.fn_once_trt,
+                info.felt252_dict_value_trt,
+                info.numeric_literal_trt,
+                info.string_literal_trt,
+            ]
+            .contains(&concrete_trait.trait_id(db))
+            && impl_def_id.parent_module(db).owning_crate(db) != core_crate(db)
+        {
+            diagnostics.report(
+                trait_path_syntax.stable_ptr(db),
+                CompilerTraitReImplementation { trait_id: concrete_trait.trait_id(db) },
+            );
+        }
+
+        // Check fully resolved.
+        let inference = &mut resolver.inference();
+        inference.finalize(&mut diagnostics, impl_ast.stable_ptr(db).untyped());
+
+        let concrete_trait: Result<ConcreteTraitId<'_>, DiagnosticAdded> =
+            inference.rewrite(concrete_trait).no_err();
+
+        let attributes = impl_ast.attributes(db).structurize(db);
+        let mut resolver_data = resolver.data;
+        resolver_data.trait_or_impl_ctx = TraitOrImplContext::Impl(impl_def_id);
+        Ok(ImplDeclarationData {
+            diagnostics: diagnostics.build(),
+            concrete_trait,
+            attributes,
+            resolver_data: Arc::new(resolver_data),
+        })
     }
-
-    // Check fully resolved.
-    let inference = &mut resolver.inference();
-    inference.finalize(&mut diagnostics, impl_ast.stable_ptr(db).untyped());
-
-    let concrete_trait: Result<ConcreteTraitId<'_>, DiagnosticAdded> =
-        inference.rewrite(concrete_trait).no_err();
-
-    let attributes = impl_ast.attributes(db).structurize(db);
-    let mut resolver_data = resolver.data;
-    resolver_data.trait_or_impl_ctx = TraitOrImplContext::Impl(impl_def_id);
-    Ok(ImplDeclarationData {
-        diagnostics: diagnostics.build(),
-        concrete_trait,
-        attributes,
-        resolver_data: Arc::new(resolver_data),
-    })
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<ImplDeclarationData<'db>> {
+        calc(db, impl_def_id, false)
+    }
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn impl_declaration_data<'db>(
+        db: &'db dyn Database,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<ImplDeclarationData<'db>> {
+        calc(db, impl_def_id, true)
+    }
+    impl_declaration_data(db, impl_def_id)
 }
 
 // === Impl Definition ===
@@ -1003,52 +1014,60 @@ pub struct DerefInfo<'db> {
     pub target_ty: TypeId<'db>,
 }
 
-/// Cycle handling for [ImplSemantic::deref_chain].
-fn deref_chain_cycle<'db>(
-    _db: &dyn Database,
-    _id: salsa::Id,
-    _ty: TypeId<'db>,
-    _crate_id: CrateId<'db>,
-    _try_deref_mut: bool,
-) -> Maybe<DerefChain<'db>> {
-    // `SemanticDiagnosticKind::DerefCycle` will be reported by `deref_impl_diagnostics`.
-    Maybe::Err(skip_diagnostic())
-}
-
 /// Query implementation of [ImplSemantic::deref_chain].
-#[salsa::tracked(cycle_result=deref_chain_cycle, returns(ref))]
 fn deref_chain<'db>(
     db: &'db dyn Database,
     ty: TypeId<'db>,
     crate_id: CrateId<'db>,
     try_deref_mut: bool,
-) -> Maybe<DerefChain<'db>> {
-    let mut opt_deref = None;
-    if try_deref_mut {
-        opt_deref = try_get_deref_func_and_target(db, ty, crate_id, true)?;
+) -> &'db Maybe<DerefChain<'db>> {
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        _db: &dyn Database,
+        _id: salsa::Id,
+        _ty: TypeId<'db>,
+        _crate_id: CrateId<'db>,
+        _try_deref_mut: bool,
+    ) -> Maybe<DerefChain<'db>> {
+        // `SemanticDiagnosticKind::DerefCycle` will be reported by `deref_impl_diagnostics`.
+        Maybe::Err(skip_diagnostic())
     }
-    let self_mutability = if opt_deref.is_some() {
-        Mutability::Reference
-    } else {
-        opt_deref = try_get_deref_func_and_target(db, ty, crate_id, false)?;
-        Mutability::Immutable
-    };
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn deref_chain<'db>(
+        db: &'db dyn Database,
+        ty: TypeId<'db>,
+        crate_id: CrateId<'db>,
+        try_deref_mut: bool,
+    ) -> Maybe<DerefChain<'db>> {
+        let mut opt_deref = None;
+        if try_deref_mut {
+            opt_deref = try_get_deref_func_and_target(db, ty, crate_id, true)?;
+        }
+        let self_mutability = if opt_deref.is_some() {
+            Mutability::Reference
+        } else {
+            opt_deref = try_get_deref_func_and_target(db, ty, crate_id, false)?;
+            Mutability::Immutable
+        };
 
-    let Some((function_id, target_ty)) = opt_deref else {
-        return Ok(DerefChain { derefs: Arc::new(vec![]) });
-    };
+        let Some((function_id, target_ty)) = opt_deref else {
+            return Ok(DerefChain { derefs: Arc::new(vec![]) });
+        };
 
-    let inner_chain = db.deref_chain(target_ty, crate_id, false)?;
+        let inner_chain = db.deref_chain(target_ty, crate_id, false)?;
 
-    Ok(DerefChain {
-        derefs: Arc::new(
-            chain!(
-                [DerefInfo { function_id, target_ty, self_mutability }],
-                inner_chain.derefs.iter().cloned()
-            )
-            .collect(),
-        ),
-    })
+        Ok(DerefChain {
+            derefs: Arc::new(
+                chain!(
+                    [DerefInfo { function_id, target_ty, self_mutability }],
+                    inner_chain.derefs.iter().cloned()
+                )
+                .collect(),
+            ),
+        })
+    }
+    deref_chain(db, ty, crate_id, try_deref_mut)
 }
 
 /// Tries to find the deref function and the target type for a given type and deref trait.
@@ -2436,66 +2455,72 @@ struct ImplItemTypeData<'db> {
 // --- Computation ---
 
 /// Returns data about an impl type definition.
-#[salsa::tracked(cycle_result=impl_type_semantic_data_cycle, returns(ref))]
 fn impl_type_semantic_data<'db>(
     db: &'db dyn Database,
     impl_type_def_id: ImplTypeDefId<'db>,
-) -> Maybe<ImplItemTypeData<'db>> {
-    impl_type_semantic_data_inner(db, impl_type_def_id, false)
-}
+) -> &'db Maybe<ImplItemTypeData<'db>> {
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_type_def_id: ImplTypeDefId<'db>,
+        in_cycle: bool,
+    ) -> Maybe<ImplItemTypeData<'db>> {
+        let mut diagnostics =
+            SemanticDiagnostics::new(impl_type_def_id.impl_def_id(db).parent_module(db));
+        let impl_type_def_ast = db.impl_type_by_id(impl_type_def_id)?;
+        let generic_params_data =
+            impl_type_def_generic_params_data(db, impl_type_def_id).maybe_as_ref()?.clone();
+        let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Type(impl_type_def_id));
 
-fn impl_type_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    impl_type_def_id: ImplTypeDefId<'db>,
-) -> Maybe<ImplItemTypeData<'db>> {
-    impl_type_semantic_data_inner(db, impl_type_def_id, true)
-}
+        let trait_type_id =
+            validate_impl_item_type(db, &mut diagnostics, impl_type_def_id, &impl_type_def_ast);
 
-/// Shared code for the query and cycle handling of [impl_type_semantic_data].
-/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
-fn impl_type_semantic_data_inner<'db>(
-    db: &'db dyn Database,
-    impl_type_def_id: ImplTypeDefId<'db>,
-    in_cycle: bool,
-) -> Maybe<ImplItemTypeData<'db>> {
-    let mut diagnostics =
-        SemanticDiagnostics::new(impl_type_def_id.impl_def_id(db).parent_module(db));
-    let impl_type_def_ast = db.impl_type_by_id(impl_type_def_id)?;
-    let generic_params_data =
-        impl_type_def_generic_params_data(db, impl_type_def_id).maybe_as_ref()?.clone();
-    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Type(impl_type_def_id));
-
-    let trait_type_id =
-        validate_impl_item_type(db, &mut diagnostics, impl_type_def_id, &impl_type_def_ast);
-
-    if in_cycle {
-        Ok(ImplItemTypeData {
-            type_alias_data: type_alias_semantic_data_cycle_helper(
-                db,
-                &mut diagnostics,
-                &impl_type_def_ast,
-                lookup_item_id,
-                generic_params_data,
-            )?,
-            trait_type_id,
-            diagnostics: diagnostics.build(),
-        })
-    } else {
-        // TODO(yuval): resolve type aliases later, like in module type aliases, to avoid cycles in
-        // non-cyclic chains.
-        Ok(ImplItemTypeData {
-            type_alias_data: type_alias_semantic_data_helper(
-                db,
-                &mut diagnostics,
-                &impl_type_def_ast,
-                lookup_item_id,
-                generic_params_data,
-            )?,
-            trait_type_id,
-            diagnostics: diagnostics.build(),
-        })
+        if in_cycle {
+            Ok(ImplItemTypeData {
+                type_alias_data: type_alias_semantic_data_cycle_helper(
+                    db,
+                    &mut diagnostics,
+                    &impl_type_def_ast,
+                    lookup_item_id,
+                    generic_params_data,
+                )?,
+                trait_type_id,
+                diagnostics: diagnostics.build(),
+            })
+        } else {
+            // TODO(yuval): resolve type aliases later, like in module type aliases, to avoid
+            // cycles in non-cyclic chains.
+            Ok(ImplItemTypeData {
+                type_alias_data: type_alias_semantic_data_helper(
+                    db,
+                    &mut diagnostics,
+                    &impl_type_def_ast,
+                    lookup_item_id,
+                    generic_params_data,
+                )?,
+                trait_type_id,
+                diagnostics: diagnostics.build(),
+            })
+        }
     }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        impl_type_def_id: ImplTypeDefId<'db>,
+    ) -> Maybe<ImplItemTypeData<'db>> {
+        calc(db, impl_type_def_id, true)
+    }
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn impl_type_semantic_data<'db>(
+        db: &'db dyn Database,
+        impl_type_def_id: ImplTypeDefId<'db>,
+    ) -> Maybe<ImplItemTypeData<'db>> {
+        calc(db, impl_type_def_id, false)
+    }
+    impl_type_semantic_data(db, impl_type_def_id)
 }
 
 /// Returns the generic parameters data of an impl type definition.
@@ -2556,60 +2581,55 @@ fn validate_impl_item_type<'db>(
 
 // === Impl Type ===
 
-/// Implementation of [ImplSemantic::impl_type_concrete_implized].
+/// Query implementation of [ImplSemantic::impl_type_concrete_implized].
 fn impl_type_concrete_implized<'db>(
     db: &'db dyn Database,
     impl_type_id: ImplTypeId<'db>,
 ) -> Maybe<TypeId<'db>> {
-    let concrete_impl = match impl_type_id.impl_id().long(db) {
-        ImplLongId::Concrete(concrete_impl) => concrete_impl,
-        ImplLongId::ImplImpl(imp_impl_id) => {
-            let ImplLongId::Concrete(concrete_impl) =
-                db.impl_impl_concrete_implized(*imp_impl_id)?.long(db)
-            else {
+    /// Shared code for the query and cycle handling.
+    fn calc<'db>(db: &'db dyn Database, impl_type_id: ImplTypeId<'db>) -> Maybe<TypeId<'db>> {
+        let concrete_impl = match impl_type_id.impl_id().long(db) {
+            ImplLongId::Concrete(concrete_impl) => concrete_impl,
+            ImplLongId::ImplImpl(imp_impl_id) => {
+                let ImplLongId::Concrete(concrete_impl) =
+                    db.impl_impl_concrete_implized(*imp_impl_id)?.long(db)
+                else {
+                    return Ok(TypeLongId::ImplType(impl_type_id).intern(db));
+                };
+                concrete_impl
+            }
+            ImplLongId::GenericParameter(_) | ImplLongId::SelfImpl(_) | ImplLongId::ImplVar(_) => {
                 return Ok(TypeLongId::ImplType(impl_type_id).intern(db));
-            };
-            concrete_impl
-        }
-        ImplLongId::GenericParameter(_) | ImplLongId::SelfImpl(_) | ImplLongId::ImplVar(_) => {
-            return Ok(TypeLongId::ImplType(impl_type_id).intern(db));
-        }
-        ImplLongId::GeneratedImpl(generated) => {
-            return Ok(*generated.long(db).impl_items.0.get(&impl_type_id.ty()).unwrap());
-        }
-    };
+            }
+            ImplLongId::GeneratedImpl(generated) => {
+                return Ok(*generated.long(db).impl_items.0.get(&impl_type_id.ty()).unwrap());
+            }
+        };
 
-    let impl_def_id = concrete_impl.impl_def_id(db);
-    let ty = db.trait_type_implized_by_context(impl_type_id.ty(), impl_def_id)?;
-    concrete_impl.substitution(db)?.substitute(db, ty)
-}
-
-#[salsa::tracked(returns(copy), cycle_result=impl_type_concrete_implized_cycle)]
-fn impl_type_concrete_implized_helper<'db>(
-    db: &'db dyn Database,
-    _tracked: Tracked,
-    impl_type_id: ImplTypeId<'db>,
-) -> Maybe<TypeId<'db>> {
-    impl_type_concrete_implized(db, impl_type_id)
-}
-
-/// Query implementation of [ImplSemantic::impl_type_concrete_implized].
-fn impl_type_concrete_implized_tracked<'db>(
-    db: &'db dyn Database,
-    impl_type_id: ImplTypeId<'db>,
-) -> Maybe<TypeId<'db>> {
-    impl_type_concrete_implized_helper(db, (), impl_type_id)
-}
-
-/// Cycle handling for [ImplSemantic::impl_type_concrete_implized].
-fn impl_type_concrete_implized_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    _tracked: Tracked,
-    impl_type_id: ImplTypeId<'db>,
-) -> Maybe<TypeId<'db>> {
-    // Forwarding cycle handling to `impl_type_semantic_data` handler.
-    impl_type_concrete_implized(db, impl_type_id)
+        let impl_def_id = concrete_impl.impl_def_id(db);
+        let ty = db.trait_type_implized_by_context(impl_type_id.ty(), impl_def_id)?;
+        concrete_impl.substitution(db)?.substitute(db, ty)
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        _tracked: Tracked,
+        impl_type_id: ImplTypeId<'db>,
+    ) -> Maybe<TypeId<'db>> {
+        // Forwarding cycle handling to `impl_type_semantic_data` handler.
+        calc(db, impl_type_id)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn impl_type_concrete_implized<'db>(
+        db: &'db dyn Database,
+        _tracked: Tracked,
+        impl_type_id: ImplTypeId<'db>,
+    ) -> Maybe<TypeId<'db>> {
+        calc(db, impl_type_id)
+    }
+    impl_type_concrete_implized(db, (), impl_type_id)
 }
 
 // === Impl Item Constant definition ===
@@ -2624,68 +2644,78 @@ struct ImplItemConstantData<'db> {
 }
 
 /// Returns data about an impl constant definition.
-#[salsa::tracked(cycle_result=impl_constant_semantic_data_cycle, returns(ref))]
 fn impl_constant_semantic_data<'db>(
     db: &'db dyn Database,
     impl_constant_def_id: ImplConstantDefId<'db>,
-) -> Maybe<ImplItemConstantData<'db>> {
-    impl_constant_semantic_data_inner(db, impl_constant_def_id, false)
-}
+) -> &'db Maybe<ImplItemConstantData<'db>> {
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_constant_def_id: ImplConstantDefId<'db>,
+        in_cycle: bool,
+    ) -> Maybe<ImplItemConstantData<'db>> {
+        let impl_def_id = impl_constant_def_id.impl_def_id(db);
+        let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
+        let impl_constant_defs = db.impl_constants(impl_def_id)?;
+        let impl_constant_def_ast = impl_constant_defs.get(&impl_constant_def_id).to_maybe()?;
+        let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Constant(impl_constant_def_id));
 
-fn impl_constant_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    impl_constant_def_id: ImplConstantDefId<'db>,
-) -> Maybe<ImplItemConstantData<'db>> {
-    impl_constant_semantic_data_inner(db, impl_constant_def_id, true)
-}
+        let inference_id = InferenceId::LookupItemGenerics(LookupItemId::ImplItem(
+            ImplItemId::Constant(impl_constant_def_id),
+        ));
+        let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
+        let mut resolver =
+            Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
 
-/// Shared code for the query and cycle handling of [impl_constant_semantic_data].
-/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
-fn impl_constant_semantic_data_inner<'db>(
-    db: &'db dyn Database,
-    impl_constant_def_id: ImplConstantDefId<'db>,
-    in_cycle: bool,
-) -> Maybe<ImplItemConstantData<'db>> {
-    let impl_def_id = impl_constant_def_id.impl_def_id(db);
-    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
-    let impl_constant_defs = db.impl_constants(impl_def_id)?;
-    let impl_constant_def_ast = impl_constant_defs.get(&impl_constant_def_id).to_maybe()?;
-    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Constant(impl_constant_def_id));
-
-    let inference_id = InferenceId::LookupItemGenerics(LookupItemId::ImplItem(
-        ImplItemId::Constant(impl_constant_def_id),
-    ));
-    let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
-    let mut resolver =
-        Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
-
-    let trait_constant_id = validate_impl_item_constant(
-        db,
-        &mut diagnostics,
-        impl_constant_def_id,
-        impl_constant_def_ast,
-        &mut resolver,
-    );
-    let mut constant_data = if in_cycle {
-        constant_semantic_data_cycle_helper(
+        let trait_constant_id = validate_impl_item_constant(
             db,
+            &mut diagnostics,
+            impl_constant_def_id,
             impl_constant_def_ast,
-            lookup_item_id,
-            Some(Arc::new(resolver.data)),
-            &impl_def_id,
-        )?
-    } else {
-        constant_semantic_data_helper(
-            db,
-            impl_constant_def_ast,
-            lookup_item_id,
-            Some(Arc::new(resolver.data)),
-            &impl_def_id,
-        )?
-    };
-    diagnostics.extend(mem::take(&mut constant_data.diagnostics));
-    Ok(ImplItemConstantData { constant_data, trait_constant_id, diagnostics: diagnostics.build() })
+            &mut resolver,
+        );
+        let mut constant_data = if in_cycle {
+            constant_semantic_data_cycle_helper(
+                db,
+                impl_constant_def_ast,
+                lookup_item_id,
+                Some(Arc::new(resolver.data)),
+                &impl_def_id,
+            )?
+        } else {
+            constant_semantic_data_helper(
+                db,
+                impl_constant_def_ast,
+                lookup_item_id,
+                Some(Arc::new(resolver.data)),
+                &impl_def_id,
+            )?
+        };
+        diagnostics.extend(mem::take(&mut constant_data.diagnostics));
+        Ok(ImplItemConstantData {
+            constant_data,
+            trait_constant_id,
+            diagnostics: diagnostics.build(),
+        })
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        impl_constant_def_id: ImplConstantDefId<'db>,
+    ) -> Maybe<ImplItemConstantData<'db>> {
+        calc(db, impl_constant_def_id, true)
+    }
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn impl_constant_semantic_data<'db>(
+        db: &'db dyn Database,
+        impl_constant_def_id: ImplConstantDefId<'db>,
+    ) -> Maybe<ImplItemConstantData<'db>> {
+        calc(db, impl_constant_def_id, false)
+    }
+    impl_constant_semantic_data(db, impl_constant_def_id)
 }
 
 /// Validates the impl item constant, and returns the matching trait constant id.
@@ -2745,30 +2775,36 @@ fn impl_constant_implized_by_context<'db>(
     impl_constant_id: ImplConstantId<'db>,
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<ConstValueId<'db>> {
-    let impl_constant_def_id: ImplConstantDefId<'_> =
-        db.impl_constant_by_trait_constant(impl_def_id, impl_constant_id.trait_constant_id())?;
+    /// Shared code for the query and cycle handling.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_constant_id: ImplConstantId<'db>,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<ConstValueId<'db>> {
+        let impl_constant_def_id: ImplConstantDefId<'_> =
+            db.impl_constant_by_trait_constant(impl_def_id, impl_constant_id.trait_constant_id())?;
 
-    db.impl_constant_def_value(impl_constant_def_id)
-}
-
-/// Query implementation of [ImplSemantic::impl_constant_implized_by_context].
-#[salsa::tracked(returns(copy), cycle_result=impl_constant_implized_by_context_cycle)]
-fn impl_constant_implized_by_context_tracked<'db>(
-    db: &'db dyn Database,
-    impl_constant_id: ImplConstantId<'db>,
-    impl_def_id: ImplDefId<'db>,
-) -> Maybe<ConstValueId<'db>> {
-    impl_constant_implized_by_context(db, impl_constant_id, impl_def_id)
-}
-
-/// Cycle handling for [PrivImplSemantic::impl_constant_implized_by_context].
-fn impl_constant_implized_by_context_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    impl_constant_id: ImplConstantId<'db>,
-    impl_def_id: ImplDefId<'db>,
-) -> Maybe<ConstValueId<'db>> {
-    // Forwarding cycle handling to `priv_impl_constant_semantic_data` handler.
+        db.impl_constant_def_value(impl_constant_def_id)
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        impl_constant_id: ImplConstantId<'db>,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<ConstValueId<'db>> {
+        // Forwarding cycle handling to `impl_constant_semantic_data` handler.
+        calc(db, impl_constant_id, impl_def_id)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn impl_constant_implized_by_context<'db>(
+        db: &'db dyn Database,
+        impl_constant_id: ImplConstantId<'db>,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<ConstValueId<'db>> {
+        calc(db, impl_constant_id, impl_def_id)
+    }
     impl_constant_implized_by_context(db, impl_constant_id, impl_def_id)
 }
 
@@ -2777,47 +2813,43 @@ fn impl_constant_concrete_implized_value<'db>(
     db: &'db dyn Database,
     impl_constant_id: ImplConstantId<'db>,
 ) -> Maybe<ConstValueId<'db>> {
-    if let ImplLongId::Concrete(concrete_impl) = impl_constant_id.impl_id().long(db) {
-        let impl_def_id = concrete_impl.impl_def_id(db);
-        let constant: ConstValueId<'db> =
-            db.impl_constant_implized_by_context(impl_constant_id, impl_def_id)?;
-        return concrete_impl.substitution(db)?.substitute(db, constant);
+    /// Shared code for the query and cycle handling.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_constant_id: ImplConstantId<'db>,
+    ) -> Maybe<ConstValueId<'db>> {
+        if let ImplLongId::Concrete(concrete_impl) = impl_constant_id.impl_id().long(db) {
+            let impl_def_id = concrete_impl.impl_def_id(db);
+            let constant: ConstValueId<'db> =
+                db.impl_constant_implized_by_context(impl_constant_id, impl_def_id)?;
+            return concrete_impl.substitution(db)?.substitute(db, constant);
+        }
+        let substitution: GenericSubstitution<'db> =
+            GenericSubstitution::from_impl(impl_constant_id.impl_id());
+        let substitution_id = substitution.substitute(db, impl_constant_id)?;
+        let const_val: ConstValue<'db> = ConstValue::ImplConstant(substitution_id);
+        Ok(const_val.intern(db))
     }
-    let substitution: GenericSubstitution<'db> =
-        GenericSubstitution::from_impl(impl_constant_id.impl_id());
-    let substitution_id = substitution.substitute(db, impl_constant_id)?;
-    let const_val: ConstValue<'db> = ConstValue::ImplConstant(substitution_id);
-    Ok(const_val.intern(db))
-}
-
-/// Query implementation of [ImplSemantic::impl_constant_concrete_implized_value].
-fn impl_constant_concrete_implized_value_tracked<'db>(
-    db: &'db dyn Database,
-    impl_constant_id: ImplConstantId<'db>,
-) -> Maybe<ConstValueId<'db>> {
-    impl_constant_concrete_implized_value_helper(db, (), impl_constant_id)
-}
-
-/// Tracked implementation of [ImplSemantic::impl_constant_concrete_implized_value].
-/// Receives a dummy id to support salsa tracking.
-#[salsa::tracked(returns(copy), cycle_result=impl_constant_concrete_implized_value_cycle)]
-fn impl_constant_concrete_implized_value_helper<'db>(
-    db: &'db dyn Database,
-    _tracked: Tracked,
-    impl_constant_id: ImplConstantId<'db>,
-) -> Maybe<ConstValueId<'db>> {
-    impl_constant_concrete_implized_value(db, impl_constant_id)
-}
-
-/// Cycle handling for [ImplSemantic::impl_constant_concrete_implized_value].
-fn impl_constant_concrete_implized_value_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    _tracked: Tracked,
-    impl_constant_id: ImplConstantId<'db>,
-) -> Maybe<ConstValueId<'db>> {
-    // Forwarding cycle handling to `priv_impl_const_semantic_data` handler.
-    impl_constant_concrete_implized_value(db, impl_constant_id)
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        _tracked: Tracked,
+        impl_constant_id: ImplConstantId<'db>,
+    ) -> Maybe<ConstValueId<'db>> {
+        // Forwarding cycle handling to `impl_constant_semantic_data` handler.
+        calc(db, impl_constant_id)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn impl_constant_concrete_implized_value<'db>(
+        db: &'db dyn Database,
+        _tracked: Tracked,
+        impl_constant_id: ImplConstantId<'db>,
+    ) -> Maybe<ConstValueId<'db>> {
+        calc(db, impl_constant_id)
+    }
+    impl_constant_concrete_implized_value(db, (), impl_constant_id)
 }
 
 /// Query implementation of [ImplSemantic::impl_constant_concrete_implized_type].
@@ -2825,57 +2857,56 @@ fn impl_constant_concrete_implized_type<'db>(
     db: &'db dyn Database,
     impl_constant_id: ImplConstantId<'db>,
 ) -> Maybe<TypeId<'db>> {
-    let concrete_trait_id = match impl_constant_id.impl_id().long(db) {
-        ImplLongId::Concrete(concrete_impl) => {
-            let impl_def_id = concrete_impl.impl_def_id(db);
-            let ty = db.impl_constant_implized_by_context(impl_constant_id, impl_def_id)?.ty(db)?;
-            return concrete_impl.substitution(db)?.substitute(db, ty);
-        }
-        ImplLongId::GenericParameter(param) => {
-            let param_impl =
-                extract_matches!(db.generic_param_semantic(*param)?, GenericParam::Impl);
-            param_impl.concrete_trait?
-        }
-        ImplLongId::ImplVar(var) => var.long(db).concrete_trait_id,
-        ImplLongId::ImplImpl(impl_impl) => db.impl_impl_concrete_trait(*impl_impl)?,
-        ImplLongId::SelfImpl(concrete_trait_id) => *concrete_trait_id,
-        ImplLongId::GeneratedImpl(generated_impl) => generated_impl.concrete_trait(db),
-    };
+    /// Shared code for the query and cycle handling.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_constant_id: ImplConstantId<'db>,
+    ) -> Maybe<TypeId<'db>> {
+        let concrete_trait_id = match impl_constant_id.impl_id().long(db) {
+            ImplLongId::Concrete(concrete_impl) => {
+                let impl_def_id = concrete_impl.impl_def_id(db);
+                let ty =
+                    db.impl_constant_implized_by_context(impl_constant_id, impl_def_id)?.ty(db)?;
+                return concrete_impl.substitution(db)?.substitute(db, ty);
+            }
+            ImplLongId::GenericParameter(param) => {
+                let param_impl =
+                    extract_matches!(db.generic_param_semantic(*param)?, GenericParam::Impl);
+                param_impl.concrete_trait?
+            }
+            ImplLongId::ImplVar(var) => var.long(db).concrete_trait_id,
+            ImplLongId::ImplImpl(impl_impl) => db.impl_impl_concrete_trait(*impl_impl)?,
+            ImplLongId::SelfImpl(concrete_trait_id) => *concrete_trait_id,
+            ImplLongId::GeneratedImpl(generated_impl) => generated_impl.concrete_trait(db),
+        };
 
-    let ty = db.concrete_trait_constant_type(ConcreteTraitConstantId::new_from_data(
-        db,
-        concrete_trait_id,
-        impl_constant_id.trait_constant_id(),
-    ))?;
-    GenericSubstitution::from_impl(impl_constant_id.impl_id()).substitute(db, ty)
-}
-
-/// Query implementation of [ImplSemantic::impl_constant_concrete_implized_type].
-fn impl_constant_concrete_implized_type_tracked<'db>(
-    db: &'db dyn Database,
-    impl_constant_id: ImplConstantId<'db>,
-) -> Maybe<TypeId<'db>> {
-    impl_constant_concrete_implized_type_helper(db, (), impl_constant_id)
-}
-
-#[salsa::tracked(returns(copy), cycle_result=impl_constant_concrete_implized_type_cycle)]
-fn impl_constant_concrete_implized_type_helper<'db>(
-    db: &'db dyn Database,
-    _tracked: Tracked,
-    impl_constant_id: ImplConstantId<'db>,
-) -> Maybe<TypeId<'db>> {
-    impl_constant_concrete_implized_type(db, impl_constant_id)
-}
-
-/// Cycle handling for [ImplSemantic::impl_constant_concrete_implized_type].
-fn impl_constant_concrete_implized_type_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    _tracked: Tracked,
-    impl_constant_id: ImplConstantId<'db>,
-) -> Maybe<TypeId<'db>> {
-    // Forwarding cycle handling to `priv_impl_const_semantic_data` handler.
-    impl_constant_concrete_implized_type(db, impl_constant_id)
+        let ty = db.concrete_trait_constant_type(ConcreteTraitConstantId::new_from_data(
+            db,
+            concrete_trait_id,
+            impl_constant_id.trait_constant_id(),
+        ))?;
+        GenericSubstitution::from_impl(impl_constant_id.impl_id()).substitute(db, ty)
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        _tracked: Tracked,
+        impl_constant_id: ImplConstantId<'db>,
+    ) -> Maybe<TypeId<'db>> {
+        // Forwarding cycle handling to `impl_constant_semantic_data` handler.
+        calc(db, impl_constant_id)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn impl_constant_concrete_implized_type<'db>(
+        db: &'db dyn Database,
+        _tracked: Tracked,
+        impl_constant_id: ImplConstantId<'db>,
+    ) -> Maybe<TypeId<'db>> {
+        calc(db, impl_constant_id)
+    }
+    impl_constant_concrete_implized_type(db, (), impl_constant_id)
 }
 
 // === Impl Item Impl definition ===
@@ -2890,65 +2921,76 @@ struct ImplItemImplData<'db> {
 }
 
 /// Returns data about an impl impl definition.
-#[salsa::tracked(cycle_result=impl_impl_semantic_data_cycle, returns(ref))]
 fn impl_impl_semantic_data<'db>(
     db: &'db dyn Database,
     impl_impl_def_id: ImplImplDefId<'db>,
-) -> Maybe<ImplItemImplData<'db>> {
-    impl_impl_semantic_data_inner(db, impl_impl_def_id, false)
-}
+) -> &'db Maybe<ImplItemImplData<'db>> {
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_impl_def_id: ImplImplDefId<'db>,
+        in_cycle: bool,
+    ) -> Maybe<ImplItemImplData<'db>> {
+        let impl_def_id = impl_impl_def_id.impl_def_id(db);
+        let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
+        let impl_impl_defs = db.impl_impls(impl_def_id)?;
+        let impl_impl_def_ast = impl_impl_defs.get(&impl_impl_def_id).to_maybe()?;
+        let generic_params_data =
+            impl_impl_def_generic_params_data(db, impl_impl_def_id).maybe_as_ref()?.clone();
+        let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Impl(impl_impl_def_id));
 
-fn impl_impl_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    impl_impl_def_id: ImplImplDefId<'db>,
-) -> Maybe<ImplItemImplData<'db>> {
-    impl_impl_semantic_data_inner(db, impl_impl_def_id, true)
-}
+        let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
+        let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
+        let mut resolver =
+            Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
 
-/// Shared code for the query and cycle handling of [impl_impl_semantic_data].
-/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
-fn impl_impl_semantic_data_inner<'db>(
-    db: &'db dyn Database,
-    impl_impl_def_id: ImplImplDefId<'db>,
-    in_cycle: bool,
-) -> Maybe<ImplItemImplData<'db>> {
-    let impl_def_id = impl_impl_def_id.impl_def_id(db);
-    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
-    let impl_impl_defs = db.impl_impls(impl_def_id)?;
-    let impl_impl_def_ast = impl_impl_defs.get(&impl_impl_def_id).to_maybe()?;
-    let generic_params_data =
-        impl_impl_def_generic_params_data(db, impl_impl_def_id).maybe_as_ref()?.clone();
-    let lookup_item_id = LookupItemId::ImplItem(ImplItemId::Impl(impl_impl_def_id));
+        let mut impl_data = if in_cycle {
+            impl_alias_semantic_data_cycle_helper(
+                db,
+                impl_impl_def_ast,
+                lookup_item_id,
+                generic_params_data,
+            )?
+        } else {
+            impl_alias_semantic_data_helper(
+                db,
+                impl_impl_def_ast,
+                lookup_item_id,
+                generic_params_data,
+            )?
+        };
 
-    let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
-    let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
-    let mut resolver =
-        Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
+        diagnostics.extend(mem::take(&mut impl_data.diagnostics));
 
-    let mut impl_data = if in_cycle {
-        impl_alias_semantic_data_cycle_helper(
+        let trait_impl_id = validate_impl_item_impl(
             db,
+            &mut diagnostics,
+            impl_impl_def_id,
             impl_impl_def_ast,
-            lookup_item_id,
-            generic_params_data,
-        )?
-    } else {
-        impl_alias_semantic_data_helper(db, impl_impl_def_ast, lookup_item_id, generic_params_data)?
-    };
+            &impl_data,
+            &mut resolver,
+        );
 
-    diagnostics.extend(mem::take(&mut impl_data.diagnostics));
-
-    let trait_impl_id = validate_impl_item_impl(
-        db,
-        &mut diagnostics,
-        impl_impl_def_id,
-        impl_impl_def_ast,
-        &impl_data,
-        &mut resolver,
-    );
-
-    Ok(ImplItemImplData { impl_data, trait_impl_id, diagnostics: diagnostics.build() })
+        Ok(ImplItemImplData { impl_data, trait_impl_id, diagnostics: diagnostics.build() })
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        impl_impl_def_id: ImplImplDefId<'db>,
+    ) -> Maybe<ImplItemImplData<'db>> {
+        calc(db, impl_impl_def_id, true)
+    }
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn impl_impl_semantic_data<'db>(
+        db: &'db dyn Database,
+        impl_impl_def_id: ImplImplDefId<'db>,
+    ) -> Maybe<ImplItemImplData<'db>> {
+        calc(db, impl_impl_def_id, false)
+    }
+    impl_impl_semantic_data(db, impl_impl_def_id)
 }
 
 /// Returns the generic parameters data of an impl impl definition.
@@ -3041,156 +3083,165 @@ struct ImplicitImplImplData<'db> {
 }
 
 /// Computes implicit impl semantic data with cycle handling.
-#[salsa::tracked(cycle_result=implicit_impl_impl_semantic_data_cycle, returns(ref))]
-fn implicit_impl_impl_semantic_data_tracked<'db>(
+fn implicit_impl_impl_semantic_data<'db>(
     db: &'db dyn Database,
     impl_def_id: ImplDefId<'db>,
     trait_impl_id: TraitImplId<'db>,
-) -> Maybe<ImplicitImplImplData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
-    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Impl(impl_def_id));
-
-    let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
-    let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
-
-    let mut resolver =
-        Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
-    // We cannot use `Self` as it will always find the implicit impl.
-    resolver.trait_or_impl_ctx = TraitOrImplContext::None;
-
-    let concrete_trait_impl_concrete_trait = db
-        .impl_def_concrete_trait(impl_def_id)
-        .and_then(|concrete_trait_id| {
-            db.concrete_trait_impl_concrete_trait(ConcreteTraitImplId::new_from_data(
-                db,
-                concrete_trait_id,
-                trait_impl_id,
-            ))
+) -> &'db Maybe<ImplicitImplImplData<'db>> {
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        impl_def_id: ImplDefId<'db>,
+        trait_impl_id: TraitImplId<'db>,
+    ) -> Maybe<ImplicitImplImplData<'db>> {
+        let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
+        let err = Err(diagnostics.report(impl_def_id.stable_ptr(db).untyped(), ImplAliasCycle));
+        Ok(ImplicitImplImplData {
+            resolved_impl: err,
+            trait_impl_id,
+            diagnostics: diagnostics.build(),
         })
-        .and_then(|concrete_trait_id| {
-            let impl_def_substitution = db.impl_def_substitution(impl_def_id)?;
-            impl_def_substitution.substitute(db, concrete_trait_id)
+    }
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn implicit_impl_impl_semantic_data<'db>(
+        db: &'db dyn Database,
+        impl_def_id: ImplDefId<'db>,
+        trait_impl_id: TraitImplId<'db>,
+    ) -> Maybe<ImplicitImplImplData<'db>> {
+        let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
+        let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::Impl(impl_def_id));
+
+        let inference_id = InferenceId::LookupItemGenerics(lookup_item_id);
+        let resolver_data = db.impl_def_resolver_data(impl_def_id)?;
+
+        let mut resolver =
+            Resolver::with_data(db, resolver_data.clone_with_inference_id(db, inference_id));
+        // We cannot use `Self` as it will always find the implicit impl.
+        resolver.trait_or_impl_ctx = TraitOrImplContext::None;
+
+        let concrete_trait_impl_concrete_trait = db
+            .impl_def_concrete_trait(impl_def_id)
+            .and_then(|concrete_trait_id| {
+                db.concrete_trait_impl_concrete_trait(ConcreteTraitImplId::new_from_data(
+                    db,
+                    concrete_trait_id,
+                    trait_impl_id,
+                ))
+            })
+            .and_then(|concrete_trait_id| {
+                let impl_def_substitution = db.impl_def_substitution(impl_def_id)?;
+                impl_def_substitution.substitute(db, concrete_trait_id)
+            });
+        let impl_lookup_context = resolver.impl_lookup_context();
+        let resolved_impl = concrete_trait_impl_concrete_trait.and_then(|concrete_trait_id| {
+            let imp =
+                resolver.inference().new_impl_var(concrete_trait_id, None, impl_lookup_context);
+            resolver.inference().finalize_without_reporting().map_err(|err_set| {
+                diagnostics.report(
+                    impl_def_id.stable_ptr(db).untyped(),
+                    ImplicitImplNotInferred { trait_impl_id, concrete_trait_id },
+                );
+                resolver.inference().report_on_pending_error(
+                    err_set,
+                    &mut diagnostics,
+                    impl_def_id.stable_ptr(db).untyped(),
+                )
+            })?;
+            resolver.inference().rewrite(imp).map_err(|_| skip_diagnostic())
         });
-    let impl_lookup_context = resolver.impl_lookup_context();
-    let resolved_impl = concrete_trait_impl_concrete_trait.and_then(|concrete_trait_id| {
-        let imp = resolver.inference().new_impl_var(concrete_trait_id, None, impl_lookup_context);
-        resolver.inference().finalize_without_reporting().map_err(|err_set| {
-            diagnostics.report(
-                impl_def_id.stable_ptr(db).untyped(),
-                ImplicitImplNotInferred { trait_impl_id, concrete_trait_id },
-            );
-            resolver.inference().report_on_pending_error(
-                err_set,
-                &mut diagnostics,
-                impl_def_id.stable_ptr(db).untyped(),
-            )
-        })?;
-        resolver.inference().rewrite(imp).map_err(|_| skip_diagnostic())
-    });
 
-    Ok(ImplicitImplImplData { resolved_impl, trait_impl_id, diagnostics: diagnostics.build() })
-}
-
-/// Cycle handling for implicit impl semantic data computation.
-fn implicit_impl_impl_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    impl_def_id: ImplDefId<'db>,
-    trait_impl_id: TraitImplId<'db>,
-) -> Maybe<ImplicitImplImplData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::new(impl_def_id.parent_module(db));
-    let err = Err(diagnostics.report(impl_def_id.stable_ptr(db).untyped(), ImplAliasCycle));
-    Ok(ImplicitImplImplData { resolved_impl: err, trait_impl_id, diagnostics: diagnostics.build() })
+        Ok(ImplicitImplImplData { resolved_impl, trait_impl_id, diagnostics: diagnostics.build() })
+    }
+    implicit_impl_impl_semantic_data(db, impl_def_id, trait_impl_id)
 }
 
 // === Impl Impl ===
 
 /// Query implementation of [PrivImplSemantic::impl_impl_implized_by_context].
-#[salsa::tracked(returns(copy), cycle_result=impl_impl_implized_by_context_cycle)]
-fn impl_impl_implized_by_context_tracked<'db>(
+fn impl_impl_implized_by_context<'db>(
     db: &'db dyn Database,
     impl_impl_id: ImplImplId<'db>,
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<ImplId<'db>> {
-    if db.is_implicit_impl_impl(impl_def_id, impl_impl_id.trait_impl_id())? {
-        return db.implicit_impl_impl_impl(impl_def_id, impl_impl_id.trait_impl_id());
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        _db: &dyn Database,
+        _id: salsa::Id,
+        _impl_impl_id: ImplImplId<'db>,
+        _impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<ImplId<'db>> {
+        // The relevant impl item is in a cycle, and the cycle diagnostic is reported by the cycle
+        // handlers of `impl_impl_semantic_data`/`implicit_impl_impl_semantic_data`.
+        Err(skip_diagnostic())
     }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn impl_impl_implized_by_context<'db>(
+        db: &'db dyn Database,
+        impl_impl_id: ImplImplId<'db>,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<ImplId<'db>> {
+        if db.is_implicit_impl_impl(impl_def_id, impl_impl_id.trait_impl_id())? {
+            return db.implicit_impl_impl_impl(impl_def_id, impl_impl_id.trait_impl_id());
+        }
 
-    let impl_impl_def_id = db.impl_impl_by_trait_impl(impl_def_id, impl_impl_id.trait_impl_id())?;
+        let impl_impl_def_id =
+            db.impl_impl_by_trait_impl(impl_def_id, impl_impl_id.trait_impl_id())?;
 
-    db.impl_impl_def_impl(impl_impl_def_id)
+        db.impl_impl_def_impl(impl_impl_def_id)
+    }
+    impl_impl_implized_by_context(db, impl_impl_id, impl_def_id)
 }
 
-/// Cycle handling for [PrivImplSemantic::impl_impl_implized_by_context].
-fn impl_impl_implized_by_context_cycle<'db>(
-    _db: &dyn Database,
-    _id: salsa::Id,
-    _impl_impl_id: ImplImplId<'db>,
-    _impl_def_id: ImplDefId<'db>,
-) -> Maybe<ImplId<'db>> {
-    // The relevant impl item is in a cycle, and the cycle diagnostic is reported by the cycle
-    // handlers of `impl_impl_semantic_data`/`implicit_impl_impl_semantic_data_tracked`.
-    Err(skip_diagnostic())
-}
-
-/// Implementation of [ImplSemantic::impl_impl_concrete_implized].
+/// Query implementation of [ImplSemantic::impl_impl_concrete_implized].
 fn impl_impl_concrete_implized<'db>(
     db: &'db dyn Database,
     impl_impl_id: ImplImplId<'db>,
 ) -> Maybe<ImplId<'db>> {
-    impl_impl_concrete_implized_ex(db, impl_impl_id, false)
-}
-
-/// Query implementation of [ImplSemantic::impl_impl_concrete_implized].
-fn impl_impl_concrete_implized_tracked<'db>(
-    db: &'db dyn Database,
-    impl_impl_id: ImplImplId<'db>,
-) -> Maybe<ImplId<'db>> {
-    impl_impl_concrete_implized_helper(db, (), impl_impl_id)
-}
-
-#[salsa::tracked(returns(copy), cycle_result=impl_impl_concrete_implized_cycle)]
-fn impl_impl_concrete_implized_helper<'db>(
-    db: &'db dyn Database,
-    _tracked: Tracked,
-    impl_impl_id: ImplImplId<'db>,
-) -> Maybe<ImplId<'db>> {
-    impl_impl_concrete_implized(db, impl_impl_id)
-}
-
-/// Cycle handling for [ImplSemantic::impl_impl_concrete_implized].
-fn impl_impl_concrete_implized_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    _tracked: Tracked,
-    impl_impl_id: ImplImplId<'db>,
-) -> Maybe<ImplId<'db>> {
-    impl_impl_concrete_implized_ex(db, impl_impl_id, true)
-}
-
-/// Shared code for the query and cycle handling of
-/// [ImplSemantic::impl_impl_concrete_implized].
-/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
-fn impl_impl_concrete_implized_ex<'db>(
-    db: &'db dyn Database,
-    impl_impl_id: ImplImplId<'db>,
-    in_cycle: bool,
-) -> Maybe<ImplId<'db>> {
-    if let ImplLongId::Concrete(concrete_impl) = impl_impl_id.impl_id().long(db) {
-        if in_cycle {
-            // The relevant impl item is in a cycle, and the cycle diagnostic is reported by the
-            // cycle handlers of the underlying queries.
-            return Err(skip_diagnostic());
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_impl_id: ImplImplId<'db>,
+        in_cycle: bool,
+    ) -> Maybe<ImplId<'db>> {
+        if let ImplLongId::Concrete(concrete_impl) = impl_impl_id.impl_id().long(db) {
+            if in_cycle {
+                // The relevant impl item is in a cycle, and the cycle diagnostic is reported by
+                // the cycle handlers of the underlying queries.
+                return Err(skip_diagnostic());
+            }
+            let impl_def_id = concrete_impl.impl_def_id(db);
+            let imp = db.impl_impl_implized_by_context(impl_impl_id, impl_def_id)?;
+            return concrete_impl.substitution(db)?.substitute(db, imp);
         }
-        let impl_def_id = concrete_impl.impl_def_id(db);
-        let imp = db.impl_impl_implized_by_context(impl_impl_id, impl_def_id)?;
-        return concrete_impl.substitution(db)?.substitute(db, imp);
-    }
 
-    Ok(ImplLongId::ImplImpl(
-        GenericSubstitution::from_impl(impl_impl_id.impl_id()).substitute(db, impl_impl_id)?,
-    )
-    .intern(db))
+        Ok(ImplLongId::ImplImpl(
+            GenericSubstitution::from_impl(impl_impl_id.impl_id()).substitute(db, impl_impl_id)?,
+        )
+        .intern(db))
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        _tracked: Tracked,
+        impl_impl_id: ImplImplId<'db>,
+    ) -> Maybe<ImplId<'db>> {
+        calc(db, impl_impl_id, true)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn impl_impl_concrete_implized<'db>(
+        db: &'db dyn Database,
+        _tracked: Tracked,
+        impl_impl_id: ImplImplId<'db>,
+    ) -> Maybe<ImplId<'db>> {
+        calc(db, impl_impl_id, false)
+    }
+    impl_impl_concrete_implized(db, (), impl_impl_id)
 }
 
 /// Implementation of [PrivImplSemantic::impl_impl_concrete_trait].
@@ -4214,7 +4265,7 @@ pub trait ImplSemantic<'db>: Database {
         &'db self,
         impl_type_def_id: ImplTypeId<'db>,
     ) -> Maybe<TypeId<'db>> {
-        impl_type_concrete_implized_tracked(self.as_dyn_database(), impl_type_def_id)
+        impl_type_concrete_implized(self.as_dyn_database(), impl_type_def_id)
     }
 
     // Impl constant def.
@@ -4246,7 +4297,7 @@ pub trait ImplSemantic<'db>: Database {
         &'db self,
         impl_constant_id: ImplConstantId<'db>,
     ) -> Maybe<ConstValueId<'db>> {
-        impl_constant_concrete_implized_value_tracked(self.as_dyn_database(), impl_constant_id)
+        impl_constant_concrete_implized_value(self.as_dyn_database(), impl_constant_id)
     }
     /// Returns the implized impl constant type if the impl is concrete.
     // TODO(Gil): Consider removing the cycle handling here if we will upgrade the salsa version.
@@ -4254,7 +4305,7 @@ pub trait ImplSemantic<'db>: Database {
         &'db self,
         impl_constant_id: ImplConstantId<'db>,
     ) -> Maybe<TypeId<'db>> {
-        impl_constant_concrete_implized_type_tracked(self.as_dyn_database(), impl_constant_id)
+        impl_constant_concrete_implized_type(self.as_dyn_database(), impl_constant_id)
     }
 
     // Impl impl def.
@@ -4275,7 +4326,7 @@ pub trait ImplSemantic<'db>: Database {
     // ================
     /// Returns the implized impl impl value if the impl is concrete.
     fn impl_impl_concrete_implized(&'db self, impl_impl_id: ImplImplId<'db>) -> Maybe<ImplId<'db>> {
-        impl_impl_concrete_implized_tracked(self.as_dyn_database(), impl_impl_id)
+        impl_impl_concrete_implized(self.as_dyn_database(), impl_impl_id)
     }
 
     // Impl function.
@@ -4523,11 +4574,7 @@ trait PrivImplSemantic<'db>: Database {
         impl_constant_id: ImplConstantId<'db>,
         impl_def_id: ImplDefId<'db>,
     ) -> Maybe<ConstValueId<'db>> {
-        impl_constant_implized_by_context_tracked(
-            self.as_dyn_database(),
-            impl_constant_id,
-            impl_def_id,
-        )
+        impl_constant_implized_by_context(self.as_dyn_database(), impl_constant_id, impl_def_id)
     }
     /// Returns the semantic diagnostics of an impl item impl.
     fn impl_impl_def_semantic_diagnostics(
@@ -4552,7 +4599,7 @@ trait PrivImplSemantic<'db>: Database {
         impl_def_id: ImplDefId<'db>,
         trait_impl_id: TraitImplId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-        implicit_impl_impl_semantic_data_tracked(self.as_dyn_database(), impl_def_id, trait_impl_id)
+        implicit_impl_impl_semantic_data(self.as_dyn_database(), impl_def_id, trait_impl_id)
             .as_ref()
             .map(|data| data.diagnostics.clone())
             .unwrap_or_default()
@@ -4563,7 +4610,7 @@ trait PrivImplSemantic<'db>: Database {
         impl_def_id: ImplDefId<'db>,
         trait_impl_id: TraitImplId<'db>,
     ) -> Maybe<ImplId<'db>> {
-        implicit_impl_impl_semantic_data_tracked(self.as_dyn_database(), impl_def_id, trait_impl_id)
+        implicit_impl_impl_semantic_data(self.as_dyn_database(), impl_def_id, trait_impl_id)
             .maybe_as_ref()?
             .resolved_impl
     }
@@ -4573,7 +4620,7 @@ trait PrivImplSemantic<'db>: Database {
         impl_impl_id: ImplImplId<'db>,
         impl_def_id: ImplDefId<'db>,
     ) -> Maybe<ImplId<'db>> {
-        impl_impl_implized_by_context_tracked(self.as_dyn_database(), impl_impl_id, impl_def_id)
+        impl_impl_implized_by_context(self.as_dyn_database(), impl_impl_id, impl_def_id)
     }
     /// Returns the concrete trait of an impl impl.
     fn impl_impl_concrete_trait(

--- a/crates/cairo-lang-semantic/src/items/impl_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/impl_alias.rs
@@ -40,13 +40,32 @@ fn impl_alias_semantic_data<'db>(
     db: &'db dyn Database,
     impl_alias_id: ImplAliasId<'db>,
 ) -> Maybe<ImplAliasData<'db>> {
+    impl_alias_semantic_data_inner(db, impl_alias_id, false)
+}
+
+/// Shared code for the query and cycle handling of [impl_alias_semantic_data].
+/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+fn impl_alias_semantic_data_inner<'db>(
+    db: &'db dyn Database,
+    impl_alias_id: ImplAliasId<'db>,
+    in_cycle: bool,
+) -> Maybe<ImplAliasData<'db>> {
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::ImplAlias(impl_alias_id));
     let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
 
     let generic_params_data =
         impl_alias_generic_params_data(db, impl_alias_id).maybe_as_ref()?.clone();
 
-    impl_alias_semantic_data_helper(db, &impl_alias_ast, lookup_item_id, generic_params_data)
+    if in_cycle {
+        impl_alias_semantic_data_cycle_helper(
+            db,
+            &impl_alias_ast,
+            lookup_item_id,
+            generic_params_data,
+        )
+    } else {
+        impl_alias_semantic_data_helper(db, &impl_alias_ast, lookup_item_id, generic_params_data)
+    }
 }
 
 /// A helper function to compute the semantic data of an impl-alias item.
@@ -95,13 +114,7 @@ fn impl_alias_semantic_data_cycle<'db>(
     _id: salsa::Id,
     impl_alias_id: ImplAliasId<'db>,
 ) -> Maybe<ImplAliasData<'db>> {
-    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::ImplAlias(impl_alias_id));
-    let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
-
-    let generic_params_data =
-        impl_alias_generic_params_data(db, impl_alias_id).maybe_as_ref()?.clone();
-
-    impl_alias_semantic_data_cycle_helper(db, &impl_alias_ast, lookup_item_id, generic_params_data)
+    impl_alias_semantic_data_inner(db, impl_alias_id, true)
 }
 
 /// A helper function to compute the semantic data of an impl-alias item when a cycle is detected.

--- a/crates/cairo-lang-semantic/src/items/impl_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/impl_alias.rs
@@ -78,13 +78,13 @@ fn impl_alias_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn impl_alias_semantic_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         impl_alias_id: ImplAliasId<'db>,
     ) -> Maybe<ImplAliasData<'db>> {
         calc(db, impl_alias_id, false)
     }
-    impl_alias_semantic_data(db, impl_alias_id)
+    query(db, impl_alias_id)
 }
 
 /// A helper function to compute the semantic data of an impl-alias item.
@@ -222,10 +222,7 @@ fn impl_alias_impl_def<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn impl_alias_impl_def<'db>(
-        db: &'db dyn Database,
-        impl_alias_id: ImplAliasId<'db>,
-    ) -> Maybe<ImplDefId<'db>> {
+    fn query<'db>(db: &'db dyn Database, impl_alias_id: ImplAliasId<'db>) -> Maybe<ImplDefId<'db>> {
         let module_id = impl_alias_id.parent_module(db);
         let mut diagnostics = SemanticDiagnostics::new(module_id);
         let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
@@ -251,7 +248,7 @@ fn impl_alias_impl_def<'db>(
             _ => Err(skip_diagnostic()),
         }
     }
-    impl_alias_impl_def(db, impl_alias_id)
+    query(db, impl_alias_id)
 }
 
 /// Trait for impl-alias-related semantic queries.

--- a/crates/cairo-lang-semantic/src/items/impl_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/impl_alias.rs
@@ -39,7 +39,6 @@ pub struct ImplAliasData<'db> {
 fn impl_alias_semantic_data<'db>(
     db: &'db dyn Database,
     impl_alias_id: ImplAliasId<'db>,
-    in_cycle: bool,
 ) -> Maybe<ImplAliasData<'db>> {
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::ImplAlias(impl_alias_id));
     let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
@@ -47,16 +46,7 @@ fn impl_alias_semantic_data<'db>(
     let generic_params_data =
         impl_alias_generic_params_data(db, impl_alias_id).maybe_as_ref()?.clone();
 
-    if in_cycle {
-        impl_alias_semantic_data_cycle_helper(
-            db,
-            &impl_alias_ast,
-            lookup_item_id,
-            generic_params_data,
-        )
-    } else {
-        impl_alias_semantic_data_helper(db, &impl_alias_ast, lookup_item_id, generic_params_data)
-    }
+    impl_alias_semantic_data_helper(db, &impl_alias_ast, lookup_item_id, generic_params_data)
 }
 
 /// A helper function to compute the semantic data of an impl-alias item.
@@ -104,9 +94,14 @@ fn impl_alias_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     impl_alias_id: ImplAliasId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<ImplAliasData<'db>> {
-    impl_alias_semantic_data(db, impl_alias_id, true).clone()
+    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::ImplAlias(impl_alias_id));
+    let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
+
+    let generic_params_data =
+        impl_alias_generic_params_data(db, impl_alias_id).maybe_as_ref()?.clone();
+
+    impl_alias_semantic_data_cycle_helper(db, &impl_alias_ast, lookup_item_id, generic_params_data)
 }
 
 /// A helper function to compute the semantic data of an impl-alias item when a cycle is detected.
@@ -239,7 +234,7 @@ pub trait ImplAliasSemantic<'db>: Database {
         &'db self,
         id: ImplAliasId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-        impl_alias_semantic_data(self.as_dyn_database(), id, false)
+        impl_alias_semantic_data(self.as_dyn_database(), id)
             .as_ref()
             .map(|data| data.diagnostics.clone())
             .unwrap_or_default()
@@ -257,7 +252,7 @@ pub trait ImplAliasSemantic<'db>: Database {
                 );
             }
         };
-        impl_alias_semantic_data(self.as_dyn_database(), id, false).maybe_as_ref()?.resolved_impl
+        impl_alias_semantic_data(self.as_dyn_database(), id).maybe_as_ref()?.resolved_impl
     }
     /// Returns the generic parameters of an impl alias.
     fn impl_alias_generic_params(&'db self, id: ImplAliasId<'db>) -> Maybe<Vec<GenericParam<'db>>> {
@@ -268,14 +263,14 @@ pub trait ImplAliasSemantic<'db>: Database {
     }
     /// Returns the resolver data of an impl alias.
     fn impl_alias_resolver_data(&'db self, id: ImplAliasId<'db>) -> Maybe<Arc<ResolverData<'db>>> {
-        Ok(impl_alias_semantic_data(self.as_dyn_database(), id, false)
+        Ok(impl_alias_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .resolver_data
             .clone())
     }
     /// Returns the attributes attached to the impl alias.
     fn impl_alias_attributes(&'db self, id: ImplAliasId<'db>) -> Maybe<&'db [Attribute<'db>]> {
-        Ok(&impl_alias_semantic_data(self.as_dyn_database(), id, false).maybe_as_ref()?.attributes)
+        Ok(&impl_alias_semantic_data(self.as_dyn_database(), id).maybe_as_ref()?.attributes)
     }
 }
 impl<'db, T: Database + ?Sized> ImplAliasSemantic<'db> for T {}

--- a/crates/cairo-lang-semantic/src/items/impl_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/impl_alias.rs
@@ -35,37 +35,56 @@ pub struct ImplAliasData<'db> {
 }
 
 /// Returns data about an impl alias.
-#[salsa::tracked(cycle_result=impl_alias_semantic_data_cycle, returns(ref))]
 fn impl_alias_semantic_data<'db>(
     db: &'db dyn Database,
     impl_alias_id: ImplAliasId<'db>,
-) -> Maybe<ImplAliasData<'db>> {
-    impl_alias_semantic_data_inner(db, impl_alias_id, false)
-}
+) -> &'db Maybe<ImplAliasData<'db>> {
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        impl_alias_id: ImplAliasId<'db>,
+        in_cycle: bool,
+    ) -> Maybe<ImplAliasData<'db>> {
+        let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::ImplAlias(impl_alias_id));
+        let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
 
-/// Shared code for the query and cycle handling of [impl_alias_semantic_data].
-/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
-fn impl_alias_semantic_data_inner<'db>(
-    db: &'db dyn Database,
-    impl_alias_id: ImplAliasId<'db>,
-    in_cycle: bool,
-) -> Maybe<ImplAliasData<'db>> {
-    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::ImplAlias(impl_alias_id));
-    let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
+        let generic_params_data =
+            impl_alias_generic_params_data(db, impl_alias_id).maybe_as_ref()?.clone();
 
-    let generic_params_data =
-        impl_alias_generic_params_data(db, impl_alias_id).maybe_as_ref()?.clone();
-
-    if in_cycle {
-        impl_alias_semantic_data_cycle_helper(
-            db,
-            &impl_alias_ast,
-            lookup_item_id,
-            generic_params_data,
-        )
-    } else {
-        impl_alias_semantic_data_helper(db, &impl_alias_ast, lookup_item_id, generic_params_data)
+        if in_cycle {
+            impl_alias_semantic_data_cycle_helper(
+                db,
+                &impl_alias_ast,
+                lookup_item_id,
+                generic_params_data,
+            )
+        } else {
+            impl_alias_semantic_data_helper(
+                db,
+                &impl_alias_ast,
+                lookup_item_id,
+                generic_params_data,
+            )
+        }
     }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        impl_alias_id: ImplAliasId<'db>,
+    ) -> Maybe<ImplAliasData<'db>> {
+        calc(db, impl_alias_id, true)
+    }
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn impl_alias_semantic_data<'db>(
+        db: &'db dyn Database,
+        impl_alias_id: ImplAliasId<'db>,
+    ) -> Maybe<ImplAliasData<'db>> {
+        calc(db, impl_alias_id, false)
+    }
+    impl_alias_semantic_data(db, impl_alias_id)
 }
 
 /// A helper function to compute the semantic data of an impl-alias item.
@@ -107,14 +126,6 @@ pub fn impl_alias_semantic_data_helper<'db>(
     let attributes = impl_alias_ast.attributes(db).structurize(db);
     let resolver_data = Arc::new(resolver.data);
     Ok(ImplAliasData { diagnostics: diagnostics.build(), resolved_impl, attributes, resolver_data })
-}
-
-fn impl_alias_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    impl_alias_id: ImplAliasId<'db>,
-) -> Maybe<ImplAliasData<'db>> {
-    impl_alias_semantic_data_inner(db, impl_alias_id, true)
 }
 
 /// A helper function to compute the semantic data of an impl-alias item when a cycle is detected.
@@ -195,44 +206,52 @@ pub fn impl_alias_generic_params_data_helper<'db>(
 }
 
 /// Implementation of [ImplAliasSemantic::impl_alias_impl_def].
-#[salsa::tracked(returns(copy), cycle_result=impl_alias_impl_def_cycle)]
 fn impl_alias_impl_def<'db>(
     db: &'db dyn Database,
     impl_alias_id: ImplAliasId<'db>,
 ) -> Maybe<ImplDefId<'db>> {
-    let module_id = impl_alias_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
-    let inference_id = InferenceId::ImplAliasImplDef(impl_alias_id);
-
-    let mut resolver = Resolver::new(db, module_id, inference_id);
-    resolver.set_feature_config(&impl_alias_id, &impl_alias_ast, &mut diagnostics);
-
-    let impl_path_syntax = impl_alias_ast.impl_path(db);
-
-    match resolver.resolve_generic_path_with_args(
-        &mut diagnostics,
-        &impl_path_syntax,
-        NotFoundItemType::Impl,
-        ResolutionContext::Default,
-    ) {
-        Ok(ResolvedGenericItem::Impl(imp)) => Ok(imp),
-        Ok(ResolvedGenericItem::GenericImplAlias(impl_alias)) => db.impl_alias_impl_def(impl_alias),
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        _db: &dyn Database,
+        _id: salsa::Id,
+        _impl_alias_id: ImplAliasId<'db>,
+    ) -> Maybe<ImplDefId<'db>> {
         // Skipping diagnostics since we will get these through when resolving in the
         // `impl_alias_semantic_data` query.
-        _ => Err(skip_diagnostic()),
+        Err(skip_diagnostic())
     }
-}
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn impl_alias_impl_def<'db>(
+        db: &'db dyn Database,
+        impl_alias_id: ImplAliasId<'db>,
+    ) -> Maybe<ImplDefId<'db>> {
+        let module_id = impl_alias_id.parent_module(db);
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        let impl_alias_ast = db.module_impl_alias_by_id(impl_alias_id)?;
+        let inference_id = InferenceId::ImplAliasImplDef(impl_alias_id);
 
-/// Cycle handling for [ImplAliasSemantic::impl_alias_impl_def].
-fn impl_alias_impl_def_cycle<'db>(
-    _db: &dyn Database,
-    _id: salsa::Id,
-    _impl_alias_id: ImplAliasId<'db>,
-) -> Maybe<ImplDefId<'db>> {
-    // Skipping diagnostics since we will get these through when resolving in the
-    // `impl_alias_semantic_data` query.
-    Err(skip_diagnostic())
+        let mut resolver = Resolver::new(db, module_id, inference_id);
+        resolver.set_feature_config(&impl_alias_id, &impl_alias_ast, &mut diagnostics);
+
+        let impl_path_syntax = impl_alias_ast.impl_path(db);
+
+        match resolver.resolve_generic_path_with_args(
+            &mut diagnostics,
+            &impl_path_syntax,
+            NotFoundItemType::Impl,
+            ResolutionContext::Default,
+        ) {
+            Ok(ResolvedGenericItem::Impl(imp)) => Ok(imp),
+            Ok(ResolvedGenericItem::GenericImplAlias(impl_alias)) => {
+                db.impl_alias_impl_def(impl_alias)
+            }
+            // Skipping diagnostics since we will get these through when resolving in the
+            // `impl_alias_semantic_data` query.
+            _ => Err(skip_diagnostic()),
+        }
+    }
+    impl_alias_impl_def(db, impl_alias_id)
 }
 
 /// Trait for impl-alias-related semantic queries.

--- a/crates/cairo-lang-semantic/src/items/implization.rs
+++ b/crates/cairo-lang-semantic/src/items/implization.rs
@@ -5,35 +5,41 @@ use salsa::Database;
 use crate::TypeId;
 use crate::items::imp::ImplSemantic;
 
-/// Implementation of [ImplizationSemantic::trait_type_implized_by_context].
+/// Query implementation of [ImplizationSemantic::trait_type_implized_by_context].
 fn trait_type_implized_by_context<'db>(
     db: &'db dyn Database,
     trait_type_id: TraitTypeId<'db>,
     impl_def_id: ImplDefId<'db>,
 ) -> Maybe<TypeId<'db>> {
-    let impl_type_def_id = db.impl_type_by_trait_type(impl_def_id, trait_type_id)?;
+    /// Shared code for the query and cycle handling.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        trait_type_id: TraitTypeId<'db>,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<TypeId<'db>> {
+        let impl_type_def_id = db.impl_type_by_trait_type(impl_def_id, trait_type_id)?;
 
-    db.impl_type_def_resolved_type(impl_type_def_id)
-}
-
-/// Query implementation of [ImplizationSemantic::trait_type_implized_by_context].
-#[salsa::tracked(returns(copy), cycle_result=trait_type_implized_by_context_cycle)]
-fn trait_type_implized_by_context_tracked<'db>(
-    db: &'db dyn Database,
-    trait_type_id: TraitTypeId<'db>,
-    impl_def_id: ImplDefId<'db>,
-) -> Maybe<TypeId<'db>> {
-    trait_type_implized_by_context(db, trait_type_id, impl_def_id)
-}
-
-/// Cycle handling for [ImplizationSemantic::trait_type_implized_by_context].
-fn trait_type_implized_by_context_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    trait_type_id: TraitTypeId<'db>,
-    impl_def_id: ImplDefId<'db>,
-) -> Maybe<TypeId<'db>> {
-    // Forwarding cycle handling to `priv_impl_type_semantic_data` handler.
+        db.impl_type_def_resolved_type(impl_type_def_id)
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        trait_type_id: TraitTypeId<'db>,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<TypeId<'db>> {
+        // Forwarding cycle handling to `impl_type_semantic_data` handler.
+        calc(db, trait_type_id, impl_def_id)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_result=cycle)]
+    fn trait_type_implized_by_context<'db>(
+        db: &'db dyn Database,
+        trait_type_id: TraitTypeId<'db>,
+        impl_def_id: ImplDefId<'db>,
+    ) -> Maybe<TypeId<'db>> {
+        calc(db, trait_type_id, impl_def_id)
+    }
     trait_type_implized_by_context(db, trait_type_id, impl_def_id)
 }
 
@@ -47,11 +53,7 @@ pub trait ImplizationSemantic<'db>: Database {
         trait_type_def_id: TraitTypeId<'db>,
         impl_def_id: ImplDefId<'db>,
     ) -> Maybe<TypeId<'db>> {
-        trait_type_implized_by_context_tracked(
-            self.as_dyn_database(),
-            trait_type_def_id,
-            impl_def_id,
-        )
+        trait_type_implized_by_context(self.as_dyn_database(), trait_type_def_id, impl_def_id)
     }
 }
 impl<'db, T: Database + ?Sized> ImplizationSemantic<'db> for T {}

--- a/crates/cairo-lang-semantic/src/items/implization.rs
+++ b/crates/cairo-lang-semantic/src/items/implization.rs
@@ -33,14 +33,14 @@ fn trait_type_implized_by_context<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_result=cycle)]
-    fn trait_type_implized_by_context<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         trait_type_id: TraitTypeId<'db>,
         impl_def_id: ImplDefId<'db>,
     ) -> Maybe<TypeId<'db>> {
         calc(db, trait_type_id, impl_def_id)
     }
-    trait_type_implized_by_context(db, trait_type_id, impl_def_id)
+    query(db, trait_type_id, impl_def_id)
 }
 
 /// Trait for implization-related semantic queries.

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -34,85 +34,161 @@ pub struct MacroCallData<'db> {
     pub parent_macro_call_data: Option<Arc<ResolverMacroData<'db>>>,
 }
 
-/// Implementation of [MacroCallSemantic::priv_macro_call_data].
+/// Query implementation of [MacroCallSemantic::priv_macro_call_data].
 fn priv_macro_call_data<'db>(
     db: &'db dyn Database,
     macro_call_id: MacroCallId<'db>,
 ) -> Maybe<MacroCallData<'db>> {
-    let inference_id = InferenceId::MacroCall(macro_call_id);
-    let module_id = macro_call_id.parent_module(db);
-    let mut resolver = Resolver::new(db, module_id, inference_id);
-    let macro_call_syntax = db.module_macro_call_by_id(macro_call_id)?;
-    // Resolve the macro call path, and report diagnostics if it finds no match or
-    // the resolved item is not a macro declaration.
-    let macro_call_path = macro_call_syntax.path(db);
-    let macro_name = macro_call_path.as_syntax_node().get_text_without_trivia(db);
-    let callsite_module_id = macro_call_id.parent_module(db);
-    // If the call is to `expose!` and no other `expose` item is locally declared - using expose.
-    if macro_name.long(db) == EXPOSE_MACRO_NAME
-        && let Ok(None) = db.module_item_by_name(callsite_module_id, macro_name)
-    {
-        let (content, mapping) = expose_content_and_mapping(db, macro_call_syntax.arguments(db))?;
-        let code_mappings: Arc<[CodeMapping]> = [mapping].into();
-        let generated_file_id = FileLongId::Virtual(VirtualFile {
-            parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),
-            name: macro_name,
-            content: SmolStrId::from(db, content),
-            code_mappings: code_mappings.clone(),
-            kind: FileKind::Module,
-            original_item_removed: false,
+    /// The initial value for the cycle handling of the query.
+    ///
+    /// Returns an empty MacroCallData with no diagnostics, to prevent infinite recursion in case
+    /// of cyclic macro calls.
+    fn cycle_initial<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        macro_call_id: MacroCallId<'db>,
+    ) -> Maybe<MacroCallData<'db>> {
+        let module_id = macro_call_id.parent_module(db);
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        let macro_call_syntax = db.module_macro_call_by_id(macro_call_id)?;
+        let macro_call_path = macro_call_syntax.path(db);
+        let macro_name = macro_call_path.as_syntax_node().get_text_without_trivia(db);
+
+        let diag_added = diagnostics.report(
+            macro_call_id.stable_ptr(db).untyped(),
+            SemanticDiagnosticKind::InlineMacroNotFound(macro_name),
+        );
+
+        Ok(MacroCallData {
+            macro_call_module: Err(diag_added),
+            diagnostics: diagnostics.build(),
+            defsite_module_id: module_id,
+            callsite_module_id: module_id,
+            expansion_mappings: Arc::new([]),
+            parent_macro_call_data: None,
         })
-        .intern(db);
-        let macro_call_module =
-            ModuleId::MacroCall { id: macro_call_id, generated_file_id, is_expose: true };
-        return Ok(MacroCallData {
-            macro_call_module: Ok(macro_call_module),
-            diagnostics: Default::default(),
-            // Defsite and callsite aren't actually used, as it defines nothing in its code.
-            defsite_module_id: callsite_module_id,
-            callsite_module_id,
-            expansion_mappings: code_mappings,
-            parent_macro_call_data: resolver.macro_call_data,
-        });
     }
-    let mut diagnostics = SemanticDiagnostics::new(callsite_module_id);
-    let macro_declaration_id = match resolver.resolve_generic_path(
-        &mut diagnostics,
-        &macro_call_path,
-        NotFoundItemType::Macro,
-        ResolutionContext::Default,
-    ) {
-        Ok(ResolvedGenericItem::Macro(macro_declaration_id)) => macro_declaration_id,
-        Ok(_) => {
+    /// The update function for the cycle handling of the query.
+    fn cycle_update<'db>(
+        _db: &'db dyn Database,
+        _cycle: &salsa::Cycle<'_>,
+        _last_provisional_value: &Maybe<MacroCallData<'db>>,
+        value: Maybe<MacroCallData<'db>>,
+        _macro_call_id: MacroCallId<'db>,
+    ) -> Maybe<MacroCallData<'db>> {
+        value
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(clone), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
+    fn priv_macro_call_data<'db>(
+        db: &'db dyn Database,
+        macro_call_id: MacroCallId<'db>,
+    ) -> Maybe<MacroCallData<'db>> {
+        let inference_id = InferenceId::MacroCall(macro_call_id);
+        let module_id = macro_call_id.parent_module(db);
+        let mut resolver = Resolver::new(db, module_id, inference_id);
+        let macro_call_syntax = db.module_macro_call_by_id(macro_call_id)?;
+        // Resolve the macro call path, and report diagnostics if it finds no match or
+        // the resolved item is not a macro declaration.
+        let macro_call_path = macro_call_syntax.path(db);
+        let macro_name = macro_call_path.as_syntax_node().get_text_without_trivia(db);
+        let callsite_module_id = macro_call_id.parent_module(db);
+        // If the call is to `expose!` and no other `expose` item is locally declared - using
+        // expose.
+        if macro_name.long(db) == EXPOSE_MACRO_NAME
+            && let Ok(None) = db.module_item_by_name(callsite_module_id, macro_name)
+        {
+            let (content, mapping) =
+                expose_content_and_mapping(db, macro_call_syntax.arguments(db))?;
+            let code_mappings: Arc<[CodeMapping]> = [mapping].into();
+            let generated_file_id = FileLongId::Virtual(VirtualFile {
+                parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),
+                name: macro_name,
+                content: SmolStrId::from(db, content),
+                code_mappings: code_mappings.clone(),
+                kind: FileKind::Module,
+                original_item_removed: false,
+            })
+            .intern(db);
+            let macro_call_module =
+                ModuleId::MacroCall { id: macro_call_id, generated_file_id, is_expose: true };
+            return Ok(MacroCallData {
+                macro_call_module: Ok(macro_call_module),
+                diagnostics: Default::default(),
+                // Defsite and callsite aren't actually used, as it defines nothing in its code.
+                defsite_module_id: callsite_module_id,
+                callsite_module_id,
+                expansion_mappings: code_mappings,
+                parent_macro_call_data: resolver.macro_call_data,
+            });
+        }
+        let mut diagnostics = SemanticDiagnostics::new(callsite_module_id);
+        let macro_declaration_id = match resolver.resolve_generic_path(
+            &mut diagnostics,
+            &macro_call_path,
+            NotFoundItemType::Macro,
+            ResolutionContext::Default,
+        ) {
+            Ok(ResolvedGenericItem::Macro(macro_declaration_id)) => macro_declaration_id,
+            Ok(_) => {
+                let diag_added = diagnostics.report(
+                    macro_call_syntax.stable_ptr(db),
+                    SemanticDiagnosticKind::InlineMacroNotFound(macro_name),
+                );
+                return Ok(MacroCallData {
+                    macro_call_module: Err(diag_added),
+                    diagnostics: diagnostics.build(),
+                    defsite_module_id: callsite_module_id,
+                    callsite_module_id,
+                    expansion_mappings: Arc::new([]),
+                    parent_macro_call_data: resolver.macro_call_data,
+                });
+            }
+            Err(diag_added) => {
+                return Ok(MacroCallData {
+                    macro_call_module: Err(diag_added),
+                    diagnostics: diagnostics.build(),
+                    defsite_module_id: callsite_module_id,
+                    callsite_module_id,
+                    expansion_mappings: Arc::new([]),
+                    parent_macro_call_data: resolver.macro_call_data,
+                });
+            }
+        };
+        let defsite_module_id = macro_declaration_id.parent_module(db);
+        let parent_macro_call_data = resolver.macro_call_data;
+        let macro_rules = match db.macro_declaration_rules(macro_declaration_id) {
+            Ok(rules) => rules,
+            Err(diag_added) => {
+                return Ok(MacroCallData {
+                    macro_call_module: Err(diag_added),
+                    diagnostics: diagnostics.build(),
+                    defsite_module_id,
+                    callsite_module_id,
+                    expansion_mappings: Arc::new([]),
+                    parent_macro_call_data,
+                });
+            }
+        };
+        let Some((rule, (captures, placeholder_to_rep_id))) = macro_rules.iter().find_map(|rule| {
+            is_macro_rule_match(db, rule, &macro_call_syntax.arguments(db)).map(|res| (rule, res))
+        }) else {
             let diag_added = diagnostics.report(
                 macro_call_syntax.stable_ptr(db),
-                SemanticDiagnosticKind::InlineMacroNotFound(macro_name),
+                SemanticDiagnosticKind::InlineMacroNoMatchingRule(macro_name),
             );
             return Ok(MacroCallData {
                 macro_call_module: Err(diag_added),
                 diagnostics: diagnostics.build(),
-                defsite_module_id: callsite_module_id,
+                defsite_module_id,
                 callsite_module_id,
                 expansion_mappings: Arc::new([]),
-                parent_macro_call_data: resolver.macro_call_data,
+                parent_macro_call_data,
             });
-        }
-        Err(diag_added) => {
-            return Ok(MacroCallData {
-                macro_call_module: Err(diag_added),
-                diagnostics: diagnostics.build(),
-                defsite_module_id: callsite_module_id,
-                callsite_module_id,
-                expansion_mappings: Arc::new([]),
-                parent_macro_call_data: resolver.macro_call_data,
-            });
-        }
-    };
-    let defsite_module_id = macro_declaration_id.parent_module(db);
-    let parent_macro_call_data = resolver.macro_call_data;
-    let macro_rules = match db.macro_declaration_rules(macro_declaration_id) {
-        Ok(rules) => rules,
-        Err(diag_added) => {
+        };
+        // If the rule has declaration-time errors, skip expansion to avoid panics on malformed
+        // rules.
+        if let Err(diag_added) = rule.err {
             return Ok(MacroCallData {
                 macro_call_module: Err(diag_added),
                 diagnostics: diagnostics.build(),
@@ -122,63 +198,29 @@ fn priv_macro_call_data<'db>(
                 parent_macro_call_data,
             });
         }
-    };
-    let Some((rule, (captures, placeholder_to_rep_id))) = macro_rules.iter().find_map(|rule| {
-        is_macro_rule_match(db, rule, &macro_call_syntax.arguments(db)).map(|res| (rule, res))
-    }) else {
-        let diag_added = diagnostics.report(
-            macro_call_syntax.stable_ptr(db),
-            SemanticDiagnosticKind::InlineMacroNoMatchingRule(macro_name),
-        );
-        return Ok(MacroCallData {
-            macro_call_module: Err(diag_added),
+        let mut matcher_ctx =
+            MatcherContext { captures, placeholder_to_rep_id, ..Default::default() };
+        let expanded_code = expand_macro_rule(db, rule, &mut matcher_ctx).unwrap();
+        let generated_file_id = FileLongId::Virtual(VirtualFile {
+            parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),
+            name: macro_name,
+            content: SmolStrId::from_arcstr(db, &expanded_code.text),
+            code_mappings: expanded_code.code_mappings.clone(),
+            kind: FileKind::Module,
+            original_item_removed: false,
+        })
+        .intern(db);
+        let macro_call_module =
+            ModuleId::MacroCall { id: macro_call_id, generated_file_id, is_expose: false };
+        Ok(MacroCallData {
+            macro_call_module: Ok(macro_call_module),
             diagnostics: diagnostics.build(),
             defsite_module_id,
             callsite_module_id,
-            expansion_mappings: Arc::new([]),
+            expansion_mappings: expanded_code.code_mappings,
             parent_macro_call_data,
-        });
-    };
-    // If the rule has declaration-time errors, skip expansion to avoid panics on malformed rules.
-    if let Err(diag_added) = rule.err {
-        return Ok(MacroCallData {
-            macro_call_module: Err(diag_added),
-            diagnostics: diagnostics.build(),
-            defsite_module_id,
-            callsite_module_id,
-            expansion_mappings: Arc::new([]),
-            parent_macro_call_data,
-        });
+        })
     }
-    let mut matcher_ctx = MatcherContext { captures, placeholder_to_rep_id, ..Default::default() };
-    let expanded_code = expand_macro_rule(db, rule, &mut matcher_ctx).unwrap();
-    let generated_file_id = FileLongId::Virtual(VirtualFile {
-        parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),
-        name: macro_name,
-        content: SmolStrId::from_arcstr(db, &expanded_code.text),
-        code_mappings: expanded_code.code_mappings.clone(),
-        kind: FileKind::Module,
-        original_item_removed: false,
-    })
-    .intern(db);
-    let macro_call_module =
-        ModuleId::MacroCall { id: macro_call_id, generated_file_id, is_expose: false };
-    Ok(MacroCallData {
-        macro_call_module: Ok(macro_call_module),
-        diagnostics: diagnostics.build(),
-        defsite_module_id,
-        callsite_module_id,
-        expansion_mappings: expanded_code.code_mappings,
-        parent_macro_call_data,
-    })
-}
-
-/// Query implementation of [MacroCallSemantic::priv_macro_call_data].
-#[salsa::tracked(returns(clone), cycle_fn=priv_macro_call_data_cycle, cycle_initial=priv_macro_call_data_initial)]
-fn priv_macro_call_data_tracked<'db>(
-    db: &'db dyn Database,
-    macro_call_id: MacroCallId<'db>,
-) -> Maybe<MacroCallData<'db>> {
     priv_macro_call_data(db, macro_call_id)
 }
 
@@ -208,46 +250,6 @@ pub fn expose_content_and_mapping<'db>(
     ))
 }
 
-/// Cycle handling for [MacroCallSemantic::priv_macro_call_data].
-fn priv_macro_call_data_cycle<'db>(
-    _db: &'db dyn Database,
-    _cycle: &salsa::Cycle<'_>,
-    _last_provisional_value: &Maybe<MacroCallData<'db>>,
-    value: Maybe<MacroCallData<'db>>,
-    _macro_call_id: MacroCallId<'db>,
-) -> Maybe<MacroCallData<'db>> {
-    value
-}
-
-/// Cycle handling for [MacroCallSemantic::priv_macro_call_data].
-fn priv_macro_call_data_initial<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    macro_call_id: MacroCallId<'db>,
-) -> Maybe<MacroCallData<'db>> {
-    // If we are in a cycle, we return an empty MacroCallData with no diagnostics.
-    // This is to prevent infinite recursion in case of cyclic macro calls.
-    let module_id = macro_call_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let macro_call_syntax = db.module_macro_call_by_id(macro_call_id)?;
-    let macro_call_path = macro_call_syntax.path(db);
-    let macro_name = macro_call_path.as_syntax_node().get_text_without_trivia(db);
-
-    let diag_added = diagnostics.report(
-        macro_call_id.stable_ptr(db).untyped(),
-        SemanticDiagnosticKind::InlineMacroNotFound(macro_name),
-    );
-
-    Ok(MacroCallData {
-        macro_call_module: Err(diag_added),
-        diagnostics: diagnostics.build(),
-        defsite_module_id: module_id,
-        callsite_module_id: module_id,
-        expansion_mappings: Arc::new([]),
-        parent_macro_call_data: None,
-    })
-}
-
 /// Implementation of [MacroCallSemantic::macro_call_diagnostics].
 fn macro_call_diagnostics<'db>(
     db: &'db dyn Database,
@@ -265,40 +267,38 @@ fn macro_call_diagnostics_tracked<'db>(
     macro_call_diagnostics(db, macro_call_id)
 }
 
-/// Implementation of [MacroCallSemantic::macro_call_module_id].
+/// Query implementation of [MacroCallSemantic::macro_call_module_id].
 fn macro_call_module_id<'db>(
     db: &'db dyn Database,
     macro_call_id: MacroCallId<'db>,
 ) -> Maybe<ModuleId<'db>> {
-    db.priv_macro_call_data(macro_call_id)?.macro_call_module
-}
-
-/// Query implementation of [MacroCallSemantic::macro_call_module_id].
-#[salsa::tracked(returns(copy), cycle_fn=macro_call_module_id_cycle, cycle_initial=macro_call_module_id_initial)]
-fn macro_call_module_id_tracked<'db>(
-    db: &'db dyn Database,
-    macro_call_id: MacroCallId<'db>,
-) -> Maybe<ModuleId<'db>> {
+    /// The initial value for the cycle handling of the query.
+    fn cycle_initial<'db>(
+        _db: &'db dyn Database,
+        _id: salsa::Id,
+        _macro_call_id: MacroCallId<'db>,
+    ) -> Maybe<ModuleId<'db>> {
+        Err(skip_diagnostic())
+    }
+    /// The update function for the cycle handling of the query.
+    fn cycle_update<'db>(
+        _db: &'db dyn Database,
+        _cycle: &salsa::Cycle<'_>,
+        _last_provisional_value: &Maybe<ModuleId<'db>>,
+        value: Maybe<ModuleId<'db>>,
+        _macro_call_id: MacroCallId<'db>,
+    ) -> Maybe<ModuleId<'db>> {
+        value
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(copy), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
+    fn macro_call_module_id<'db>(
+        db: &'db dyn Database,
+        macro_call_id: MacroCallId<'db>,
+    ) -> Maybe<ModuleId<'db>> {
+        db.priv_macro_call_data(macro_call_id)?.macro_call_module
+    }
     macro_call_module_id(db, macro_call_id)
-}
-
-/// Cycle handling for [MacroCallSemantic::macro_call_module_id].
-fn macro_call_module_id_cycle<'db>(
-    _db: &'db dyn Database,
-    _cycle: &salsa::Cycle<'_>,
-    _last_provisional_value: &Maybe<ModuleId<'db>>,
-    value: Maybe<ModuleId<'db>>,
-    _macro_call_id: MacroCallId<'db>,
-) -> Maybe<ModuleId<'db>> {
-    value
-}
-/// Cycle handling for [MacroCallSemantic::macro_call_module_id].
-fn macro_call_module_id_initial<'db>(
-    _db: &'db dyn Database,
-    _id: salsa::Id,
-    _macro_call_id: MacroCallId<'db>,
-) -> Maybe<ModuleId<'db>> {
-    Err(skip_diagnostic())
 }
 
 /// Returns the modules that are considered a part of this module.
@@ -358,11 +358,11 @@ pub trait MacroCallSemantic<'db>: Database {
         &'db self,
         macro_call_id: MacroCallId<'db>,
     ) -> Maybe<MacroCallData<'db>> {
-        priv_macro_call_data_tracked(self.as_dyn_database(), macro_call_id)
+        priv_macro_call_data(self.as_dyn_database(), macro_call_id)
     }
     /// Returns the expansion result of a macro call.
     fn macro_call_module_id(&'db self, macro_call_id: MacroCallId<'db>) -> Maybe<ModuleId<'db>> {
-        macro_call_module_id_tracked(self.as_dyn_database(), macro_call_id)
+        macro_call_module_id(self.as_dyn_database(), macro_call_id)
     }
     /// Returns the semantic diagnostics of a macro call.
     fn macro_call_diagnostics(

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -80,7 +80,7 @@ fn priv_macro_call_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(clone), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
-    fn priv_macro_call_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         macro_call_id: MacroCallId<'db>,
     ) -> Maybe<MacroCallData<'db>> {
@@ -221,7 +221,7 @@ fn priv_macro_call_data<'db>(
             parent_macro_call_data,
         })
     }
-    priv_macro_call_data(db, macro_call_id)
+    query(db, macro_call_id)
 }
 
 /// The name of the `expose!` macro.
@@ -292,13 +292,10 @@ fn macro_call_module_id<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(copy), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
-    fn macro_call_module_id<'db>(
-        db: &'db dyn Database,
-        macro_call_id: MacroCallId<'db>,
-    ) -> Maybe<ModuleId<'db>> {
+    fn query<'db>(db: &'db dyn Database, macro_call_id: MacroCallId<'db>) -> Maybe<ModuleId<'db>> {
         db.priv_macro_call_data(macro_call_id)?.macro_call_module
     }
-    macro_call_module_id(db, macro_call_id)
+    query(db, macro_call_id)
 }
 
 /// Returns the modules that are considered a part of this module.

--- a/crates/cairo-lang-semantic/src/items/module_type_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/module_type_alias.rs
@@ -29,6 +29,25 @@ fn module_type_alias_semantic_data<'db>(
     db: &'db dyn Database,
     module_type_alias_id: ModuleTypeAliasId<'db>,
 ) -> Maybe<ModuleTypeAliasData<'db>> {
+    module_type_alias_semantic_data_inner(db, module_type_alias_id, false)
+}
+
+/// Cycle handling for [module_type_alias_semantic_data].
+fn module_type_alias_semantic_data_cycle<'db>(
+    db: &'db dyn Database,
+    _id: salsa::Id,
+    module_type_alias_id: ModuleTypeAliasId<'db>,
+) -> Maybe<ModuleTypeAliasData<'db>> {
+    module_type_alias_semantic_data_inner(db, module_type_alias_id, true)
+}
+
+/// Shared code for the query and cycle handling of [module_type_alias_semantic_data].
+/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+fn module_type_alias_semantic_data_inner<'db>(
+    db: &'db dyn Database,
+    module_type_alias_id: ModuleTypeAliasId<'db>,
+    in_cycle: bool,
+) -> Maybe<ModuleTypeAliasData<'db>> {
     let module_id = module_type_alias_id.parent_module(db);
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
     // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
@@ -41,37 +60,23 @@ fn module_type_alias_semantic_data<'db>(
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::TypeAlias(module_type_alias_id));
 
     let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let type_alias_data = type_alias_semantic_data_helper(
-        db,
-        &mut diagnostics,
-        module_type_alias_ast,
-        lookup_item_id,
-        generic_params_data,
-    )?;
-    Ok(ModuleTypeAliasData { type_alias_data, diagnostics: diagnostics.build() })
-}
-
-/// Cycle handling for [module_type_alias_semantic_data].
-fn module_type_alias_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    module_type_alias_id: ModuleTypeAliasId<'db>,
-) -> Maybe<ModuleTypeAliasData<'db>> {
-    let module_id = module_type_alias_id.parent_module(db);
-    let module_type_aliases = module_id.module_data(db)?.type_aliases(db);
-    let module_type_alias_ast = module_type_aliases.get(&module_type_alias_id).to_maybe()?;
-    let generic_params_data =
-        module_type_alias_generic_params_data(db, module_type_alias_id).maybe_as_ref()?.clone();
-    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::TypeAlias(module_type_alias_id));
-
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let type_alias_data = type_alias_semantic_data_cycle_helper(
-        db,
-        &mut diagnostics,
-        module_type_alias_ast,
-        lookup_item_id,
-        generic_params_data,
-    )?;
+    let type_alias_data = if in_cycle {
+        type_alias_semantic_data_cycle_helper(
+            db,
+            &mut diagnostics,
+            module_type_alias_ast,
+            lookup_item_id,
+            generic_params_data,
+        )?
+    } else {
+        type_alias_semantic_data_helper(
+            db,
+            &mut diagnostics,
+            module_type_alias_ast,
+            lookup_item_id,
+            generic_params_data,
+        )?
+    };
     Ok(ModuleTypeAliasData { type_alias_data, diagnostics: diagnostics.build() })
 }
 

--- a/crates/cairo-lang-semantic/src/items/module_type_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/module_type_alias.rs
@@ -77,13 +77,13 @@ fn module_type_alias_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn module_type_alias_semantic_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         module_type_alias_id: ModuleTypeAliasId<'db>,
     ) -> Maybe<ModuleTypeAliasData<'db>> {
         calc(db, module_type_alias_id, false)
     }
-    module_type_alias_semantic_data(db, module_type_alias_id)
+    query(db, module_type_alias_id)
 }
 
 /// Returns the generic parameters data of a type alias.

--- a/crates/cairo-lang-semantic/src/items/module_type_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/module_type_alias.rs
@@ -28,7 +28,6 @@ struct ModuleTypeAliasData<'db> {
 fn module_type_alias_semantic_data<'db>(
     db: &'db dyn Database,
     module_type_alias_id: ModuleTypeAliasId<'db>,
-    in_cycle: bool,
 ) -> Maybe<ModuleTypeAliasData<'db>> {
     let module_id = module_type_alias_id.parent_module(db);
     // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
@@ -42,23 +41,13 @@ fn module_type_alias_semantic_data<'db>(
     let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::TypeAlias(module_type_alias_id));
 
     let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let type_alias_data = if in_cycle {
-        type_alias_semantic_data_cycle_helper(
-            db,
-            &mut diagnostics,
-            module_type_alias_ast,
-            lookup_item_id,
-            generic_params_data,
-        )?
-    } else {
-        type_alias_semantic_data_helper(
-            db,
-            &mut diagnostics,
-            module_type_alias_ast,
-            lookup_item_id,
-            generic_params_data,
-        )?
-    };
+    let type_alias_data = type_alias_semantic_data_helper(
+        db,
+        &mut diagnostics,
+        module_type_alias_ast,
+        lookup_item_id,
+        generic_params_data,
+    )?;
     Ok(ModuleTypeAliasData { type_alias_data, diagnostics: diagnostics.build() })
 }
 
@@ -67,9 +56,23 @@ fn module_type_alias_semantic_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     module_type_alias_id: ModuleTypeAliasId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<ModuleTypeAliasData<'db>> {
-    module_type_alias_semantic_data(db, module_type_alias_id, true).clone()
+    let module_id = module_type_alias_id.parent_module(db);
+    let module_type_aliases = module_id.module_data(db)?.type_aliases(db);
+    let module_type_alias_ast = module_type_aliases.get(&module_type_alias_id).to_maybe()?;
+    let generic_params_data =
+        module_type_alias_generic_params_data(db, module_type_alias_id).maybe_as_ref()?.clone();
+    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::TypeAlias(module_type_alias_id));
+
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
+    let type_alias_data = type_alias_semantic_data_cycle_helper(
+        db,
+        &mut diagnostics,
+        module_type_alias_ast,
+        lookup_item_id,
+        generic_params_data,
+    )?;
+    Ok(ModuleTypeAliasData { type_alias_data, diagnostics: diagnostics.build() })
 }
 
 /// Returns the generic parameters data of a type alias.
@@ -92,7 +95,7 @@ pub trait ModuleTypeAliasSemantic<'db>: Database {
         &'db self,
         id: ModuleTypeAliasId<'db>,
     ) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
-        module_type_alias_semantic_data(self.as_dyn_database(), id, false)
+        module_type_alias_semantic_data(self.as_dyn_database(), id)
             .as_ref()
             .map(|data| data.diagnostics.clone())
             .unwrap_or_default()
@@ -102,7 +105,7 @@ pub trait ModuleTypeAliasSemantic<'db>: Database {
         &'db self,
         id: ModuleTypeAliasId<'db>,
     ) -> Maybe<TypeId<'db>> {
-        module_type_alias_semantic_data(self.as_dyn_database(), id, false)
+        module_type_alias_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .type_alias_data
             .resolved_type
@@ -122,7 +125,7 @@ pub trait ModuleTypeAliasSemantic<'db>: Database {
         &'db self,
         id: ModuleTypeAliasId<'db>,
     ) -> Maybe<Arc<ResolverData<'db>>> {
-        Ok(module_type_alias_semantic_data(self.as_dyn_database(), id, false)
+        Ok(module_type_alias_semantic_data(self.as_dyn_database(), id)
             .maybe_as_ref()?
             .type_alias_data
             .resolver_data

--- a/crates/cairo-lang-semantic/src/items/module_type_alias.rs
+++ b/crates/cairo-lang-semantic/src/items/module_type_alias.rs
@@ -24,60 +24,66 @@ struct ModuleTypeAliasData<'db> {
 }
 
 /// Returns the data of a type alias.
-#[salsa::tracked(cycle_result=module_type_alias_semantic_data_cycle, returns(ref))]
 fn module_type_alias_semantic_data<'db>(
     db: &'db dyn Database,
     module_type_alias_id: ModuleTypeAliasId<'db>,
-) -> Maybe<ModuleTypeAliasData<'db>> {
-    module_type_alias_semantic_data_inner(db, module_type_alias_id, false)
-}
+) -> &'db Maybe<ModuleTypeAliasData<'db>> {
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        module_type_alias_id: ModuleTypeAliasId<'db>,
+        in_cycle: bool,
+    ) -> Maybe<ModuleTypeAliasData<'db>> {
+        let module_id = module_type_alias_id.parent_module(db);
+        // TODO(spapini): when code changes in a file, all the AST items change (as they contain a
+        // path to the green root that changes. Once ASTs are rooted on items, use a selector
+        // that picks only the item instead of all the module data.
+        // TODO(spapini): Add generic args when they are supported on structs.
+        let module_type_aliases = module_id.module_data(db)?.type_aliases(db);
+        let module_type_alias_ast = module_type_aliases.get(&module_type_alias_id).to_maybe()?;
+        let generic_params_data =
+            module_type_alias_generic_params_data(db, module_type_alias_id).maybe_as_ref()?.clone();
+        let lookup_item_id =
+            LookupItemId::ModuleItem(ModuleItemId::TypeAlias(module_type_alias_id));
 
-/// Cycle handling for [module_type_alias_semantic_data].
-fn module_type_alias_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    module_type_alias_id: ModuleTypeAliasId<'db>,
-) -> Maybe<ModuleTypeAliasData<'db>> {
-    module_type_alias_semantic_data_inner(db, module_type_alias_id, true)
-}
-
-/// Shared code for the query and cycle handling of [module_type_alias_semantic_data].
-/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
-fn module_type_alias_semantic_data_inner<'db>(
-    db: &'db dyn Database,
-    module_type_alias_id: ModuleTypeAliasId<'db>,
-    in_cycle: bool,
-) -> Maybe<ModuleTypeAliasData<'db>> {
-    let module_id = module_type_alias_id.parent_module(db);
-    // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
-    // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
-    // the item instead of all the module data.
-    // TODO(spapini): Add generic args when they are supported on structs.
-    let module_type_aliases = module_id.module_data(db)?.type_aliases(db);
-    let module_type_alias_ast = module_type_aliases.get(&module_type_alias_id).to_maybe()?;
-    let generic_params_data =
-        module_type_alias_generic_params_data(db, module_type_alias_id).maybe_as_ref()?.clone();
-    let lookup_item_id = LookupItemId::ModuleItem(ModuleItemId::TypeAlias(module_type_alias_id));
-
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let type_alias_data = if in_cycle {
-        type_alias_semantic_data_cycle_helper(
-            db,
-            &mut diagnostics,
-            module_type_alias_ast,
-            lookup_item_id,
-            generic_params_data,
-        )?
-    } else {
-        type_alias_semantic_data_helper(
-            db,
-            &mut diagnostics,
-            module_type_alias_ast,
-            lookup_item_id,
-            generic_params_data,
-        )?
-    };
-    Ok(ModuleTypeAliasData { type_alias_data, diagnostics: diagnostics.build() })
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        let type_alias_data = if in_cycle {
+            type_alias_semantic_data_cycle_helper(
+                db,
+                &mut diagnostics,
+                module_type_alias_ast,
+                lookup_item_id,
+                generic_params_data,
+            )?
+        } else {
+            type_alias_semantic_data_helper(
+                db,
+                &mut diagnostics,
+                module_type_alias_ast,
+                lookup_item_id,
+                generic_params_data,
+            )?
+        };
+        Ok(ModuleTypeAliasData { type_alias_data, diagnostics: diagnostics.build() })
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        module_type_alias_id: ModuleTypeAliasId<'db>,
+    ) -> Maybe<ModuleTypeAliasData<'db>> {
+        calc(db, module_type_alias_id, true)
+    }
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn module_type_alias_semantic_data<'db>(
+        db: &'db dyn Database,
+        module_type_alias_id: ModuleTypeAliasId<'db>,
+    ) -> Maybe<ModuleTypeAliasData<'db>> {
+        calc(db, module_type_alias_id, false)
+    }
+    module_type_alias_semantic_data(db, module_type_alias_id)
 }
 
 /// Returns the generic parameters data of a type alias.

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -30,6 +30,7 @@ use super::functions::{
 };
 use super::generics::{
     GenericParamsData, displayable_concrete, generic_params_to_args, semantic_generic_params,
+    semantic_generic_params_ex,
 };
 use super::imp::{GenericsHeadFilter, ImplLongId, TraitFilter};
 use crate::db::get_resolver_data_options;
@@ -292,11 +293,13 @@ struct TraitDeclarationData<'db> {
     resolver_data: Arc<ResolverData<'db>>,
 }
 
-/// Query implementation of [PrivTraitSemantic::trait_generic_params_data].
-#[salsa::tracked(cycle_result=trait_generic_params_data_cycle, returns(ref))]
-fn trait_generic_params_data_tracked<'db>(
+/// Shared code for the query and cycle handling of
+/// [PrivTraitSemantic::trait_generic_params_data].
+/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+fn trait_generic_params_data<'db>(
     db: &'db dyn Database,
     trait_id: TraitId<'db>,
+    in_cycle: bool,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = trait_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::new(module_id);
@@ -307,12 +310,13 @@ fn trait_generic_params_data_tracked<'db>(
         InferenceId::LookupItemGenerics(LookupItemId::ModuleItem(ModuleItemId::Trait(trait_id)));
     let mut resolver = Resolver::new(db, module_id, inference_id);
     resolver.set_feature_config(&trait_id, &trait_ast, &mut diagnostics);
-    let generic_params = semantic_generic_params(
+    let generic_params = semantic_generic_params_ex(
         db,
         &mut diagnostics,
         &mut resolver,
         module_id,
         &trait_ast.generic_params(db),
+        in_cycle,
     );
 
     let inference = &mut resolver.inference();
@@ -323,28 +327,22 @@ fn trait_generic_params_data_tracked<'db>(
     Ok(GenericParamsData { diagnostics: diagnostics.build(), generic_params, resolver_data })
 }
 
+/// Query implementation of [PrivTraitSemantic::trait_generic_params_data].
+#[salsa::tracked(cycle_result=trait_generic_params_data_cycle, returns(ref))]
+fn trait_generic_params_data_tracked<'db>(
+    db: &'db dyn Database,
+    trait_id: TraitId<'db>,
+) -> Maybe<GenericParamsData<'db>> {
+    trait_generic_params_data(db, trait_id, false)
+}
+
 /// Cycle handling for [PrivTraitSemantic::trait_generic_params_data].
 fn trait_generic_params_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     trait_id: TraitId<'db>,
 ) -> Maybe<GenericParamsData<'db>> {
-    let module_id = trait_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let trait_ast = db.module_trait_by_id(trait_id)?;
-    let inference_id =
-        InferenceId::LookupItemGenerics(LookupItemId::ModuleItem(ModuleItemId::Trait(trait_id)));
-    let mut resolver = Resolver::new(db, module_id, inference_id);
-    resolver.set_feature_config(&trait_id, &trait_ast, &mut diagnostics);
-    for generic_param_id in db.trait_generic_params_ids(trait_id)? {
-        resolver.add_generic_param(*generic_param_id);
-        diagnostics.report(generic_param_id.stable_ptr(db).untyped(), ImplRequirementCycle);
-    }
-    Ok(GenericParamsData {
-        diagnostics: diagnostics.build(),
-        generic_params: vec![],
-        resolver_data: Arc::new(resolver.data),
-    })
+    trait_generic_params_data(db, trait_id, true)
 }
 
 /// Query implementation of [TraitSemantic::trait_generic_params_ids].

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -341,13 +341,10 @@ fn trait_generic_params_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(cycle_result=cycle, returns(ref))]
-    fn trait_generic_params_data<'db>(
-        db: &'db dyn Database,
-        trait_id: TraitId<'db>,
-    ) -> Maybe<GenericParamsData<'db>> {
+    fn query<'db>(db: &'db dyn Database, trait_id: TraitId<'db>) -> Maybe<GenericParamsData<'db>> {
         calc(db, trait_id, false)
     }
-    trait_generic_params_data(db, trait_id)
+    query(db, trait_id)
 }
 
 /// Query implementation of [TraitSemantic::trait_generic_params_ids].

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -293,56 +293,61 @@ struct TraitDeclarationData<'db> {
     resolver_data: Arc<ResolverData<'db>>,
 }
 
-/// Shared code for the query and cycle handling of
-/// [PrivTraitSemantic::trait_generic_params_data].
-/// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+/// Returns the generic parameters data of a trait.
 fn trait_generic_params_data<'db>(
     db: &'db dyn Database,
     trait_id: TraitId<'db>,
-    in_cycle: bool,
-) -> Maybe<GenericParamsData<'db>> {
-    let module_id = trait_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let trait_ast = db.module_trait_by_id(trait_id)?;
+) -> &'db Maybe<GenericParamsData<'db>> {
+    /// Shared code for the query and cycle handling.
+    /// The cycle handling logic needs to pass in_cycle=true to prevent the cycle.
+    fn calc<'db>(
+        db: &'db dyn Database,
+        trait_id: TraitId<'db>,
+        in_cycle: bool,
+    ) -> Maybe<GenericParamsData<'db>> {
+        let module_id = trait_id.parent_module(db);
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        let trait_ast = db.module_trait_by_id(trait_id)?;
 
-    // Generic params.
-    let inference_id =
-        InferenceId::LookupItemGenerics(LookupItemId::ModuleItem(ModuleItemId::Trait(trait_id)));
-    let mut resolver = Resolver::new(db, module_id, inference_id);
-    resolver.set_feature_config(&trait_id, &trait_ast, &mut diagnostics);
-    let generic_params = semantic_generic_params_ex(
-        db,
-        &mut diagnostics,
-        &mut resolver,
-        module_id,
-        &trait_ast.generic_params(db),
-        in_cycle,
-    );
+        // Generic params.
+        let inference_id = InferenceId::LookupItemGenerics(LookupItemId::ModuleItem(
+            ModuleItemId::Trait(trait_id),
+        ));
+        let mut resolver = Resolver::new(db, module_id, inference_id);
+        resolver.set_feature_config(&trait_id, &trait_ast, &mut diagnostics);
+        let generic_params = semantic_generic_params_ex(
+            db,
+            &mut diagnostics,
+            &mut resolver,
+            module_id,
+            &trait_ast.generic_params(db),
+            in_cycle,
+        );
 
-    let inference = &mut resolver.inference();
-    inference.finalize(&mut diagnostics, trait_ast.stable_ptr(db).untyped());
+        let inference = &mut resolver.inference();
+        inference.finalize(&mut diagnostics, trait_ast.stable_ptr(db).untyped());
 
-    let generic_params = inference.rewrite(generic_params).no_err();
-    let resolver_data = Arc::new(resolver.data);
-    Ok(GenericParamsData { diagnostics: diagnostics.build(), generic_params, resolver_data })
-}
-
-/// Query implementation of [PrivTraitSemantic::trait_generic_params_data].
-#[salsa::tracked(cycle_result=trait_generic_params_data_cycle, returns(ref))]
-fn trait_generic_params_data_tracked<'db>(
-    db: &'db dyn Database,
-    trait_id: TraitId<'db>,
-) -> Maybe<GenericParamsData<'db>> {
-    trait_generic_params_data(db, trait_id, false)
-}
-
-/// Cycle handling for [PrivTraitSemantic::trait_generic_params_data].
-fn trait_generic_params_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    trait_id: TraitId<'db>,
-) -> Maybe<GenericParamsData<'db>> {
-    trait_generic_params_data(db, trait_id, true)
+        let generic_params = inference.rewrite(generic_params).no_err();
+        let resolver_data = Arc::new(resolver.data);
+        Ok(GenericParamsData { diagnostics: diagnostics.build(), generic_params, resolver_data })
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        trait_id: TraitId<'db>,
+    ) -> Maybe<GenericParamsData<'db>> {
+        calc(db, trait_id, true)
+    }
+    /// Query implementation.
+    #[salsa::tracked(cycle_result=cycle, returns(ref))]
+    fn trait_generic_params_data<'db>(
+        db: &'db dyn Database,
+        trait_id: TraitId<'db>,
+    ) -> Maybe<GenericParamsData<'db>> {
+        calc(db, trait_id, false)
+    }
+    trait_generic_params_data(db, trait_id)
 }
 
 /// Query implementation of [TraitSemantic::trait_generic_params_ids].
@@ -1493,7 +1498,7 @@ trait PrivTraitSemantic<'db>: Database {
         &'db self,
         trait_id: TraitId<'db>,
     ) -> Maybe<&'db GenericParamsData<'db>> {
-        trait_generic_params_data_tracked(self.as_dyn_database(), trait_id).maybe_as_ref()
+        trait_generic_params_data(self.as_dyn_database(), trait_id).maybe_as_ref()
     }
     /// Private query to compute declaration data about a trait.
     fn priv_trait_declaration_data(

--- a/crates/cairo-lang-semantic/src/items/trt.rs
+++ b/crates/cairo-lang-semantic/src/items/trt.rs
@@ -30,7 +30,6 @@ use super::functions::{
 };
 use super::generics::{
     GenericParamsData, displayable_concrete, generic_params_to_args, semantic_generic_params,
-    semantic_generic_params_ex,
 };
 use super::imp::{GenericsHeadFilter, ImplLongId, TraitFilter};
 use crate::db::get_resolver_data_options;
@@ -293,11 +292,11 @@ struct TraitDeclarationData<'db> {
     resolver_data: Arc<ResolverData<'db>>,
 }
 
-/// Implementation of [PrivTraitSemantic::trait_generic_params_data].
-fn trait_generic_params_data<'db>(
+/// Query implementation of [PrivTraitSemantic::trait_generic_params_data].
+#[salsa::tracked(cycle_result=trait_generic_params_data_cycle, returns(ref))]
+fn trait_generic_params_data_tracked<'db>(
     db: &'db dyn Database,
     trait_id: TraitId<'db>,
-    in_cycle: bool,
 ) -> Maybe<GenericParamsData<'db>> {
     let module_id = trait_id.parent_module(db);
     let mut diagnostics = SemanticDiagnostics::new(module_id);
@@ -308,13 +307,12 @@ fn trait_generic_params_data<'db>(
         InferenceId::LookupItemGenerics(LookupItemId::ModuleItem(ModuleItemId::Trait(trait_id)));
     let mut resolver = Resolver::new(db, module_id, inference_id);
     resolver.set_feature_config(&trait_id, &trait_ast, &mut diagnostics);
-    let generic_params = semantic_generic_params_ex(
+    let generic_params = semantic_generic_params(
         db,
         &mut diagnostics,
         &mut resolver,
         module_id,
         &trait_ast.generic_params(db),
-        in_cycle,
     );
 
     let inference = &mut resolver.inference();
@@ -325,25 +323,28 @@ fn trait_generic_params_data<'db>(
     Ok(GenericParamsData { diagnostics: diagnostics.build(), generic_params, resolver_data })
 }
 
-/// Query implementation of [TraitSemantic::trait_generic_params_data].
-#[salsa::tracked(cycle_result=trait_generic_params_data_cycle, returns(ref))]
-fn trait_generic_params_data_tracked<'db>(
-    db: &'db dyn Database,
-    trait_id: TraitId<'db>,
-    in_cycle: bool,
-) -> Maybe<GenericParamsData<'db>> {
-    trait_generic_params_data(db, trait_id, in_cycle)
-}
-
 /// Cycle handling for [PrivTraitSemantic::trait_generic_params_data].
 fn trait_generic_params_data_cycle<'db>(
     db: &'db dyn Database,
     _id: salsa::Id,
     trait_id: TraitId<'db>,
-    _in_cycle: bool,
 ) -> Maybe<GenericParamsData<'db>> {
-    // Forwarding cycle handling to `priv_generic_param_data` handler.
-    trait_generic_params_data(db, trait_id, true)
+    let module_id = trait_id.parent_module(db);
+    let mut diagnostics = SemanticDiagnostics::new(module_id);
+    let trait_ast = db.module_trait_by_id(trait_id)?;
+    let inference_id =
+        InferenceId::LookupItemGenerics(LookupItemId::ModuleItem(ModuleItemId::Trait(trait_id)));
+    let mut resolver = Resolver::new(db, module_id, inference_id);
+    resolver.set_feature_config(&trait_id, &trait_ast, &mut diagnostics);
+    for generic_param_id in db.trait_generic_params_ids(trait_id)? {
+        resolver.add_generic_param(*generic_param_id);
+        diagnostics.report(generic_param_id.stable_ptr(db).untyped(), ImplRequirementCycle);
+    }
+    Ok(GenericParamsData {
+        diagnostics: diagnostics.build(),
+        generic_params: vec![],
+        resolver_data: Arc::new(resolver.data),
+    })
 }
 
 /// Query implementation of [TraitSemantic::trait_generic_params_ids].
@@ -383,7 +384,7 @@ fn priv_trait_declaration_data<'db>(
     let trait_ast = db.module_trait_by_id(trait_id)?;
 
     // Generic params.
-    let generic_params_data = db.trait_generic_params_data(trait_id, false)?;
+    let generic_params_data = db.trait_generic_params_data(trait_id)?;
     let inference_id =
         InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(ModuleItemId::Trait(trait_id)));
     let mut resolver = Resolver::with_data(
@@ -1185,7 +1186,7 @@ pub trait TraitSemantic<'db>: Database {
     }
     /// Returns the generic parameters of a trait.
     fn trait_generic_params(&'db self, trait_id: TraitId<'db>) -> Maybe<&'db [GenericParam<'db>]> {
-        Ok(&self.trait_generic_params_data(trait_id, false)?.generic_params)
+        Ok(&self.trait_generic_params_data(trait_id)?.generic_params)
     }
     /// Returns the ids of the generic parameters of a trait.
     fn trait_generic_params_ids(
@@ -1493,9 +1494,8 @@ trait PrivTraitSemantic<'db>: Database {
     fn trait_generic_params_data(
         &'db self,
         trait_id: TraitId<'db>,
-        in_cycle: bool,
     ) -> Maybe<&'db GenericParamsData<'db>> {
-        trait_generic_params_data_tracked(self.as_dyn_database(), trait_id, in_cycle).maybe_as_ref()
+        trait_generic_params_data_tracked(self.as_dyn_database(), trait_id).maybe_as_ref()
     }
     /// Private query to compute declaration data about a trait.
     fn priv_trait_declaration_data(

--- a/crates/cairo-lang-semantic/src/items/us.rs
+++ b/crates/cairo-lang-semantic/src/items/us.rs
@@ -48,38 +48,56 @@ pub enum UsePathOrDollar<'db> {
     None,
 }
 
-/// Implementation of [UseSemantic::priv_use_semantic_data].
+/// Query implementation of [UseSemantic::priv_use_semantic_data].
 fn priv_use_semantic_data<'db>(
     db: &'db dyn Database,
     use_id: UseId<'db>,
 ) -> Maybe<Arc<UseData<'db>>> {
-    let module_id = use_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let module_item_id = ModuleItemId::Use(use_id);
-    let inference_id = InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(module_item_id));
-    let mut resolver = Resolver::new(db, module_id, inference_id);
-    // TODO(spapini): when code changes in a file, all the AST items change (as they contain a path
-    // to the green root that changes. Once ASTs are rooted on items, use a selector that picks only
-    // the item instead of all the module data.
-    let use_ast = ast::UsePath::Leaf(db.module_use_by_id(use_id)?);
-    let item = use_ast.get_item(db);
-    resolver.set_feature_config(&use_id, &item, &mut diagnostics);
-    let resolved_item = resolver.resolve_use_path(
-        &mut diagnostics,
-        use_ast,
-        ResolutionContext::ModuleItem(module_item_id),
-    );
-    let resolver_data: Arc<ResolverData<'_>> = Arc::new(resolver.data);
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        use_id: UseId<'db>,
+    ) -> Maybe<Arc<UseData<'db>>> {
+        let module_id = use_id.parent_module(db);
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        let use_ast = db.module_use_by_id(use_id)?;
+        let err = Err(diagnostics.report(use_ast.stable_ptr(db), UseCycle));
+        let inference_id =
+            InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(ModuleItemId::Use(use_id)));
+        Ok(Arc::new(UseData {
+            diagnostics: diagnostics.build(),
+            resolved_item: err,
+            resolver_data: Arc::new(ResolverData::new(module_id, inference_id)),
+        }))
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(clone), cycle_result=cycle)]
+    fn priv_use_semantic_data<'db>(
+        db: &'db dyn Database,
+        use_id: UseId<'db>,
+    ) -> Maybe<Arc<UseData<'db>>> {
+        let module_id = use_id.parent_module(db);
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        let module_item_id = ModuleItemId::Use(use_id);
+        let inference_id =
+            InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(module_item_id));
+        let mut resolver = Resolver::new(db, module_id, inference_id);
+        // TODO(spapini): when code changes in a file, all the AST items change (as they contain a
+        // path to the green root that changes. Once ASTs are rooted on items, use a selector
+        // that picks only the item instead of all the module data.
+        let use_ast = ast::UsePath::Leaf(db.module_use_by_id(use_id)?);
+        let item = use_ast.get_item(db);
+        resolver.set_feature_config(&use_id, &item, &mut diagnostics);
+        let resolved_item = resolver.resolve_use_path(
+            &mut diagnostics,
+            use_ast,
+            ResolutionContext::ModuleItem(module_item_id),
+        );
+        let resolver_data: Arc<ResolverData<'_>> = Arc::new(resolver.data);
 
-    Ok(Arc::new(UseData { diagnostics: diagnostics.build(), resolved_item, resolver_data }))
-}
-
-/// Query implementation of [UseSemantic::priv_use_semantic_data].
-#[salsa::tracked(returns(clone), cycle_result=priv_use_semantic_data_cycle)]
-fn priv_use_semantic_data_tracked<'db>(
-    db: &'db dyn Database,
-    use_id: UseId<'db>,
-) -> Maybe<Arc<UseData<'db>>> {
+        Ok(Arc::new(UseData { diagnostics: diagnostics.build(), resolved_item, resolver_data }))
+    }
     priv_use_semantic_data(db, use_id)
 }
 
@@ -175,25 +193,6 @@ fn get_parent_single_use_path<'db>(
     }
 }
 
-/// Cycle handling for [UseSemantic::priv_use_semantic_data].
-fn priv_use_semantic_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    use_id: UseId<'db>,
-) -> Maybe<Arc<UseData<'db>>> {
-    let module_id = use_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let use_ast = db.module_use_by_id(use_id)?;
-    let err = Err(diagnostics.report(use_ast.stable_ptr(db), UseCycle));
-    let inference_id =
-        InferenceId::LookupItemDeclaration(LookupItemId::ModuleItem(ModuleItemId::Use(use_id)));
-    Ok(Arc::new(UseData {
-        diagnostics: diagnostics.build(),
-        resolved_item: err,
-        resolver_data: Arc::new(ResolverData::new(module_id, inference_id)),
-    }))
-}
-
 /// Implementation of [UseSemantic::use_semantic_diagnostics].
 fn use_semantic_diagnostics<'db>(
     db: &'db dyn Database,
@@ -211,30 +210,32 @@ fn use_semantic_diagnostics_tracked<'db>(
     use_semantic_diagnostics(db, use_id)
 }
 
-/// Implementation of [UseSemantic::use_resolver_data].
+/// Query implementation of [UseSemantic::use_resolver_data].
 fn use_resolver_data<'db>(
     db: &'db dyn Database,
     use_id: UseId<'db>,
 ) -> Maybe<Arc<ResolverData<'db>>> {
-    Ok(db.priv_use_semantic_data(use_id)?.resolver_data.clone())
-}
-
-/// Query implementation of [UseSemantic::use_resolver_data].
-#[salsa::tracked(returns(clone), cycle_result=use_resolver_data_cycle)]
-fn use_resolver_data_tracked<'db>(
-    db: &'db dyn Database,
-    use_id: UseId<'db>,
-) -> Maybe<Arc<ResolverData<'db>>> {
-    use_resolver_data(db, use_id)
-}
-
-/// Trivial cycle handler for [UseSemantic::use_resolver_data].
-fn use_resolver_data_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    use_id: UseId<'db>,
-) -> Maybe<Arc<ResolverData<'db>>> {
-    // Forwarding (not as a query) cycle handling to `priv_use_semantic_data` cycle handler.
+    /// Shared code for the query and cycle handling.
+    fn calc<'db>(db: &'db dyn Database, use_id: UseId<'db>) -> Maybe<Arc<ResolverData<'db>>> {
+        Ok(db.priv_use_semantic_data(use_id)?.resolver_data.clone())
+    }
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        use_id: UseId<'db>,
+    ) -> Maybe<Arc<ResolverData<'db>>> {
+        // Forwarding (not as a query) cycle handling to `priv_use_semantic_data` cycle handler.
+        calc(db, use_id)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(clone), cycle_result=cycle)]
+    fn use_resolver_data<'db>(
+        db: &'db dyn Database,
+        use_id: UseId<'db>,
+    ) -> Maybe<Arc<ResolverData<'db>>> {
+        calc(db, use_id)
+    }
     use_resolver_data(db, use_id)
 }
 
@@ -257,91 +258,89 @@ pub struct UseGlobalData<'db> {
     imported_module: Maybe<ModuleId<'db>>,
 }
 
-/// Implementation of [UseSemantic::priv_global_use_semantic_data].
+/// Query implementation of [UseSemantic::priv_global_use_semantic_data].
 fn priv_global_use_semantic_data<'db>(
     db: &'db dyn Database,
     global_use_id: GlobalUseId<'db>,
 ) -> Maybe<UseGlobalData<'db>> {
-    let module_id = global_use_id.parent_module(db);
-    let mut diagnostics = SemanticDiagnostics::new(module_id);
-    let inference_id = InferenceId::GlobalUseStar(global_use_id);
-    let star_ast = ast::UsePath::Star(db.module_global_use_by_id(global_use_id)?);
-    let mut resolver = Resolver::new(db, module_id, inference_id);
-    let edition = resolver.settings.edition;
-    if edition.ignore_visibility() {
-        // We block support for global use where visibility is ignored.
-        diagnostics.report(star_ast.stable_ptr(db), GlobalUsesNotSupportedInEdition(edition));
+    /// The initial value for the cycle handling of the query.
+    fn cycle_initial<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        global_use_id: GlobalUseId<'db>,
+    ) -> Maybe<UseGlobalData<'db>> {
+        let mut diagnostics = SemanticDiagnostics::new(global_use_id.parent_module(db));
+        let global_use_ast = db.module_global_use_by_id(global_use_id)?;
+        let segments = get_use_path_segments(db, ast::UsePath::Star(global_use_ast.clone()))?;
+        let err = if segments.segments.len() == 1 {
+            // `use bad_name::*`, will attempt to find `bad_name` in the current module's global
+            // uses, which includes the global use `use bad_name::*` (itself) - but we don't want
+            // to report a cycle in this case.
+            diagnostics.report(
+                segments.segments.last().unwrap().stable_ptr(db),
+                PathNotFound(NotFoundItemType::Identifier),
+            )
+        } else {
+            diagnostics.report(global_use_ast.stable_ptr(db), UseCycle)
+        };
+        Ok(UseGlobalData { diagnostics: diagnostics.build(), imported_module: Err(err) })
     }
-
-    let item = star_ast.get_item(db);
-    let segments = get_use_path_segments(db, star_ast.clone())?;
-    let Some(last_segment) = segments.segments.last() else {
-        let imported_module = Err(diagnostics.report(star_ast.stable_ptr(db), UseStarEmptyPath));
-        return Ok(UseGlobalData { diagnostics: diagnostics.build(), imported_module });
-    };
-    let last_element_ptr = last_segment.stable_ptr(db);
-    resolver.set_feature_config(&global_use_id, &item, &mut diagnostics);
-    let imported_module = resolver
-        .resolve_generic_path(
-            &mut diagnostics,
-            segments,
-            NotFoundItemType::Identifier,
-            ResolutionContext::Default,
-        )
-        .and_then(|resolved_item| match &resolved_item {
-            ResolvedGenericItem::Module(module_id) => Ok(*module_id),
-            other => Err(diagnostics.report(
-                last_element_ptr,
-                UnexpectedElement { expected: vec![ElementKind::Module], actual: other.into() },
-            )),
-        });
-    if imported_module == Ok(module_id) {
-        diagnostics.report(star_ast.stable_ptr(db), SelfGlobalUse);
+    /// The update function for the cycle handling of the query.
+    fn cycle_update<'db>(
+        _db: &'db dyn Database,
+        _cycle: &salsa::Cycle<'_>,
+        _last_provisional_value: &Maybe<UseGlobalData<'db>>,
+        value: Maybe<UseGlobalData<'db>>,
+        _global_use_id: GlobalUseId<'db>,
+    ) -> Maybe<UseGlobalData<'db>> {
+        value
     }
-    Ok(UseGlobalData { diagnostics: diagnostics.build(), imported_module })
-}
+    /// Query implementation.
+    #[salsa::tracked(returns(clone), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
+    fn priv_global_use_semantic_data<'db>(
+        db: &'db dyn Database,
+        global_use_id: GlobalUseId<'db>,
+    ) -> Maybe<UseGlobalData<'db>> {
+        let module_id = global_use_id.parent_module(db);
+        let mut diagnostics = SemanticDiagnostics::new(module_id);
+        let inference_id = InferenceId::GlobalUseStar(global_use_id);
+        let star_ast = ast::UsePath::Star(db.module_global_use_by_id(global_use_id)?);
+        let mut resolver = Resolver::new(db, module_id, inference_id);
+        let edition = resolver.settings.edition;
+        if edition.ignore_visibility() {
+            // We block support for global use where visibility is ignored.
+            diagnostics.report(star_ast.stable_ptr(db), GlobalUsesNotSupportedInEdition(edition));
+        }
 
-/// Query implementation of [UseSemantic::priv_global_use_semantic_data].
-#[salsa::tracked(returns(clone), cycle_fn=priv_global_use_semantic_data_tracked_cycle_fn, cycle_initial=priv_global_use_semantic_data_tracked_initial)]
-fn priv_global_use_semantic_data_tracked<'db>(
-    db: &'db dyn Database,
-    global_use_id: GlobalUseId<'db>,
-) -> Maybe<UseGlobalData<'db>> {
+        let item = star_ast.get_item(db);
+        let segments = get_use_path_segments(db, star_ast.clone())?;
+        let Some(last_segment) = segments.segments.last() else {
+            let imported_module =
+                Err(diagnostics.report(star_ast.stable_ptr(db), UseStarEmptyPath));
+            return Ok(UseGlobalData { diagnostics: diagnostics.build(), imported_module });
+        };
+        let last_element_ptr = last_segment.stable_ptr(db);
+        resolver.set_feature_config(&global_use_id, &item, &mut diagnostics);
+        let imported_module = resolver
+            .resolve_generic_path(
+                &mut diagnostics,
+                segments,
+                NotFoundItemType::Identifier,
+                ResolutionContext::Default,
+            )
+            .and_then(|resolved_item| match &resolved_item {
+                ResolvedGenericItem::Module(module_id) => Ok(*module_id),
+                other => Err(diagnostics.report(
+                    last_element_ptr,
+                    UnexpectedElement { expected: vec![ElementKind::Module], actual: other.into() },
+                )),
+            });
+        if imported_module == Ok(module_id) {
+            diagnostics.report(star_ast.stable_ptr(db), SelfGlobalUse);
+        }
+        Ok(UseGlobalData { diagnostics: diagnostics.build(), imported_module })
+    }
     priv_global_use_semantic_data(db, global_use_id)
-}
-
-/// Cycle handling for [UseSemantic::priv_global_use_semantic_data].
-fn priv_global_use_semantic_data_tracked_cycle_fn<'db>(
-    _db: &'db dyn Database,
-    _cycle: &salsa::Cycle<'_>,
-    _last_provisional_value: &Maybe<UseGlobalData<'db>>,
-    value: Maybe<UseGlobalData<'db>>,
-    _global_use_id: GlobalUseId<'db>,
-) -> Maybe<UseGlobalData<'db>> {
-    value
-}
-
-/// Cycle handling for [UseSemantic::priv_global_use_semantic_data].
-fn priv_global_use_semantic_data_tracked_initial<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    global_use_id: GlobalUseId<'db>,
-) -> Maybe<UseGlobalData<'db>> {
-    let mut diagnostics = SemanticDiagnostics::new(global_use_id.parent_module(db));
-    let global_use_ast = db.module_global_use_by_id(global_use_id)?;
-    let segments = get_use_path_segments(db, ast::UsePath::Star(global_use_ast.clone()))?;
-    let err = if segments.segments.len() == 1 {
-        // `use bad_name::*`, will attempt to find `bad_name` in the current module's global
-        // uses, which includes the global use `use bad_name::*` (itself) - but we don't want to
-        // report a cycle in this case.
-        diagnostics.report(
-            segments.segments.last().unwrap().stable_ptr(db),
-            PathNotFound(NotFoundItemType::Identifier),
-        )
-    } else {
-        diagnostics.report(global_use_ast.stable_ptr(db), UseCycle)
-    };
-    Ok(UseGlobalData { diagnostics: diagnostics.build(), imported_module: Err(err) })
 }
 
 /// Implementation of [UseSemantic::priv_global_use_imported_module].
@@ -390,89 +389,98 @@ pub struct ImportInfo<'db> {
 
 /// Returns the modules that are imported with `use *` and macro calls in the current module.
 /// Query implementation of [UseSemantic::module_imported_modules].
-#[salsa::tracked(returns(ref),cycle_fn=module_imported_modules_cycle_fn, cycle_initial=module_imported_modules_initial)]
 fn module_imported_modules<'db>(
     db: &'db dyn Database,
-    _tracked: Tracked,
+    tracked: Tracked,
     module_id: ModuleId<'db>,
-) -> ImportedModules<'db> {
-    let mut visited = UnorderedHashSet::<_>::default();
-    let mut stack = vec![(module_id, module_id)];
-    let mut modules = OrderedHashMap::<ModuleId<'db>, ImportInfo<'db>>::default();
-    modules.insert(module_id, ImportInfo { user_modules: vec![module_id] });
-    // Iterate over all modules that are imported through `use *`, and are accessible from the
-    // current module.
-    while let Some((user_module, containing_module)) = stack.pop() {
-        if !visited.insert((user_module, containing_module)) {
-            continue;
-        }
-        for defined_module in
-            chain!([&containing_module], module_macro_modules(db, false, containing_module))
-        {
-            let Ok(glob_uses) = get_module_global_uses(db, *defined_module) else {
+) -> &'db ImportedModules<'db> {
+    /// The initial value for the cycle handling of the query.
+    fn cycle_initial<'db>(
+        _db: &'db dyn Database,
+        _id: salsa::Id,
+        _tracked: Tracked,
+        _module_id: ModuleId<'db>,
+    ) -> ImportedModules<'db> {
+        Default::default()
+    }
+    /// The update function for the cycle handling of the query.
+    fn cycle_update<'db>(
+        _db: &dyn Database,
+        _cycle: &salsa::Cycle<'_>,
+        _last_provisional_value: &ImportedModules<'db>,
+        value: ImportedModules<'db>,
+        _tracked: Tracked,
+        _module_id: ModuleId<'db>,
+    ) -> ImportedModules<'db> {
+        value
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(ref), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
+    fn module_imported_modules<'db>(
+        db: &'db dyn Database,
+        _tracked: Tracked,
+        module_id: ModuleId<'db>,
+    ) -> ImportedModules<'db> {
+        let mut visited = UnorderedHashSet::<_>::default();
+        let mut stack = vec![(module_id, module_id)];
+        let mut modules = OrderedHashMap::<ModuleId<'db>, ImportInfo<'db>>::default();
+        modules.insert(module_id, ImportInfo { user_modules: vec![module_id] });
+        // Iterate over all modules that are imported through `use *`, and are accessible from the
+        // current module.
+        while let Some((user_module, containing_module)) = stack.pop() {
+            if !visited.insert((user_module, containing_module)) {
                 continue;
-            };
-            for (glob_use, item_visibility) in glob_uses.iter() {
-                let Ok(module_id_found) = db.priv_global_use_imported_module(*glob_use) else {
+            }
+            for defined_module in
+                chain!([&containing_module], module_macro_modules(db, false, containing_module))
+            {
+                let Ok(glob_uses) = get_module_global_uses(db, *defined_module) else {
                     continue;
                 };
-                // Add the module to the map to find all reachable modules.
-                let entry = modules.entry(module_id_found).or_default();
-                if peek_visible_in(db, *item_visibility, containing_module, user_module) {
-                    stack.push((containing_module, module_id_found));
-                    entry.user_modules.push(containing_module);
+                for (glob_use, item_visibility) in glob_uses.iter() {
+                    let Ok(module_id_found) = db.priv_global_use_imported_module(*glob_use) else {
+                        continue;
+                    };
+                    // Add the module to the map to find all reachable modules.
+                    let entry = modules.entry(module_id_found).or_default();
+                    if peek_visible_in(db, *item_visibility, containing_module, user_module) {
+                        stack.push((containing_module, module_id_found));
+                        entry.user_modules.push(containing_module);
+                    }
                 }
             }
         }
-    }
-    let mut stack =
-        modules.iter().filter(|(_, v)| v.user_modules.is_empty()).map(|(k, _)| *k).collect_vec();
-    // Iterate over all modules that are imported through `use *`.
-    while let Some(curr_module_id) = stack.pop() {
-        for defined_module in
-            chain!([&curr_module_id], module_macro_modules(db, false, curr_module_id))
-        {
-            let Ok(glob_uses) = get_module_global_uses(db, *defined_module) else { continue };
-            for glob_use in glob_uses.keys() {
-                if let Ok(module_id_found) = db.priv_global_use_imported_module(*glob_use)
-                    && let Entry::Vacant(entry) = modules.entry(module_id_found)
-                {
-                    entry.insert(ImportInfo::default());
-                    stack.push(module_id_found);
+        let mut stack = modules
+            .iter()
+            .filter(|(_, v)| v.user_modules.is_empty())
+            .map(|(k, _)| *k)
+            .collect_vec();
+        // Iterate over all modules that are imported through `use *`.
+        while let Some(curr_module_id) = stack.pop() {
+            for defined_module in
+                chain!([&curr_module_id], module_macro_modules(db, false, curr_module_id))
+            {
+                let Ok(glob_uses) = get_module_global_uses(db, *defined_module) else { continue };
+                for glob_use in glob_uses.keys() {
+                    if let Ok(module_id_found) = db.priv_global_use_imported_module(*glob_use)
+                        && let Entry::Vacant(entry) = modules.entry(module_id_found)
+                    {
+                        entry.insert(ImportInfo::default());
+                        stack.push(module_id_found);
+                    }
                 }
             }
         }
+        modules
     }
-    modules
-}
-
-/// Cycle handling for [UseSemantic::module_imported_modules].
-fn module_imported_modules_cycle_fn<'db>(
-    _db: &dyn Database,
-    _cycle: &salsa::Cycle<'_>,
-    _last_provisional_value: &ImportedModules<'db>,
-    value: ImportedModules<'db>,
-    _tracked: Tracked,
-    _module_id: ModuleId<'db>,
-) -> ImportedModules<'db> {
-    value
-}
-
-/// Cycle handling for [UseSemantic::module_imported_modules].
-fn module_imported_modules_initial<'db>(
-    _db: &'db dyn Database,
-    _id: salsa::Id,
-    _tracked: Tracked,
-    _module_id: ModuleId<'db>,
-) -> ImportedModules<'db> {
-    Default::default()
+    module_imported_modules(db, tracked, module_id)
 }
 
 /// Trait for use-related semantic queries.
 pub trait UseSemantic<'db>: Database {
     /// Private query to compute data about a use.
     fn priv_use_semantic_data(&'db self, use_id: UseId<'db>) -> Maybe<Arc<UseData<'db>>> {
-        priv_use_semantic_data_tracked(self.as_dyn_database(), use_id)
+        priv_use_semantic_data(self.as_dyn_database(), use_id)
     }
     /// Returns the semantic diagnostics of a use.
     fn use_semantic_diagnostics(
@@ -483,14 +491,14 @@ pub trait UseSemantic<'db>: Database {
     }
     /// Returns the resolver data of a use.
     fn use_resolver_data(&'db self, use_id: UseId<'db>) -> Maybe<Arc<ResolverData<'db>>> {
-        use_resolver_data_tracked(self.as_dyn_database(), use_id)
+        use_resolver_data(self.as_dyn_database(), use_id)
     }
     /// Private query to compute data about a global use.
     fn priv_global_use_semantic_data(
         &'db self,
         global_use_id: GlobalUseId<'db>,
     ) -> Maybe<UseGlobalData<'db>> {
-        priv_global_use_semantic_data_tracked(self.as_dyn_database(), global_use_id)
+        priv_global_use_semantic_data(self.as_dyn_database(), global_use_id)
     }
     /// Private query to compute the imported module, given a global use.
     fn priv_global_use_imported_module(

--- a/crates/cairo-lang-semantic/src/items/us.rs
+++ b/crates/cairo-lang-semantic/src/items/us.rs
@@ -73,10 +73,7 @@ fn priv_use_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(clone), cycle_result=cycle)]
-    fn priv_use_semantic_data<'db>(
-        db: &'db dyn Database,
-        use_id: UseId<'db>,
-    ) -> Maybe<Arc<UseData<'db>>> {
+    fn query<'db>(db: &'db dyn Database, use_id: UseId<'db>) -> Maybe<Arc<UseData<'db>>> {
         let module_id = use_id.parent_module(db);
         let mut diagnostics = SemanticDiagnostics::new(module_id);
         let module_item_id = ModuleItemId::Use(use_id);
@@ -98,7 +95,7 @@ fn priv_use_semantic_data<'db>(
 
         Ok(Arc::new(UseData { diagnostics: diagnostics.build(), resolved_item, resolver_data }))
     }
-    priv_use_semantic_data(db, use_id)
+    query(db, use_id)
 }
 
 /// Returns the segments that are the parts of the use path.
@@ -230,13 +227,10 @@ fn use_resolver_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(clone), cycle_result=cycle)]
-    fn use_resolver_data<'db>(
-        db: &'db dyn Database,
-        use_id: UseId<'db>,
-    ) -> Maybe<Arc<ResolverData<'db>>> {
+    fn query<'db>(db: &'db dyn Database, use_id: UseId<'db>) -> Maybe<Arc<ResolverData<'db>>> {
         calc(db, use_id)
     }
-    use_resolver_data(db, use_id)
+    query(db, use_id)
 }
 
 pub trait SemanticUseEx<'a>: Database {
@@ -297,7 +291,7 @@ fn priv_global_use_semantic_data<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(clone), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
-    fn priv_global_use_semantic_data<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         global_use_id: GlobalUseId<'db>,
     ) -> Maybe<UseGlobalData<'db>> {
@@ -340,7 +334,7 @@ fn priv_global_use_semantic_data<'db>(
         }
         Ok(UseGlobalData { diagnostics: diagnostics.build(), imported_module })
     }
-    priv_global_use_semantic_data(db, global_use_id)
+    query(db, global_use_id)
 }
 
 /// Implementation of [UseSemantic::priv_global_use_imported_module].
@@ -416,7 +410,7 @@ fn module_imported_modules<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(ref), cycle_fn=cycle_update, cycle_initial=cycle_initial)]
-    fn module_imported_modules<'db>(
+    fn query<'db>(
         db: &'db dyn Database,
         _tracked: Tracked,
         module_id: ModuleId<'db>,
@@ -473,7 +467,7 @@ fn module_imported_modules<'db>(
         }
         modules
     }
-    module_imported_modules(db, tracked, module_id)
+    query(db, tracked, module_id)
 }
 
 /// Trait for use-related semantic queries.

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -130,10 +130,10 @@ impl<'db> TypeId<'db> {
         }
         /// Query implementation.
         #[salsa::tracked(returns(copy), cycle_result=cycle)]
-        fn is_phantom<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> bool {
+        fn query<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> bool {
             ty.long(db).is_phantom(db)
         }
-        is_phantom(db, *self)
+        query(db, *self)
     }
 
     /// Short name of the type argument.
@@ -1037,16 +1037,13 @@ fn array_element_violation<'db>(
     }
     /// Query implementation.
     #[salsa::tracked(returns(clone), cycle_result=cycle)]
-    fn array_element_violation<'db>(
-        db: &'db dyn Database,
-        ty: TypeId<'db>,
-    ) -> Option<ArrayElementViolation<'db>> {
+    fn query<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> Option<ArrayElementViolation<'db>> {
         if ty.is_phantom(db) {
             return None;
         }
-        array_element_deps_or_issue(db, ty, |dep| array_element_violation(db, dep))
+        array_element_deps_or_issue(db, ty, |dep| query(db, dep))
     }
-    array_element_violation(db, ty)
+    query(db, ty)
 }
 
 /// Searches `ty` for a bad array element. An array's element is checked directly (phantom or
@@ -1119,7 +1116,7 @@ fn type_size_info<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> Maybe<TypeSize
     }
     /// Query implementation.
     #[salsa::tracked(returns(clone), cycle_result=cycle)]
-    fn type_size_info<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> Maybe<TypeSizeInformation> {
+    fn query<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> Maybe<TypeSizeInformation> {
         match ty.long(db) {
             TypeLongId::Concrete(concrete_type_id) => match concrete_type_id {
                 ConcreteTypeId::Struct(id) => {
@@ -1169,7 +1166,7 @@ fn type_size_info<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> Maybe<TypeSize
         }
         Ok(TypeSizeInformation::Other)
     }
-    type_size_info(db, ty)
+    query(db, ty)
 }
 
 /// Checks if all types in the iterator are zero sized.

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -120,17 +120,20 @@ impl<'db> TypeId<'db> {
     /// by a plugin), or if any of its struct members, enum variants, tuple or fixed-size-array
     /// elements, or its snapshotted type is (transitively) phantom.
     pub fn is_phantom(&self, db: &dyn Database) -> bool {
-        #[salsa::tracked(returns(copy), cycle_result=is_phantom_cycle)]
-        fn is_phantom_tracked<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> bool {
-            ty.long(db).is_phantom(db)
-        }
+        /// Cycle handling for the query.
+        ///
         /// A type that (transitively) contains itself is not made phantom by the cycle - any
         /// phantom is found through the non-cyclic branches, so the cyclic edge contributes
         /// `false`.
-        fn is_phantom_cycle<'db>(_db: &'db dyn Database, _id: salsa::Id, _ty: TypeId<'db>) -> bool {
+        fn cycle<'db>(_db: &'db dyn Database, _id: salsa::Id, _ty: TypeId<'db>) -> bool {
             false
         }
-        is_phantom_tracked(db, *self)
+        /// Query implementation.
+        #[salsa::tracked(returns(copy), cycle_result=cycle)]
+        fn is_phantom<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> bool {
+            ty.long(db).is_phantom(db)
+        }
+        is_phantom(db, *self)
     }
 
     /// Short name of the type argument.
@@ -1001,43 +1004,49 @@ impl<'db> ArrayElementViolation<'db> {
 /// the `NonPhantomTypeContainingPhantomType` check for a definition), so it is not descended into.
 /// Only concrete types are searched; a generic parameter is assumed instantiable, so a generic
 /// `Array<T>` is only diagnosed once `T` is concretely disallowed.
-#[salsa::tracked(returns(clone), cycle_result=array_element_violation_cycle)]
 fn array_element_violation<'db>(
     db: &'db dyn Database,
     ty: TypeId<'db>,
 ) -> Option<ArrayElementViolation<'db>> {
-    if ty.is_phantom(db) {
-        return None;
-    }
-    array_element_deps_or_issue(db, ty, |dep| array_element_violation(db, dep))
-}
-
-/// Cycle handling for [array_element_violation], hit when a type is recursive through an array
-/// element (e.g. `Array<Self>`).
-///
-/// Implements the same logic as [array_element_violation], but iteratively over an explicit
-/// work-stack with a visited set so it never re-enters the query. Recursing back into the query
-/// mid-cycle would let salsa cache a false negative for whichever participant is computed first -
-/// its violation may be reachable only through the rest of the cycle.
-fn array_element_violation_cycle<'db>(
-    db: &'db dyn Database,
-    _id: salsa::Id,
-    ty: TypeId<'db>,
-) -> Option<ArrayElementViolation<'db>> {
-    let mut visited: OrderedHashSet<TypeId<'db>> = OrderedHashSet::default();
-    let mut stack = vec![ty];
-    while let Some(ty) = stack.pop() {
-        if ty.is_phantom(db) || !visited.insert(ty) {
-            continue;
+    /// Cycle handling for the query, hit when a type is recursive through an array element (e.g.
+    /// `Array<Self>`).
+    ///
+    /// Implements the same logic as the query, but iteratively over an explicit work-stack with a
+    /// visited set so it never re-enters the query. Recursing back into the query mid-cycle would
+    /// let salsa cache a false negative for whichever participant is computed first - its
+    /// violation may be reachable only through the rest of the cycle.
+    fn cycle<'db>(
+        db: &'db dyn Database,
+        _id: salsa::Id,
+        ty: TypeId<'db>,
+    ) -> Option<ArrayElementViolation<'db>> {
+        let mut visited: OrderedHashSet<TypeId<'db>> = OrderedHashSet::default();
+        let mut stack = vec![ty];
+        while let Some(ty) = stack.pop() {
+            if ty.is_phantom(db) || !visited.insert(ty) {
+                continue;
+            }
+            if let Some(violation) = array_element_deps_or_issue(db, ty, |dep| {
+                stack.push(dep);
+                None
+            }) {
+                return Some(violation);
+            }
         }
-        if let Some(violation) = array_element_deps_or_issue(db, ty, |dep| {
-            stack.push(dep);
-            None
-        }) {
-            return Some(violation);
-        }
+        None
     }
-    None
+    /// Query implementation.
+    #[salsa::tracked(returns(clone), cycle_result=cycle)]
+    fn array_element_violation<'db>(
+        db: &'db dyn Database,
+        ty: TypeId<'db>,
+    ) -> Option<ArrayElementViolation<'db>> {
+        if ty.is_phantom(db) {
+            return None;
+        }
+        array_element_deps_or_issue(db, ty, |dep| array_element_violation(db, dep))
+    }
+    array_element_violation(db, ty)
 }
 
 /// Searches `ty` for a bad array element. An array's element is checked directly (phantom or
@@ -1098,64 +1107,68 @@ pub enum TypeSizeInformation {
     Other,
 }
 
-/// Implementation of [TypesSemantic::type_size_info].
-fn type_size_info(db: &dyn Database, ty: TypeId<'_>) -> Maybe<TypeSizeInformation> {
-    match ty.long(db) {
-        TypeLongId::Concrete(concrete_type_id) => match concrete_type_id {
-            ConcreteTypeId::Struct(id) => {
-                if check_all_type_are_zero_sized(
-                    db,
-                    db.concrete_struct_members(*id)?.iter().map(|(_, member)| &member.ty),
-                )? {
+/// Query implementation of [TypesSemantic::type_size_info].
+fn type_size_info<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> Maybe<TypeSizeInformation> {
+    /// Cycle handling for the query.
+    fn cycle<'db>(
+        _db: &'db dyn Database,
+        _id: salsa::Id,
+        _ty: TypeId<'db>,
+    ) -> Maybe<TypeSizeInformation> {
+        Ok(TypeSizeInformation::Infinite)
+    }
+    /// Query implementation.
+    #[salsa::tracked(returns(clone), cycle_result=cycle)]
+    fn type_size_info<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> Maybe<TypeSizeInformation> {
+        match ty.long(db) {
+            TypeLongId::Concrete(concrete_type_id) => match concrete_type_id {
+                ConcreteTypeId::Struct(id) => {
+                    if check_all_type_are_zero_sized(
+                        db,
+                        db.concrete_struct_members(*id)?.iter().map(|(_, member)| &member.ty),
+                    )? {
+                        return Ok(TypeSizeInformation::ZeroSized);
+                    }
+                }
+                ConcreteTypeId::Enum(id) => {
+                    for variant in &db.concrete_enum_variants(*id)? {
+                        // Recursive calling in order to find infinite sized types.
+                        db.type_size_info(variant.ty)?;
+                    }
+                }
+                ConcreteTypeId::Extern(_) => {}
+            },
+            TypeLongId::Tuple(types) => {
+                if check_all_type_are_zero_sized(db, types.iter())? {
                     return Ok(TypeSizeInformation::ZeroSized);
                 }
             }
-            ConcreteTypeId::Enum(id) => {
-                for variant in &db.concrete_enum_variants(*id)? {
-                    // Recursive calling in order to find infinite sized types.
-                    db.type_size_info(variant.ty)?;
+            TypeLongId::Snapshot(ty) => {
+                if db.type_size_info(*ty)? == TypeSizeInformation::ZeroSized {
+                    return Ok(TypeSizeInformation::ZeroSized);
                 }
             }
-            ConcreteTypeId::Extern(_) => {}
-        },
-        TypeLongId::Tuple(types) => {
-            if check_all_type_are_zero_sized(db, types.iter())? {
-                return Ok(TypeSizeInformation::ZeroSized);
+            TypeLongId::Closure(closure_ty) => {
+                if check_all_type_are_zero_sized(db, closure_ty.captured_types.iter())? {
+                    return Ok(TypeSizeInformation::ZeroSized);
+                }
+            }
+            TypeLongId::Coupon(_) => return Ok(TypeSizeInformation::ZeroSized),
+            TypeLongId::GenericParameter(_)
+            | TypeLongId::Var(_)
+            | TypeLongId::NumericLiteral(_)
+            | TypeLongId::Missing(_)
+            | TypeLongId::ImplType(_) => {}
+            TypeLongId::FixedSizeArray { type_id, size } => {
+                if matches!(size.long(db), ConstValue::Int(value,_) if value.is_zero())
+                    || db.type_size_info(*type_id)? == TypeSizeInformation::ZeroSized
+                {
+                    return Ok(TypeSizeInformation::ZeroSized);
+                }
             }
         }
-        TypeLongId::Snapshot(ty) => {
-            if db.type_size_info(*ty)? == TypeSizeInformation::ZeroSized {
-                return Ok(TypeSizeInformation::ZeroSized);
-            }
-        }
-        TypeLongId::Closure(closure_ty) => {
-            if check_all_type_are_zero_sized(db, closure_ty.captured_types.iter())? {
-                return Ok(TypeSizeInformation::ZeroSized);
-            }
-        }
-        TypeLongId::Coupon(_) => return Ok(TypeSizeInformation::ZeroSized),
-        TypeLongId::GenericParameter(_)
-        | TypeLongId::Var(_)
-        | TypeLongId::NumericLiteral(_)
-        | TypeLongId::Missing(_)
-        | TypeLongId::ImplType(_) => {}
-        TypeLongId::FixedSizeArray { type_id, size } => {
-            if matches!(size.long(db), ConstValue::Int(value,_) if value.is_zero())
-                || db.type_size_info(*type_id)? == TypeSizeInformation::ZeroSized
-            {
-                return Ok(TypeSizeInformation::ZeroSized);
-            }
-        }
+        Ok(TypeSizeInformation::Other)
     }
-    Ok(TypeSizeInformation::Other)
-}
-
-/// Query implementation of [TypesSemantic::type_size_info].
-#[salsa::tracked(returns(clone), cycle_result=type_size_info_cycle)]
-fn type_size_info_tracked<'db>(
-    db: &'db dyn Database,
-    ty: TypeId<'db>,
-) -> Maybe<TypeSizeInformation> {
     type_size_info(db, ty)
 }
 
@@ -1171,15 +1184,6 @@ fn check_all_type_are_zero_sized<'a>(
         }
     }
     Ok(zero_sized)
-}
-
-/// Cycle handling of [TypesSemantic::type_size_info].
-fn type_size_info_cycle<'db>(
-    _db: &'db dyn Database,
-    _id: salsa::Id,
-    _ty: TypeId<'db>,
-) -> Maybe<TypeSizeInformation> {
-    Ok(TypeSizeInformation::Infinite)
 }
 
 // TODO(spapini): type info lookup for non generic types needs to not depend on lookup_context.
@@ -1443,7 +1447,7 @@ pub trait TypesSemantic<'db>: Database {
     }
     /// Returns the type size information for the given type.
     fn type_size_info(&'db self, ty: TypeId<'db>) -> Maybe<TypeSizeInformation> {
-        type_size_info_tracked(self.as_dyn_database(), ty)
+        type_size_info(self.as_dyn_database(), ty)
     }
     /// Returns the type info for a type in a context.
     fn type_info(


### PR DESCRIPTION
## Summary
Refactor cycle handling in semantic analysis by removing the `in_cycle` parameter from various semantic data computation functions. Instead of passing a boolean flag to determine cycle behavior, the cycle handling is now delegated to dedicated `*_cycle` functions that are properly registered with Salsa's cycle handling mechanism.

## Key Changes

- **Removed `in_cycle` parameter** from:
  - `impl_type_semantic_data()` and `impl_type_semantic_data_cycle()`
  - `impl_constant_semantic_data()` and `impl_constant_semantic_data_cycle()`
  - `impl_impl_semantic_data()` and `impl_impl_semantic_data_cycle()`
  - `implicit_impl_impl_semantic_data()` and `implicit_impl_impl_semantic_data_cycle()`
  - `impl_impl_implized_by_context()` and `impl_impl_implized_by_context_cycle()`
  - `generic_param_data()` and `generic_param_data_cycle()`
  - `module_type_alias_semantic_data()` and `module_type_alias_semantic_data_cycle()`
  - `trait_generic_params_data()` and `trait_generic_params_data_cycle()`
  - `constant_semantic_data()` and `constant_semantic_data_cycle()`
  - `impl_alias_semantic_data()` and `impl_alias_semantic_data_cycle()`

- **Consolidated logic** in cycle handler functions:
  - Moved cycle-specific behavior (e.g., reporting `ImplAliasCycle` diagnostics) directly into `*_cycle` functions
  - Removed conditional branching based on `in_cycle` flag from main functions
  - Each `*_cycle` function now contains the complete logic needed for cycle handling

- **Simplified function signatures**:
  - Removed `in_cycle` parameter from all call sites
  - Removed `semantic_generic_params_ex()` function (consolidated into `semantic_generic_params()`)
  - Removed `impl_impl_concrete_implized_ex()` helper function

- **Improved cycle handling**:
  - `implicit_impl_impl_semantic_data_cycle()` now properly reports `ImplAliasCycle` diagnostic
  - `impl_impl_implized_by_context_cycle()` returns `skip_diagnostic()` for proper cycle error handling
  - `trait_generic_params_data_cycle()` reports `ImplRequirementCycle` for all generic parameters

## Implementation Details

The refactoring leverages Salsa's built-in cycle detection mechanism more effectively. Instead of manually tracking cycle state with a boolean parameter, the framework now automatically invokes the designated `*_cycle` functions when cycles are detected. This makes the code clearer and reduces the risk of inconsistent cycle handling across different call sites.

All cycle handlers now contain the complete, self-contained logic needed to handle their respective cycles, eliminating the need for shared code paths that branch on the `in_cycle` flag.

https://claude.ai/code/session_01MwUAoo79zFqfVTiDCy17nv