### PR TITLE
(refactor): migrate cairo-lang-semantic golden test data to the cairo_code format

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/test_data/assignment
+++ b/crates/cairo-lang-semantic/src/expr/test_data/assignment
@@ -3,7 +3,9 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern type MyType;
 fn foo(p: felt252) {
     p = 7;
     a = 1 + 2;
@@ -12,13 +14,6 @@ fn foo(p: felt252) {
     let mut x = 1;
     x = true;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern type MyType;
 
 //! > expected_diagnostics
 error[E2083]: Cannot assign to an immutable variable.
@@ -53,13 +48,10 @@ error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "()".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: ByteArray = "error";
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -70,13 +62,10 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: felt252 = "error";
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2311]: Mismatched types. The type `core::felt252` cannot be created from a string literal.
@@ -91,13 +80,10 @@ error[E2311]: Mismatched types. The type `core::felt252` cannot be created from 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: felt252 = 252;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -108,13 +94,10 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: ByteArray = 252;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2315]: Mismatched types. The type `core::byte_array::ByteArray` cannot be created from a numeric literal.

--- a/crates/cairo-lang-semantic/src/expr/test_data/attributes
+++ b/crates/cairo-lang-semantic/src/expr/test_data/attributes
@@ -3,22 +3,17 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyStruct {};
-    MyEnum::a(3);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 struct MyStruct {}
 
 #[phantom]
 enum MyEnum {
     a: felt252,
+}
+fn foo() {
+    MyStruct {};
+    MyEnum::a(3);
 }
 
 //! > expected_diagnostics
@@ -39,13 +34,7 @@ error[E2019]: Phantom types cannot be instantiated.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[cfg(ref x)]
 fn f() {}
 
