### PR TITLE
ci: move starknet_sierra_validate to RPC v0_9; report the failing status

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,6 +163,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: >
-          scripts/starknet_sierra_validate.sh https://starknet-mainnet.core.chainstack.com/57088c25afa0ff21277c6ee5f3b536bb/rpc/v0_7 10000
+          scripts/starknet_sierra_validate.sh https://starknet-mainnet.core.chainstack.com/57088c25afa0ff21277c6ee5f3b536bb/rpc/v0_9 10000
       - run: >
-          scripts/starknet_sierra_validate.sh https://starknet-sepolia.core.chainstack.com/2eaebe8806ed2208f571223be415f594/rpc/v0_7 10000
+          scripts/starknet_sierra_validate.sh https://starknet-sepolia.core.chainstack.com/2eaebe8806ed2208f571223be415f594/rpc/v0_9 10000

--- a/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
+++ b/crates/bin/starknet-sierra-upgrade-validate/src/main.rs
@@ -649,8 +649,10 @@ impl FullNodeClient {
             }))
             .send()
             .await?;
-        if !res.status().is_success() {
-            return Err(anyhow::anyhow!("Request failed."));
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!("Request failed with status {status}: {body}"));
         }
         Ok(res.json::<RpcResponse<Response>>().await?.result)
     }

--- a/scripts/starknet_sierra_validate.sh
+++ b/scripts/starknet_sierra_validate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export FULLNODE_URL="${1:-https://starknet-mainnet.core.chainstack.com/57088c25afa0ff21277c6ee5f3b536bb/rpc/v0_7}"
+export FULLNODE_URL="${1:-https://starknet-mainnet.core.chainstack.com/57088c25afa0ff21277c6ee5f3b536bb/rpc/v0_9}"
 export N_BLOCKS="${2:-1000}"
 
 cargo run --bin starknet-sierra-upgrade-validate --profile=release -- --fullnode-url $FULLNODE_URL --last-n-blocks $N_BLOCKS


### PR DESCRIPTION
## Summary

Switches the nightly `starknet_sierra_validate` endpoints (mainnet + sepolia, plus the script's default) from `/rpc/v0_7` to `/rpc/v0_9`, and makes the fullnode client's error include the HTTP status and response body instead of a bare `"Request failed."`.

---

## Type of change

- [x] Bug fix (fixes incorrect behavior)

---

## Why is this change needed?

The nightly `starknet_sierra_validate` job has failed every night since 2026-07-22, dying ~200ms after launch on its very first request (`starknet_blockNumber`) with only `Error: Request failed.` (e.g. run [30502247291](https://github.com/starkware-libs/cairo/actions/runs/30502247291/job/90744212556)). The sepolia step is skipped as a result, so both networks have been unvalidated for over a week.

Root cause: [Pathfinder 0.23.0](https://github.com/eqlabs/pathfinder/releases) (released 2026-07-20, two days before the breakage) removed JSON-RPC 0.6/0.7/0.8 support, and Chainstack's node upgrade dropped the `/rpc/v0_7` path both endpoints use. Supported versions are now v0_9 (the default) and v0_10, per [Chainstack's Starknet docs](https://docs.chainstack.com/reference/getting-started-starknet).

---

## What was the behavior or documentation before?

- Both endpoints target `/rpc/v0_7`, which now returns an immediate HTTP error → nightly job fails before validating anything.
- A non-2xx response produced a bare `Request failed.` with no status code or body, making the outage undiagnosable from the CI log.

## What is the behavior or documentation after?

- Endpoints target `/rpc/v0_9`. The three methods used (`starknet_blockNumber`, `starknet_getStateUpdate`, `starknet_getClass`) are schema-compatible between 0.7 and 0.9, so no other code changes are needed.
- HTTP failures report `Request failed with status {status}: {body}`.

---

## Related issue or discussion (if any)

Nightly failures since the 2026-07-22 run ([29879768488](https://github.com/starkware-libs/cairo/actions/runs/29879768488)).

---

## Additional context

`scripts/rust_fmt.sh` and `scripts/clippy.sh -p starknet-sierra-upgrade-validate` pass locally. The v0_9 endpoints couldn't be probed from this sandbox (network policy), so the first nightly run after merge is the real verification; if v0_9 is also unavailable on these nodes, the new error message will now say exactly what came back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDW1JHcCbDRgiGw8QBiDXE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDW1JHcCbDRgiGw8QBiDXE)_