### PR TITLE
(refactor): support a single `cairo_code` test input with `#[target_function]`

### DIFF
--- a/crates/cairo-lang-lowering/src/test_utils.rs
+++ b/crates/cairo-lang-lowering/src/test_utils.rs
@@ -8,6 +8,7 @@ use cairo_lang_filesystem::flag::{Flag, FlagsGroup};
 use cairo_lang_filesystem::ids::FlagLongId;
 use cairo_lang_semantic::db::{PluginSuiteInput, init_semantic_group};
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
+use cairo_lang_semantic::test_utils::with_target_function_plugin;
 use salsa::Database;
 
 use crate::Lowered;
@@ -32,7 +33,7 @@ impl LoweringDatabaseForTesting {
         init_defs_group(&mut res);
         init_semantic_group(&mut res);
 
-        res.set_default_plugins_from_suite(get_default_plugin_suite());
+        res.set_default_plugins_from_suite(with_target_function_plugin(get_default_plugin_suite()));
 
         let corelib_path = detect_corelib().expect("Corelib not found in default location.");
         init_dev_corelib(&mut res, corelib_path);

--- a/crates/cairo-lang-runner/src/profiling_test.rs
+++ b/crates/cairo-lang-runner/src/profiling_test.rs
@@ -1,6 +1,6 @@
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
-use cairo_lang_semantic::test_utils::setup_test_module;
+use cairo_lang_semantic::test_utils::{setup_test_module, with_target_function_plugin};
 use cairo_lang_sierra_generator::db::SierraGenGroup;
 use cairo_lang_sierra_generator::program_generator::SierraProgramWithDebug;
 use cairo_lang_sierra_generator::replace_ids::replace_sierra_ids_in_program;
@@ -40,7 +40,7 @@ pub fn test_profiling(
     }
 
     let db = RootDatabase::builder()
-        .with_default_plugin_suite(starknet_plugin_suite())
+        .with_default_plugin_suite(with_target_function_plugin(starknet_plugin_suite()))
         .detect_corelib()
         .build()
         .unwrap();

--- a/crates/cairo-lang-semantic/src/items/tests/module
+++ b/crates/cairo-lang-semantic/src/items/tests/module
@@ -3,13 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn abc() {}
 
 fn abc(a: felt252) {}

--- a/crates/cairo-lang-semantic/src/items/tests/panicable
+++ b/crates/cairo-lang-semantic/src/items/tests/panicable
@@ -3,18 +3,13 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+fn bar_panic() {}
+fn bar_nopanic() nopanic {}
 fn foo_panic() {
     bar_panic();
     bar_nopanic();
 }
-
-//! > function_name
-foo_panic
-
-//! > module_code
-fn bar_panic() {}
-fn bar_nopanic() nopanic {}
 
 //! > expected_diagnostics
 
@@ -25,18 +20,13 @@ fn bar_nopanic() nopanic {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar_panic() {}
+fn bar_nopanic() nopanic {}
 fn foo_nopanic() nopanic {
     bar_panic();
     bar_nopanic();
 }
-
-//! > function_name
-foo_nopanic
-
-//! > module_code
-fn bar_panic() {}
-fn bar_nopanic() nopanic {}
 
 //! > expected_diagnostics
 error[E2115]: Function is declared as nopanic but calls a function that may panic.

--- a/crates/cairo-lang-semantic/src/test.rs
+++ b/crates/cairo-lang-semantic/src/test.rs
@@ -7,6 +7,7 @@ use cairo_lang_filesystem::ids::{CodeMapping, CodeOrigin, SmolStrId};
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use cairo_lang_utils::extract_matches;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use indoc::indoc;
 use itertools::Itertools;
 use salsa::Database;
@@ -15,7 +16,10 @@ use crate::db::SemanticGroup;
 use crate::inline_macros::get_default_plugin_suite;
 use crate::items::free_function::FreeFunctionSemantic;
 use crate::items::module::ModuleSemantic;
-use crate::test_utils::{SemanticDatabaseForTesting, setup_test_module};
+use crate::test_utils::{
+    SemanticDatabaseForTesting, resolve_target_functions, setup_test_function, setup_test_module,
+    test_function_diagnostics,
+};
 
 #[test]
 fn test_resolve() {
@@ -172,5 +176,64 @@ fn test_mapping_translate_consecutive_spans() {
             ^^^^^
 
     "#}
+    );
+}
+
+/// Builds the inputs map of a test block with a single `cairo_code` tag.
+fn cairo_code_inputs(cairo_code: &str) -> OrderedHashMap<String, String> {
+    OrderedHashMap::from([("cairo_code".to_string(), cairo_code.to_string())])
+}
+
+#[test]
+fn test_target_function_resolution() {
+    let db = &SemanticDatabaseForTesting::default();
+    let inputs = cairo_code_inputs(indoc! {"
+        fn not_the_target() {}
+        #[target_function]
+        fn the_target() {}
+    "});
+    let test_function = setup_test_function(db, &inputs).unwrap();
+    assert_eq!(
+        format!("{:?}", test_function.function_id.debug(db)),
+        "FreeFunctionId(test::the_target)"
+    );
+}
+
+#[test]
+fn test_multiple_target_functions_resolution() {
+    let db = &SemanticDatabaseForTesting::default();
+    let (test_module, diagnostics) = setup_test_module(
+        db,
+        indoc! {"
+            #[target_function]
+            fn first() {}
+            fn untargeted() {}
+            #[target_function]
+            fn second() {}
+        "},
+    )
+    .split();
+    // The `#[target_function]` attribute is declared by the testing plugin, so it is not reported
+    // as an unsupported attribute.
+    assert_eq!(diagnostics, "");
+    let target_functions = resolve_target_functions(db, test_module.module_id);
+    assert_eq!(
+        target_functions.iter().map(|id| format!("{:?}", id.debug(db))).collect_vec(),
+        vec!["FreeFunctionId(test::first)", "FreeFunctionId(test::second)"]
+    );
+}
+
+#[test]
+fn test_no_target_function_is_fine_for_module_diagnostics() {
+    let inputs = cairo_code_inputs("fn foo() { let _x: felt252 = 5_u8; }");
+    let result = test_function_diagnostics(
+        &inputs,
+        &OrderedHashMap::from([("expect_diagnostics".to_string(), "true".to_string())]),
+    );
+    assert!(result.error.is_none(), "{:?}", result.error);
+    assert!(
+        result.outputs["expected_diagnostics"].contains("Unexpected argument type"),
+        "{}",
+        result.outputs["expected_diagnostics"]
     );
 }

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -1,7 +1,8 @@
 use std::sync::{LazyLock, Mutex};
 
 use cairo_lang_defs::db::{DefsGroup, init_defs_group, init_external_files};
-use cairo_lang_defs::ids::{FunctionWithBodyId, ModuleId};
+use cairo_lang_defs::ids::{FreeFunctionId, FunctionWithBodyId, ModuleId};
+use cairo_lang_defs::plugin::{MacroPlugin, MacroPluginMetadata, PluginResult};
 use cairo_lang_diagnostics::{Diagnostics, DiagnosticsBuilder};
 use cairo_lang_filesystem::db::{
     CrateSettings, Edition, ExperimentalFeaturesConfig, init_dev_corelib, init_files_group,
@@ -11,8 +12,10 @@ use cairo_lang_filesystem::ids::{
     BlobId, CrateId, CrateLongId, FileKind, FileLongId, SmolStrId, VirtualFile,
 };
 use cairo_lang_parser::db::ParserGroup;
+use cairo_lang_syntax::node::ast;
+use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
-use cairo_lang_test_utils::verify_diagnostics_expectation;
+use cairo_lang_test_utils::{get_direct_or_file_content, verify_diagnostics_expectation};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::{Intern, OptionFrom, extract_matches};
 use salsa::Database;
@@ -24,6 +27,60 @@ use crate::items::functions::GenericFunctionId;
 use crate::items::module::ModuleSemantic;
 use crate::plugin::PluginSuite;
 use crate::{ConcreteFunctionWithBodyId, SemanticDiagnostic, semantic};
+
+/// The attribute marking the function(s) a test block targets, within its `cairo_code` input.
+pub const TARGET_FUNCTION_ATTR: &str = "target_function";
+
+/// A test-only no-op macro plugin, whose sole purpose is to declare the `#[target_function]`
+/// attribute, so that marking a function with it in test code is not reported as an
+/// "Unsupported attribute." error.
+///
+/// It never generates code and never removes the original item, so it has no effect on any other
+/// plugin in the suite.
+#[derive(Debug, Default)]
+pub struct TargetFunctionPlugin;
+
+impl MacroPlugin for TargetFunctionPlugin {
+    fn generate_code<'db>(
+        &self,
+        _db: &'db dyn Database,
+        _item_ast: ast::ModuleItem<'db>,
+        _metadata: &MacroPluginMetadata<'_>,
+    ) -> PluginResult<'db> {
+        PluginResult::default()
+    }
+
+    fn declared_attributes<'db>(&self, db: &'db dyn Database) -> Vec<SmolStrId<'db>> {
+        vec![SmolStrId::from(db, TARGET_FUNCTION_ATTR)]
+    }
+}
+
+/// Adds [TargetFunctionPlugin] to the given suite, and returns it.
+///
+/// Every testing database that runs golden test files must use this, otherwise `#[target_function]`
+/// markers in the test code would produce "Unsupported attribute." diagnostics.
+pub fn with_target_function_plugin(mut suite: PluginSuite) -> PluginSuite {
+    suite.add_plugin::<TargetFunctionPlugin>();
+    suite
+}
+
+/// Returns the free functions of the given module marked with `#[target_function]`, in the order
+/// they appear in the module.
+pub fn resolve_target_functions<'a>(
+    db: &'a dyn Database,
+    module_id: ModuleId<'a>,
+) -> Vec<FreeFunctionId<'a>> {
+    db.module_free_functions_ids(module_id)
+        .expect("Failed to load module.")
+        .iter()
+        .copied()
+        .filter(|free_function_id| {
+            db.module_free_function_by_id(*free_function_id)
+                .expect("Failed to load free function.")
+                .has_attr(db, TARGET_FUNCTION_ATTR)
+        })
+        .collect()
+}
 
 #[salsa::db]
 #[derive(Clone)]
