### PR TITLE
refactor(sierra-generator): derive function params from the final lowering

### DIFF
--- a/crates/cairo-lang-lowering/src/objects.rs
+++ b/crates/cairo-lang-lowering/src/objects.rs
@@ -145,6 +145,9 @@ pub struct Lowered<'db> {
     /// Diagnostics produced while lowering.
     pub diagnostics: Diagnostics<'db, LoweringDiagnostic<'db>>,
     /// Function signature.
+    /// Note that `signature.params` holds only the explicit parameters - unlike `parameters`,
+    /// which is the actual parameter list of the function and includes the implicits once the
+    /// `LowerImplicits` phase has run.
     pub signature: Signature<'db>,
     /// Arena of allocated lowered variables.
     /// SAFETY: `id_arena::Arena` is a foreign type, so this cannot be derived; the arena holds

--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -287,7 +287,13 @@ fn get_function_signature(
     // it in the end of program_generator::get_sierra_program instead of calling this function from
     // there.
     let lowered_function_id = db.lookup_sierra_function(&function_id);
-    let signature = lowered_function_id.signature(db)?;
+    // For functions with a body, take the signature from the final lowering, as optimization
+    // phases may change the signature of compiler-generated functions (whose signatures are not
+    // user-visible).
+    let signature = match lowered_function_id.body(db)? {
+        Some(body) => db.lowered_body(body, lowering::LoweringStage::Final)?.signature.clone(),
+        None => lowered_function_id.signature(db)?,
+    };
 
     let implicits = db
         .function_implicits(lowered_function_id)?

--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -287,7 +287,6 @@ fn get_function_signature(
     // it in the end of program_generator::get_sierra_program instead of calling this function from
     // there.
     let lowered_function_id = db.lookup_sierra_function(&function_id);
-    let signature = lowered_function_id.signature(db)?;
 
     let implicits = db
         .function_implicits(lowered_function_id)?
@@ -295,13 +294,33 @@ fn get_function_signature(
         .map(|ty| db.get_concrete_type_id(*ty).cloned())
         .collect::<Maybe<Vec<ConcreteTypeId>>>()?;
 
+    // For functions with a body, the actual parameters are those of the final lowering: they
+    // include the implicits, and reflect optimization phases that may change the signature of
+    // compiler-generated functions (whose signatures are not user-visible). The signature is used
+    // only for the return-side types, which no lowering phase changes.
+    // For body-less functions everything is derived from the declared signature.
+    let (signature, all_params) = match lowered_function_id.body(db)? {
+        Some(body) => {
+            let lowered = db.lowered_body(body, lowering::LoweringStage::Final)?;
+            let params = lowered
+                .parameters
+                .iter()
+                .map(|var| db.get_concrete_type_id(lowered.variables[*var].ty).cloned())
+                .collect::<Maybe<Vec<_>>>()?;
+            (lowered.signature.clone(), params)
+        }
+        None => {
+            let signature = lowered_function_id.signature(db)?;
+            let mut params = implicits.clone();
+            for param in &signature.params {
+                params.push(db.get_concrete_type_id(param.ty)?.clone());
+            }
+            (signature, params)
+        }
+    };
+
     // TODO(spapini): Handle ret_types in lowering.
-    let mut all_params = implicits.clone();
     let mut extra_rets = vec![];
-    for param in &signature.params {
-        let concrete_type_id = db.get_concrete_type_id(param.ty)?;
-        all_params.push(concrete_type_id.clone());
-    }
     for var in &signature.extra_rets {
         let concrete_type_id = db.get_concrete_type_id(var.ty())?;
         extra_rets.push(concrete_type_id.clone());


### PR DESCRIPTION
For functions with a body, derive the Sierra function's parameter types directly from the final-stage `Lowered` parameters (which include the implicits) instead of re-deriving them as `function_implicits` ++ the pre-optimization signature params.

Previously there were two independent derivations of the same list that had to agree positionally: the pre-Sierra function body takes its params from `Lowered.parameters`, while `get_function_signature` rebuilt them from the semantic-shaped signature. Now both read from a single source of truth, which also lets optimization phases change the parameters of compiler-generated functions (whose signatures are not user-visible) without sierra-gen needing to know about each such phase. The lowered signature is still used for the return-side types, which no phase changes.

On main this is a no-op refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)