### PR TITLE
fix(doc): keep a list item's marker outside the emphasis that opens it

### DIFF
--- a/crates/cairo-lang-doc/src/parser.rs
+++ b/crates/cairo-lang-doc/src/parser.rs
@@ -115,12 +115,15 @@ pub fn parse_documentation_comment(documentation_comment: &str) -> Vec<Documenta
     let mut table_alignment: Vec<Alignment> = Vec::new();
 
     for (event, range) in parser.into_offset_iter() {
+        let mut maybe_write_list_item_prefix = || {
+            if prefix_list_item {
+                write_list_item_prefix(&mut list_nesting, &mut tokens);
+                prefix_list_item = false;
+            }
+        };
         match &event {
             Event::Text(text) => {
-                if prefix_list_item {
-                    write_list_item_prefix(&mut list_nesting, &mut tokens);
-                    prefix_list_item = false;
-                }
+                maybe_write_list_item_prefix();
                 if let Some(link) = current_link.as_mut() {
                     link.label.push_str(text.as_ref());
                     link.label_range = Some(range.clone());
@@ -136,10 +139,7 @@ pub fn parse_documentation_comment(documentation_comment: &str) -> Vec<Documenta
                 }
             }
             Event::Code(code) => {
-                if prefix_list_item {
-                    write_list_item_prefix(&mut list_nesting, &mut tokens);
-                    prefix_list_item = false;
-                }
+                maybe_write_list_item_prefix();
                 let complete_code = format!("`{code}`");
                 if let Some(link) = current_link.as_mut() {
                     link.label.push_str(&complete_code);
@@ -214,9 +214,11 @@ pub fn parse_documentation_comment(documentation_comment: &str) -> Vec<Documenta
                     tokens.push(DocumentationCommentToken::Content("|".to_string()));
                 }
                 Tag::Strong => {
+                    maybe_write_list_item_prefix();
                     tokens.push(DocumentationCommentToken::Content("**".to_string()));
                 }
                 Tag::Emphasis => {
+                    maybe_write_list_item_prefix();
                     tokens.push(DocumentationCommentToken::Content("_".to_string()));
                 }
                 _ => {}

--- a/crates/cairo-lang-doc/src/tests/test-data/lists_formatting.txt
+++ b/crates/cairo-lang-doc/src/tests/test-data/lists_formatting.txt
@@ -34,6 +34,15 @@ hello = "src"
 //! - B
 //! - `multiple elements item` gets prefix only once
 //!
+//! bold list items
+//! - **bold item**
+//! - *italic item*
+//! - **bold** then plain
+//!
+//! bold ordered items
+//! 1. **bold item**
+//! 2. plain
+//!
 //! not a list
 //! 0. First item
 //! 5. Second item
@@ -69,6 +78,15 @@ unordered list
 - A
 - B
 - `multiple elements item` gets prefix only once
+
+bold list items
+- **bold item**
+- _italic item_
+- **bold** then plain
+
+bold ordered items
+1. **bold item**
+2. plain
 
 not a list
 0. First item
@@ -142,6 +160,36 @@ Content("\n")
 Content("- ")
 Content("`multiple elements item`")
 Content(" gets prefix only once")
+Content("\n")
+Content("\n")
+Content("bold list items")
+Content("\n")
+Content("- ")
+Content("**")
+Content("bold item")
+Content("**")
+Content("\n")
+Content("- ")
+Content("_")
+Content("italic item")
+Content("_")
+Content("\n")
+Content("- ")
+Content("**")
+Content("bold")
+Content("**")
+Content(" then plain")
+Content("\n")
+Content("\n")
+Content("bold ordered items")
+Content("\n")
+Content("1. ")
+Content("**")
+Content("bold item")
+Content("**")
+Content("\n")
+Content("2. ")
+Content("plain")
 Content("\n")
 Content("\n")
 Content("not a list")


### PR DESCRIPTION
## Summary

Fixes list item prefixes (`- ` or `N. `) not being emitted before bold (`**`) and italic (`_`) inline formatting tags when they appear at the start of a list item in documentation comments. The duplicated `prefix_list_item` check logic is also consolidated into a single closure `maybe_write_list_item_prefix` and reused across `Event::Text`, `Event::Code`, `Tag::Strong`, and `Tag::Emphasis` handlers.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a list item began with bold or italic markup (e.g., `- **bold item**`), the list item prefix (`- ` or `1. `) was never written because the `prefix_list_item` flag was only checked in the `Event::Text` and `Event::Code` handlers, not in the `Tag::Strong` or `Tag::Emphasis` handlers. This caused the rendered output to be missing the bullet or number prefix for such items.

---

## What was the behavior or documentation before?

List items starting with bold or italic formatting would silently drop their prefix, producing malformed output without the leading `- ` or `N. ` marker.

---

## What is the behavior or documentation after?

List items starting with bold or italic formatting correctly emit their prefix before the formatting token. For example:

```
- **bold item**
- _italic item_
1. **bold item**
```

---

## Related issue or discussion (if any)

None.

---

## Additional context

Test cases covering bold and italic list items (both unordered and ordered) have been added to `lists_formatting.txt` to prevent regressions.