@@ -47,7 +104,7 @@ impl SemanticDatabaseForTesting {
         init_defs_group(&mut res);
         init_semantic_group(&mut res);
 
-        res.set_default_plugins_from_suite(suite);
+        res.set_default_plugins_from_suite(with_target_function_plugin(suite));
 
         let corelib_path = detect_corelib().expect("Corelib not found in default location.");
         init_dev_corelib(&mut res, corelib_path);
@@ -176,20 +233,41 @@ pub struct TestFunction<'a> {
     pub body: semantic::ExprId,
 }
 
-/// Returns the semantic model of a given function.
-/// `inputs["function_code"]` - code of the function.
-/// `inputs["function_name"]` - name of the function.
-/// `inputs["module_code"]` - optional extra setup code in the module context.
+/// Returns the code of the module described by the given test inputs.
+///
+/// Supports both formats:
+/// * New: `inputs["cairo_code"]` is the whole module (possibly a `>>> file: <path>` reference).
+/// * Legacy: `inputs["module_code"]` (optional) and `inputs["function_code"]`, joined by a single
+///   `'\n'`.
+pub fn test_module_code(inputs: &OrderedHashMap<String, String>) -> String {
+    if let Some(cairo_code) = inputs.get("cairo_code") {
+        let (_path, content) = get_direct_or_file_content(cairo_code);
+        return content;
+    }
+    let function_code = &inputs["function_code"];
+    let module_code = inputs.get("module_code").map_or("", String::as_str);
+    if module_code.is_empty() {
+        function_code.clone()
+    } else {
+        format!("{module_code}\n{function_code}")
+    }
+}
+
+/// Returns the semantic model of the function a test targets.
+///
+/// The module code is taken as described in [test_module_code], and the target function within it
+/// is resolved either by `inputs["function_name"]`, or - if that tag is absent - by the single
+/// function marked with `#[target_function]`.
+///
 /// `inputs["crate_settings"]` - optional extra settings for the crate.
 pub fn setup_test_function<'a>(
     db: &'a dyn Database,
     inputs: &'a OrderedHashMap<String, String>,
 ) -> WithStringDiagnostics<TestFunction<'a>> {
