### PR TITLE
fix(semantic): expand a nested repetition over its own group of captures

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -79,7 +79,7 @@ use crate::items::imp::{
     DerefInfo, ImplLookupContextId, ImplSemantic, filter_candidate_traits, infer_impl_by_self,
 };
 use crate::items::macro_declaration::{
-    MacroDeclarationSemantic, MatcherContext, expand_macro_rule, is_macro_rule_match,
+    MacroDeclarationSemantic, expand_macro_rule, is_macro_rule_match,
 };
 use crate::items::modifiers::compute_mutability;
 use crate::items::module::ModuleSemantic;
@@ -822,11 +822,9 @@ fn expand_inline_macro<'db>(
     );
     if let Ok(ResolvedGenericItem::Macro(macro_declaration_id)) = user_defined_macro {
         let macro_rules = ctx.db.macro_declaration_rules(macro_declaration_id)?;
-        let Some((rule, (captures, placeholder_to_rep_id, rep_depths))) =
-            macro_rules.iter().find_map(|rule| {
-                is_macro_rule_match(ctx.db, rule, &syntax.arguments(db)).map(|res| (rule, res))
-            })
-        else {
+        let Some((rule, mut matcher_ctx)) = macro_rules.iter().find_map(|rule| {
+            is_macro_rule_match(ctx.db, rule, &syntax.arguments(db)).map(|res| (rule, res))
+        }) else {
             return Err(ctx.diagnostics.report(
                 syntax.stable_ptr(ctx.db),
                 InlineMacroNoMatchingRule(macro_path.identifier(db)),
@@ -835,8 +833,6 @@ fn expand_inline_macro<'db>(
         // If the rule has declaration-time errors, skip expansion to avoid panics on malformed
         // rules.
         rule.err?;
-        let mut matcher_ctx =
-            MatcherContext { captures, placeholder_to_rep_id, rep_depths, ..Default::default() };
         let expanded_code = expand_macro_rule(ctx.db, rule, &mut matcher_ctx)?;
 
         let macro_defsite_resolver_data =

--- a/crates/cairo-lang-semantic/src/expr/expansion_test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/expansion_test_data/inline_macros
@@ -520,10 +520,54 @@ macro three_levels {
 }
 
 //! > expr_code
-three_levels!(1 => [2 => (3, 4)])
+three_levels!(1 => [2 => (3, 4), 5 => (6, 7)], 8 => [9 => (10, 11)])
 
 //! > expanded_code
-1 + 2 + 3+4+0
+1 + 2 + 3+4+5 + 6+7+8 + 9 + 10+11+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a pattern whose placeholders are not ordered by their repetition depth.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro unsorted_lhs {
+    ($([$($b:expr),*] => $a:expr),*) => { $($a + $($b +)*)* 0 };
+}
+
+//! > expr_code
+unsorted_lhs!([1, 2] => 3, [4] => 5)
+
+//! > expanded_code
+3+ 1+2+5+ 4+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test several placeholders bound at each of two repetition depths.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro multi_vars {
+    ($($a1:expr, $a2:expr => [$($b1:expr; $b2:expr),*]),*) => {
+        $($a1 + $a2 + $($b1 + $b2 +)*)* 0
+    };
+}
+
+//! > expr_code
+multi_vars!(1, 2 => [3; 4, 5; 6], 7, 8 => [9; 10])
+
+//! > expanded_code
+1+ 2 + 3+ 4+5+ 6+7+ 8 + 9+ 10+0
 
 //! > diagnostics
 
@@ -587,5 +631,47 @@ deeper_only!([1])
 
 //! > expanded_code
 1+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test a nested repetition matching a different number of times per outer iteration.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro groups {
+    ($($a:expr => [$($b:expr),*]),*) => { $($a + $($b +)*)* 0 };
+}
+
+//! > expr_code
+groups!(1 => [7, 8], 2 => [9])
+
+//! > expanded_code
+1 + 7+8+2 + 9+0
+
+//! > diagnostics
+
+//! > ==========================================================================
+
+//! > Test three repetition levels, each with several groups.
+
+//! > test_runner_name
+test_expand_expr(expect_diagnostics: false)
+
+//! > module_code
+#[feature("user_defined_inline_macros")]
+macro deep_groups {
+    ($($a:expr => [$($b:expr => ($($c:expr),*)),*]),*) => { $($a + $($b + $($c +)*)*)* 0 };
+}
+
+//! > expr_code
+deep_groups!(1 => [2 => (3, 4), 5 => (6)])
+
+//! > expanded_code
+1 + 2 + 3+4+5 + 6+0
 
 //! > diagnostics

--- a/crates/cairo-lang-semantic/src/items/macro_call.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_call.rs
@@ -17,7 +17,7 @@ use crate::diagnostic::{
 };
 use crate::expr::inference::InferenceId;
 use crate::items::macro_declaration::{
-    MacroDeclarationSemantic, MatcherContext, expand_macro_rule, is_macro_rule_match,
+    MacroDeclarationSemantic, expand_macro_rule, is_macro_rule_match,
 };
 use crate::items::module::ModuleSemantic;
 use crate::resolve::{ResolutionContext, ResolvedGenericItem, Resolver, ResolverMacroData};
@@ -123,11 +123,9 @@ fn priv_macro_call_data<'db>(
             });
         }
     };
-    let Some((rule, (captures, placeholder_to_rep_id, rep_depths))) =
-        macro_rules.iter().find_map(|rule| {
-            is_macro_rule_match(db, rule, &macro_call_syntax.arguments(db)).map(|res| (rule, res))
-        })
-    else {
+    let Some((rule, mut matcher_ctx)) = macro_rules.iter().find_map(|rule| {
+        is_macro_rule_match(db, rule, &macro_call_syntax.arguments(db)).map(|res| (rule, res))
+    }) else {
         let diag_added = diagnostics.report(
             macro_call_syntax.stable_ptr(db),
             SemanticDiagnosticKind::InlineMacroNoMatchingRule(macro_name),
@@ -152,8 +150,6 @@ fn priv_macro_call_data<'db>(
             parent_macro_call_data,
         });
     }
-    let mut matcher_ctx =
-        MatcherContext { captures, placeholder_to_rep_id, rep_depths, ..Default::default() };
     let expanded_code = expand_macro_rule(db, rule, &mut matcher_ctx).unwrap();
     let generated_file_id = FileLongId::Virtual(VirtualFile {
         parent: Some(macro_call_syntax.stable_ptr(db).untyped().span_in_file(db)),

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -32,14 +32,6 @@ pub struct RepetitionId(usize);
 /// Each macro parameter name maps to a flat list of matched strings.
 type Captures<'db> = OrderedHashMap<SmolStrId<'db>, Vec<CapturedValue<'db>>>;
 
-/// What a successful macro rule match hands to the expansion: the captured values, the repetition
-/// each placeholder is bound to, and the pattern nesting depth of each repetition.
-type MacroMatch<'db> = (
-    Captures<'db>,
-    OrderedHashMap<SmolStrId<'db>, RepetitionId>,
-    OrderedHashMap<RepetitionId, usize>,
-);
-
 /// Context used during macro pattern matching and expansion.
 /// Tracks captured values, active repetition scopes, and repetition ownership per placeholder.
 #[derive(Default, Clone, Debug)]
@@ -56,12 +48,24 @@ pub struct MatcherContext<'db> {
     /// to their correct `RepetitionId` while recursing into nested repetitions.
     pub current_repetition_stack: Vec<RepetitionId>,
 
-    /// Counter for generating unique `RepetitionId`s.
-    pub next_repetition_id: usize,
+    /// The `RepetitionId` of each `$()` in the pattern, keyed by its syntax node. A repetition is
+    /// re-walked once per iteration of its enclosing repetition, so the id has to come from the
+    /// pattern site rather than from the traversal, or a nested repetition would get a fresh id -
+    /// and no stable identity - on every outer iteration.
+    pub rep_ids: OrderedHashMap<SyntaxStablePtrId<'db>, RepetitionId>,
 
     /// The nesting depth of each repetition within the pattern, starting at 1. Used to pick the
     /// driver of an expansion block: the outermost repetition still available drives it.
     pub rep_depths: OrderedHashMap<RepetitionId, usize>,
+
+    /// The repetition each repetition is nested in, absent for a top-level one.
+    pub rep_parents: OrderedHashMap<RepetitionId, RepetitionId>,
+
+    /// How many times each repetition matched, once per entry into it. A top-level repetition is
+    /// entered once, a nested one once per iteration of its parent - so this is indexed by the
+    /// parent's iteration, and its running sum gives the offset of that group in
+    /// [`Self::captures`].
+    pub rep_group_lens: OrderedHashMap<RepetitionId, Vec<usize>>,
 
     /// Tracks the current index for each active repetition during expansion.
     pub repetition_indices: OrderedHashMap<RepetitionId, usize>,
@@ -347,7 +351,7 @@ pub fn is_macro_rule_match<'db>(
     db: &'db dyn Database,
     rule: &MacroRuleData<'db>,
     input: &ast::TokenTreeNode<'db>,
-) -> Option<MacroMatch<'db>> {
+) -> Option<MatcherContext<'db>> {
     let mut ctx = MatcherContext::default();
 
     let matcher_elements = get_macro_elements(db, rule.pattern.clone());
