### PR TITLE
fix(semantic): report an infinitely-sized type only where its cycle is closed

### DIFF
--- a/crates/cairo-lang-semantic/src/items/tests/struct
+++ b/crates/cairo-lang-semantic/src/items/tests/struct
@@ -68,6 +68,32 @@ error[E2052]: Recursive type "test::B" has infinite size.
 
 //! > ==========================================================================
 
+//! > Test a recursive struct used as a value is reported only where the cycle is closed.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > function_code
+fn foo(a: A) -> A {
+    a
+}
+
+//! > function_name
+foo
+
+//! > module_code
+struct A {
+    member: A,
+}
+
+//! > expected_diagnostics
+error[E2052]: Recursive type "test::A" has infinite size.
+ --> lib.cairo:2:5
+    member: A,
+    ^^^^^^^^^
+
+//! > ==========================================================================
+
 //! > Test phantom recursive struct.
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -939,9 +939,13 @@ fn single_value_type_tracked<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> May
 
 /// Adds diagnostics for a type used as a value - in a parameter, return type, or expression.
 ///
-/// Like [add_type_based_diagnostics], but additionally rejects a phantom type: a phantom type has
-/// no runtime representation and so cannot be used as a value. Type definitions (e.g. struct
-/// members and enum variants) allow phantom types and so use [add_type_based_diagnostics] directly.
+/// Rejects a phantom type, which has no runtime representation, and an array whose element cannot
+/// be instantiated. Both are faults of this use rather than of the type.
+///
+/// An infinitely-sized type is deliberately not reported here: the cycle is closed by a struct
+/// member or an enum variant, and [add_type_based_diagnostics] already reports it there. Repeating
+/// it at every use names a location the author cannot act on, and one broken type would otherwise
+/// produce a diagnostic per parameter, return type and expression mentioning it.
 pub fn add_value_type_based_diagnostics<'db>(
     db: &'db dyn Database,
     diagnostics: &mut SemanticDiagnostics<'db>,
@@ -950,16 +954,16 @@ pub fn add_value_type_based_diagnostics<'db>(
 ) {
     if ty.is_phantom(db) {
         diagnostics.report(stable_ptr, InstancesOfPhantomTypes);
-    } else {
-        add_type_based_diagnostics(db, diagnostics, ty, stable_ptr);
+    } else if let Some(violation) = array_element_violation(db, ty) {
+        diagnostics.report(stable_ptr, violation.to_kind());
     }
 }
 
-/// Adds diagnostics based on a type's structure: an infinitely-sized type, or a (possibly nested)
-/// array of zero-sized or phantom elements.
+/// Adds diagnostics for a type in a definition - a struct member or an enum variant.
 ///
-/// This does not reject the type itself being phantom; a value position should use
-/// [add_value_type_based_diagnostics] for that.
+/// This is where an infinitely-sized type is reported, as the member being checked is the one
+/// closing the cycle. A phantom type is allowed here, and so is not rejected; a value position
+/// should use [add_value_type_based_diagnostics] instead.
 pub fn add_type_based_diagnostics<'db>(
     db: &'db dyn Database,
     diagnostics: &mut SemanticDiagnostics<'db>,


### PR DESCRIPTION
## Summary

`add_value_type_based_diagnostics` no longer calls `add_type_based_diagnostics` and therefore no longer re-reports infinitely-sized type errors at every value-position use (parameters, return types, expressions). The infinite-size diagnostic is now emitted exclusively by `add_type_based_diagnostics`, which is called at the struct member or enum variant that closes the cycle. `add_value_type_based_diagnostics` retains only the phantom-type rejection and the array-element violation check.

A new test case confirms that a self-referential struct (`struct A { member: A }`) produces exactly one diagnostic, pointing at the member declaration, rather than one diagnostic per use of `A` as a value.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

When a struct or enum type was infinitely sized, the compiler emitted a diagnostic not only at the member or variant that closed the recursive cycle, but also at every parameter, return type, and expression that mentioned the broken type. Those secondary diagnostics pointed at locations the author cannot act on, and a single broken type definition could produce a large number of redundant errors.

---

## What was the behavior or documentation before?

An infinitely-sized type was reported both at the struct member or enum variant closing the cycle and at each value-position use of that type, producing duplicate diagnostics across unrelated call sites.

---

## What is the behavior or documentation after?

The infinite-size diagnostic is reported exactly once, at the struct member or enum variant that closes the recursive cycle. Value-position uses of the type are not independently diagnosed for infinite size.

---

## Related issue or discussion (if any)

None listed.

---

## Additional context

The distinction between `add_type_based_diagnostics` (definition sites) and `add_value_type_based_diagnostics` (value sites) is now more clearly documented in the code comments to explain why each function handles or omits the infinite-size check.