-    setup_test_function_ex(
+    setup_test_function_from_content(
         db,
-        &inputs["function_code"],
-        &inputs["function_name"],
-        inputs.get("module_code").map_or("", String::as_str),
+        &test_module_code(inputs),
+        inputs.get("function_name").map(String::as_str),
         inputs.get("crate_settings").map(String::as_str),
         None,
     )
@@ -214,14 +292,46 @@ pub fn setup_test_function_ex<'a>(
     } else {
         format!("{module_code}\n{function_code}")
     };
+    setup_test_function_from_content(db, &content, Some(function_name), crate_settings, cache_crate)
+}
+
+/// Returns the semantic model of a function within the module of the given `content`.
+///
+/// The function is looked up by `function_name` if given, and otherwise by the `#[target_function]`
+/// marker - which must mark exactly one function.
+fn setup_test_function_from_content<'a>(
+    db: &'a dyn Database,
+    content: &str,
+    function_name: Option<&'a str>,
+    crate_settings: Option<&str>,
+    cache_crate: Option<BlobId<'a>>,
+) -> WithStringDiagnostics<TestFunction<'a>> {
     let (test_module, diagnostics) =
-        setup_test_module_ex(db, &content, crate_settings, cache_crate).split();
-    let generic_function_id = db
-        .module_item_by_name(test_module.module_id, SmolStrId::from(db, function_name))
-        .expect("Failed to load module")
-        .and_then(GenericFunctionId::option_from)
-        .unwrap_or_else(|| panic!("Function '{function_name}' was not found."));
-    let free_function_id = extract_matches!(generic_function_id, GenericFunctionId::Free);
+        setup_test_module_ex(db, content, crate_settings, cache_crate).split();
+    let free_function_id = match function_name {
+        Some(function_name) => {
+            let generic_function_id = db
+                .module_item_by_name(test_module.module_id, SmolStrId::from(db, function_name))
+                .expect("Failed to load module")
+                .and_then(GenericFunctionId::option_from)
+                .unwrap_or_else(|| panic!("Function '{function_name}' was not found."));
+            extract_matches!(generic_function_id, GenericFunctionId::Free)
+        }
+        None => {
+            let target_functions = resolve_target_functions(db, test_module.module_id);
+            match target_functions.as_slice() {
+                [free_function_id] => *free_function_id,
+                [] => panic!(
+                    "No function marked with `#[{TARGET_FUNCTION_ATTR}]` was found. Mark the \
+                     tested function, or add a `function_name` tag."
+                ),
+                _ => panic!(
+                    "Expected a single function marked with `#[{TARGET_FUNCTION_ATTR}]`, found {}.",
+                    target_functions.len()
+                ),
+            }
+        }
+    };
     let function_id = FunctionWithBodyId::Free(free_function_id);
     WithStringDiagnostics {
         value: TestFunction {
@@ -330,7 +440,21 @@ pub fn test_function_diagnostics(
 ) -> TestRunnerResult {
     let db = &SemanticDatabaseForTesting::default();
 
-    let diagnostics = setup_test_function(db, inputs).get_diagnostics();
+    // The reported diagnostics are the recursive module diagnostics, so the target function is
+    // never actually required here. In the new format no function has to be resolved at all -
+    // which also allows test blocks that have no function to target.
+    let diagnostics = if inputs.contains_key("cairo_code") && !inputs.contains_key("function_name")
+    {
+        setup_test_module_ex(
+            db,
+            &test_module_code(inputs),
+            inputs.get("crate_settings").map(String::as_str),
+            None,
+        )
+        .get_diagnostics()
+    } else {
+        setup_test_function(db, inputs).get_diagnostics()
+    };
     let error = verify_diagnostics_expectation(args, &diagnostics);
 
     TestRunnerResult {

--- a/crates/cairo-lang-semantic/src/usage/test_data/usage
+++ b/crates/cairo-lang-semantic/src/usage/test_data/usage
@@ -3,7 +3,13 @@
 //! > test_runner_name
 test_function_usage
 
-//! > function_code
+//! > cairo_code
+struct A {
+    b: B,
+}
+struct B {
+    c: usize,
+}
 fn foo(mut a: A, ref b: A) {
     let c = 5_usize;
     loop {
@@ -22,14 +28,6 @@ fn foo(mut a: A, ref b: A) {
 //! > function_name
 foo
 
-//! > module_code
-struct A {
-    b: B,
-}
-struct B {
-    c: usize,
-}
-
 //! > semantic_diagnostics
 
 //! > usage
@@ -45,7 +43,13 @@ Loop 8:4:
 //! > test_runner_name
 test_function_usage
 
-//! > function_code
+//! > cairo_code
+struct A {
+    b: B,
+}
+struct B {
+    c: usize,
+}
 fn foo(mut a: A, ref b: A) {
     let c = 5_usize;
     let only_used_in_condition = 5;
@@ -56,14 +60,6 @@ fn foo(mut a: A, ref b: A) {
 
 //! > function_name
 foo
-
-//! > module_code
-struct A {
-    b: B,
-}
-struct B {
-    c: usize,
-}
 
 //! > semantic_diagnostics
 
@@ -80,7 +76,15 @@ While 9:4:
 //! > test_runner_name
 test_function_usage
 
-//! > function_code
+//! > cairo_code
+struct A {
+    b: B,
+}
+struct B {
+    c: usize,
+}
+fn consume_B(b: B) {}
+fn borrow_B(b: @B) {}
 fn foo(mut a: A, ref b: B) {
     let c = 5_usize;
     let only_used_in_condition = 5;
@@ -97,16 +101,6 @@ fn foo(mut a: A, ref b: B) {
 //! > function_name
 foo
 
-//! > module_code
-struct A {
-    b: B,
-}
-struct B {
-    c: usize,
-}
-fn consume_B(b: B) {}
-fn borrow_B(b: @B) {}
-
 //! > semantic_diagnostics
 
 //! > usage
@@ -122,7 +116,7 @@ While 11:4:
 //! > test_runner_name
 test_function_usage
 
-//! > function_code
+//! > cairo_code
 fn foo(a: u32) {
     |b: u32| {
         || a + b;
@@ -151,7 +145,7 @@ Closure 1:4:
 //! > test_runner_name
 test_function_usage
 
-//! > function_code
+//! > cairo_code
 fn foo(a: u32) {
     let arr = array![1, 2, 3];
     for b in arr {
@@ -177,7 +171,7 @@ For 2:4:
 //! > test_runner_name
 test_function_usage
 
-//! > function_code
+//! > cairo_code
 fn foo() -> u32 {
     let mut counter = 0;
     let outer = array![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -212,7 +206,7 @@ For 4:4:
 //! > test_runner_name
 test_function_usage
 
-//! > function_code
+//! > cairo_code
 fn foo(mut a: Span<u32>, mut b: Span<u32>) -> Option<usize> {
     let Some(_) = a.pop_front() else {
         return b.pop_front().map(|q| *q);

--- a/crates/cairo-lang-sierra-generator/src/test_utils.rs
+++ b/crates/cairo-lang-sierra-generator/src/test_utils.rs
@@ -12,7 +12,7 @@ use cairo_lang_lowering::db::{LoweringGroup, lowering_group_input};
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::corelib::CorelibSemantic;
 use cairo_lang_semantic::db::{PluginSuiteInput, SemanticGroup, init_semantic_group};
-use cairo_lang_semantic::test_utils::setup_test_crate;
+use cairo_lang_semantic::test_utils::{setup_test_crate, with_target_function_plugin};
 use cairo_lang_sierra::ids::{ConcreteLibfuncId, GenericLibfuncId};
 use cairo_lang_sierra::program;
 use cairo_lang_utils::{CloneableDatabase, Intern};
@@ -66,7 +66,7 @@ impl SierraGenDatabaseForTesting {
         init_defs_group(&mut res);
         init_semantic_group(&mut res);
 
-        let plugin_suite = get_default_plugin_suite();
+        let plugin_suite = with_target_function_plugin(get_default_plugin_suite());
         res.set_default_plugins_from_suite(plugin_suite);
 
         lowering_group_input(&res)


### PR DESCRIPTION
Adds a test-only no-op `TargetFunctionPlugin` declaring the `target_function`
attribute, registered in the semantic, lowering, sierra-generator and runner
testing databases.

`setup_test_function` now accepts both formats simultaneously:
* content: `cairo_code` (with `>>> file:` support), else the legacy
  `module_code` + '\n' + `function_code` join, unchanged.
* target: `function_name` if present, else the single `#[target_function]`
  marked function.

`test_function_diagnostics` routes through `setup_test_module_ex` when
`cairo_code` is given without `function_name`, so diagnostics-only blocks no
longer need a dummy function.

`setup_test_function_ex`'s signature is unchanged. Three pilot data files are
migrated with byte-identical golden outputs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>