@@ -363,7 +367,7 @@ pub fn is_macro_rule_match<'db>(
     if !validate_repetition_operator_constraints(&ctx) {
         return None;
     }
-    Some((ctx.captures, ctx.placeholder_to_rep_id, ctx.rep_depths))
+    Some(ctx)
 }
 
 /// Helper function for [expand_macro_rule].
@@ -495,8 +499,12 @@ fn is_macro_rule_match_ex<'db>(
                 }
             }
             ast::MacroElement::Repetition(repetition) => {
-                let rep_id = RepetitionId(ctx.next_repetition_id);
-                ctx.next_repetition_id += 1;
+                let next_id = RepetitionId(ctx.rep_ids.len());
+                let rep_id =
+                    *ctx.rep_ids.entry(repetition.stable_ptr(db).untyped()).or_insert(next_id);
+                if let Some(parent) = ctx.current_repetition_stack.last() {
+                    ctx.rep_parents.insert(rep_id, *parent);
+                }
                 ctx.current_repetition_stack.push(rep_id);
                 ctx.rep_depths.insert(rep_id, ctx.current_repetition_stack.len());
                 let elements = repetition.elements(db);
@@ -544,9 +552,7 @@ fn is_macro_rule_match_ex<'db>(
                 }
                 ctx.repetition_match_counts.insert(rep_id, match_count);
                 ctx.repetition_operators.insert(rep_id, operator.clone());