@@ -58,19 +47,14 @@ fn f() {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: Option<Ph>) -> Option<Ph> {
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 enum Ph {
     A: felt252,
     B: (felt252, felt252),
+}
+fn foo(x: Option<Ph>) -> Option<Ph> {
+    x
 }
 
 //! > expected_diagnostics
@@ -91,19 +75,14 @@ fn foo(x: Option<Ph>) -> Option<Ph> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: Option<Ph>) -> Option<Ph> {
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 struct Ph {
     a: felt252,
     b: felt252,
+}
+fn foo(x: Option<Ph>) -> Option<Ph> {
+    x
 }
 
 //! > expected_diagnostics
@@ -124,15 +103,7 @@ fn foo(x: Option<Ph>) -> Option<Ph> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: Wrapper<Ph>) -> Wrapper<Ph> {
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 struct Ph {
     a: felt252,
@@ -140,6 +111,9 @@ struct Ph {
 
 struct Wrapper<T> {
     value: T,
+}
+fn foo(x: Wrapper<Ph>) -> Wrapper<Ph> {
+    x
 }
 
 //! > expected_diagnostics
@@ -160,15 +134,10 @@ fn foo(x: Wrapper<Ph>) -> Wrapper<Ph> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: @Ph) {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 enum Ph {}
+fn foo(x: @Ph) {}
 
 //! > expected_diagnostics
 error[E2019]: Phantom types cannot be instantiated.
@@ -183,15 +152,10 @@ fn foo(x: @Ph) {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() implicits(Ph) {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 enum Ph {}
+fn foo() implicits(Ph) {}
 
 //! > expected_diagnostics
 error[E2019]: Phantom types cannot be instantiated.
@@ -206,17 +170,12 @@ fn foo() implicits(Ph) {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[phantom]
+enum Ph {}
 fn foo() {
     let _f = |_x: Option<Ph>| {};
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[phantom]
-enum Ph {}
 
 //! > expected_diagnostics
 error[E2019]: Phantom types cannot be instantiated.
@@ -231,18 +190,13 @@ error[E2019]: Phantom types cannot be instantiated.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: Array<Ph>) -> Array<Ph> {
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 enum Ph {
     A: felt252,
+}
+fn foo(x: Array<Ph>) -> Array<Ph> {
+    x
 }
 
 //! > expected_diagnostics
@@ -263,17 +217,12 @@ fn foo(x: Array<Ph>) -> Array<Ph> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[phantom]
+struct Ph {}
 fn foo(x: Array<Ph>) -> Array<Ph> {
     x
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[phantom]
-struct Ph {}
 
 //! > expected_diagnostics
 error[E2019]: Phantom types cannot be instantiated.
@@ -293,13 +242,7 @@ fn foo(x: Array<Ph>) -> Array<Ph> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 enum Ph {
     A: felt252,
@@ -322,18 +265,13 @@ error[E2019]: Phantom types cannot be instantiated.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: Span<Ph>) -> Span<Ph> {
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 enum Ph {
     A: felt252,
+}
+fn foo(x: Span<Ph>) -> Span<Ph> {
+    x
 }
 
 //! > expected_diagnostics
@@ -354,15 +292,10 @@ fn foo(x: Span<Ph>) -> Span<Ph> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: Span<()>) -> Span<()> {
     x
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E2053]: Cannot have array of type "()" that is zero sized.
@@ -382,13 +315,7 @@ fn foo(x: Span<()>) -> Span<()> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: B, y: A) {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 enum Ph {
     A: felt252,
@@ -402,6 +329,7 @@ struct B {
     a: Array<A>,
     bad: Array<Ph>,
 }
+fn foo(x: B, y: A) {}
 
 //! > expected_diagnostics
 error[E2019]: Phantom types cannot be instantiated.
@@ -436,15 +364,10 @@ fn foo(x: B, y: A) {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: A) {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     a: Array<A>,
 }
+fn foo(x: A) {}
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/closure
@@ -3,16 +3,13 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     || -> i32 {
         let d: u32 = 3;
         d
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::i32", found: "core::integer::u32".
@@ -27,16 +24,13 @@ error[E2042]: Unexpected return type. Expected: "core::integer::i32", found: "co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     |a| -> i32 {
         let d: i32 = a;
         d
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -47,16 +41,13 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     |a: u32| -> i32 {
         let d: i32 = a;
         d
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "core::integer::i32", found: "core::integer::u32".
@@ -71,16 +62,13 @@ error[E2041]: Unexpected argument type. Expected: "core::integer::i32", found: "
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: i32 = || {
         let d: u32 = 3;
         d
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "core::integer::i32", found: "{closure@lib.cairo:2:19: 2:21}".
@@ -98,13 +86,7 @@ error[E2041]: Unexpected argument type. Expected: "core::integer::i32", found: "
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const _x: i32 = || {
     let d: u32 = 3;
     d
@@ -134,18 +116,13 @@ error[E2302]: Type mismatch: `{closure@lib.cairo:1:17: 1:19}` and `core::integer
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar<const N: u32>() {}
 fn foo() {
     bar::<{ || -> u32 {
         2
     } }>();
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar<const N: u32>() {}
 
 //! > expected_diagnostics
 error[E2182]: Closures are not allowed in this context.
@@ -171,16 +148,13 @@ error[E2302]: Type mismatch: `{closure@lib.cairo:3:13: 3:15}` and `core::integer
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     |a| {
         let d = a;
         d
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2314]: Type annotations needed. Failed to infer ?0.
@@ -195,21 +169,16 @@ error[E2314]: Type annotations needed. Failed to infer ?0.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+fn bar<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>::Output {
+    core::ops::FnOnce::call(c, (2,))
+}
 fn foo() {
     let c = |a| {
         let d = a;
         d.into()
     };
     let _k: felt252 = bar(c);
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>::Output {
-    core::ops::FnOnce::call(c, (2,))
 }
 
 //! > expected_diagnostics
@@ -221,7 +190,10 @@ fn bar<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>::Output {
+    core::ops::FnOnce::call(c, (2,))
+}
 fn foo() {
     let c = |a| {
         let d = a;
@@ -229,14 +201,6 @@ fn foo() {
     };
     let _f: felt252 = core::ops::FnOnce::call(c, (2_u64,));
     let _k: felt252 = bar(c);
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>::Output {
-    core::ops::FnOnce::call(c, (2,))
 }
 
 //! > expected_diagnostics
@@ -252,7 +216,10 @@ error[E2311]: Trait has no implementation in context: core::ops::function::FnOnc
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>::Output {
+    core::ops::FnOnce::call(c, (2,))
+}
 fn foo() {
     let c = |a| {
         let d = a;
@@ -260,14 +227,6 @@ fn foo() {
     };
     let _f: u128 = core::ops::FnOnce::call(c, (2,));
     let _k: felt252 = bar(c);
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>::Output {
-    core::ops::FnOnce::call(c, (2,))
 }
 
 //! > expected_diagnostics
@@ -283,16 +242,13 @@ error[E2308]: `core::ops::function::FnOnceImpl::<{closure@lib.cairo:5:13: 5:16},
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let c = |a, b, c| {
         a.into() + b.into() + c.into()
     };
     let _f: u256 = c(2_felt252, 2_u256, 6_u64);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -303,16 +259,13 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let c = |a, b, c| {
         a.into() + b.into() + c.into()
     };
     let _f: u32 = c(2_felt252, 2_u256, 6_u64);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: core::traits::Into::<core::integer::u256, core::integer::u32>.
@@ -327,18 +280,13 @@ error[E2311]: Trait has no implementation in context: core::traits::Into::<core:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
+//! > cairo_code
+fn bar() -> u32 {
+    2
+}
 fn foo() {
     let bar: u8 = 3;
     let _f: u32 = bar(2);
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar() -> u32 {
-    2
 }
 
 //! > expected_diagnostics
@@ -354,17 +302,7 @@ warning[E2184]: Function `bar` is shadowed by a local variable.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let _y: u16 = baz(|a| {
-        a.into()
-    });
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar() -> u32 {
     2
 }
@@ -373,6 +311,11 @@ fn baz<T, +core::ops::FnOnce<T, (u32,)>>(c: T) -> core::ops::FnOnce::<T, (u32,)>
     let bar = 3;
     let _x: u32 = bar();
     c(9)
+}
+fn foo() {
+    let _y: u16 = baz(|a| {
+        a.into()
+    });
 }
 
 //! > expected_diagnostics
@@ -393,20 +336,15 @@ error[E2311]: Trait has no implementation in context: core::traits::Into::<core:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar(a: felt252) -> u32 {
+    2
+}
 fn foo() {
     let bar = |_a, _b, _c| -> u32 {
         3
     };
     let _f: u32 = bar(2);
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar(a: felt252) -> u32 {
-    2
 }
 
 //! > expected_diagnostics
@@ -422,7 +360,7 @@ error[E2311]: Trait has no implementation in context: core::ops::function::Fn::<
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let bar = |a| -> u32 {
         a
@@ -430,9 +368,6 @@ fn foo() {
     let a = 5;
     let _f: u32 = bar(ref a);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2185]: Arguments to closure functions cannot be references
@@ -447,7 +382,7 @@ error[E2185]: Arguments to closure functions cannot be references
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let bar = |a| {
         return a;
@@ -455,9 +390,6 @@ fn foo() {
     let a = 5;
     let _f: u32 = bar(a);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -468,7 +400,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let bar = |a: Option<u32>| -> Option<u32> {
         Some(a?)
@@ -476,9 +408,6 @@ fn foo() {
     let a = Some(5);
     let _f: u32 = bar(a).unwrap();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -489,7 +418,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 //TODO(Tomer): Add support for inference of Option type in closures.
 fn foo() {
     let bar1 = |a| -> Option<u32> {
@@ -502,9 +431,6 @@ fn foo() {
     let _f: u32 = bar(a).unwrap();
     let _f: u32 = bar2(a).unwrap();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2063]: Type "?0" cannot error propagate
@@ -544,7 +470,7 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     loop {
         let c = || {
@@ -553,9 +479,6 @@ fn foo() {
         c();
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2146]: `break` only allowed inside a `loop`.
@@ -570,7 +493,7 @@ error[E2146]: `break` only allowed inside a `loop`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     loop {
         let c = || {
@@ -579,9 +502,6 @@ fn foo() {
         c();
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2145]: `continue` only allowed inside a `loop`.
@@ -596,7 +516,7 @@ error[E2145]: `continue` only allowed inside a `loop`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut a = 5;
     let b = a;
@@ -604,9 +524,6 @@ fn foo() {
         a + b
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
@@ -621,16 +538,11 @@ error[E2188]: Capture of mutable variables in a closure is not supported
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+fn bar<T, +Destruct<T>>(a: T) {}
 fn foo() {
     bar(|| {});
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar<T, +Destruct<T>>(a: T) {}
 
 //! > expected_diagnostics
 
@@ -641,15 +553,12 @@ fn bar<T, +Destruct<T>>(a: T) {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _y = || 2;
     let x: u32 = 5;
     x()
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2138]: Call expression requires a function, found `core::integer::u32`.
@@ -665,22 +574,17 @@ Candidate `core::ops::function::FnOnce::call` inference failed with: Trait has n
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> u32 {
-    let _y = || 2;
-    let x: u32 = 5;
-    x()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 impl MyImpl of core::ops::FnOnce<u32, ()> {
     type Output = u32;
     fn call(self: u32, args: ()) -> u32 {
         self
     }
+}
+fn foo() -> u32 {
+    let _y = || 2;
+    let x: u32 = 5;
+    x()
 }
 
 //! > expected_diagnostics
@@ -696,15 +600,12 @@ impl MyImpl of core::ops::FnOnce<u32, ()> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _ = |a| {
         a = a + 2
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2083]: Cannot assign to an immutable variable.
@@ -719,15 +620,12 @@ error[E2083]: Cannot assign to an immutable variable.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _ = |ref a| {
         a = a + 2
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2186]: Closure parameters cannot be references
@@ -742,14 +640,11 @@ error[E2186]: Closure parameters cannot be references
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> Option<u32> {
     let x: Option<Array<i32>> = Some(array![1, 2, 3]);
     x.map(|x| x.len())
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -760,23 +655,18 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::call_with(|arr| {
-        arr.len();
-    });
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<F, +core::ops::Fn<F, (Array::<i32>,)>> {
     fn call_with(func: F) {
         func(ArrayTrait::<i32>::new());
     }
 }
 impl MyImpl<F, impl Func: core::ops::Fn<F, (Array::<i32>,)>> of MyTrait<F, Func>;
+fn foo() {
+    MyTrait::call_with(|arr| {
+        arr.len();
+    });
+}
 
 //! > expected_diagnostics
 error[E2046]: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::len and SpanTrait::len. Consider adding type annotations or explicitly refer to the impl function.
@@ -791,17 +681,12 @@ error[E2046]: Ambiguous method call. More than one applicable trait function wit
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    call_with(|| {})
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn call_with<F, +core::ops::Fn<F, (i32,)>>(func: F) {
     func(1);
+}
+fn foo() {
+    call_with(|| {})
 }
 
 //! > expected_diagnostics
@@ -817,16 +702,13 @@ error[E2302]: Type mismatch: `()` and `(core::integer::i32,)`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let c = |a, b| {
         a + b
     };
     c(b: 2_u32, a: 1_u32);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2121]: Named arguments are not supported in this context.
@@ -841,7 +723,7 @@ error[E2121]: Named arguments are not supported in this context.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn unify<T, +Drop<T>>(_a: T, _b: T) {}
 fn foo() {
     let x = Default::default();
@@ -850,9 +732,6 @@ fn foo() {
     };
     unify(x, f);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "?0", found: "{closure@lib.cairo:4:13: 4:15}".

--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -3,16 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let _x = MY_CONST + my_module::CONST_IN_MODULE;
-    let (_y, _z) = FELT_TUPLE;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const MY_CONST: felt252 = 0x1234;
 
 const FELT_TUPLE: (felt252, felt252) = (1, 2);
@@ -128,6 +119,10 @@ const PARTIAL_STRUCT2: () = assert({
     let u256 { high, .. } = 1337;
     high
 } == 0, 'partial_struct');
+fn foo() {
+    let _x = MY_CONST + my_module::CONST_IN_MODULE;
+    let (_y, _z) = FELT_TUPLE;
+}
 
 //! > expected_diagnostics
 
@@ -138,13 +133,7 @@ const PARTIAL_STRUCT2: () = assert({
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const MY_CONST: MissingType = {
     return foo();
     Option::<felt252>::Some(0)?
@@ -262,6 +251,7 @@ const LET_ELSE_FAIL: u8 = {
     };
     0
 };
+fn foo() {}
 
 //! > expected_diagnostics
 error[E0006]: Type not found.
@@ -334,13 +324,7 @@ error[E2128]: Failed to calculate constant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const DEFAULT_VAR: bool = 1;
 
 //! > expected_diagnostics
@@ -356,13 +340,7 @@ const DEFAULT_VAR: bool = 1;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const FULLY_UNKNOWN: _ = 1_u8;
 const FIXED_SIZED_TYPE_UNKNOWN: [_; 2] = [1_u8, 2_u8];
 
@@ -384,13 +362,7 @@ const FIXED_SIZED_TYPE_UNKNOWN: [_; 2] = [1_u8, 2_u8];
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const B: u8 = -1;
 
 //! > expected_diagnostics
@@ -406,13 +378,7 @@ const B: u8 = -1;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const A: i8 = A;
 const B: i8 = C;
 const C: i8 = B;
@@ -440,15 +406,7 @@ const C: i8 = B;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> (felt252, felt252, u256, i8) {
-    (FELT_WRAPAROUND_OVER, FELT_WRAPAROUND_UNDER, U256_CALCULATION, BASIC_CALCULATION)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const UNSIGNED_VAR: u8 = 256;
 const SIGNED_VAR: i8 = 128;
 const IN_RANGE_NEGATIVE1: i8 = -0x80;
@@ -483,6 +441,9 @@ const COMPLEX_STRUCT: ComplexStruct = ComplexStruct {
 };
 
 const CONST_MEMBER: u8 = COMPLEX_STRUCT.a;
+fn foo() -> (felt252, felt252, u256, i8) {
+    (FELT_WRAPAROUND_OVER, FELT_WRAPAROUND_UNDER, U256_CALCULATION, BASIC_CALCULATION)
+}
 
 //! > expected_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u8.
@@ -532,16 +493,13 @@ error[E2008]: The value does not fit within the range of type core::zeroable::No
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> () {
     {
         const X: u8 = 2;
     }
     let y = X;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 warning[E2070]: Unused constant. Consider ignoring by prefixing with `_`.
@@ -566,7 +524,7 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> () {
     const A: u8 = 1;
     const A: u8 = 2;
@@ -583,9 +541,6 @@ fn foo() -> () {
         const F: u8 = 12;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2072]: Multiple definitions of constant "A".
@@ -655,16 +610,13 @@ warning[E2070]: Unused constant. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(param: u8) -> () {
     const A: u8 = param;
     let local: u8 = 1;
     const B: u8 = local;
     const _C: u8 = A + B;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2127]: This expression is not supported as constant.
@@ -684,13 +636,7 @@ error[E2127]: This expression is not supported as constant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const ADDRESS: starknet::ContractAddress = my_unwrap((-1).try_into());
 const CLASS_HASH: starknet::ClassHash = my_unwrap((-1).try_into());
 
@@ -728,13 +674,7 @@ note: In `test::my_unwrap::<core::starknet::class_hash::ClassHash>`:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 // `2 ** 251` is one past the valid range of `ClassHash`/`ContractAddress`.
 const ADDRESS: starknet::ContractAddress = my_unwrap(
     0x800000000000000000000000000000000000000000000000000000000000000.try_into(),
@@ -783,7 +723,7 @@ note: In `test::my_unwrap::<core::starknet::class_hash::ClassHash>`:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     const A: Option<Option<Option<felt252>>> = Some(Some(Some(1_felt252)));
     const _B: felt252 = if let Some(a) = A && let Some(b) = a && let Some(c) = b {
@@ -792,9 +732,6 @@ fn foo() {
         0
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -805,13 +742,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 /// Copy of `assert` to avoid getting paths from the corelib.
 const fn assert(cond: bool) {
     if !cond {
@@ -835,13 +766,7 @@ const V_AS_I128: () = assert(V.try_into() == Some(-1_i128));
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const fn assert(cond: bool) {
     if !cond {
         core::panic_with_felt252('failed assertion')
@@ -867,13 +792,7 @@ const OR_SHORT_CIRCUIT: () = assert(true || boom());
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Foo {
     const VALUE: felt252;
 }
@@ -897,13 +816,7 @@ error[E2127]: This expression is not supported as constant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Foo {
     const VALUE: felt252;
 }
@@ -923,13 +836,7 @@ impl AnotherFoo<impl F: Foo> of Foo {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern const fn f() -> felt252 nopanic;
 const X: felt252 = f();
@@ -947,18 +854,13 @@ const X: felt252 = f();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    const X: S = S { a: 1 };
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S {
     a: felt252,
     b: felt252,
+}
+fn foo() {
+    const X: S = S { a: 1 };
 }
 
 //! > expected_diagnostics
@@ -979,13 +881,7 @@ warning[E2070]: Unused constant. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Foo {
     const VALUE: felt252;
 }
@@ -1010,13 +906,7 @@ error[E2127]: This expression is not supported as constant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Foo {
     const VALUE: felt252;
 }
@@ -1041,13 +931,7 @@ error[E2127]: This expression is not supported as constant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait BoolConst {
     const VALUE: bool;
 }
@@ -1068,20 +952,15 @@ error[E2127]: This expression is not supported as constant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > module_code
+//! > cairo_code
 const fn outer() -> felt252 {
     const fn inner() -> felt252 { 7 }
     inner()
 }
 const X: felt252 = outer();
-
-//! > function_code
 fn foo() -> felt252 {
     X
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1004]: Unexpected token, expected ':' followed by a type.
@@ -1126,13 +1005,7 @@ error[E0006]: Identifier not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait BoolConst {
     const VALUE: bool;
 }
@@ -1153,13 +1026,7 @@ error[E2127]: This expression is not supported as constant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait BoolConst {
     const VALUE: bool;
 }

--- a/crates/cairo-lang-semantic/src/expr/test_data/constructor
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constructor
@@ -3,18 +3,13 @@
 //! > test_runner_name
 test_function_diagnostics
 
-//! > function_code
-fn foo() {
-    let _x = MyStruct { a, b, a: 3 };
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: usize,
     b: usize,
+}
+fn foo() {
+    let _x = MyStruct { a, b, a: 3 };
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/coupon
+++ b/crates/cairo-lang-semantic/src/expr/test_data/coupon
@@ -3,7 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 type A = foo::Coupon;
 type B = bar::Coupon; // Invalid: missing type annotation.
 type C = bar::<u8>::Coupon;
@@ -22,9 +22,6 @@ fn foo(x: foo::Coupon) {
 
 #[allow(extern_outside_corelib)]
 extern fn extern_func() nopanic;
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2314]: Type annotations needed. Failed to infer ?0.
@@ -54,7 +51,7 @@ error[E2057]: Type "test::foo::Coupon" has no members.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > module_code
+//! > cairo_code
 struct MyStruct<S> {
     a: S,
 }
@@ -65,8 +62,6 @@ fn bar2<S, T>() {}
 fn get_coupon<S, T>() -> bar::<S, T>::Coupon {}
 fn get_coupon2<S, T>() -> bar2::<S, T>::Coupon {}
 fn get_struct<S>() -> MyStruct<S> {}
-
-//! > function_code
 fn foo() {
     let mut x = get_coupon();
     x = get_coupon::<u8>();
@@ -84,9 +79,6 @@ fn foo() {
     let mut z = get_coupon();
     z = get_struct();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "test::bar::<S, T>::Coupon", found: "()".
@@ -131,7 +123,7 @@ error[E2041]: Unexpected argument type. Expected: "test::bar::<?12, ?13>::Coupon
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > module_code
+//! > cairo_code
 mod m {
     fn bar() {}
     fn bar_no_drop() {}
@@ -145,8 +137,6 @@ mod m {
 }
 
 fn use_drop<A, +Drop<A>>(x: A) {}
-
-//! > function_code
 fn foo0(x: m::bar::Coupon) {
     use_drop(x);
 }
@@ -158,9 +148,6 @@ fn foo1(x: m::bar_no_drop::Coupon) {
 fn foo2(x: m::MyImpl::<u8>::trait_fn::Coupon) {
     use_drop(x);
 }
-
-//! > function_name
-foo0
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: core::traits::Drop::<test::m::bar_no_drop::Coupon>.
@@ -175,12 +162,10 @@ error[E2311]: Trait has no implementation in context: core::traits::Drop::<test:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > module_code
+//! > cairo_code
 fn bar<S, T>(x: T) {}
 
 fn bar2<S, T>(x: T) {}
-
-//! > function_code
 fn foo(x: bar::<u8, u16>::Coupon) {
     bar(1); // Cannot infer S.
     bar(1, __coupon__: x); // Valid call. S is inferred from the coupon.
@@ -189,9 +174,6 @@ fn foo(x: bar::<u8, u16>::Coupon) {
     bar(1, mut __coupon__: x); // Wrong mutability.
     bar(1, ref __coupon__: x); // Wrong mutability.
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::bar2::<?6, ?7>::Coupon", found: "test::bar::<core::integer::u8, core::integer::u16>::Coupon".
@@ -216,13 +198,10 @@ error[E2166]: The __coupon__ argument cannot have modifiers.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: foo::Coupon) {
     foo(x, __coupon__: x);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2167]: Coupons are disabled in the current crate.

--- a/crates/cairo-lang-semantic/src/expr/test_data/deref
+++ b/crates/cairo-lang-semantic/src/expr/test_data/deref
@@ -3,20 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let s1 = S1 { a: 1, b: 2 };
-    let s2 = S2 { inner: s1, c: 5 };
-    let s3 = S3 { inner: s2 };
-
-    (@s3).a;
-    s3.c;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct S1 {
     a: usize,
@@ -55,6 +42,14 @@ impl S3SnapDeref of core::ops::Deref<@S3> {
         *self.inner.inner
     }
 }
+fn foo() {
+    let s1 = S1 { a: 1, b: 2 };
+    let s2 = S2 { inner: s1, c: 5 };
+    let s3 = S3 { inner: s2 };
+
+    (@s3).a;
+    s3.c;
+}
 
 //! > expected_diagnostics
 
@@ -65,18 +60,7 @@ impl S3SnapDeref of core::ops::Deref<@S3> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let s1 = S1 { a: 1, b: 2 };
-    let s2 = S2 { inner: s1, c: 5 };
-
-    s2.foo();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct S1 {
     a: usize,
@@ -100,6 +84,12 @@ impl S2Deref of core::ops::Deref<S2> {
 impl MyImpl of MyTrait {
     fn foo(self: @S1) {}
 }
+fn foo() {
+    let s1 = S1 { a: 1, b: 2 };
+    let s2 = S2 { inner: s1, c: 5 };
+
+    s2.foo();
+}
 
 //! > expected_diagnostics
 
@@ -110,14 +100,11 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let a = BoxTrait::new(@array![1_u32]);
     let _ = a.len();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -128,14 +115,11 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut a = BoxTrait::new(@array![1_u32]);
     let _ = (*a);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -146,16 +130,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let mut a = S1 { inner: 1 };
-    let _ = (*a);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S1 {
     inner: usize,
 }
@@ -165,6 +140,10 @@ impl S1DerefMut of core::ops::DerefMut<S1> {
     fn deref_mut(ref self: S1) -> Self::Target {
         self.inner
     }
+}
+fn foo() {
+    let mut a = S1 { inner: 1 };
+    let _ = (*a);
 }
 
 //! > expected_diagnostics
@@ -176,16 +155,7 @@ impl S1DerefMut of core::ops::DerefMut<S1> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let a = S1 { inner: 1 };
-    let _ = (*a);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S1 {
     inner: usize,
 }
@@ -195,6 +165,10 @@ impl S1DerefMut of core::ops::DerefMut<S1> {
     fn deref_mut(ref self: S1) -> Self::Target {
         self.inner
     }
+}
+fn foo() {
+    let a = S1 { inner: 1 };
+    let _ = (*a);
 }
 
 //! > expected_diagnostics
@@ -210,18 +184,13 @@ error[E2135]: Type `test::S1` cannot be dereferenced
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: Box<@A>) -> @usize {
-    a.b
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     a: usize,
     b: usize,
+}
+fn foo(a: Box<@A>) -> @usize {
+    a.b
 }
 
 //! > expected_diagnostics
@@ -233,18 +202,13 @@ struct A {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: Box<@@@A>) -> @@@usize {
-    a.b
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     a: usize,
     b: usize,
+}
+fn foo(a: Box<@@@A>) -> @@@usize {
+    a.b
 }
 
 //! > expected_diagnostics
@@ -256,16 +220,7 @@ struct A {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let b = MyBox {};
-    b.get();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct Inner {}
 
@@ -277,6 +232,10 @@ impl MyDeref of core::ops::Deref<MyBox> {
     fn deref(self: MyBox) -> Inner {
         Inner {}
     }
+}
+fn foo() {
+    let b = MyBox {};
+    b.get();
 }
 
 //! > expected_diagnostics
@@ -300,13 +259,7 @@ Candidate `core::dict::Felt252DictTrait::get` inference failed with: Type mismat
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct A {}
 
@@ -343,13 +296,7 @@ impl BDeref of core::ops::Deref<B> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct A {}
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/enum
+++ b/crates/cairo-lang-semantic/src/expr/test_data/enum
@@ -3,7 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 enum A {
     a: (),
     b: felt252,
@@ -23,9 +23,6 @@ fn foo() {
     let _a: A = A::d;
     let _a: A = A;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2030]: Wrong number of arguments. Expected 1, found: 0

--- a/crates/cairo-lang-semantic/src/expr/test_data/error_propagate
+++ b/crates/cairo-lang-semantic/src/expr/test_data/error_propagate
@@ -3,17 +3,12 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> Option<felt252> {
-    with_err()?;
+//! > cairo_code
+fn with_err() -> Option<felt252> {
     Option::<felt252>::None
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn with_err() -> Option<felt252> {
+fn foo() -> Option<felt252> {
+    with_err()?;
     Option::<felt252>::None
 }
 
@@ -26,18 +21,13 @@ fn with_err() -> Option<felt252> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn with_err() -> Option<felt252> {
+    Option::<felt252>::None
+}
 fn foo() -> felt252 {
     with_err()?;
     1
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn with_err() -> Option<felt252> {
-    Option::<felt252>::None
 }
 
 //! > expected_diagnostics
@@ -53,22 +43,17 @@ error[E2061]: `?` can only be used in a function with `Option` or `Result` retur
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> Result<felt252, u128> {
-    with_err()?;
-    Result::<felt252, u128>::Ok(with_err2()?)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn with_err() -> Result<(), u128> {
     Result::<(), u128>::Ok(())
 }
 
 fn with_err2() -> Result<felt252, u128> {
     Result::<felt252, u128>::Ok((0))
+}
+fn foo() -> Result<felt252, u128> {
+    with_err()?;
+    Result::<felt252, u128>::Ok(with_err2()?)
 }
 
 //! > expected_diagnostics
@@ -80,18 +65,13 @@ fn with_err2() -> Result<felt252, u128> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn with_err() -> Result<felt252, u128> {
+    Result::<felt252, u128>::Ok((0))
+}
 fn foo() -> felt252 {
     with_err()?;
     1
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn with_err() -> Result<felt252, u128> {
-    Result::<felt252, u128>::Ok((0))
 }
 
 //! > expected_diagnostics
@@ -107,17 +87,12 @@ error[E2061]: `?` can only be used in a function with `Option` or `Result` retur
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> Result<felt252, u128> {
-    with_other_err()?;
+//! > cairo_code
+fn with_other_err() -> Result<felt252, felt252> {
     Result::<felt252, felt252>::Ok((0))
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn with_other_err() -> Result<felt252, felt252> {
+fn foo() -> Result<felt252, u128> {
+    with_other_err()?;
     Result::<felt252, felt252>::Ok((0))
 }
 
@@ -139,14 +114,11 @@ error[E2042]: Unexpected return type. Expected: "core::result::Result::<core::fe
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> Option<felt252> {
     6_u32?;
     None
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2063]: Type "core::integer::u32" cannot error propagate
@@ -161,18 +133,13 @@ error[E2063]: Type "core::integer::u32" cannot error propagate
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(a: Option<felt252>) -> Option<felt252> {
-    bar(a)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<T, +Copy<T>>(t: T) -> T {
     t?;
     t
+}
+fn foo(a: Option<felt252>) -> Option<felt252> {
+    bar(a)
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
+++ b/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
@@ -3,15 +3,12 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: [u32; 3] = [1; 3];
     let _y: [u32; 3] = [1, 2, 3];
     let _z = [1, 2, 3];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -22,18 +19,13 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+const SIZE: usize = 3;
 fn foo() {
     let _x: [u32; 1 + 2] = [1; 1 + 2];
     let _x: [u32; SIZE] = [1; 1 + 2];
     let _x: [u32; SIZE + 1] = [1; 5 - 1];
 }
-
-//! > function_name
-foo
-
-//! > module_code
-const SIZE: usize = 3;
 
 //! > expected_diagnostics
 
@@ -44,14 +36,11 @@ const SIZE: usize = 3;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: [u32; 2] = [1, 2, 3];
     let _x: [u32; 2] = [1; 3];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[{numeric}; 3]".
@@ -71,7 +60,7 @@ error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", fou
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: [u32, u32; 2] = [1, 2];
     let _x: [; 2] = [1, 2];
@@ -79,9 +68,6 @@ fn foo() {
     let _x: [u32; 2] = [];
     let _x: [u32; 2] = [; 2];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2170]: Fixed size array type must have exactly one type.
@@ -116,7 +102,8 @@ error[E2173]: Fixed size array with defined size must have exactly one value.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+const SIZE: usize = 2;
 fn foo() {
     let _x: [u32; -1] = [1; -1];
     let _x: [u32; SIZE] = [1; SIZE];
@@ -124,12 +111,6 @@ fn foo() {
     let _x: [u32; 32768] = [1; 32768];
     let _x = [1_felt252; 32768];
 }
-
-//! > function_name
-foo
-
-//! > module_code
-const SIZE: usize = 2;
 
 //! > expected_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u32.
@@ -174,18 +155,13 @@ error[E2174]: Fixed size array size must be smaller than 2^15.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+const SIZE: usize = 2;
 fn foo() {
     let _x: [u32; 2] = [1, 2_u16];
     let _x = [1_u32, 2_u16];
     let _x: [u32; 2] = [true, false];
 }
-
-//! > function_name
-foo
-
-//! > module_code
-const SIZE: usize = 2;
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[core::integer::u16; 2]".
@@ -210,17 +186,12 @@ error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", fou
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> [felt252; 1] {
-    bar()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<const N: usize>() -> [felt252; N] {
     [0; N]
+}
+fn foo() -> [felt252; 1] {
+    bar()
 }
 
 //! > expected_diagnostics
@@ -236,17 +207,12 @@ error[E2172]: Fixed size array type must have a positive integer size.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar<const N: usize>() -> [felt252; N] nopanic;
 fn foo() {
     let [_a, _b] = bar();
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar<const N: usize>() -> [felt252; N] nopanic;
 
 //! > expected_diagnostics
 
@@ -257,17 +223,12 @@ extern fn bar<const N: usize>() -> [felt252; N] nopanic;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar<const N: usize>() -> [felt252; N] nopanic;
 fn foo() {
     let [_a, _b] = bar::<3>();
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar<const N: usize>() -> [felt252; N] nopanic;
 
 //! > expected_diagnostics
 error[E2108]: Wrong number of fixed size array elements in pattern. Expected: 3. Got: 2.
@@ -282,13 +243,7 @@ error[E2108]: Wrong number of fixed size array elements in pattern. Expected: 3.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Default, Clone, Debug, Drop, PartialEq, Serde)]
 pub struct StructWithByteArray {
     pub features: [felt252; 2],
@@ -303,13 +258,10 @@ pub struct StructWithByteArray {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: [_; 3] = [1_u8, 2_u8, 3_u8];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -320,13 +272,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn f() -> [felt252; for _ in 0..1_u32 {}] {
     [0]
 }

--- a/crates/cairo-lang-semantic/src/expr/test_data/for
+++ b/crates/cairo-lang-semantic/src/expr/test_data/for
@@ -3,7 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut _iter = array![10, 11, 12, 13_felt252].span();
     for _x in _iter {
@@ -12,9 +12,6 @@ fn foo() {
         break;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2147]: Can only break with a value inside a `loop`.
@@ -29,20 +26,15 @@ error[E2147]: Can only break with a value inside a `loop`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+struct A {
+    x: Option<i32>,
+}
 fn foo() {
     let arr = array![A { x: Some(1) }, A { x: None }, A { x: Some(2) }].span();
     for A(x) in arr {
         x;
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-struct A {
-    x: Option<i32>,
 }
 
 //! > expected_diagnostics
@@ -63,13 +55,10 @@ error[E0006]: Identifier not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     for (_a, _a) in array![(1, 2)] {}
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2049]: Redefinition of variable name "_a" in pattern.

--- a/crates/cairo-lang-semantic/src/expr/test_data/function_call
+++ b/crates/cairo-lang-semantic/src/expr/test_data/function_call
@@ -3,7 +3,12 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar(a: felt252, b: felt252, c: felt252, d: felt252, e: felt252) {}
+
+enum MyEnum {
+    A: felt252,
+}
 fn foo(d: bool) {
     // Valid names (one wrong type).
     bar(0, 1, 2, :d, e: 0);
@@ -15,16 +20,6 @@ fn foo(d: bool) {
     bar(0, 1, 2, 3);
     // Wrong number of params.
     bar(0, 1, 2, 3, 4, 5);
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar(a: felt252, b: felt252, c: felt252, d: felt252, e: felt252) {}
-
-enum MyEnum {
-    A: felt252,
 }
 
 //! > expected_diagnostics
@@ -70,7 +65,8 @@ error[E2030]: Wrong number of arguments. Expected 5, found: 6
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar(a: felt252, ref b: felt252) {}
 fn foo(ref a: felt252) {
     let b = 1;
     let mut c = 2;
@@ -81,12 +77,6 @@ fn foo(ref a: felt252) {
     bar(ref b, ref b);
     bar(ref c, ref c);
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar(a: felt252, ref b: felt252) {}
 
 //! > expected_diagnostics
 error[E2081]: ref argument must be passed with a preceding 'ref'.
@@ -136,19 +126,7 @@ error[E2082]: Argument to immutable parameter cannot have modifiers.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(d: MyStruct) {
-    bar(0);
-    d + 0;
-    -d;
-    d.bar();
-    d.baz();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {}
 
 struct OtherStruct {}
@@ -158,6 +136,13 @@ trait MyTrait<T> {
 }
 impl OtherStructImpl of MyTrait<OtherStruct> {
     fn baz(self: OtherStruct) {}
+}
+fn foo(d: MyStruct) {
+    bar(0);
+    d + 0;
+    -d;
+    d.bar();
+    d.baz();
 }
 
 //! > expected_diagnostics
@@ -189,13 +174,10 @@ Candidate `test::MyTrait::baz` inference failed with: Trait has no implementatio
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> () {
     4_u8
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u8".
@@ -210,11 +192,8 @@ error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u8"
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> u8 {}
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "()".
@@ -229,18 +208,13 @@ fn foo() -> u8 {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> () {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn bar() -> u8 {
         1_u16
     }
 }
+fn foo() -> () {}
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u16".
@@ -255,13 +229,7 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "cor
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> () {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn bar() -> u8;
 }
@@ -271,6 +239,7 @@ impl MyImpl of MyTrait {
         1_u16
     }
 }
+fn foo() -> () {}
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u16".
@@ -285,15 +254,12 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "cor
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> () {
     || -> u8 {
         1_u16
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u16".
@@ -308,18 +274,13 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "cor
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+fn takes_val(x: felt252) -> felt252 {
+    x
+}
 fn foo() -> felt252 {
     const x: felt252 = 42;
     takes_val(:x)
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn takes_val(x: felt252) -> felt252 {
-    x
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/generics
+++ b/crates/cairo-lang-semantic/src/expr/test_data/generics
@@ -3,7 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type A<S>;
 #[allow(extern_outside_corelib)]
@@ -14,9 +14,6 @@ fn foo(a: A<felt252>) -> A<A<felt252>> {
     let _bad: A<A<bool>> = res;
     res
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::A::<test::A::<core::bool>>", found: "test::A::<test::A::<core::felt252>>".
@@ -31,13 +28,7 @@ error[E2041]: Unexpected argument type. Expected: "test::A::<test::A::<core::boo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    5.foo(true);
-    MyTrait::foo(6, false);
-}
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo<S>(self: T, y: S) -> (T, S);
 }
@@ -46,9 +37,10 @@ impl MyImpl of MyTrait<felt252> {
         (self, y)
     }
 }
-
-//! > function_name
-foo
+fn foo() {
+    5.foo(true);
+    MyTrait::foo(6, false);
+}
 
 //! > expected_diagnostics
 
@@ -59,22 +51,17 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let mut x = 5;
-    x.foo();
-}
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo(ref self: T);
 }
 impl MyImpl of MyTrait<felt252> {
     fn foo(ref self: felt252) {}
 }
-
-//! > function_name
-foo
+fn foo() {
+    let mut x = 5;
+    x.foo();
+}
 
 //! > expected_diagnostics
 
@@ -85,7 +72,15 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar<A, const B: usize, impl C: MyTrait<felt252>>() {}
+
+#[generate_trait]
+impl MyImpl of Generics {
+    fn method_no_generics(self: felt252) {}
+    fn method_one_generic<T>(self: felt252) {}
+    fn method_two_generics<T, S>(self: felt252) {}
+}
 fn foo() {
     bar::<1, 1, 1, 1>();
     bar::<felt252, felt252>();
@@ -95,19 +90,6 @@ fn foo() {
     1_felt252.method_one_generic::<felt252, felt252>();
     1_felt252.method_two_generics::<felt252, felt252, felt252>();
 }
-
-//! > module_code
-fn bar<A, const B: usize, impl C: MyTrait<felt252>>() {}
-
-#[generate_trait]
-impl MyImpl of Generics {
-    fn method_no_generics(self: felt252) {}
-    fn method_one_generic<T>(self: felt252) {}
-    fn method_two_generics<T, S>(self: felt252) {}
-}
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E0006]: Trait not found.
@@ -157,13 +139,7 @@ error[E2163]: Expected 2 generic arguments, found 3.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    bar::<MyImpl>();
-    bar::<AnotherImpl>();
-}
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {}
 impl MyImpl of MyTrait<felt252> {}
 fn bar<impl C: MyTrait<felt252>>() {}
@@ -179,9 +155,10 @@ extern fn ioo<T, impl C: MyTrait<felt252>, S>() nopanic;
 
 trait AnotherTrait<T> {}
 impl AnotherImpl of AnotherTrait<felt252> {}
-
-//! > function_name
-foo
+fn foo() {
+    bar::<MyImpl>();
+    bar::<AnotherImpl>();
+}
 
 //! > expected_diagnostics
 error[E2132]: Extern types with impl generics are not supported.
@@ -201,10 +178,7 @@ error[E2134]: Expected an impl of `test::MyTrait::<core::felt252>`. Got an impl 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn f() {}
-
-//! > module_code
+//! > cairo_code
 fn foo<T, impl GenericImpl: MyTrait<T>>(x: T) {
     GenericImpl::foo(x);
     MyImpl::foo(4);
@@ -229,9 +203,6 @@ impl AnotherImpl of AnotherTrait<felt252> {
     fn foo(self: felt252) {}
 }
 
-//! > function_name
-f
-
 //! > expected_diagnostics
 error[E2134]: Expected an impl of `test::MyTrait::<core::felt252>`. Got an impl of `test::MyTrait::<T>`.
  --> lib.cairo:7:14
@@ -245,12 +216,7 @@ error[E2134]: Expected an impl of `test::MyTrait::<core::felt252>`. Got an impl 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn f() {
-    MyImpl::<MyImpl2>::foo();
-}
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo();
 }
@@ -265,9 +231,9 @@ impl MyImpl<impl Imp: MyTrait2> of MyTrait {
 impl MyImpl2 of MyTrait2 {
     fn foo2() {}
 }
-
-//! > function_name
-f
+fn f() {
+    MyImpl::<MyImpl2>::foo();
+}
 
 //! > expected_diagnostics
 
@@ -278,22 +244,17 @@ f
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+struct MyStruct<S, T> {}
+
+#[allow(extern_outside_corelib)]
+extern fn bar<S, T>() -> MyStruct<S, T> nopanic;
 fn foo() {
     let mut x = bar();
     x = bar::<felt252, _>();
     x = bar::<_, u8>();
     x = bar::<u16, u32>();
 }
-
-//! > module_code
-struct MyStruct<S, T> {}
-
-#[allow(extern_outside_corelib)]
-extern fn bar<S, T>() -> MyStruct<S, T> nopanic;
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::MyStruct::<core::felt252, core::integer::u8>", found: "test::MyStruct::<core::integer::u16, core::integer::u32>".
@@ -308,13 +269,7 @@ error[E2041]: Unexpected argument type. Expected: "test::MyStruct::<core::felt25
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait ATrait<T> {}
 trait ATrait2<T, impl Timpl: ATrait<T>> {}
 
@@ -331,13 +286,7 @@ struct B<impl Timpl1: ATrait<T>, T, impl Timpl2: ATrait2<T>> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait ATrait<T> {}
 trait ATrait2<T, impl Timpl: ATrait<T>> {}
 
@@ -354,7 +303,13 @@ struct B<T, impl Timpl2: ATrait2<T>, impl Timpl1: ATrait<T>> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+trait ATrait<T> {}
+impl AFelt of ATrait<felt252> {}
+trait BTrait<T> {}
+impl BUint of BTrait<u32> {}
+
+fn bar<T, S, impl X: ATrait<T>, impl Y: BTrait<S>>() {}
 fn foo() {
     // Failures.
     bar::<felt252, G: felt252>();
@@ -370,17 +325,6 @@ fn foo() {
     bar::<S: _, X: AFelt, Y: BUint>();
     bar::<felt252, u32, X: AFelt, Y: BUint>();
 }
-
-//! > function_name
-foo
-
-//! > module_code
-trait ATrait<T> {}
-impl AFelt of ATrait<felt252> {}
-trait BTrait<T> {}
-impl BUint of BTrait<u32> {}
-
-fn bar<T, S, impl X: ATrait<T>, impl Y: BTrait<S>>() {}
 
 //! > expected_diagnostics
 error[E2160]: Unknown generic parameter `G`.
@@ -420,13 +364,7 @@ error[E2164]: Generic argument `T` is out of order.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<+unknown>() {}
 
 //! > expected_diagnostics
@@ -442,13 +380,7 @@ fn bar<+unknown>() {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<impl X: unknown>() {}
 
 //! > expected_diagnostics
@@ -464,7 +396,7 @@ fn bar<impl X: unknown>() {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 trait Introspect<T> {}
 
 #[derive(Drop)]
@@ -480,9 +412,6 @@ impl GenericStructIntrospect<
     T, impl IntrospectTImp: Introspect<Generic<T>>,
 > of Introspect<Generic<T>> {}
 impl Felt252Introspect of Introspect<felt252> {}
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2301]: Inference cycle detected
@@ -502,16 +431,8 @@ error[E2028]: Cycle detected while resolving generic param. Try specifying the g
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<+Drop<T>, T> {}
-
-//! > function_body
 
 //! > expected_diagnostics
 
@@ -522,16 +443,8 @@ trait MyTrait<+Drop<T>, T> {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<+Drop<T>, +Copy<T>> {}
-
-//! > function_body
 
 //! > expected_diagnostics
 error[E0006]: Type not found.
@@ -551,18 +464,10 @@ trait MyTrait<+Drop<T>, +Copy<T>> {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T, +Drop<T>> {}
 
 impl MyImpl<T> of MyTrait<T, T> {}
-
-//! > function_body
 
 //! > expected_diagnostics
 error[E2004]: Unknown impl.
@@ -577,19 +482,12 @@ impl MyImpl<T> of MyTrait<T, T> {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar<const M: felt252>() nopanic;
 fn foo() {
     bar::<{ 1 + 2 }>();
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar<const M: felt252>() nopanic;
-
-//! > function_body
 
 //! > expected_diagnostics
 
@@ -600,15 +498,7 @@ extern fn bar<const M: felt252>() nopanic;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let _s: S<{ 1 - 2 }> = bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type S<const N: felt252>;
 #[allow(extern_outside_corelib)]
@@ -619,8 +509,9 @@ mod A {
         let _x: super::S<{ super::K + 9 }> = super::bar();
     }
 }
-
-//! > function_body
+fn foo() {
+    let _s: S<{ 1 - 2 }> = bar();
+}
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::S::<-1>", found: "test::S::<11>".
@@ -640,20 +531,13 @@ error[E2041]: Unexpected argument type. Expected: "test::S::<107>", found: "test
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    bar::<1>()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<const N: felt252>() -> felt252 {
     N + 5
 }
-
-//! > function_body
+fn foo() -> felt252 {
+    bar::<1>()
+}
 
 //! > expected_diagnostics
 
@@ -664,23 +548,16 @@ fn bar<const N: felt252>() -> felt252 {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> S<1> {
-    bar::<1>()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<const N: felt252>() -> S<{ 3 - 2 }> {
     S::<N> { field: 1 }
 }
 struct S<const N: felt252> {
     field: felt252,
 }
-
-//! > function_body
+fn foo() -> S<1> {
+    bar::<1>()
+}
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "test::S::<1>", found: "test::S::<N>".
@@ -695,18 +572,7 @@ error[E2042]: Unexpected return type. Expected: "test::S::<1>", found: "test::S:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> MyStruct<1> {
-    let s = new();
-    bar1(s);
-    bar2(s);
-    s
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct<const N: felt252> {}
 fn new<const N: felt252>() -> MyStruct<N> {
     MyStruct::<N> {}
@@ -714,8 +580,12 @@ fn new<const N: felt252>() -> MyStruct<N> {
 
 fn bar1(s: MyStruct<1>) {}
 fn bar2(s: MyStruct<2>) {}
-
-//! > function_body
+fn foo() -> MyStruct<1> {
+    let s = new();
+    bar1(s);
+    bar2(s);
+    s
+}
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::MyStruct::<2>", found: "test::MyStruct::<1>".
@@ -730,13 +600,7 @@ error[E2041]: Unexpected argument type. Expected: "test::MyStruct::<2>", found: 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Foo {
     fn bar<T>(self: T);
 }
@@ -762,13 +626,7 @@ error[E2038]: Generic parameter kind of impl function `FooImpl::bar` is incompat
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type Real;
 }

--- a/crates/cairo-lang-semantic/src/expr/test_data/if
+++ b/crates/cairo-lang-semantic/src/expr/test_data/if
@@ -3,7 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let x = 7_felt252;
     if x {
@@ -12,9 +12,6 @@ fn foo() {
         0
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2055]: Condition has type "core::felt252", expected bool.
@@ -42,7 +39,7 @@ error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> bool {
     let x = 7_u64;
     if x {
@@ -50,9 +47,6 @@ fn foo() -> bool {
     } else {}
     false
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2055]: Condition has type "core::integer::u64", expected bool.
@@ -67,7 +61,10 @@ error[E2055]: Condition has type "core::integer::u64", expected bool.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+}
 fn foo() -> bool {
     let x = Some(7_u64);
     if let MyEnum::A(y) = x {
@@ -75,14 +72,6 @@ fn foo() -> bool {
     } else {
         return false;
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
 }
 
 //! > expected_diagnostics
@@ -103,7 +92,7 @@ error[E0006]: Identifier not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> bool {
     let x = Some(7_u64);
     if let Some(y) = x || true {
@@ -112,9 +101,6 @@ fn foo() -> bool {
         return false;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1030]: Operator '||' is not allowed in let chains. Consider wrapping the expression in parentheses.
@@ -129,7 +115,7 @@ error[E1030]: Operator '||' is not allowed in let chains. Consider wrapping the 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> bool {
     let x = Some(7_u64);
     if let Some = x {
@@ -138,9 +124,6 @@ fn foo() -> bool {
         return false;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 warning[E2192]: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
@@ -155,7 +138,10 @@ warning[E2192]: Pattern missing subpattern for the payload of variant. Consider 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    B: (),
+}
 fn foo() -> bool {
     let a = A::B(());
     if let A::B = a {
@@ -163,14 +149,6 @@ fn foo() -> bool {
     } else {
         return false;
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    B: (),
 }
 
 //! > expected_diagnostics
@@ -182,7 +160,7 @@ enum A {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(a: Option<Option<Option<felt252>>>) {
     if let Some(b) = a && let Some(_c) = b {}
     // The opposite order doesn't work.
@@ -195,9 +173,6 @@ fn foo(a: Option<Option<Option<felt252>>>) {
         1
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E0006]: Identifier not found.

--- a/crates/cairo-lang-semantic/src/expr/test_data/impl
+++ b/crates/cairo-lang-semantic/src/expr/test_data/impl
@@ -3,13 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo(x: u8, y: T, z: u8) -> u8;
     fn bar() -> T;
@@ -55,16 +49,7 @@ error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> MyImpl::AsType {
-    let _c = MyImpl::AsConst;
-    MyImpl::AsImpl::method(0)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait<T> {
     fn method(x: T) -> T;
 }
@@ -85,6 +70,10 @@ impl MyImpl of MyTrait {
     const AsType: felt252 = 5;
     type AsConst = felt252;
     type AsImpl = felt252;
+}
+fn foo() -> MyImpl::AsType {
+    let _c = MyImpl::AsConst;
+    MyImpl::AsImpl::method(0)
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/inference
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inference
@@ -3,13 +3,10 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> Option<felt252> {
     Some(5)
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -20,14 +17,11 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut arr = array::array_new();
     array::array_append(ref arr, 1);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -41,21 +35,16 @@ test_function_diagnostics(expect_diagnostics: true)
 //! > comments
 // TODO(spapini): Make better diagnostics.
 
-//! > function_code
-fn foo() {
-    MyTrait::foo();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo();
 }
 
 impl MyImpl<+MyTrait> of MyTrait {
     fn foo() {}
+}
+fn foo() {
+    MyTrait::foo();
 }
 
 //! > expected_diagnostics
@@ -71,13 +60,10 @@ error[E2301]: Inference cycle detected
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut _arr = array::array_new();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2314]: Type annotations needed. Failed to infer ?0.
@@ -92,13 +78,10 @@ error[E2314]: Type annotations needed. Failed to infer ?0.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut _arr: felt252 = array::array_new::<felt252>();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "core::array::Array::<core::felt252>".
@@ -113,13 +96,10 @@ error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "core:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> felt252 {
     panic(array::array_new())
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -130,13 +110,10 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> never {
     5_felt252
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::never", found: "core::felt252".
@@ -151,17 +128,7 @@ error[E2042]: Unexpected return type. Expected: "core::never", found: "core::fel
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo(5);
-    MyTrait::foo(true);
-    MyTrait::foo(None);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo(x: T);
 }
@@ -174,6 +141,11 @@ impl MyImpl2 of MyTrait<bool> {
 impl MyImpl3 of MyTrait<Option<felt252>> {
     fn foo(x: Option<felt252>) {}
 }
+fn foo() {
+    MyTrait::foo(5);
+    MyTrait::foo(true);
+    MyTrait::foo(None);
+}
 
 //! > expected_diagnostics
 
@@ -184,15 +156,7 @@ impl MyImpl3 of MyTrait<Option<felt252>> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo(true);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo(x: T);
 }
@@ -207,6 +171,9 @@ impl MyImpl3 of MyTrait<Option<felt252>> {
 }
 impl MyImpl4 of MyTrait<Option<bool>> {
     fn foo(x: Option<bool>) {}
+}
+fn foo() {
+    MyTrait::foo(true);
 }
 
 //! > expected_diagnostics
@@ -222,16 +189,7 @@ error[E2311]: Trait has no implementation in context: test::MyTrait::<core::bool
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo(5);
-    MyTrait::foo(Option::<felt252>::None);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo(x: T);
 }
@@ -246,6 +204,10 @@ impl MyImpl3 of MyTrait<Option<felt252>> {
 }
 impl MyImpl4 of MyTrait<Option<bool>> {
     fn foo(x: Option<bool>) {}
+}
+fn foo() {
+    MyTrait::foo(5);
+    MyTrait::foo(Option::<felt252>::None);
 }
 
 //! > expected_diagnostics
@@ -261,15 +223,7 @@ error[E2313]: Trait `test::MyTrait::<core::felt252>` has multiple implementation
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    Marker::<-1>::tag()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Marker<const K: felt252> {
     fn tag() -> felt252;
 }
@@ -285,6 +239,9 @@ impl MarkerPrimeMinus1 of Marker<
         200
     }
 }
+fn foo() -> felt252 {
+    Marker::<-1>::tag()
+}
 
 //! > expected_diagnostics
 
@@ -295,15 +252,7 @@ impl MarkerPrimeMinus1 of Marker<
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo(None);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo(x: T);
 }
@@ -318,6 +267,9 @@ impl MyImpl3 of MyTrait<Option<felt252>> {
 }
 impl MyImpl4 of MyTrait<Option<bool>> {
     fn foo(x: Option<bool>) {}
+}
+fn foo() {
+    MyTrait::foo(None);
 }
 
 //! > expected_diagnostics
@@ -333,17 +285,12 @@ error[E2313]: Trait `test::MyTrait::<core::option::Option::<?0>>` has multiple i
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(my_box: Box<MyStruct>) -> felt252 {
-    box::unbox(my_box).a
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: felt252,
+}
+fn foo(my_box: Box<MyStruct>) -> felt252 {
+    box::unbox(my_box).a
 }
 
 //! > expected_diagnostics
@@ -355,15 +302,7 @@ struct MyStruct {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar(true);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<impl Tr: MyTrait<bool>>(x: bool) {}
 
 trait MyTrait<T> {
@@ -371,6 +310,9 @@ trait MyTrait<T> {
 }
 impl MyImpl1 of MyTrait<bool> {
     fn foo(x: bool) {}
+}
+fn foo() {
+    bar(true);
 }
 
 //! > expected_diagnostics
@@ -382,15 +324,7 @@ impl MyImpl1 of MyTrait<bool> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar(Some(5));
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<S, impl Tr: MyTrait<S>>(x: S) {}
 
 trait MyTrait<T> {
@@ -407,6 +341,9 @@ impl MyImpl3 of MyTrait<Option<felt252>> {
 }
 impl MyImpl4 of MyTrait<Option<bool>> {
     fn foo(x: Option<bool>) {}
+}
+fn foo() {
+    bar(Some(5));
 }
 
 //! > expected_diagnostics
@@ -418,15 +355,7 @@ impl MyImpl4 of MyTrait<Option<bool>> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    bar(true);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<S, impl Tr: MyTrait<S>>(x: S) {}
 
 trait MyTrait<T> {
@@ -443,6 +372,9 @@ impl MyImpl3 of MyTrait<Option<felt252>> {
 }
 impl MyImpl4 of MyTrait<Option<bool>> {
     fn foo(x: Option<bool>) {}
+}
+fn foo() {
+    bar(true);
 }
 
 //! > expected_diagnostics
@@ -458,15 +390,7 @@ error[E2311]: Trait has no implementation in context: test::MyTrait::<core::bool
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    A::<felt252> {}.foo();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A<T> {}
 trait MyTrait<T> {
     fn foo<impl TDrop: Drop<T>>(self: A<T>);
@@ -478,6 +402,9 @@ impl MyImpl<T> of MyTrait<T> {
     }
     fn bar<impl TDrop: Drop<T>>(self: A<T>) {}
 }
+fn foo() {
+    A::<felt252> {}.foo();
+}
 
 //! > expected_diagnostics
 
@@ -488,14 +415,11 @@ impl MyImpl<T> of MyTrait<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _ = (@5).clone();
     let _ = 5.clone();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -506,17 +430,12 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    clone_loop(5)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn clone_loop<T, impl TClone: Clone<T>>(x: T) {
     clone_loop::<T>(x)
+}
+fn foo() {
+    clone_loop(5)
 }
 
 //! > expected_diagnostics
@@ -528,13 +447,7 @@ fn clone_loop<T, impl TClone: Clone<T>>(x: T) {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {}
 struct B {
     a: A,
@@ -550,18 +463,13 @@ impl I<impl TI: Drop<A>> of Drop<B>;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    assert_eq(1, 2 + 3, '4');
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn assert_eq<T, impl TPartialEq: PartialEq<T>>(a: T, b: T, err_code: felt252) {
     assert(a == b, err_code);
+}
+fn foo() {
+    assert_eq(1, 2 + 3, '4');
 }
 
 //! > expected_diagnostics
@@ -573,13 +481,10 @@ fn assert_eq<T, impl TPartialEq: PartialEq<T>>(a: T, b: T, err_code: felt252) {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let u256 { low: _, high: _ } = 123;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -590,13 +495,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Bash<S> {
     fn foo(state: S);
 }
@@ -618,13 +517,10 @@ impl BashEx<S, +Bash<S>> of BashExTrait<S> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x = "hello";
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2314]: Type annotations needed. Failed to infer ?0.
@@ -639,17 +535,12 @@ error[E2314]: Type annotations needed. Failed to infer ?0.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+impl MyImpl of NonExistingTrait {}
 fn foo() {
     // A NumericLiteral<felt252> should be inferred here.
     let _x = 123;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-impl MyImpl of NonExistingTrait {}
 
 //! > expected_diagnostics
 error[E0006]: Trait not found.
@@ -664,14 +555,11 @@ impl MyImpl of NonExistingTrait {}
 //! > test_runner_name
 test_function_diagnostics
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut data_hash = 0;
     data_hash = unknown_return_unknown();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E0006]: Function not found.
@@ -686,15 +574,7 @@ error[E0006]: Function not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    bar(0_u8);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {}
 
 impl MyIpls<T, +Drop<T>> of MyTrait<T> {}
@@ -712,6 +592,9 @@ fn bar<T, +Drop<T>, +MyTrait<T>>(a: T) -> T {
 fn baz<T, +Drop<T>, +MyTrait<T>>(a: T) -> T {
     a
 }
+fn foo() {
+    bar(0_u8);
+}
 
 //! > expected_diagnostics
 error[E2313]: Trait `test::MyTrait::<T>` has multiple implementations, in: `+MyTrait<T>`, `test::MyIpls::<T, +Drop<T>>`
@@ -726,18 +609,13 @@ error[E2313]: Trait `test::MyTrait::<T>` has multiple implementations, in: `+MyT
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn takes_snapshots<T>(x: @T, y: @T) {}
 fn foo() {
     let x = 5;
     let y: u32 = 5;
     takes_snapshots(x, y);
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn takes_snapshots<T>(x: @T, y: @T) {}
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "@?2", found: "core::integer::u32".
@@ -754,13 +632,10 @@ Consider adding or removing snapshots.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> Option {
     Some(5_u32)
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2314]: Type annotations needed. Failed to infer ?0.
@@ -775,15 +650,7 @@ fn foo() -> Option {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::f();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn f() -> Self::ty;
@@ -792,6 +659,9 @@ impl MyImpl of MyTrait {
     fn f() -> u32 {
         5_u32
     }
+}
+fn foo() {
+    MyTrait::f();
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -3,13 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const a: felt252 = consteval_int!(func_call(24));
 
 const b: felt252 = consteval_int!('some string');
@@ -109,13 +103,7 @@ const out_of_range: u8 = consteval_int!(120 + 160);
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const div_lit: felt252 = consteval_int!(1 / 0);
 
 const mod_lit: felt252 = consteval_int!(1 % 0);
@@ -172,13 +160,7 @@ const mod_computed: felt252 = consteval_int!(5 % (7 * 0));
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const div_ok: felt252 = consteval_int!(10 / 2);
 
 const mod_ok: felt252 = consteval_int!(10 % 3);
@@ -215,14 +197,11 @@ const mod_negative: felt252 = consteval_int!(-7 % 3);
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> u8 {
     // A comment before the macro.
     consteval_int!(120 + 160)
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
@@ -242,14 +221,11 @@ error[E2008]: The value does not fit within the range of type core::integer::u8.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x = array!(0);
     let _x = array![0_felt252, 1_u8];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2200]: Plugin diagnostic: Macro `array` does not support this bracket type.
@@ -269,7 +245,7 @@ error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "core:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut f: core::fmt::Formatter = Default::default();
     let ba: ByteArray = "hello";
@@ -326,9 +302,6 @@ fn foo() {
     write!(f, "{");
     write!(f, "{x");
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2200]: Plugin diagnostic: Macro `write` does not support this bracket type.
@@ -458,7 +431,7 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut f: core::fmt::Formatter = Default::default();
     write!(f, "prefix\n{name}").unwrap();
@@ -471,11 +444,6 @@ fn foo() {
     write!(f, "\u{7B}uni_brace}").unwrap();
     write!(f, "\u007Buni4_brace}").unwrap();
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E0006]: Identifier not found.
@@ -530,7 +498,7 @@ error[E0006]: Identifier not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut f: core::fmt::Formatter = Default::default();
     let ba: ByteArray = "hello";
@@ -587,9 +555,6 @@ fn foo() {
     writeln!(f, "{");
     writeln!(f, "{x");
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2200]: Plugin diagnostic: Macro `writeln` does not support this bracket type.
@@ -714,7 +679,7 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let ba: ByteArray = "hello";
 
@@ -748,9 +713,6 @@ fn foo() {
     // No parens.
     format!;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1006]: Missing tokens. Expected an argument list wrapped in either parentheses, brackets, or braces.
@@ -815,7 +777,7 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let ba: ByteArray = "hello";
 
@@ -849,9 +811,6 @@ fn foo() {
     // Missing parens.
     print!;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1006]: Missing tokens. Expected an argument list wrapped in either parentheses, brackets, or braces.
@@ -916,7 +875,7 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let ba: ByteArray = "hello";
 
@@ -950,9 +909,6 @@ fn foo() {
     // Missing parens.
     println!;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1006]: Missing tokens. Expected an argument list wrapped in either parentheses, brackets, or braces.
@@ -1012,7 +968,7 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let ba: ByteArray = "hello";
 
@@ -1043,9 +999,6 @@ fn foo() {
     // Unused arguments.
     panic!("{2}{0}", ba, 2, 1);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2200]: Plugin diagnostic: Macro `panic` does not support this bracket type.
@@ -1100,13 +1053,10 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x = foo!(0);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2156]: Inline macro `foo` not found.
@@ -1121,14 +1071,11 @@ error[E2156]: Inline macro `foo` not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     // This comment should not appear in the macro name
     array![0_felt252];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -1139,19 +1086,14 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    add_one!(xyz);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro add_one {
     ($x:ident) => {
         1
     };
+}
+fn foo() {
+    add_one!(xyz);
 }
 
 //! > expected_diagnostics
@@ -1163,15 +1105,7 @@ macro add_one {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    unwrap_or_zero!(Option::<felt252>::Some(7))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro unwrap_or_zero {
     ($opt: expr) => {
         match $opt {
@@ -1179,6 +1113,9 @@ macro unwrap_or_zero {
             $defsite::Option::None => 0,
         }
     };
+}
+fn foo() -> felt252 {
+    unwrap_or_zero!(Option::<felt252>::Some(7))
 }
 
 //! > expected_diagnostics
@@ -1190,21 +1127,16 @@ macro unwrap_or_zero {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    bare_modifier_pattern!(7)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro bare_modifier_pattern {
     ($opt: expr) => {
         match $opt {
             $defsite => 0,
         }
     };
+}
+fn foo() -> felt252 {
+    bare_modifier_pattern!(7)
 }
 
 //! > expected_diagnostics
@@ -1220,23 +1152,18 @@ error[E2179]: Expected path after modifier.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let x = 1;
-    let y = 1;
-    assert_eq!(x, y);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro assert_eq {
     ($x:ident, $y:ident) => {
         if $x != $y {
             $defsite::panic!("Panic!");
         }
     };
+}
+fn foo() {
+    let x = 1;
+    let y = 1;
+    assert_eq!(x, y);
 }
 
 //! > expected_diagnostics
@@ -1248,19 +1175,14 @@ macro assert_eq {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    add_one!(x z);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro add_one {
     ($x:ident) => {
         1
     };
+}
+fn foo() {
+    add_one!(x z);
 }
 
 //! > expected_diagnostics
@@ -1276,19 +1198,14 @@ error[E2158]: No matching rule found in inline macro `add_one`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    a_macro!(x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro a_macro {
     ($x:ident) => {
         $defsite
     };
+}
+fn foo() {
+    a_macro!(x);
 }
 
 //! > expected_diagnostics
@@ -1304,19 +1221,14 @@ error[E2179]: Expected path after modifier.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    test_macro!(x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($x:ident) => {
         let y = $undefined;
     };
+}
+fn foo() {
+    test_macro!(x);
 }
 
 //! > expected_diagnostics
@@ -1332,19 +1244,14 @@ error[E2193]: Undefined macro placeholder: 'undefined'.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    add_nums!(1_u8, 2_u16);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro add_nums {
     ($x:expr, $y:expr) => {
         $x + $y
     };
+}
+fn foo() {
+    add_nums!(1_u8, 2_u16);
 }
 
 //! > expected_diagnostics
@@ -1360,17 +1267,7 @@ error[E2041]: Unexpected argument type. Expected: "core::integer::u8", found: "c
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let z = 1;
-    bas_use_z_from_callsite!();
-    consume_z(z);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro bas_use_z_from_callsite {
     () => {
         z
@@ -1378,6 +1275,11 @@ macro bas_use_z_from_callsite {
 }
 
 fn consume_z(_z: felt252) {}
+fn foo() {
+    let z = 1;
+    bas_use_z_from_callsite!();
+    consume_z(z);
+}
 
 //! > expected_diagnostics
 error[E0006]: Identifier not found.
@@ -1392,17 +1294,7 @@ error[E0006]: Identifier not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let z = 1;
-    wrap_bas_use_z_from_callsite!();
-    consume_z(z);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro bas_use_z_from_callsite {
     () => {
         $callsite::z
@@ -1416,6 +1308,11 @@ macro wrap_bas_use_z_from_callsite {
     () => {
         $defsite::bas_use_z_from_callsite!()
     };
+}
+fn foo() {
+    let z = 1;
+    wrap_bas_use_z_from_callsite!();
+    consume_z(z);
 }
 
 //! > expected_diagnostics
@@ -1431,15 +1328,7 @@ error[E0006]: Identifier not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    call_bar!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro call_bar {
     () => {
         bar()
@@ -1447,6 +1336,9 @@ macro call_bar {
 }
 
 fn bar() {}
+fn foo() {
+    call_bar!();
+}
 
 //! > expected_diagnostics
 error[E0006]: Function not found.
@@ -1461,19 +1353,14 @@ error[E0006]: Function not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    test_macro!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($x:expr) => {
         1
     };
+}
+fn foo() {
+    test_macro!();
 }
 
 //! > expected_diagnostics
@@ -1489,19 +1376,14 @@ error[E2158]: No matching rule found in inline macro `test_macro`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    test_macro!(1 2);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($($x:expr)?) => {
         1
     };
+}
+fn foo() {
+    test_macro!(1 2);
 }
 
 //! > expected_diagnostics
@@ -1517,19 +1399,14 @@ error[E2158]: No matching rule found in inline macro `test_macro`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    test_macro!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($($x:expr), +) => {
         1
     };
+}
+fn foo() {
+    test_macro!();
 }
 
 //! > expected_diagnostics
@@ -1545,19 +1422,14 @@ error[E2158]: No matching rule found in inline macro `test_macro`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    test_macro!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($($x:expr), *) => {
         1
     };
+}
+fn foo() {
+    test_macro!();
 }
 
 //! > expected_diagnostics
@@ -1569,19 +1441,14 @@ macro test_macro {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    test_macro!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($($x:expr), *) => {
         1 +
     };
+}
+fn foo() {
+    test_macro!();
 }
 
 //! > expected_diagnostics
@@ -1597,19 +1464,14 @@ error[E2117]: Parser error in macro-expanded code: Missing tokens. Expected an e
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    test_macro!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($x:expr) => {
         1
     };
+}
+fn foo() {
+    test_macro!();
 }
 
 //! > crate_settings
@@ -1642,13 +1504,7 @@ error[E2158]: No matching rule found in inline macro `test_macro`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 unknown_item_macro!();
 
 //! > expected_diagnostics
@@ -1664,14 +1520,9 @@ unknown_item_macro!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 foo!();
+fn foo() {}
 
 //! > expected_diagnostics
 error[E2156]: Inline macro `foo` not found.
@@ -1686,19 +1537,14 @@ foo!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    statement_list_returning_macro!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro statement_list_returning_macro {
     () => {
         let _a = 1;
     };
+}
+fn foo() {
+    statement_list_returning_macro!();
 }
 
 //! > expected_diagnostics
@@ -1710,20 +1556,15 @@ macro statement_list_returning_macro {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let _x = statement_list_returning_macro!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro statement_list_returning_macro {
     () => {
         let a = 1;
         let b = 2;
     };
+}
+fn foo() {
+    let _x = statement_list_returning_macro!();
 }
 
 //! > expected_diagnostics
@@ -1744,19 +1585,14 @@ error[E2117]: Parser error in macro-expanded code: Skipped tokens. Expected: end
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    only_statements!()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro only_statements {
     () => {
         let _a = 1;
     };
+}
+fn foo() {
+    only_statements!()
 }
 
 //! > expected_diagnostics
@@ -1772,19 +1608,14 @@ error[E2133]: Missing semicolon
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    assert_eq3!(1 + 2);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro assert_eq3 {
     ($x:expr) => {
         assert!($x == 3);
     };
+}
+fn foo() {
+    assert_eq3!(1 + 2);
 }
 
 //! > expected_diagnostics
@@ -1796,20 +1627,15 @@ macro assert_eq3 {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    empty_path!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro empty_path {
     () => {
         $defsite;
         $callsite;
     };
+}
+fn foo() {
+    empty_path!();
 }
 
 //! > expected_diagnostics
@@ -1825,15 +1651,12 @@ error[E2179]: Expected path after modifier.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     $path();
     $defsite::some::path();
     $callsite::other::path();
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2177]: `$` is not supported in this context.
@@ -1858,19 +1681,14 @@ error[E2177]: `$` is not supported in this context.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    super_path!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro super_path {
     () => {
         super::some::path();
     };
+}
+fn foo() {
+    super_path!();
 }
 
 //! > expected_diagnostics
@@ -1886,15 +1704,7 @@ error[E2098]: `super` used in macro call top level.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u8 {
-    use_module_path!()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro use_module_path {
     () => {
         use $defsite::a::b;
@@ -1908,6 +1718,9 @@ mod a {
         const C: u8 = 1;
     }
 }
+fn foo() -> u8 {
+    use_module_path!()
+}
 
 //! > expected_diagnostics
 
@@ -1918,15 +1731,7 @@ mod a {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u8 {
-    use_self_path!()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro use_self_path {
     () => {
         use $defsite::a::b::{self, C1};
@@ -1941,6 +1746,9 @@ mod a {
         const C2: u8 = 2;
     }
 }
+fn foo() -> u8 {
+    use_self_path!()
+}
 
 //! > expected_diagnostics
 
@@ -1951,15 +1759,7 @@ mod a {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u8 {
-    use_self_path!()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro use_self_path {
     () => {
         use $defsite::C;
@@ -1968,6 +1768,9 @@ macro use_self_path {
 }
 
 const C: u8 = 1;
+fn foo() -> u8 {
+    use_self_path!()
+}
 
 //! > expected_diagnostics
 
@@ -1978,27 +1781,7 @@ const C: u8 = 1;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    // Test macro-generated function.
-    fn_item();
-
-    // Test macro-generated struct.
-    let s = StructItem { a: 42 };
-    let _ = s.a;
-
-    // Test macro-generated enum.
-    let e = EnumItem::A;
-    match e {
-        EnumItem::A => {},
-        EnumItem::B => {},
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro define_items {
     () => {
         expose! {
@@ -2015,6 +1798,21 @@ macro define_items {
 }
 
 define_items!();
+fn foo() {
+    // Test macro-generated function.
+    fn_item();
+
+    // Test macro-generated struct.
+    let s = StructItem { a: 42 };
+    let _ = s.a;
+
+    // Test macro-generated enum.
+    let e = EnumItem::A;
+    match e {
+        EnumItem::A => {},
+        EnumItem::B => {},
+    }
+}
 
 //! > expected_diagnostics
 
@@ -2025,15 +1823,7 @@ define_items!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let _num = item_level();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro macro_item_level {
     () => {
         expose! {
@@ -2042,6 +1832,9 @@ macro macro_item_level {
     };
 }
 macro_item_level!();
+fn foo() {
+    let _num = item_level();
+}
 
 //! > expected_diagnostics
 error[E2311]: Mismatched types. The type `core::felt252` cannot be created from a string literal.
@@ -2064,15 +1857,7 @@ associated_item_constraints = false
 coupons = false
 user_defined_inline_macros = true
 
-//! > function_code
-fn foo() {
-    bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod with_bar {
     pub fn bar() {}
 }
@@ -2086,6 +1871,9 @@ macro import_with_bar {
 }
 
 import_with_bar!();
+fn foo() {
+    bar();
+}
 
 //! > expected_diagnostics
 
@@ -2104,13 +1892,7 @@ associated_item_constraints = false
 coupons = false
 user_defined_inline_macros = true
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro define_foo_caller {
     () => {
         use $callsite::*;
@@ -2148,15 +1930,7 @@ associated_item_constraints = false
 coupons = false
 user_defined_inline_macros = true
 
-//! > function_code
-fn foo() {
-    bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     macro define_bar {
         () => {
@@ -2167,6 +1941,9 @@ mod a {
     define_bar!();
 }
 use a::*;
+fn foo() {
+    bar();
+}
 
 //! > expected_diagnostics
 
@@ -2185,15 +1962,7 @@ associated_item_constraints = false
 coupons = false
 user_defined_inline_macros = true
 
-//! > function_code
-fn foo() {
-    bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     pub fn bar() {}
 }
@@ -2207,6 +1976,9 @@ macro import_a_star {
 }
 
 import_a_star!();
+fn foo() {
+    bar();
+}
 
 //! > expected_diagnostics
 
@@ -2217,15 +1989,7 @@ import_a_star!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     pub fn bar() {}
 }
@@ -2239,6 +2003,9 @@ macro import {
 }
 
 import!(a::bar);
+fn foo() {
+    bar();
+}
 
 //! > expected_diagnostics
 
@@ -2249,15 +2016,7 @@ import!(a::bar);
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    a::bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     macro define_bar {
         () => {
@@ -2267,6 +2026,9 @@ mod a {
         };
     }
     define_bar!();
+}
+fn foo() {
+    a::bar();
 }
 
 //! > expected_diagnostics
@@ -2278,15 +2040,7 @@ mod a {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    BarTrait::<a::Bar>::bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     pub struct Bar {}
     macro impl_bar_trait {
@@ -2301,6 +2055,9 @@ mod a {
 trait BarTrait<T> {
     fn bar() {}
 }
+fn foo() {
+    BarTrait::<a::Bar>::bar();
+}
 
 //! > expected_diagnostics
 
@@ -2311,15 +2068,7 @@ trait BarTrait<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    BarTrait::<a::Bar>::bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     macro define_ty {
         ($ty: ident) => {
@@ -2336,6 +2085,9 @@ mod a {
 trait BarTrait<T> {
     fn bar() {}
 }
+fn foo() {
+    BarTrait::<a::Bar>::bar();
+}
 
 //! > expected_diagnostics
 
@@ -2346,15 +2098,7 @@ trait BarTrait<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    BarTrait::<a::Bar>::bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     macro define_ty {
         ($ty: ident) => {
@@ -2376,6 +2120,9 @@ mod a {
 trait BarTrait<T> {
     fn bar() {}
 }
+fn foo() {
+    BarTrait::<a::Bar>::bar();
+}
 
 //! > expected_diagnostics
 
@@ -2386,13 +2133,7 @@ trait BarTrait<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro define_bar {
     () => {
         expose!(fn bar() {});
@@ -2414,13 +2155,7 @@ define_bar!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro define_bar {
     () => {
         expose!(fn bar() {});
@@ -2448,13 +2183,7 @@ define_bar_twice!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro define_bar {
     () => {
         fn bar() {}
@@ -2478,13 +2207,7 @@ fn bar() {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar() {}
 
 macro define_bar {
@@ -2507,13 +2230,7 @@ define_bar!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro inner_macro {
     () => {
         expose!(fn bar() {});
@@ -2543,15 +2260,7 @@ outer_macro!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro define_bar {
     () => {
         expose! (
@@ -2560,6 +2269,9 @@ macro define_bar {
     };
 }
 define_bar!();
+fn foo() {
+    bar();
+}
 
 //! > expected_diagnostics
 
@@ -2570,21 +2282,16 @@ define_bar!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro define_bar {
     () => {
         fn bar() {}
     };
 }
 define_bar!();
+fn foo() {
+    bar();
+}
 
 //! > expected_diagnostics
 error[E0006]: Function not found.
@@ -2599,13 +2306,10 @@ error[E0006]: Function not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     not::a::path::format!("");
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2156]: Inline macro `not::a::path::format` not found.
@@ -2628,17 +2332,12 @@ associated_item_constraints = false
 coupons = false
 user_defined_inline_macros = true
 
-//! > function_code
-fn foo() {
-    test_macro!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($()*) => { 1 };
+}
+fn foo() {
+    test_macro!();
 }
 
 //! > expected_diagnostics
@@ -2658,17 +2357,12 @@ associated_item_constraints = false
 coupons = false
 user_defined_inline_macros = true
 
-//! > function_code
-fn foo() {
-    test_macro!(() ());
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro test_macro {
     ($(())*) => { 1 };
+}
+fn foo() {
+    test_macro!(() ());
 }
 
 //! > expected_diagnostics
@@ -2680,17 +2374,12 @@ macro test_macro {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    m!();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro m {
     ($($x:expr),*) => { $x };
+}
+fn foo() {
+    m!();
 }
 
 //! > expected_diagnostics
@@ -2706,17 +2395,12 @@ error[E2198]: Macro placeholder 'x' requires 1 repetition level(s) in the expans
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    m!(1, 2, 3);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro m {
     ($($x:expr),*) => { $($x)* };
+}
+fn foo() {
+    m!(1, 2, 3);
 }
 
 //! > expected_diagnostics
@@ -2728,17 +2412,12 @@ macro m {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    m!(1 + 2, 3, 4);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro m {
     ($x:expr, $($y:expr),*) => { $($x + $y),* };
+}
+fn foo() {
+    m!(1 + 2, 3, 4);
 }
 
 //! > expected_diagnostics
@@ -2750,13 +2429,7 @@ macro m {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro m {
     ($($x:expr),* ; $($y:expr),*) => { $($x + $y),* };
 }
@@ -2774,13 +2447,7 @@ error[E2199]: Macro placeholder 'y' is from a different repetition than the one 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro m {
     ($($x:expr),* ; $($($y:expr),*),*) => { $($($x + $y),*),* };
 }
@@ -2798,13 +2465,7 @@ error[E2199]: Macro placeholder 'y' is from a different repetition than the one 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const a: felt252 = consteval_int!(1_u32);
 
 //! > expected_diagnostics
@@ -2825,13 +2486,7 @@ const a: felt252 = consteval_int!(1_u32);
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 const a: felt252 = consteval_int!(1_u32 + 2);
 
 //! > expected_diagnostics
@@ -2852,18 +2507,13 @@ const a: felt252 = consteval_int!(1_u32 + 2);
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> u32 {
-    mymac!(0)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[feature("user_defined_inline_macros")]
 macro mymac {
     ($x:literal) => { 5_u32 };
+}
+fn foo() -> u32 {
+    mymac!(0)
 }
 
 //! > expected_diagnostics
@@ -2884,13 +2534,7 @@ error[E2158]: No matching rule found in inline macro `mymac`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[feature("user_defined_inline_macros")]
 macro m {
     ($x:ident) => { 1 };
@@ -2920,18 +2564,13 @@ m!
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    mymac!($(x));
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[feature("user_defined_inline_macros")]
 macro mymac {
     ($x:ident) => { 1 };
+}
+fn foo() {
+    mymac!($(x));
 }
 
 //! > expected_diagnostics
@@ -2947,13 +2586,7 @@ error[E2158]: No matching rule found in inline macro `mymac`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[feature("user_defined_inline_macros")]
 macro make_const {
     () => { const C: felt252 = consteval_int!(4 + 5); };
@@ -2971,13 +2604,7 @@ make_const!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[feature("user_defined_inline_macros")]
 macro make_const {
     () => { const C: felt252 = consteval_int!(4 + 5); };
@@ -2998,15 +2625,7 @@ make_const!();
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo();
 }
@@ -3021,6 +2640,9 @@ macro make_impl {
 
 make_impl!();
 make_impl!();
+fn foo() {
+    MyTrait::foo();
+}
 
 //! > expected_diagnostics
 error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::make_impl!_#156::ConflictImpl`, `test::make_impl!_#171::ConflictImpl`
@@ -3035,15 +2657,7 @@ error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::mak
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo();
 }
@@ -3060,6 +2674,9 @@ mod helpers {
 
 helpers::make_impl!();
 helpers::make_impl!();
+fn foo() {
+    MyTrait::foo();
+}
 
 //! > expected_diagnostics
 error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::make_impl!_#204::ConflictImpl`, `test::make_impl!_#228::ConflictImpl`

--- a/crates/cairo-lang-semantic/src/expr/test_data/let_else
+++ b/crates/cairo-lang-semantic/src/expr/test_data/let_else
@@ -3,7 +3,16 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+
+enum MyEnum2 {
+    A: felt252,
+    B: felt252,
+}
 fn foo() {
     let MyEnum::A(x): felt252 = MyEnum::A(7) else {
         return;
@@ -14,20 +23,6 @@ fn foo() {
     let MyEnum2::A(x): MyEnum = MyEnum::A(7) else {
         return;
     };
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B: felt252,
-}
-
-enum MyEnum2 {
-    A: felt252,
-    B: felt252,
 }
 
 //! > expected_diagnostics
@@ -58,20 +53,15 @@ error[E2109]: Wrong enum in pattern. Expected: "MyEnum". Got: "MyEnum2".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
 fn foo() {
     let MyEnum::A(x) = MyEnum::A(7) else {
         return x;
     };
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B: felt252,
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/let_statement
+++ b/crates/cairo-lang-semantic/src/expr/test_data/let_statement
@@ -3,13 +3,10 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut ref mut ref ref _a = 3;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2101]: `ref` modifier was specified after another modifier (`mut`). Only a single modifier is allowed.
@@ -39,13 +36,10 @@ error[E2101]: `ref` modifier was specified after another modifier (`mut`). Only 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let ref mut _a = 3;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2101]: `mut` modifier was specified after another modifier (`ref`). Only a single modifier is allowed.
@@ -65,13 +59,10 @@ error[E2102]: `ref` is only allowed for function parameters, not for local varia
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let ref _a = 3;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2102]: `ref` is only allowed for function parameters, not for local variables.
@@ -86,14 +77,11 @@ error[E2102]: `ref` is only allowed for function parameters, not for local varia
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x = not_found;
     let _x = foo;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E0006]: Identifier not found.
@@ -113,13 +101,10 @@ error[E2005]: Expected variable or constant, found function.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _a: () = 3_felt252;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "()", found: "core::felt252".
@@ -134,7 +119,7 @@ error[E2041]: Unexpected argument type. Expected: "()", found: "core::felt252".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let (a, b, c) = undefined();
     let [d, e, f] = (a, b, c);
@@ -143,9 +128,6 @@ fn foo() {
     let [n, o, p] = [j, k, l, m];
     let _ignore = n + o + p;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E0006]: Function not found.

--- a/crates/cairo-lang-semantic/src/expr/test_data/literal
+++ b/crates/cairo-lang-semantic/src/expr/test_data/literal
@@ -3,13 +3,10 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _a = 'a'_Pedersen;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2008]: A numeric literal of type core::pedersen::Pedersen cannot be created.
@@ -24,13 +21,10 @@ error[E2008]: A numeric literal of type core::pedersen::Pedersen cannot be creat
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: u8 = 256;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u8.
@@ -45,13 +39,10 @@ error[E2008]: The value does not fit within the range of type core::integer::u8.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x = 1_boolean;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2011]: Not a type.
@@ -66,13 +57,10 @@ error[E2011]: Not a type.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x = 1_u32_u8;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2006]: Unknown type.
@@ -87,13 +75,10 @@ error[E2006]: Unknown type.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x = -1_u32_u8;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2006]: Unknown type.
@@ -108,14 +93,11 @@ error[E2006]: Unknown type.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let x = 5;
     let _y: felt252 = x;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -126,14 +108,11 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let x: u32 = 5;
     let _y: u32 = x;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -144,13 +123,10 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _arr: Array<u32> = array![0, 1, 2_u32];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -161,16 +137,13 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut total: u32 = 0;
     for (k, v) in array![0, 1, 2].into_iter().enumerate() {
         total = total + k + v;
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -181,13 +154,10 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: ByteArray = 252;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2315]: Mismatched types. The type `core::byte_array::ByteArray` cannot be created from a numeric literal.
@@ -202,13 +172,10 @@ error[E2315]: Mismatched types. The type `core::byte_array::ByteArray` cannot be
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: bool = 5;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
@@ -225,14 +192,11 @@ error[E2315]: Mismatched types. The type `core::bool` cannot be created from a n
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn incorrect_return_type() {
     let x = 5;
     x
 }
-
-//! > function_name
-incorrect_return_type
 
 //! > expected_diagnostics
 error[E2315]: Mismatched types. The type `()` cannot be created from a numeric literal.
@@ -247,16 +211,13 @@ error[E2315]: Mismatched types. The type `()` cannot be created from a numeric l
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _a = 42_Option;
     let _b = 42_Result;
     let _c = 42_PanicResult;
     let _d = 42_Span;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2008]: A numeric literal of type core::option::Option cannot be created.

--- a/crates/cairo-lang-semantic/src/expr/test_data/logical_operator
+++ b/crates/cairo-lang-semantic/src/expr/test_data/logical_operator
@@ -3,13 +3,10 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(a: u128, b: u128, c: u128) -> bool {
     a && b || c
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2039]: Expected type "core::bool", found: "core::integer::u128".
@@ -34,17 +31,12 @@ error[E2039]: Expected type "core::bool", found: "core::integer::u128".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(a: bool, b: bool, c: bool) -> bool {
-    bar(a, b, c)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<S, T>(a: S, b: bool, c: T) -> bool {
     a && Default::default() || c
+}
+fn foo(a: bool, b: bool, c: bool) -> bool {
+    bar(a, b, c)
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/loop
+++ b/crates/cairo-lang-semantic/src/expr/test_data/loop
@@ -3,7 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     loop {
         if true {
@@ -13,9 +13,6 @@ fn foo() {
         }
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2056]: Loop has incompatible return types: "core::bool" and "{numeric}"
@@ -30,7 +27,7 @@ error[E2056]: Loop has incompatible return types: "core::bool" and "{numeric}"
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: Option<()>) {
     loop {
         if true {
@@ -40,9 +37,6 @@ fn foo(x: Option<()>) {
         }
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2056]: Loop has incompatible return types: "core::bool" and "{numeric}"
@@ -65,13 +59,10 @@ error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     continue;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2145]: `continue` only allowed inside a `loop`.
@@ -86,13 +77,10 @@ error[E2145]: `continue` only allowed inside a `loop`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     break 5;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2146]: `break` only allowed inside a `loop`.
@@ -107,15 +95,12 @@ error[E2146]: `break` only allowed inside a `loop`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> bool {
     loop {
         break true;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -126,13 +111,10 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> bool {
     return;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
@@ -147,13 +129,10 @@ error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     return;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -164,15 +143,12 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> bool {
     loop {
         return;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
@@ -187,15 +163,12 @@ error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> bool {
     loop {
         break;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
@@ -213,15 +186,12 @@ error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     loop {
         break;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -232,13 +202,10 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     break;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2146]: `break` only allowed inside a `loop`.
@@ -253,7 +220,8 @@ error[E2146]: `break` only allowed inside a `loop`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+use option::Option;
 fn foo() -> Option<bool> {
     loop {
         let res = Some(true);
@@ -262,12 +230,6 @@ fn foo() -> Option<bool> {
     }
     None
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use option::Option;
 
 //! > expected_diagnostics
 
@@ -278,19 +240,14 @@ use option::Option;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+use option::Option;
 fn foo() -> Option<bool> {
     loop {
         1
     }
     None
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use option::Option;
 
 //! > expected_diagnostics
 error[E2144]: Tail expression not allowed in a `loop` block.
@@ -305,19 +262,14 @@ error[E2144]: Tail expression not allowed in a `loop` block.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+use option::Option;
 fn foo() -> Option<bool> {
     loop {
         ()
     }
     None
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use option::Option;
 
 //! > expected_diagnostics
 
@@ -328,19 +280,14 @@ use option::Option;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+use option::Option;
 fn foo() -> Option<bool> {
     loop {
         panic_with_felt252('no return')
     }
     None
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use option::Option;
 
 //! > expected_diagnostics
 
@@ -351,7 +298,7 @@ use option::Option;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(a: u32) -> Option<bool> {
     loop {
         if a == 0 {
@@ -361,9 +308,6 @@ fn foo(a: u32) -> Option<bool> {
     }
     None
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2056]: Loop has incompatible return types: "core::never" and "()"

--- a/crates/cairo-lang-semantic/src/expr/test_data/match
+++ b/crates/cairo-lang-semantic/src/expr/test_data/match
@@ -3,7 +3,11 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    a: (),
+    b: felt252,
+}
 fn foo(b: A) -> felt252 {
     match (b, 4) {
         (A::a(_x), _) => { 1 },
@@ -14,15 +18,6 @@ fn foo(b: A) -> felt252 {
     let x = (5, true);
     let (y, _) = x;
     y
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    a: (),
-    b: felt252,
 }
 
 //! > expected_diagnostics
@@ -53,21 +48,16 @@ error[E0006]: Identifier not found.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    a: (),
+    b: felt252,
+}
 fn foo(a: bool) -> felt252 {
     match a + 1 {
         A::a(_) => 0,
         A::b(_) => 1,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    a: (),
-    b: felt252,
 }
 
 //! > expected_diagnostics
@@ -93,21 +83,16 @@ error[E2109]: Wrong enum in pattern. Expected: "bool". Got: "A".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    a: (),
+    b: felt252,
+}
 fn foo(a: felt252, b: bool) -> felt252 {
     match a {
         0 => 0_felt252,
         _ => b,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    a: (),
-    b: felt252,
 }
 
 //! > expected_diagnostics
@@ -123,21 +108,16 @@ error[E2056]: Match arms have incompatible types: "core::felt252" and "core::boo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    a: (),
+    b: felt252,
+}
 fn foo(a: A) -> felt252 {
     match a {
         true => 2,
         false => 3,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    a: (),
-    b: felt252,
 }
 
 //! > expected_diagnostics
@@ -158,16 +138,13 @@ error[E2109]: Wrong enum in pattern. Expected: "A". Got: "bool".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: Option<()>) {
     match x {
         Some(_) => true,
         None => 0,
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2056]: Match arms have incompatible types: "core::bool" and "{numeric}"
@@ -187,18 +164,7 @@ error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(a: MyEnum) -> felt252 {
-    match a {
-        MyEnum::A(mut x) | MyEnum::B((x, _)) => x,
-        MyEnum::C((x, _, t)) | MyEnum::D(P { x, z: mut t, .. }) => x + t,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct P {
     x: felt252,
     y: felt252,
@@ -210,6 +176,12 @@ enum MyEnum {
     B: (felt252, felt252),
     C: (felt252, felt252, felt252),
     D: P,
+}
+fn foo(a: MyEnum) -> felt252 {
+    match a {
+        MyEnum::A(mut x) | MyEnum::B((x, _)) => x,
+        MyEnum::C((x, _, t)) | MyEnum::D(P { x, z: mut t, .. }) => x + t,
+    }
 }
 
 //! > expected_diagnostics
@@ -230,7 +202,12 @@ error[E2040]: variable is bound inconsistently across alternatives separated by 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum<T> {
+    A: T,
+    B: (felt252, felt252),
+}
+fn bar(a: MyEnum<u32>) {}
 fn foo() {
     let a = MyEnum::A(5);
     match a {
@@ -238,16 +215,6 @@ fn foo() {
     }
     bar(a);
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum<T> {
-    A: T,
-    B: (felt252, felt252),
-}
-fn bar(a: MyEnum<u32>) {}
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "test::MyEnum::<core::integer::u32>", found: "test::MyEnum::<core::felt252>".
@@ -262,21 +229,16 @@ error[E2041]: Unexpected argument type. Expected: "test::MyEnum::<core::integer:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+}
 fn foo(a: A, b: A) -> felt252 {
     match (a, b) {
         (A::One, _) => 2,
         (_, _) => 6,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum A {
-    One: felt252,
 }
 
 //! > expected_diagnostics
@@ -292,22 +254,17 @@ warning[E2192]: Pattern missing subpattern for the payload of variant. Consider 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+    Two: (),
+}
 fn foo(a: A, b: A) -> felt252 {
     match (a, b) {
         (A::One(_), _) => 2,
         (A::Two, _) => 6,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum A {
-    One: felt252,
-    Two: (),
 }
 
 //! > expected_diagnostics
@@ -319,22 +276,17 @@ enum A {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+    Two: (),
+}
 fn foo(a: A, b: A) -> felt252 {
     match (a, b) {
         (A::One(_), _) => 2,
         (A::Two(_), _) => 6,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum A {
-    One: felt252,
-    Two: (),
 }
 
 //! > expected_diagnostics
@@ -346,7 +298,7 @@ enum A {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo<T>(a: Option<T>) -> felt252 {
     match a {
         Some => 2,
@@ -357,9 +309,6 @@ fn bar() -> felt252 {
     let a = Some(());
     foo(a)
 }
-
-//! > function_name
-bar
 
 //! > expected_diagnostics
 warning[E2192]: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
@@ -374,24 +323,19 @@ warning[E2192]: Pattern missing subpattern for the payload of variant. Consider 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A, b: A) -> felt252 {
-    match (a, b) {
-        (A::One(_), _) => 2,
-        (Two, _) => 6,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy, Drop)]
 enum A {
     One: felt252,
     Two: (),
 }
 use A::Two;
+fn foo(a: A, b: A) -> felt252 {
+    match (a, b) {
+        (A::One(_), _) => 2,
+        (Two, _) => 6,
+    }
+}
 
 //! > expected_diagnostics
 
@@ -402,7 +346,7 @@ use A::Two;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn fb() -> Option<()> {
     let x = None;
     match x {
@@ -411,9 +355,6 @@ fn fb() -> Option<()> {
     }
     return x;
 }
-
-//! > function_name
-fb
 
 //! > expected_diagnostics
 warning[E2192]: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
@@ -428,7 +369,7 @@ warning[E2192]: Pattern missing subpattern for the payload of variant. Consider 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn fb() -> Option<()> {
     let x = None;
     match x {
@@ -437,9 +378,6 @@ fn fb() -> Option<()> {
     }
     return x;
 }
-
-//! > function_name
-fb
 
 //! > expected_diagnostics
 warning[E2192]: Pattern missing subpattern for the payload of variant. Consider using `Option::Some(_)`
@@ -454,7 +392,7 @@ warning[E2192]: Pattern missing subpattern for the payload of variant. Consider 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> u32 {
     let x = Some(3);
     match x {
@@ -462,9 +400,6 @@ fn foo() -> u32 {
         None::<u8> => 6,
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2302]: Type mismatch: `core::option::Option::<core::integer::u32>` and `core::option::Option::<core::integer::u8>`.
@@ -479,16 +414,13 @@ error[E2302]: Type mismatch: `core::option::Option::<core::integer::u32>` and `c
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: Result<Option<u8>, felt252>) {
     let _y = match x {
         Ok(Some(x)) | Err(x) => x,
         _ => 3,
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2039]: Expected type "core::integer::u8", found: "core::felt252".
@@ -503,16 +435,13 @@ error[E2039]: Expected type "core::integer::u8", found: "core::felt252".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: Result<Option<u8>, felt252>) {
     let _y = match x {
         Ok(Ok(x)) | Err(x) => x,
         _ => 3,
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2109]: Wrong enum in pattern. Expected: "Option". Got: "Result".
@@ -532,20 +461,15 @@ error[E2048]: Missing variable in pattern.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar(x: felt252) {
-    foo(Ok(Some(x)));
-}
-
-//! > function_name
-bar
-
-//! > module_code
+//! > cairo_code
 fn foo<T>(x: Result<Option<T>, felt252>) {
     let _y = match x {
         Ok(Some(x)) | Err(x) => x,
         _ => 3,
     };
+}
+fn bar(x: felt252) {
+    foo(Ok(Some(x)));
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/method
+++ b/crates/cairo-lang-semantic/src/expr/test_data/method
@@ -3,17 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> Option<felt252> {
-    let x = None;
-    let _ = x.is_some();
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     fn is_some(self: felt252) -> bool;
 }
@@ -21,6 +11,11 @@ impl OtherImpl of AnotherTrait {
     fn is_some(self: felt252) -> bool {
         true
     }
+}
+fn foo() -> Option<felt252> {
+    let x = None;
+    let _ = x.is_some();
+    x
 }
 
 //! > expected_diagnostics
@@ -32,21 +27,7 @@ impl OtherImpl of AnotherTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> Option<felt252> {
-    let x = None;
-    x.is_foo();
-    x.is_bla();
-    let y = Some(true);
-    y.is_bar();
-    y.SomeOtherPrefix::is_bar();
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn is_bla(self: Option<T>) -> bool;
     fn is_bar(self: Option<T>) -> bool;
@@ -81,6 +62,15 @@ impl AnotherTraitImpl of AnotherTrait {
         false
     }
 }
+fn foo() -> Option<felt252> {
+    let x = None;
+    x.is_foo();
+    x.is_bla();
+    let y = Some(true);
+    y.is_bar();
+    y.SomeOtherPrefix::is_bar();
+    x
+}
 
 //! > expected_diagnostics
 error[E0002]: Method `is_foo` not found on type `core::option::Option::<?0>`. Did you import the correct trait and impl?
@@ -110,15 +100,7 @@ error[E2313]: Candidate impl test::AnotherMyTraitImpl::<?0> has an unused generi
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar(3_u8);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<T, impl CallableImpl: callable::CallableTrait<T>>(x: T) {
     x.call();
 }
@@ -130,6 +112,9 @@ mod callable {
         fn call(self: u8) {}
     }
 }
+fn foo() {
+    bar(3_u8);
+}
 
 //! > expected_diagnostics
 
@@ -140,15 +125,7 @@ mod callable {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    bar(3_u8);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<T, +unknown, +callable::CallableTrait<T>>(x: T) {
     x.call();
 }
@@ -159,6 +136,9 @@ mod callable {
     impl U8Callable of CallableTrait<u8> {
         fn call(self: u8) {}
     }
+}
+fn foo() {
+    bar(3_u8);
 }
 
 //! > expected_diagnostics
@@ -174,15 +154,7 @@ fn bar<T, +unknown, +callable::CallableTrait<T>>(x: T) {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar(3_u8);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(x: u8) {
     x.call();
 }
@@ -194,6 +166,9 @@ mod callable {
 impl U8Callable of callable::CallableTrait<u8> {
     fn call(self: u8) {}
 }
+fn foo() {
+    bar(3_u8);
+}
 
 //! > expected_diagnostics
 
@@ -204,15 +179,7 @@ impl U8Callable of callable::CallableTrait<u8> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar(3_u8);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(x: u8) {
     x.call();
 }
@@ -227,6 +194,9 @@ mod callable {
 impl U16Callable of callable::CallableTrait<u16> {
     fn call(self: u16) {}
 }
+fn foo() {
+    bar(3_u8);
+}
 
 //! > expected_diagnostics
 
@@ -237,15 +207,7 @@ impl U16Callable of callable::CallableTrait<u16> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar(3_u8);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 impl X = callable::U8Callable;
 fn bar(x: u8) {
     x.call();
@@ -258,6 +220,9 @@ mod callable {
         fn call(self: u8) {}
     }
 }
+fn foo() {
+    bar(3_u8);
+}
 
 //! > expected_diagnostics
 
@@ -268,15 +233,7 @@ mod callable {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar(3_u8);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 impl X = callable::U16Callable;
 fn bar(x: u8) {
     x.call();
@@ -292,6 +249,9 @@ mod callable {
         fn call(self: u16) {}
     }
 }
+fn foo() {
+    bar(3_u8);
+}
 
 //! > expected_diagnostics
 
@@ -302,17 +262,12 @@ mod callable {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    3_u16.bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn bar(self: T);
+}
+fn foo() {
+    3_u16.bar();
 }
 
 //! > expected_diagnostics
@@ -329,17 +284,12 @@ Candidate `test::MyTrait::bar` inference failed with: Trait has no implementatio
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    (3_u16 + 3_u16).bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn bar(self: T);
+}
+fn foo() {
+    (3_u16 + 3_u16).bar();
 }
 
 //! > expected_diagnostics
@@ -356,21 +306,16 @@ Candidate `test::MyTrait::bar` inference failed with: Trait has no implementatio
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    0.bar(1);
-    0.bar(1, 2, 3);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn bar(self: T, a: felt252, b: felt252);
 }
 impl MyImpl of MyTrait<felt252> {
     fn bar(self: felt252, a: felt252, b: felt252) {}
+}
+fn foo() {
+    0.bar(1);
+    0.bar(1, 2, 3);
 }
 
 //! > expected_diagnostics
@@ -391,16 +336,7 @@ error[E2030]: Wrong number of arguments. Expected 3, found: 4
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let channel = PoseidonChannel {};
-    channel.draw_felt();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait ChannelTrait {
     type Channel;
 
@@ -415,6 +351,10 @@ impl PoseidonChannelImpl of ChannelTrait {
     fn draw_felt(ref self: PoseidonChannel) -> felt252 {
         5
     }
+}
+fn foo() {
+    let channel = PoseidonChannel {};
+    channel.draw_felt();
 }
 
 //! > expected_diagnostics
@@ -431,17 +371,7 @@ Candidate `test::ChannelTrait::draw_felt` inference failed with: Type mismatch: 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    // ref self method called on expression (not a variable) should work
-    let _ = make_counter().increment();
-    let _ = make_counter().increment().increment();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct Counter {
     value: u32,
@@ -461,6 +391,11 @@ impl CounterImpl of CounterTrait {
 fn make_counter() -> Counter {
     Counter { value: 0 }
 }
+fn foo() {
+    // ref self method called on expression (not a variable) should work
+    let _ = make_counter().increment();
+    let _ = make_counter().increment().increment();
+}
 
 //! > expected_diagnostics
 
@@ -471,18 +406,7 @@ fn make_counter() -> Counter {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    // ref self on expression works
-    let _ = make_counter().increment();
-    // but regular ref arg (not self) still requires a variable
-    bar(make_counter());
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct Counter {
     value: u32,
@@ -504,6 +428,12 @@ fn make_counter() -> Counter {
 }
 
 fn bar(ref x: Counter) {}
+fn foo() {
+    // ref self on expression works
+    let _ = make_counter().increment();
+    // but regular ref arg (not self) still requires a variable
+    bar(make_counter());
+}
 
 //! > expected_diagnostics
 error[E2079]: ref argument must be a variable.

--- a/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
+++ b/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
@@ -3,16 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: u8) -> Option<u8> {
-    let b: Option<u8> = a.try_into();
-    b
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 use core::traits::TryInto;
 pub trait DowncastableInt<Type>;
 
@@ -29,6 +20,10 @@ impl DowncastableTryInto<
         core::integer::downcast(self)
     }
 }
+fn foo(a: u8) -> Option<u8> {
+    let b: Option<u8> = a.try_into();
+    b
+}
 
 //! > expected_diagnostics
 
@@ -39,15 +34,7 @@ impl DowncastableTryInto<
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(a: u8) -> u8 {
-    bar(a)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn f(t: T) -> T;
 }
@@ -59,6 +46,9 @@ impl MyImpl<T, -Drop<T>> of MyTrait<T> {
 
 fn bar<T>(t: T) -> T {
     MyTrait::f(t)
+}
+fn foo(a: u8) -> u8 {
+    bar(a)
 }
 
 //! > expected_diagnostics
@@ -74,15 +64,7 @@ error[E2311]: Trait has no implementation in context: test::MyTrait::<T>.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> u32 {
-    MyTrait2::foo(5_u32)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 pub trait MyTrait<T> {}
 
 impl I of MyTrait<u32> {}
@@ -95,6 +77,9 @@ impl I2<T, -MyTrait<T>> of MyTrait2<T> {
     fn foo(self: T) -> T {
         self
     }
+}
+fn foo() -> u32 {
+    MyTrait2::foo(5_u32)
 }
 
 //! > expected_diagnostics
@@ -110,15 +95,7 @@ error[E2311]: Trait has no implementation in context: test::MyTrait2::<core::int
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> u32 {
-    I2::foo(5_u32)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 pub trait MyTrait<T> {}
 
 impl I of MyTrait<u32> {}
@@ -131,6 +108,9 @@ impl I2<T, -MyTrait<T>> of MyTrait2<T> {
     fn foo(self: T) -> T {
         self
     }
+}
+fn foo() -> u32 {
+    I2::foo(5_u32)
 }
 
 //! > expected_diagnostics
@@ -146,13 +126,7 @@ error[E2312]: Trait has implementation in context: test::MyTrait::<core::integer
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 pub trait Consumer<T> {
     fn consume(self: T, input: u32);
     fn bar(x: T);
@@ -191,15 +165,7 @@ impl TConsumerImpl<T, +core::fmt::Debug<T>, +Drop<T>, -Producer<T>> of Consumer<
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    Trait3::bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Trait<T> {}
 
 impl I of Trait<u32> {}
@@ -222,6 +188,9 @@ impl I3<-Trait<u32>> of Trait3 {
         Trait2::foo();
     }
 }
+fn foo() {
+    Trait3::bar();
+}
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: test::Trait3.
@@ -236,15 +205,7 @@ error[E2311]: Trait has no implementation in context: test::Trait3.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar::<felt252>();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 use core::metaprogramming::TypeEqual;
 trait MyTrait {
     fn f();
@@ -258,6 +219,9 @@ impl MyImpl<T, const SIZE: usize, -TypeEqual<[T; SIZE], [T; 0]>> of MyTrait {
 fn bar<T>() {
     MyImpl::<T, 1>::f();
 }
+fn foo() {
+    bar::<felt252>();
+}
 
 //! > expected_diagnostics
 
@@ -268,15 +232,7 @@ fn bar<T>() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    Bad::<u128>::bad();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 pub trait NegImpl<+Drop<u32>> {}
 
 pub trait Bad<T> {
@@ -287,6 +243,9 @@ pub impl ImplBad<T, -NegImpl<_>> of Bad<T> {
     fn bad() -> T {
         panic!("Bad::bad() called")
     }
+}
+fn foo() {
+    Bad::<u128>::bad();
 }
 
 //! > expected_diagnostics
@@ -302,15 +261,7 @@ pub trait NegImpl<+Drop<u32>> {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    bar::<5>();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 use core::metaprogramming::TypeEqual;
 pub trait NegImpl<T> {}
 
@@ -329,6 +280,9 @@ pub impl ImplBad<const C: u32, -TypeEqual<A<C>, A<0>>> of Bad {
         C
     }
 }
+fn foo() {
+    bar::<5>();
+}
 
 //! > expected_diagnostics
 error[E2313]: Cannot infer trait core::metaprogramming::TypeEqual::<test::A::<?0>, test::A::<0>>. First generic argument must be known.
@@ -343,7 +297,7 @@ error[E2313]: Cannot infer trait core::metaprogramming::TypeEqual::<test::A::<?0
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo(a: u32) -> (u32, u32) {
     let s0 = array![a].span();
     let s1 = array![a + 1].span();
@@ -354,11 +308,6 @@ fn foo(a: u32) -> (u32, u32) {
     (*c0.pop_front().unwrap(), *c1.pop_front().unwrap())
 }
 
-//! > function_name
-foo
-
-//! > module_code
-
 //! > expected_diagnostics
 
 //! > ==========================================================================
@@ -368,13 +317,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait IsSpecificSize<T>;
 impl IsSpecificSizeImpl of IsSpecificSize<[u32; 3]>;
 
@@ -400,15 +343,7 @@ error[E2313]: Negative impl has an unsupported generic argument GenericParamCons
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    MyTrait::<felt252>::f()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn f() -> felt252;
 }
@@ -417,6 +352,9 @@ impl BlanketNonCopy<T, -MissomgTrait<T>> of MyTrait<T> {
     fn f() -> felt252 {
         7
     }
+}
+fn foo() -> felt252 {
+    MyTrait::<felt252>::f()
 }
 
 //! > expected_diagnostics
@@ -437,15 +375,7 @@ error[E2311]: Trait has no implementation in context: test::MyTrait::<core::felt
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    MyTrait::<felt252>::f()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn f() -> felt252;
 }
@@ -454,6 +384,9 @@ impl BlanketNonCopy<T, +MissingTrait<T>> of MyTrait<T> {
     fn f() -> felt252 {
         7
     }
+}
+fn foo() -> felt252 {
+    MyTrait::<felt252>::f()
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/operators
+++ b/crates/cairo-lang-semantic/src/expr/test_data/operators
@@ -3,17 +3,12 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern type MyType;
 fn foo(a: MyType) {
     a + a * a;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern type MyType;
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: core::traits::Add::<test::MyType>.
@@ -28,7 +23,7 @@ error[E2311]: Trait has no implementation in context: core::traits::Add::<test::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(a: u128, b: bool) implicits(RangeCheck) {
     // Valid.
     a + a * a - a;
@@ -37,9 +32,6 @@ fn foo(a: u128, b: bool) implicits(RangeCheck) {
     a > a > a;
     a - b
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1028]: Consecutive comparison operators are not allowed: '>' followed by '>'
@@ -69,15 +61,12 @@ error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u12
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     -(1 == 2);
     -1_u8;
     !17;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u8.
@@ -97,18 +86,7 @@ error[E2311]: Trait has no implementation in context: core::traits::Neg::<core::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let x1 = Struct1 { x: 0 };
-    let _y1 = x1[0];
-    let x2 = Struct2 { x: 0 };
-    let _y2 = x2[0];
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct Struct1 {
     x: felt252,
 }
@@ -126,6 +104,12 @@ impl Struct2Index of Index<Struct2, usize, felt252> {
     fn index(ref self: Struct2, index: usize) -> felt252 {
         self.x
     }
+}
+fn foo() {
+    let x1 = Struct1 { x: 0 };
+    let _y1 = x1[0];
+    let x2 = Struct2 { x: 0 };
+    let _y2 = x2[0];
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/pattern
+++ b/crates/cairo-lang-semantic/src/expr/test_data/pattern
@@ -3,11 +3,8 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: (felt252, felt252)) {}
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -18,17 +15,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(s2: Struct2) {
-    let Struct2 { member1: _, member2: _, member3: _ } = s2;
-    let Struct2 { member1: _, member2: _, .. } = s2;
-    let Struct2 { member1: _, member2: _, member3: Struct1 { member1: _a, .. } } = s2;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct Struct1 {
     member1: felt252,
     member2: (),
@@ -37,6 +24,11 @@ struct Struct2 {
     member1: felt252,
     member2: (),
     member3: Struct1,
+}
+fn foo(s2: Struct2) {
+    let Struct2 { member1: _, member2: _, member3: _ } = s2;
+    let Struct2 { member1: _, member2: _, .. } = s2;
+    let Struct2 { member1: _, member2: _, member3: Struct1 { member1: _a, .. } } = s2;
 }
 
 //! > expected_diagnostics
@@ -48,18 +40,13 @@ struct Struct2 {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(s: MyStruct) {
-    let MyStruct { a: _ } = s;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: usize,
     b: usize,
+}
+fn foo(s: MyStruct) {
+    let MyStruct { a: _ } = s;
 }
 
 //! > expected_diagnostics
@@ -75,16 +62,11 @@ error[E0003]: Missing member "b".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+struct MyStruct {}
 fn foo(s: MyStruct) {
     let MyStruct { a, b } = s;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-struct MyStruct {}
 
 //! > expected_diagnostics
 error[E2058]: Struct "MyStruct" has no member "a"
@@ -104,18 +86,13 @@ error[E2058]: Struct "MyStruct" has no member "b"
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(s: MyStruct) {
-    let MyStruct { a: _, b: _, a: _, b: _ } = s;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: usize,
     b: usize,
+}
+fn foo(s: MyStruct) {
+    let MyStruct { a: _, b: _, a: _, b: _ } = s;
 }
 
 //! > expected_diagnostics
@@ -136,18 +113,13 @@ error[E2050]: Redefinition of member "b" on struct "MyStruct".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(s: MyStruct) {
-    let MyStruct { a: _, c: _, a: _ } = s;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: usize,
     b: usize,
+}
+fn foo(s: MyStruct) {
+    let MyStruct { a: _, c: _, a: _ } = s;
 }
 
 //! > expected_diagnostics
@@ -173,13 +145,10 @@ error[E0003]: Missing member "b".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(s: [felt252; 3]) {
     let [_a, _b] = s;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2108]: Wrong number of fixed size array elements in pattern. Expected: 3. Got: 2.
@@ -194,13 +163,10 @@ error[E2108]: Wrong number of fixed size array elements in pattern. Expected: 3.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(s: (felt252, felt252, felt252)) {
     let [_a, _b, _c] = s;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2103]: Mismatched types: pattern cannot match against type "(core::felt252, core::felt252, core::felt252)".
@@ -215,13 +181,10 @@ error[E2103]: Mismatched types: pattern cannot match against type "(core::felt25
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(s: [felt252; 3]) {
     let (_a, _b, _c) = s;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2103]: Mismatched types: pattern cannot match against type "[core::felt252; 3]".
@@ -236,16 +199,13 @@ error[E2103]: Mismatched types: pattern cannot match against type "[core::felt25
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(s: [felt252; 3]) {
     let (unresolved,) = if true {} else {
         (array![(1, 2, 3)],)
     };
     for (_x, _y, _z) in unresolved.span() {}
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2056]: If blocks have incompatible types: "()" and "(core::array::Array::<({numeric}, {numeric}, {numeric})>,)"
@@ -268,13 +228,10 @@ error[E2107]: Wrong number of tuple elements in pattern. Expected: 0. Got: 1.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let (_a, _a) = (1, 2);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2049]: Redefinition of variable name "_a" in pattern.
@@ -289,7 +246,7 @@ error[E2049]: Redefinition of variable name "_a" in pattern.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     match (1, 2) {
         (_a, _a) => (),
@@ -299,9 +256,6 @@ fn foo() {
         ((_b, _), _b) => (),
     };
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2049]: Redefinition of variable name "_a" in pattern.
@@ -321,18 +275,13 @@ error[E2049]: Redefinition of variable name "_b" in pattern.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo(s: Span<u32>) -> u32 {
     let [a, b] = s else {
         return 0;
     };
     *a + *b
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 
@@ -343,7 +292,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let a: Array<u8> = array![1, 2, 3];
     let c: u16 = 0;
@@ -352,11 +301,6 @@ fn foo() {
         _ => 0,
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: core::array::ToSpanTrait::<core::array::Array::<core::integer::u8>, core::integer::u16>.
@@ -371,17 +315,12 @@ error[E2311]: Trait has no implementation in context: core::array::ToSpanTrait::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(s: MyStruct<u8>) {
-    let [_x, _y] = s;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct<T> {
     value: T,
+}
+fn foo(s: MyStruct<u8>) {
+    let [_x, _y] = s;
 }
 
 //! > expected_diagnostics
@@ -397,7 +336,7 @@ error[E2103]: Mismatched types: pattern cannot match against type "test::MyStruc
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let a: Array<u8> = array![1, 2, 3];
     match a {
@@ -405,11 +344,6 @@ fn foo() {
         _ => {},
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E2103]: Mismatched types: pattern cannot match against type "core::array::Array::<core::integer::u8>".
@@ -424,7 +358,7 @@ error[E2103]: Mismatched types: pattern cannot match against type "core::array::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let a: [u8; 3] = [1, 2, 3];
     match a {
@@ -432,11 +366,6 @@ fn foo() {
         _ => {},
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 
@@ -447,7 +376,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a, b] => *a + *b,
@@ -456,11 +385,6 @@ fn foo(s: Span<u32>) -> u32 {
         Some(a) => *a,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E2315]: Mismatched types. The type `core::array::Span::<core::integer::u32>` cannot be created from a numeric literal.

--- a/crates/cairo-lang-semantic/src/expr/test_data/return
+++ b/crates/cairo-lang-semantic/src/expr/test_data/return
@@ -3,13 +3,10 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> felt252 {
     return 1 + 2;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -20,14 +17,11 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> felt252 {
     return 1 + 2;
     35
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -38,7 +32,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: felt252) -> felt252 {
     match x {
         0 => { return 5; },
@@ -46,9 +40,6 @@ fn foo(x: felt252) -> felt252 {
         2 => { return 9; },
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -59,11 +50,8 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> felt252 {}
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::felt252", found: "()".

--- a/crates/cairo-lang-semantic/src/expr/test_data/snapshot
+++ b/crates/cairo-lang-semantic/src/expr/test_data/snapshot
@@ -3,20 +3,15 @@
 //! > test_runner_name
 test_function_diagnostics
 
-//! > function_code
-fn foo(a: @A) {
-    bar(a.a, a.b);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     a: Array<felt252>,
     b: felt252,
 }
 fn bar(a: @Array::<felt252>, b: @felt252) {}
+fn foo(a: @A) {
+    bar(a.a, a.b);
+}
 
 //! > expected_diagnostics
 
@@ -27,14 +22,11 @@ fn bar(a: @Array::<felt252>, b: @felt252) {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: @felt252 = 5;
     let _y: felt252 = @6;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2315]: Mismatched types. The type `@core::felt252` cannot be created from a numeric literal.
@@ -56,14 +48,11 @@ Consider adding or removing snapshots.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _x: @felt252 = 5_felt252;
     let _y: felt252 = @6_felt252;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "@core::felt252", found: "core::felt252".
@@ -86,7 +75,11 @@ test_function_diagnostics
 //! > crate_settings
 edition = "2025_12"
 
-//! > function_code
+//! > cairo_code
+struct A {
+    a: Array<felt252>,
+    b: felt252,
+}
 fn foo(a: @A) {
     let _: @Array<felt252> = @a.a;
     let _: @Array<felt252> = @(@a).a;
@@ -95,15 +88,6 @@ fn foo(a: @A) {
     let _: @felt252 = @a.b;
     let _: @felt252 = @(@a).b;
     let _: @@felt252 = @@(@a).b;
-}
-
-//! > function_name
-foo
-
-//! > module_code
-struct A {
-    a: Array<felt252>,
-    b: felt252,
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/statements
+++ b/crates/cairo-lang-semantic/src/expr/test_data/statements
@@ -3,14 +3,11 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut x = 3
     x = 2;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1001]: Missing token ';'.
@@ -25,13 +22,10 @@ error[E1001]: Missing token ';'.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let mut _x = 3
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1001]: Missing token ';'.
@@ -46,16 +40,13 @@ error[E1001]: Missing token ';'.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> felt252 {
     if true {
         return 1
     }
     2
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1001]: Missing token ';'.
@@ -70,13 +61,10 @@ error[E1001]: Missing token ';'.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> felt252 {
     return 1
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E1001]: Missing token ';'.
@@ -91,17 +79,12 @@ error[E1001]: Missing token ';'.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar() {}
 fn foo() {
     bar()
     bar();
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar() {}
 
 //! > expected_diagnostics
 error[E2133]: Missing semicolon
@@ -116,13 +99,10 @@ error[E2133]: Missing semicolon
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() -> felt252 {
     2
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -133,7 +113,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     // `if` without ';' in the end
     if true {}
@@ -149,9 +129,6 @@ fn foo() {
     let _x = 3;
 }
 
-//! > function_name
-foo
-
 //! > expected_diagnostics
 
 //! > ==========================================================================
@@ -161,16 +138,13 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     #[unknown_attr1]
     #[unknown_attr2]
     #[cairofmt::skip]
     let _x = 3;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2155]: Unknown statement attribute.
@@ -190,7 +164,11 @@ error[E2155]: Unknown statement attribute.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[unstable(feature: "testing", note: "Some reason", since: "1.0.0")]
+fn unstable_function_with_note() -> felt252 {
+    0
+}
 fn foo() {
     let _x = {
         #[feature("testing")]
@@ -204,17 +182,6 @@ fn foo() {
     unstable_function_with_note(); // Attr on non-expression tail works.
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[unstable(feature: "testing", note: "Some reason", since: "1.0.0")]
-fn unstable_function_with_note() -> felt252 {
-    0
-}
-
-//! > function_body
-
 //! > expected_diagnostics
 
 //! > ==========================================================================
@@ -224,15 +191,10 @@ fn unstable_function_with_note() -> felt252 {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     type MyAlias = felt252;
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E2197]: Item not supported as a statement.
@@ -247,17 +209,12 @@ error[E2197]: Item not supported as a statement.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    m!(1);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro m {
     ($x) => { 0 };
+}
+fn foo() {
+    m!(1);
 }
 
 //! > expected_diagnostics
@@ -278,15 +235,10 @@ error[E2158]: No matching rule found in inline macro `m`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     use core::array::*;
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E2075]: Unsupported use item in statement.

--- a/crates/cairo-lang-semantic/src/expr/test_data/structure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/structure
@@ -3,7 +3,11 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+struct A {
+    a: felt252,
+    b: (),
+}
 #[cairofmt::skip]
 fn foo(a: A) -> A {
     A {
@@ -14,15 +18,6 @@ fn foo(a: A) -> A {
         ..d,
         f: 4,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-struct A {
-    a: felt252,
-    b: (),
 }
 
 //! > expected_diagnostics
@@ -58,22 +53,17 @@ error[E2018]: Unknown member.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+struct A {
+    a: (felt252,),
+    b: felt252,
+    c: felt252,
+}
 fn foo(a: A) {
     a.f;
     a.a::b;
     a.4.4;
     5_felt252.a;
-}
-
-//! > function_name
-foo
-
-//! > module_code
-struct A {
-    a: (felt252,),
-    b: felt252,
-    c: felt252,
 }
 
 //! > expected_diagnostics
@@ -104,17 +94,12 @@ error[E0007]: Type "core::felt252" has no member "a"
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(a: A) -> A {
-    A { a: 4, ..a }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     a: felt252,
+}
+fn foo(a: A) -> A {
+    A { a: 4, ..a }
 }
 
 //! > expected_diagnostics
@@ -130,13 +115,7 @@ error[E2023]: Base struct has no effect, all the fields in the struct have alrea
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S {
     val: felt252,
 }

--- a/crates/cairo-lang-semantic/src/expr/test_data/tuple
+++ b/crates/cairo-lang-semantic/src/expr/test_data/tuple
@@ -3,15 +3,10 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo(t: (felt252, u8)) -> u8 {
     t.1
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 
@@ -22,15 +17,10 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(t: (felt252, u8)) -> felt252 {
     t.5
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E0007]: Type "(core::felt252, core::integer::u8)" has no member "5"
@@ -45,15 +35,10 @@ error[E0007]: Type "(core::felt252, core::integer::u8)" has no member "5"
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(x: felt252) -> felt252 {
     x.0
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E0007]: Type "core::felt252" has no member "0"
@@ -68,15 +53,10 @@ error[E0007]: Type "core::felt252" has no member "0"
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(t: (felt252, u8)) -> felt252 {
     t.0_u8
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E2085]: Invalid member expression.
@@ -91,15 +71,10 @@ error[E2085]: Invalid member expression.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(t: (felt252, u8)) -> u8 {
     t.0x1
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E2085]: Invalid member expression.
@@ -114,15 +89,10 @@ error[E2085]: Invalid member expression.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(t: (felt252, u8)) -> (felt252, felt252) {
     (t.00, t.0x1)
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 error[E0007]: Type "(core::felt252, core::integer::u8)" has no member "00"
@@ -142,15 +112,10 @@ error[E2085]: Invalid member expression.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo(mut t: (felt252, u8)) {
     t.0 = 5;
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics
 
@@ -161,15 +126,7 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(w: Wrapper) -> u8 {
-    w.1
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct Wrapper {
     inner: (felt252, u8),
@@ -180,6 +137,9 @@ impl WrapperDeref of core::ops::Deref<Wrapper> {
     fn deref(self: Wrapper) -> (felt252, u8) {
         self.inner
     }
+}
+fn foo(w: Wrapper) -> u8 {
+    w.1
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/expr/test_data/while
+++ b/crates/cairo-lang-semantic/src/expr/test_data/while
@@ -3,7 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     while true {
         1;
@@ -11,9 +11,6 @@ fn foo() {
         break;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2147]: Can only break with a value inside a `loop`.
@@ -28,7 +25,7 @@ error[E2147]: Can only break with a value inside a `loop`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     while let Some(x) = Some(5) && 4 == 7 {
         1;
@@ -36,9 +33,6 @@ fn foo() {
         break;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2000]: Unsupported feature.
@@ -53,16 +47,13 @@ error[E2000]: Unsupported feature.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     while let Some = Some(5) {
         1;
         break;
     }
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 warning[E2192]: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
@@ -77,21 +68,16 @@ warning[E2192]: Pattern missing subpattern for the payload of variant. Consider 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    B: (),
+}
 fn foo() {
     let a = A::B(());
     while let A::B = a {
         1;
         break;
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    B: (),
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/items/tests/early_conform
+++ b/crates/cairo-lang-semantic/src/items/tests/early_conform
@@ -3,13 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -35,13 +29,7 @@ fn main() -> MyType {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -67,13 +55,7 @@ fn main() -> MyType {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -99,13 +81,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -135,13 +111,7 @@ test irrelevant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -172,13 +142,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -204,13 +168,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -236,13 +194,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -277,13 +229,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -310,13 +256,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -349,13 +289,7 @@ fn main(my_enum: MyEnum) {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -387,13 +321,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -421,13 +349,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -457,13 +379,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -493,13 +409,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -529,13 +439,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -572,13 +476,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -625,13 +523,7 @@ fn main() -> MyType16 {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -667,13 +559,7 @@ fn main(other: MyGenericType<MyType>) {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -699,13 +585,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -732,13 +612,7 @@ fn bar(_x: MyType) {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -770,13 +644,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -810,13 +678,7 @@ impl MyIndexView of IndexView<u64, MyType, ()> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -847,13 +709,7 @@ impl MyAdd of Add<MyType> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -881,13 +737,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -917,13 +767,7 @@ fn main() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -950,13 +794,7 @@ fn main() -> Option<()> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -983,13 +821,7 @@ fn main() -> Result<(), ()> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }

--- a/crates/cairo-lang-semantic/src/items/tests/enum
+++ b/crates/cairo-lang-semantic/src/items/tests/enum
@@ -3,19 +3,14 @@
 //! > test_runner_name
 test_function_diagnostics
 
-//! > function_code
+//! > cairo_code
+enum A<T> {
+    Variant0: T,
+}
 fn foo(a: A<felt252>) -> felt252 {
     match a {
         A::Variant0(t) => { t },
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A<T> {
-    Variant0: T,
 }
 
 //! > expected_diagnostics
@@ -27,13 +22,7 @@ enum A<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     Variant: A,
 }
@@ -51,13 +40,7 @@ error[E2052]: Recursive type "test::A" has infinite size.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 enum A {
     Variant: A,
@@ -72,13 +55,7 @@ enum A {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 struct A {}
 
@@ -99,13 +76,7 @@ error[E2020]: Non-phantom type containing phantom type.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     Variant: Array<()>,
 }
@@ -123,7 +94,10 @@ error[E2053]: Cannot have array of type "()" that is zero sized.
 //! > test_runner_name
 test_function_diagnostics
 
-//! > function_code
+//! > cairo_code
+enum E {
+    aa: i32,
+}
 fn foo() {}
 fn bar<E>() -> i32 {
     let E::aa(b) = makeE();
@@ -131,14 +105,6 @@ fn bar<E>() -> i32 {
 }
 fn makeE() -> E {
     E::aa(3)
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum E {
-    aa: i32,
 }
 
 //! > expected_diagnostics
@@ -159,7 +125,12 @@ error[E0006]: Identifier not found.
 //! > test_runner_name
 test_function_diagnostics
 
-//! > function_code
+//! > cairo_code
+enum A {
+    T: i32,
+    E: (),
+}
+use A::{E, T};
 fn foo() {}
 fn bar<T, E>() -> i32 {
     let T(a) = A::T(2);
@@ -167,16 +138,6 @@ fn bar<T, E>() -> i32 {
 
     a
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    T: i32,
-    E: (),
-}
-use A::{E, T};
 
 //! > expected_diagnostics
 error[E2009]: Not a variant. Use the full name Enum::Variant.
@@ -201,13 +162,7 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     A: P,
 }
@@ -237,13 +192,7 @@ MyEnum::A(());
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum W<T, +Drop<T>> {
     X: T,
 }

--- a/crates/cairo-lang-semantic/src/items/tests/extern_func
+++ b/crates/cairo-lang-semantic/src/items/tests/extern_func
@@ -3,17 +3,12 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar() -> bad_type;
 fn foo() {
     bar()
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar() -> bad_type;
 
 //! > expected_diagnostics
 error[E0006]: Type not found.
@@ -35,13 +30,7 @@ error[E2116]: An extern function must be marked as nopanic.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn g<T, +Drop<T>>(x: T) nopanic;
 enum E {

--- a/crates/cairo-lang-semantic/src/items/tests/free_function
+++ b/crates/cairo-lang-semantic/src/items/tests/free_function
@@ -3,11 +3,8 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(a: bool, a: felt252) {}
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2054]: Redefinition of parameter name "a" in function "foo".
@@ -22,11 +19,8 @@ fn foo(a: bool, a: felt252) {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 fn foo(a: bool) implicits(felt252, bool) {}
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -37,16 +31,11 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar<const n: u16>(a: bool) {}
 fn foo(a: bool) {
     bar(a)
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar<const n: u16>(a: bool) {}
 
 //! > expected_diagnostics
 error[E2310]: Failed to infer constant.
@@ -61,13 +50,7 @@ error[E2310]: Failed to infer constant.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn g<T, +Drop<T>>(x: T) {}
 enum E {
     A: g::<felt252>::Coupon,

--- a/crates/cairo-lang-semantic/src/items/tests/impl_alias
+++ b/crates/cairo-lang-semantic/src/items/tests/impl_alias
@@ -3,15 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> usize {
-    MyImpl1::foo()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo() -> usize;
 }
@@ -21,6 +13,9 @@ impl MyImpl of MyTrait {
     }
 }
 impl MyImpl1 = MyImpl;
+fn foo() -> usize {
+    MyImpl1::foo()
+}
 
 //! > expected_diagnostics
 
@@ -31,15 +26,7 @@ impl MyImpl1 = MyImpl;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> usize {
-    MyTrait::foo()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo() -> usize;
 }
@@ -53,6 +40,9 @@ mod other_mod {
     }
 }
 impl MyImplAlias = other_mod::other_other_mod::MyImpl;
+fn foo() -> usize {
+    MyTrait::foo()
+}
 
 //! > expected_diagnostics
 
@@ -63,15 +53,7 @@ impl MyImplAlias = other_mod::other_other_mod::MyImpl;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: Option<Box<usize>>) -> usize {
-    MyTrait::foo(x)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo(x: T) -> usize;
 }
@@ -85,6 +67,9 @@ mod other_mod {
     }
 }
 impl MyImplAlias<T> = other_mod::other_other_mod::MyImpl<Box<T>>;
+fn foo(x: Option<Box<usize>>) -> usize {
+    MyTrait::foo(x)
+}
 
 //! > expected_diagnostics
 
@@ -95,15 +80,7 @@ impl MyImplAlias<T> = other_mod::other_other_mod::MyImpl<Box<T>>;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: Option<Box<usize>>) -> usize {
-    MyTrait::foo(x)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo(x: T) -> usize;
 }
@@ -117,6 +94,9 @@ mod other_mod {
     }
 }
 impl MyImplAlias<T> = other_mod::other_other_mod::MyImpl<Option<T>>;
+fn foo(x: Option<Box<usize>>) -> usize {
+    MyTrait::foo(x)
+}
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: test::MyTrait::<core::option::Option::<core::box::Box::<core::integer::u32>>>.

--- a/crates/cairo-lang-semantic/src/items/tests/impl_def
+++ b/crates/cairo-lang-semantic/src/items/tests/impl_def
@@ -3,13 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr<T> {
     type Ty;
 }

--- a/crates/cairo-lang-semantic/src/items/tests/struct
+++ b/crates/cairo-lang-semantic/src/items/tests/struct
@@ -3,17 +3,12 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A<felt252>) -> felt252 {
-    a.a
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A<T> {
     a: T,
+}
+fn foo(a: A<felt252>) -> felt252 {
+    a.a
 }
 
 //! > expected_diagnostics
@@ -25,13 +20,7 @@ struct A<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     member: A,
 }
@@ -73,13 +62,7 @@ error[E2052]: Recursive type "test::B" has infinite size.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 struct A {
     member: A,
@@ -94,13 +77,7 @@ struct A {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[phantom]
 struct A {}
 
@@ -121,13 +98,7 @@ error[E2020]: Non-phantom type containing phantom type.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     member: Array<((), ())>,
 }
@@ -145,13 +116,7 @@ error[E2053]: Cannot have array of type "((), ())" that is zero sized.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct W<T, +Drop<T>> {
     x: T,
 }

--- a/crates/cairo-lang-semantic/src/items/tests/trait
+++ b/crates/cairo-lang-semantic/src/items/tests/trait
@@ -3,13 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {}
 trait MyTrait<T> {
     fn param_test(ref a: u128) -> bad_type nopanic;
@@ -187,17 +181,12 @@ impl abc of abc;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {}
 trait MyTrait<T>;
 impl MyImpl3 of NonExistingTrait;
 impl MyImpl4 of foo;
+fn foo() {}
 
 //! > expected_diagnostics
 error[E0006]: Trait not found.
@@ -217,13 +206,7 @@ impl MyImpl4 of foo;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct NonCopy {}
 
 struct A {}
@@ -292,13 +275,7 @@ impl T2Drop of Drop<(felt252, NonCopy)>;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn f(mut a: felt252);
 }
@@ -316,13 +293,7 @@ error[E2033]: Parameter of trait function `MyTrait::f` can't be defined as mutab
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn f(a: felt252);
 }
@@ -342,13 +313,7 @@ impl MyImpl2<T> of MyTrait<T> {
 //! > test_runner_name
 test_function_diagnostics
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo() {}
 }
@@ -362,17 +327,12 @@ trait MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo();
+}
+fn foo() {
+    MyTrait::foo()
 }
 
 //! > expected_diagnostics
@@ -388,15 +348,7 @@ error[E2311]: Trait has no implementation in context: test::MyTrait.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo();
 }
@@ -405,6 +357,9 @@ impl MyImpl1 of MyTrait {
 }
 impl MyImpl2 of MyTrait {
     fn foo() {}
+}
+fn foo() {
+    MyTrait::foo()
 }
 
 //! > expected_diagnostics
@@ -420,13 +375,7 @@ error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::MyI
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo1();
     fn foo2();
@@ -446,13 +395,7 @@ impl MyImpl of MyTrait;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {}
 trait MyTrait {
     fn foo1();
@@ -488,13 +431,7 @@ impl MyImpl of MyTrait;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {}
 mod inner {
     impl I of super::OtherTrait {}
@@ -547,13 +484,7 @@ error[E2311]: Trait has no implementation in context: test::OtherTrait.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {}
 impl MyImpl of MyTrait {
     type X = u32;
@@ -592,13 +523,7 @@ error[E2014]: Impl item impl `MyImpl::E` is not a member of trait `MyTrait`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait Identity<T> {
     fn foo(a: T);
 }
@@ -622,13 +547,7 @@ error[E2031]: Parameter type of impl function `Felt252Identity::foo` is incompat
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait Identity<T> {
     fn foo() -> T;
 }
@@ -652,13 +571,7 @@ error[E2045]: Return type of impl function `Felt252Identity::foo` is incompatibl
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait Identity<T, T> {
     fn foo(a: T);
 }
@@ -676,13 +589,7 @@ impl Felt252Identity of Identity<felt252, felt252> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait Identity<T> {
     fn foo<T>(a: T);
 }
@@ -704,13 +611,7 @@ error[E2031]: Parameter type of impl function `Felt252Identity::foo` is incompat
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait Identity<T> {
     fn foo<S>(a: T, b: S);
 }
@@ -728,13 +629,7 @@ impl Felt252Identity of Identity<felt252> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type X;
     type X;
@@ -763,13 +658,7 @@ error[E2118]: The name `X` is defined multiple times.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     const X: i32;
     const X: i32;
@@ -789,13 +678,7 @@ error[E2118]: The name `X` is defined multiple times.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     impl X: MyTrait<u32>;
     impl X: MyTrait<i32>;
@@ -828,13 +711,7 @@ error[E2134]: Expected an impl of `test::MyTrait::<core::integer::i32>`. Got an 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo<S>(a: T, b: S, c: felt252);
     fn foo<S>(a: T, b: S);
@@ -868,13 +745,7 @@ error[E2029]: The number of parameters in the impl function `MyImpl::foo` is inc
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bla() {}
-
-//! > function_name
-bla
-
-//! > module_code
+//! > cairo_code
 trait t1 {}
 impl imp1 of t1 {}
 impl imp2 of imp1 {}
@@ -909,13 +780,7 @@ impl imp4 of inner_imp {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type X;
 }
@@ -932,13 +797,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
     fn foo() -> u32;
@@ -960,13 +819,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo1() -> u32;
     fn foo2() -> u32;
@@ -989,13 +842,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo1() -> u32;
     fn foo2() -> u16;
@@ -1022,13 +869,7 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod inner {
     trait MyTrait {
         fn foo1();
@@ -1055,13 +896,7 @@ error[E2176]: `Self` can only be the first segment of a path.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo(x: u16, y: u16) -> u16;
 }
@@ -1094,13 +929,7 @@ error[E2045]: Return type of impl function `MyImpl::foo` is incompatible with `M
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 pub struct Foo {}
 pub struct FooIter {}
@@ -1139,15 +968,7 @@ error[E2311]: Trait has no implementation in context: core::iter::traits::iterat
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: *)
 
-//! > function_code
-fn foo1() -> felt252 {
-    2
-}
-
-//! > function_name
-foo1
-
-//! > module_code
+//! > cairo_code
 pub trait Tr {}
 impl I0 of Tr {}
 
@@ -1159,6 +980,9 @@ fn foo<impl I: Tr>(x: A<I>) -> A<I> {
 fn bar<impl I: Tr>(x: A<I>) -> A<I> {
     foo(x)
 }
+fn foo1() -> felt252 {
+    2
+}
 
 //! > expected_diagnostics
 
@@ -1169,16 +993,11 @@ fn bar<impl I: Tr>(x: A<I>) -> A<I> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: *)
 
-//! > function_code
+//! > cairo_code
+pub trait Tr<+Tr> {}
 fn foo() -> felt252 {
     2
 }
-
-//! > function_name
-foo
-
-//! > module_code
-pub trait Tr<+Tr> {}
 
 //! > expected_diagnostics
 error[E2028]: Cycle detected while resolving generic param. Try specifying the generic impl parameter explicitly to break the cycle.
@@ -1193,18 +1012,13 @@ pub trait Tr<+Tr> {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: *)
 
-//! > function_code
-fn foo() -> felt252 {
-    2
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr {}
 impl I0<T, +Ifelt252> of Tr {}
 impl Ifelt = I0<Ifelt>;
+fn foo() -> felt252 {
+    2
+}
 
 //! > expected_diagnostics
 error[E0006]: Trait not found.
@@ -1224,21 +1038,16 @@ impl Ifelt = I0<Ifelt>;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    2
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr {
     fn foo<T>(x: T);
 }
 
 impl I of Tr {
     fn foo<U>(x: U) {}
+}
+fn foo() -> felt252 {
+    2
 }
 
 //! > expected_diagnostics
@@ -1254,21 +1063,16 @@ error[E2036]: Parameter name of impl function I::foo is incompatible with Tr::fo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    2
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr {
     fn foo<T, +Destruct<T>>(x: T);
 }
 
 impl I of Tr {
     fn foo<T, +Drop<T>>(x: T) {}
+}
+fn foo() -> felt252 {
+    2
 }
 
 //! > expected_diagnostics
@@ -1284,21 +1088,16 @@ error[E2037]: Generic parameter trait of impl function `I::foo` is incompatible 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    2
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr {
     fn foo<T, S, +Destruct<T>>(x: T);
 }
 
 impl I of Tr {
     fn foo<T, S, +Destruct<S>>(x: T) {}
+}
+fn foo() -> felt252 {
+    2
 }
 
 //! > expected_diagnostics
@@ -1314,21 +1113,16 @@ error[E2037]: Generic parameter trait of impl function `I::foo` is incompatible 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    2
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr {
     fn foo<T, +Destruct<T>>(x: T);
 }
 
 impl I of Tr {
     fn foo<T, +Destruct<T>>(x: T) {}
+}
+fn foo() -> felt252 {
+    2
 }
 
 //! > expected_diagnostics
@@ -1340,21 +1134,16 @@ impl I of Tr {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    2
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr {
     fn foo<T, +Destruct<T>>();
 }
 
 impl I of Tr {
     fn foo<const T: i32, S>() {}
+}
+fn foo() -> felt252 {
+    2
 }
 
 //! > expected_diagnostics
@@ -1375,21 +1164,16 @@ error[E2038]: Generic parameter kind of impl function `I::foo` is incompatible w
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    2
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr {
     fn foo<T, const C: T>();
 }
 
 impl I of Tr {
     fn foo<T, const C: i32>() {}
+}
+fn foo() -> felt252 {
+    2
 }
 
 //! > expected_diagnostics
@@ -1405,13 +1189,7 @@ error[E2031]: Parameter type of impl function `I::foo` is incompatible with `Tr:
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Tr {
     fn g<S, +Drop<S>>(x: S);
 }

--- a/crates/cairo-lang-semantic/src/items/tests/trait_const
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_const
@@ -3,15 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::foo() + MyImpl::X;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
     fn foo() -> u32;
@@ -21,6 +13,9 @@ impl MyImpl of MyTrait {
     fn foo() -> u32 {
         Self::X + 5
     }
+}
+fn foo() {
+    MyImpl::foo() + MyImpl::X;
 }
 
 //! > expected_diagnostics
@@ -32,13 +27,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
     fn foo() -> u32;
@@ -63,13 +52,7 @@ warning[E2096]: In an impl, paths of the same impl are not allowed. Did you mean
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
     fn foo() -> u32;
@@ -94,13 +77,7 @@ warning[E2096]: In an impl, paths of the same impl are not allowed. Did you mean
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     const X: u32;
     fn foo() -> u32;
@@ -121,13 +98,7 @@ impl MyImpl<T> of MyTrait<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait SomeTrait {}
 trait MyTrait {
     const X: u32;
@@ -153,13 +124,7 @@ warning[E2093]: In an impl, paths of the same impl must be fully explicit. Eithe
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
 }
@@ -180,15 +145,7 @@ error[E2039]: Expected type "core::integer::u32", found: "core::integer::i32".
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::foo();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: i32;
     fn foo() -> i32;
@@ -198,6 +155,9 @@ impl MyImpl of MyTrait {
     fn foo() -> i32 {
         -Self::X
     }
+}
+fn foo() {
+    MyImpl::foo();
 }
 
 //! > expected_diagnostics
@@ -209,15 +169,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyImpl::foo();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
     fn foo() -> u32;
@@ -227,6 +179,9 @@ impl MyImpl of MyTrait {
     fn foo() -> u32 {
         -Self::X
     }
+}
+fn foo() {
+    MyImpl::foo();
 }
 
 //! > expected_diagnostics
@@ -242,13 +197,7 @@ error[E2311]: Trait has no implementation in context: core::traits::Neg::<core::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: felt252;
     const Y: felt252;
@@ -275,13 +224,7 @@ error[E2311]: Trait has no implementation in context: core::traits::PartialOrd::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     const X: u32;
 }
@@ -306,13 +249,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     const X: u32;
 }
@@ -341,13 +278,7 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 // A trait with 0 impls in the context.
 trait AnotherTrait0 {
     const X: u32;
@@ -393,13 +324,7 @@ error[E2311]: Trait has no implementation in context: test::AnotherTrait0.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S<const N: u32> {}
 trait AnotherTrait {
     const X: u32;
@@ -429,13 +354,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S<const N: u32> {}
 
 trait AnotherTrait {
@@ -475,13 +394,7 @@ error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible wit
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S<const N: u32> {}
 
 trait MyTrait {
@@ -499,13 +412,7 @@ trait MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S<const N: u32> {}
 trait MyTrait {
     const X: u32;
@@ -529,13 +436,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S<const N: u32> {}
 
 trait MyTrait {
@@ -569,15 +470,7 @@ error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible wit
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let _: u32 = MyImpl::my_function;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
     fn my_function() -> u16;
@@ -587,6 +480,9 @@ impl MyImpl of MyTrait {
     fn my_function() -> u16 {
         2_u16
     }
+}
+fn foo() {
+    let _: u32 = MyImpl::my_function;
 }
 
 //! > expected_diagnostics
@@ -602,13 +498,7 @@ error[E2005]: Expected variable or constant, found function.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
     const Y: u32;
@@ -627,13 +517,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u16;
     const Y: u32;
@@ -656,13 +540,7 @@ error[E2302]: Type mismatch: `core::integer::u32` and `core::integer::u16`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
 }
@@ -683,13 +561,7 @@ error[E2024]: Cycle detected while resolving 'const' items.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
     const Y: u32;
@@ -717,19 +589,14 @@ error[E2024]: Cycle detected while resolving 'const' items.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> i32 {
-    MyImpl::Y
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const Y: u32;
 }
 impl MyImpl of MyTrait {}
+fn foo() -> i32 {
+    MyImpl::Y
+}
 
 //! > expected_diagnostics
 error[E0004]: Not all trait items are implemented. Missing: 'Y'.
@@ -752,17 +619,12 @@ error[E2311]: Trait has no implementation in context: test::MyTrait.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+use core::num::traits::Bounded;
+pub const MAX_U64: u64 = Bounded::<u64>::MAX;
 fn foo() -> u64 {
     MAX_U64 - 5
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use core::num::traits::Bounded;
-pub const MAX_U64: u64 = Bounded::<u64>::MAX;
 
 //! > expected_diagnostics
 
@@ -773,13 +635,7 @@ pub const MAX_U64: u64 = Bounded::<u64>::MAX;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AsBinary<T> {
     const SIZE: usize;
     fn as_binary(self: T) -> [bool; Self::SIZE];
@@ -800,13 +656,7 @@ impl AsBinaryU8 of AsBinary<u8> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Repeated<T> {
     const SIZE: usize;
     fn repeated(self: T) -> [T; Self::SIZE];
@@ -827,13 +677,7 @@ impl CopyRepeated<T, +Copy<T>> of Repeated<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait SomeTrait {
     const SIZE: usize;
     const IDS: [felt252; Self::SIZE];
@@ -854,13 +698,7 @@ impl SomeImpl of SomeTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const X: u32;
 }

--- a/crates/cairo-lang-semantic/src/items/tests/trait_default_fn
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_default_fn
@@ -3,16 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyTrait::foo(5_u64);
-    MyTrait::foo(3_u32);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo(t: T) -> T {
         t
@@ -24,6 +15,10 @@ impl MyImplU32 of MyTrait<u32> {
         t + 1
     }
 }
+fn foo() {
+    MyTrait::foo(5_u64);
+    MyTrait::foo(3_u32);
+}
 
 //! > expected_diagnostics
 
@@ -34,13 +29,7 @@ impl MyImplU32 of MyTrait<u32> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn inner(x: T, y: T) -> T;
     fn foo<+Copy<T>>(x: T) -> T {
@@ -64,13 +53,7 @@ impl MyImplU32 of MyTrait<u32> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo(mut x: u32) -> u32 {
         x += 1;
@@ -91,13 +74,7 @@ error[E2033]: Parameter of trait function `MyTrait::foo` can't be defined as mut
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn default_impl() {
         bar::<Self>();

--- a/crates/cairo-lang-semantic/src/items/tests/trait_impl
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_impl
@@ -3,15 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::foo1(3_u32);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     impl MyImpl: TypeTrait;
     fn foo1(x: Self::MyImpl::MyType) -> Self::MyImpl::MyType;
@@ -32,6 +24,9 @@ mod myMod {
         type MyType = u32;
     }
 }
+fn foo() {
+    MyImpl::foo1(3_u32);
+}
 
 //! > expected_diagnostics
 
@@ -42,13 +37,7 @@ mod myMod {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     impl impl1: OtherTrait;
     impl impl2: OtherTrait;
@@ -69,17 +58,7 @@ trait OtherTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::<u32>::foo1(3_u32);
-    MyImpl::<u32>::foo2(3_u32);
-    MyImpl::<u32>::foo3(3_u32);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T, S> {
     impl impl1: OtherTrait;
     fn foo1(x: Self::impl1::InputType) -> Self::impl1::OutputType;
@@ -108,6 +87,11 @@ impl OtherImpl of OtherTrait {
     type InputType = u32;
     type OutputType = u32;
 }
+fn foo() {
+    MyImpl::<u32>::foo1(3_u32);
+    MyImpl::<u32>::foo2(3_u32);
+    MyImpl::<u32>::foo3(3_u32);
+}
 
 //! > expected_diagnostics
 
@@ -118,16 +102,7 @@ impl OtherImpl of OtherTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let x = MyStruct { value: 3_u32 };
-    let _: MyStruct<u32> = MyImpl::foo(x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct<T> {
     value: T,
 }
@@ -149,6 +124,10 @@ impl MyImpl of MyTrait {
         MyStruct { value: x.value }
     }
 }
+fn foo() {
+    let x = MyStruct { value: 3_u32 };
+    let _: MyStruct<u32> = MyImpl::foo(x);
+}
 
 //! > expected_diagnostics
 
@@ -159,13 +138,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -200,13 +173,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -250,13 +217,7 @@ error[E2045]: Return type of impl function `MyImpl::bar2` is incompatible with `
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -315,13 +276,7 @@ error[E2313]: Trait `test::AnotherTrait2` has multiple implementations, in: `tes
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -354,13 +309,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -407,13 +356,7 @@ error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible wit
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -453,13 +396,7 @@ fn bar3() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -488,13 +425,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -527,13 +458,7 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
     impl Impl: Self;
@@ -590,13 +515,7 @@ fn complex(
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
     impl Impl: Self;
@@ -657,13 +576,7 @@ error[E2042]: Unexpected return type. Expected: "@(core::integer::u32, core::opt
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -692,13 +605,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type InputType;
 }
@@ -731,13 +638,7 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {}
 trait MyTrait {
     impl MyImpl: OtherTrait;
@@ -759,13 +660,7 @@ error[E2027]: Cycle detected while resolving 'impls alias' items.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {}
 trait MyTrait {
     impl Impl1: OtherTrait;
@@ -794,16 +689,7 @@ error[E2027]: Cycle detected while resolving 'impls alias' items.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u32 {
-    let x: MyImpl::<u32>::Impl::ty = 4;
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type ty;
 }
@@ -818,6 +704,10 @@ trait MyTrait {
 impl MyImpl<K> of MyTrait {
     impl Impl = OtherImpl<K>;
 }
+fn foo() -> u32 {
+    let x: MyImpl::<u32>::Impl::ty = 4;
+    x
+}
 
 //! > expected_diagnostics
 
@@ -828,18 +718,7 @@ impl MyImpl<K> of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    bar::<MyImpl<felt252>>(2)
-}
-pub fn bar<impl O: MyTrait>(x: O::Impl::ty) -> O::Impl::ty {
-    O::foo(x)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type ty;
 }
@@ -862,6 +741,12 @@ impl MyImpl<K> of MyTrait {
         x
     }
 }
+fn foo() -> felt252 {
+    bar::<MyImpl<felt252>>(2)
+}
+pub fn bar<impl O: MyTrait>(x: O::Impl::ty) -> O::Impl::ty {
+    O::foo(x)
+}
 
 //! > expected_diagnostics
 
@@ -872,18 +757,7 @@ impl MyImpl<K> of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    bar::<myMod::MyImpl<felt252>>(2)
-}
-pub fn bar<+MyTrait>(x: MyTrait::Impl::ty) -> MyTrait::Impl::ty {
-    MyTrait::foo(x)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type ty;
 }
@@ -905,6 +779,12 @@ trait MyTrait {
     impl Impl: OtherTrait;
     fn foo(x: Self::Impl::ty) -> Self::Impl::ty;
 }
+fn foo() -> felt252 {
+    bar::<myMod::MyImpl<felt252>>(2)
+}
+pub fn bar<+MyTrait>(x: MyTrait::Impl::ty) -> MyTrait::Impl::ty {
+    MyTrait::foo(x)
+}
 
 //! > expected_diagnostics
 
@@ -915,18 +795,7 @@ trait MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    bar::<_, DepAdd>(3_felt252, 4)
-}
-pub fn bar<T, impl O: OtherAdd<T, T>>(x: T, y: T) -> O::Impl::ty {
-    O::other_add(x, y)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type ty;
 }
@@ -950,6 +819,12 @@ impl DepAdd<T, +Drop<T>> of OtherAdd<T, T> {
         lhs
     }
 }
+fn foo() -> felt252 {
+    bar::<_, DepAdd>(3_felt252, 4)
+}
+pub fn bar<T, impl O: OtherAdd<T, T>>(x: T, y: T) -> O::Impl::ty {
+    O::other_add(x, y)
+}
 
 //! > expected_diagnostics
 
@@ -960,18 +835,7 @@ impl DepAdd<T, +Drop<T>> of OtherAdd<T, T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    bar(3_felt252, 4)
-}
-pub fn bar<T, +OtherAdd<T, T>>(x: T, y: T) -> OtherAdd::<T, T>::Impl::ty {
-    OtherAdd::other_add(x, y)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     type ty;
 }
@@ -995,6 +859,12 @@ impl DepAdd<T, +Drop<T>> of OtherAdd<T, T> {
         lhs
     }
 }
+fn foo() -> felt252 {
+    bar(3_felt252, 4)
+}
+pub fn bar<T, +OtherAdd<T, T>>(x: T, y: T) -> OtherAdd::<T, T>::Impl::ty {
+    OtherAdd::other_add(x, y)
+}
 
 //! > expected_diagnostics
 
@@ -1005,7 +875,16 @@ impl DepAdd<T, +Drop<T>> of OtherAdd<T, T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+trait Iterator<T> {
+    type Item;
+    fn next(ref self: T) -> Option<Self::Item>;
+}
+trait IntoIterator<T> {
+    type IntoIter;
+    impl Impl: Iterator<Self::IntoIter>;
+    fn into_iter(self: T) -> Self::IntoIter;
+}
 fn foo() -> felt252 {
     21
 }
@@ -1018,20 +897,6 @@ fn bar<T, impl I: IntoIterator<T>>(a: T) {
     y;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-trait Iterator<T> {
-    type Item;
-    fn next(ref self: T) -> Option<Self::Item>;
-}
-trait IntoIterator<T> {
-    type IntoIter;
-    impl Impl: Iterator<Self::IntoIter>;
-    fn into_iter(self: T) -> Self::IntoIter;
-}
-
 //! > expected_diagnostics
 
 //! > ==========================================================================
@@ -1041,7 +906,16 @@ trait IntoIterator<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+trait Iterator<T> {
+    type Item;
+    fn next(ref self: T) -> Option<Self::Item>;
+}
+trait IntoIterator<T> {
+    type IntoIter;
+    impl Impl: Iterator<Self::IntoIter>;
+    fn into_iter(self: T) -> Self::IntoIter;
+}
 fn foo() -> felt252 {
     21
 }
@@ -1054,20 +928,6 @@ fn bar<T, +IntoIterator<T>>(a: T) {
     y;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-trait Iterator<T> {
-    type Item;
-    fn next(ref self: T) -> Option<Self::Item>;
-}
-trait IntoIterator<T> {
-    type IntoIter;
-    impl Impl: Iterator<Self::IntoIter>;
-    fn into_iter(self: T) -> Self::IntoIter;
-}
-
 //! > expected_diagnostics
 
 //! > ==========================================================================
@@ -1077,13 +937,7 @@ trait IntoIterator<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait<T> {
     const X: u32;
 }
@@ -1109,15 +963,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    MyImpl::I::f()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     fn f();
 }
@@ -1125,6 +971,9 @@ trait MyTrait {
     impl I: OtherTrait;
 }
 impl MyImpl of MyTrait {}
+fn foo() {
+    MyImpl::I::f()
+}
 
 //! > expected_diagnostics
 error[E2015]: Cannot infer implicit impl `I`.
@@ -1153,15 +1002,7 @@ error[E2311]: Trait has no implementation in context: test::MyTrait.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: *)
 
-//! > function_code
-fn foo() {
-    MyImpl::I::f()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait {
     fn f();
 }
@@ -1173,6 +1014,9 @@ trait MyTrait {
 }
 
 impl MyImpl of MyTrait {}
+fn foo() {
+    MyImpl::I::f()
+}
 
 //! > expected_diagnostics
 
@@ -1183,15 +1027,7 @@ impl MyImpl of MyTrait {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::<u32>::I::f()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait<T> {
     fn f();
 }
@@ -1205,6 +1041,9 @@ trait MyTrait<T> {
 impl MyImpl<T> of MyTrait<T> {
     impl I = OtherImpl<T>;
 }
+fn foo() {
+    MyImpl::<u32>::I::f()
+}
 
 //! > expected_diagnostics
 
@@ -1215,13 +1054,7 @@ impl MyImpl<T> of MyTrait<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherTrait<T> {
     fn f();
 }
@@ -1251,13 +1084,7 @@ fn bar2<impl M: MyTrait<u32>>() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait InnerTrait<R> {
     type X;
     fn foo() -> Self::X;
@@ -1296,15 +1123,7 @@ mod my_mod {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    1_u64.foo(1_u32);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Outer<R> {
     impl InnerImpl: Inner<R>;
     type Item;
@@ -1333,6 +1152,9 @@ impl OuterU32 of Outer<u32> {
     fn into(self: u32) -> u64 {
         self.into()
     }
+}
+fn foo() {
+    1_u64.foo(1_u32);
 }
 
 //! > expected_diagnostics
@@ -1375,16 +1197,7 @@ error[E2311]: Trait has no implementation in context: core::metaprogramming::Typ
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    // TODO(orizi): Remove this diagnostic.
-    extra_into_inner(Outer::into_inner(1_u32));
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Outer<T> {
     type Inner;
     impl Impl: Inner<Self::Inner>;
@@ -1417,6 +1230,10 @@ impl OuterU64 of Outer<u64> {
 
 impl InnerImpl of Inner<u64> {
     type InnerMost = u128;
+}
+fn foo() {
+    // TODO(orizi): Remove this diagnostic.
+    extra_into_inner(Outer::into_inner(1_u32));
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/items/tests/trait_type
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_type
@@ -3,17 +3,7 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::foo1(3_u32);
-    MyImpl::foo2(3_u32);
-    MyImpl::foo3(3_u32);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     type OutputType;
@@ -34,6 +24,11 @@ impl MyImpl of MyTrait {
         x
     }
 }
+fn foo() {
+    MyImpl::foo1(3_u32);
+    MyImpl::foo2(3_u32);
+    MyImpl::foo3(3_u32);
+}
 
 //! > expected_diagnostics
 
@@ -44,13 +39,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type InputType;
     type OutputType;
@@ -80,13 +69,7 @@ impl MyImplU32 of MyTrait<u32> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     type OutputType;
@@ -102,13 +85,7 @@ trait MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type InputType;
     type OutputType;
@@ -124,17 +101,7 @@ trait MyTrait<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::<u32>::foo1(3_u32);
-    MyImpl::<u32>::foo2(3_u32);
-    MyImpl::<u32>::foo3(3_u32);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T, S> {
     type InputType;
     type OutputType;
@@ -155,6 +122,11 @@ impl MyImpl<T> of MyTrait<T, u32> {
         x
     }
 }
+fn foo() {
+    MyImpl::<u32>::foo1(3_u32);
+    MyImpl::<u32>::foo2(3_u32);
+    MyImpl::<u32>::foo3(3_u32);
+}
 
 //! > expected_diagnostics
 
@@ -165,13 +137,7 @@ impl MyImpl<T> of MyTrait<T, u32> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     type OutputType;
@@ -196,13 +162,7 @@ warning[E2094]: In a trait, paths of the same trait are not allowed. Did you mea
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type InputType;
     type OutputType;
@@ -227,13 +187,7 @@ warning[E2094]: In a trait, paths of the same trait are not allowed. Did you mea
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type InputType;
     type OutputType;
@@ -256,13 +210,7 @@ impl MyImpl of MyTrait<u32> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait SomeTrait {}
 trait MyTrait<T, +SomeTrait> {
     type InputType;
@@ -282,13 +230,7 @@ warning[E2092]: In a trait, paths of the same trait must be fully explicit. Eith
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     type OutputType;
@@ -329,13 +271,7 @@ warning[E2096]: In an impl, paths of the same impl are not allowed. Did you mean
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     type OutputType;
@@ -373,13 +309,7 @@ warning[E2096]: In an impl, paths of the same impl are not allowed. Did you mean
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type InputType;
     type OutputType;
@@ -412,13 +342,7 @@ error[E2045]: Return type of impl function `MyImpl::foo` is incompatible with `M
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait SomeTrait {}
 trait MyTrait {
     type InputType;
@@ -444,13 +368,7 @@ warning[E2093]: In an impl, paths of the same impl must be fully explicit. Eithe
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     type OutputType;
@@ -491,13 +409,7 @@ warning[E2095]: In an impl, paths of the impl's trait are not allowed. Did you m
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: warnings_only)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type InputType;
     type OutputType;
@@ -538,13 +450,7 @@ warning[E2095]: In an impl, paths of the impl's trait are not allowed. Did you m
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     type InputType;
     type OutputType;
@@ -576,13 +482,7 @@ impl MyImpl_u32 of MyTrait<u32> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     type OutputType;
@@ -632,16 +532,7 @@ error[E2045]: Return type of impl function `MyImpl::foo4` is incompatible with `
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let x = MyStruct { value: 3_u32 };
-    let _: MyStruct<u32> = MyImpl::foo(x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct<T> {
     value: T,
 }
@@ -657,6 +548,10 @@ impl MyImpl of MyTrait {
         MyStruct { value: x.value }
     }
 }
+fn foo() {
+    let x = MyStruct { value: 3_u32 };
+    let _: MyStruct<u32> = MyImpl::foo(x);
+}
 
 //! > expected_diagnostics
 
@@ -667,15 +562,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::foo(Some(3));
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     fn foo(x: Self::InputType);
@@ -685,6 +572,9 @@ impl MyImpl of MyTrait {
     fn foo(x: Self::InputType) {
         x.unwrap();
     }
+}
+fn foo() {
+    MyImpl::foo(Some(3));
 }
 
 //! > expected_diagnostics
@@ -696,13 +586,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     fn foo(x: Self::InputType);
@@ -729,15 +613,7 @@ Candidate `core::result::ResultTrait::unwrap` inference failed with: Type mismat
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::foo(3);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     fn foo(x: Self::InputType);
@@ -747,6 +623,9 @@ impl MyImpl of MyTrait {
     fn foo(x: Self::InputType) {
         -x;
     }
+}
+fn foo() {
+    MyImpl::foo(3);
 }
 
 //! > expected_diagnostics
@@ -758,13 +637,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     fn foo(x: Self::InputType);
@@ -789,15 +662,7 @@ error[E2311]: Trait has no implementation in context: core::traits::Neg::<core::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let _: usize = MyImpl::foo(3, 4);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType1;
     type InputType2;
@@ -812,6 +677,9 @@ impl MyImpl of MyTrait {
         x + y
     }
 }
+fn foo() {
+    let _: usize = MyImpl::foo(3, 4);
+}
 
 //! > expected_diagnostics
 
@@ -822,13 +690,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     fn foo(x: Self::InputType);
@@ -853,15 +715,7 @@ error[E2311]: Trait has no implementation in context: core::traits::Add::<core::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyImpl::foo(array![0]);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     type OutputType;
@@ -874,6 +728,9 @@ impl MyImpl of MyTrait {
         *x[0_u32]
     }
 }
+fn foo() {
+    MyImpl::foo(array![0]);
+}
 
 //! > expected_diagnostics
 
@@ -884,13 +741,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
     fn foo(x: Self::InputType);
@@ -917,13 +768,7 @@ Candidate `core::ops::index::IndexView::index` inference failed with: Trait has 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     type AnotherType;
 }
@@ -950,13 +795,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     type AnotherType;
 }
@@ -992,13 +831,7 @@ error[E2045]: Return type of impl function `MyImpl::bar2` is incompatible with `
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 // A trait with 0 impls in the context.
 trait AnotherTrait0 {
     type AnotherType;
@@ -1049,13 +882,7 @@ error[E2313]: Trait `test::AnotherTrait2` has multiple implementations, in: `tes
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     type AnotherType;
 }
@@ -1093,13 +920,7 @@ fn bar3() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     type AnotherType;
 }
@@ -1163,13 +984,7 @@ error[E2308]: `test::MyImpl::MyType` type mismatch: `core::integer::u32` and `co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     type AnotherType;
 }
@@ -1224,13 +1039,7 @@ error[E2311]: Trait has no implementation in context: test::AnotherTrait.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     type AnotherType;
 }
@@ -1291,13 +1100,7 @@ error[E2313]: Trait `test::AnotherTrait` has multiple implementations, in: `test
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait AnotherTrait {
     type AnotherType;
 }
@@ -1334,13 +1137,7 @@ fn bar3() {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType;
     fn foo1() -> MyImpl::MyType;
@@ -1363,13 +1160,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType;
     fn foo1() -> MyImpl::MyType;
@@ -1396,13 +1187,7 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
     type MyType2;
@@ -1459,13 +1244,7 @@ fn error_propagation(x: Option<MyTrait::MyType1>) -> Option<MyTrait::MyType2> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
     type MyType2;
@@ -1559,13 +1338,7 @@ error[E2042]: Unexpected return type. Expected: "core::option::Option::<core::in
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
     type MyType2;
@@ -1619,13 +1392,7 @@ fn complex2(
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
     type MyType2;
@@ -1713,15 +1480,7 @@ error[E2042]: Unexpected return type. Expected: "@(core::integer::u16, core::opt
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: MyImpl::my_function) {
-    let _: MyImpl::my_function = 3;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType;
     fn my_function() -> u16;
@@ -1731,6 +1490,9 @@ impl MyImpl of MyTrait {
     fn my_function() -> u16 {
         2_u16
     }
+}
+fn foo(x: MyImpl::my_function) {
+    let _: MyImpl::my_function = 3;
 }
 
 //! > expected_diagnostics
@@ -1751,13 +1513,7 @@ error[E2011]: Not a type.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
     type MyType2;
@@ -1780,13 +1536,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
     type MyType2;
@@ -1813,13 +1563,7 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
 }
@@ -1840,13 +1584,7 @@ error[E2026]: Cycle detected while resolving type-alias/impl-type items.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
     type MyType2;
@@ -1874,13 +1612,7 @@ error[E2026]: Cycle detected while resolving type-alias/impl-type items.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType1;
     type MyType2;
@@ -1903,13 +1635,7 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn free_func(x: Self::MyType1) -> Self::MyType2 {
     let _: Self::MyType3 = 3;
 }
@@ -1937,13 +1663,7 @@ error[E2175]: `Self` is not supported in this context.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyInto<T, S> {
     fn my_into(self: T) -> S;
 }
@@ -1977,22 +1697,17 @@ impl MyImpl of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u32 {
-    let x: MyImpl::<u32>::ty = 4;
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
 }
 
 impl MyImpl<K> of MyTrait {
     type ty = K;
+}
+fn foo() -> u32 {
+    let x: MyImpl::<u32>::ty = 4;
+    x
 }
 
 //! > expected_diagnostics
@@ -2004,16 +1719,7 @@ impl MyImpl<K> of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> u32 {
-    let x: MyTrait::ty = 4_u32;
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
 }
@@ -2022,6 +1728,10 @@ impl MyImpl<K> of MyTrait {
     type ty = K;
 }
 ///TODO(TomerStarkware): infer impl types from trait types.
+fn foo() -> u32 {
+    let x: MyTrait::ty = 4_u32;
+    x
+}
 
 //! > expected_diagnostics
 error[E2313]: Candidate impl test::MyImpl::<?0> has an unused generic parameter.
@@ -2036,15 +1746,7 @@ error[E2313]: Candidate impl test::MyImpl::<?0> has an unused generic parameter.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u32 {
-    MyTrait::<u32>::foo()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T, K> {
     type ty;
     fn foo() -> Self::ty;
@@ -2056,6 +1758,9 @@ impl MyImpl<K, +Default<K>> of MyTrait<u32, K> {
         Default::default()
     }
 }
+fn foo() -> u32 {
+    MyTrait::<u32>::foo()
+}
 
 //! > expected_diagnostics
 
@@ -2066,15 +1771,7 @@ impl MyImpl<K, +Default<K>> of MyTrait<u32, K> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: felt252, y: felt252, z: felt252, w: felt252) -> felt252 {
-    DepAdd::<felt252>::other_add(x, y)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherAdd<Lhs, Rhs> {
     type Output;
     fn other_add(lhs: Lhs, rhs: Rhs) -> Self::Output;
@@ -2084,6 +1781,9 @@ impl DepAdd<T> of OtherAdd<T, T> {
     fn other_add(lhs: T, rhs: T) -> T {
         lhs
     }
+}
+fn foo(x: felt252, y: felt252, z: felt252, w: felt252) -> felt252 {
+    DepAdd::<felt252>::other_add(x, y)
 }
 
 //! > expected_diagnostics
@@ -2095,15 +1795,7 @@ impl DepAdd<T> of OtherAdd<T, T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: felt252, y: felt252, z: felt252, w: felt252) -> felt252 {
-    OtherAdd::<felt252>::other_add(x, y)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherAdd<Lhs, Rhs> {
     type Output;
     fn other_add(lhs: Lhs, rhs: Rhs) -> Self::Output;
@@ -2113,6 +1805,9 @@ impl DepAdd<T> of OtherAdd<T, T> {
     fn other_add(lhs: T, rhs: T) -> T {
         lhs
     }
+}
+fn foo(x: felt252, y: felt252, z: felt252, w: felt252) -> felt252 {
+    OtherAdd::<felt252>::other_add(x, y)
 }
 
 //! > expected_diagnostics
@@ -2124,18 +1819,7 @@ impl DepAdd<T> of OtherAdd<T, T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    bar::<_, DepAdd>(3_felt252, 4)
-}
-pub fn bar<T, +OtherAdd<T, T>>(x: T, y: T) -> OtherAdd::<T, T>::Output {
-    OtherAdd::other_add(x, y)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait OtherAdd<Lhs, Rhs> {
     type Output;
     fn other_add(lhs: Lhs, rhs: Rhs) -> Self::Output;
@@ -2145,6 +1829,12 @@ impl DepAdd<T, +Drop<T>> of OtherAdd<T, T> {
     fn other_add(lhs: T, rhs: T) -> T {
         lhs
     }
+}
+fn foo() -> felt252 {
+    bar::<_, DepAdd>(3_felt252, 4)
+}
+pub fn bar<T, +OtherAdd<T, T>>(x: T, y: T) -> OtherAdd::<T, T>::Output {
+    OtherAdd::other_add(x, y)
 }
 
 //! > expected_diagnostics
@@ -2156,19 +1846,14 @@ impl DepAdd<T, +Drop<T>> of OtherAdd<T, T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> felt252 {
-    let x = Trt::foo();
-    x.t
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Trt {
     type T;
     fn foo() -> Self::T;
+}
+fn foo() -> felt252 {
+    let x = Trt::foo();
+    x.t
 }
 
 //! > expected_diagnostics
@@ -2189,13 +1874,7 @@ error[E2311]: Trait has no implementation in context: test::Trt.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Trt<T> {
     type Assoc;
     fn func(self: T) -> Self::Assoc;
@@ -2214,15 +1893,7 @@ fn bar<T, impl TrtImp: Trt<T>>(x: T) -> TrtImp::Assoc {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u32 {
-    array![12, 13, 14].first()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait FirstTrait<T> {
     type Element;
     fn first(self: T) -> Self::Element;
@@ -2234,6 +1905,9 @@ impl ArrayFirst<T> of FirstTrait<Array<T>> {
         self.pop_front().unwrap()
     }
 }
+fn foo() -> u32 {
+    array![12, 13, 14].first()
+}
 
 //! > expected_diagnostics
 
@@ -2244,19 +1918,14 @@ impl ArrayFirst<T> of FirstTrait<Array<T>> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let _: MyImpl::ty = 5;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
 }
 impl MyImpl of MyTrait {}
+fn foo() {
+    let _: MyImpl::ty = 5;
+}
 
 //! > expected_diagnostics
 error[E0004]: Not all trait items are implemented. Missing: 'ty'.
@@ -2279,21 +1948,16 @@ error[E2311]: Trait has no implementation in context: test::MyTrait.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+}
 fn bar<+MyTrait, +core::metaprogramming::TypeEqual<MyTrait::ty, felt252>>(
     _y: MyTrait::ty,
 ) -> felt252 {
     _y + 3
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-}
 
 //! > expected_diagnostics
 
@@ -2304,7 +1968,10 @@ trait MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+}
 fn bar<
     impl I1: MyTrait,
     impl I2: MyTrait,
@@ -2314,14 +1981,6 @@ fn bar<
     3_u32
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-}
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::felt252", found: "core::integer::u32".
@@ -2336,7 +1995,10 @@ error[E2042]: Unexpected return type. Expected: "core::felt252", found: "core::i
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+}
 fn bar<
     +MyTrait,
     +core::metaprogramming::TypeEqual<MyTrait::ty, felt252>,
@@ -2347,14 +2009,6 @@ fn bar<
     _y
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-}
 
 //! > expected_diagnostics
 error[E2302]: Type mismatch: `core::felt252` and `core::integer::u32`.
@@ -2372,23 +2026,7 @@ error[E2302]: Type mismatch: `core::felt252` and `core::integer::u32`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-///TODO(TomerStarkware): remove diagnostic and make it compile without errors.
-fn bar<
-    +MyTrait,
-    +core::metaprogramming::TypeEqual<MyTrait::ty, felt252>,
-    +TraitWithInferredParams<MyTrait::ty>,
->(
-    _y: MyTrait::ty,
-) -> MyTrait::ty {
-    _y + TraitWithInferredParams::<MyTrait::ty>::foo()
-}
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
 }
@@ -2403,6 +2041,17 @@ impl OtherImpl of OtherTrait<felt252> {
 trait TraitWithInferredParams<T, +OtherTrait<T>> {
     fn foo() -> T;
 }
+///TODO(TomerStarkware): remove diagnostic and make it compile without errors.
+fn bar<
+    +MyTrait,
+    +core::metaprogramming::TypeEqual<MyTrait::ty, felt252>,
+    +TraitWithInferredParams<MyTrait::ty>,
+>(
+    _y: MyTrait::ty,
+) -> MyTrait::ty {
+    _y + TraitWithInferredParams::<MyTrait::ty>::foo()
+}
+fn foo() {}
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: test::OtherTrait::<+MyTrait::ty>.
@@ -2422,21 +2071,7 @@ error[E2311]: Trait has no implementation in context: test::TraitWithInferredPar
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn bar<
-    impl I1: MyTrait, impl I2: MyTrait, +core::metaprogramming::TypeEqual<I1::ty, I2::ty>,
->() -> I1::ty {
-    I2::foo()
-}
-fn foo() {
-    bar::<MyImplu32, MyImplu32>();
-    bar::<MyImplfelt252, MyImplfelt252>();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -2452,6 +2087,15 @@ impl MyImplfelt252 of MyTrait {
     fn foo() -> Self::ty {
         3
     }
+}
+fn bar<
+    impl I1: MyTrait, impl I2: MyTrait, +core::metaprogramming::TypeEqual<I1::ty, I2::ty>,
+>() -> I1::ty {
+    I2::foo()
+}
+fn foo() {
+    bar::<MyImplu32, MyImplu32>();
+    bar::<MyImplfelt252, MyImplfelt252>();
 }
 
 //! > expected_diagnostics
@@ -2463,20 +2107,7 @@ impl MyImplfelt252 of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar<
-    impl I1: MyTrait, impl I2: MyTrait, +core::metaprogramming::TypeEqual<I1::ty, I2::ty>,
->() -> I1::ty {
-    I2::foo()
-}
-fn foo() {
-    bar::<MyImplu32, MyImplfelt252>();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -2492,6 +2123,14 @@ impl MyImplfelt252 of MyTrait {
     fn foo() -> Self::ty {
         3
     }
+}
+fn bar<
+    impl I1: MyTrait, impl I2: MyTrait, +core::metaprogramming::TypeEqual<I1::ty, I2::ty>,
+>() -> I1::ty {
+    I2::foo()
+}
+fn foo() {
+    bar::<MyImplu32, MyImplfelt252>();
 }
 
 //! > expected_diagnostics
@@ -2507,7 +2146,11 @@ error[E2311]: Trait has no implementation in context: core::metaprogramming::Typ
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+    fn foo() -> Self::ty;
+}
 fn bar<
     impl I1: MyTrait, impl I2: MyTrait, +core::metaprogramming::TypeEqual<I1::ty, I2::ty>,
 >() -> I2::ty {
@@ -2517,15 +2160,6 @@ fn bar2<impl I1: MyTrait, impl I2: MyTrait>() -> I2::ty {
     bar::<I1, I2>()
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-    fn foo() -> Self::ty;
-}
 
 //! > expected_diagnostics
 error[E2311]: Trait has no implementation in context: core::metaprogramming::TypeEqual::<I1::ty, I2::ty>.
@@ -2540,13 +2174,7 @@ error[E2311]: Trait has no implementation in context: core::metaprogramming::Typ
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 impl I of core::metaprogramming::TypeEqual<u32, felt252>;
 
 //! > expected_diagnostics
@@ -2562,13 +2190,7 @@ impl I of core::metaprogramming::TypeEqual<u32, felt252>;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<T, impl I: core::metaprogramming::TypeEqual<T, T, T>>() {}
 
 //! > expected_diagnostics
@@ -2584,13 +2206,7 @@ fn bar<T, impl I: core::metaprogramming::TypeEqual<T, T, T>>() {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<T, const C: u32, impl I: core::metaprogramming::TypeEqual<T, C>>() {}
 
 //! > expected_diagnostics
@@ -2606,16 +2222,7 @@ fn bar<T, const C: u32, impl I: core::metaprogramming::TypeEqual<T, C>>() {}
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-///TODO(TomerStarkware): change diagnostics to mismatch types instead of missing impl.
-fn foo() {
-    let _: felt252 = MyTrait::my_function();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type MyType;
     fn my_function() -> Self::MyType;
@@ -2625,6 +2232,10 @@ impl MyImpl of MyTrait {
     fn my_function() -> u16 {
         2_u16
     }
+}
+///TODO(TomerStarkware): change diagnostics to mismatch types instead of missing impl.
+fn foo() {
+    let _: felt252 = MyTrait::my_function();
 }
 
 //! > expected_diagnostics
@@ -2640,19 +2251,14 @@ error[E2308]: `test::MyImpl::MyType` type mismatch: `core::felt252` and `core::i
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+}
 fn bar<+MyTrait[ty: felt252]>(y: MyTrait::ty) -> felt252 {
     y + 3
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-}
 
 //! > expected_diagnostics
 
@@ -2663,19 +2269,14 @@ trait MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+}
 fn bar<impl I1: MyTrait[ty: u32], impl I2: MyTrait[ty: I1::ty]>() -> I2::ty {
     3_u8
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-}
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u8".
@@ -2690,21 +2291,16 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "co
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+}
 fn bar<+MyTrait[ty: felt252], +core::metaprogramming::TypeEqual<MyTrait::ty, u32>>(
     _y: MyTrait::ty,
 ) -> MyTrait::ty {
     _y
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-}
 
 //! > expected_diagnostics
 error[E2302]: Type mismatch: `core::felt252` and `core::integer::u32`.
@@ -2722,19 +2318,7 @@ error[E2302]: Type mismatch: `core::felt252` and `core::integer::u32`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn bar<impl I1: MyTrait, impl I2: MyTrait[ty: I1::ty]>() -> I1::ty {
-    I2::foo()
-}
-fn foo() {
-    bar::<MyImplu32, MyImplu32>();
-    bar::<MyImplfelt252, MyImplfelt252>();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -2750,6 +2334,13 @@ impl MyImplfelt252 of MyTrait {
     fn foo() -> Self::ty {
         3
     }
+}
+fn bar<impl I1: MyTrait, impl I2: MyTrait[ty: I1::ty]>() -> I1::ty {
+    I2::foo()
+}
+fn foo() {
+    bar::<MyImplu32, MyImplu32>();
+    bar::<MyImplfelt252, MyImplfelt252>();
 }
 
 //! > expected_diagnostics
@@ -2761,18 +2352,7 @@ impl MyImplfelt252 of MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar<impl I1: MyTrait[ty: I2::ty], impl I2: MyTrait>() -> I1::ty {
-    I2::foo()
-}
-fn foo() {
-    bar::<MyImplu32, MyImplfelt252>();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -2788,6 +2368,12 @@ impl MyImplfelt252 of MyTrait {
     fn foo() -> Self::ty {
         3
     }
+}
+fn bar<impl I1: MyTrait[ty: I2::ty], impl I2: MyTrait>() -> I1::ty {
+    I2::foo()
+}
+fn foo() {
+    bar::<MyImplu32, MyImplfelt252>();
 }
 
 //! > expected_diagnostics
@@ -2803,7 +2389,11 @@ error[E2302]: Type mismatch: `core::integer::u32` and `I2::ty`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+    fn foo() -> Self::ty;
+}
 fn bar<impl I1: MyTrait[ty: felt252]>() -> I1::ty {
     I1::foo()
 }
@@ -2811,15 +2401,6 @@ fn bar2<impl J1: MyTrait>() -> J1::ty {
     bar()
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-    fn foo() -> Self::ty;
-}
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "J1::ty", found: "core::felt252".
@@ -2834,7 +2415,11 @@ error[E2042]: Unexpected return type. Expected: "J1::ty", found: "core::felt252"
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+    fn foo() -> Self::ty;
+}
 fn bar<impl I1: MyTrait[ty: u32]>() -> I1::ty {
     I1::foo()
 }
@@ -2843,15 +2428,6 @@ fn bar2<impl J1: MyTrait[ty: u32]>() -> J1::ty {
     bar()
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-    fn foo() -> Self::ty;
-}
 
 //! > expected_diagnostics
 
@@ -2862,7 +2438,11 @@ trait MyTrait {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+trait MyTrait {
+    type ty;
+    fn foo() -> Self::ty;
+}
 fn bar<impl I1: MyTrait[ty: u32]>() -> I1::ty {
     I1::foo()
 }
@@ -2870,15 +2450,6 @@ fn bar2<impl I1: MyTrait[ty: u8]>() -> I1::ty {
     bar()
 }
 fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
-trait MyTrait {
-    type ty;
-    fn foo() -> Self::ty;
-}
 
 //! > expected_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u32".
@@ -2893,18 +2464,7 @@ error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "cor
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar<impl I1: MyTrait[ty: u32]>() -> I1::ty {
-    I1::foo()
-}
-fn foo() {
-    bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -2923,6 +2483,12 @@ impl I2 of MyTrait {
         3
     }
 }
+fn bar<impl I1: MyTrait[ty: u32]>() -> I1::ty {
+    I1::foo()
+}
+fn foo() {
+    bar();
+}
 
 //! > expected_diagnostics
 error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::I1`, `test::I2`
@@ -2937,21 +2503,16 @@ error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::I1`
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar<impl I1: MyTrait[ty: u32]>() -> u32 {
-    I1::foo()
-}
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     const ty: u32;
 
     fn foo() -> u32;
 }
+fn bar<impl I1: MyTrait[ty: u32]>() -> u32 {
+    I1::foo()
+}
+fn foo() {}
 
 //! > expected_diagnostics
 error[E2189]: associated type `ty` not found for `MyTrait`
@@ -2966,20 +2527,15 @@ fn bar<impl I1: MyTrait[ty: u32]>() -> u32 {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar<impl I1: MyTrait[ty: u32, ty: felt252]>() -> u32 {
-    I1::foo()
-}
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
 }
+fn bar<impl I1: MyTrait[ty: u32, ty: felt252]>() -> u32 {
+    I1::foo()
+}
+fn foo() {}
 
 //! > expected_diagnostics
 error[E2190]: the value of the associated type `ty` in trait `MyTrait` is already specified
@@ -2994,18 +2550,7 @@ fn bar<impl I1: MyTrait[ty: u32, ty: felt252]>() -> u32 {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar<impl I1: MyTrait[ty: u32]>() {
-    I1::foo();
-}
-fn foo() {
-    bar::<MyImpl>();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -3015,6 +2560,12 @@ impl MyImpl of MyTrait {
     fn foo() -> u8 {
         3
     }
+}
+fn bar<impl I1: MyTrait[ty: u32]>() {
+    I1::foo();
+}
+fn foo() {
+    bar::<MyImpl>();
 }
 
 //! > expected_diagnostics
@@ -3030,18 +2581,7 @@ error[E2302]: Type mismatch: `core::integer::u8` and `core::integer::u32`.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar<impl I1: MyTrait[ty: u32]>() {
-    I1::foo();
-}
-fn foo() {
-    bar::<MyImpl>();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -3055,6 +2595,12 @@ impl MyImpl of OtherTrait {
     fn foo() -> u8 {
         3
     }
+}
+fn bar<impl I1: MyTrait[ty: u32]>() {
+    I1::foo();
+}
+fn foo() {
+    bar::<MyImpl>();
 }
 
 //! > expected_diagnostics
@@ -3070,16 +2616,7 @@ error[E2134]: Expected an impl of `test::MyTrait`. Got an impl of `test::OtherTr
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn bar<impl I1: MyTrait[ty: u32], +OtherTrait<I1::ty>>() {
-    OtherTrait::foo(5_u32);
-}
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -3087,6 +2624,10 @@ trait MyTrait {
 trait OtherTrait<T> {
     fn foo(a: T) -> T;
 }
+fn bar<impl I1: MyTrait[ty: u32], +OtherTrait<I1::ty>>() {
+    OtherTrait::foo(5_u32);
+}
+fn foo() {}
 
 //! > expected_diagnostics
 
@@ -3097,16 +2638,7 @@ trait OtherTrait<T> {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn bar<impl I1: MyTrait[ty: u32], +OtherTrait<I1::ty>, +OtherTrait<u32>>() {
-    OtherTrait::foo(5_u32);
-}
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
     fn foo() -> Self::ty;
@@ -3114,6 +2646,10 @@ trait MyTrait {
 trait OtherTrait<T> {
     fn foo(a: T) -> T;
 }
+fn bar<impl I1: MyTrait[ty: u32], +OtherTrait<I1::ty>, +OtherTrait<u32>>() {
+    OtherTrait::foo(5_u32);
+}
+fn foo() {}
 
 //! > expected_diagnostics
 error[E2313]: Trait `test::OtherTrait::<core::integer::u32>` has multiple implementations, in: `+OtherTrait<I1::ty>`, `+OtherTrait<u32>`
@@ -3128,13 +2664,7 @@ error[E2313]: Trait `test::OtherTrait::<core::integer::u32>` has multiple implem
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type ty;
 }
@@ -3159,15 +2689,7 @@ error[E2037]: Generic parameter trait of impl function `I::foo` is incompatible 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> S<M> {
-    S { x: 3_felt252 }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     type InputType;
 }
@@ -3178,6 +2700,9 @@ impl M of MyTrait {
 
 struct S<impl M: MyTrait> {
     x: M::InputType,
+}
+fn foo() -> S<M> {
+    S { x: 3_felt252 }
 }
 
 //! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/items/tests/type_alias
+++ b/crates/cairo-lang-semantic/src/items/tests/type_alias
@@ -3,20 +3,15 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: RenamedStruct) -> felt252 {
-    a.a
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: felt252,
 }
 
 type RenamedStruct = MyStruct;
+fn foo(a: RenamedStruct) -> felt252 {
+    a.a
+}
 
 //! > expected_diagnostics
 
@@ -27,22 +22,17 @@ type RenamedStruct = MyStruct;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: RenamedEnum) -> felt252 {
-    match a {
-        MyEnum::f(v) => v,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     f: felt252,
 }
 
 type RenamedEnum = MyEnum;
+fn foo(a: RenamedEnum) -> felt252 {
+    match a {
+        MyEnum::f(v) => v,
+    }
+}
 
 //! > expected_diagnostics
 
@@ -53,17 +43,12 @@ type RenamedEnum = MyEnum;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+type RenamedTuple = (felt252, u128);
 fn foo(a: RenamedTuple) -> felt252 {
     let (v, _) = a;
     v
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type RenamedTuple = (felt252, u128);
 
 //! > expected_diagnostics
 
@@ -74,19 +59,14 @@ type RenamedTuple = (felt252, u128);
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+type OptionFelt252 = Option::<felt252>;
 fn foo(a: OptionFelt252) -> felt252 {
     match a {
         Some(v) => v,
         None => 1,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type OptionFelt252 = Option::<felt252>;
 
 //! > expected_diagnostics
 
@@ -97,17 +77,12 @@ type OptionFelt252 = Option::<felt252>;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+type RenamedTuple<T> = (felt252, T);
 fn foo(a: RenamedTuple<u128>) -> u128 {
     let (_, v) = a;
     v
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type RenamedTuple<T> = (felt252, T);
 
 //! > expected_diagnostics
 
@@ -118,17 +93,12 @@ type RenamedTuple<T> = (felt252, T);
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+type A<P4> = B::<felt252, P4, u128>;
+type B<P1, P2, P3> = (P1, P3, P2);
 fn foo(a: A<bool>) -> (felt252, u128, bool) {
     a
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type A<P4> = B::<felt252, P4, u128>;
-type B<P1, P2, P3> = (P1, P3, P2);
 
 //! > expected_diagnostics
 
@@ -139,17 +109,12 @@ type B<P1, P2, P3> = (P1, P3, P2);
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+type A<T> = (felt252, T);
 fn foo(a: A<5>) -> felt252 {
     let (v, _) = a;
     v
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type A<T> = (felt252, T);
 
 //! > expected_diagnostics
 error[E2006]: Unknown type.
@@ -164,17 +129,12 @@ fn foo(a: A<5>) -> felt252 {
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+type A = B;
+type B = A;
 fn foo(a: A) -> B {
     a
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type A = B;
-type B = A;
 
 //! > expected_diagnostics
 error[E2026]: Cycle detected while resolving type-alias/impl-type items.
@@ -194,16 +154,11 @@ type B = A;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+type A = A;
 fn foo(a: A) -> A {
     a
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type A = A;
 
 //! > expected_diagnostics
 error[E2026]: Cycle detected while resolving type-alias/impl-type items.
@@ -218,16 +173,11 @@ type A = A;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+type Alias = bad_type;
 fn foo(a: Alias) -> felt252 {
     a.a
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type Alias = bad_type;
 
 //! > expected_diagnostics
 error[E0006]: Type not found.
@@ -242,13 +192,7 @@ type Alias = bad_type;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 type W<T, +Drop<T>> = T;
 enum E {
     A: W<felt252>,

--- a/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
+++ b/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
@@ -3,13 +3,10 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _: felt252 = (3, 3);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "({numeric}, {numeric})".
@@ -24,14 +21,11 @@ error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "({num
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _: felt252 = @3_felt252;
     let _: @u32 = @3_felt252;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "@core::felt252".
@@ -51,13 +45,10 @@ error[E2041]: Unexpected argument type. Expected: "@core::integer::u32", found: 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _: felt252 = *3_u32;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2135]: Type `core::integer::u32` cannot be dereferenced
@@ -72,13 +63,10 @@ error[E2135]: Type `core::integer::u32` cannot be dereferenced
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _: [felt252; 2] = [3_u16; 2];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "[core::felt252; 2]", found: "[core::integer::u16; 2]".
@@ -93,13 +81,10 @@ error[E2041]: Unexpected argument type. Expected: "[core::felt252; 2]", found: "
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _: [felt252; 2] = [3_u16, 3_u32];
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "core::integer::u16", found: "core::integer::u32".
@@ -114,17 +99,12 @@ error[E2041]: Unexpected argument type. Expected: "core::integer::u16", found: "
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let _: MyGenericType<felt252> = MyGenericType { x: 3_u32 };
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyGenericType<T> {
     x: T,
+}
+fn foo() {
+    let _: MyGenericType<felt252> = MyGenericType { x: 3_u32 };
 }
 
 //! > expected_diagnostics
@@ -140,17 +120,12 @@ error[E2041]: Unexpected argument type. Expected: "test::MyGenericType::<core::f
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo(other: MyGenericType<u32>) {
-    let _: MyGenericType<felt252> = MyGenericType { x: 3_felt252, ..other };
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyGenericType<T> {
     x: T,
+}
+fn foo(other: MyGenericType<u32>) {
+    let _: MyGenericType<felt252> = MyGenericType { x: 3_felt252, ..other };
 }
 
 //! > expected_diagnostics
@@ -166,13 +141,10 @@ error[E2041]: Unexpected argument type. Expected: "test::MyGenericType::<core::f
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _: Option<felt252> = Some(3_u16);
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "core::option::Option::<core::felt252>", found: "core::option::Option::<core::integer::u16>".
@@ -187,15 +159,7 @@ error[E2041]: Unexpected argument type. Expected: "core::option::Option::<core::
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    1_felt252.issue(@2_felt252);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Issue<T> {
     type Index;
     fn issue(self: T, index: Self::Index) -> felt252;
@@ -206,6 +170,9 @@ impl ImplIssue of Issue<felt252> {
     fn issue(self: felt252, index: felt252) -> felt252 {
         self + index
     }
+}
+fn foo() {
+    1_felt252.issue(@2_felt252);
 }
 
 //! > expected_diagnostics
@@ -221,14 +188,11 @@ error[E2308]: `test::ImplIssue::Index` type mismatch: `@core::felt252` and `core
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo() {
     let _: Box<u32> = &3_u32;
     let _: Box<@felt252> = &3_u32;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2041]: Unexpected argument type. Expected: "core::box::Box::<core::integer::u32>", found: "core::box::Box::<@core::integer::u32>".
@@ -248,7 +212,7 @@ error[E2041]: Unexpected argument type. Expected: "core::box::Box::<@core::felt2
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 fn foo(mut param: u32) {
     let mut x = 3_u32;
     let _r = &x;
@@ -258,9 +222,6 @@ fn foo(mut param: u32) {
     let _s = &y;
     y = 10;
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 error[E2169]: Cannot assign to a variable with a taken pointer

--- a/crates/cairo-lang-semantic/src/items/tests/use_
+++ b/crates/cairo-lang-semantic/src/items/tests/use_
@@ -3,14 +3,11 @@
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 use u32 as myU32;
 fn foo(a: myU32) -> u32 {
     a
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -21,21 +18,16 @@ foo
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let x = @1.into();
-    bar(x, @1);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod internal {
     fn bar<T, +PartialEq<T>>(a: @T, b: @T) {}
 }
 use NonExisting;
 use internal::bar;
+fn foo() {
+    let x = @1.into();
+    bar(x, @1);
+}
 
 //! > expected_diagnostics
 error[E0006]: Identifier not found.
@@ -50,13 +42,7 @@ use NonExisting;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 use Array;
 
 //! > expected_diagnostics
@@ -68,13 +54,7 @@ use Array;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 use core;
 
 //! > expected_diagnostics
@@ -86,13 +66,7 @@ use core;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     use super::a::b;
 }
@@ -110,13 +84,7 @@ error[E2025]: Cycle detected while resolving 'use' items.
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     mod b {
         mod c {}
@@ -134,13 +102,7 @@ use b::c as again;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     mod b {
         mod c {}
@@ -162,13 +124,7 @@ use a::b::self;
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 use {self, u8};
 
 //! > expected_diagnostics
@@ -184,13 +140,7 @@ use {self, u8};
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 use self;
 
 //! > expected_diagnostics
@@ -209,15 +159,7 @@ test_function_diagnostics(expect_diagnostics: false)
 //! > crate_settings
 edition = "2024_07"
 
-//! > function_code
-fn foo() {
-    C::test();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod A {
     pub mod B {
         pub mod C {
@@ -227,6 +169,9 @@ mod A {
 }
 use A::*;
 use B::*;
+fn foo() {
+    C::test();
+}
 
 //! > expected_diagnostics
 
@@ -240,16 +185,11 @@ edition = "2024_07"
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+use B::*;
 fn foo() {
     C::test();
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use B::*;
 
 //! > expected_diagnostics
 error[E0006]: Identifier not found.
@@ -272,13 +212,7 @@ test_function_diagnostics(expect_diagnostics: true)
 //! > crate_settings
 edition = "2024_07"
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod a {
     pub use super::b::*;
 }

--- a/crates/cairo-lang-semantic/src/usage/test_data/usage
+++ b/crates/cairo-lang-semantic/src/usage/test_data/usage
@@ -10,6 +10,7 @@ struct A {
 struct B {
     c: usize,
 }
+#[target_function]
 fn foo(mut a: A, ref b: A) {
     let c = 5_usize;
     loop {
@@ -25,13 +26,10 @@ fn foo(mut a: A, ref b: A) {
     };
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > usage
-Loop 8:4:
+Loop 9:4:
   Usage: LocalVarId(test::c), ParamId(test::foo::b), ParamId(test::foo::a)::b,
   Changes: ParamId(test::foo::a)::b::c, ParamId(test::foo::b),
   Snapshot_Usage:
@@ -50,6 +48,7 @@ struct A {
 struct B {
     c: usize,
 }
+#[target_function]
 fn foo(mut a: A, ref b: A) {
     let c = 5_usize;
     let only_used_in_condition = 5;
@@ -58,13 +57,10 @@ fn foo(mut a: A, ref b: A) {
     };
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > usage
-While 9:4:
+While 10:4:
   Usage: LocalVarId(test::c), ParamId(test::foo::a)::b::c,
   Changes: ParamId(test::foo::a)::b::c,
   Snapshot_Usage: LocalVarId(test::only_used_in_condition),
@@ -85,6 +81,7 @@ struct B {
 }
 fn consume_B(b: B) {}
 fn borrow_B(b: @B) {}
+#[target_function]
 fn foo(mut a: A, ref b: B) {
     let c = 5_usize;
     let only_used_in_condition = 5;
@@ -98,13 +95,10 @@ fn foo(mut a: A, ref b: B) {
     };
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > usage
-While 11:4:
+While 12:4:
   Usage: LocalVarId(test::c), ParamId(test::foo::b),
   Changes:
   Snapshot_Usage: LocalVarId(test::only_used_in_condition), ParamId(test::foo::a)::b,
@@ -117,23 +111,21 @@ While 11:4:
 test_function_usage
 
 //! > cairo_code
+#[target_function]
 fn foo(a: u32) {
     |b: u32| {
         || a + b;
     };
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > usage
-Closure 2:8:
-  Usage: ParamId(test::foo::a), ParamId(test::foo::{closure@17}::b),
+Closure 3:8:
+  Usage: ParamId(test::foo::a), ParamId(test::foo::{closure@36}::b),
   Changes:
   Snapshot_Usage:
-Closure 1:4:
+Closure 2:4:
   Usage: ParamId(test::foo::a),
   Changes:
   Snapshot_Usage:
@@ -146,6 +138,7 @@ Closure 1:4:
 test_function_usage
 
 //! > cairo_code
+#[target_function]
 fn foo(a: u32) {
     let arr = array![1, 2, 3];
     for b in arr {
@@ -153,13 +146,10 @@ fn foo(a: u32) {
     };
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > usage
-For 2:4:
+For 3:4:
   Usage: LocalVarId(test::in), ParamId(test::foo::a),
   Changes: LocalVarId(test::in),
   Snapshot_Usage:
@@ -172,6 +162,7 @@ For 2:4:
 test_function_usage
 
 //! > cairo_code
+#[target_function]
 fn foo() -> u32 {
     let mut counter = 0;
     let outer = array![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -184,17 +175,14 @@ fn foo() -> u32 {
     counter
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > usage
-For 5:8:
+For 6:8:
   Usage: LocalVarId(test::in), LocalVarId(test::counter),
   Changes: LocalVarId(test::in), LocalVarId(test::counter),
   Snapshot_Usage:
-For 4:4:
+For 5:4:
   Usage: LocalVarId(test::in), LocalVarId(test::counter),
   Changes: LocalVarId(test::in), LocalVarId(test::counter),
   Snapshot_Usage: LocalVarId(test::inner),
@@ -207,6 +195,7 @@ For 4:4:
 test_function_usage
 
 //! > cairo_code
+#[target_function]
 fn foo(mut a: Span<u32>, mut b: Span<u32>) -> Option<usize> {
     let Some(_) = a.pop_front() else {
         return b.pop_front().map(|q| *q);
@@ -215,13 +204,10 @@ fn foo(mut a: Span<u32>, mut b: Span<u32>) -> Option<usize> {
     None
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > usage
-Closure 2:33:
+Closure 3:33:
   Usage:
   Changes:
   Snapshot_Usage:


### PR DESCRIPTION
Merge the legacy module_code/function_code/function_name tag family into a
single cairo_code section across all in-scope cairo-lang-semantic test data
(49 files, 694 blocks).

- 48 test_function_diagnostics files: module_code + '\n' + function_code merged
  into cairo_code, function_name dropped, 222 trivial `fn foo() {}` stubs
  dropped. The join is byte-identical to the legacy one, so every golden output
  is unchanged - the suite passes with CAIRO_FIX_TESTS unset.
- usage/test_data/usage: function_name replaced by a #[target_function] marker;
  the only regenerated goldens (uniform +1 line shift, no semantic change).
- Removed 9 dead, empty `function_body` tags from expr/test_data.

Three blocks (constant, inline_macros, items/tests/trait) keep their `fn foo()
{}` because the surrounding module code actually references it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>