### PR TITLE
fix(lowering): correct copy-pasted test_file_test module args

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/early_unsafe_panic_test.rs
@@ -13,7 +13,7 @@ use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
-    scrub_units,
+    early_unsafe_panic,
     "src/optimizations/test_data",
     {
         early_unsafe_panic: "early_unsafe_panic"

--- a/crates/cairo-lang-lowering/src/optimizations/trim_unreachable_test.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/trim_unreachable_test.rs
@@ -11,7 +11,7 @@ use crate::optimizations::strategy::{ApplyOptimization, OptimizationPhase};
 use crate::test_utils::LoweringDatabaseForTesting;
 
 cairo_lang_test_utils::test_file_test!(
-    scrub_units,
+    trim_unreachable,
     "src/optimizations/test_data",
     {
         trim_unreachable: "trim_unreachable"


### PR DESCRIPTION
## Summary

Three optimization test files in `cairo-lang-lowering` shared the
`test_file_test!` module arg `scrub_units` due to copy-paste:
`scrub_units_test.rs` (correct), `trim_unreachable_test.rs`, and
`early_unsafe_panic_test.rs`. This renames the module args in the two
wrong files to `trim_unreachable` and `early_unsafe_panic` respectively.

## Type of change

- [x] Bug fix (fixes incorrect behavior)

## Why is this change needed?

`cargo test -p cairo-lang-lowering scrub_units` ran all three test
suites, and the per-file cargo filter paths were misleading (e.g. the
trim_unreachable test appeared as
`optimizations::trim_unreachable::test::scrub_units::trim_unreachable`).

## What is the behavior after?

Each test now lives under its own filter path, e.g.
`optimizations::trim_unreachable::test::trim_unreachable::trim_unreachable`.
Only cargo test filter paths change - golden files and runner names are
untouched, and no CI scripts reference the old paths.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>