-                for i in 0..match_count {
-                    ctx.repetition_indices.insert(rep_id, i);
-                }
+                ctx.rep_group_lens.entry(rep_id).or_default().push(match_count);
                 ctx.current_repetition_stack.pop();
                 continue;
             }
@@ -637,13 +643,12 @@ fn expand_macro_rule_ex(
             let repetition = ast::MacroRepetition::from_syntax_node(db, node);
             let elements = repetition.elements(db);
             // A block with no driver is rejected at declaration time.
-            let (placeholder_name, rep_id) =
+            let (_placeholder_name, rep_id) =
                 find_repetition_driver(db, elements.elements(db), matcher_ctx)
                     .ok_or_else(skip_diagnostic)?;
-            let repetition_len =
-                matcher_ctx.captures.get(&placeholder_name).map(|v| v.len()).unwrap_or(0);
+            let (group_offset, repetition_len) = repetition_group(matcher_ctx, rep_id);
             for i in 0..repetition_len {
-                matcher_ctx.repetition_indices.insert(rep_id, i);
+                matcher_ctx.repetition_indices.insert(rep_id, group_offset + i);
                 for element in elements.elements(db) {
                     expand_macro_rule_ex(
                         db,
@@ -714,6 +719,27 @@ fn register_repetition_placeholders<'db>(
         };
         register_repetition_placeholders(db, inner_elements.elements(db), rep_id, ctx);
     }
+}
+
+/// Returns where the group of `rep_id` now being expanded starts in the flat capture lists, and how
+/// many iterations it has.
+///
+/// A repetition is entered once per iteration of its parent, so the parent's current index selects
+/// the group, and the lengths of the groups before it give the offset.
+fn repetition_group(matcher_ctx: &MatcherContext<'_>, rep_id: RepetitionId) -> (usize, usize) {
+    let group_lens = matcher_ctx
+        .rep_group_lens
+        .get(&rep_id)
+        .expect("Every repetition records its group lengths while matching.");
+    // A block driven by a repetition whose parent is not being iterated is the degenerate shape
+    // where the pattern binds nothing at this level - every such block then uses the first group.
+    let group = matcher_ctx
+        .rep_parents
+        .get(&rep_id)
+        .and_then(|parent| matcher_ctx.repetition_indices.get(parent))
+        .copied()
+        .unwrap_or(0);
+    (group_lens[..group].iter().sum(), group_lens.get(group).copied().unwrap_or(0))
 }
 
 /// Returns the placeholder driving the given expansion repetition block, and the repetition it is


### PR DESCRIPTION
Stacked on #10270.

A nested repetition now expands over **its own group** of captures rather than the whole flat list.

Captures are stored flat, one list per placeholder, so a nested repetition had no way to say "this iteration's slice". With more than one group at a level the inner block re-walked every capture on every outer step:

```
($($a:expr => [$($b:expr),*]),*) => { $($a + $($b +)*)* 0 }
groups!(1 => [7, 8], 2 => [9])
  before: 1 + 7+8+9+2 + 7+8+9+0
  after:  1 + 7+8+2 + 9+0
```

`MatcherContext` gains `rep_ids`, `rep_parents` and `rep_group_lens`. A repetition is entered once per iteration of its parent, so the parent's current index selects the group and the lengths of preceding groups give the offset. `rep_ids` is keyed by the pattern's syntax node rather than by traversal order — a nested repetition is re-walked on every outer iteration and would otherwise get a fresh id, and no stable identity, each time.

### Tests

Goldens in `expansion_test_data/inline_macros`, all expected values cross-checked against `macro_rules!` under rustc:

- nested repetition matching a different number of times per outer iteration
- three repetition levels, each with several groups
- `three_levels` strengthened to repeat at every level (per review) — `1 => [2 => (3, 4), 5 => (6, 7)], 8 => [9 => (10, 11)]`
- `unsorted_lhs` — a pattern whose placeholders are not ordered by repetition depth
- `multi_vars` — several placeholders bound at each of two depths

The last three were requested on #10270 but cannot live there: that commit still walks the flat list, so they emit wrong output and landing them there would mean blessing it.
