### PR TITLE
(refactor): migrate cairo-lang-lowering golden test data to `#[target_function]`

### DIFF
--- a/crates/cairo-lang-lowering/src/analysis/test.rs
+++ b/crates/cairo-lang-lowering/src/analysis/test.rs
@@ -162,14 +162,10 @@ impl<'db, 'a> DataflowAnalyzer<'db, 'a> for ReachabilityAnalyzer {
 #[test]
 fn test_block_level_analysis() {
     let db = LoweringDatabaseForTesting::default();
-    let inputs = OrderedHashMap::from([
-        (
-            "function_code".to_string(),
-            "fn foo(x: bool) -> felt252 { if x { 1 } else { 2 } }".to_string(),
-        ),
-        ("function_name".to_string(), "foo".to_string()),
-        ("module_code".to_string(), "".to_string()),
-    ]);
+    let inputs = OrderedHashMap::from([(
+        "cairo_code".to_string(),
+        "#[target_function]\nfn foo(x: bool) -> felt252 { if x { 1 } else { 2 } }".to_string(),
+    )]);
     let (test_function, _) = setup_test_function(&db, &inputs).split();
     let lowered = db
         .function_with_body_lowering(
@@ -192,11 +188,10 @@ fn test_block_level_analysis() {
 #[test]
 fn test_forward_single_block() {
     let db = LoweringDatabaseForTesting::default();
-    let inputs = OrderedHashMap::from([
-        ("function_code".to_string(), "fn foo() {}".to_string()),
-        ("function_name".to_string(), "foo".to_string()),
-        ("module_code".to_string(), "".to_string()),
-    ]);
+    let inputs = OrderedHashMap::from([(
+        "cairo_code".to_string(),
+        "#[target_function]\nfn foo() {}".to_string(),
+    )]);
     let (test_function, _) = setup_test_function(&db, &inputs).split();
     let lowered = db
         .function_with_body_lowering(
@@ -217,14 +212,10 @@ fn test_forward_single_block() {
 fn test_forward_with_branching() {
     let db = LoweringDatabaseForTesting::default();
     // A function with branching creates multiple blocks
-    let inputs = OrderedHashMap::from([
-        (
-            "function_code".to_string(),
-            "fn foo(x: bool) -> felt252 { if x { 1 } else { 2 } }".to_string(),
-        ),
-        ("function_name".to_string(), "foo".to_string()),
-        ("module_code".to_string(), "".to_string()),
-    ]);
+    let inputs = OrderedHashMap::from([(
+        "cairo_code".to_string(),
+        "#[target_function]\nfn foo(x: bool) -> felt252 { if x { 1 } else { 2 } }".to_string(),
+    )]);
     let (test_function, _) = setup_test_function(&db, &inputs).split();
     let lowered = db
         .function_with_body_lowering(

--- a/crates/cairo-lang-lowering/src/analysis/test_data/def_site
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/def_site
@@ -3,15 +3,11 @@
 //! > test_runner_name
 test_analysis(analysis: def_site)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252, y: felt252) -> felt252 {
     x + y
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -37,7 +33,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: def_site)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool) -> felt252 {
     if x {
         1
@@ -45,11 +42,6 @@ fn foo(x: bool) -> felt252 {
         2
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -91,7 +83,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: def_site)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool) -> felt252 {
     let y = if x {
         1
@@ -100,11 +93,6 @@ fn foo(x: bool) -> felt252 {
     };
     y + 3
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -156,7 +144,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: def_site)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(n: felt252) -> felt252 {
     let mut i = n;
     loop {
@@ -167,18 +156,13 @@ fn foo(n: felt252) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-
 //! > semantic_diagnostics
 
 //! > lowering
 Parameters: v0: core::felt252
 blk0 (root):
 Statements:
-  (v1: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[51-138](v0)
+  (v1: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[70-157](v0)
 End:
   Match(match_enum(v1) {
     PanicResult::Ok(v2) => blk1,
@@ -219,16 +203,12 @@ End:
 //! > test_runner_name
 test_analysis(analysis: def_site)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: Array<felt252>) -> @Array<felt252> {
     let snap = @x;
     snap
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/analysis/test_data/dominator
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/dominator
@@ -3,15 +3,11 @@
 //! > test_runner_name
 test_analysis(analysis: dominator)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252, y: felt252) -> felt252 {
     x + y
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -35,7 +31,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: dominator)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool) -> felt252 {
     if x {
         1
@@ -43,11 +40,6 @@ fn foo(x: bool) -> felt252 {
         2
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -87,7 +79,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: dominator)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool) -> felt252 {
     let y = if x {
         1
@@ -96,11 +89,6 @@ fn foo(x: bool) -> felt252 {
     };
     y + 3
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -148,7 +136,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: dominator)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool, y: bool) -> felt252 {
     if x {
         if y {
@@ -160,11 +149,6 @@ fn foo(x: bool, y: bool) -> felt252 {
         3
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -220,18 +204,14 @@ End:
 //! > test_runner_name
 test_analysis(analysis: dominator)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     match x {
         0 => 10,
         _ => 20,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/analysis/test_data/equality
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/equality
@@ -3,17 +3,13 @@
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: Array<felt252>) -> (@Array<felt252>, @Array<felt252>) {
     let snap1 = @x;
     let snap2 = @x;
     (snap1, snap2)
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -38,15 +34,11 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252, y: felt252) -> felt252 {
     x + y
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -69,18 +61,14 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: Array<felt252>) -> (@Array<felt252>, @Array<felt252>, @Array<felt252>) {
     let snap1 = @x;
     let snap2 = @x;
     let snap3 = @x;
     (snap1, snap2, snap3)
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -106,17 +94,13 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> (Box<felt252>, Box<felt252>) {
     let box1 = BoxTrait::new(x);
     let box2 = BoxTrait::new(x);
     (box1, box2)
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -141,21 +125,17 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
-fn foo(a: felt252, b: felt252) -> (MyStruct, felt252, felt252) {
-    let s = MyStruct { x: a, y: b };
-    let MyStruct { x, y } = s;
-    (MyStruct { x, y }, x, y)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct MyStruct {
     x: felt252,
     y: felt252,
+}
+#[target_function]
+fn foo(a: felt252, b: felt252) -> (MyStruct, felt252, felt252) {
+    let s = MyStruct { x: a, y: b };
+    let MyStruct { x, y } = s;
+    (MyStruct { x, y }, x, y)
 }
 
 //! > semantic_diagnostics
@@ -182,19 +162,15 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
-fn foo(x: felt252) -> MyEnum {
-    MyEnum::A(x)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 enum MyEnum {
     A: felt252,
     B: felt252,
+}
+#[target_function]
+fn foo(x: felt252) -> MyEnum {
+    MyEnum::A(x)
 }
 
 //! > semantic_diagnostics
@@ -218,7 +194,8 @@ A(v0) = v1
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     let snap1 = @x;
     let result = match x {
@@ -228,14 +205,9 @@ fn foo(x: felt252) -> felt252 {
     result
 }
 
-//! > function_name
-foo
-
-//! > module_code
-
 //! > semantic_diagnostics
 warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:2:9
+ --> lib.cairo:3:9
     let snap1 = @x;
         ^^^^^
 
@@ -279,18 +251,14 @@ Block 2:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(opt: Option<felt252>) -> felt252 {
     match opt {
         Option::Some(val) => val,
         Option::None => 0,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -332,7 +300,8 @@ None(v2) = v0
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(arr: Array<felt252>) -> @Array<felt252> {
     match arr.len() {
         0 => {
@@ -345,11 +314,6 @@ fn foo(arr: Array<felt252>) -> @Array<felt252> {
         },
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -395,7 +359,8 @@ Block 2:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> (Box<Box<felt252>>, felt252) {
     let box1 = BoxTrait::new(x);
     let box2 = BoxTrait::new(box1);
@@ -404,11 +369,6 @@ fn foo(x: felt252) -> (Box<Box<felt252>>, felt252) {
     // Return both to prevent optimization from eliminating the boxes
     (box2, unbox2)
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -435,18 +395,14 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: Array<felt252>) -> @Box<@Array<felt252>> {
     let snap = @x;
     let boxed = BoxTrait::new(snap);
     let box_snap = @boxed;
     box_snap
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -473,21 +429,17 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn identity(x: felt252) -> felt252 {
+    x
+}
+#[target_function]
 fn foo(boxed: Box<felt252>) -> Box<felt252> {
     let unboxed = boxed.unbox();
     let modified = identity(unboxed);
     let reboxed = BoxTrait::new(modified);
     reboxed
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn identity(x: felt252) -> felt252 {
-    x
 }
 
 //! > semantic_diagnostics
@@ -513,7 +465,16 @@ Box(v1) = v0, Box(v2) = v3
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+
+#[inline(never)]
+fn use_enum(e: MyEnum) {}
+#[target_function]
 fn foo(cond: bool, x: felt252) -> felt252 {
     // Construct same enum variant in both branches
     let e = if cond {
@@ -526,19 +487,6 @@ fn foo(cond: bool, x: felt252) -> felt252 {
     use_enum(e);
     x
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-enum MyEnum {
-    A: felt252,
-    B: felt252,
-}
-
-#[inline(never)]
-fn use_enum(e: MyEnum) {}
 
 //! > semantic_diagnostics
 
@@ -590,7 +538,16 @@ Block 3:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+
+#[inline(never)]
+fn use_enum(e: MyEnum) {}
+#[target_function]
 fn foo(cond: bool, x: felt252, y: felt252) -> felt252 {
     // Construct different enum variants in branches
     let e = if cond {
@@ -603,19 +560,6 @@ fn foo(cond: bool, x: felt252, y: felt252) -> felt252 {
     use_enum(e);
     x
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-enum MyEnum {
-    A: felt252,
-    B: felt252,
-}
-
-#[inline(never)]
-fn use_enum(e: MyEnum) {}
 
 //! > semantic_diagnostics
 
@@ -667,7 +611,8 @@ Block 3:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(boxed: Box<felt252>) -> (@Box<felt252>, Box<felt252>) {
     let snap = @boxed;
     let desnapped = *snap;
@@ -675,11 +620,6 @@ fn foo(boxed: Box<felt252>) -> (@Box<felt252>, Box<felt252>) {
     let reboxed = BoxTrait::new(unboxed);
     (snap, reboxed)
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -706,7 +646,10 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn use_snap(x: @felt252) {}
+#[target_function]
 fn foo(boxed: Box<felt252>) -> Box<felt252> {
     let unboxed = boxed.unbox();
     let snap = @unboxed;
@@ -714,13 +657,6 @@ fn foo(boxed: Box<felt252>) -> Box<felt252> {
     let reboxed = BoxTrait::new(unboxed);
     reboxed
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn use_snap(x: @felt252) {}
 
 //! > semantic_diagnostics
 
@@ -746,18 +682,14 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(boxed: Box<u32>) -> Box<felt252> {
     let unboxed: u32 = boxed.unbox();
     let converted: felt252 = unboxed.into();
     let reboxed = BoxTrait::new(converted);
     reboxed
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -782,19 +714,15 @@ Box(v1) = v0, Box(v2) = v3
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop, Copy)]
+struct EmptyStruct {}
+#[target_function]
 fn foo() -> (EmptyStruct, EmptyStruct) {
     let s1 = EmptyStruct {};
     let s2 = EmptyStruct {};
     (s1, s2)
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop, Copy)]
-struct EmptyStruct {}
 
 //! > semantic_diagnostics
 
@@ -819,16 +747,7 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
-fn foo(a: felt252) -> Outer {
-    let inner = Inner { x: a };
-    Outer { inner }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct Inner {
     x: felt252,
@@ -837,6 +756,11 @@ struct Inner {
 #[derive(Drop, Copy)]
 struct Outer {
     inner: Inner,
+}
+#[target_function]
+fn foo(a: felt252) -> Outer {
+    let inner = Inner { x: a };
+    Outer { inner }
 }
 
 //! > semantic_diagnostics
@@ -861,7 +785,15 @@ test::Inner(v0) = v1, test::Outer(v1) = v2
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop, Copy)]
+struct MyStruct {
+    a: @Array<felt252>,
+}
+
+#[inline(never)]
+fn use_struct(s: @MyStruct) {}
+#[target_function]
 fn foo(arr: Array<felt252>, cond: bool) -> @MyStruct {
     let snap = @arr;
     let s = if cond {
@@ -875,18 +807,6 @@ fn foo(arr: Array<felt252>, cond: bool) -> @MyStruct {
     };
     @s
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop, Copy)]
-struct MyStruct {
-    a: @Array<felt252>,
-}
-
-#[inline(never)]
-fn use_struct(s: @MyStruct) {}
 
 //! > semantic_diagnostics
 
@@ -943,18 +863,14 @@ Block 3:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252, b: felt252) -> Array<felt252> {
     let mut arr = ArrayTrait::new();
     arr.append(a);
     arr.append(b);
     arr
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -983,7 +899,8 @@ test_equality_analysis
 Only the last MAX_ARRAY_TRACKED_ITEMS elements stay individually tracked; everything before
 them is forgotten into a placeholder prefix (rendered `?(*)`).
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(
     a0: felt252, a1: felt252, a2: felt252, a3: felt252, a4: felt252, a5: felt252, a6: felt252,
 ) -> Array<felt252> {
@@ -997,11 +914,6 @@ fn foo(
     arr.append(a6);
     arr
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1035,7 +947,8 @@ test_equality_analysis
 The popped element comes off the forgotten prefix, so its value is unknown; the remainder
 stays tracked under a fresh prefix.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(
     a0: felt252, a1: felt252, a2: felt252, a3: felt252, a4: felt252, a5: felt252, a6: felt252,
 ) -> felt252 {
@@ -1052,11 +965,6 @@ fn foo(
         None => 0,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1113,7 +1021,8 @@ Both branches build the same 7-element array, whose forgotten prefix has a branc
 placeholder; the merge keeps the shared suffix elements under a fresh placeholder, and the
 post-merge append extends the merged relation.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(
     a0: felt252,
     a1: felt252,
@@ -1146,11 +1055,6 @@ fn foo(
     arr.append(a7);
     arr
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1215,7 +1119,10 @@ core::array::Array::<core::felt252>[?(*), v2, v3, v4, v5, v6] = v19, core::array
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_arr(x: @Array<felt252>) nopanic;
+#[target_function]
 fn foo(a: felt252, b: felt252) -> Array<felt252> {
     let mut arr = ArrayTrait::new();
     arr.append(a);
@@ -1231,13 +1138,6 @@ fn foo(a: felt252, b: felt252) -> Array<felt252> {
     use_arr(@result);
     result
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_arr(x: @Array<felt252>) nopanic;
 
 //! > semantic_diagnostics
 
@@ -1327,7 +1227,10 @@ test_equality_analysis
 
 //! > This allows the analysis to track Box(@a)/Box(@b) relationships when popping.
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_snap_felt(x: @felt252) nopanic;
+#[target_function]
 fn foo(a: felt252, b: felt252) {
     let mut arr = ArrayTrait::new();
     arr.append(a);
@@ -1346,13 +1249,6 @@ fn foo(a: felt252, b: felt252) {
         Option::None => {},
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_snap_felt(x: @felt252) nopanic;
 
 //! > semantic_diagnostics
 
@@ -1435,7 +1331,10 @@ test_equality_analysis
 
 //! > This allows the analysis to track Box(@a)/Box(@b) relationships when popping.
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_snap_felt(x: @felt252) nopanic;
+#[target_function]
 fn foo(a: felt252, b: felt252) {
     let mut arr = ArrayTrait::new();
     arr.append(a);
@@ -1454,13 +1353,6 @@ fn foo(a: felt252, b: felt252) {
         Option::None => {},
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_snap_felt(x: @felt252) nopanic;
 
 //! > semantic_diagnostics
 
@@ -1541,7 +1433,10 @@ Block 4:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_snap_felt(x: @felt252) nopanic;
+#[target_function]
 fn foo(mut arr: Array<felt252>) {
     arr.append(3);
     let mut span = arr.span();
@@ -1550,13 +1445,6 @@ fn foo(mut arr: Array<felt252>) {
         Option::None => {},
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_snap_felt(x: @felt252) nopanic;
 
 //! > semantic_diagnostics
 
@@ -1609,7 +1497,8 @@ test_equality_analysis
 The branches build arrays of different lengths (sharing their trailing elements); the
 common trailing elements survive the merge behind a fresh forgotten prefix.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a0: felt252, a1: felt252, a2: felt252, a3: felt252, c: bool) -> Array<felt252> {
     let mut arr = ArrayTrait::new();
     if c {
@@ -1623,11 +1512,6 @@ fn foo(a0: felt252, a1: felt252, a2: felt252, a3: felt252, c: bool) -> Array<fel
     arr.append(a3);
     arr
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1688,7 +1572,8 @@ One branch's array has a forgotten prefix while the other's is fully known (shar
 trailing elements); all the common trailing elements survive the merge behind a fresh,
 possibly-empty forgotten prefix.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(
     a0: felt252,
     a1: felt252,
@@ -1717,11 +1602,6 @@ fn foo(
     arr.append(a6);
     arr
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1787,7 +1667,8 @@ test_equality_analysis
 The array is built before the branch and untouched by it, so both arms reach the merge with
 the same placeholder and the relation survives intact.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(
     a0: felt252,
     a1: felt252,
@@ -1813,11 +1694,6 @@ fn foo(
     arr.append(x);
     arr
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1876,7 +1752,8 @@ core::array::Array::<core::felt252>[?(*), v1, v2, v3, v4, v5] = v14, core::array
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut arr: Array<felt252>) -> Array<felt252> {
     match arr.pop_front() {
         Option::Some(_val) => arr,
@@ -1886,11 +1763,6 @@ fn foo(mut arr: Array<felt252>) -> Array<felt252> {
         },
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1934,7 +1806,10 @@ Block 2:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_boxes(a: Box<Option<felt252>>, b: Box<Option<felt252>>) nopanic;
+#[target_function]
 fn foo(x: felt252, y: felt252) {
     let a = Option::Some(x);
     let b: Option<felt252> = Option::None;
@@ -1942,13 +1817,6 @@ fn foo(x: felt252, y: felt252) {
     let box_b = BoxTrait::new(b);
     use_boxes(box_a, box_b);
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_boxes(a: Box<Option<felt252>>, b: Box<Option<felt252>>) nopanic;
 
 //! > semantic_diagnostics
 
@@ -1976,20 +1844,7 @@ Block 0:
 //! > test_runner_name
 test_equality_analysis
 
-//! > function_code
-fn foo(x: @Array<felt252>, cond: bool) {
-    let s = if cond {
-        MyStruct { a: x, b: 1 }
-    } else {
-        MyStruct { a: x, b: 2 }
-    };
-    use_struct(@s);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct MyStruct {
     a: @Array<felt252>,
@@ -1998,6 +1853,15 @@ struct MyStruct {
 
 #[inline(never)]
 fn use_struct(s: @MyStruct) {}
+#[target_function]
+fn foo(x: @Array<felt252>, cond: bool) {
+    let s = if cond {
+        MyStruct { a: x, b: 1 }
+    } else {
+        MyStruct { a: x, b: 2 }
+    };
+    use_struct(@s);
+}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/analysis/test_data/topological_order
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/topological_order
@@ -3,15 +3,11 @@
 //! > test_runner_name
 test_analysis(analysis: topological_order)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252, y: felt252) -> felt252 {
     x + y
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -35,7 +31,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: topological_order)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool) -> felt252 {
     if x {
         1
@@ -43,11 +40,6 @@ fn foo(x: bool) -> felt252 {
         2
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -87,7 +79,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: topological_order)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool) -> felt252 {
     let y = if x {
         1
@@ -96,11 +89,6 @@ fn foo(x: bool) -> felt252 {
     };
     y + 3
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -148,7 +136,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: topological_order)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool, y: bool) -> felt252 {
     if x {
         if y {
@@ -160,11 +149,6 @@ fn foo(x: bool, y: bool) -> felt252 {
         3
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -220,18 +204,14 @@ End:
 //! > test_runner_name
 test_analysis(analysis: topological_order)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     match x {
         0 => 10,
         _ => 20,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/analysis/test_data/use_sites
+++ b/crates/cairo-lang-lowering/src/analysis/test_data/use_sites
@@ -3,15 +3,11 @@
 //! > test_runner_name
 test_analysis(analysis: use_sites)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252, y: felt252) -> felt252 {
     x + y
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -37,15 +33,11 @@ End:
 //! > test_runner_name
 test_analysis(analysis: use_sites)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     x + x + x
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -72,7 +64,8 @@ End:
 //! > test_runner_name
 test_analysis(analysis: use_sites)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool) -> felt252 {
     let y = if x {
         1
@@ -81,11 +74,6 @@ fn foo(x: bool) -> felt252 {
     };
     y + 3
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -137,19 +125,15 @@ End:
 //! > test_runner_name
 test_analysis(analysis: use_sites)
 
-//! > function_code
-fn foo(x: felt252) -> felt252 {
-    let y = bar(x);
-    y + y
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn bar(x: felt252) -> felt252 {
     x
+}
+#[target_function]
+fn foo(x: felt252) -> felt252 {
+    let y = bar(x);
+    y + y
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
@@ -3,21 +3,7 @@
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(x: ACopy, y: ADrop) {
-    if true {
-        use_a_copy(x);
-        use_a_drop(y);
-    } else {
-        use_a_drop(y);
-    }
-    use_a_copy(x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type ACopy;
 impl ACopyCopy of Copy<ACopy>;
@@ -29,6 +15,16 @@ impl ADropDrop of Drop<ADrop>;
 extern fn use_a_copy(x: ACopy) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
+#[target_function]
+fn foo(x: ACopy, y: ADrop) {
+    if true {
+        use_a_copy(x);
+        use_a_drop(y);
+    } else {
+        use_a_drop(y);
+    }
+    use_a_copy(x);
+}
 
 //! > semantic_diagnostics
 
@@ -73,19 +69,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(x: ACopy, y: ADrop) -> ADrop {
-    if true {
-        use_a_copy(x);
-        use_a_drop(y);
-    } else {}
-    y
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type ACopy;
 impl ACopyCopy of Copy<ACopy>;
@@ -97,26 +81,34 @@ impl ADropDrop of Drop<ADrop>;
 extern fn use_a_copy(x: ACopy) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
+#[target_function]
+fn foo(x: ACopy, y: ADrop) -> ADrop {
+    if true {
+        use_a_copy(x);
+        use_a_drop(y);
+    } else {}
+    y
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:17:5
+ --> lib.cairo:18:5
     y
     ^
 note: variable was previously used here:
-  --> lib.cairo:15:20
+  --> lib.cairo:16:20
         use_a_drop(y);
                    ^
 note: Trait has no implementation in context: core::traits::Copy::<test::ADrop>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:12:8
+ --> lib.cairo:13:8
 fn foo(x: ACopy, y: ADrop) -> ADrop {
        ^
 note: the variable needs to be dropped due to the divergence here:
-  --> lib.cairo:13:5-16:13
+  --> lib.cairo:14:5-17:13
       if true {
  _____^
 | ...
@@ -161,23 +153,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(ref x: ADrop, y: ADrop) {
-    use_a_drop(x);
-    bar();
-    x = y;
-}
-
-fn bar() {
-    let mut data = array![];
-    data.append(1);
-    panic(data);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type ACopy;
 impl ACopyCopy of Copy<ACopy>;
@@ -189,6 +165,18 @@ impl ADropDrop of Drop<ADrop>;
 extern fn use_a_copy(x: ACopy) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
+#[target_function]
+fn foo(ref x: ADrop, y: ADrop) {
+    use_a_drop(x);
+    bar();
+    x = y;
+}
+
+fn bar() {
+    let mut data = array![];
+    data.append(1);
+    panic(data);
+}
 
 //! > semantic_diagnostics
 
@@ -211,17 +199,13 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(ref self: Query<felt252>, value: felt252) {
-    self.data.append(value)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct Query<T> {
     data: Array<T>,
+}
+#[target_function]
+fn foo(ref self: Query<felt252>, value: felt252) {
+    self.data.append(value)
 }
 
 //! > semantic_diagnostics
@@ -245,14 +229,12 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     let mut arr: Array<u256> = Default::default();
     arr.append(1.into());
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -277,26 +259,22 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+struct A {}
+#[target_function]
 fn foo(ref a: A) {
     1 + 1;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-struct A {}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:2:12
+ --> lib.cairo:3:12
 fn foo(ref a: A) {
            ^
 note: the variable needs to be dropped due to the potential panic here:
-  --> lib.cairo:3:5
+  --> lib.cairo:4:5
     1 + 1;
     ^^^^^
 note: Trait has no implementation in context: core::traits::Drop::<test::A>.
@@ -321,7 +299,14 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern type ADrop;
+impl ADropDrop of Drop<ADrop>;
+
+#[allow(extern_outside_corelib)]
+extern fn use_a_drop(x: ADrop) nopanic;
+#[target_function]
 fn foo(x: ADrop, mut y: ADrop) -> ADrop {
     if true {
         use_a_drop(y);
@@ -332,26 +317,15 @@ fn foo(x: ADrop, mut y: ADrop) -> ADrop {
     return y;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern type ADrop;
-impl ADropDrop of Drop<ADrop>;
-
-#[allow(extern_outside_corelib)]
-extern fn use_a_drop(x: ADrop) nopanic;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:14:12
+ --> lib.cairo:15:12
     return y;
            ^
 note: variable was previously used here:
-  --> lib.cairo:9:20
+  --> lib.cairo:10:20
         use_a_drop(y);
                    ^
 note: Trait has no implementation in context: core::traits::Copy::<test::ADrop>.
@@ -391,7 +365,8 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     let arr = array!['err_code'];
     let mut b = arr;
@@ -400,18 +375,15 @@ fn foo() {
     panic(arr);
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:6:11
+ --> lib.cairo:7:11
     panic(arr);
           ^^^
 note: variable was previously used here:
-  --> lib.cairo:3:17
+  --> lib.cairo:4:17
     let mut b = arr;
                 ^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
@@ -437,16 +409,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(x: NonCopy) -> Option<NonCopy> {
-    use_non_copy(x);
-    do_match_extern(x)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type NonCopy;
 
@@ -455,16 +418,21 @@ extern fn use_non_copy(x: NonCopy) nopanic;
 
 #[allow(extern_outside_corelib)]
 extern fn do_match_extern(x: NonCopy) -> Option<NonCopy> nopanic;
+#[target_function]
+fn foo(x: NonCopy) -> Option<NonCopy> {
+    use_non_copy(x);
+    do_match_extern(x)
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:11:21
+ --> lib.cairo:12:21
     do_match_extern(x)
                     ^
 note: variable was previously used here:
-  --> lib.cairo:10:18
+  --> lib.cairo:11:18
     use_non_copy(x);
                  ^
 note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
@@ -505,17 +473,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(mut x: MyStruct) -> MyStruct {
-    x.a = 17;
-    use_non_copy(x.b);
-    return x;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type NonCopy;
 
@@ -526,16 +484,22 @@ struct MyStruct {
     a: u32,
     b: NonCopy,
 }
+#[target_function]
+fn foo(mut x: MyStruct) -> MyStruct {
+    x.a = 17;
+    use_non_copy(x.b);
+    return x;
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:14:12
+ --> lib.cairo:15:12
     return x;
            ^
 note: variable was previously used here:
-  --> lib.cairo:13:18
+  --> lib.cairo:14:18
     use_non_copy(x.b);
                  ^^^
 note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
@@ -558,16 +522,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(ref s1: MyStruct, ref s2: MyStruct) {
-    invalidate(s1.a);
-    invalidate(s2.a);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn invalidate(a: Array<felt252>) nopanic;
 
@@ -576,26 +531,31 @@ struct MyStruct {
     a: Array<felt252>,
     b: u8,
 }
+#[target_function]
+fn foo(ref s1: MyStruct, ref s2: MyStruct) {
+    invalidate(s1.a);
+    invalidate(s2.a);
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:9:12
+ --> lib.cairo:10:12
 fn foo(ref s1: MyStruct, ref s2: MyStruct) {
            ^^
 note: variable was previously used here:
-  --> lib.cairo:10:16
+  --> lib.cairo:11:16
     invalidate(s1.a);
                ^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
 
 error[E3001]: Variable was previously moved.
- --> lib.cairo:9:30
+ --> lib.cairo:10:30
 fn foo(ref s1: MyStruct, ref s2: MyStruct) {
                              ^^
 note: variable was previously used here:
-  --> lib.cairo:11:16
+  --> lib.cairo:12:16
     invalidate(s2.a);
                ^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
@@ -621,18 +581,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(ref self: MyStruct) {
-    if self.b == 0 {
-        self.a = Default::default();
-        invalidate(self.a);
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn invalidate(a: Array<felt252>) nopanic;
 
@@ -641,16 +590,23 @@ struct MyStruct {
     a: Array<felt252>,
     b: u8,
 }
+#[target_function]
+fn foo(ref self: MyStruct) {
+    if self.b == 0 {
+        self.a = Default::default();
+        invalidate(self.a);
+    }
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:9:12
+ --> lib.cairo:10:12
 fn foo(ref self: MyStruct) {
            ^^^^
 note: variable was previously used here:
-  --> lib.cairo:12:20
+  --> lib.cairo:13:20
         invalidate(self.a);
                    ^^^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
@@ -696,19 +652,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(mut v: MyStruct) -> u8 {
-    if v.b == 0 {
-        v.a = Default::default();
-        invalidate(v.a);
-    }
-    v.b
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn invalidate(a: Array<felt252>) nopanic;
 
@@ -716,6 +660,14 @@ extern fn invalidate(a: Array<felt252>) nopanic;
 struct MyStruct {
     a: Array<felt252>,
     b: u8,
+}
+#[target_function]
+fn foo(mut v: MyStruct) -> u8 {
+    if v.b == 0 {
+        v.a = Default::default();
+        invalidate(v.a);
+    }
+    v.b
 }
 
 //! > semantic_diagnostics
@@ -761,17 +713,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(mut x: MyStruct) -> MyStruct {
-    x.a = 17;
-    x.a += 1;
-    return x;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type NonCopy;
 
@@ -782,16 +724,22 @@ struct MyStruct {
     a: felt252,
     b: NonCopy,
 }
+#[target_function]
+fn foo(mut x: MyStruct) -> MyStruct {
+    x.a = 17;
+    x.a += 1;
+    return x;
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:11:12
+ --> lib.cairo:12:12
 fn foo(mut x: MyStruct) -> MyStruct {
            ^
 note: the variable needs to be dropped due to the potential panic here:
-  --> lib.cairo:13:5
+  --> lib.cairo:14:5
     x.a += 1;
     ^^^^^^^^
 note: Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
@@ -817,22 +765,18 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(ref a: A) {
-    if true {
-        bar(@a.x);
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(a: @usize) {}
 
 #[derive(Drop)]
 struct A {
     x: usize,
+}
+#[target_function]
+fn foo(ref a: A) {
+    if true {
+        bar(@a.x);
+    }
 }
 
 //! > semantic_diagnostics
@@ -879,7 +823,15 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern type NonCopy;
+
+struct MyStruct {
+    a: felt252,
+    b: NonCopy,
+}
+#[target_function]
 fn foo(mut x: MyStruct) -> MyStruct {
     let _arr = array![{
         x.a = 17;
@@ -889,27 +841,15 @@ fn foo(mut x: MyStruct) -> MyStruct {
     return x;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern type NonCopy;
-
-struct MyStruct {
-    a: felt252,
-    b: NonCopy,
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:8:12
+ --> lib.cairo:9:12
 fn foo(mut x: MyStruct) -> MyStruct {
            ^
 note: the variable needs to be dropped due to the potential panic here:
-  --> lib.cairo:11:9
+  --> lib.cairo:12:9
         x.a += 1;
         ^^^^^^^^
 note: Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
@@ -938,16 +878,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(x: MyStruct) -> MyStruct {
-    consume(x.b);
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type NonCopy;
 
@@ -958,16 +889,21 @@ struct MyStruct {
     a: felt252,
     b: NonCopy,
 }
+#[target_function]
+fn foo(x: MyStruct) -> MyStruct {
+    consume(x.b);
+    x
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:13:5
+ --> lib.cairo:14:5
     x
     ^
 note: variable was previously used here:
-  --> lib.cairo:12:13
+  --> lib.cairo:13:13
     consume(x.b);
             ^^^
 note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
@@ -989,22 +925,18 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(x: NonDrop) {
-    if let Some(x) = maybe_consume(x) {
-        foo(x)
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type NonDrop;
 
 #[allow(extern_outside_corelib)]
 extern fn maybe_consume(x: NonDrop) -> Option<NonDrop> nopanic;
+#[target_function]
+fn foo(x: NonDrop) {
+    if let Some(x) = maybe_consume(x) {
+        foo(x)
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -1038,12 +970,12 @@ End:
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:6:8
+ --> lib.cairo:7:8
 fn foo(x: NonDrop) {
        ^
 note: the variable needs to be dropped due to the potential panic here:
-  --> lib.cairo:6:1-10:1
-  fn foo(x: NonDrop) {
+  --> lib.cairo:6:1-11:1
+  #[target_function]
  _^
 | ...
 | }
@@ -1060,17 +992,7 @@ note: Trait has no implementation in context: core::traits::PanicDestruct::<test
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(x: Wrapper) {
-    if x.inner.is_zero() {
-        use_x(x);
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 // Non-copyable struct.
 struct Wrapper {
     inner: u16,
@@ -1078,6 +1000,12 @@ struct Wrapper {
 
 #[allow(extern_outside_corelib)]
 extern fn use_x(x: Wrapper) nopanic;
+#[target_function]
+fn foo(x: Wrapper) {
+    if x.inner.is_zero() {
+        use_x(x);
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -1120,7 +1048,15 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+// Non-copyable struct.
+struct Wrapper {
+    inner: u16,
+}
+
+#[allow(extern_outside_corelib)]
+extern fn use_x(x: Wrapper) nopanic;
+#[target_function]
 fn foo(x: Wrapper) {
     if x.inner.is_zero() {
         use_x(x); // First use.
@@ -1129,37 +1065,25 @@ fn foo(x: Wrapper) {
     use_x(x); // Second use.
 }
 
-//! > function_name
-foo
-
-//! > module_code
-// Non-copyable struct.
-struct Wrapper {
-    inner: u16,
-}
-
-#[allow(extern_outside_corelib)]
-extern fn use_x(x: Wrapper) nopanic;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:13:11
+ --> lib.cairo:14:11
     use_x(x); // Second use.
           ^
 note: variable was previously used here:
-  --> lib.cairo:10:15
+  --> lib.cairo:11:15
         use_x(x); // First use.
               ^
 note: Trait has no implementation in context: core::traits::Copy::<test::Wrapper>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:8:8
+ --> lib.cairo:9:8
 fn foo(x: Wrapper) {
        ^
 note: the variable needs to be dropped due to the divergence here:
-  --> lib.cairo:9:5-11:5
+  --> lib.cairo:10:5-12:5
       if x.inner.is_zero() {
  _____^
 |         use_x(x); // First use.
@@ -1206,7 +1130,16 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+struct Wrapper {
+    inner: u16,
+}
+
+#[allow(extern_outside_corelib)]
+extern fn use_x(x: Wrapper) nopanic;
+#[allow(extern_outside_corelib)]
+extern fn use_snap_x(x: @Wrapper) nopanic;
+#[target_function]
 fn foo() {
     let x = Wrapper { inner: 5 };
     if x.inner.is_zero() {
@@ -1216,24 +1149,11 @@ fn foo() {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-struct Wrapper {
-    inner: u16,
-}
-
-#[allow(extern_outside_corelib)]
-extern fn use_x(x: Wrapper) nopanic;
-#[allow(extern_outside_corelib)]
-extern fn use_snap_x(x: @Wrapper) nopanic;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:10:9
+ --> lib.cairo:11:9
     let x = Wrapper { inner: 5 };
         ^
 note: Trait has no implementation in context: core::traits::Drop::<test::Wrapper>.
@@ -1281,19 +1201,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(o: Outer) {
-    if o.inner.x.is_zero() {
-        use_outer(o);
-    } else {
-        use_snap_outer(@o);
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct Inner {
     x: u16,
 }
@@ -1306,12 +1214,20 @@ struct Outer {
 extern fn use_outer(x: Outer) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn use_snap_outer(x: @Outer) nopanic;
+#[target_function]
+fn foo(o: Outer) {
+    if o.inner.x.is_zero() {
+        use_outer(o);
+    } else {
+        use_snap_outer(@o);
+    }
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:13:8
+ --> lib.cairo:14:8
 fn foo(o: Outer) {
        ^
 note: Trait has no implementation in context: core::traits::Drop::<test::Outer>.
@@ -1360,7 +1276,13 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+// Non-copyable struct.
+#[derive(Drop)]
+pub struct Wrapper {
+    pub inner: u16,
+}
+#[target_function]
 fn foo(x: Wrapper) -> u16 {
     let w = if x.inner.is_zero() {
         Wrapper { inner: 6 }
@@ -1369,16 +1291,6 @@ fn foo(x: Wrapper) -> u16 {
     };
 
     w.inner
-}
-
-//! > function_name
-foo
-
-//! > module_code
-// Non-copyable struct.
-#[derive(Drop)]
-pub struct Wrapper {
-    pub inner: u16,
 }
 
 //! > semantic_diagnostics
@@ -1423,19 +1335,17 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     let _foo = ();
 }
 
 mod non_existent;
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 error[E0005]: Module file not found. Expected path: non_existent.cairo
- --> lib.cairo:5:1
+ --> lib.cairo:6:1
 mod non_existent;
 ^^^^^^^^^^^^^^^^^
 
@@ -1457,17 +1367,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(outer: Outer) {
-    bar(outer.inner.a);
-    consume(outer.b);
-    use_outer(outer);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type NonCopy;
 
@@ -1486,16 +1386,22 @@ extern fn bar(x: felt252) nopanic;
 extern fn consume(x: NonCopy) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn use_outer(x: Outer) nopanic;
+#[target_function]
+fn foo(outer: Outer) {
+    bar(outer.inner.a);
+    consume(outer.b);
+    use_outer(outer);
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:22:15
+ --> lib.cairo:23:15
     use_outer(outer);
               ^^^^^
 note: variable was previously used here:
-  --> lib.cairo:21:13
+  --> lib.cairo:22:13
     consume(outer.b);
             ^^^^^^^
 note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
@@ -1522,23 +1428,7 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(mut o: Outer) {
-    if some_cond() {
-        use_outer(o);
-        o = Outer { inner: Inner { x: 5_u16 } };
-    }
-    if o.inner.x.is_zero() {
-        use_outer(o);
-    } else {
-        use_snap_outer(@o);
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct Inner {
     x: u16,
 }
@@ -1553,12 +1443,24 @@ extern fn use_outer(x: Outer) nopanic;
 extern fn use_snap_outer(x: @Outer) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn some_cond() -> bool nopanic;
+#[target_function]
+fn foo(mut o: Outer) {
+    if some_cond() {
+        use_outer(o);
+        o = Outer { inner: Inner { x: 5_u16 } };
+    }
+    if o.inner.x.is_zero() {
+        use_outer(o);
+    } else {
+        use_snap_outer(@o);
+    }
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:15:12
+ --> lib.cairo:16:12
 fn foo(mut o: Outer) {
            ^
 note: Trait has no implementation in context: core::traits::Drop::<test::Outer>.

--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/closure
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/closure
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: u32, mut b: Array<u32>, mut c: Felt252Dict<felt252>) {
     |d: u32| {
         let _ = a + d;
@@ -16,17 +17,14 @@ fn foo(a: u32, mut b: Array<u32>, mut c: Felt252Dict<felt252>) {
     };
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:6:17
+ --> lib.cairo:7:17
         let _ = b.append(d);
                 ^
 
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:9:17
+ --> lib.cairo:10:17
         let _ = c.insert(d, d);
                 ^
 
@@ -41,24 +39,20 @@ error[E2188]: Capture of mutable variables in a closure is not supported
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(a: PanicDestructable) {
-    || {
-        let PanicDestructable { } = a;
-    };
-    panic_with_felt252('Panic');
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct PanicDestructable {}
 
 impl MyPanicDestruct of PanicDestruct<PanicDestructable> {
     fn panic_destruct(self: PanicDestructable, ref panic: Panic) nopanic {
         let PanicDestructable { } = self;
     }
+}
+#[target_function]
+fn foo(a: PanicDestructable) {
+    || {
+        let PanicDestructable { } = a;
+    };
+    panic_with_felt252('Panic');
 }
 
 //! > semantic_diagnostics
@@ -69,7 +63,7 @@ impl MyPanicDestruct of PanicDestruct<PanicDestructable> {
 Parameters: v0: test::PanicDestructable
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:9:5: 9:7}) <- struct_construct(v0{`a`})
+  (v1: {closure@lib.cairo:10:5: 10:7}) <- struct_construct(v0{`a`})
   (v2: core::felt252) <- 345232009571
   (v3: core::never) <- core::panic_with_felt252(v2{`'Panic'`})
 End:
@@ -83,7 +77,8 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut a: Array<u32>) {
     |b: u32| {
         let _ = a.append(b);
@@ -91,12 +86,9 @@ fn foo(mut a: Array<u32>) {
     a.append(0);
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:3:17
+ --> lib.cairo:4:17
         let _ = a.append(b);
                 ^
 
@@ -111,7 +103,15 @@ error[E2188]: Capture of mutable variables in a closure is not supported
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct S {
+    a: u32,
+}
+
+#[allow(extern_outside_corelib)]
+extern fn use_s(s: S) nopanic;
+#[target_function]
 fn foo(a: S) {
     || {
         use_s(a)
@@ -121,27 +121,15 @@ fn foo(a: S) {
     let _ = a.a;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct S {
-    a: u32,
-}
-
-#[allow(extern_outside_corelib)]
-extern fn use_s(s: S) nopanic;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:14:13
+ --> lib.cairo:15:13
     let _ = a.a;
             ^^^
 note: variable was previously used here:
-  --> lib.cairo:10:15
+  --> lib.cairo:11:15
         use_s(a)
               ^
 note: Trait has no implementation in context: core::traits::Copy::<test::S>.
@@ -150,7 +138,7 @@ note: Trait has no implementation in context: core::traits::Copy::<test::S>.
 Parameters: v0: test::S
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:9:5: 9:7}) <- struct_construct(v0{`a`})
+  (v1: {closure@lib.cairo:10:5: 10:7}) <- struct_construct(v0{`a`})
   (v3: ()) <- struct_construct()
 End:
   Return(v3)
@@ -162,7 +150,10 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_f<T>(f: T) nopanic;
+#[target_function]
 fn foo(mut a: Array<u32>) {
     let f = |b: u32| {
         let _ = a.append(b);
@@ -171,16 +162,9 @@ fn foo(mut a: Array<u32>) {
     use_f(f)
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_f<T>(f: T) nopanic;
-
 //! > semantic_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:5:17
+ --> lib.cairo:6:17
         let _ = a.append(b);
                 ^
 
@@ -195,7 +179,10 @@ error[E2188]: Capture of mutable variables in a closure is not supported
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_value<T>(f: T) nopanic;
+#[target_function]
 fn foo(a: Array<u32>) {
     let f = |_b: u32| {
         let _ = a.len();
@@ -206,13 +193,6 @@ fn foo(a: Array<u32>) {
     use_value(f);
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_value<T>(f: T) nopanic;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -222,9 +202,9 @@ Parameters: v0: core::array::Array::<core::integer::u32>
 blk0 (root):
 Statements:
   (v1: core::array::Array::<core::integer::u32>, v2: @core::array::Array::<core::integer::u32>) <- snapshot(v0{`a`})
-  (v3: {closure@lib.cairo:4:13: 4:22}) <- struct_construct(v2{`|_b: u32| { let _ = a.len(); }`})
+  (v3: {closure@lib.cairo:5:13: 5:22}) <- struct_construct(v2{`|_b: u32| { let _ = a.len(); }`})
   () <- test::use_value::<core::array::Array::<core::integer::u32>>(v1{`a`})
-  () <- test::use_value::<{closure@lib.cairo:4:13: 4:22}>(v3{`f`})
+  () <- test::use_value::<{closure@lib.cairo:5:13: 5:22}>(v3{`f`})
   (v4: ()) <- struct_construct()
 End:
   Return(v4)
@@ -236,7 +216,10 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_f<T>(f: T) nopanic;
+#[target_function]
 fn foo(mut a: Array<u32>) {
     |_b: u32| {
         a = array![];
@@ -244,16 +227,9 @@ fn foo(mut a: Array<u32>) {
     a.append(0);
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_f<T>(f: T) nopanic;
-
 //! > semantic_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:5:9
+ --> lib.cairo:6:9
         a = array![];
         ^
 
@@ -268,7 +244,8 @@ error[E2188]: Capture of mutable variables in a closure is not supported
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let x = 8;
     let c = |a| {
@@ -277,9 +254,6 @@ fn foo() -> felt252 {
     let y = c(2);
     y + x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -290,11 +264,11 @@ Parameters:
 blk0 (root):
 Statements:
   (v0: core::felt252) <- 8
-  (v1: {closure@lib.cairo:3:13: 3:16}) <- struct_construct(v0{`x`})
-  (v2: {closure@lib.cairo:3:13: 3:16}, v3: @{closure@lib.cairo:3:13: 3:16}) <- snapshot(v1{`c`})
+  (v1: {closure@lib.cairo:4:13: 4:16}) <- struct_construct(v0{`x`})
+  (v2: {closure@lib.cairo:4:13: 4:16}, v3: @{closure@lib.cairo:4:13: 4:16}) <- snapshot(v1{`c`})
   (v4: core::felt252) <- 2
   (v5: (core::felt252,)) <- struct_construct(v4{`2`})
-  (v6: core::felt252) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:3:13: 3:16}(v3{`c`}, v5{`c(2)`})
+  (v6: core::felt252) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:4:13: 4:16}(v3{`c`}, v5{`c(2)`})
   (v7: core::felt252) <- core::Felt252Add::add(v6{`y`}, v0{`x`})
 End:
   Return(v7)
@@ -306,7 +280,8 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let x = array![99_felt252];
     let c = |a| {
@@ -315,9 +290,6 @@ fn foo() -> felt252 {
     let _ = c(2);
     *x[0]
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -331,11 +303,11 @@ Statements:
   (v1: core::felt252) <- 99
   (v3: core::array::Array::<core::felt252>, v2: ()) <- core::array::ArrayImpl::<core::felt252>::append(v0{`__array_builder_macro_result__`}, v1{`99_felt252`})
   (v4: core::array::Array::<core::felt252>, v5: @core::array::Array::<core::felt252>) <- snapshot(v3{`x`})
-  (v6: {closure@lib.cairo:3:13: 3:16}) <- struct_construct(v5{`|a| { (@x).len() * (a + 3) }`})
-  (v7: {closure@lib.cairo:3:13: 3:16}, v8: @{closure@lib.cairo:3:13: 3:16}) <- snapshot(v6{`c`})
+  (v6: {closure@lib.cairo:4:13: 4:16}) <- struct_construct(v5{`|a| { (@x).len() * (a + 3) }`})
+  (v7: {closure@lib.cairo:4:13: 4:16}, v8: @{closure@lib.cairo:4:13: 4:16}) <- snapshot(v6{`c`})
   (v9: core::integer::u32) <- 2
   (v10: (core::integer::u32,)) <- struct_construct(v9{`2`})
-  (v11: core::integer::u32) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:3:13: 3:16}(v8{`c`}, v10{`c(2)`})
+  (v11: core::integer::u32) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:4:13: 4:16}(v8{`c`}, v10{`c(2)`})
   (v12: core::array::Array::<core::felt252>, v13: @core::array::Array::<core::felt252>) <- snapshot(v4{`x`})
   (v14: core::integer::u32) <- 0
   (v15: @core::felt252) <- core::ops::index::DeprecatedIndexViewImpl::<core::array::Array::<core::felt252>, core::integer::u32, @core::felt252, core::array::ArrayIndex::<core::felt252>>::index(v13{`x`}, v14{`0`})
@@ -350,7 +322,8 @@ End:
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let mut x = 8;
     let c = |a| {
@@ -361,12 +334,9 @@ fn foo() -> felt252 {
     y + x
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:4:9
+ --> lib.cairo:5:9
         x * (a + 3)
         ^
 
@@ -381,10 +351,11 @@ error[E2188]: Capture of mutable variables in a closure is not supported
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
+//! > cairo_code
 fn identity<T>(x: T) -> T {
     x
 }
+#[target_function]
 fn foo() {
     let mut x = 8;
     let c = |a| {
@@ -395,17 +366,14 @@ fn foo() {
     let y = c2(2);
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 error[E2188]: Capture of mutable variables in a closure is not supported
- --> lib.cairo:7:9
+ --> lib.cairo:8:9
         x * (a + 3)
         ^
 
 warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:11:9
+ --> lib.cairo:12:9
     let y = c2(2);
         ^
 
@@ -420,25 +388,21 @@ warning[E0001]: Unused variable. Consider ignoring by prefixing with `_`.
 //! > test_runner_name
 test_borrow_check
 
-//! > function_code
-fn foo(a: Destructable, b: Destructable) {
-    let c = || {
-        let Destructable { } = a;
-        let Destructable { } = b;
-    };
-    c.destruct();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct Destructable {}
 
 impl MyDestruct of Destruct<Destructable> {
     fn destruct(self: Destructable) nopanic {
         let Destructable { } = self;
     }
+}
+#[target_function]
+fn foo(a: Destructable, b: Destructable) {
+    let c = || {
+        let Destructable { } = a;
+        let Destructable { } = b;
+    };
+    c.destruct();
 }
 
 //! > semantic_diagnostics
@@ -449,8 +413,8 @@ impl MyDestruct of Destruct<Destructable> {
 Parameters: v0: test::Destructable, v1: test::Destructable
 blk0 (root):
 Statements:
-  (v2: {closure@lib.cairo:9:13: 9:15}) <- struct_construct(v0{`a`}, v1{`b`})
-  (v3: ()) <- Generated `core::traits::Destruct::destruct` for {closure@lib.cairo:9:13: 9:15}(v2{`c`})
+  (v2: {closure@lib.cairo:10:13: 10:15}) <- struct_construct(v0{`a`}, v1{`b`})
+  (v3: ()) <- Generated `core::traits::Destruct::destruct` for {closure@lib.cairo:10:13: 10:15}(v2{`c`})
   (v4: ()) <- struct_construct()
 End:
   Return(v4)

--- a/crates/cairo-lang-lowering/src/cache/test.rs
+++ b/crates/cairo-lang-lowering/src/cache/test.rs
@@ -1,10 +1,13 @@
 use cairo_lang_defs::db::DefsGroup;
-use cairo_lang_defs::ids::LanguageElementId;
+use cairo_lang_defs::ids::{LanguageElementId, ModuleId};
 use cairo_lang_filesystem::db::{FilesGroup, files_group_input, set_crate_configs_input};
 use cairo_lang_filesystem::ids::{BlobLongId, FileLongId};
 use cairo_lang_parser::db::ParserGroup;
+use cairo_lang_semantic::ConcreteFunctionWithBodyId as SemanticConcreteFunctionWithBodyId;
 use cairo_lang_semantic::corelib::CorelibSemantic;
-use cairo_lang_semantic::test_utils::setup_test_function_ex;
+use cairo_lang_semantic::test_utils::{
+    resolve_target_functions, setup_test_module_ex, test_module_code,
+};
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_test_utils::verify_diagnostics_expectation;
 use cairo_lang_utils::Intern;
@@ -29,24 +32,19 @@ fn test_cache_check(
     inputs: &OrderedHashMap<String, String>,
     args: &OrderedHashMap<String, String>,
 ) -> TestRunnerResult {
-    let function = &inputs["function_code"];
-    let function_name = &inputs["function_name"];
-    let module_code = inputs.get("module_code").map_or("", String::as_str);
+    // The very same module content must be used for generating the cache and for loading it, so
+    // that the cached stable pointers match the module they are loaded into.
+    let content = test_module_code(inputs);
 
-    let (new_db, artifact) = generate_cached_db(function, function_name, module_code);
+    let (new_db, artifact) = generate_cached_db(&content);
     let cached_file = BlobLongId::Virtual(artifact).intern(&new_db);
-    let (test_function, semantic_diagnostics) = setup_test_function_ex(
-        &new_db,
-        function,
-        function_name,
-        module_code,
-        None,
-        Some(cached_file),
-    )
-    .split();
+    let (test_module, semantic_diagnostics) =
+        setup_test_module_ex(&new_db, &content, None, Some(cached_file)).split();
 
-    let function_id: ConcreteFunctionWithBodyId<'_> =
-        ConcreteFunctionWithBodyId::from_semantic(&new_db, test_function.concrete_function_id);
+    let function_id = ConcreteFunctionWithBodyId::from_semantic(
+        &new_db,
+        target_concrete_function(&new_db, test_module.module_id),
+    );
 
     let lowered = new_db.lowered_body(function_id, LoweringStage::Final);
     if let Ok(lowered) = &lowered {
@@ -55,8 +53,7 @@ fn test_cache_check(
             "There should not be any unset flat blocks"
         );
     }
-    let diagnostics =
-        new_db.module_lowering_diagnostics(test_function.module_id).unwrap_or_default();
+    let diagnostics = new_db.module_lowering_diagnostics(test_module.module_id).unwrap_or_default();
     let formatted_lowering_diagnostics = diagnostics.format(&new_db);
     let combined_diagnostics = format!("{semantic_diagnostics}\n{formatted_lowering_diagnostics}");
     let error = verify_diagnostics_expectation(args, &combined_diagnostics);
@@ -70,20 +67,30 @@ fn test_cache_check(
     }
 }
 
-/// Compiles `function`/`module_code` to generate the crate cache (and the corelib cache), then
-/// returns a fresh db with the corelib cache loaded plus the crate-cache artifact. Callers wire the
-/// artifact in as the test crate's `cache_file` via
-/// `setup_test_function_ex(.., Some(BlobLongId::Virtual(artifact).intern(&db)))`.
-fn generate_cached_db(
-    function: &str,
-    function_name: &str,
-    module_code: &str,
-) -> (LoweringDatabaseForTesting, Vec<u8>) {
-    let db = &mut LoweringDatabaseForTesting::default();
-    let (test_function, _) =
-        setup_test_function_ex(db, function, function_name, module_code, None, None).split();
+/// Returns the single function marked with `#[target_function]` in the given module, as a semantic
+/// concrete function.
+///
+/// This mirrors what `setup_test_function` does, which can't be used here as it doesn't support
+/// loading a crate cache.
+fn target_concrete_function<'db>(
+    db: &'db LoweringDatabaseForTesting,
+    module_id: ModuleId<'db>,
+) -> SemanticConcreteFunctionWithBodyId<'db> {
+    let [free_function_id] = resolve_target_functions(db, module_id)[..] else {
+        panic!("Expected exactly one function marked with `#[target_function]`.");
+    };
+    SemanticConcreteFunctionWithBodyId::from_no_generics_free(db, free_function_id).unwrap()
+}
 
-    let artifact = generate_crate_cache(db, test_function.module_id.owning_crate(db)).unwrap();
+/// Compiles `content` to generate the crate cache (and the corelib cache), then returns a fresh db
+/// with the corelib cache loaded plus the crate-cache artifact. Callers wire the artifact in as the
+/// test crate's `cache_file` via
+/// `setup_test_module_ex(.., Some(BlobLongId::Virtual(artifact).intern(&db)))`.
+fn generate_cached_db(content: &str) -> (LoweringDatabaseForTesting, Vec<u8>) {
+    let db = &mut LoweringDatabaseForTesting::default();
+    let (test_module, _) = setup_test_module_ex(db, content, None, None).split();
+
+    let artifact = generate_crate_cache(db, test_module.crate_id).unwrap();
     let core_artifact = generate_crate_cache(db, db.core_crate()).unwrap();
 
     let mut new_db = LoweringDatabaseForTesting::new();
@@ -99,21 +106,19 @@ fn generate_cached_db(
 /// stable ptr must therefore be the very node `db.file_syntax` mints — not a detached duplicate.
 #[test]
 fn cached_external_file_root_is_canonical() {
-    let function = "fn foo() {}";
-    let module_code = "\
+    let content = "\
 #[derive(Drop)]
 struct MyStruct {
     x: felt252,
 }";
-    let (db, artifact) = generate_cached_db(function, "foo", module_code);
+    let (db, artifact) = generate_cached_db(content);
     let cached_file = BlobLongId::Virtual(artifact).intern(&db);
-    let (cached_function, _) =
-        setup_test_function_ex(&db, function, "foo", module_code, None, Some(cached_file)).split();
+    let (cached_module, _) = setup_test_module_ex(&db, content, None, Some(cached_file)).split();
 
     // The `#[derive(Drop)]` impl lives in an external file; its cached stable ptr must resolve to
     // the canonical `file_syntax` root.
     let mut checked = 0;
-    for impl_id in db.module_impls_ids(cached_function.module_id).unwrap() {
+    for impl_id in db.module_impls_ids(cached_module.module_id).unwrap() {
         let stable_ptr = impl_id.untyped_stable_ptr(&db);
         let ext_file = stable_ptr.file_id(&db);
         if !matches!(ext_file.long(&db), FileLongId::External(_)) {

--- a/crates/cairo-lang-lowering/src/cache/test_data/cache
+++ b/crates/cairo-lang-lowering/src/cache/test_data/cache
@@ -3,21 +3,7 @@
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
-fn foo(x: ACopy, y: ADrop) {
-    if true {
-        use_a_copy(x);
-        use_a_drop(y);
-    } else {
-        use_a_drop(y);
-    }
-    use_a_copy(x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern type ACopy;
 impl ACopyCopy of Copy<ACopy>;
@@ -29,6 +15,16 @@ impl ADropDrop of Drop<ADrop>;
 extern fn use_a_copy(x: ACopy) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn use_a_drop(x: ADrop) nopanic;
+#[target_function]
+fn foo(x: ACopy, y: ADrop) {
+    if true {
+        use_a_copy(x);
+        use_a_drop(y);
+    } else {
+        use_a_drop(y);
+    }
+    use_a_copy(x);
+}
 
 //! > semantic_diagnostics
 
@@ -51,16 +47,14 @@ End:
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u32 {
     let x = |a| {
         a + 5
     };
     x(5)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -83,19 +77,7 @@ End:
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
-fn foo() {
-    bar::<MyOuter>();
-}
-
-fn bar<impl I: Outer>() {
-    I::Impl::foo();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait Inner {
     fn foo();
 }
@@ -109,6 +91,14 @@ impl MyInner of Inner {
 }
 
 impl MyOuter of Outer {}
+#[target_function]
+fn foo() {
+    bar::<MyOuter>();
+}
+
+fn bar<impl I: Outer>() {
+    I::Impl::foo();
+}
 
 //! > semantic_diagnostics
 
@@ -128,15 +118,7 @@ End:
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
-fn foo() -> i32 {
-    MyTrait::foo()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo() -> i32 {
         let y = |x| x;
@@ -145,6 +127,10 @@ trait MyTrait {
 }
 
 impl MyImpl of MyTrait {}
+#[target_function]
+fn foo() -> i32 {
+    MyTrait::foo()
+}
 
 //! > semantic_diagnostics
 
@@ -165,15 +151,7 @@ End:
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
-fn foo() -> i32 {
-    MyTrait::foo()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn foo() -> i32 {
         loop {
@@ -185,6 +163,10 @@ trait MyTrait {
 }
 
 impl MyImpl of MyTrait {}
+#[target_function]
+fn foo() -> i32 {
+    MyTrait::foo()
+}
 
 //! > semantic_diagnostics
 
@@ -205,19 +187,15 @@ End:
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
-fn foo() -> i32 {
-    my_macro!(3)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro my_macro {
     ($x:expr) => {
         $x + 1
     };
+}
+#[target_function]
+fn foo() -> i32 {
+    my_macro!(3)
 }
 
 //! > semantic_diagnostics
@@ -241,15 +219,7 @@ End:
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
-fn foo() {
-    bar();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro define_bar {
     () => {
         expose! (
@@ -258,6 +228,10 @@ macro define_bar {
     };
 }
 define_bar!();
+#[target_function]
+fn foo() {
+    bar();
+}
 
 //! > semantic_diagnostics
 
@@ -277,19 +251,15 @@ End:
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
-fn foo() -> felt252 {
-    let s = MyStruct { x: 5 };
-    s.x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct MyStruct {
     x: felt252,
+}
+#[target_function]
+fn foo() -> felt252 {
+    let s = MyStruct { x: 5 };
+    s.x
 }
 
 //! > semantic_diagnostics
@@ -311,21 +281,17 @@ End:
 //! > test_runner_name
 test_cache_check
 
-//! > function_code
-fn foo() -> felt252 {
-    let s = inner::InnerStruct { x: 5 };
-    s.x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 mod inner {
     #[derive(Drop)]
     pub struct InnerStruct {
         pub x: felt252,
     }
+}
+#[target_function]
+fn foo() -> felt252 {
+    let s = inner::InnerStruct { x: 5 };
+    s.x
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/inline/test_data/inline
+++ b/crates/cairo-lang-lowering/src/inline/test_data/inline
@@ -3,13 +3,11 @@
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(n: felt252) -> felt252 {
     -n
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -49,15 +47,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(val: Option<felt252>) -> felt252 {
-    bar(val, 2)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 /// If `val` is `Some(x)`, returns `x`. Otherwise, panics.
 #[inline]
 fn bar<T, impl TDrop: Drop<T>>(val: Option<T>, val2: T) -> T {
@@ -65,6 +55,10 @@ fn bar<T, impl TDrop: Drop<T>>(val: Option<T>, val2: T) -> T {
         Some(x) => x,
         None => val2,
     }
+}
+#[target_function]
+fn foo(val: Option<felt252>) -> felt252 {
+    bar(val, 2)
 }
 
 //! > semantic_diagnostics
@@ -118,18 +112,14 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(n: felt252) -> felt252 {
-    bar(n, n)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn bar(a: felt252, b: felt252) -> felt252 {
     a + b
+}
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n, n)
 }
 
 //! > semantic_diagnostics
@@ -169,15 +159,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(a: felt252, b: felt252) -> felt252 {
-    bar(a + b, b)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn bar(a: felt252, b: felt252) -> felt252 implicits() {
     bar2(a, b) + bar2(b, a)
@@ -186,6 +168,10 @@ fn bar(a: felt252, b: felt252) -> felt252 implicits() {
 #[inline(always)]
 fn bar2(a: felt252, b: felt252) -> felt252 implicits() {
     a * b
+}
+#[target_function]
+fn foo(a: felt252, b: felt252) -> felt252 {
+    bar(a + b, b)
 }
 
 //! > semantic_diagnostics
@@ -239,15 +225,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(a: felt252) -> felt252 {
-    first(a)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn first(a: felt252) -> felt252 {
     second(a)
@@ -261,6 +239,10 @@ fn second(a: felt252) -> felt252 {
 #[inline(always)]
 fn third(a: felt252) -> felt252 {
     a * a
+}
+#[target_function]
+fn foo(a: felt252) -> felt252 {
+    first(a)
 }
 
 //! > semantic_diagnostics
@@ -300,14 +282,12 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     let mut arr = array![];
     arr.append(5)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -364,25 +344,21 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(a: felt252) -> felt252 {
-    if a == 2 {
-        bar(a)
-    } else {
-        a
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn bar(a: felt252) -> felt252 {
     if a == 0 {
         return 1;
     }
     0
+}
+#[target_function]
+fn foo(a: felt252) -> felt252 {
+    if a == 2 {
+        bar(a)
+    } else {
+        a
+    }
 }
 
 //! > before
@@ -509,21 +485,17 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(a: felt252) -> felt252 {
-    bar(a) + bar2(a)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(a: felt252) -> felt252 {
     bar2(a)
 }
 
 fn bar2(a: felt252) -> felt252 {
     1
+}
+#[target_function]
+fn foo(a: felt252) -> felt252 {
+    bar(a) + bar2(a)
 }
 
 //! > before
@@ -587,15 +559,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(a: felt252) -> felt252 {
-    bar(a) + bar2(a)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn bar(a: felt252) -> felt252 {
     bar2(a)
@@ -604,6 +568,10 @@ fn bar(a: felt252) -> felt252 {
 #[inline(never)]
 fn bar2(a: felt252) -> felt252 {
     1
+}
+#[target_function]
+fn foo(a: felt252) -> felt252 {
+    bar(a) + bar2(a)
 }
 
 //! > before
@@ -647,21 +615,17 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo() -> felt252 {
-    bar(0)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn bar(a: felt252) -> felt252 {
     if a == 0 {
         return a;
     }
     1
+}
+#[target_function]
+fn foo() -> felt252 {
+    bar(0)
 }
 
 //! > semantic_diagnostics
@@ -716,18 +680,14 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(n: felt252) -> felt252 {
-    identity(n)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn identity(n: felt252) -> felt252 {
     n
+}
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    identity(n)
 }
 
 //! > semantic_diagnostics
@@ -772,15 +732,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
-fn foo(a: u128, b: u128) -> u128 {
-    bar1(a, b)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn bar1(a: u128, b: u128) -> u128 {
     if a == 1_u128 {
@@ -792,6 +744,10 @@ fn bar1(a: u128, b: u128) -> u128 {
 #[inline(always)]
 fn bar2(a: u128, b: u128) -> u128 {
     a + b
+}
+#[target_function]
+fn foo(a: u128, b: u128) -> u128 {
+    bar1(a, b)
 }
 
 //! > semantic_diagnostics
@@ -907,15 +863,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-fn foo(n: felt252) -> felt252 {
-    bar(n)
-}
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn bar(n: felt252) -> felt252 {
     if n == 0 {
@@ -923,6 +871,10 @@ fn bar(n: felt252) -> felt252 {
     } else {
         return 1;
     }
+}
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n)
 }
 
 //! > semantic_diagnostics
@@ -984,16 +936,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-#[inline]
-fn foo(n: felt252) -> felt252 {
-    bar(n)
-}
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn bar(n: felt252) -> felt252 {
     if n == 0 {
@@ -1001,6 +944,11 @@ fn bar(n: felt252) -> felt252 {
     } else {
         return 1;
     }
+}
+#[inline]
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n)
 }
 
 //! > semantic_diagnostics
@@ -1104,11 +1052,9 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
+//! > cairo_code
 #[inline]
+#[target_function]
 fn foo(n: felt252) -> felt252 {
     foo(n)
 }
@@ -1214,16 +1160,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-#[inline]
-fn foo(n: felt252) -> felt252 {
-    bar(n)
-}
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn bar(n: felt252) -> felt252 {
     if n == 0 {
@@ -1231,6 +1168,11 @@ fn bar(n: felt252) -> felt252 {
     } else {
         return 1;
     }
+}
+#[inline]
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n)
 }
 
 //! > semantic_diagnostics
@@ -1304,16 +1246,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-#[inline]
-fn foo(n: felt252) -> felt252 {
-    bar(n)
-}
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn bar(n: felt252) -> felt252 {
     baz(n)
@@ -1326,6 +1259,11 @@ fn baz(n: felt252) -> felt252 {
     } else {
         return 1;
     }
+}
+#[inline]
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n)
 }
 
 //! > semantic_diagnostics
@@ -1409,16 +1347,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-#[inline]
-fn foo(n: felt252) -> felt252 {
-    bar(n)
-}
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn bar(n: felt252) -> felt252 {
     baz(n)
@@ -1431,6 +1360,11 @@ fn baz(n: felt252) -> felt252 {
     } else {
         return 1;
     }
+}
+#[inline]
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n)
 }
 
 //! > semantic_diagnostics
@@ -1504,16 +1438,7 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-#[inline]
-fn foo(n: felt252) -> felt252 {
-    bar(n)
-}
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn bar(n: felt252) -> felt252 {
     baz(n)
@@ -1526,6 +1451,11 @@ fn baz(n: felt252) -> felt252 {
     } else {
         return 1;
     }
+}
+#[inline]
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n)
 }
 
 //! > semantic_diagnostics
@@ -1629,18 +1559,14 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-fn foo(n: felt252) -> felt252 {
-    bar(n) + bar(n)
-}
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn bar(n: felt252) -> felt252 {
     n
+}
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n) + bar(n)
 }
 
 //! > semantic_diagnostics
@@ -1702,18 +1628,14 @@ End:
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-fn foo(n: felt252) {
-    bar(n);
-}
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn bar<T, +PanicDestruct<T>>(n: T) {
     panic_with_felt252('panic')
+}
+#[target_function]
+fn foo(n: felt252) {
+    bar(n);
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/inline/test_data/inline_diagnostics
+++ b/crates/cairo-lang-lowering/src/inline/test_data/inline_diagnostics
@@ -3,21 +3,19 @@
 //! > test_runner_name
 test_function_inlining
 
-//! > function_code
+//! > cairo_code
 #[inline(always)]
+#[target_function]
 fn foo(ref a: felt252, b: felt252) -> felt252 {
     foo(ref a, b);
     b
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3005]: Cannot inline a function that might call itself.
- --> lib.cairo:1:1-5:1
+ --> lib.cairo:1:1-6:1
   #[inline(always)]
  _^
 | ...
@@ -37,15 +35,7 @@ error[E3005]: Cannot inline a function that might call itself.
 //! > test_runner_name
 test_function_inlining
 
-//! > function_name
-foo
-
-//! > function_code
-fn foo(n: felt252) -> felt252 {
-    bar(n)
-}
-
-//! > module_code
+//! > cairo_code
 #[inline(always)]
 fn bar(n: felt252) -> felt252 {
     if n == 0 {
@@ -53,6 +43,10 @@ fn bar(n: felt252) -> felt252 {
     } else {
         return 1;
     }
+}
+#[target_function]
+fn foo(n: felt252) -> felt252 {
+    bar(n)
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/lower/block_builder_test.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder_test.rs
@@ -1,7 +1,7 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_semantic::corelib::unit_ty;
 use cairo_lang_semantic::expr::fmt::ExprFormatter;
-use cairo_lang_semantic::test_utils::{TestFunction, setup_test_function_ex};
+use cairo_lang_semantic::test_utils::{TARGET_FUNCTION_ATTR, TestFunction, setup_test_function};
 use cairo_lang_semantic::usage::MemberPath;
 use cairo_lang_semantic::{self as semantic, Expr, Statement, StatementId};
 use cairo_lang_syntax::node::TypedStablePtr;
@@ -46,7 +46,10 @@ cairo_lang_test_utils::test_file_test!(
 ///
 ///   Note that `x` and `x.*` should not be specified together in one block.
 ///
-/// - `module_code`: Additional code for defining structs and helper functions.
+/// - `helper_code`: Additional code for defining structs and helper functions.
+///
+/// Unlike other test runners, the tested module's code is not given directly - it is synthesized
+/// from the above sections into the single `cairo_code` input [setup_test_function] expects.
 fn test_merge_block_builders(
     inputs: &OrderedHashMap<String, String>,
     _args: &OrderedHashMap<String, String>,
@@ -56,15 +59,14 @@ fn test_merge_block_builders(
     // as a dummy function body.
     // Note that the function body is not lowered at any point, and it is only used to parse the
     // semantic to lowering map.
-    let test_function = setup_test_function_ex(
-        &db,
-        &format!("fn foo ({}) {{ {} }}", inputs["variables"], inputs["block_definitions"]),
-        "foo",
-        inputs.get("module_code").map_or("", String::as_str),
-        None,
-        None,
-    )
-    .unwrap();
+    let cairo_code = format!(
+        "{}#[{TARGET_FUNCTION_ATTR}]\nfn foo ({}) {{ {} }}",
+        inputs.get("helper_code").map_or(String::new(), |code| format!("{code}\n")),
+        inputs["variables"],
+        inputs["block_definitions"]
+    );
+    let synthesized_inputs = OrderedHashMap::from([("cairo_code".to_string(), cairo_code)]);
+    let test_function = setup_test_function(&db, &synthesized_inputs).unwrap();
 
     let mut encapsulating_ctx =
         create_encapsulating_ctx(&db, test_function.function_id, &test_function.signature);

--- a/crates/cairo-lang-lowering/src/lower/flow_control/graph_test.rs
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/graph_test.rs
@@ -1,7 +1,7 @@
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_semantic::expr::fmt::ExprFormatter;
 use cairo_lang_semantic::items::function_with_body::FunctionWithBodySemantic;
-use cairo_lang_semantic::test_utils::setup_test_function_ex;
+use cairo_lang_semantic::test_utils::setup_test_function;
 use cairo_lang_semantic::{self as semantic, ExprVarMemberPath};
 use cairo_lang_syntax::node::TypedStablePtr;
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
@@ -44,15 +44,7 @@ fn test_create_graph(
     } else {
         LoweringDatabaseForTesting::default()
     };
-    let (test_function, semantic_diagnostics) = setup_test_function_ex(
-        db,
-        inputs["function_code"].as_str(),
-        "foo",
-        inputs.get("module_code").map_or("", String::as_str),
-        None,
-        None,
-    )
-    .split();
+    let (test_function, semantic_diagnostics) = setup_test_function(db, inputs).split();
     let semantic_db: &dyn Database = db;
 
     // Extract the expression from the function's body.

--- a/crates/cairo-lang-lowering/src/lower/flow_control/test_data/if
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/test_data/if
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: bool) -> felt252 {
     if x {
         3
@@ -57,15 +58,14 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+fn bar() {}
+#[target_function]
 fn foo(x: bool) {
     if x {
         bar();
     }
 }
-
-//! > module_code
-fn bar() {}
 
 //! > graph
 Root: 3
@@ -112,7 +112,10 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn modify(ref x: felt252) -> felt252 nopanic;
+#[target_function]
 fn foo(mut x: felt252, mut y: felt252) -> felt252 {
     if let Some(z) = Some(modify(ref x)) && let Some(_) = Some(modify(ref y)) {
         x + y + z
@@ -120,10 +123,6 @@ fn foo(mut x: felt252, mut y: felt252) -> felt252 {
         x + y
     }
 }
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn modify(ref x: felt252) -> felt252 nopanic;
 
 //! > graph
 Root: 6
@@ -196,7 +195,15 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+struct MyStruct {
+    a: felt252,
+    b: felt252,
+}
+
+#[allow(extern_outside_corelib)]
+extern fn modify(ref x: felt252) -> felt252 nopanic;
+#[target_function]
 fn foo(mut x: felt252, mut y: MyStruct) -> (MyStruct, bool) {
     if let Some(_) = Some(modify(ref x))
         && let Some(_) = Some(modify(ref y.a))
@@ -206,15 +213,6 @@ fn foo(mut x: felt252, mut y: MyStruct) -> (MyStruct, bool) {
         (y, false)
     }
 }
-
-//! > module_code
-struct MyStruct {
-    a: felt252,
-    b: felt252,
-}
-
-#[allow(extern_outside_corelib)]
-extern fn modify(ref x: felt252) -> felt252 nopanic;
 
 //! > graph
 Root: 7
@@ -310,7 +308,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     if panic!() {
         0
@@ -330,7 +329,7 @@ Root: 3
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable clause.
- --> lib.cairo:4:12-6:5
+ --> lib.cairo:5:12-7:5
       } else {
  ____________^
 |         1
@@ -338,7 +337,7 @@ warning[E3004]: Unreachable clause.
 |_____^
 
 warning[E3004]: Unreachable clause.
- --> lib.cairo:2:17-4:5
+ --> lib.cairo:3:17-5:5
       if panic!() {
  _________________^
 |         0
@@ -366,7 +365,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     if true {
         panic!()
@@ -428,7 +428,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     if true {
         return 0;
@@ -485,7 +486,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: Option<Option<felt252>>) -> felt252 {
     if let Some(Some(_)) = x {
         0
@@ -558,7 +560,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     if let Some(_) = Some(0) && panic!() {
         0
@@ -580,7 +583,7 @@ Root: 5
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable clause.
- --> lib.cairo:2:42-4:5
+ --> lib.cairo:3:42-5:5
       if let Some(_) = Some(0) && panic!() {
  __________________________________________^
 |         0
@@ -629,7 +632,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: Option<felt252>) -> felt252 {
     if let Some(_) | None = x {
         0
@@ -648,7 +652,7 @@ Root: 2
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable clause.
- --> lib.cairo:4:12-6:5
+ --> lib.cairo:5:12-7:5
       } else {
  ____________^
 |         1
@@ -670,7 +674,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true, skip_lowering: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: [u16; 2]) -> felt252 {
     if let [_, _] = x {
         0
@@ -690,7 +695,7 @@ Root: 3
 
 //! > lowering_diagnostics
 error[E3004]: Unsupported type in if-let. Type: `[core::integer::u16; 2]`.
- --> lib.cairo:2:12
+ --> lib.cairo:3:12
     if let [_, _] = x {
            ^^^^^^
 

--- a/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
@@ -3,7 +3,15 @@
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum Color {
+    Red,
+    Green,
+    Blue,
+    Black,
+    White,
+}
+#[target_function]
 fn foo(color: Color) -> felt252 {
     match color {
         Color::Red | Color::Green(_) => 1,
@@ -11,15 +19,6 @@ fn foo(color: Color) -> felt252 {
         Color::Blue | Color::Green => 3,
         _ => 4,
     }
-}
-
-//! > module_code
-enum Color {
-    Red,
-    Green,
-    Blue,
-    Black,
-    White,
 }
 
 //! > graph
@@ -35,7 +34,7 @@ Root: 5
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:12:39
+ --> lib.cairo:13:39
         Color::Blue | Color::Green => 3,
                                       ^
 
@@ -102,21 +101,20 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum Color {
+    Red: felt252,
+    Green: felt252,
+    Blue: felt252,
+    Black,
+}
+#[target_function]
 fn foo(color: Color) -> felt252 {
     match color {
         Color::Red(x) | Color::Green(x) => 2 * x,
         Color::Blue(x) => x,
         _ => 0,
     }
-}
-
-//! > module_code
-enum Color {
-    Red: felt252,
-    Green: felt252,
-    Blue: felt252,
-    Black,
 }
 
 //! > graph
@@ -186,20 +184,19 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+#[target_function]
 fn foo(color: (Color, Color)) -> felt252 {
     match color {
         (Color::Red, _) => 1,
         (_, Color::Red) => 2,
         _ => 3,
     }
-}
-
-//! > module_code
-enum Color {
-    Red,
-    Green,
-    Blue,
 }
 
 //! > graph
@@ -287,19 +284,18 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum Color {
+    Red,
+    Green,
+}
+#[target_function]
 fn foo(color: Option<(Color, Color)>) -> felt252 {
     match color {
         Some((Color::Red, _)) | None => 1,
         Some((_, Color::Red)) => 2,
         _ => 3,
     }
-}
-
-//! > module_code
-enum Color {
-    Red,
-    Green,
 }
 
 //! > graph
@@ -384,20 +380,19 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false, skip_lowering: true)
 
-//! > function_code
+//! > cairo_code
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+#[target_function]
 fn foo(color: (Option<Color>, Color)) -> felt252 {
     match color {
         (Some(Color::Red), Color::Red) | (Some(Color::Green), Color::Red) | (None, Color::Red) => 1,
         (_, Color::Green) => 2,
         _ => 3,
     }
-}
-
-//! > module_code
-enum Color {
-    Red,
-    Green,
-    Blue,
 }
 
 //! > graph
@@ -427,22 +422,21 @@ Root: 10
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false, skip_lowering: true)
 
-//! > function_code
-// Tests that the same-node optimization is not applied when the inner value is used (for
-// future match or pattern binding).
-fn foo(x: Enum1) -> felt252 {
-    match x {
-        Enum1::A(Enum2::B(x)) => x,
-    }
-}
-
-//! > module_code
+//! > cairo_code
 enum Enum1 {
     A: Enum2,
 }
 
 enum Enum2 {
     B: felt252,
+}
+// Tests that the same-node optimization is not applied when the inner value is used (for
+// future match or pattern binding).
+#[target_function]
+fn foo(x: Enum1) -> felt252 {
+    match x {
+        Enum1::A(Enum2::B(x)) => x,
+    }
 }
 
 //! > graph
@@ -466,7 +460,8 @@ Root: 4
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     match x {
         2 | 4 => x,
@@ -558,7 +553,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u16) -> u16 {
     match x {
         2 | 4 => x,
@@ -635,7 +631,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false, skip_lowering: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u16) -> u16 {
     match x {
         0 | 2 | 4 | 5 | 6 | 7 => x,
@@ -750,7 +747,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u128) -> u128 {
     match x {
         0 | 2 | 4 | 5 | 6 | 7 | 100000000000000000000 => x,
@@ -915,7 +913,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252, y: felt252) -> felt252 {
     match (x, y) {
         (1, 3) => 0,
@@ -1138,7 +1137,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: Option<felt252>) -> felt252 {
     match x {
         _ => 0,
@@ -1169,20 +1169,19 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum Color {
+    Red: felt252,
+    Green,
+    Blue,
+}
+#[target_function]
 fn foo(color: @(Color, Color)) -> felt252 {
     match color {
         // x can be bound to different tuple items.
         (Color::Red(x), _) | (_, Color::Red(x)) => *x,
         _ => 0,
     }
-}
-
-//! > module_code
-enum Color {
-    Red: felt252,
-    Green,
-    Blue,
 }
 
 //! > graph
@@ -1275,20 +1274,19 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+#[target_function]
 fn foo(color: (Color, Color)) -> Color {
     match color {
         // x can be bound to different tuple items.
         (Color::Red, x) | (x, Color::Red) => x,
         _ => Color::Green,
     }
-}
-
-//! > module_code
-enum Color {
-    Red,
-    Green,
-    Blue,
 }
 
 //! > graph
@@ -1381,18 +1379,17 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+struct MyStruct {
+    a: Option<Option<felt252>>,
+    b: (Option<felt252>, felt252, felt252),
+}
+#[target_function]
 fn foo(x: MyStruct) -> felt252 {
     match x {
         MyStruct { a: Some(Some(_)), .. } => 1,
         MyStruct { b: (None, _, _), .. } => 1,
     }
-}
-
-//! > module_code
-struct MyStruct {
-    a: Option<Option<felt252>>,
-    b: (Option<felt252>, felt252, felt252),
 }
 
 //! > graph
@@ -1412,7 +1409,7 @@ Root: 9
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `MyStruct{a: Some(None(_)), b: (Some(_), _, _)}` not covered.
- --> lib.cairo:6:5-9:5
+ --> lib.cairo:7:5-10:5
       match x {
  _____^
 | ...
@@ -1429,7 +1426,8 @@ Parameters: v0: test::MyStruct
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: (Option<(felt252, felt252)>, felt252)) -> felt252 {
     match x {
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
@@ -1449,33 +1447,33 @@ Root: 7
 
 //! > semantic_diagnostics
 error[E2103]: Mismatched types: pattern cannot match against type "core::felt252".
- --> lib.cairo:3:13
+ --> lib.cairo:4:13
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
             ^^
 
 error[E2103]: Mismatched types: pattern cannot match against type "core::option::Option::<(core::felt252, core::felt252)>".
- --> lib.cairo:3:20
+ --> lib.cairo:4:20
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
                    ^^
 
 error[E2103]: Mismatched types: pattern cannot match against type "(core::felt252, core::felt252)".
- --> lib.cairo:3:35
+ --> lib.cairo:4:35
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
                                   ^^^^
 
 //! > lowering_diagnostics
 error[E3007]: Unexpected error has occurred, Please submit a full bug report. See https://github.com/starkware-libs/cairo/issues/new/choose for instructions.
- --> lib.cairo:3:20
+ --> lib.cairo:4:20
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
                    ^^
 
 error[E3007]: Unexpected error has occurred, Please submit a full bug report. See https://github.com/starkware-libs/cairo/issues/new/choose for instructions.
- --> lib.cairo:3:35
+ --> lib.cairo:4:35
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
                                   ^^^^
 
 error[E3007]: Unexpected error has occurred, Please submit a full bug report. See https://github.com/starkware-libs/cairo/issues/new/choose for instructions.
- --> lib.cairo:3:13
+ --> lib.cairo:4:13
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
             ^^
 
@@ -1489,7 +1487,8 @@ Parameters: v0: (core::option::Option::<(core::felt252, core::felt252)>, core::f
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true, skip_lowering: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: u8) -> bool {
     match a {
         255 | 256 | 257 => false,
@@ -1509,12 +1508,12 @@ Root: 6
 
 //! > semantic_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u8.
- --> lib.cairo:3:15
+ --> lib.cairo:4:15
         255 | 256 | 257 => false,
               ^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u8.
- --> lib.cairo:3:21
+ --> lib.cairo:4:21
         255 | 256 | 257 => false,
                     ^^^
 
@@ -1529,7 +1528,8 @@ error[E2008]: The value does not fit within the range of type core::integer::u8.
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: Option<felt252>) -> felt252 {
     match x {}
 }
@@ -1543,7 +1543,7 @@ Root: 1
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `_` not covered.
- --> lib.cairo:2:5
+ --> lib.cairo:3:5
     match x {}
     ^^^^^^^^^^
 
@@ -1557,7 +1557,8 @@ Parameters: v0: core::option::Option::<core::felt252>
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: never) -> felt252 {
     match x {}
 }
@@ -1586,14 +1587,13 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
-fn foo(x: NeverEnum) -> felt252 {
-    match x {}
-}
-
-//! > module_code
+//! > cairo_code
 enum NeverEnum {
     Never: never,
+}
+#[target_function]
+fn foo(x: NeverEnum) -> felt252 {
+    match x {}
 }
 
 //! > graph
@@ -1605,7 +1605,7 @@ Root: 1
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `_` not covered.
- --> lib.cairo:5:5
+ --> lib.cairo:6:5
     match x {}
     ^^^^^^^^^^
 
@@ -1619,19 +1619,18 @@ Parameters: v0: test::NeverEnum
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+struct MyStruct {
+    a: Option<felt252>,
+    b: (Option<felt252>, felt252),
+    c: Option<felt252>,
+}
+#[target_function]
 fn foo(x: MyStruct) -> felt252 {
     match x {
         MyStruct { b: (None, 0), a: Some(x), .. } => x,
         _ => 0,
     }
-}
-
-//! > module_code
-struct MyStruct {
-    a: Option<felt252>,
-    b: (Option<felt252>, felt252),
-    c: Option<felt252>,
 }
 
 //! > graph
@@ -1716,22 +1715,7 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
-fn foo(mut x: felt252) -> felt252 {
-    match bar(ref x) {
-        MyEnum::Pair1(a) => {
-            let (b, _c) = a;
-            b.into() + x
-        },
-        MyEnum::Pair2((_, c)) => { c.into() + x },
-        MyEnum::Struct(MyStruct { c, .. }) => { c.into() + x },
-        MyEnum::Single(a) => { a.into() + x },
-        MyEnum::Opt(Some(a)) => { a.into() + x },
-        _ => x + 1,
-    }
-}
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     Single: u8,
     Pair1: (u8, u8),
@@ -1748,6 +1732,20 @@ struct MyStruct {
 
 #[allow(extern_outside_corelib)]
 extern fn bar(ref x: felt252) -> MyEnum nopanic;
+#[target_function]
+fn foo(mut x: felt252) -> felt252 {
+    match bar(ref x) {
+        MyEnum::Pair1(a) => {
+            let (b, _c) = a;
+            b.into() + x
+        },
+        MyEnum::Pair2((_, c)) => { c.into() + x },
+        MyEnum::Struct(MyStruct { c, .. }) => { c.into() + x },
+        MyEnum::Single(a) => { a.into() + x },
+        MyEnum::Opt(Some(a)) => { a.into() + x },
+        _ => x + 1,
+    }
+}
 
 //! > graph
 Root: 15
@@ -1864,17 +1862,16 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar() -> Option<felt252> nopanic;
+#[target_function]
 fn foo() -> felt252 {
     match bar() {
         Some(a) => a,
         _x => 0,
     }
 }
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar() -> Option<felt252> nopanic;
 
 //! > graph
 Root: 5
@@ -1943,16 +1940,15 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar() -> Option<felt252> nopanic;
+#[target_function]
 fn foo() -> felt252 {
     match bar() {
         _ => 0,
     }
 }
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar() -> Option<felt252> nopanic;
 
 //! > graph
 Root: 1
@@ -1999,7 +1995,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true, skip_lowering: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u256) -> felt252 {
     match x {
         0 => 1,
@@ -2038,7 +2035,7 @@ Root: 19
 
 //! > semantic_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u256.
- --> lib.cairo:10:9
+ --> lib.cairo:11:9
         0x10000000000000000000000000000000000000000000000000000000000000000 => 7,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -2053,7 +2050,8 @@ error[E2008]: The value does not fit within the range of type core::integer::u25
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true, skip_lowering: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u256) -> felt252 {
     match x {
         // Value out of range: must report E3009 only, no spurious E3004 non-exhaustive.
@@ -2075,7 +2073,7 @@ Root: 7
 
 //! > semantic_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u256.
- --> lib.cairo:4:9
+ --> lib.cairo:5:9
         0x10000000000000000000000000000000000000000000000000000000000000000 => 1,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -2090,7 +2088,8 @@ error[E2008]: The value does not fit within the range of type core::integer::u25
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true, skip_lowering: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u256) -> felt252 {
     match x {
         // Out of range: the arm can never match, so the match is non-exhaustive (E3009 + E3004).
@@ -2111,13 +2110,13 @@ Root: 7
 
 //! > semantic_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u256.
- --> lib.cairo:4:9
+ --> lib.cairo:5:9
         0x10000000000000000000000000000000000000000000000000000000000000000 => 1,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `u256{low: _, high: _}` not covered.
- --> lib.cairo:2:5-5:5
+ --> lib.cairo:3:5-6:5
       match x {
  _____^
 | ...
@@ -2133,8 +2132,9 @@ error[E3004]: Match is non-exhaustive: `u256{low: _, high: _}` not covered.
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false, skip_lowering: true)
 
-//! > function_code
+//! > cairo_code
 // TODO(lior): Consider optimizing to avoid the multiple `EqualsLiteral` nodes.
+#[target_function]
 fn foo(x: u256) -> u256 {
     match x {
         0 | 2 | 4 | 5 | 6 | 7 => x,
@@ -2182,7 +2182,8 @@ Root: 22
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false, skip_lowering: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u256) -> u256 {
     match x {
         0x000000000000000000000000000000004 | 0x200000000000000000000000000000004 |
@@ -2218,15 +2219,7 @@ Root: 8
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: (@@Box<@@@Outer>, @@@Inner)) -> (@@Box<@@@Leaf>,) {
-    match x {
-        (Outer::Wrap(Inner::Next(leaf)), Inner::Next(_)) => (leaf,),
-        _ => (@@BoxTrait::new(@@@Leaf::A(5)),),
-    }
-}
-
-//! > module_code
+//! > cairo_code
 enum Outer {
     Wrap: Inner,
     Other: felt252,
@@ -2238,6 +2231,13 @@ enum Inner {
 
 enum Leaf {
     A: felt252,
+}
+#[target_function]
+fn foo(x: (@@Box<@@@Outer>, @@@Inner)) -> (@@Box<@@@Leaf>,) {
+    match x {
+        (Outer::Wrap(Inner::Next(leaf)), Inner::Next(_)) => (leaf,),
+        _ => (@@BoxTrait::new(@@@Leaf::A(5)),),
+    }
 }
 
 //! > graph
@@ -2304,13 +2304,12 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum Never {}
+#[target_function]
 fn foo(x: Box<Never>) -> felt252 {
     match x {}
 }
-
-//! > module_code
-enum Never {}
 
 //! > graph
 Root: 1
@@ -2336,19 +2335,18 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    Variant1: felt252,
+    Variant2: felt252,
+}
+#[target_function]
 fn foo(x: Box<(MyEnum, MyEnum)>) -> Box<felt252> {
     match x {
         (MyEnum::Variant1(x), MyEnum::Variant1(_)) => x,
         (MyEnum::Variant2(x), MyEnum::Variant2(_)) => x,
         _ => BoxTrait::new(2),
     }
-}
-
-//! > module_code
-enum MyEnum {
-    Variant1: felt252,
-    Variant2: felt252,
 }
 
 //! > graph
@@ -2434,7 +2432,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a, b] => *a + *b,
@@ -2528,7 +2527,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a] => *a,
@@ -2611,7 +2611,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a, b] => *a + *b,
@@ -2635,7 +2636,7 @@ Root: 7
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:5:22
+ --> lib.cairo:6:22
         [a, b, c] => *a + *b + *c,
                      ^^^^^^^^^^^^
 
@@ -2681,7 +2682,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a, b] => *a + *b,
@@ -2705,7 +2707,7 @@ Root: 7
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:4:19
+ --> lib.cairo:5:19
         [a, b] => *a + *b,
                   ^^^^^^^
 
@@ -2751,7 +2753,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a, b] | [a, b, _] => *a + *b,
@@ -2841,7 +2844,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<bool>) -> felt252 {
     match s {
         [true, true] => 1,
@@ -2937,7 +2941,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a] => *a,
@@ -2962,7 +2967,7 @@ Root: 9
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `_` not covered.
- --> lib.cairo:2:5-5:5
+ --> lib.cairo:3:5-6:5
       match s {
  _____^
 | ...
@@ -2979,7 +2984,8 @@ Parameters: v0: core::array::Span::<core::integer::u32>
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a] => *a,
@@ -3002,7 +3008,7 @@ Root: 6
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:5:19
+ --> lib.cairo:6:19
         [a, b] => *a + *b,
                   ^^^^^^^
 
@@ -3046,7 +3052,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [a] => *a,
@@ -3072,12 +3079,12 @@ Root: 8
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:6:37
+ --> lib.cairo:7:37
         Span { snapshot: inner } => 2 * inner.len(),
                                     ^^^^^^^^^^^^^^^
 
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:5:19
+ --> lib.cairo:6:19
         [a, b] => *a + *b,
                   ^^^^^^^
 
@@ -3121,7 +3128,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: *)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>, val: u32) -> u32 {
     match (s, val) {
         ([a], v) => *a + v,
@@ -3313,7 +3321,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: *)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         Span { snapshot: x } => x.len(),
@@ -3333,7 +3342,7 @@ Root: 4
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:4:33
+ --> lib.cairo:5:33
         Span { snapshot: y } => y.len() + 1,
                                 ^^^^^^^^^^^
 
@@ -3353,7 +3362,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: *)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>, v: u32) -> u32 {
     match (s, v) {
         ([a], _) => *a,
@@ -3463,7 +3473,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: *)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<bool>, v: u32) -> u32 {
     match (s, v) {
         ([true], _) => 1,
@@ -3585,7 +3596,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Option<Span<u32>>) -> u32 {
     match s {
         Some([a]) => *a,
@@ -3691,7 +3703,8 @@ End:
 //! > test_runner_name
 test_create_graph(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Option<Span<u32>>) -> u32 {
     match s {
         Some([a]) => *a,
@@ -3720,7 +3733,7 @@ Root: 11
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `Some(_)` not covered.
- --> lib.cairo:2:5-7:5
+ --> lib.cairo:3:5-8:5
       match s {
  _____^
 | ...
@@ -3737,7 +3750,8 @@ Parameters: v0: core::option::Option::<core::array::Span::<core::integer::u32>>
 //! > test_runner_name
 test_create_graph(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: Span<u32>) -> u32 {
     match s {
         [_, _] | _ => 0,

--- a/crates/cairo-lang-lowering/src/lower/test_data/closure
+++ b/crates/cairo-lang-lowering/src/lower/test_data/closure
@@ -3,15 +3,13 @@
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Felt252Dict<felt252>) {
     || {
         let _ = a;
     };
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -22,7 +20,7 @@ Main:
 Parameters: v0: core::dict::Felt252Dict::<core::felt252>
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:2:5: 2:7}) <- struct_construct(v0)
+  (v1: {closure@lib.cairo:3:5: 3:7}) <- struct_construct(v0)
   (v2: ()) <- struct_construct()
 End:
   Return(v2)
@@ -41,7 +39,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
     || {
     ^^
 
-Parameters: v0: {closure@lib.cairo:2:5: 2:7}
+Parameters: v0: {closure@lib.cairo:3:5: 3:7}
 blk0 (root):
 Statements:
   (v1: core::dict::Felt252Dict::<core::felt252>) <- struct_destructure(v0)
@@ -51,7 +49,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: core::RangeCheck, v1: core::SegmentArena, v2: core::gas::GasBuiltin, v3: {closure@lib.cairo:2:5: 2:7}
+Parameters: v0: core::RangeCheck, v1: core::SegmentArena, v2: core::gas::GasBuiltin, v3: {closure@lib.cairo:3:5: 3:7}
 blk0 (root):
 Statements:
   (v4: core::dict::Felt252Dict::<core::felt252>) <- struct_destructure(v3)
@@ -64,7 +62,7 @@ Generated core::ops::function::FnOnce::call lowering for source location:
     || {
     ^^
 
-Parameters: v0: {closure@lib.cairo:2:5: 2:7}, v1: ()
+Parameters: v0: {closure@lib.cairo:3:5: 3:7}, v1: ()
 blk0 (root):
 Statements:
   (v2: core::dict::Felt252Dict::<core::felt252>) <- struct_destructure(v0)
@@ -75,7 +73,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: core::RangeCheck, v1: core::SegmentArena, v2: core::gas::GasBuiltin, v3: {closure@lib.cairo:2:5: 2:7}, v4: ()
+Parameters: v0: core::RangeCheck, v1: core::SegmentArena, v2: core::gas::GasBuiltin, v3: {closure@lib.cairo:3:5: 3:7}, v4: ()
 blk0 (root):
 Statements:
   (v5: core::dict::Felt252Dict::<core::felt252>) <- struct_destructure(v3)
@@ -90,18 +88,7 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
-fn foo(a: PanicDestructable) {
-    || {
-        let PanicDestructable { } = a;
-    };
-    panic!("Panic");
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct PanicDestructable {}
 
 impl MyPanicDestruct of PanicDestruct<PanicDestructable> {
@@ -110,6 +97,13 @@ impl MyPanicDestruct of PanicDestruct<PanicDestructable> {
     fn panic_destruct(self: PanicDestructable, ref panic: Panic) nopanic {
         let PanicDestructable { } = self;
     }
+}
+#[target_function]
+fn foo(a: PanicDestructable) {
+    || {
+        let PanicDestructable { } = a;
+    };
+    panic!("Panic");
 }
 
 //! > semantic_diagnostics
@@ -121,7 +115,7 @@ Main:
 Parameters: v0: test::PanicDestructable
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:11:5: 11:7}) <- struct_construct(v0)
+  (v1: {closure@lib.cairo:12:5: 12:7}) <- struct_construct(v0)
   (v2: core::array::Array::<core::bytes_31::bytes31>) <- core::array::array_new::<core::bytes_31::bytes31>()
   (v3: core::felt252) <- 345232009571
   (v4: core::internal::bounded_int::BoundedInt::<0, 30>) <- 5
@@ -158,7 +152,7 @@ Generated core::traits::PanicDestruct::panic_destruct lowering for source locati
     || {
     ^^
 
-Parameters: v0: {closure@lib.cairo:11:5: 11:7}, v1: core::panics::Panic
+Parameters: v0: {closure@lib.cairo:12:5: 12:7}, v1: core::panics::Panic
 blk0 (root):
 Statements:
   (v2: test::PanicDestructable) <- struct_destructure(v0)
@@ -168,7 +162,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:11:5: 11:7}, v1: core::panics::Panic
+Parameters: v0: {closure@lib.cairo:12:5: 12:7}, v1: core::panics::Panic
 blk0 (root):
 Statements:
   (v2: test::PanicDestructable) <- struct_destructure(v0)
@@ -181,7 +175,7 @@ Generated core::ops::function::FnOnce::call lowering for source location:
     || {
     ^^
 
-Parameters: v0: {closure@lib.cairo:11:5: 11:7}, v1: ()
+Parameters: v0: {closure@lib.cairo:12:5: 12:7}, v1: ()
 blk0 (root):
 Statements:
   (v2: test::PanicDestructable) <- struct_destructure(v0)
@@ -193,7 +187,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:11:5: 11:7}, v1: ()
+Parameters: v0: {closure@lib.cairo:12:5: 12:7}, v1: ()
 blk0 (root):
 Statements:
   (v2: test::PanicDestructable) <- struct_destructure(v0)
@@ -208,20 +202,16 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn identity<T>(t: T) -> T {
+    t
+}
+#[target_function]
 fn foo(a: u32) {
     let c = || a;
     identity(c);
     identity(c);
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn identity<T>(t: T) -> T {
-    t
 }
 
 //! > semantic_diagnostics
@@ -233,9 +223,9 @@ Main:
 Parameters: v0: core::integer::u32
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:6:13: 6:15}) <- struct_construct(v0)
-  (v2: {closure@lib.cairo:6:13: 6:15}) <- test::identity::<{closure@lib.cairo:6:13: 6:15}>(v1)
-  (v3: {closure@lib.cairo:6:13: 6:15}) <- test::identity::<{closure@lib.cairo:6:13: 6:15}>(v1)
+  (v1: {closure@lib.cairo:7:13: 7:15}) <- struct_construct(v0)
+  (v2: {closure@lib.cairo:7:13: 7:15}) <- test::identity::<{closure@lib.cairo:7:13: 7:15}>(v1)
+  (v3: {closure@lib.cairo:7:13: 7:15}) <- test::identity::<{closure@lib.cairo:7:13: 7:15}>(v1)
   (v4: ()) <- struct_construct()
 End:
   Return(v4)
@@ -245,9 +235,9 @@ Final lowering:
 Parameters: v0: core::integer::u32
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:6:13: 6:15}) <- struct_construct(v0)
-  (v2: {closure@lib.cairo:6:13: 6:15}) <- test::identity::<{closure@lib.cairo:6:13: 6:15}>(v1)
-  (v3: {closure@lib.cairo:6:13: 6:15}) <- test::identity::<{closure@lib.cairo:6:13: 6:15}>(v1)
+  (v1: {closure@lib.cairo:7:13: 7:15}) <- struct_construct(v0)
+  (v2: {closure@lib.cairo:7:13: 7:15}) <- test::identity::<{closure@lib.cairo:7:13: 7:15}>(v1)
+  (v3: {closure@lib.cairo:7:13: 7:15}) <- test::identity::<{closure@lib.cairo:7:13: 7:15}>(v1)
 End:
   Return()
 
@@ -256,7 +246,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
     let c = || a;
             ^^
 
-Parameters: v0: {closure@lib.cairo:6:13: 6:15}
+Parameters: v0: {closure@lib.cairo:7:13: 7:15}
 blk0 (root):
 Statements:
   (v1: core::integer::u32) <- struct_destructure(v0)
@@ -266,7 +256,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:6:13: 6:15}
+Parameters: v0: {closure@lib.cairo:7:13: 7:15}
 blk0 (root):
 Statements:
 End:
@@ -277,10 +267,10 @@ Generated core::ops::function::Fn::call lowering for source location:
     let c = || a;
             ^^
 
-Parameters: v0: @{closure@lib.cairo:6:13: 6:15}, v2: ()
+Parameters: v0: @{closure@lib.cairo:7:13: 7:15}, v2: ()
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:6:13: 6:15}) <- desnap(v0)
+  (v1: {closure@lib.cairo:7:13: 7:15}) <- desnap(v0)
   (v3: core::integer::u32) <- struct_destructure(v1)
   () <- struct_destructure(v2)
 End:
@@ -288,10 +278,10 @@ End:
 
 
 Final lowering:
-Parameters: v0: @{closure@lib.cairo:6:13: 6:15}, v1: ()
+Parameters: v0: @{closure@lib.cairo:7:13: 7:15}, v1: ()
 blk0 (root):
 Statements:
-  (v2: {closure@lib.cairo:6:13: 6:15}) <- desnap(v0)
+  (v2: {closure@lib.cairo:7:13: 7:15}) <- desnap(v0)
   (v3: core::integer::u32) <- struct_destructure(v2)
 End:
   Return(v3)
@@ -303,7 +293,12 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn bar(a: felt252) -> felt252 {
+    a + 1
+}
+#[target_function]
 fn foo(a: u32) {
     let f = |a: felt252| {
         let mut b = @0;
@@ -316,15 +311,6 @@ fn foo(a: u32) {
     let _ = f(0);
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn bar(a: felt252) -> felt252 {
-    a + 1
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -334,11 +320,11 @@ Main:
 Parameters: v0: core::integer::u32
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:6:13: 6:25}) <- struct_construct()
-  (v2: {closure@lib.cairo:6:13: 6:25}, v3: @{closure@lib.cairo:6:13: 6:25}) <- snapshot(v1)
+  (v1: {closure@lib.cairo:7:13: 7:25}) <- struct_construct()
+  (v2: {closure@lib.cairo:7:13: 7:25}, v3: @{closure@lib.cairo:7:13: 7:25}) <- snapshot(v1)
   (v4: core::felt252) <- 0
   (v5: (core::felt252,)) <- struct_construct(v4)
-  (v6: ()) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:6:13: 6:25}(v3, v5)
+  (v6: ()) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:7:13: 7:25}(v3, v5)
   (v7: ()) <- struct_construct()
 End:
   Return(v7)
@@ -373,7 +359,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
     let f = |a: felt252| {
             ^^^^^^^^^^^^
 
-Parameters: v0: {closure@lib.cairo:6:13: 6:25}
+Parameters: v0: {closure@lib.cairo:7:13: 7:25}
 blk0 (root):
 Statements:
   () <- struct_destructure(v0)
@@ -383,7 +369,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:6:13: 6:25}
+Parameters: v0: {closure@lib.cairo:7:13: 7:25}
 blk0 (root):
 Statements:
 End:
@@ -394,10 +380,10 @@ Generated core::ops::function::Fn::call lowering for source location:
     let f = |a: felt252| {
             ^^^^^^^^^^^^
 
-Parameters: v0: @{closure@lib.cairo:6:13: 6:25}, v2: (core::felt252,)
+Parameters: v0: @{closure@lib.cairo:7:13: 7:25}, v2: (core::felt252,)
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:6:13: 6:25}) <- desnap(v0)
+  (v1: {closure@lib.cairo:7:13: 7:25}) <- desnap(v0)
   () <- struct_destructure(v1)
   (v3: core::felt252) <- struct_destructure(v2)
   (v4: core::felt252) <- 0
@@ -434,7 +420,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: @{closure@lib.cairo:6:13: 6:25}, v1: (core::felt252,)
+Parameters: v0: @{closure@lib.cairo:7:13: 7:25}, v1: (core::felt252,)
 blk0 (root):
 Statements:
   (v2: core::felt252) <- 2
@@ -464,7 +450,11 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+fn apply<F, +Drop<F>, impl func: core::ops::FnOnce<F, (felt252,)>, +Drop<func::Output>>(f: F) {
+    f(2);
+}
+#[target_function]
 fn foo() {
     let uninlined_closure = |mut a| {
         // Making sure the closure is long enough to not be inlined.
@@ -480,14 +470,6 @@ fn foo() {
     apply(uninlined_closure);
 }
 
-//! > function_name
-foo
-
-//! > module_code
-fn apply<F, +Drop<F>, impl func: core::ops::FnOnce<F, (felt252,)>, +Drop<func::Output>>(f: F) {
-    f(2);
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -497,8 +479,8 @@ Main:
 Parameters:
 blk0 (root):
 Statements:
-  (v0: {closure@lib.cairo:5:29: 5:36}) <- struct_construct()
-  (v1: ()) <- test::apply::<{closure@lib.cairo:5:29: 5:36}, Generated core::traits::Drop::<{closure@lib.cairo:5:29: 5:36}>, core::ops::function::FnOnceImpl::<{closure@lib.cairo:5:29: 5:36}, (core::felt252,), core::traits::DestructFromDrop::<{closure@lib.cairo:5:29: 5:36}, Generated core::traits::Drop::<{closure@lib.cairo:5:29: 5:36}>>, Generated core::ops::function::Fn::<{closure@lib.cairo:5:29: 5:36}, (core::felt252,)>>, core::felt252Drop>(v0)
+  (v0: {closure@lib.cairo:6:29: 6:36}) <- struct_construct()
+  (v1: ()) <- test::apply::<{closure@lib.cairo:6:29: 6:36}, Generated core::traits::Drop::<{closure@lib.cairo:6:29: 6:36}>, core::ops::function::FnOnceImpl::<{closure@lib.cairo:6:29: 6:36}, (core::felt252,), core::traits::DestructFromDrop::<{closure@lib.cairo:6:29: 6:36}, Generated core::traits::Drop::<{closure@lib.cairo:6:29: 6:36}>>, Generated core::ops::function::Fn::<{closure@lib.cairo:6:29: 6:36}, (core::felt252,)>>, core::felt252Drop>(v0)
   (v2: ()) <- struct_construct()
 End:
   Return(v2)
@@ -516,7 +498,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
     let uninlined_closure = |mut a| {
                             ^^^^^^^
 
-Parameters: v0: {closure@lib.cairo:5:29: 5:36}
+Parameters: v0: {closure@lib.cairo:6:29: 6:36}
 blk0 (root):
 Statements:
   () <- struct_destructure(v0)
@@ -526,7 +508,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:5:29: 5:36}
+Parameters: v0: {closure@lib.cairo:6:29: 6:36}
 blk0 (root):
 Statements:
 End:
@@ -537,10 +519,10 @@ Generated core::ops::function::Fn::call lowering for source location:
     let uninlined_closure = |mut a| {
                             ^^^^^^^
 
-Parameters: v0: @{closure@lib.cairo:5:29: 5:36}, v2: (core::felt252,)
+Parameters: v0: @{closure@lib.cairo:6:29: 6:36}, v2: (core::felt252,)
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:5:29: 5:36}) <- desnap(v0)
+  (v1: {closure@lib.cairo:6:29: 6:36}) <- desnap(v0)
   () <- struct_destructure(v1)
   (v3: core::felt252) <- struct_destructure(v2)
   (v4: core::felt252) <- core::Felt252Add::add(v3, v3)
@@ -573,7 +555,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: @{closure@lib.cairo:5:29: 5:36}, v1: (core::felt252,)
+Parameters: v0: @{closure@lib.cairo:6:29: 6:36}, v1: (core::felt252,)
 blk0 (root):
 Statements:
   (v2: core::felt252) <- struct_destructure(v1)
@@ -612,7 +594,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Array<felt252>) -> u32 {
     let inner = |x| {
         let nested = |y| {
@@ -622,9 +605,6 @@ fn foo(a: Array<felt252>) -> u32 {
     };
     inner(42)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -636,11 +616,11 @@ Parameters: v0: core::array::Array::<core::felt252>
 blk0 (root):
 Statements:
   (v1: core::array::Array::<core::felt252>, v2: @core::array::Array::<core::felt252>) <- snapshot(v0)
-  (v3: {closure@lib.cairo:2:17: 2:20}) <- struct_construct(v2)
-  (v4: {closure@lib.cairo:2:17: 2:20}, v5: @{closure@lib.cairo:2:17: 2:20}) <- snapshot(v3)
+  (v3: {closure@lib.cairo:3:17: 3:20}) <- struct_construct(v2)
+  (v4: {closure@lib.cairo:3:17: 3:20}, v5: @{closure@lib.cairo:3:17: 3:20}) <- snapshot(v3)
   (v6: core::integer::u32) <- 42
   (v7: (core::integer::u32,)) <- struct_construct(v6)
-  (v8: core::integer::u32) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:2:17: 2:20}(v5, v7)
+  (v8: core::integer::u32) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:3:17: 3:20}(v5, v7)
 End:
   Return(v8)
 
@@ -677,7 +657,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
     let inner = |x| {
                 ^^^
 
-Parameters: v0: {closure@lib.cairo:2:17: 2:20}
+Parameters: v0: {closure@lib.cairo:3:17: 3:20}
 blk0 (root):
 Statements:
   (v1: @core::array::Array::<core::felt252>) <- struct_destructure(v0)
@@ -687,7 +667,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:2:17: 2:20}
+Parameters: v0: {closure@lib.cairo:3:17: 3:20}
 blk0 (root):
 Statements:
 End:
@@ -698,7 +678,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
         let nested = |y| {
                      ^^^
 
-Parameters: v0: {closure@lib.cairo:3:22: 3:25}
+Parameters: v0: {closure@lib.cairo:4:22: 4:25}
 blk0 (root):
 Statements:
   (v1: @core::array::Array::<core::felt252>) <- struct_destructure(v0)
@@ -708,7 +688,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:3:22: 3:25}
+Parameters: v0: {closure@lib.cairo:4:22: 4:25}
 blk0 (root):
 Statements:
 End:
@@ -719,10 +699,10 @@ Generated core::ops::function::Fn::call lowering for source location:
         let nested = |y| {
                      ^^^
 
-Parameters: v0: @{closure@lib.cairo:3:22: 3:25}, v2: (core::integer::u32,)
+Parameters: v0: @{closure@lib.cairo:4:22: 4:25}, v2: (core::integer::u32,)
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:3:22: 3:25}) <- desnap(v0)
+  (v1: {closure@lib.cairo:4:22: 4:25}) <- desnap(v0)
   (v3: @core::array::Array::<core::felt252>) <- struct_destructure(v1)
   (v4: core::integer::u32) <- struct_destructure(v2)
   (v5: core::integer::u32) <- core::array::ArrayImpl::<core::felt252>::len(v3)
@@ -732,10 +712,10 @@ End:
 
 
 Final lowering:
-Parameters: v0: core::RangeCheck, v1: @{closure@lib.cairo:3:22: 3:25}, v2: (core::integer::u32,)
+Parameters: v0: core::RangeCheck, v1: @{closure@lib.cairo:4:22: 4:25}, v2: (core::integer::u32,)
 blk0 (root):
 Statements:
-  (v3: {closure@lib.cairo:3:22: 3:25}) <- desnap(v1)
+  (v3: {closure@lib.cairo:4:22: 4:25}) <- desnap(v1)
   (v4: @core::array::Array::<core::felt252>) <- struct_destructure(v3)
   (v5: core::integer::u32) <- core::array::array_len::<core::felt252>(v4)
   (v6: core::integer::u32) <- struct_destructure(v2)
@@ -764,25 +744,25 @@ Generated core::ops::function::Fn::call lowering for source location:
     let inner = |x| {
                 ^^^
 
-Parameters: v0: @{closure@lib.cairo:2:17: 2:20}, v2: (core::integer::u32,)
+Parameters: v0: @{closure@lib.cairo:3:17: 3:20}, v2: (core::integer::u32,)
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:2:17: 2:20}) <- desnap(v0)
+  (v1: {closure@lib.cairo:3:17: 3:20}) <- desnap(v0)
   (v3: @core::array::Array::<core::felt252>) <- struct_destructure(v1)
   (v4: core::integer::u32) <- struct_destructure(v2)
-  (v5: {closure@lib.cairo:3:22: 3:25}) <- struct_construct(v3)
-  (v6: {closure@lib.cairo:3:22: 3:25}, v7: @{closure@lib.cairo:3:22: 3:25}) <- snapshot(v5)
+  (v5: {closure@lib.cairo:4:22: 4:25}) <- struct_construct(v3)
+  (v6: {closure@lib.cairo:4:22: 4:25}, v7: @{closure@lib.cairo:4:22: 4:25}) <- snapshot(v5)
   (v8: (core::integer::u32,)) <- struct_construct(v4)
-  (v9: core::integer::u32) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:3:22: 3:25}(v7, v8)
+  (v9: core::integer::u32) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:4:22: 4:25}(v7, v8)
 End:
   Return(v9)
 
 
 Final lowering:
-Parameters: v0: core::RangeCheck, v1: @{closure@lib.cairo:2:17: 2:20}, v2: (core::integer::u32,)
+Parameters: v0: core::RangeCheck, v1: @{closure@lib.cairo:3:17: 3:20}, v2: (core::integer::u32,)
 blk0 (root):
 Statements:
-  (v3: {closure@lib.cairo:2:17: 2:20}) <- desnap(v1)
+  (v3: {closure@lib.cairo:3:17: 3:20}) <- desnap(v1)
   (v4: @core::array::Array::<core::felt252>) <- struct_destructure(v3)
   (v5: core::integer::u32) <- core::array::array_len::<core::felt252>(v4)
   (v6: core::integer::u32) <- struct_destructure(v2)
@@ -813,7 +793,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(n: felt252) -> felt252 {
     let mut i = n;
     loop {
@@ -827,9 +808,6 @@ fn foo(n: felt252) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -839,7 +817,7 @@ Main:
 Parameters: v0: core::felt252
 blk0 (root):
 Statements:
-  (v2: core::felt252, v1: core::felt252) <- test::foo[51-208](v0)
+  (v2: core::felt252, v1: core::felt252) <- test::foo[70-227](v0)
 End:
   Return(v1)
 
@@ -848,7 +826,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::felt252
 blk0 (root):
 Statements:
-  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[51-208](v0, v1, v2)
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[70-227](v0, v1, v2)
 End:
   Match(match_enum(v5) {
     PanicResult::Ok(v6) => blk1,
@@ -875,7 +853,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
         let f = || -> felt252 {
                 ^^
 
-Parameters: v0: {closure@lib.cairo:4:17: 4:19}
+Parameters: v0: {closure@lib.cairo:5:17: 5:19}
 blk0 (root):
 Statements:
   () <- struct_destructure(v0)
@@ -885,7 +863,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:4:17: 4:19}
+Parameters: v0: {closure@lib.cairo:5:17: 5:19}
 blk0 (root):
 Statements:
 End:
@@ -896,10 +874,10 @@ Generated core::ops::function::Fn::call lowering for source location:
         let f = || -> felt252 {
                 ^^
 
-Parameters: v0: @{closure@lib.cairo:4:17: 4:19}, v2: ()
+Parameters: v0: @{closure@lib.cairo:5:17: 5:19}, v2: ()
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:4:17: 4:19}) <- desnap(v0)
+  (v1: {closure@lib.cairo:5:17: 5:19}) <- desnap(v0)
   () <- struct_destructure(v1)
   () <- struct_destructure(v2)
   (v3: core::felt252) <- 7
@@ -908,7 +886,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: @{closure@lib.cairo:4:17: 4:19}, v1: ()
+Parameters: v0: @{closure@lib.cairo:5:17: 5:19}, v1: ()
 blk0 (root):
 Statements:
   (v2: core::felt252) <- 7
@@ -926,10 +904,10 @@ Generated loop lowering for source location:
 Parameters: v0: core::felt252
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:4:17: 4:19}) <- struct_construct()
-  (v2: {closure@lib.cairo:4:17: 4:19}, v3: @{closure@lib.cairo:4:17: 4:19}) <- snapshot(v1)
+  (v1: {closure@lib.cairo:5:17: 5:19}) <- struct_construct()
+  (v2: {closure@lib.cairo:5:17: 5:19}, v3: @{closure@lib.cairo:5:17: 5:19}) <- snapshot(v1)
   (v4: ()) <- struct_construct()
-  (v5: core::felt252) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:4:17: 4:19}(v3, v4)
+  (v5: core::felt252) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:5:17: 5:19}(v3, v4)
   (v6: core::felt252) <- core::Felt252Add::add(v0, v5)
   (v7: core::felt252, v8: @core::felt252) <- snapshot(v6)
   (v9: core::felt252) <- 100
@@ -953,7 +931,7 @@ End:
 
 blk3:
 Statements:
-  (v16: core::felt252, v15: core::felt252) <- test::foo[51-208](v7)
+  (v16: core::felt252, v15: core::felt252) <- test::foo[70-227](v7)
 End:
   Return(v16, v15)
 
@@ -991,7 +969,7 @@ End:
 blk3:
 Statements:
   (v15: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[51-208](v3, v15, v8)
+  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[70-227](v3, v15, v8)
 End:
   Return(v16, v17, v18)
 
@@ -1003,7 +981,7 @@ End:
   Return(v5, v6, v20)
 
 
-Final lowering of specialized call "test::foo[51-208]":
+Final lowering of specialized call "test::foo[70-227]":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::felt252
 blk0 (root):
 Statements:
@@ -1036,7 +1014,7 @@ End:
 blk3:
 Statements:
   (v15: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[51-208](v3, v15, v8)
+  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::felt252, core::felt252)>) <- test::foo[70-227](v3, v15, v8)
 End:
   Return(v16, v17, v18)
 
@@ -1054,14 +1032,12 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let f = || *(@a);
     f()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1073,10 +1049,10 @@ Parameters: v0: core::felt252
 blk0 (root):
 Statements:
   (v1: core::felt252, v2: @core::felt252) <- snapshot(v0)
-  (v3: {closure@lib.cairo:2:13: 2:15}) <- struct_construct(v2)
-  (v4: {closure@lib.cairo:2:13: 2:15}, v5: @{closure@lib.cairo:2:13: 2:15}) <- snapshot(v3)
+  (v3: {closure@lib.cairo:3:13: 3:15}) <- struct_construct(v2)
+  (v4: {closure@lib.cairo:3:13: 3:15}, v5: @{closure@lib.cairo:3:13: 3:15}) <- snapshot(v3)
   (v6: ()) <- struct_construct()
-  (v7: core::felt252) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:2:13: 2:15}(v5, v6)
+  (v7: core::felt252) <- Generated `core::ops::function::Fn::call` for {closure@lib.cairo:3:13: 3:15}(v5, v6)
 End:
   Return(v7)
 
@@ -1093,7 +1069,7 @@ Generated core::traits::Destruct::destruct lowering for source location:
     let f = || *(@a);
             ^^
 
-Parameters: v0: {closure@lib.cairo:2:13: 2:15}
+Parameters: v0: {closure@lib.cairo:3:13: 3:15}
 blk0 (root):
 Statements:
   (v1: @core::felt252) <- struct_destructure(v0)
@@ -1103,7 +1079,7 @@ End:
 
 
 Final lowering:
-Parameters: v0: {closure@lib.cairo:2:13: 2:15}
+Parameters: v0: {closure@lib.cairo:3:13: 3:15}
 blk0 (root):
 Statements:
 End:
@@ -1114,10 +1090,10 @@ Generated core::ops::function::Fn::call lowering for source location:
     let f = || *(@a);
             ^^
 
-Parameters: v0: @{closure@lib.cairo:2:13: 2:15}, v2: ()
+Parameters: v0: @{closure@lib.cairo:3:13: 3:15}, v2: ()
 blk0 (root):
 Statements:
-  (v1: {closure@lib.cairo:2:13: 2:15}) <- desnap(v0)
+  (v1: {closure@lib.cairo:3:13: 3:15}) <- desnap(v0)
   (v3: @core::felt252) <- struct_destructure(v1)
   () <- struct_destructure(v2)
   (v4: core::felt252) <- desnap(v3)
@@ -1126,10 +1102,10 @@ End:
 
 
 Final lowering:
-Parameters: v0: @{closure@lib.cairo:2:13: 2:15}, v1: ()
+Parameters: v0: @{closure@lib.cairo:3:13: 3:15}, v1: ()
 blk0 (root):
 Statements:
-  (v2: {closure@lib.cairo:2:13: 2:15}) <- desnap(v0)
+  (v2: {closure@lib.cairo:3:13: 3:15}) <- desnap(v0)
   (v3: @core::felt252) <- struct_destructure(v2)
   (v4: core::felt252) <- desnap(v3)
 End:

--- a/crates/cairo-lang-lowering/src/lower/test_data/for
+++ b/crates/cairo-lang-lowering/src/lower/test_data/for
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let mut x = 1;
     let y = x + 1;
@@ -13,9 +14,6 @@ fn foo() -> felt252 {
     }
     x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -43,7 +41,7 @@ Statements:
   (v16: core::array::Array::<core::felt252>, v17: @core::array::Array::<core::felt252>) <- snapshot(v15)
   (v18: core::array::Span::<core::felt252>) <- core::array::ArrayToSpan::<core::felt252>::span(v17)
   (v19: core::array::SpanIter::<core::felt252>) <- core::array::SpanIntoIterator::<core::felt252>::into_iter(v18)
-  (v21: core::array::SpanIter::<core::felt252>, v22: core::felt252, v20: ()) <- test::foo[118-164](v19, v0, v2)
+  (v21: core::array::SpanIter::<core::felt252>, v22: core::felt252, v20: ()) <- test::foo[137-183](v19, v0, v2)
 End:
   Return(v22)
 
@@ -64,7 +62,7 @@ Statements:
   (v11: core::array::Array::<core::felt252>, v12: @core::array::Array::<core::felt252>) <- snapshot(v10)
   (v13: core::array::Span::<core::felt252>) <- struct_construct(v12)
   (v14: core::array::SpanIter::<core::felt252>) <- struct_construct(v13)
-  (v15: core::RangeCheck, v16: core::gas::GasBuiltin, v17: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::felt252, ())>) <- test::foo[118-164]{NotSpecialized, 1, 2, }(v0, v1, v14)
+  (v15: core::RangeCheck, v16: core::gas::GasBuiltin, v17: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::felt252, ())>) <- test::foo[137-183]{NotSpecialized, 1, 2, }(v0, v1, v14)
 End:
   Match(match_enum(v17) {
     PanicResult::Ok(v18) => blk1,
@@ -107,7 +105,7 @@ End:
 blk1:
 Statements:
   (v6: core::felt252) <- core::Felt252Add::add(v1, v2)
-  (v8: core::array::SpanIter::<core::felt252>, v9: core::felt252, v7: ()) <- test::foo[118-164](v4, v6, v2)
+  (v8: core::array::SpanIter::<core::felt252>, v9: core::felt252, v7: ()) <- test::foo[137-183](v4, v6, v2)
 End:
   Return(v8, v9, v7)
 
@@ -144,7 +142,7 @@ Statements:
   (v15: core::felt252) <- core::felt252_add(v3, v4)
   (v16: core::array::Span::<core::felt252>) <- struct_construct(v11)
   (v17: core::array::SpanIter::<core::felt252>) <- struct_construct(v16)
-  (v18: core::RangeCheck, v19: core::gas::GasBuiltin, v20: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::felt252, ())>) <- test::foo[118-164](v5, v14, v17, v15, v4)
+  (v18: core::RangeCheck, v19: core::gas::GasBuiltin, v20: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::felt252, ())>) <- test::foo[137-183](v5, v14, v17, v15, v4)
 End:
   Return(v18, v19, v20)
 
@@ -167,7 +165,7 @@ End:
   Return(v7, v8, v28)
 
 
-Final lowering of specialized call "test::foo[118-164]{NotSpecialized, 1, 2, }":
+Final lowering of specialized call "test::foo[137-183]{NotSpecialized, 1, 2, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::array::SpanIter::<core::felt252>
 blk0 (root):
 Statements:
@@ -193,7 +191,7 @@ Statements:
   (v13: core::felt252) <- 3
   (v14: core::array::Span::<core::felt252>) <- struct_construct(v9)
   (v15: core::array::SpanIter::<core::felt252>) <- struct_construct(v14)
-  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::felt252, ())>) <- test::foo[118-164]{NotSpecialized, NotSpecialized, 2, }(v3, v12, v15, v13)
+  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::felt252, ())>) <- test::foo[137-183]{NotSpecialized, NotSpecialized, 2, }(v3, v12, v15, v13)
 End:
   Return(v16, v17, v18)
 
@@ -223,16 +221,7 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
-fn foo() {
-    let v = 1_u32;
-    v.foo()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T, +Drop<T>, +Copy<T>, +Add<T>> {
     #[inline(never)]
     fn bar(self: T) -> T {
@@ -252,6 +241,11 @@ fn bar<T, +Drop<T>, +Copy<T>, +Add<T>>(v: T) {
 }
 
 impl MyImpl of MyTrait<u32> {}
+#[target_function]
+fn foo() {
+    let v = 1_u32;
+    v.foo()
+}
 
 //! > semantic_diagnostics
 
@@ -326,7 +320,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Box<Span<felt252>>) -> Array<felt252> {
     let mut arr = array![];
     for b in a {
@@ -334,9 +329,6 @@ fn foo(a: Box<Span<felt252>>) -> Array<felt252> {
     }
     return arr;
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -352,7 +344,7 @@ Statements:
   (v1: core::array::Array::<core::felt252>) <- core::array::ArrayImpl::<core::felt252>::new()
   (v2: core::array::Span::<core::felt252>) <- core::box::BoxDeref::<core::array::Span::<core::felt252>>::deref(v0)
   (v3: core::array::SpanIter::<core::felt252>) <- core::array::SpanIntoIterator::<core::felt252>::into_iter(v2)
-  (v5: core::array::SpanIter::<core::felt252>, v6: core::array::Array::<core::felt252>, v4: ()) <- test::foo[78-125](v3, v1)
+  (v5: core::array::SpanIter::<core::felt252>, v6: core::array::Array::<core::felt252>, v4: ()) <- test::foo[97-144](v3, v1)
 End:
   Return(v6)
 
@@ -364,7 +356,7 @@ Statements:
   (v3: core::array::Array::<core::felt252>) <- core::array::array_new::<core::felt252>()
   (v4: core::array::Span::<core::felt252>) <- unbox(v2)
   (v5: core::array::SpanIter::<core::felt252>) <- struct_construct(v4)
-  (v6: core::RangeCheck, v7: core::gas::GasBuiltin, v8: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::array::Array::<core::felt252>, ())>) <- test::foo[78-125](v0, v1, v5, v3)
+  (v6: core::RangeCheck, v7: core::gas::GasBuiltin, v8: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::array::Array::<core::felt252>, ())>) <- test::foo[97-144](v0, v1, v5, v3)
 End:
   Match(match_enum(v8) {
     PanicResult::Ok(v9) => blk1,
@@ -408,7 +400,7 @@ blk1:
 Statements:
   (v5: core::felt252) <- desnap(v4)
   (v7: core::array::Array::<core::felt252>, v6: ()) <- core::array::ArrayImpl::<core::felt252>::append(v1, v5)
-  (v9: core::array::SpanIter::<core::felt252>, v10: core::array::Array::<core::felt252>, v8: ()) <- test::foo[78-125](v3, v7)
+  (v9: core::array::SpanIter::<core::felt252>, v10: core::array::Array::<core::felt252>, v8: ()) <- test::foo[97-144](v3, v7)
 End:
   Return(v9, v10, v8)
 
@@ -447,7 +439,7 @@ Statements:
   (v16: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v3, v15)
   (v17: core::array::Span::<core::felt252>) <- struct_construct(v10)
   (v18: core::array::SpanIter::<core::felt252>) <- struct_construct(v17)
-  (v19: core::RangeCheck, v20: core::gas::GasBuiltin, v21: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::array::Array::<core::felt252>, ())>) <- test::foo[78-125](v4, v13, v18, v16)
+  (v19: core::RangeCheck, v20: core::gas::GasBuiltin, v21: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::array::Array::<core::felt252>, ())>) <- test::foo[97-144](v4, v13, v18, v16)
 End:
   Return(v19, v20, v21)
 
@@ -470,7 +462,7 @@ End:
   Return(v6, v7, v29)
 
 
-Final lowering of specialized call "test::foo[78-125]":
+Final lowering of specialized call "test::foo[97-144]":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::array::SpanIter::<core::felt252>, v3: core::array::Array::<core::felt252>
 blk0 (root):
 Statements:
@@ -498,7 +490,7 @@ Statements:
   (v16: core::array::Array::<core::felt252>) <- core::array::array_append::<core::felt252>(v3, v15)
   (v17: core::array::Span::<core::felt252>) <- struct_construct(v10)
   (v18: core::array::SpanIter::<core::felt252>) <- struct_construct(v17)
-  (v19: core::RangeCheck, v20: core::gas::GasBuiltin, v21: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::array::Array::<core::felt252>, ())>) <- test::foo[78-125](v4, v13, v18, v16)
+  (v19: core::RangeCheck, v20: core::gas::GasBuiltin, v21: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, core::array::Array::<core::felt252>, ())>) <- test::foo[97-144](v4, v13, v18, v16)
 End:
   Return(v19, v20, v21)
 

--- a/crates/cairo-lang-lowering/src/lower/test_data/loop
+++ b/crates/cairo-lang-lowering/src/lower/test_data/loop
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     let mut x = 5;
     loop {
@@ -14,9 +15,6 @@ fn foo() -> bool {
         };
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -31,7 +29,7 @@ Parameters:
 blk0 (root):
 Statements:
   (v0: core::felt252) <- 5
-  (v2: core::felt252, v1: core::bool) <- test::foo[38-149](v0)
+  (v2: core::felt252, v1: core::bool) <- test::foo[57-168](v0)
 End:
   Return(v1)
 
@@ -40,7 +38,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-149]{5, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-168]{5, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -99,7 +97,7 @@ End:
 
 blk3:
 Statements:
-  (v14: core::felt252, v13: core::bool) <- test::foo[38-149](v2)
+  (v14: core::felt252, v13: core::bool) <- test::foo[57-168](v2)
 End:
   Return(v14, v13)
 
@@ -139,7 +137,7 @@ End:
 blk3:
 Statements:
   (v17: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v18: core::RangeCheck, v19: core::gas::GasBuiltin, v20: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-149](v3, v17, v8)
+  (v18: core::RangeCheck, v19: core::gas::GasBuiltin, v20: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-168](v3, v17, v8)
 End:
   Return(v18, v19, v20)
 
@@ -151,7 +149,7 @@ End:
   Return(v5, v6, v22)
 
 
-Final lowering of specialized call "test::foo[38-149]{5, }":
+Final lowering of specialized call "test::foo[57-168]{5, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
@@ -165,7 +163,7 @@ blk1:
 Statements:
   (v6: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v3)
   (v7: core::felt252) <- 6
-  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-149](v2, v6, v7)
+  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-168](v2, v6, v7)
 End:
   Return(v8, v9, v10)
 
@@ -183,7 +181,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     let mut x = 5;
     loop {
@@ -193,9 +192,6 @@ fn foo() -> bool {
         };
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -210,7 +206,7 @@ Parameters:
 blk0 (root):
 Statements:
   (v0: core::felt252) <- 5
-  (v2: core::felt252, v1: core::bool) <- test::foo[38-130](v0)
+  (v2: core::felt252, v1: core::bool) <- test::foo[57-149](v0)
 End:
   Return(v1)
 
@@ -219,7 +215,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-130]{5, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-149]{5, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -278,7 +274,7 @@ End:
 
 blk3:
 Statements:
-  (v14: core::felt252, v13: core::bool) <- test::foo[38-130](v3)
+  (v14: core::felt252, v13: core::bool) <- test::foo[57-149](v3)
 End:
   Return(v14, v13)
 
@@ -318,7 +314,7 @@ End:
 blk3:
 Statements:
   (v17: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v18: core::RangeCheck, v19: core::gas::GasBuiltin, v20: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-130](v3, v17, v8)
+  (v18: core::RangeCheck, v19: core::gas::GasBuiltin, v20: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-149](v3, v17, v8)
 End:
   Return(v18, v19, v20)
 
@@ -330,7 +326,7 @@ End:
   Return(v5, v6, v22)
 
 
-Final lowering of specialized call "test::foo[38-130]{5, }":
+Final lowering of specialized call "test::foo[57-149]{5, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
@@ -344,7 +340,7 @@ blk1:
 Statements:
   (v6: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v3)
   (v7: core::felt252) <- 6
-  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-130](v2, v6, v7)
+  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-149](v2, v6, v7)
 End:
   Return(v8, v9, v10)
 
@@ -362,7 +358,18 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+struct A {
+    b: B,
+    x: felt252,
+}
+#[derive(Copy, Drop)]
+struct B {
+    c: usize,
+    y: u128,
+}
+#[target_function]
 fn foo(mut a: A, ref b: A) {
     let c = 5_usize;
     loop {
@@ -376,21 +383,6 @@ fn foo(mut a: A, ref b: A) {
             break b;
         };
     };
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-struct A {
-    b: B,
-    x: felt252,
-}
-#[derive(Copy, Drop)]
-struct B {
-    c: usize,
-    y: u128,
 }
 
 //! > semantic_diagnostics
@@ -407,7 +399,7 @@ blk0 (root):
 Statements:
   (v2: core::integer::u32) <- 5
   (v3: test::B, v4: core::felt252) <- struct_destructure(v0)
-  (v6: core::integer::u32, v7: test::A, v5: test::A) <- test::foo[50-256](v2, v1, v3)
+  (v6: core::integer::u32, v7: test::A, v5: test::A) <- test::foo[69-275](v2, v1, v3)
   (v8: core::integer::u32, v9: core::integer::u128) <- struct_destructure(v3)
   (v10: ()) <- struct_construct()
 End:
@@ -420,7 +412,7 @@ blk0 (root):
 Statements:
   (v4: core::integer::u32) <- 5
   (v5: test::B, v6: core::felt252) <- struct_destructure(v2)
-  (v7: core::RangeCheck, v8: core::gas::GasBuiltin, v9: core::panics::PanicResult::<(core::integer::u32, test::A, test::A)>) <- test::foo[50-256](v0, v1, v4, v3, v5)
+  (v7: core::RangeCheck, v8: core::gas::GasBuiltin, v9: core::panics::PanicResult::<(core::integer::u32, test::A, test::A)>) <- test::foo[69-275](v0, v1, v4, v3, v5)
 End:
   Match(match_enum(v9) {
     PanicResult::Ok(v10) => blk1,
@@ -483,7 +475,7 @@ End:
 blk3:
 Statements:
   (v17: test::B) <- struct_construct(v0, v5)
-  (v19: core::integer::u32, v20: test::A, v18: test::A) <- test::foo[50-256](v0, v1, v17)
+  (v19: core::integer::u32, v20: test::A, v18: test::A) <- test::foo[69-275](v0, v1, v17)
   (v21: core::integer::u32, v22: core::integer::u128) <- struct_destructure(v17)
 End:
   Return(v19, v20, v18)
@@ -519,7 +511,7 @@ End:
   Return(v7, v8, v18)
 
 
-Final lowering of specialized call "test::foo[50-256]":
+Final lowering of specialized call "test::foo[69-275]":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::integer::u32, v3: test::A, v4: test::B
 blk0 (root):
 Statements:
@@ -555,7 +547,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     let mut x = 5;
     loop {
@@ -570,9 +563,6 @@ fn foo() -> bool {
     }
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -586,7 +576,7 @@ Parameters:
 blk0 (root):
 Statements:
   (v0: core::felt252) <- 5
-  (v2: core::felt252, v1: core::bool) <- test::foo[38-201](v0)
+  (v2: core::felt252, v1: core::bool) <- test::foo[57-220](v0)
 End:
   Return(v1)
 
@@ -595,7 +585,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-201]{5, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-220]{5, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -642,7 +632,7 @@ End:
 
 blk1:
 Statements:
-  (v12: core::felt252, v11: core::bool) <- test::foo[38-201](v2)
+  (v12: core::felt252, v11: core::bool) <- test::foo[57-220](v2)
 End:
   Return(v12, v11)
 
@@ -677,7 +667,7 @@ End:
 
 blk6:
 Statements:
-  (v24: core::felt252, v23: core::bool) <- test::foo[38-201](v2)
+  (v24: core::felt252, v23: core::bool) <- test::foo[57-220](v2)
 End:
   Return(v24, v23)
 
@@ -738,7 +728,7 @@ End:
 
 blk6:
 Statements:
-  (v23: core::RangeCheck, v24: core::gas::GasBuiltin, v25: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-201](v3, v13, v8)
+  (v23: core::RangeCheck, v24: core::gas::GasBuiltin, v25: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-220](v3, v13, v8)
 End:
   Return(v23, v24, v25)
 
@@ -750,7 +740,7 @@ End:
   Return(v5, v6, v27)
 
 
-Final lowering of specialized call "test::foo[38-201]{5, }":
+Final lowering of specialized call "test::foo[57-220]{5, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
@@ -764,7 +754,7 @@ blk1:
 Statements:
   (v6: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v3)
   (v7: core::felt252) <- 6
-  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[38-201](v2, v6, v7)
+  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[57-220](v2, v6, v7)
 End:
   Return(v8, v9, v10)
 
@@ -782,15 +772,13 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     loop {
         break;
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -804,7 +792,7 @@ Main:
 Parameters:
 blk0 (root):
 Statements:
-  (v0: ()) <- test::foo[11-43]()
+  (v0: ()) <- test::foo[30-62]()
 End:
   Return(v0)
 
@@ -846,7 +834,13 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop, Debug)]
+struct A {
+    a: u8,
+    b: u8,
+}
+#[target_function]
 fn foo() {
     let mut x = A { a: 3, b: 4 };
     loop {
@@ -860,16 +854,6 @@ fn foo() {
             break;
         };
     };
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop, Debug)]
-struct A {
-    a: u8,
-    b: u8,
 }
 
 //! > semantic_diagnostics
@@ -888,7 +872,7 @@ Statements:
   (v1: core::integer::u8) <- 4
   (v2: test::A) <- struct_construct(v0, v1)
   (v3: core::integer::u8, v4: core::integer::u8) <- struct_destructure(v2)
-  (v6: core::integer::u8, v5: ()) <- test::foo[45-203](v3)
+  (v6: core::integer::u8, v5: ()) <- test::foo[64-222](v3)
   (v7: ()) <- struct_construct()
 End:
   Return(v7)
@@ -899,7 +883,7 @@ Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
   (v2: core::integer::u8) <- 3
-  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::integer::u8, ())>) <- test::foo[45-203](v0, v1, v2)
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::integer::u8, ())>) <- test::foo[64-222](v0, v1, v2)
 End:
   Match(match_enum(v5) {
     PanicResult::Ok(v6) => blk1,
@@ -977,7 +961,7 @@ End:
 
 blk6:
 Statements:
-  (v18: core::integer::u8, v17: ()) <- test::foo[45-203](v8)
+  (v18: core::integer::u8, v17: ()) <- test::foo[64-222](v8)
 End:
   Return(v18, v17)
 
@@ -1010,7 +994,7 @@ End:
   Return(v5, v6, v13)
 
 
-Final lowering of specialized call "test::foo[45-203]":
+Final lowering of specialized call "test::foo[64-222]":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::integer::u8
 blk0 (root):
 Statements:
@@ -1044,7 +1028,16 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct S {}
+trait T {
+    fn foo(self: @S);
+}
+impl I of T {
+    fn foo(self: @S) {}
+}
+#[target_function]
 fn foo() -> bool {
     let mut s = S {};
     loop {
@@ -1053,19 +1046,6 @@ fn foo() -> bool {
     }
     s.foo();
     false
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct S {}
-trait T {
-    fn foo(self: @S);
-}
-impl I of T {
-    fn foo(self: @S) {}
 }
 
 //! > semantic_diagnostics
@@ -1082,7 +1062,7 @@ blk0 (root):
 Statements:
   (v0: test::S) <- struct_construct()
   (v1: test::S, v2: @test::S) <- snapshot(v0)
-  (v3: ()) <- test::foo[41-90](v2)
+  (v3: ()) <- test::foo[60-109](v2)
   (v4: test::S, v5: @test::S) <- snapshot(v1)
   (v6: ()) <- test::I::foo(v5)
   (v7: ()) <- struct_construct()
@@ -1131,20 +1111,7 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
-fn foo() {
-    let t = T { s: S {} };
-    loop {
-        TT::f1oo(@t.s);
-        break;
-    }
-    TT::f1oo(@t.s);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct S {}
 #[derive(Drop)]
@@ -1156,6 +1123,15 @@ trait TT {
 }
 impl STT of TT {
     fn f1oo(self: @S) {}
+}
+#[target_function]
+fn foo() {
+    let t = T { s: S {} };
+    loop {
+        TT::f1oo(@t.s);
+        break;
+    }
+    TT::f1oo(@t.s);
 }
 
 //! > semantic_diagnostics
@@ -1174,7 +1150,7 @@ Statements:
   (v1: test::T) <- struct_construct(v0)
   (v2: test::S) <- struct_destructure(v1)
   (v3: test::S, v4: @test::S) <- snapshot(v2)
-  (v5: ()) <- test::foo[38-94](v4)
+  (v5: ()) <- test::foo[57-113](v4)
   (v6: test::S, v7: @test::S) <- snapshot(v3)
   (v8: ()) <- test::STT::f1oo(v7)
   (v9: ()) <- struct_construct()
@@ -1220,7 +1196,20 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn ex(a: u32) nopanic;
+#[allow(extern_outside_corelib)]
+extern fn ex1(a: @B) nopanic;
+#[derive(Drop)]
+struct B {
+    c: u32,
+}
+#[derive(Drop)]
+struct A {
+    b: B,
+}
+#[target_function]
 fn foo() {
     let a = A { b: B { c: 3 } };
     loop {
@@ -1233,23 +1222,6 @@ fn foo() {
         }
         break;
     };
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn ex(a: u32) nopanic;
-#[allow(extern_outside_corelib)]
-extern fn ex1(a: @B) nopanic;
-#[derive(Drop)]
-struct B {
-    c: u32,
-}
-#[derive(Drop)]
-struct A {
-    b: B,
 }
 
 //! > semantic_diagnostics
@@ -1271,7 +1243,7 @@ Statements:
   (v4: core::integer::u32) <- struct_destructure(v3)
   (v5: test::B) <- struct_construct(v4)
   (v6: test::B, v7: @test::B) <- snapshot(v5)
-  (v8: ()) <- test::foo[44-207](v4, v7)
+  (v8: ()) <- test::foo[63-226](v4, v7)
   (v9: ()) <- struct_construct()
 End:
   Return(v9)
@@ -1326,7 +1298,7 @@ Parameters: v0: core::integer::u32, v1: @test::B
 blk0 (root):
 Statements:
   () <- test::ex1(v1)
-  (v2: ()) <- test::foo[95-187](v0)
+  (v2: ()) <- test::foo[114-206](v0)
   (v3: ()) <- struct_construct()
 End:
   Return(v3)
@@ -1348,7 +1320,20 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn ex(a: @u32) nopanic;
+#[allow(extern_outside_corelib)]
+extern fn ex1(a: B) nopanic;
+#[derive(Drop, Copy)]
+struct B {
+    c: u32,
+}
+#[derive(Drop)]
+struct A {
+    b: B,
+}
+#[target_function]
 fn foo() {
     let a = A { b: B { c: 3 } };
     loop {
@@ -1361,23 +1346,6 @@ fn foo() {
         }
         break;
     };
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn ex(a: @u32) nopanic;
-#[allow(extern_outside_corelib)]
-extern fn ex1(a: B) nopanic;
-#[derive(Drop, Copy)]
-struct B {
-    c: u32,
-}
-#[derive(Drop)]
-struct A {
-    b: B,
 }
 
 //! > semantic_diagnostics
@@ -1396,7 +1364,7 @@ Statements:
   (v1: test::B) <- struct_construct(v0)
   (v2: test::A) <- struct_construct(v1)
   (v3: test::B) <- struct_destructure(v2)
-  (v4: ()) <- test::foo[44-207](v3)
+  (v4: ()) <- test::foo[63-226](v3)
   (v5: ()) <- struct_construct()
 End:
   Return(v5)
@@ -1453,7 +1421,7 @@ Statements:
   () <- test::ex1(v0)
   (v1: core::integer::u32) <- struct_destructure(v0)
   (v2: core::integer::u32, v3: @core::integer::u32) <- snapshot(v1)
-  (v4: ()) <- test::foo[94-187](v3)
+  (v4: ()) <- test::foo[113-206](v3)
   (v5: ()) <- struct_construct()
 End:
   Return(v5)
@@ -1477,7 +1445,14 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct A {
+    x: felt252,
+}
+#[allow(extern_outside_corelib)]
+extern fn use_a(a: @A) nopanic;
+#[target_function]
 fn foo() {
     let mut a = A { x: 0 };
     let mut i = 1;
@@ -1487,17 +1462,6 @@ fn foo() {
         i += 1;
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct A {
-    x: felt252,
-}
-#[allow(extern_outside_corelib)]
-extern fn use_a(a: @A) nopanic;
 
 //! > semantic_diagnostics
 
@@ -1514,7 +1478,7 @@ Statements:
   (v0: core::felt252) <- 0
   (v1: test::A) <- struct_construct(v0)
   (v2: core::felt252) <- 1
-  (v4: test::A, v5: core::felt252, v3: ()) <- test::foo[58-134](v2, v1)
+  (v4: test::A, v5: core::felt252, v3: ()) <- test::foo[77-153](v2, v1)
   (v6: ()) <- struct_construct()
 End:
   Return(v6)
@@ -1524,7 +1488,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(test::A, core::felt252, ())>) <- test::foo[58-134]{1, { 0 }, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(test::A, core::felt252, ())>) <- test::foo[77-153]{1, { 0 }, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -1575,7 +1539,7 @@ Statements:
   () <- test::use_a(v12)
   (v13: core::felt252) <- 1
   (v15: core::felt252, v14: ()) <- core::ops::arith::DeprecatedAddAssign::<core::felt252, core::Felt252AddEq>::add_assign(v2, v13)
-  (v17: test::A, v18: core::felt252, v16: ()) <- test::foo[58-134](v15, v11)
+  (v17: test::A, v18: core::felt252, v16: ()) <- test::foo[77-153](v15, v11)
 End:
   Return(v17, v18, v16)
 
@@ -1623,7 +1587,7 @@ Statements:
   () <- test::use_a(v18)
   (v19: core::felt252) <- 1
   (v20: core::felt252) <- core::felt252_add(v2, v19)
-  (v21: core::RangeCheck, v22: core::gas::GasBuiltin, v23: core::panics::PanicResult::<(test::A, core::felt252, ())>) <- test::foo[58-134](v4, v15, v20, v17)
+  (v21: core::RangeCheck, v22: core::gas::GasBuiltin, v23: core::panics::PanicResult::<(test::A, core::felt252, ())>) <- test::foo[77-153](v4, v15, v20, v17)
 End:
   Return(v21, v22, v23)
 
@@ -1635,7 +1599,7 @@ End:
   Return(v6, v7, v25)
 
 
-Final lowering of specialized call "test::foo[58-134]{1, { 0 }, }":
+Final lowering of specialized call "test::foo[77-153]{1, { 0 }, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
@@ -1653,7 +1617,7 @@ Statements:
   (v9: test::A, v10: @test::A) <- snapshot(v8)
   () <- test::use_a(v10)
   (v11: core::felt252) <- 2
-  (v12: core::RangeCheck, v13: core::gas::GasBuiltin, v14: core::panics::PanicResult::<(test::A, core::felt252, ())>) <- test::foo[58-134](v2, v6, v11, v9)
+  (v12: core::RangeCheck, v13: core::gas::GasBuiltin, v14: core::panics::PanicResult::<(test::A, core::felt252, ())>) <- test::foo[77-153](v2, v6, v11, v9)
 End:
   Return(v12, v13, v14)
 
@@ -1671,15 +1635,7 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
-fn foo() {
-    MyTrait::impl_in_trait();
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait {
     fn impl_in_impl(x: u8) -> bool;
     fn impl_in_trait() -> u8 {
@@ -1698,6 +1654,10 @@ impl MyImpl of MyTrait {
     fn impl_in_impl(x: u8) -> bool {
         x == 30
     }
+}
+#[target_function]
+fn foo() {
+    MyTrait::impl_in_trait();
 }
 
 //! > expected_diagnostics
@@ -1750,7 +1710,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u32 {
     let mut x = 5;
     loop {
@@ -1771,9 +1732,6 @@ fn foo() -> u32 {
     1
 }
 
-//! > function_name
-foo
-
 //! > expected_diagnostics
 
 //! > semantic_diagnostics
@@ -1784,7 +1742,7 @@ Parameters:
 blk0 (root):
 Statements:
   (v0: core::felt252) <- 5
-  (v2: core::felt252, v1: core::internal::LoopResult::<core::bool, core::integer::u32>) <- test::foo[37-253](v0)
+  (v2: core::felt252, v1: core::internal::LoopResult::<core::bool, core::integer::u32>) <- test::foo[56-272](v0)
 End:
   Match(match_enum(v1) {
     LoopResult::Normal(v3) => blk1,
@@ -1812,7 +1770,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, core::internal::LoopResult::<core::bool, core::integer::u32>)>) <- test::foo[37-253]{5, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, core::internal::LoopResult::<core::bool, core::integer::u32>)>) <- test::foo[56-272]{5, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -1925,7 +1883,7 @@ End:
 
 blk7:
 Statements:
-  (v33: core::felt252, v32: core::internal::LoopResult::<core::bool, core::integer::u32>) <- test::foo[37-253](v2)
+  (v33: core::felt252, v32: core::internal::LoopResult::<core::bool, core::integer::u32>) <- test::foo[56-272](v2)
 End:
   Return(v33, v32)
 
@@ -1936,7 +1894,7 @@ End:
 
 blk9:
 Statements:
-  (v35: core::felt252, v34: core::internal::LoopResult::<core::bool, core::integer::u32>) <- test::foo[37-253](v2)
+  (v35: core::felt252, v34: core::internal::LoopResult::<core::bool, core::integer::u32>) <- test::foo[56-272](v2)
 End:
   Return(v35, v34)
 
@@ -2018,7 +1976,7 @@ End:
 
 blk8:
 Statements:
-  (v32: core::RangeCheck, v33: core::gas::GasBuiltin, v34: core::panics::PanicResult::<(core::felt252, core::internal::LoopResult::<core::bool, core::integer::u32>)>) <- test::foo[37-253](v3, v30, v8)
+  (v32: core::RangeCheck, v33: core::gas::GasBuiltin, v34: core::panics::PanicResult::<(core::felt252, core::internal::LoopResult::<core::bool, core::integer::u32>)>) <- test::foo[56-272](v3, v30, v8)
 End:
   Return(v32, v33, v34)
 
@@ -2030,7 +1988,7 @@ End:
   Return(v5, v6, v36)
 
 
-Final lowering of specialized call "test::foo[37-253]{5, }":
+Final lowering of specialized call "test::foo[56-272]{5, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
@@ -2044,7 +2002,7 @@ blk1:
 Statements:
   (v6: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v3)
   (v7: core::felt252) <- 6
-  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, core::internal::LoopResult::<core::bool, core::integer::u32>)>) <- test::foo[37-253](v2, v6, v7)
+  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, core::internal::LoopResult::<core::bool, core::integer::u32>)>) <- test::foo[56-272](v2, v6, v7)
 End:
   Return(v8, v9, v10)
 
@@ -2064,7 +2022,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: u32) -> u32 {
     loop {
         if a == 0 {
@@ -2074,9 +2033,6 @@ fn foo(a: u32) -> u32 {
     }
     1
 }
-
-//! > function_name
-foo
 
 //! > expected_diagnostics
 
@@ -2088,7 +2044,7 @@ Parameters: v0: core::integer::u32
 blk0 (root):
 Statements:
   (v1: core::integer::u32, v2: @core::integer::u32) <- snapshot(v0)
-  (v3: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[24-108](v2)
+  (v3: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[43-127](v2)
 End:
   Match(match_enum(v3) {
     LoopResult::Normal(v4) => blk1,
@@ -2208,7 +2164,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut a: Array<u32>) -> u32 {
     while let Some(v) = a.pop_front() {
         if v == 1 {
@@ -2228,9 +2185,6 @@ fn foo(mut a: Array<u32>) -> u32 {
     7
 }
 
-//! > function_name
-foo
-
 //! > expected_diagnostics
 
 //! > semantic_diagnostics
@@ -2240,7 +2194,7 @@ Main:
 Parameters: v0: core::array::Array::<core::integer::u32>
 blk0 (root):
 Statements:
-  (v2: core::array::Array::<core::integer::u32>, v1: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[35-262](v0)
+  (v2: core::array::Array::<core::integer::u32>, v1: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[54-281](v0)
 End:
   Match(match_enum(v1) {
     LoopResult::Normal(v3) => blk1,
@@ -2268,7 +2222,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::array::Array::<core::integer::u32>
 blk0 (root):
 Statements:
-  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[35-262](v0, v1, v2)
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[54-281](v0, v1, v2)
 End:
   Match(match_enum(v5) {
     PanicResult::Ok(v6) => blk1,
@@ -2409,7 +2363,7 @@ End:
 
 blk3:
 Statements:
-  (v14: core::array::Array::<core::integer::u32>, v13: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[35-262](v2)
+  (v14: core::array::Array::<core::integer::u32>, v13: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[54-281](v2)
 End:
   Return(v14, v13)
 
@@ -2421,7 +2375,7 @@ End:
 blk5:
 Statements:
   (v15: core::integer::u32, v16: @core::integer::u32) <- snapshot(v5)
-  (v17: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[127-237](v16)
+  (v17: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[146-256](v16)
 End:
   Match(match_enum(v17) {
     LoopResult::Normal(v18) => blk6,
@@ -2513,7 +2467,7 @@ End:
 blk6:
 Statements:
   (v23: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v24: core::RangeCheck, v25: core::gas::GasBuiltin, v26: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[35-262](v3, v23, v7)
+  (v24: core::RangeCheck, v25: core::gas::GasBuiltin, v26: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[54-281](v3, v23, v7)
 End:
   Return(v24, v25, v26)
 
@@ -2535,7 +2489,7 @@ End:
   Return(v5, v6, v33)
 
 
-Final lowering of specialized call "test::foo[35-262]":
+Final lowering of specialized call "test::foo[54-281]":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::array::Array::<core::integer::u32>
 blk0 (root):
 Statements:
@@ -2594,7 +2548,7 @@ End:
 blk6:
 Statements:
   (v23: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v24: core::RangeCheck, v25: core::gas::GasBuiltin, v26: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[35-262](v3, v23, v7)
+  (v24: core::RangeCheck, v25: core::gas::GasBuiltin, v26: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[54-281](v3, v23, v7)
 End:
   Return(v24, v25, v26)
 
@@ -2624,7 +2578,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut a: Array<u32>) -> u32 {
     while let Some(v) = a.pop_front() {
         if v == 1 {
@@ -2644,9 +2599,6 @@ fn foo(mut a: Array<u32>) -> u32 {
     7
 }
 
-//! > function_name
-foo
-
 //! > expected_diagnostics
 
 //! > semantic_diagnostics
@@ -2656,7 +2608,7 @@ Main:
 Parameters: v0: core::array::Array::<core::integer::u32>
 blk0 (root):
 Statements:
-  (v2: core::array::Array::<core::integer::u32>, v1: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[35-262](v0)
+  (v2: core::array::Array::<core::integer::u32>, v1: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[54-281](v0)
 End:
   Match(match_enum(v1) {
     LoopResult::Normal(v3) => blk1,
@@ -2684,7 +2636,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::array::Array::<core::integer::u32>
 blk0 (root):
 Statements:
-  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[35-262](v0, v1, v2)
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[54-281](v0, v1, v2)
 End:
   Match(match_enum(v5) {
     PanicResult::Ok(v6) => blk1,
@@ -2825,7 +2777,7 @@ End:
 
 blk3:
 Statements:
-  (v14: core::array::Array::<core::integer::u32>, v13: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[35-262](v2)
+  (v14: core::array::Array::<core::integer::u32>, v13: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[54-281](v2)
 End:
   Return(v14, v13)
 
@@ -2837,7 +2789,7 @@ End:
 blk5:
 Statements:
   (v15: core::integer::u32, v16: @core::integer::u32) <- snapshot(v5)
-  (v17: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[127-237](v16)
+  (v17: core::internal::LoopResult::<(), core::integer::u32>) <- test::foo[146-256](v16)
 End:
   Match(match_enum(v17) {
     LoopResult::Normal(v18) => blk6,
@@ -2929,7 +2881,7 @@ End:
 blk6:
 Statements:
   (v23: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v24: core::RangeCheck, v25: core::gas::GasBuiltin, v26: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[35-262](v3, v23, v7)
+  (v24: core::RangeCheck, v25: core::gas::GasBuiltin, v26: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[54-281](v3, v23, v7)
 End:
   Return(v24, v25, v26)
 
@@ -2951,7 +2903,7 @@ End:
   Return(v5, v6, v33)
 
 
-Final lowering of specialized call "test::foo[35-262]":
+Final lowering of specialized call "test::foo[54-281]":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::array::Array::<core::integer::u32>
 blk0 (root):
 Statements:
@@ -3010,7 +2962,7 @@ End:
 blk6:
 Statements:
   (v23: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v24: core::RangeCheck, v25: core::gas::GasBuiltin, v26: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[35-262](v3, v23, v7)
+  (v24: core::RangeCheck, v25: core::gas::GasBuiltin, v26: core::panics::PanicResult::<(core::array::Array::<core::integer::u32>, core::internal::LoopResult::<(), core::integer::u32>)>) <- test::foo[54-281](v3, v23, v7)
 End:
   Return(v24, v25, v26)
 
@@ -3040,20 +2992,16 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar() -> Result<(), u32> nopanic;
+#[target_function]
 fn foo() -> Result<(), u32> {
     for _ in 1..5_u32 {
         bar()?;
     }
     Ok(())
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar() -> Result<(), u32> nopanic;
 
 //! > expected_diagnostics
 
@@ -3068,7 +3016,7 @@ Statements:
   (v1: core::integer::u32) <- 5
   (v2: core::ops::range::Range::<core::integer::u32>) <- core::ops::range::RangeOpImpl::<core::integer::u32>::range(v0, v1)
   (v3: core::ops::range::internal::IntRange::<core::integer::u32>) <- core::ops::range::SierraRangeIntoIterator::<core::integer::u32, core::integer::u32Copy, core::integer::u32Drop, core::ops::range::SierraIntRangeSupportU32>::into_iter(v2)
-  (v5: core::ops::range::internal::IntRange::<core::integer::u32>, v4: core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>) <- test::foo[30-76](v3)
+  (v5: core::ops::range::internal::IntRange::<core::integer::u32>, v4: core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>) <- test::foo[49-95](v3)
 End:
   Match(match_enum(v4) {
     LoopResult::Normal(v6) => blk1,
@@ -3119,7 +3067,7 @@ End:
 
 blk3:
 Statements:
-  (v13: core::RangeCheck, v14: core::gas::GasBuiltin, v15: core::panics::PanicResult::<(core::ops::range::internal::IntRange::<core::integer::u32>, core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>)>) <- test::foo[30-76](v9, v10, v11)
+  (v13: core::RangeCheck, v14: core::gas::GasBuiltin, v15: core::panics::PanicResult::<(core::ops::range::internal::IntRange::<core::integer::u32>, core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>)>) <- test::foo[49-95](v9, v10, v11)
 End:
   Match(match_enum(v15) {
     PanicResult::Ok(v16) => blk4,
@@ -3200,7 +3148,7 @@ End:
 
 blk4:
 Statements:
-  (v10: core::ops::range::internal::IntRange::<core::integer::u32>, v9: core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>) <- test::foo[30-76](v2)
+  (v10: core::ops::range::internal::IntRange::<core::integer::u32>, v9: core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>) <- test::foo[49-95](v2)
 End:
   Return(v10, v9)
 
@@ -3251,7 +3199,7 @@ End:
 blk4:
 Statements:
   (v15: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::ops::range::internal::IntRange::<core::integer::u32>, core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>)>) <- test::foo[30-76](v3, v15, v7)
+  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::ops::range::internal::IntRange::<core::integer::u32>, core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>)>) <- test::foo[49-95](v3, v15, v7)
 End:
   Return(v16, v17, v18)
 
@@ -3273,7 +3221,7 @@ End:
   Return(v5, v6, v25)
 
 
-Final lowering of specialized call "test::foo[30-76]":
+Final lowering of specialized call "test::foo[49-95]":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::ops::range::internal::IntRange::<core::integer::u32>
 blk0 (root):
 Statements:
@@ -3312,7 +3260,7 @@ End:
 blk4:
 Statements:
   (v15: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
-  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::ops::range::internal::IntRange::<core::integer::u32>, core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>)>) <- test::foo[30-76](v3, v15, v7)
+  (v16: core::RangeCheck, v17: core::gas::GasBuiltin, v18: core::panics::PanicResult::<(core::ops::range::internal::IntRange::<core::integer::u32>, core::internal::LoopResult::<(), core::result::Result::<(), core::integer::u32>>)>) <- test::foo[49-95](v3, v15, v7)
 End:
   Return(v16, v17, v18)
 
@@ -3342,20 +3290,16 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn bar() -> Result<(), u32> {
+    Ok(())
+}
+#[target_function]
 fn foo() -> Result<(), u32> {
     loop {
         bar()?;
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn bar() -> Result<(), u32> {
-    Ok(())
 }
 
 //! > expected_diagnostics
@@ -3367,7 +3311,7 @@ Main:
 Parameters:
 blk0 (root):
 Statements:
-  (v0: core::result::Result::<(), core::integer::u32>) <- test::foo[30-63]()
+  (v0: core::result::Result::<(), core::integer::u32>) <- test::foo[49-82]()
 End:
   Return(v0)
 
@@ -3376,7 +3320,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::result::Result::<(), core::integer::u32>,)>) <- test::foo[30-63](v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::result::Result::<(), core::integer::u32>,)>) <- test::foo[49-82](v0, v1)
 End:
   Return(v2, v3, v4)
 
@@ -3411,7 +3355,7 @@ End:
 
 blk3:
 Statements:
-  (v5: core::result::Result::<(), core::integer::u32>) <- test::foo[30-63]()
+  (v5: core::result::Result::<(), core::integer::u32>) <- test::foo[49-82]()
 End:
   Return(v5)
 
@@ -3438,7 +3382,7 @@ End:
 blk2:
 Statements:
   (v9: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v3)
-  (v10: core::RangeCheck, v11: core::gas::GasBuiltin, v12: core::panics::PanicResult::<(core::result::Result::<(), core::integer::u32>,)>) <- test::foo[30-63](v2, v9)
+  (v10: core::RangeCheck, v11: core::gas::GasBuiltin, v12: core::panics::PanicResult::<(core::result::Result::<(), core::integer::u32>,)>) <- test::foo[49-82](v2, v9)
 End:
   Return(v10, v11, v12)
 
@@ -3458,7 +3402,7 @@ End:
   Return(v4, v5, v17)
 
 
-Final lowering of specialized call "test::foo[30-63]":
+Final lowering of specialized call "test::foo[49-82]":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
@@ -3480,7 +3424,7 @@ End:
 blk2:
 Statements:
   (v9: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v3)
-  (v10: core::RangeCheck, v11: core::gas::GasBuiltin, v12: core::panics::PanicResult::<(core::result::Result::<(), core::integer::u32>,)>) <- test::foo[30-63](v2, v9)
+  (v10: core::RangeCheck, v11: core::gas::GasBuiltin, v12: core::panics::PanicResult::<(core::result::Result::<(), core::integer::u32>,)>) <- test::foo[49-82](v2, v9)
 End:
   Return(v10, v11, v12)
 
@@ -3508,7 +3452,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252, b: felt252, c: felt252) -> bool {
     let mut x = 5;
     let mut s = S { a: 1, b: 2, c: 3 };
@@ -3532,9 +3477,6 @@ struct S {
     c: felt252,
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -3552,7 +3494,7 @@ Statements:
   (v5: core::felt252) <- 2
   (v6: core::felt252) <- 3
   (v7: test::S) <- struct_construct(v4, v5, v6)
-  (v9: core::felt252, v8: core::bool) <- test::foo[112-254](v7, v0, v3)
+  (v9: core::felt252, v8: core::bool) <- test::foo[131-273](v7, v0, v3)
   (v10: core::felt252, v11: core::felt252, v12: core::felt252) <- struct_destructure(v7)
 End:
   Return(v8)
@@ -3562,7 +3504,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::felt252, v3: core::felt252, v4: core::felt252
 blk0 (root):
 Statements:
-  (v5: core::RangeCheck, v6: core::gas::GasBuiltin, v7: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[112-254]{{ 1, 2, 3 }, NotSpecialized, 5, }(v0, v1, v2)
+  (v5: core::RangeCheck, v6: core::gas::GasBuiltin, v7: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[131-273]{{ 1, 2, 3 }, NotSpecialized, 5, }(v0, v1, v2)
 End:
   Match(match_enum(v7) {
     PanicResult::Ok(v8) => blk1,
@@ -3626,7 +3568,7 @@ End:
 blk3:
 Statements:
   (v20: test::S) <- struct_construct(v1, v4, v5)
-  (v22: core::felt252, v21: core::bool) <- test::foo[112-254](v20, v1, v2)
+  (v22: core::felt252, v21: core::bool) <- test::foo[131-273](v20, v1, v2)
   (v23: core::felt252, v24: core::felt252, v25: core::felt252) <- struct_destructure(v20)
 End:
   Return(v22, v21)
@@ -3672,7 +3614,7 @@ blk3:
 Statements:
   (v24: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v6)
   (v25: test::S) <- struct_construct(v3, v10, v11)
-  (v26: core::RangeCheck, v27: core::gas::GasBuiltin, v28: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[112-254](v5, v24, v25, v3, v4)
+  (v26: core::RangeCheck, v27: core::gas::GasBuiltin, v28: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[131-273](v5, v24, v25, v3, v4)
 End:
   Return(v26, v27, v28)
 
@@ -3684,7 +3626,7 @@ End:
   Return(v7, v8, v30)
 
 
-Final lowering of specialized call "test::foo[112-254]{{ 1, 2, 3 }, NotSpecialized, 5, }":
+Final lowering of specialized call "test::foo[131-273]{{ 1, 2, 3 }, NotSpecialized, 5, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::felt252
 blk0 (root):
 Statements:
@@ -3702,7 +3644,7 @@ Statements:
   (v10: core::felt252) <- 3
   (v11: test::S) <- struct_construct(v8, v9, v10)
   () <- test::bar(v11)
-  (v12: core::RangeCheck, v13: core::gas::GasBuiltin, v14: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[112-254]{{ NotSpecialized, 2, 3 }, NotSpecialized, 5, }(v3, v7, v2, v2)
+  (v12: core::RangeCheck, v13: core::gas::GasBuiltin, v14: core::panics::PanicResult::<(core::felt252, core::bool)>) <- test::foo[131-273]{{ NotSpecialized, 2, 3 }, NotSpecialized, 5, }(v3, v7, v2, v2)
 End:
   Return(v12, v13, v14)
 
@@ -3720,7 +3662,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(s: S) -> bool {
     let x = 5;
     let mut o = Outer { a: 1, s: s };
@@ -3746,9 +3689,6 @@ struct Outer {
     s: S,
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -3764,7 +3704,7 @@ Statements:
   (v1: core::felt252) <- 5
   (v2: core::felt252) <- 1
   (v3: test::Outer) <- struct_construct(v2, v0)
-  (v5: test::S, v4: core::bool) <- test::foo[76-191](v3, v1)
+  (v5: test::S, v4: core::bool) <- test::foo[95-210](v3, v1)
   (v6: core::felt252, v7: test::S) <- struct_destructure(v3)
 End:
   Return(v4)
@@ -3774,7 +3714,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: test::S
 blk0 (root):
 Statements:
-  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(test::S, core::bool)>) <- test::foo[76-191]{{ 1, NotSpecialized }, 5, }(v0, v1, v2)
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(test::S, core::bool)>) <- test::foo[95-210]{{ 1, NotSpecialized }, 5, }(v0, v1, v2)
 End:
   Match(match_enum(v5) {
     PanicResult::Ok(v6) => blk1,
@@ -3835,7 +3775,7 @@ End:
 blk3:
 Statements:
   (v15: test::Outer) <- struct_construct(v3, v2)
-  (v17: test::S, v16: core::bool) <- test::foo[76-191](v15, v5)
+  (v17: test::S, v16: core::bool) <- test::foo[95-210](v15, v5)
   (v18: core::felt252, v19: test::S) <- struct_destructure(v15)
 End:
   Return(v17, v16)
@@ -3878,7 +3818,7 @@ Statements:
   (v17: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v5)
   (v18: core::felt252, v19: test::S) <- struct_destructure(v2)
   (v20: test::Outer) <- struct_construct(v18, v10)
-  (v21: core::RangeCheck, v22: core::gas::GasBuiltin, v23: core::panics::PanicResult::<(test::S, core::bool)>) <- test::foo[76-191](v4, v17, v20, v3)
+  (v21: core::RangeCheck, v22: core::gas::GasBuiltin, v23: core::panics::PanicResult::<(test::S, core::bool)>) <- test::foo[95-210](v4, v17, v20, v3)
 End:
   Return(v21, v22, v23)
 
@@ -3890,7 +3830,7 @@ End:
   Return(v6, v7, v25)
 
 
-Final lowering of specialized call "test::foo[76-191]{{ 1, NotSpecialized }, 5, }":
+Final lowering of specialized call "test::foo[95-210]{{ 1, NotSpecialized }, 5, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: test::S
 blk0 (root):
 Statements:
@@ -3909,7 +3849,7 @@ Statements:
   (v10: core::felt252) <- 5
   (v11: test::S) <- struct_construct(v10)
   (v12: test::Outer) <- struct_construct(v8, v11)
-  (v13: core::RangeCheck, v14: core::gas::GasBuiltin, v15: core::panics::PanicResult::<(test::S, core::bool)>) <- test::foo[76-191]{NotSpecialized, 5, }(v3, v7, v12)
+  (v13: core::RangeCheck, v14: core::gas::GasBuiltin, v15: core::panics::PanicResult::<(test::S, core::bool)>) <- test::foo[95-210]{NotSpecialized, 5, }(v3, v7, v12)
 End:
   Return(v13, v14, v15)
 

--- a/crates/cairo-lang-lowering/src/lower/test_data/merge_block_builders
+++ b/crates/cairo-lang-lowering/src/lower/test_data/merge_block_builders
@@ -114,7 +114,7 @@ x: B
     (x.n, 2), // Different.
 );
 
-//! > module_code
+//! > helper_code
 struct A {
     m: felt252,
     n: felt252,
@@ -193,7 +193,7 @@ x: C
     (x.b.m, 7), // Same in both blocks.
 );
 
-//! > module_code
+//! > helper_code
 struct A {
     m: felt252,
     n: felt252,

--- a/crates/cairo-lang-lowering/src/lower/test_data/specialized
+++ b/crates/cairo-lang-lowering/src/lower/test_data/specialized
@@ -3,15 +3,7 @@
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo() {
-    bar(false, 1)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, x: felt252) {
     if keep {
         bar_ext(x);
@@ -20,6 +12,10 @@ fn bar(keep: bool, x: felt252) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(x: felt252) nopanic;
+#[target_function]
+fn foo() {
+    bar(false, 1)
+}
 
 //! > caller_lowering
 Parameters:
@@ -51,15 +47,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo() {
-    bar(false, BoxTrait::new(2))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, x: Box<felt252>) {
     if keep {
         bar_ext(x);
@@ -68,6 +56,10 @@ fn bar(keep: bool, x: Box<felt252>) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(x: Box<felt252>) nopanic;
+#[target_function]
+fn foo() {
+    bar(false, BoxTrait::new(2))
+}
 
 //! > caller_lowering
 Parameters:
@@ -99,15 +91,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo() {
-    bar(false, array![])
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, x: Array<felt252>) {
     if keep {
         bar_ext(x);
@@ -116,6 +100,10 @@ fn bar(keep: bool, x: Array<felt252>) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(x: Array<felt252>) nopanic;
+#[target_function]
+fn foo() {
+    bar(false, array![])
+}
 
 //! > caller_lowering
 Parameters:
@@ -148,19 +136,15 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo() {
-    bar(false, array![1, 2, 3])
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, x: Array<felt252>) {
     if keep {
         println!("Ensuring long code: {}{}{}", x[0], x[1], x[2]);
     }
+}
+#[target_function]
+fn foo() {
+    bar(false, array![1, 2, 3])
 }
 
 //! > caller_lowering
@@ -206,15 +190,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo() {
-    bar(false, array![])
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, x: Array<felt252>) {
     if keep {
         bar_ext(x);
@@ -223,6 +199,10 @@ fn bar(keep: bool, x: Array<felt252>) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(x: Array<felt252>) nopanic;
+#[target_function]
+fn foo() {
+    bar(false, array![])
+}
 
 //! > caller_lowering
 Parameters:
@@ -255,16 +235,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(x: felt252) {
-    let mut arr = array![];
-    bar(false, ref arr, arr.span(), x, 0, BoxTrait::new(1))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(
     keep: bool, ref arr: Array<felt252>, d: Span<felt252>, x: felt252, y: felt252, z: Box<felt252>,
 ) {
@@ -277,6 +248,11 @@ fn bar(
 extern fn bar_ext(
     ref arr: Array<felt252>, d: Span<felt252>, x: felt252, y: felt252, z: Box<felt252>,
 ) nopanic;
+#[target_function]
+fn foo(x: felt252) {
+    let mut arr = array![];
+    bar(false, ref arr, arr.span(), x, 0, BoxTrait::new(1))
+}
 
 //! > caller_lowering
 Parameters: v0: core::felt252
@@ -314,15 +290,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(b: felt252, e: felt252, d: felt252) {
-    bar(false, S6 { a: 1, b, c: 3, d, e, f: 6 })
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct S6 {
     a: felt252,
@@ -341,6 +309,10 @@ fn bar(keep: bool, s: S6) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(s: S6) nopanic;
+#[target_function]
+fn foo(b: felt252, e: felt252, d: felt252) {
+    bar(false, S6 { a: 1, b, c: 3, d, e, f: 6 })
+}
 
 //! > caller_lowering
 Parameters: v0: core::felt252, v1: core::felt252, v2: core::felt252
@@ -375,16 +347,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(b: felt252) {
-    // TODO(TomerStarkware): propagate array info in case of specialized function call.
-    bar(false, SA1 { a: array![1, 2, 3], b, c: array![] })
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct SA1 {
     a: Array<felt252>,
@@ -400,6 +363,11 @@ fn bar(keep: bool, s: SA1) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(s: SA1) nopanic;
+#[target_function]
+fn foo(b: felt252) {
+    // TODO(TomerStarkware): propagate array info in case of specialized function call.
+    bar(false, SA1 { a: array![1, 2, 3], b, c: array![] })
+}
 
 //! > caller_lowering
 Parameters: v0: core::felt252
@@ -439,16 +407,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(a: Array<felt252>) {
-    // TODO(TomerStarkware): propagate array info in case of specialized function call.
-    bar(false, SA1 { a, b: 7, c: array![5, 6] })
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct SA1 {
     a: Array<felt252>,
@@ -464,6 +423,11 @@ fn bar(keep: bool, s: SA1) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(s: SA1) nopanic;
+#[target_function]
+fn foo(a: Array<felt252>) {
+    // TODO(TomerStarkware): propagate array info in case of specialized function call.
+    bar(false, SA1 { a, b: 7, c: array![5, 6] })
+}
 
 //! > caller_lowering
 Parameters: v0: core::array::Array::<core::felt252>
@@ -501,18 +465,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(a: NoDrop) {
-    // TODO(TomerStarkware): Allow for specialzing with non-droppable fields.
-    let c = NoDrop { a: 7 };
-    not_consume(c);
-    bar(false, SB { a, b: 5, c })
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy)]
 struct SB {
     a: NoDrop,
@@ -541,6 +494,13 @@ fn bar(keep: bool, s: SB) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(s: SB) nopanic;
+#[target_function]
+fn foo(a: NoDrop) {
+    // TODO(TomerStarkware): Allow for specialzing with non-droppable fields.
+    let c = NoDrop { a: 7 };
+    not_consume(c);
+    bar(false, SB { a, b: 5, c })
+}
 
 //! > caller_lowering
 Parameters: v0: test::NoDrop
@@ -576,15 +536,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(a: felt252) {
-    bar(false, S { a, b: 5 })
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct S {
     a: felt252,
@@ -599,6 +551,10 @@ fn bar(keep: bool, s: S) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(s: S) nopanic;
+#[target_function]
+fn foo(a: felt252) {
+    bar(false, S { a, b: 5 })
+}
 
 //! > caller_lowering
 Parameters: v0: core::felt252
@@ -631,18 +587,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(x: felt252, y: felt252) {
-    let mut arr = array![];
-    arr.append(Outer { inner: Inner { a: 1, b: x }, c: 3 });
-    arr.append(Outer { inner: Inner { a: y, b: 5 }, c: y });
-    bar(false, arr);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy, Debug)]
 struct Inner {
     a: felt252,
@@ -662,6 +607,13 @@ fn bar(keep: bool, x: Array<Outer>) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(arr: Array<Outer>) nopanic;
+#[target_function]
+fn foo(x: felt252, y: felt252) {
+    let mut arr = array![];
+    arr.append(Outer { inner: Inner { a: 1, b: x }, c: 3 });
+    arr.append(Outer { inner: Inner { a: y, b: 5 }, c: y });
+    bar(false, arr);
+}
 
 //! > caller_lowering
 Parameters: v0: core::felt252, v1: core::felt252
@@ -712,15 +664,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(x: felt252) {
-    bar(false, E::A(x))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 enum E {
     A: felt252,
@@ -735,6 +679,10 @@ fn bar(keep: bool, e: E) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(e: E) nopanic;
+#[target_function]
+fn foo(x: felt252) {
+    bar(false, E::A(x))
+}
 
 //! > semantic_diagnostics
 
@@ -766,16 +714,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(b: felt252) {
-    let s = S { a: 1, b };
-    bar(false, E::A(s))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct S {
     a: felt252,
@@ -795,6 +734,11 @@ fn bar(keep: bool, e: E) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(e: E) nopanic;
+#[target_function]
+fn foo(b: felt252) {
+    let s = S { a: 1, b };
+    bar(false, E::A(s))
+}
 
 //! > semantic_diagnostics
 
@@ -828,15 +772,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(b: felt252) {
-    bar1(false, 100000);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar1(keep: bool, a: felt252) -> felt252 {
     if !keep || a == 0 {
         0
@@ -851,6 +787,10 @@ fn bar2(keep: bool, a: felt252) -> felt252 {
     } else {
         bar1(keep, a - 1)
     }
+}
+#[target_function]
+fn foo(b: felt252) {
+    bar1(false, 100000);
 }
 
 //! > semantic_diagnostics
@@ -901,15 +841,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo() {
-    bar(false, (1, 2, 3))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, t: (felt252, felt252, felt252)) {
     if keep {
         bar_ext(t);
@@ -918,6 +850,10 @@ fn bar(keep: bool, t: (felt252, felt252, felt252)) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(t: (felt252, felt252, felt252)) nopanic;
+#[target_function]
+fn foo() {
+    bar(false, (1, 2, 3))
+}
 
 //! > semantic_diagnostics
 
@@ -952,15 +888,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(b: felt252) {
-    bar(false, (1, b, 3))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, t: (felt252, felt252, felt252)) {
     if keep {
         bar_ext(t);
@@ -969,6 +897,10 @@ fn bar(keep: bool, t: (felt252, felt252, felt252)) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(t: (felt252, felt252, felt252)) nopanic;
+#[target_function]
+fn foo(b: felt252) {
+    bar(false, (1, b, 3))
+}
 
 //! > semantic_diagnostics
 
@@ -1002,15 +934,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo() {
-    bar(false, [1, 2, 3])
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, arr: [felt252; 3]) {
     if keep {
         bar_ext(arr);
@@ -1019,6 +943,10 @@ fn bar(keep: bool, arr: [felt252; 3]) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(arr: [felt252; 3]) nopanic;
+#[target_function]
+fn foo() {
+    bar(false, [1, 2, 3])
+}
 
 //! > semantic_diagnostics
 
@@ -1053,15 +981,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(b: felt252) {
-    bar(false, [1, b, 3])
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar(keep: bool, arr: [felt252; 3]) {
     if keep {
         bar_ext(arr);
@@ -1070,6 +990,10 @@ fn bar(keep: bool, arr: [felt252; 3]) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(arr: [felt252; 3]) nopanic;
+#[target_function]
+fn foo(b: felt252) {
+    bar(false, [1, b, 3])
+}
 
 //! > semantic_diagnostics
 
@@ -1103,15 +1027,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(x: felt252) {
-    bar(false, S { t: (1, x), a: 3 })
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct S {
     t: (felt252, felt252),
@@ -1126,6 +1042,10 @@ fn bar(keep: bool, s: S) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(s: S) nopanic;
+#[target_function]
+fn foo(x: felt252) {
+    bar(false, S { t: (1, x), a: 3 })
+}
 
 //! > semantic_diagnostics
 
@@ -1160,15 +1080,7 @@ End:
 //! > test_runner_name
 test_specialized_function
 
-//! > function_code
-fn foo(x: felt252) {
-    bar(false, S { arr: [1, x, 3], a: 4 })
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct S {
     arr: [felt252; 3],
@@ -1183,6 +1095,10 @@ fn bar(keep: bool, s: S) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar_ext(s: S) nopanic;
+#[target_function]
+fn foo(x: felt252) {
+    bar(false, S { arr: [1, x, 3], a: 4 })
+}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/lower/test_data/while
+++ b/crates/cairo-lang-lowering/src/lower/test_data/while
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(y: felt252) -> felt252 {
     let mut x = 5;
     while x != 0 {
@@ -11,9 +12,6 @@ fn foo(y: felt252) -> felt252 {
     }
     x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -28,7 +26,7 @@ Parameters: v0: core::felt252
 blk0 (root):
 Statements:
   (v1: core::felt252) <- 5
-  (v3: core::felt252, v2: ()) <- test::foo[51-95](v1)
+  (v3: core::felt252, v2: ()) <- test::foo[70-114](v1)
 End:
   Return(v3)
 
@@ -37,7 +35,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: core::felt252
 blk0 (root):
 Statements:
-  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[51-95]{5, }(v0, v1)
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[70-114]{5, }(v0, v1)
 End:
   Match(match_enum(v5) {
     PanicResult::Ok(v6) => blk1,
@@ -84,7 +82,7 @@ blk1:
 Statements:
   (v8: core::felt252) <- 1
   (v9: core::felt252) <- core::Felt252Sub::sub(v1, v8)
-  (v11: core::felt252, v10: ()) <- test::foo[51-95](v9)
+  (v11: core::felt252, v10: ()) <- test::foo[70-114](v9)
 End:
   Return(v11, v10)
 
@@ -127,7 +125,7 @@ Statements:
   (v12: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
   (v13: core::felt252) <- 1
   (v14: core::felt252) <- core::felt252_sub(v2, v13)
-  (v15: core::RangeCheck, v16: core::gas::GasBuiltin, v17: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[51-95](v3, v12, v14)
+  (v15: core::RangeCheck, v16: core::gas::GasBuiltin, v17: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[70-114](v3, v12, v14)
 End:
   Return(v15, v16, v17)
 
@@ -139,7 +137,7 @@ End:
   Return(v5, v6, v19)
 
 
-Final lowering of specialized call "test::foo[51-95]{5, }":
+Final lowering of specialized call "test::foo[70-114]{5, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
@@ -153,7 +151,7 @@ blk1:
 Statements:
   (v6: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v3)
   (v7: core::felt252) <- 4
-  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[51-95](v2, v6, v7)
+  (v8: core::RangeCheck, v9: core::gas::GasBuiltin, v10: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[70-114](v2, v6, v7)
 End:
   Return(v8, v9, v10)
 
@@ -171,7 +169,8 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(ref arr: Array<felt252>, mut x: felt252) -> felt252 {
     while let true = (x != 0) {
         x = x - 1;
@@ -179,9 +178,6 @@ fn foo(ref arr: Array<felt252>, mut x: felt252) -> felt252 {
     }
     x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -195,7 +191,7 @@ Main:
 Parameters: v0: core::array::Array::<core::felt252>, v1: core::felt252
 blk0 (root):
 Statements:
-  (v3: core::felt252, v2: ()) <- test::foo[61-133](v1)
+  (v3: core::felt252, v2: ()) <- test::foo[80-152](v1)
 End:
   Return(v0, v3)
 
@@ -292,7 +288,15 @@ End:
 //! > test_runner_name
 test_generated_function
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[allow(extern_outside_corelib)]
+extern fn a() -> MyEnum nopanic;
+#[target_function]
 fn foo() -> felt252 {
     let mut y = 0;
     while let MyEnum::A(x) = a() {
@@ -301,18 +305,6 @@ fn foo() -> felt252 {
     y = y + 1;
     return y;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
-}
-#[allow(extern_outside_corelib)]
-extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
 
@@ -326,7 +318,7 @@ Parameters:
 blk0 (root):
 Statements:
   (v0: core::felt252) <- 0
-  (v2: core::felt252, v1: ()) <- test::foo[41-100](v0)
+  (v2: core::felt252, v1: ()) <- test::foo[60-119](v0)
   (v3: core::felt252) <- 1
   (v4: core::felt252) <- core::Felt252Add::add(v2, v3)
 End:
@@ -337,7 +329,7 @@ Final lowering:
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[41-100]{0, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[60-119]{0, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -382,7 +374,7 @@ End:
 blk1:
 Statements:
   (v4: core::felt252) <- core::Felt252Add::add(v0, v1)
-  (v6: core::felt252, v5: ()) <- test::foo[41-100](v4)
+  (v6: core::felt252, v5: ()) <- test::foo[60-119](v4)
 End:
   Return(v6, v5)
 
@@ -433,7 +425,7 @@ blk2:
 Statements:
   (v8: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v4)
   (v9: core::felt252) <- core::felt252_add(v2, v7)
-  (v10: core::RangeCheck, v11: core::gas::GasBuiltin, v12: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[41-100](v3, v8, v9)
+  (v10: core::RangeCheck, v11: core::gas::GasBuiltin, v12: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[60-119](v3, v8, v9)
 End:
   Return(v10, v11, v12)
 
@@ -465,7 +457,7 @@ End:
   Return(v5, v6, v20)
 
 
-Final lowering of specialized call "test::foo[41-100]{0, }":
+Final lowering of specialized call "test::foo[60-119]{0, }":
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
@@ -488,7 +480,7 @@ End:
 blk2:
 Statements:
   (v8: core::gas::GasBuiltin) <- core::gas::redeposit_gas(v3)
-  (v9: core::RangeCheck, v10: core::gas::GasBuiltin, v11: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[41-100](v2, v8, v7)
+  (v9: core::RangeCheck, v10: core::gas::GasBuiltin, v11: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[60-119](v2, v8, v7)
 End:
   Return(v9, v10, v11)
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/arm_pattern_destructure
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/arm_pattern_destructure
@@ -3,7 +3,20 @@
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    a: (felt252, (felt252, felt252)),
+    b: (felt252, (felt252, felt252)),
+    c: (felt252, (felt252, felt252)),
+    d: (felt252, felt252),
+    e: (felt252, felt252),
+    f: (felt252,),
+    g: (felt252,),
+    h: felt252,
+}
+#[allow(extern_outside_corelib)]
+extern fn bar(ref r: felt252) -> MyEnum implicits(RangeCheck) nopanic;
+#[target_function]
 fn foo(mut z: felt252) {
     let y = bar(ref z);
     match y {
@@ -17,23 +30,6 @@ fn foo(mut z: felt252) {
         MyEnum::h(_x) => {},
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    a: (felt252, (felt252, felt252)),
-    b: (felt252, (felt252, felt252)),
-    c: (felt252, (felt252, felt252)),
-    d: (felt252, felt252),
-    e: (felt252, felt252),
-    f: (felt252,),
-    g: (felt252,),
-    h: felt252,
-}
-#[allow(extern_outside_corelib)]
-extern fn bar(ref r: felt252) -> MyEnum implicits(RangeCheck) nopanic;
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/branch_inversion
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/branch_inversion
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_branch_inversion
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: bool, x: felt252) -> felt252 {
     if !a {
         1
@@ -11,9 +12,6 @@ fn foo(a: bool, x: felt252) -> felt252 {
         x
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/const_folding
@@ -3,14 +3,12 @@
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let b = a - 0;
     b - 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -45,16 +43,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+const PRIME_MINUS_1: felt252 = -1;
+#[target_function]
 fn foo() -> felt252 {
     PRIME_MINUS_1 + 2
 }
-
-//! > function_name
-foo
-
-//! > module_code
-const PRIME_MINUS_1: felt252 = -1;
 
 //! > semantic_diagnostics
 
@@ -87,13 +81,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     0 - 1
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -126,16 +118,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+const PRIME_MINUS_1: felt252 = -1;
+#[target_function]
 fn foo() -> felt252 {
     PRIME_MINUS_1 * 2
 }
-
-//! > function_name
-foo
-
-//! > module_code
-const PRIME_MINUS_1: felt252 = -1;
 
 //! > semantic_diagnostics
 
@@ -168,16 +156,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+const PRIME_MINUS_1: felt252 = -1;
+#[target_function]
 fn foo() -> felt252 {
     (PRIME_MINUS_1 + 2) * 2
 }
-
-//! > function_name
-foo
-
-//! > module_code
-const PRIME_MINUS_1: felt252 = -1;
 
 //! > semantic_diagnostics
 
@@ -214,13 +198,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Box<felt252> {
     BoxTrait::new(0)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -251,17 +233,15 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
 struct A {
     a: felt252,
 }
 
+#[target_function]
 fn foo() -> Box<A> {
     BoxTrait::new(A { a: 1 })
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -294,13 +274,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Box<Option<felt252>> {
     BoxTrait::new(Some(2))
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -333,19 +311,15 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn use_box<T>(b: @Box<T>) nopanic;
-
-//! > function_code
+#[target_function]
 fn foo() -> felt252 {
     let box = BoxTrait::new(2);
     use_box(@box);
     box.unbox()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -380,13 +354,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u8 {
     8 / 4
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -492,13 +464,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> u8 {
     x / 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -600,13 +570,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u256) -> u256 {
     x / 4
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -711,13 +679,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u256) -> u256 {
     x / 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -821,13 +787,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u128) -> u128 {
     x / 1_u64.into()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -932,13 +896,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u64) -> u64 {
     x / 1_u128.try_into().unwrap()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1153,13 +1115,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> u8 {
     x / 300_u16.try_into().unwrap()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1375,13 +1335,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> starknet::StorageBaseAddress {
     starknet::storage_access::storage_base_address_from_felt252(10)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1412,7 +1370,10 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+use starknet::StorageBaseAddress;
+use starknet::storage_access::storage_base_address_from_felt252;
+#[target_function]
 fn foo() -> [StorageBaseAddress; 6] {
     [
         storage_base_address_from_felt252(1), storage_base_address_from_felt252(2),
@@ -1425,13 +1386,6 @@ fn foo() -> [StorageBaseAddress; 6] {
         storage_base_address_from_felt252(-1), storage_base_address_from_felt252(-2),
     ]
 }
-
-//! > module_code
-use starknet::StorageBaseAddress;
-use starknet::storage_access::storage_base_address_from_felt252;
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1484,16 +1438,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+use starknet::storage::StoragePathTrait;
+#[target_function]
 fn foo() -> starknet::storage::StorageBaseAddress {
     starknet::storage::StorageBase::<felt252> { __base_address__: 1337 }.deref().finalize()
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use starknet::storage::StoragePathTrait;
 
 //! > semantic_diagnostics
 
@@ -1532,13 +1482,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u8 {
     1 + 3
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1641,13 +1589,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u8 {
     250 + 50
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1750,13 +1696,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u8 {
     7 - 5
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1859,13 +1803,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u8 {
     1 - 3
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1968,13 +1910,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u8 {
     5 * 3
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2079,13 +2019,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> i8 {
     -50 + 100
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2203,13 +2141,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> i8 {
     100 + 100
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2327,13 +2263,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> i8 {
     -100 + -100
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2451,13 +2385,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> i8 {
     50 - 100
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2575,13 +2507,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> i8 {
     100 - -100
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2699,13 +2629,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> i8 {
     -100 - 100
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2823,13 +2751,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     100_i8 < 90_i8
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2902,13 +2828,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     90_i8 < 100_i8
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2981,15 +2905,13 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     let x: (felt252, Felt252Dict<felt252>) = (0, Default::<Felt252Dict>::default());
     let (l, _) = @x;
     *l == 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -3075,13 +2997,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: i8) -> i8 {
     x / 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -3349,13 +3269,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> i8 {
     8 / 4
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -3623,13 +3541,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> (u8, bool) {
     core::integer::AbsAndSign::<i8, u8>::abs_and_sign(6_i8)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -3712,13 +3628,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> (u8, bool) {
     core::integer::AbsAndSign::<i8, u8>::abs_and_sign(-6_i8)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -3801,13 +3715,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u8 {
     ~5
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -3842,21 +3754,17 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
 #[feature("bounded-int-utils")]
+use core::internal::bounded_int::BoundedInt;
+#[feature("bounded-int-utils")]
+#[target_function]
 fn foo() -> Result<Box<NonZero<BoundedInt<-0x80, -1>>>, Box<NonZero<BoundedInt<0, 0x7f>>>> {
     match core::internal::bounded_int::constrain::<NonZero<i8>, 0>(-5) {
         Ok(v) => Ok(BoxTrait::new(v)),
         Err(v) => Err(BoxTrait::new(v)),
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[feature("bounded-int-utils")]
-use core::internal::bounded_int::BoundedInt;
 
 //! > semantic_diagnostics
 
@@ -3927,21 +3835,17 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
 #[feature("bounded-int-utils")]
+use core::internal::bounded_int::BoundedInt;
+#[feature("bounded-int-utils")]
+#[target_function]
 fn foo() -> Result<Box<NonZero<BoundedInt<-0x80, -1>>>, Box<NonZero<BoundedInt<0, 0x7f>>>> {
     match core::internal::bounded_int::constrain::<NonZero<i8>, 0>(5) {
         Ok(v) => Ok(BoxTrait::new(v)),
         Err(v) => Err(BoxTrait::new(v)),
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[feature("bounded-int-utils")]
-use core::internal::bounded_int::BoundedInt;
 
 //! > semantic_diagnostics
 
@@ -4012,13 +3916,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     1_u8 == 1
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4090,13 +3992,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     2_u8 == 1
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4168,13 +4068,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> u8 {
     x * 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4277,13 +4175,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> u8 {
     x + 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4383,13 +4279,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> u8 {
     0 + x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4489,13 +4383,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> u8 {
     x - 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4595,13 +4487,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> u8 {
     x + 1
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4705,13 +4595,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> u8 {
     x - 1
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4815,13 +4703,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u8) -> bool {
     x == 0
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4894,13 +4780,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: @Array<u8>) -> Option<Box<@u8>> {
     x.get(0)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -4971,7 +4855,10 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[feature("bounded-int-utils")]
+use core::internal::bounded_int::BoundedInt;
+#[target_function]
 fn foo(x: BoundedInt<0, 10>) -> u8 {
     match x {
         0 => 1,
@@ -4988,13 +4875,6 @@ fn foo(x: BoundedInt<0, 10>) -> u8 {
         _ => 12,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[feature("bounded-int-utils")]
-use core::internal::bounded_int::BoundedInt;
 
 //! > semantic_diagnostics
 
@@ -5213,7 +5093,8 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> u8 {
     match 5 {
         0 => 1,
@@ -5230,9 +5111,6 @@ fn foo() -> u8 {
         _ => 12,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -5442,13 +5320,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Option<Box<@u8>> {
     array![0, 1, 2].get(1)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -5535,13 +5411,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Option<Box<@u8>> {
     array![0, 1, 2].get(5)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -5625,13 +5499,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(v: u8) -> Option<Box<@u8>> {
     array![v, v, v].get(1)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -5712,13 +5584,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(v: u8) -> Option<Box<@u8>> {
     array![v, v, v].get(5)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -5796,13 +5666,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> usize {
     array![x, x].len()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -5839,14 +5707,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Option<felt252> {
     let mut arr = array![];
     arr.pop_front()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -5916,14 +5782,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut arr: Array<felt252>) -> Option<felt252> {
     arr.append(1);
     arr.pop_front()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -5998,14 +5862,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Option<@felt252> {
     let mut span = array![].span();
     span.pop_front()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6077,14 +5939,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Option<@felt252> {
     let mut span = array![].span();
     span.pop_back()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6156,13 +6016,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     core::panics::panic_with_byte_array(@"hello world");
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6213,7 +6071,8 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let v = @Some(1);
     match v {
@@ -6221,9 +6080,6 @@ fn foo() -> felt252 {
         None => 0,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6295,7 +6151,8 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let v = Some(@1);
     match v {
@@ -6303,9 +6160,6 @@ fn foo() -> felt252 {
         None => 0,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6375,7 +6229,8 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let v = Some(a);
     match v {
@@ -6383,9 +6238,6 @@ fn foo(a: felt252) -> felt252 {
         None => 0,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6449,7 +6301,8 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let v = @Some(a);
     match v {
@@ -6457,9 +6310,6 @@ fn foo(a: felt252) -> felt252 {
         None => 0,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6528,7 +6378,8 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let v = @(@Some(1));
     match v {
@@ -6536,9 +6387,6 @@ fn foo() -> felt252 {
         None => 0,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6615,13 +6463,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     1 + 2
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6654,13 +6500,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     5 - 3
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6693,13 +6537,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     2 * 3
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6732,13 +6574,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     1 + 2 * 3 - 4
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6779,14 +6619,12 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let x = core::felt252_div(6, 30);
     x * 5
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6823,13 +6661,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     core::felt252_div(a, 1)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6860,13 +6696,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: NonZero<felt252>) -> felt252 {
     core::felt252_div(0, a)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -6897,20 +6731,16 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[feature("bounded-int-utils")]
+use core::internal::bounded_int::{trim_min, upcast};
+#[target_function]
 fn foo() -> felt252 {
     match trim_min(0_i8) {
         core::internal::OptionRev::Some(x) => upcast(x),
         core::internal::OptionRev::None => 200,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[feature("bounded-int-utils")]
-use core::internal::bounded_int::{trim_min, upcast};
 
 //! > semantic_diagnostics
 
@@ -6977,20 +6807,16 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[feature("bounded-int-utils")]
+use core::internal::bounded_int::{trim_min, upcast};
+#[target_function]
 fn foo() -> felt252 {
     match trim_min(-0x80_i8) {
         core::internal::OptionRev::Some(x) => upcast(x),
         core::internal::OptionRev::None => 200,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[feature("bounded-int-utils")]
-use core::internal::bounded_int::{trim_min, upcast};
 
 //! > semantic_diagnostics
 
@@ -7056,20 +6882,16 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[feature("bounded-int-utils")]
+use core::internal::bounded_int::{trim_max, upcast};
+#[target_function]
 fn foo() -> felt252 {
     match trim_max(0_i8) {
         core::internal::OptionRev::Some(x) => upcast(x),
         core::internal::OptionRev::None => 200,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[feature("bounded-int-utils")]
-use core::internal::bounded_int::{trim_max, upcast};
 
 //! > semantic_diagnostics
 
@@ -7136,20 +6958,16 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[feature("bounded-int-utils")]
+use core::internal::bounded_int::{trim_max, upcast};
+#[target_function]
 fn foo() -> felt252 {
     match trim_max(0x7f_i8) {
         core::internal::OptionRev::Some(x) => upcast(x),
         core::internal::OptionRev::None => 200,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[feature("bounded-int-utils")]
-use core::internal::bounded_int::{trim_max, upcast};
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/cse
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/cse
@@ -3,13 +3,11 @@
 //! > test_runner_name
 test_cse
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u32, y: u32) -> ((u32, u32), (u32, u32)) {
     ((x, y), (x, y))
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -41,15 +39,13 @@ End:
 //! > test_runner_name
 test_cse
 
-//! > function_code
+//! > cairo_code
 use core::option::Option;
 
+#[target_function]
 fn foo(x: u32) -> (Option<u32>, Option<u32>) {
     (Option::Some(x), Option::Some(x))
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -81,13 +77,11 @@ End:
 //! > test_runner_name
 test_cse
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u32) -> (@u32, @u32) {
     (@x, @x)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -119,13 +113,11 @@ End:
 //! > test_runner_name
 test_cse
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: @u32) -> (u32, u32) {
     (*x, *x)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -157,15 +149,13 @@ End:
 //! > test_runner_name
 test_cse
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(tuple: (u32, u32)) -> (u32, u32, u32, u32) {
     let (a, b) = tuple;
     let (c, d) = tuple;
     (a, b, c, d)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -197,7 +187,8 @@ End:
 //! > test_runner_name
 test_cse
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u32, y: u32) -> u32 {
     let tuple1 = (x, y);
     let tuple2 = (x, y); // Duplicate struct construct
@@ -209,9 +200,6 @@ fn foo(x: u32, y: u32) -> u32 {
     let val2 = *snap2; // Using duplicate snapshots
     a + b + c + d + val1 + val2
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -260,15 +248,13 @@ End:
 //! > test_runner_name
 test_cse
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u32, y: u32, z: u32) -> ((u32, u32), (u32, u32)) {
     let tuple1 = (x, y); // Different inputs
     let tuple2 = (x, z); // Should NOT be eliminated
     (tuple1, tuple2)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/dedup_blocks
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/dedup_blocks
@@ -3,14 +3,12 @@
 //! > test_runner_name
 test_dedup_blocks
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut a: Array<u32>) {
     a.pop_front().unwrap();
     a.pop_front().unwrap();
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -105,7 +103,8 @@ End:
 //! > test_runner_name
 test_dedup_blocks
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut a: Array<felt252>) -> felt252 {
     if let Some(val) = a.pop_front() {
         return val + 5;
@@ -115,9 +114,6 @@ fn foo(mut a: Array<felt252>) -> felt252 {
     }
     1
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -228,7 +224,14 @@ End:
 //! > test_runner_name
 test_dedup_blocks
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    V0: felt252,
+    V1: felt252,
+    V2: felt252,
+    V3: felt252,
+}
+#[target_function]
 fn foo(t: MyEnum) -> felt252 {
     let mut w = 8;
     let v = match t {
@@ -242,17 +245,6 @@ fn foo(t: MyEnum) -> felt252 {
     };
     v + w
 }
-
-//! > module_code
-enum MyEnum {
-    V0: felt252,
-    V1: felt252,
-    V2: felt252,
-    V3: felt252,
-}
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/early_unsafe_panic
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/early_unsafe_panic
@@ -3,16 +3,14 @@
 //! > test_runner_name
 test_early_unsafe_panic
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Option<u32>) -> u32 {
     match a {
         Some(x) => x,
         None => core::panic_with_felt252('error'),
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -68,14 +66,12 @@ End:
 //! > test_runner_name
 test_early_unsafe_panic
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Option<u32>) -> u32 {
     a.unwrap();
     core::panic_with_felt252('error')
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -134,16 +130,14 @@ End:
 //! > test_runner_name
 test_early_unsafe_panic
 
-//! > function_code
+//! > cairo_code
 use core::debug::PrintTrait;
 
+#[target_function]
 fn foo(a: Option<u32>) -> u32 {
     'error'.print();
     core::panic_with_felt252('error')
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -181,17 +175,15 @@ End:
 //! > test_runner_name
 test_early_unsafe_panic
 
-//! > function_code
+//! > cairo_code
 use core::debug::PrintTrait;
 
+#[target_function]
 fn foo(a: Option<u32>) -> u32 {
     'error1'.print();
     'error2'.print();
     core::panic_with_felt252('error3')
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/gas_redeposit
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/gas_redeposit
@@ -3,19 +3,7 @@
 //! > test_runner_name
 GetRedepositTestRunner
 
-//! > function_code
-fn foo(x: felt252) -> felt252 {
-    if x == 0 {
-        heavy_op1()
-    } else {
-        heavy_op2()
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn heavy_op1() -> felt252 {
     0
@@ -24,6 +12,14 @@ fn heavy_op1() -> felt252 {
 #[inline(never)]
 fn heavy_op2() -> felt252 {
     1
+}
+#[target_function]
+fn foo(x: felt252) -> felt252 {
+    if x == 0 {
+        heavy_op1()
+    } else {
+        heavy_op2()
+    }
 }
 
 //! > semantic_diagnostics
@@ -99,19 +95,7 @@ End:
 //! > test_runner_name
 GetRedepositTestRunner
 
-//! > function_code
-fn foo(x: felt252) -> felt252 {
-    if x == 0 {
-        heavy_op1()
-    } else {
-        heavy_op2()
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn heavy_op1() -> felt252 implicits(GasBuiltin) {
     0
@@ -120,6 +104,14 @@ fn heavy_op1() -> felt252 implicits(GasBuiltin) {
 #[inline(never)]
 fn heavy_op2() -> felt252 {
     1
+}
+#[target_function]
+fn foo(x: felt252) -> felt252 {
+    if x == 0 {
+        heavy_op1()
+    } else {
+        heavy_op2()
+    }
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/match_optimization
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/match_optimization
@@ -3,7 +3,10 @@
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn get_option() -> Option<u16> nopanic;
+#[target_function]
 fn foo() -> Option<u16> {
     let v = get_option();
     match v {
@@ -11,13 +14,6 @@ fn foo() -> Option<u16> {
         None => None,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn get_option() -> Option<u16> nopanic;
 
 //! > semantic_diagnostics
 
@@ -138,7 +134,10 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn get_option() -> Option<u16> nopanic;
+#[target_function]
 fn foo(a: felt252) -> Option<u16> {
     let v = get_option();
 
@@ -154,13 +153,6 @@ fn foo(a: felt252) -> Option<u16> {
         None => Some(2_u16),
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn get_option() -> Option<u16> nopanic;
 
 //! > semantic_diagnostics
 
@@ -329,7 +321,10 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn get_option() -> Option<felt252> nopanic;
+#[target_function]
 fn foo() -> felt252 {
     let opt = get_option();
     match opt {
@@ -337,13 +332,6 @@ fn foo() -> felt252 {
         None => None,
     }.unwrap()
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn get_option() -> Option<felt252> nopanic;
 
 //! > semantic_diagnostics
 
@@ -560,13 +548,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     gas::withdraw_gas().expect('Out of gas');
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -731,7 +717,13 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum MyEnum {
+    A: u32,
+    B: u32,
+}
+#[target_function]
 fn foo(a: MyEnum) -> u32 {
     let b = match a {
         MyEnum::A(_) => MyEnum::A(5),
@@ -742,16 +734,6 @@ fn foo(a: MyEnum) -> u32 {
         MyEnum::A(x) => x,
         MyEnum::B(x) => x,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum MyEnum {
-    A: u32,
-    B: u32,
 }
 
 //! > semantic_diagnostics
@@ -859,7 +841,15 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum Color {
+    Red: u32,
+    Green: u32,
+    Blue: u32,
+    White: u32,
+}
+#[target_function]
 fn foo(ref a: u32, c: Color) -> Color {
     let c = match c {
         Color::Red(x) => {
@@ -877,18 +867,6 @@ fn foo(ref a: u32, c: Color) -> Color {
         Color::Blue(x) => { return Color::Blue(x); },
         Color::White(x) => { return Color::White(x); },
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum Color {
-    Red: u32,
-    Green: u32,
-    Blue: u32,
-    White: u32,
 }
 
 //! > semantic_diagnostics
@@ -1049,7 +1027,15 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum Color {
+    Red: u32,
+    Green: u32,
+    Blue: u32,
+    White: u32,
+}
+#[target_function]
 fn foo(ref a: u32, c: Color) -> Color {
     let c = match c {
         Color::Red(x) => {
@@ -1067,18 +1053,6 @@ fn foo(ref a: u32, c: Color) -> Color {
         Color::Blue(x) => Color::Blue(x),
         Color::White(x) => Color::White(x),
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum Color {
-    Red: u32,
-    Green: u32,
-    Blue: u32,
-    White: u32,
 }
 
 //! > semantic_diagnostics
@@ -1242,17 +1216,7 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
-fn foo(ref a: Array<felt252>, ref b: Array<felt252>) -> Option<()> {
-    let _ = double_merge(ref a, ref b)?;
-    let _ = double_merge(ref a, ref b)?;
-    Some(())
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn double_merge(ref a: Array<felt252>, ref b: Array<felt252>) -> Option<felt252> {
     if let Some(q) = a.pop_front() {
         if q == 0 {
@@ -1260,6 +1224,12 @@ fn double_merge(ref a: Array<felt252>, ref b: Array<felt252>) -> Option<felt252>
         }
     }
     b.pop_front()
+}
+#[target_function]
+fn foo(ref a: Array<felt252>, ref b: Array<felt252>) -> Option<()> {
+    let _ = double_merge(ref a, ref b)?;
+    let _ = double_merge(ref a, ref b)?;
+    Some(())
 }
 
 //! > semantic_diagnostics
@@ -1665,7 +1635,9 @@ test_match_optimizer
 
 //! > test_comments
 
-//! > function_code
+//! > cairo_code
+use core::array::array_snapshot_pop_front;
+#[target_function]
 fn foo(ref input: Span<felt252>) -> Option<@felt252> {
     let mut snapshot = input.snapshot;
     let item = array_snapshot_pop_front(ref snapshot);
@@ -1676,12 +1648,6 @@ fn foo(ref input: Span<felt252>) -> Option<@felt252> {
     }
     None
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use core::array::array_snapshot_pop_front;
 
 //! > semantic_diagnostics
 
@@ -1798,7 +1764,11 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+struct MyStruct {
+    v: Option<u32>,
+}
+#[target_function]
 fn foo() -> MyStruct {
     let v = Some(1);
     let res = MyStruct { v };
@@ -1806,14 +1776,6 @@ fn foo() -> MyStruct {
         return res;
     }
     res
-}
-
-//! > function_name
-foo
-
-//! > module_code
-struct MyStruct {
-    v: Option<u32>,
 }
 
 //! > semantic_diagnostics
@@ -1849,7 +1811,9 @@ test_match_optimizer
 
 //! > test_comments
 
-//! > function_code
+//! > cairo_code
+use core::array::array_snapshot_multi_pop_front;
+#[target_function]
 fn foo(ref input: Span<felt252>) -> felt252 {
     let res: Option<@Box<[felt252; 4]>> = input.multi_pop_front();
 
@@ -1858,12 +1822,6 @@ fn foo(ref input: Span<felt252>) -> felt252 {
     }
     2
 }
-
-//! > function_name
-foo
-
-//! > module_code
-use core::array::array_snapshot_multi_pop_front;
 
 //! > semantic_diagnostics
 
@@ -1979,20 +1937,7 @@ test_match_optimizer
 //! > test_comments
 optimization is not applicable.
 
-//! > function_code
-fn foo(b: bool) -> felt252 {
-    let v = if b {
-        true
-    } else {
-        false
-    };
-    bar(v)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn use_var(a: bool) nopanic;
 
@@ -2004,6 +1949,15 @@ fn bar(b: bool) -> felt252 {
     }
     use_var(a);
     return 2;
+}
+#[target_function]
+fn foo(b: bool) -> felt252 {
+    let v = if b {
+        true
+    } else {
+        false
+    };
+    bar(v)
 }
 
 //! > semantic_diagnostics
@@ -2126,7 +2080,8 @@ optimization is not applicable: the inner match is on the result of `bool_not_im
 which is opaque to the equality analysis, so the inner match cannot be folded even
 though the outer arm pins `c` to `true`.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(c: bool) -> felt252 {
     if c {
         if !c {
@@ -2138,11 +2093,6 @@ fn foo(c: bool) -> felt252 {
         3
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -2253,7 +2203,8 @@ test_match_optimizer
 
 //! >   variants, fold the downstream match_enum to direct gotos for each predecessor.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(c: bool, x: felt252) -> felt252 {
     let t: (Option<felt252>,) = if c {
         (Option::Some(x),)
@@ -2266,11 +2217,6 @@ fn foo(c: bool, x: felt252) -> felt252 {
         Option::None => 0,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -2383,7 +2329,8 @@ End:
 //! > test_runner_name
 test_match_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(c: bool) -> felt252 {
     if c {
         if c {
@@ -2395,11 +2342,6 @@ fn foo(c: bool) -> felt252 {
         3
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/reboxing
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/reboxing
@@ -3,17 +3,13 @@
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-main
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct A {
     a: felt252,
     b: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn main(a: Box<A>) -> Box<felt252> {
     BoxTrait::new(a.b)
 }
@@ -52,18 +48,14 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-multi_member
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct Point {
     x: u32,
     y: u32,
     z: u32,
 }
-
-//! > function_code
+#[target_function]
 fn multi_member(p: Box<Point>) -> (Box<u32>, Box<u32>) {
     (BoxTrait::new(p.x), BoxTrait::new(p.z))
 }
@@ -110,10 +102,7 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-nested_struct
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct Inner {
     value: felt252,
@@ -124,8 +113,7 @@ struct Outer {
     inner: Inner,
     other: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn nested_struct(o: Box<Outer>) -> Box<felt252> {
     BoxTrait::new(o.inner.value)
 }
@@ -167,10 +155,7 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-with_snapshot
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct Data {
     non_copy: NonCopy,
@@ -181,8 +166,7 @@ struct Data {
 struct NonCopy {
     a: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn with_snapshot(data: Box<@Data>) -> Box<@NonCopy> {
     BoxTrait::new(data.unbox().non_copy)
 }
@@ -221,15 +205,11 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-rebox_whole
-
-//! > module_code
+//! > cairo_code
 struct Simple {
     value: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn rebox_whole(s: Box<Simple>) -> Box<Simple> {
     BoxTrait::new(s.unbox())
 }
@@ -265,17 +245,13 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-no_opportunity
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct Data {
     a: felt252,
     b: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn no_opportunity(d: Box<Data>, x: felt252) -> Box<felt252> {
     let _unused = d.a;
     BoxTrait::new(x)
@@ -310,17 +286,13 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-enum_rebox
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 enum MyEnum {
     A: u32,
     B: u32,
 }
-
-//! > function_code
+#[target_function]
 fn enum_rebox(e: Box<MyEnum>) -> Box<u32> {
     let a = match e.unbox() {
         MyEnum::A(x) => x,
@@ -396,12 +368,8 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-tuple_rebox
-
-//! > module_code
-
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn tuple_rebox(t: Box<(u32, felt252, u64)>) -> Box<felt252> {
     let (_, mid, _) = t.unbox();
     BoxTrait::new(mid)
@@ -441,19 +409,15 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-non_copy_struct_rebox
-
 //! > TODO(eytan-starkware): Add support for non-copy structs where applicable
 
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct NonCopyStruct {
     arr: Array<felt252>,
     val: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn non_copy_struct_rebox(s: Box<NonCopyStruct>) -> Box<felt252> {
     BoxTrait::new(s.unbox().val)
 }
@@ -491,12 +455,8 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-non_copy_tuple_rebox
-
-//! > module_code
-
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn non_copy_tuple_rebox(t: Box<(Array<felt252>, felt252)>) -> Box<felt252> {
     let (_, val) = t.unbox();
     BoxTrait::new(val)
@@ -535,19 +495,15 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-branch_mut_unbox
-
 //! > TODO(eytan-starkware): Support equality tracking and replacing the original deconstruct statement
 
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct Pair {
     left: felt252,
     right: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn branch_mut_unbox(flag: bool, p1: Box<Pair>, p2: Box<Pair>) -> Box<felt252> {
     let mut x = p1.unbox();
     if flag {
@@ -629,12 +585,9 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-main
-
 //! > TODO(eytan-starkware): Support non-drop by unboxing each member.
 
-//! > module_code
+//! > cairo_code
 #[derive(Copy)]
 struct NonDrop {
     b: felt252,
@@ -645,8 +598,7 @@ struct A {
     a: felt252,
     non_drop: NonDrop,
 }
-
-//! > function_code
+#[target_function]
 fn main(a: Box<A>) -> (Box<felt252>, NonDrop) {
     let unboxed = a.unbox();
     (BoxTrait::new(unboxed.a), unboxed.non_drop)
@@ -687,10 +639,7 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-main
-
-//! > module_code
+//! > cairo_code
 use core::box::BoxTrait;
 
 #[derive(Copy)]
@@ -703,8 +652,7 @@ struct A {
     a: felt252,
     non_drop: NonDrop,
 }
-
-//! > function_code
+#[target_function]
 fn main(a: Box<@A>) -> (Box<@felt252>, @NonDrop) {
     let a = a.unbox();
     (BoxTrait::new(a.a), a.non_drop)
@@ -748,21 +696,17 @@ End:
 //! > test_runner_name
 test_reboxing_analysis
 
-//! > function_name
-mixed_reboxing
-
 //! > TODO(eytan-starkware): When removing demand for Copy, check no double
 
 //! >     into_box remain
 
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct Point {
     x: felt252,
     y: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn mixed_reboxing(p: Box<Point>, flag: bool) -> Box<felt252> {
     if flag {
         let unboxed = p.unbox();

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/reorder_statements
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/reorder_statements
@@ -3,7 +3,10 @@
 //! > test_runner_name
 test_reorder_statements
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn get_option() -> Option<u16> nopanic;
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     let opt = get_option();
 
@@ -25,13 +28,6 @@ fn foo(x: felt252) -> felt252 {
         },
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn get_option() -> Option<u16> nopanic;
 
 //! > semantic_diagnostics
 
@@ -187,7 +183,10 @@ End:
 //! > test_runner_name
 test_reorder_statements
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn get_option() -> Option<u16> nopanic;
+#[target_function]
 fn foo() {
     let a = true;
 
@@ -199,13 +198,6 @@ fn foo() {
         None => false ^ b,
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn get_option() -> Option<u16> nopanic;
 
 //! > semantic_diagnostics
 
@@ -285,18 +277,14 @@ End:
 //! > test_runner_name
 test_reorder_statements
 
-//! > function_code
+//! > cairo_code
+struct NonDupStruct {
+    a: felt252,
+}
+#[target_function]
 fn foo(a: felt252) {
     let b = NonDupStruct { a };
     let NonDupStruct { a: _ } = b;
-}
-
-//! > function_name
-foo
-
-//! > module_code
-struct NonDupStruct {
-    a: felt252,
 }
 
 //! > semantic_diagnostics
@@ -330,7 +318,8 @@ End:
 //! > test_runner_name
 test_reorder_statements
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let a = true;
     let v = 5;
@@ -340,9 +329,6 @@ fn foo() -> felt252 {
         v + 3
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/return_optimization
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/return_optimization
@@ -3,16 +3,14 @@
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(ref a: (), v: Option<u16>) -> Option<u16> {
     match v {
         Some(x) => { return Some(x); },
         None => { return None; },
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -68,7 +66,8 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(ref a: (), v: Option<u16>) -> Option<u16> {
     match v {
         Some(x) => {
@@ -78,9 +77,6 @@ fn foo(ref a: (), v: Option<u16>) -> Option<u16> {
         None => { return None; },
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -141,16 +137,14 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(v: Option<u16>) -> Option<u16> {
     match v {
         Some(x) => Some(x),
         None => None,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -216,7 +210,8 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(v: Option<(u16,)>) -> Option<(u16,)> {
     match v {
         Some(tuple) => {
@@ -226,9 +221,6 @@ fn foo(v: Option<(u16,)>) -> Option<(u16,)> {
         None => { return None; },
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -286,7 +278,10 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct MyStruct {}
+#[target_function]
 fn foo(ref a: MyStruct, v: Option<u16>) -> Option<u16> {
     match v {
         Some(x) => {
@@ -296,13 +291,6 @@ fn foo(ref a: MyStruct, v: Option<u16>) -> Option<u16> {
         None => None,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct MyStruct {}
 
 //! > semantic_diagnostics
 
@@ -373,7 +361,8 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(v: Option<(u16, ())>) -> Option<(u16, ())> {
     match v {
         Some(v) => {
@@ -383,9 +372,6 @@ fn foo(v: Option<(u16, ())>) -> Option<(u16, ())> {
         None => { None },
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -454,7 +440,12 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+enum MyEnum {
+    MyVariant: u16,
+}
+#[target_function]
 fn foo(ref a: u16, v: MyEnum) -> MyEnum {
     match v {
         MyEnum::MyVariant(val) => {
@@ -462,15 +453,6 @@ fn foo(ref a: u16, v: MyEnum) -> MyEnum {
             return MyEnum::MyVariant(val);
         },
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-enum MyEnum {
-    MyVariant: u16,
 }
 
 //! > semantic_diagnostics
@@ -514,21 +496,17 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+#[target_function]
 fn foo(ref a: felt252, b: MyEnum) -> MyEnum {
     match b {
         MyEnum::A(x) => MyEnum::A(x),
         MyEnum::B(x) => MyEnum::B(x),
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B: felt252,
 }
 
 //! > semantic_diagnostics
@@ -593,7 +571,12 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+#[target_function]
 fn foo(ref a: felt252, b: MyEnum) -> felt252 {
     // TODO: find a better solution for the following workaround.
     // Need to produce the return value before the match to allow the optimization.
@@ -603,15 +586,6 @@ fn foo(ref a: felt252, b: MyEnum) -> felt252 {
         MyEnum::B(x) => x,
     }
     res
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B: felt252,
 }
 
 //! > semantic_diagnostics
@@ -677,7 +651,12 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct FeltWrap {
+    value: felt252,
+}
+#[target_function]
 fn foo(a: felt252, b: (felt252,)) -> FeltWrap {
     // create goto, since the return optimization works on block boundaries.
     let (value,) = match a {
@@ -686,15 +665,6 @@ fn foo(a: felt252, b: (felt252,)) -> FeltWrap {
     };
 
     FeltWrap { value }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct FeltWrap {
-    value: felt252,
 }
 
 //! > semantic_diagnostics
@@ -762,14 +732,12 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: (felt252,)) -> (felt252,) {
     let (v,) = a;
     (v,)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -798,20 +766,16 @@ End:
 //! > test_runner_name
 test_return_optimizer
 
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 enum MyEnum {
     A: u32,
     B: u32,
 }
-
-//! > function_code
+#[target_function]
 fn foo(x: u32) -> (MyEnum, MyEnum) {
     (MyEnum::A(x), MyEnum::B(x))
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/scrub_units
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/scrub_units
@@ -3,15 +3,7 @@
 //! > test_runner_name
 test_scrub_units
 
-//! > function_code
-fn foo(a: Option<()>) {
-    bar::<(), MyDestruct>(a.expect('Should be some.'))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<T, +Destruct<T>>(a: T) {}
 
 
@@ -24,6 +16,10 @@ pub impl MyDestruct of Destruct<()> {
 
 #[allow(extern_outside_corelib)]
 extern fn my_fn() nopanic;
+#[target_function]
+fn foo(a: Option<()>) {
+    bar::<(), MyDestruct>(a.expect('Should be some.'))
+}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/split_structs
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/split_structs
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_split_structs
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let b = (a,);
     let c = (b,);
@@ -11,9 +12,6 @@ fn foo(a: felt252) -> felt252 {
     let (e,) = d;
     e
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -44,7 +42,8 @@ End:
 //! > test_runner_name
 test_split_structs
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let (b,) = match a {
         0 => (0,),
@@ -52,9 +51,6 @@ fn foo(a: felt252) -> felt252 {
     };
     b
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -122,7 +118,10 @@ End:
 //! > test_runner_name
 test_split_structs
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn consume(arg: (felt252, Array<felt252>)) nopanic;
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let arr = array![10, 11, 12];
 
@@ -135,13 +134,6 @@ fn foo(a: felt252) -> felt252 {
         return 1;
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn consume(arg: (felt252, Array<felt252>)) nopanic;
 
 //! > semantic_diagnostics
 
@@ -263,7 +255,10 @@ End:
 //! > test_runner_name
 test_split_structs
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_tuple<T>(a: (felt252, T)) nopanic;
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let tuple = match a {
         0 => (1, (2, 3)),
@@ -276,13 +271,6 @@ fn foo(a: felt252) -> felt252 {
     let (b, (c, d)) = tuple;
     b + c + d
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_tuple<T>(a: (felt252, T)) nopanic;
 
 //! > semantic_diagnostics
 
@@ -367,7 +355,10 @@ End:
 //! > test_runner_name
 test_split_structs
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_tuple<T>(a: (felt252, T)) nopanic;
+#[target_function]
 fn foo(a: felt252) -> (felt252, felt252) {
     let b = (a, a);
     let tuple = match a {
@@ -379,13 +370,6 @@ fn foo(a: felt252) -> (felt252, felt252) {
     };
     tuple
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_tuple<T>(a: (felt252, T)) nopanic;
 
 //! > semantic_diagnostics
 
@@ -452,7 +436,10 @@ End:
 //! > test_runner_name
 test_split_structs
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_tuple<T>(a: (felt252, T)) nopanic;
+#[target_function]
 fn foo(a: felt252) {
     let b = (a, a);
     match a {
@@ -466,13 +453,6 @@ fn foo(a: felt252) {
         },
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_tuple<T>(a: (felt252, T)) nopanic;
 
 //! > semantic_diagnostics
 
@@ -541,7 +521,13 @@ End:
 //! > test_runner_name
 test_split_structs
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_tuple<T>(a: (felt252, T)) nopanic;
+
+#[allow(extern_outside_corelib)]
+extern fn get_tuple<T>() -> (felt252, T) nopanic;
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let b = (a, a);
     let c = if a == 0 {
@@ -558,16 +544,6 @@ fn foo(a: felt252) -> felt252 {
     }
     return a;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_tuple<T>(a: (felt252, T)) nopanic;
-
-#[allow(extern_outside_corelib)]
-extern fn get_tuple<T>() -> (felt252, T) nopanic;
 
 //! > semantic_diagnostics
 
@@ -846,7 +822,22 @@ End:
 //! > test_runner_name
 test_split_structs
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn use_tuple<T>(a: (felt252, T)) nopanic;
+#[allow(extern_outside_corelib)]
+extern fn use_struct(a: NonDupStruct) nopanic;
+
+struct NonDupStruct {
+    a: felt252,
+}
+
+enum ThreeCases {
+    One,
+    Two,
+    Three,
+}
+#[target_function]
 fn foo(a: felt252, e: ThreeCases) -> (felt252, NonDupStruct) {
     let b = (a, NonDupStruct { a });
     match e {
@@ -865,25 +856,6 @@ fn foo(a: felt252, e: ThreeCases) -> (felt252, NonDupStruct) {
             (a, NonDupStruct { a: 0 })
         },
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn use_tuple<T>(a: (felt252, T)) nopanic;
-#[allow(extern_outside_corelib)]
-extern fn use_struct(a: NonDupStruct) nopanic;
-
-struct NonDupStruct {
-    a: felt252,
-}
-
-enum ThreeCases {
-    One,
-    Two,
-    Three,
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/trim_unreachable
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/trim_unreachable
@@ -3,7 +3,10 @@
 //! > test_runner_name
 test_trim_unreachable
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+enum NeverWithDrop {}
+#[target_function]
 fn foo(x: Option<NeverWithDrop>, a: u32) {
     match x {
         Some(i_am_never) => {
@@ -13,13 +16,6 @@ fn foo(x: Option<NeverWithDrop>, a: u32) {
         None => {},
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-enum NeverWithDrop {}
 
 //! > semantic_diagnostics
 
@@ -91,7 +87,10 @@ End:
 //! > test_runner_name
 test_trim_unreachable
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+enum NeverWithDrop {}
+#[target_function]
 fn foo(never_ty: NeverWithDrop, a: u32) {
     if a == 0 {
         let _b: u16 = a.try_into().unwrap_or(0);
@@ -99,13 +98,6 @@ fn foo(never_ty: NeverWithDrop, a: u32) {
 
     match never_ty {}
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-enum NeverWithDrop {}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/variable_forwarding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/variable_forwarding
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252, b: felt252) -> felt252 {
     let c = a + b;
     let d = ((c,),);
@@ -11,9 +12,6 @@ fn foo(a: felt252, b: felt252) -> felt252 {
     let (f,) = e;
     f + c
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -48,7 +46,8 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let b = if a == 0 {
         a
@@ -57,9 +56,6 @@ fn foo(a: felt252) -> felt252 {
     };
     b + a
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -174,15 +170,13 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252, b: felt252) -> felt252 {
     let t = (a, b);
     let (c, d) = t;
     c + d
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -213,15 +207,13 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Array<felt252>, b: Array<felt252>) -> Array<felt252> {
     let t = (a, b);
     let (c, _d) = t;
     c
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -252,7 +244,8 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Array<felt252>, b: Array<felt252>) -> (Array<felt252>, Array<felt252>) {
     let t = (a, b);
     let snap = @t;
@@ -260,9 +253,6 @@ fn foo(a: Array<felt252>, b: Array<felt252>) -> (Array<felt252>, Array<felt252>)
     let (c, d) = t;
     (c, d)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -294,15 +284,13 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Array<felt252>) -> Array<felt252> {
     let boxed = BoxTrait::new(a);
     let unboxed = boxed.unbox();
     unboxed
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -331,19 +319,17 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
 #[inline(never)]
 fn use_snapshot(s: @Array<felt252>) {
     let _ = s;
 }
 
+#[target_function]
 fn foo(a: Array<felt252>) -> Array<felt252> {
     use_snapshot(@a);
     a
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -380,7 +366,8 @@ test_variable_forwarding
 
 //! > can fold to per-predecessor known variants.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(c: bool, x: felt252) -> felt252 {
     let t: (Option<felt252>,) = if c {
         (Option::Some(x),)
@@ -393,11 +380,6 @@ fn foo(c: bool, x: felt252) -> felt252 {
         Option::None => 0,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -516,16 +498,12 @@ test_variable_forwarding
 
 //! > of B.
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Box<u256>) -> Box<u128> {
     let val: u256 = a.unbox();
     BoxTrait::new(val.high)
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -562,10 +540,11 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn keep_snap(s: @Option<Array<felt252>>) -> bool nopanic;
 
+#[target_function]
 fn foo(arr: Array<felt252>) -> Array<felt252> {
     let opt: Option<Array<felt252>> = Option::Some(arr);
     let _ = keep_snap(@opt);
@@ -574,11 +553,6 @@ fn foo(arr: Array<felt252>) -> Array<felt252> {
         Option::None => array![],
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -689,25 +663,7 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
-#[allow(extern_outside_corelib)]
-extern fn drop_nondrop<T>(c: T) nopanic;
-#[allow(extern_outside_corelib)]
-extern fn make_mixed() -> Mixed nopanic;
-
-fn foo() -> Array<felt252> {
-    let m = make_mixed();
-    let Mixed { a, b } = m;
-    let wa = (a,);
-    drop_nondrop(b);
-    let (a2,) = wa;
-    a2
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct NonDrop {
     x: u64,
 }
@@ -715,6 +671,20 @@ struct NonDrop {
 struct Mixed {
     a: Array<felt252>,
     b: NonDrop,
+}
+#[allow(extern_outside_corelib)]
+extern fn drop_nondrop<T>(c: T) nopanic;
+#[allow(extern_outside_corelib)]
+extern fn make_mixed() -> Mixed nopanic;
+
+#[target_function]
+fn foo() -> Array<felt252> {
+    let m = make_mixed();
+    let Mixed { a, b } = m;
+    let wa = (a,);
+    drop_nondrop(b);
+    let (a2,) = wa;
+    a2
 }
 
 //! > semantic_diagnostics
@@ -758,7 +728,16 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy)]
+struct CopyOnly {
+    x: felt252,
+}
+
+struct Mixed {
+    a: Array<felt252>,
+    u: CopyOnly,
+}
 #[allow(extern_outside_corelib)]
 extern fn make_arr() -> Array<felt252> nopanic;
 #[allow(extern_outside_corelib)]
@@ -766,6 +745,7 @@ extern fn make_copy_only() -> CopyOnly nopanic;
 #[allow(extern_outside_corelib)]
 extern fn consume_copy_only(c: CopyOnly) nopanic;
 
+#[target_function]
 fn foo() -> Array<felt252> {
     let a_val = make_arr();
     let u_val = make_copy_only();
@@ -775,20 +755,6 @@ fn foo() -> Array<felt252> {
     consume_copy_only(u);
     let (a2,) = wa;
     a2
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy)]
-struct CopyOnly {
-    x: felt252,
-}
-
-struct Mixed {
-    a: Array<felt252>,
-    u: CopyOnly,
 }
 
 //! > semantic_diagnostics
@@ -832,7 +798,10 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn consume(arg: (felt252, Array<felt252>)) nopanic;
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let arr = array![10, 11, 12];
 
@@ -845,13 +814,6 @@ fn foo(a: felt252) -> felt252 {
         return 1;
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn consume(arg: (felt252, Array<felt252>)) nopanic;
 
 //! > semantic_diagnostics
 
@@ -971,15 +933,11 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: u32) -> u32 {
     a + a
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1082,7 +1040,8 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: (u32,), b: felt252) -> u32 {
     let d = @if b == 0 {
         let (c,) = a;
@@ -1094,11 +1053,6 @@ fn foo(a: (u32,), b: felt252) -> u32 {
 
     *d
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -1213,10 +1167,11 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn sink(a: Array<felt252>) -> felt252 nopanic;
 
+#[target_function]
 fn foo(flag: bool, a: Array<felt252>) -> felt252 {
     let t = (a,);
     let (b,) = t;
@@ -1225,9 +1180,6 @@ fn foo(flag: bool, a: Array<felt252>) -> felt252 {
         false => sink(b),
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1298,7 +1250,8 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Array<felt252>, flag: bool) -> Array<felt252> {
     let t = (a,);
     let _z = if flag {
@@ -1309,9 +1262,6 @@ fn foo(a: Array<felt252>, flag: bool) -> Array<felt252> {
     let (b,) = t;
     b
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1376,22 +1326,18 @@ End:
 //! > test_runner_name
 test_variable_forwarding
 
-//! > function_code
-#[allow(extern_outside_corelib)]
-extern fn make_copy_only() -> CopyOnly nopanic;
-
-fn foo() {
-    let CopyOnly { x } = make_copy_only();
-    let _ = x;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy)]
 struct CopyOnly {
     x: felt252,
+}
+#[allow(extern_outside_corelib)]
+extern fn make_copy_only() -> CopyOnly nopanic;
+
+#[target_function]
+fn foo() {
+    let CopyOnly { x } = make_copy_only();
+    let _ = x;
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/arm_pattern_destructure
+++ b/crates/cairo-lang-lowering/src/test_data/arm_pattern_destructure
@@ -3,7 +3,18 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    a: (felt252, (felt252, felt252)),
+    b: (felt252, (felt252, felt252)),
+    c: (felt252, (felt252, felt252)),
+    d: (felt252, felt252),
+    e: (felt252, felt252),
+    f: (felt252,),
+    g: (felt252,),
+    h: felt252,
+}
+#[target_function]
 fn foo(e: MyEnum) {
     match e {
         MyEnum::a((_x, (_y, _z))) => {},
@@ -15,21 +26,6 @@ fn foo(e: MyEnum) {
         MyEnum::g(_x) => {},
         MyEnum::h(_x) => {},
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    a: (felt252, (felt252, felt252)),
-    b: (felt252, (felt252, felt252)),
-    c: (felt252, (felt252, felt252)),
-    d: (felt252, felt252),
-    e: (felt252, felt252),
-    f: (felt252,),
-    g: (felt252,),
-    h: felt252,
 }
 
 //! > semantic_diagnostics
@@ -99,24 +95,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(ref a: felt252) {
-    match bar(ref a) {
-        MyEnum::a((_x, (_y, _z))) => {},
-        MyEnum::b((_x, _y)) => {},
-        MyEnum::c(_x) => {},
-        MyEnum::d((_x, _y)) => {},
-        MyEnum::e(_x) => {},
-        MyEnum::f((_x,)) => {},
-        MyEnum::g(_x) => {},
-        MyEnum::h(_x) => {},
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     a: (felt252, (felt252, felt252)),
     b: (felt252, (felt252, felt252)),
@@ -129,6 +108,19 @@ enum MyEnum {
 }
 #[allow(extern_outside_corelib)]
 extern fn bar(ref a: felt252) -> MyEnum nopanic;
+#[target_function]
+fn foo(ref a: felt252) {
+    match bar(ref a) {
+        MyEnum::a((_x, (_y, _z))) => {},
+        MyEnum::b((_x, _y)) => {},
+        MyEnum::c(_x) => {},
+        MyEnum::d((_x, _y)) => {},
+        MyEnum::e(_x) => {},
+        MyEnum::f((_x,)) => {},
+        MyEnum::g(_x) => {},
+        MyEnum::h(_x) => {},
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -197,7 +189,20 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    a: (felt252, (felt252, felt252)),
+    b: (felt252, (felt252, felt252)),
+    c: (felt252, (felt252, felt252)),
+    d: (felt252, felt252),
+    e: (felt252, felt252),
+    f: (felt252,),
+    g: (felt252,),
+    h: felt252,
+}
+#[allow(extern_outside_corelib)]
+extern fn bar() -> MyEnum nopanic;
+#[target_function]
 fn foo() {
     let y = bar();
     match y {
@@ -211,23 +216,6 @@ fn foo() {
         MyEnum::h(_x) => {},
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    a: (felt252, (felt252, felt252)),
-    b: (felt252, (felt252, felt252)),
-    c: (felt252, (felt252, felt252)),
-    d: (felt252, felt252),
-    e: (felt252, felt252),
-    f: (felt252,),
-    g: (felt252,),
-    h: felt252,
-}
-#[allow(extern_outside_corelib)]
-extern fn bar() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
 
@@ -296,24 +284,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(mut z: felt252) {
-    match bar(ref z) {
-        MyEnum::a((_x, (_y, _z))) => {},
-        MyEnum::b((_x, _y)) => {},
-        MyEnum::c(_x) => {},
-        MyEnum::d((_x, _y)) => {},
-        MyEnum::e(_x) => {},
-        MyEnum::f((_x,)) => {},
-        MyEnum::g(_x) => {},
-        MyEnum::h(_x) => {},
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     a: (felt252, (felt252, felt252)),
     b: (felt252, (felt252, felt252)),
@@ -326,6 +297,19 @@ enum MyEnum {
 }
 #[allow(extern_outside_corelib)]
 extern fn bar(ref r: felt252) -> MyEnum implicits(RangeCheck) nopanic;
+#[target_function]
+fn foo(mut z: felt252) {
+    match bar(ref z) {
+        MyEnum::a((_x, (_y, _z))) => {},
+        MyEnum::b((_x, _y)) => {},
+        MyEnum::c(_x) => {},
+        MyEnum::d((_x, _y)) => {},
+        MyEnum::e(_x) => {},
+        MyEnum::f((_x,)) => {},
+        MyEnum::g(_x) => {},
+        MyEnum::h(_x) => {},
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -394,7 +378,20 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    a: (felt252, (felt252, felt252)),
+    b: (felt252, (felt252, felt252)),
+    c: (felt252, (felt252, felt252)),
+    d: (felt252, felt252),
+    e: (felt252, felt252),
+    f: (felt252,),
+    g: (felt252,),
+    h: felt252,
+}
+#[allow(extern_outside_corelib)]
+extern fn bar(ref r: felt252) -> MyEnum implicits(RangeCheck) nopanic;
+#[target_function]
 fn foo(mut z: felt252) {
     let y = bar(ref z);
     match y {
@@ -408,23 +405,6 @@ fn foo(mut z: felt252) {
         MyEnum::h(_x) => {},
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    a: (felt252, (felt252, felt252)),
-    b: (felt252, (felt252, felt252)),
-    c: (felt252, (felt252, felt252)),
-    d: (felt252, felt252),
-    e: (felt252, felt252),
-    f: (felt252,),
-    g: (felt252,),
-    h: felt252,
-}
-#[allow(extern_outside_corelib)]
-extern fn bar(ref r: felt252) -> MyEnum implicits(RangeCheck) nopanic;
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/assignment
+++ b/crates/cairo-lang-lowering/src/test_data/assignment
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: bool) -> felt252 {
     let mut x = 2;
     if a {
@@ -14,9 +15,6 @@ fn foo(a: bool) -> felt252 {
     }
     x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/call
+++ b/crates/cairo-lang-lowering/src/test_data/call
@@ -3,7 +3,10 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn bar(ref a: felt252, b: bool) {}
+#[target_function]
 fn foo(ref a: felt252) -> felt252 {
     let b = true;
     if true {
@@ -14,13 +17,6 @@ fn foo(ref a: felt252) -> felt252 {
     } else {}
     5
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn bar(ref a: felt252, b: bool) {}
 
 //! > semantic_diagnostics
 
@@ -44,15 +40,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Option<felt252> {
     let x = None;
     let _ = x.is_some();
     x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -74,16 +68,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u32 {
-    // ref self method called on expression (not a variable) should work
-    make_counter().increment()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct Counter {
     value: u32,
@@ -104,6 +89,11 @@ impl CounterImpl of CounterTrait {
 #[inline(never)]
 fn make_counter() -> Counter {
     Counter { value: 0 }
+}
+#[target_function]
+fn foo() -> u32 {
+    // ref self method called on expression (not a variable) should work
+    make_counter().increment()
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/closure
+++ b/crates/cairo-lang-lowering/src/test_data/closure
@@ -3,16 +3,14 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let c = |a| {
         a + 3
     };
     c(2)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -33,7 +31,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let x = 8;
     let c = |a| {
@@ -42,9 +41,6 @@ fn foo() -> felt252 {
     let y = c(2);
     y + x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -65,20 +61,18 @@ End:
 //! > test_runner_name
 test_function_lowering
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Array<felt252>) -> Array<felt252> {
     let f = || *(@a);
     f()
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3003]: Cannot desnap a non copyable type.
- --> lib.cairo:2:16
+ --> lib.cairo:3:16
     let f = || *(@a);
                ^^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
@@ -93,8 +87,9 @@ note: Trait has no implementation in context: core::traits::Copy::<core::array::
 //! > test_runner_name
 test_function_lowering
 
-//! > function_code
+//! > cairo_code
 fn use_snap(a: @Array<felt252>) {}
+#[target_function]
 fn foo(a: Array<felt252>) -> Array<felt252> {
     let f = || {
         use_snap(@a);
@@ -103,14 +98,11 @@ fn foo(a: Array<felt252>) -> Array<felt252> {
     f()
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3003]: Cannot desnap a non copyable type.
- --> lib.cairo:5:9
+ --> lib.cairo:6:9
         *(@a)
         ^^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.

--- a/crates/cairo-lang-lowering/src/test_data/constant
+++ b/crates/cairo-lang-lowering/src/test_data/constant
@@ -3,16 +3,12 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+const MY_CONST: felt252 = 0x1234;
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     MY_CONST + x
 }
-
-//! > function_name
-foo
-
-//! > module_code
-const MY_CONST: felt252 = 0x1234;
 
 //! > semantic_diagnostics
 
@@ -34,15 +30,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> MyStruct {
-    MY_CONST
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     felt_val: felt252,
     bool_val: bool,
@@ -58,6 +46,10 @@ enum MyEnum {
 const MY_CONST: MyStruct = MyStruct {
     felt_val: 1234, bool_val: true, my_enum_val1: MyEnum::A(5678), my_enum_val2: MyEnum::B,
 };
+#[target_function]
+fn foo() -> MyStruct {
+    MY_CONST
+}
 
 //! > semantic_diagnostics
 
@@ -78,18 +70,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> u32 {
-    bar(S::<4> {})
-}
-fn bar<T, +MyTrait<T>, +Drop<T>>(x: T) -> u32 {
-    MyTrait::<S<MyTrait::<T>::C>>::C
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct S<const N: u32> {}
 trait MyTrait<T> {
     const C: u32;
@@ -98,6 +79,13 @@ impl MyImpl<const N: u32> of MyTrait<S<N>> {
     const C: u32 = N;
 }
 impl SDrop<const N: u32> of Drop<S<N>> {}
+#[target_function]
+fn foo() -> u32 {
+    bar(S::<4> {})
+}
+fn bar<T, +MyTrait<T>, +Drop<T>>(x: T) -> u32 {
+    MyTrait::<S<MyTrait::<T>::C>>::C
+}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/coupon
+++ b/crates/cairo-lang-lowering/src/test_data/coupon
@@ -3,16 +3,12 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+fn bar() nopanic {}
+#[target_function]
 fn foo(x: bar::Coupon) {
     bar(__coupon__: x);
 }
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar() nopanic {}
 
 //! > semantic_diagnostics
 
@@ -33,20 +29,16 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: MyImpl::bar::Coupon) {
-    5.bar(__coupon__: x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn bar(self: T);
 }
 impl MyImpl of MyTrait<felt252> {
     fn bar(self: felt252) {}
+}
+#[target_function]
+fn foo(x: MyImpl::bar::Coupon) {
+    5.bar(__coupon__: x);
 }
 
 //! > semantic_diagnostics
@@ -69,20 +61,16 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: MyTrait::<felt252>::bar::Coupon) {
-    5.bar(__coupon__: x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn bar(self: T);
 }
 impl MyImpl of MyTrait<felt252> {
     fn bar(self: felt252) {}
+}
+#[target_function]
+fn foo(x: MyTrait::<felt252>::bar::Coupon) {
+    5.bar(__coupon__: x);
 }
 
 //! > semantic_diagnostics
@@ -105,27 +93,23 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+fn bar() nopanic {}
+#[target_function]
 fn foo(x: bar::Coupon) -> bar::Coupon {
     bar(__coupon__: x);
     x // Variable was previously moved.
 }
 
-//! > function_name
-foo
-
-//! > module_code
-fn bar() nopanic {}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3001]: Variable was previously moved.
- --> lib.cairo:4:5
+ --> lib.cairo:5:5
     x // Variable was previously moved.
     ^
 note: variable was previously used here:
-  --> lib.cairo:3:21
+  --> lib.cairo:4:21
     bar(__coupon__: x);
                     ^
 note: Trait has no implementation in context: core::traits::Copy::<test::bar::Coupon>.
@@ -140,17 +124,13 @@ note: Trait has no implementation in context: core::traits::Copy::<test::bar::Co
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: bar::Coupon) {
-    bar(__coupon__: x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar() {
     panic(array![])
+}
+#[target_function]
+fn foo(x: bar::Coupon) {
+    bar(__coupon__: x);
 }
 
 //! > semantic_diagnostics
@@ -172,17 +152,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[inline(always)]
+fn bar() {}
+#[target_function]
 fn foo(x: bar::Coupon) {
     bar(__coupon__: x);
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[inline(always)]
-fn bar() {}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/cycles
+++ b/crates/cairo-lang-lowering/src/test_data/cycles
@@ -3,22 +3,20 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) nopanic {
     foo(x);
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3008]: Call cycle of `nopanic` functions is not allowed.
- --> lib.cairo:1:1-3:1
-  fn foo(x: felt252) nopanic {
+ --> lib.cairo:1:1-4:1
+  #[target_function]
  _^
-|     foo(x);
+| ...
 | }
 |_^
 
@@ -32,16 +30,14 @@ error[E3008]: Call cycle of `nopanic` functions is not allowed.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) {
     match core::gas::withdraw_gas() {
         Some(_) => foo(x),
         None => {},
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -77,16 +73,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252, costs: core::gas::BuiltinCosts) nopanic {
     match core::gas::withdraw_gas_all(costs) {
         Some(_) => foo(x, costs),
         None => {},
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -122,13 +116,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {}
 impl ADestruct of Destruct<A> {
     fn destruct(self: A) nopanic {
@@ -144,6 +132,8 @@ impl BDestruct of Destruct<B> {
         A {};
     }
 }
+#[target_function]
+fn foo() {}
 
 //! > semantic_diagnostics
 
@@ -178,18 +168,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false, no_gas: true)
 
-//! > function_code
-fn foo() {
-    let _ = D {};
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct D {}
 impl DDestruct of Destruct<D> {
     fn destruct(self: D) nopanic {}
+}
+#[target_function]
+fn foo() {
+    let _ = D {};
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/destruct
+++ b/crates/cairo-lang-lowering/src/test_data/destruct
@@ -3,20 +3,7 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(flag: bool, x: u128) -> Option<A> {
-    let a = A { x };
-    if flag {
-        Some(a)
-    } else {
-        None
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     x: u128,
 }
@@ -30,6 +17,15 @@ impl ADestruct of Destruct<A> {
             Ok(v) => v,
             Err(v) => v,
         };
+    }
+}
+#[target_function]
+fn foo(flag: bool, x: u128) -> Option<A> {
+    let a = A { x };
+    if flag {
+        Some(a)
+    } else {
+        None
     }
 }
 
@@ -70,17 +66,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(d: Felt252Dict<felt252>) {
-    get_total_signed_weight(d);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn get_total_signed_weight(used_keys: Felt252Dict<felt252>) -> u128 {
     1_u128
+}
+#[target_function]
+fn foo(d: Felt252Dict<felt252>) {
+    get_total_signed_weight(d);
 }
 
 //! > semantic_diagnostics
@@ -102,17 +94,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A, b: B) {
-    may_panic();
-    may_panic();
-    panic_with_felt252('123');
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn may_panic() {
     panic_with_felt252('123');
@@ -134,6 +116,12 @@ impl BPanicDestruct of PanicDestruct<B> {
     fn panic_destruct(self: B, ref panic: Panic) nopanic {
         let B { a: _ } = self;
     }
+}
+#[target_function]
+fn foo(a: A, b: B) {
+    may_panic();
+    may_panic();
+    panic_with_felt252('123');
 }
 
 //! > semantic_diagnostics
@@ -198,18 +186,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: bool, d: A) -> A {
-    if a {
-        may_panic();
-    }
-    return d;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn may_panic() {
     panic_with_felt252('123');
@@ -221,6 +198,13 @@ impl APanicDestruct of PanicDestruct<A> {
     fn panic_destruct(self: A, ref panic: Panic) nopanic {
         let A { } = self;
     }
+}
+#[target_function]
+fn foo(a: bool, d: A) -> A {
+    if a {
+        may_panic();
+    }
+    return d;
 }
 
 //! > semantic_diagnostics
@@ -276,15 +260,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: Option<()>) {
-    bar::<(), MyDestruct>(a.expect('Should be Some.'))
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline]
 fn bar<T, +Destruct<T>>(a: T) {}
 
@@ -297,6 +273,10 @@ pub impl MyDestruct of Destruct<()> {
 
 #[allow(extern_outside_corelib)]
 extern fn my_fn() nopanic;
+#[target_function]
+fn foo(a: Option<()>) {
+    bar::<(), MyDestruct>(a.expect('Should be Some.'))
+}
 
 //! > semantic_diagnostics
 
@@ -335,19 +315,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
-fn foo() {
-    let _a = A {};
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {}
 impl ADestruct of Destruct<A> {
     #[inline(always)]
     fn destruct(self: A) nopanic {}
+}
+#[target_function]
+fn foo() {
+    let _a = A {};
 }
 
 //! > semantic_diagnostics
@@ -377,22 +353,7 @@ Parameters:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(flag: bool) {
-    let d: Felt252Dict<u64> = Default::default();
-    let _w = Wrap { d };
-    if flag {
-        let _a = 1_u8;
-    } else {
-        let _b = 2_u8;
-    }
-    core::panic_with_felt252('x');
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct Wrap {
     d: Felt252Dict<u64>,
 }
@@ -402,6 +363,17 @@ impl WrapPanicDestruct of core::traits::PanicDestruct<Wrap> {
         let Wrap { d } = self;
         d.squash();
     }
+}
+#[target_function]
+fn foo(flag: bool) {
+    let d: Felt252Dict<u64> = Default::default();
+    let _w = Wrap { d };
+    if flag {
+        let _a = 1_u8;
+    } else {
+        let _b = 2_u8;
+    }
+    core::panic_with_felt252('x');
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/enums
+++ b/crates/cairo-lang-lowering/src/test_data/enums
@@ -3,19 +3,7 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: felt252) -> MyEnum {
-    immovable(true);
-    MyEnum::B({
-        ();
-        5
-    })
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     A: (),
     B: felt252,
@@ -25,6 +13,14 @@ enum MyEnum {
 #[inline(never)]
 fn immovable<T>(t: T) -> T {
     t
+}
+#[target_function]
+fn foo(a: felt252) -> MyEnum {
+    immovable(true);
+    MyEnum::B({
+        ();
+        5
+    })
 }
 
 //! > semantic_diagnostics
@@ -50,21 +46,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     Dup: felt252,
     Dup: felt252,
 }
-
-//! > function_code
+#[target_function]
 fn foo(v: MyEnum) -> felt252 {
     match v {
         MyEnum::Dup(x) => x,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 error[E2051]: Redefinition of variant "Dup" on enum "MyEnum".

--- a/crates/cairo-lang-lowering/src/test_data/error_propagate
+++ b/crates/cairo-lang-lowering/src/test_data/error_propagate
@@ -3,14 +3,12 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Result<Result<u128, felt252>, felt252>) -> Result<felt252, felt252> {
     a??;
     Result::<felt252, felt252>::Ok(1)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/extern
+++ b/crates/cairo-lang-lowering/src/test_data/extern
@@ -3,18 +3,7 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(ref a: felt252, b: felt252) {
-    f(ref a, b);
-    g(ref a, b);
-    h(ref a, b);
-    i(ref a, b);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn f(ref a: felt252, b: felt252) -> felt252 nopanic;
 #[allow(extern_outside_corelib)]
@@ -23,6 +12,13 @@ extern fn g(ref a: felt252, b: felt252) -> (felt252,) nopanic;
 extern fn h(ref a: felt252, b: felt252) -> (felt252, felt252) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn i(ref a: felt252, b: felt252) -> ((felt252,),) nopanic;
+#[target_function]
+fn foo(ref a: felt252, b: felt252) {
+    f(ref a, b);
+    g(ref a, b);
+    h(ref a, b);
+    i(ref a, b);
+}
 
 //! > semantic_diagnostics
 
@@ -46,7 +42,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B: (felt252,),
+    C: (felt252, felt252),
+}
+#[allow(extern_outside_corelib)]
+extern fn f(ref a: felt252, b: felt252) -> MyEnum nopanic;
+#[target_function]
 fn foo(ref a: felt252, b: felt252) {
     let x = f(ref a, b);
     match x {
@@ -55,18 +59,6 @@ fn foo(ref a: felt252, b: felt252) {
         MyEnum::C(_y) => (),
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B: (felt252,),
-    C: (felt252, felt252),
-}
-#[allow(extern_outside_corelib)]
-extern fn f(ref a: felt252, b: felt252) -> MyEnum nopanic;
 
 //! > semantic_diagnostics
 
@@ -105,19 +97,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: felt252, b: felt252) -> felt252 {
-    match f(a, b) {
-        MyEnum::A(y) => y,
-        MyEnum::B((y,)) => y,
-        MyEnum::C((y, _)) => y,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     A: felt252,
     B: (felt252,),
@@ -125,6 +105,14 @@ enum MyEnum {
 }
 #[allow(extern_outside_corelib)]
 extern fn f(a: felt252, b: felt252) -> MyEnum nopanic;
+#[target_function]
+fn foo(a: felt252, b: felt252) -> felt252 {
+    match f(a, b) {
+        MyEnum::A(y) => y,
+        MyEnum::B((y,)) => y,
+        MyEnum::C((y, _)) => y,
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -163,19 +151,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(ref a: felt252, b: felt252) -> felt252 {
-    match f(ref a, b) {
-        MyEnum::A(y) => y,
-        MyEnum::B((y,)) => y,
-        MyEnum::C((y, _)) => y,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     A: felt252,
     B: (felt252,),
@@ -183,6 +159,14 @@ enum MyEnum {
 }
 #[allow(extern_outside_corelib)]
 extern fn f(ref a: felt252, b: felt252) -> MyEnum nopanic;
+#[target_function]
+fn foo(ref a: felt252, b: felt252) -> felt252 {
+    match f(ref a, b) {
+        MyEnum::A(y) => y,
+        MyEnum::B((y,)) => y,
+        MyEnum::C((y, _)) => y,
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -221,7 +205,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B: (felt252,),
+    C: (felt252, felt252),
+}
+#[allow(extern_outside_corelib)]
+extern fn f(ref a: felt252, b: felt252) -> MyEnum implicits(RangeCheck) nopanic;
+#[target_function]
 fn foo(ref a: felt252, b: felt252) {
     let x = f(ref a, b);
     match x {
@@ -230,18 +222,6 @@ fn foo(ref a: felt252, b: felt252) {
         MyEnum::C(_y) => (),
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B: (felt252,),
-    C: (felt252, felt252),
-}
-#[allow(extern_outside_corelib)]
-extern fn f(ref a: felt252, b: felt252) -> MyEnum implicits(RangeCheck) nopanic;
 
 //! > semantic_diagnostics
 
@@ -280,19 +260,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(ref a: felt252, b: felt252) -> felt252 {
-    match f(ref a, b) {
-        MyEnum::A(y) => y,
-        MyEnum::B((y,)) => y,
-        MyEnum::C((y, _)) => y,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     A: felt252,
     B: (felt252,),
@@ -300,6 +268,14 @@ enum MyEnum {
 }
 #[allow(extern_outside_corelib)]
 extern fn f(ref a: felt252, b: felt252) -> MyEnum implicits(RangeCheck) nopanic;
+#[target_function]
+fn foo(ref a: felt252, b: felt252) -> felt252 {
+    match f(ref a, b) {
+        MyEnum::A(y) => y,
+        MyEnum::B((y,)) => y,
+        MyEnum::C((y, _)) => y,
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -338,23 +314,19 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+}
+#[allow(extern_outside_corelib)]
+extern fn f(ref arr: Array<felt252>, ref b: (felt252,)) -> MyEnum nopanic;
+#[target_function]
 fn foo(mut arr: Array<felt252>, mut b: (felt252,)) -> Array<felt252> {
     let y = match f(ref arr, ref b) {
         MyEnum::A(_x) => arr,
     };
     y
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-}
-#[allow(extern_outside_corelib)]
-extern fn f(ref arr: Array<felt252>, ref b: (felt252,)) -> MyEnum nopanic;
 
 //! > semantic_diagnostics
 
@@ -381,13 +353,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     let _unused = gas::withdraw_gas();
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -422,13 +392,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Option<()> {
     gas::withdraw_gas()
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -467,13 +435,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> Option<()> {
     return gas::withdraw_gas();
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/fixed_size_array
+++ b/crates/cairo-lang-lowering/src/test_data/fixed_size_array
@@ -3,19 +3,15 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    let x = [10, 20, 30];
-    bar(x);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn bar(x: [felt252; 3]) {
     let _y = x;
+}
+#[target_function]
+fn foo() {
+    let x = [10, 20, 30];
+    bar(x);
 }
 
 //! > semantic_diagnostics
@@ -41,15 +37,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> [felt252; 3] {
-    [get_10(); 3]
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn get_10() -> felt252 {
     10
@@ -58,6 +46,10 @@ fn get_10() -> felt252 {
 #[inline(never)]
 fn bar(x: [felt252; 3]) {
     let _y = x;
+}
+#[target_function]
+fn foo() -> [felt252; 3] {
+    [get_10(); 3]
 }
 
 //! > semantic_diagnostics
@@ -80,18 +72,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> [MyStruct; 3] {
-    foo_ex()
-}
-fn foo_ex<T, +Drop<[T; 3]>, +Copy<T>, +CtorTrait<T>>() -> [T; 3] {
-    [CtorTrait::<T>::new(); 3]
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct MyStruct {
     x: felt252,
@@ -105,6 +86,13 @@ impl CtorMyStruct of CtorTrait<MyStruct> {
     fn new() -> MyStruct {
         MyStruct { x: 10 }
     }
+}
+#[target_function]
+fn foo() -> [MyStruct; 3] {
+    foo_ex()
+}
+fn foo_ex<T, +Drop<[T; 3]>, +Copy<T>, +CtorTrait<T>>() -> [T; 3] {
+    [CtorTrait::<T>::new(); 3]
 }
 
 //! > semantic_diagnostics
@@ -128,25 +116,21 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> [MyStruct; 3] {
-    [MyStruct { x: 10 }; 3]
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct MyStruct {
     x: felt252,
+}
+#[target_function]
+fn foo() -> [MyStruct; 3] {
+    [MyStruct { x: 10 }; 3]
 }
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3012]: Fixed size array inner type must implement the `Copy` trait when the array size is greater than 1.
- --> lib.cairo:6:5
+ --> lib.cairo:7:5
     [MyStruct { x: 10 }; 3]
     ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -160,18 +144,7 @@ error[E3012]: Fixed size array inner type must implement the `Copy` trait when t
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
-fn foo() -> [MyStruct; 3] {
-    foo_ex()
-}
-fn foo_ex<T, +Drop<[T; 3]>, +CtorTrait<T>>() -> [T; 3] {
-    [CtorTrait::<T>::new(); 3]
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct MyStruct {
     x: felt252,
@@ -186,12 +159,19 @@ impl CtorMyStruct of CtorTrait<MyStruct> {
         MyStruct { x: 10 }
     }
 }
+#[target_function]
+fn foo() -> [MyStruct; 3] {
+    foo_ex()
+}
+fn foo_ex<T, +Drop<[T; 3]>, +CtorTrait<T>>() -> [T; 3] {
+    [CtorTrait::<T>::new(); 3]
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3012]: Fixed size array inner type must implement the `Copy` trait when the array size is greater than 1.
- --> lib.cairo:19:5
+ --> lib.cairo:20:5
     [CtorTrait::<T>::new(); 3]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -205,18 +185,14 @@ error[E3012]: Fixed size array inner type must implement the `Copy` trait when t
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> [MyStruct; 1] {
-    [MyStruct { x: 10 }; 1]
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct MyStruct {
     x: felt252,
+}
+#[target_function]
+fn foo() -> [MyStruct; 1] {
+    [MyStruct { x: 10 }; 1]
 }
 
 //! > semantic_diagnostics
@@ -240,19 +216,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> [u32; 0] {
     [0_u32; 0]
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3013]: Fixed size array repeated element size must be greater than 0.
- --> lib.cairo:2:5
+ --> lib.cairo:3:5
     [0_u32; 0]
     ^^^^^^^^^^
 

--- a/crates/cairo-lang-lowering/src/test_data/for
+++ b/crates/cairo-lang-lowering/src/test_data/for
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let x = 1;
     let y = x + 1;
@@ -13,9 +14,6 @@ fn foo() -> felt252 {
     }
     y
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -37,7 +35,7 @@ Statements:
   (v11: core::array::Array::<core::felt252>, v12: @core::array::Array::<core::felt252>) <- snapshot(v10)
   (v13: core::array::Span::<core::felt252>) <- struct_construct(v12)
   (v14: core::array::SpanIter::<core::felt252>) <- struct_construct(v13)
-  (v15: core::RangeCheck, v16: core::gas::GasBuiltin, v17: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, ())>) <- test::foo[114-152](v0, v1, v14)
+  (v15: core::RangeCheck, v16: core::gas::GasBuiltin, v17: core::panics::PanicResult::<(core::array::SpanIter::<core::felt252>, ())>) <- test::foo[133-171](v0, v1, v14)
 End:
   Match(match_enum(v17) {
     PanicResult::Ok(v18) => blk1,

--- a/crates/cairo-lang-lowering/src/test_data/generics
+++ b/crates/cairo-lang-lowering/src/test_data/generics
@@ -3,16 +3,7 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    immovable(5.foo(true));
-    immovable(MyTrait::foo(6, false));
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn foo<S>(self: T, y: S) -> (T, S);
 }
@@ -25,6 +16,11 @@ impl MyImpl of MyTrait<felt252> {
 
 #[allow(extern_outside_corelib)]
 extern fn immovable<T>(t: T) -> T nopanic;
+#[target_function]
+fn foo() {
+    immovable(5.foo(true));
+    immovable(MyTrait::foo(6, false));
+}
 
 //! > semantic_diagnostics
 
@@ -53,19 +49,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+struct Query<V> {
+    data: V,
+}
+#[target_function]
 fn foo() -> felt252 {
     let q = Query { data: 1 };
     let Query { data } = q;
     Query { data: 2 }.data + data
-}
-
-//! > function_name
-foo
-
-//! > module_code
-struct Query<V> {
-    data: V,
 }
 
 //! > semantic_diagnostics
@@ -87,15 +79,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    bar::<MyImpl>()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<impl Imp: MyTrait>() {
     Imp::foo()
 }
@@ -104,6 +88,10 @@ trait MyTrait {
 }
 impl MyImpl of MyTrait {
     fn foo() {}
+}
+#[target_function]
+fn foo() {
+    bar::<MyImpl>()
 }
 
 //! > semantic_diagnostics
@@ -124,21 +112,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() {
-    MyTrait::bar(5);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 trait MyTrait<T> {
     fn bar(x: T);
 }
 impl MyImpl<T, impl TDrop: Drop<T>> of MyTrait<T> {
     #[inline(never)]
     fn bar(x: T) {}
+}
+#[target_function]
+fn foo() {
+    MyTrait::bar(5);
 }
 
 //! > semantic_diagnostics
@@ -161,16 +145,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+const one: felt252 = 1;
+#[target_function]
 fn foo() -> felt252 {
     felt252_const::<one>()
 }
-
-//! > function_name
-foo
-
-//! > module_code
-const one: felt252 = 1;
 
 //! > semantic_diagnostics
 
@@ -191,17 +171,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    bar::<{ 1 + 2 }>() + bar::<2>()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 fn bar<const N: felt252>() -> felt252 {
     N + 5
+}
+#[target_function]
+fn foo() -> felt252 {
+    bar::<{ 1 + 2 }>() + bar::<2>()
 }
 
 //! > semantic_diagnostics
@@ -223,18 +199,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> MyStruct<9> {
-    let s1 = foo_helper();
-    s1.bar();
-    s1.bar();
-    s1
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct MyStruct<const N: felt252> {}
 trait MyTrait<T> {
@@ -250,6 +215,13 @@ impl MyStructMyTrait<const N: felt252> of MyTrait<MyStruct<N>> {
 #[inline(never)]
 fn foo_helper<const N: felt252>() -> MyStruct<N> {
     MyStruct::<N> {}
+}
+#[target_function]
+fn foo() -> MyStruct<9> {
+    let s1 = foo_helper();
+    s1.bar();
+    s1.bar();
+    s1
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/if
+++ b/crates/cairo-lang-lowering/src/test_data/if
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: bool, x: felt252) -> felt252 {
     if a {
         1
@@ -11,9 +12,6 @@ fn foo(a: bool, x: felt252) -> felt252 {
         x
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -47,7 +45,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     if x == 0 {
         1
@@ -55,9 +54,6 @@ fn foo(x: felt252) -> felt252 {
         x
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -91,16 +87,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252) -> felt252 {
     if 0 == x {
         return 10;
     }
     20
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -137,7 +131,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: felt252, y: felt252, z: felt252, w: felt252) -> felt252 {
     if x + y == z - w {
         0
@@ -145,9 +140,6 @@ fn foo(x: felt252, y: felt252, z: felt252, w: felt252) -> felt252 {
         1
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -185,7 +177,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     if a == 0 || a == 5 {
         0
@@ -193,9 +186,6 @@ fn foo(a: felt252) -> felt252 {
         1
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -250,23 +240,19 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[target_function]
 fn foo(a: MyEnum) -> felt252 {
     if let MyEnum::A(x) = a {
         x
     } else {
         0
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
 }
 
 //! > semantic_diagnostics
@@ -312,7 +298,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[allow(extern_outside_corelib)]
+extern fn a() -> MyEnum nopanic;
+#[target_function]
 fn foo() -> felt252 {
     let mut y = 0;
     if let MyEnum::A(x) = a() {
@@ -321,18 +315,6 @@ fn foo() -> felt252 {
     y = y + 1;
     return y;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
-}
-#[allow(extern_outside_corelib)]
-extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
 
@@ -384,7 +366,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[allow(extern_outside_corelib)]
+extern fn a() -> MyEnum nopanic;
+#[target_function]
 fn foo(z: felt252) -> felt252 {
     let mut y = 0;
     if let (MyEnum::A(x), true) = (a(), z == 6) {
@@ -393,18 +383,6 @@ fn foo(z: felt252) -> felt252 {
     y = y + 1;
     return y;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
-}
-#[allow(extern_outside_corelib)]
-extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
 
@@ -493,7 +471,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[allow(extern_outside_corelib)]
+extern fn a() -> MyEnum nopanic;
+#[target_function]
 fn foo(z: felt252) -> felt252 {
     let mut y = 0;
     if let (MyEnum::A(x), 3) = (a(), z) {
@@ -502,18 +488,6 @@ fn foo(z: felt252) -> felt252 {
     y = y + 1;
     return y;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
-}
-#[allow(extern_outside_corelib)]
-extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
 
@@ -580,7 +554,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let mut y = 0;
     if let x = y {
@@ -589,9 +564,6 @@ fn foo() -> felt252 {
     y = y + 1;
     return y;
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -612,7 +584,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[target_function]
 fn foo(a: MyEnum) -> felt252 {
     let mut y = 0;
     if let _ = a {
@@ -620,17 +599,6 @@ fn foo(a: MyEnum) -> felt252 {
     }
     y = y + 1;
     return y;
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
 }
 
 //! > semantic_diagnostics
@@ -652,7 +620,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[target_function]
 fn foo(a: MyEnum) -> felt252 {
     let mut y = 0;
     if let _ = a {
@@ -664,22 +639,11 @@ fn foo(a: MyEnum) -> felt252 {
     return y;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable clause.
- --> lib.cairo:11:12-13:5
+ --> lib.cairo:12:12-14:5
       } else {
  ____________^
 |         y = y + 8;
@@ -701,7 +665,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct MyStruct {
+    A: felt252,
+    B: felt252,
+}
+#[target_function]
 fn foo(a: [u16; 2]) -> felt252 {
     let mut y = 0;
     if let [_, _] = a {
@@ -713,21 +683,11 @@ fn foo(a: [u16; 2]) -> felt252 {
     return y;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct MyStruct {
-    A: felt252,
-    B: felt252,
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Unsupported type in if-let. Type: `[core::integer::u16; 2]`.
- --> lib.cairo:8:12
+ --> lib.cairo:9:12
     if let [_, _] = a {
            ^^^^^^
 
@@ -741,7 +701,13 @@ error[E3004]: Unsupported type in if-let. Type: `[core::integer::u16; 2]`.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop, Copy)]
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+#[target_function]
 fn foo(a: MyEnum) -> felt252 {
     loop {
         // Some statements to prevent the loop function from being inlined.
@@ -758,16 +724,6 @@ fn foo(a: MyEnum) -> felt252 {
             break 2;
         }
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop, Copy)]
-enum MyEnum {
-    A: felt252,
-    B: felt252,
 }
 
 //! > semantic_diagnostics
@@ -789,7 +745,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Option<felt252>) -> felt252 {
     let mut y = 0;
     if let None | Some(_) = a {
@@ -801,14 +758,11 @@ fn foo(a: Option<felt252>) -> felt252 {
     return y;
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable clause.
- --> lib.cairo:5:12-7:5
+ --> lib.cairo:6:12-8:5
       } else {
  ____________^
 |         y = y + 8;
@@ -830,7 +784,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Option<Result<felt252, felt252>>) -> felt252 {
     let mut y = 0;
     if let Some(Err(v)) | Some(Ok(v)) = a {
@@ -841,9 +796,6 @@ fn foo(a: Option<Result<felt252, felt252>>) -> felt252 {
     y = y + 1;
     return y;
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -902,16 +854,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Option<Option<Option<felt252>>>, x: felt252) -> felt252 {
     if let Some(b) = a && let Some(c) = b && x == 3 && let Some(d) = c {
         return d;
     }
     return 0;
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -991,7 +941,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Option<Option<felt252>>) -> felt252 {
     if let Some(b) = a && let Some(c) = b {
         c
@@ -999,9 +950,6 @@ fn foo(a: Option<Option<felt252>>) -> felt252 {
         0
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1053,24 +1001,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
-fn foo(a: MyEnum, b: MyEnum, c: MyEnum2, d: MyEnum2, e: MyEnum3) {
-    // TODO(lior): Fix the locations in this test.
-    if let MyEnum::A(_x) = a {}
-    // If the variable is not bound, the match is skipped, which leads to an error.
-    if let MyEnum::A(_) = b {}
-    // If there are two variants, the match is forced. In this case, the error is due to the inner
-    // value not being dropped. Test with and without binding.
-    if let MyEnum2::B(_x) = c {}
-    if let MyEnum2::B(_) = d {}
-    // Three levels of nesting. Both MyEnum2::B and MyEnum2::C are not dropped.
-    if let MyEnum3::D(MyEnum2::B(_)) = e {}
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum MyEnum {
     A: felt252,
 }
@@ -1085,19 +1016,32 @@ enum MyEnum2 {
 enum MyEnum3 {
     D: MyEnum2,
 }
+#[target_function]
+fn foo(a: MyEnum, b: MyEnum, c: MyEnum2, d: MyEnum2, e: MyEnum3) {
+    // TODO(lior): Fix the locations in this test.
+    if let MyEnum::A(_x) = a {}
+    // If the variable is not bound, the match is skipped, which leads to an error.
+    if let MyEnum::A(_) = b {}
+    // If there are two variants, the match is forced. In this case, the error is due to the inner
+    // value not being dropped. Test with and without binding.
+    if let MyEnum2::B(_x) = c {}
+    if let MyEnum2::B(_) = d {}
+    // Three levels of nesting. Both MyEnum2::B and MyEnum2::C are not dropped.
+    if let MyEnum3::D(MyEnum2::B(_)) = e {}
+}
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3002]: Variable not dropped.
- --> lib.cairo:25:34
+ --> lib.cairo:26:34
     if let MyEnum3::D(MyEnum2::B(_)) = e {}
                                  ^
 note: Trait has no implementation in context: core::traits::Drop::<test::MyEnum>.
 note: Trait has no implementation in context: core::traits::Destruct::<test::MyEnum>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:25:23
+ --> lib.cairo:26:23
     if let MyEnum3::D(MyEnum2::B(_)) = e {}
                       ^^^^^^^^^^^^^
 note: In variant MyEnum2::C.
@@ -1105,14 +1049,14 @@ note: Trait has no implementation in context: core::traits::Drop::<test::NonDrop
 note: Trait has no implementation in context: core::traits::Destruct::<test::NonDroppable>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:23:23
+ --> lib.cairo:24:23
     if let MyEnum2::B(_) = d {}
                       ^
 note: Trait has no implementation in context: core::traits::Drop::<test::MyEnum>.
 note: Trait has no implementation in context: core::traits::Destruct::<test::MyEnum>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:23:28
+ --> lib.cairo:24:28
     if let MyEnum2::B(_) = d {}
                            ^
 note: In variant MyEnum2::C.
@@ -1120,14 +1064,14 @@ note: Trait has no implementation in context: core::traits::Drop::<test::NonDrop
 note: Trait has no implementation in context: core::traits::Destruct::<test::NonDroppable>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:22:23
+ --> lib.cairo:23:23
     if let MyEnum2::B(_x) = c {}
                       ^^
 note: Trait has no implementation in context: core::traits::Drop::<test::MyEnum>.
 note: Trait has no implementation in context: core::traits::Destruct::<test::MyEnum>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:22:29
+ --> lib.cairo:23:29
     if let MyEnum2::B(_x) = c {}
                             ^
 note: In variant MyEnum2::C.
@@ -1135,7 +1079,7 @@ note: Trait has no implementation in context: core::traits::Drop::<test::NonDrop
 note: Trait has no implementation in context: core::traits::Destruct::<test::NonDroppable>.
 
 error[E3002]: Variable not dropped.
- --> lib.cairo:15:19
+ --> lib.cairo:16:19
 fn foo(a: MyEnum, b: MyEnum, c: MyEnum2, d: MyEnum2, e: MyEnum3) {
                   ^
 note: Trait has no implementation in context: core::traits::Drop::<test::MyEnum>.

--- a/crates/cairo-lang-lowering/src/test_data/implicits
+++ b/crates/cairo-lang-lowering/src/test_data/implicits
@@ -3,15 +3,7 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: u256) -> u64 {
-    U256TryIntoU64::try_into(a).unwrap()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 impl U256TryIntoU64 of TryInto<u256, u64> {
     #[inline(always)]
     fn try_into(self: u256) -> Option<u64> {
@@ -21,6 +13,10 @@ impl U256TryIntoU64 of TryInto<u256, u64> {
             None
         }
     }
+}
+#[target_function]
+fn foo(a: u256) -> u64 {
+    U256TryIntoU64::try_into(a).unwrap()
 }
 
 //! > semantic_diagnostics
@@ -120,7 +116,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u128) -> u128 {
     if false {
         x + 1
@@ -128,9 +125,6 @@ fn foo(x: u128) -> u128 {
         x
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/inline_macros
+++ b/crates/cairo-lang-lowering/src/test_data/inline_macros
@@ -3,13 +3,7 @@
 //! > test_runner_name
 test_function_lowering
 
-//! > function_code
-fn foo() {}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 macro generate_unreachable {
     () => {
         fn unreachable_code() {
@@ -19,6 +13,8 @@ macro generate_unreachable {
     };
 }
 generate_unreachable!();
+#[target_function]
+fn foo() {}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/let_else
+++ b/crates/cairo-lang-lowering/src/test_data/let_else
@@ -3,7 +3,12 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B: felt252,
+}
+#[target_function]
 fn foo(a: MyEnum) {
     let MyEnum::A(x) = a else {
         bar(0);
@@ -14,15 +19,6 @@ fn foo(a: MyEnum) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar(x: felt252) nopanic;
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B: felt252,
-}
 
 //! > semantic_diagnostics
 
@@ -58,7 +54,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: (felt252, felt252, felt252, felt252),
+    B: felt252,
+    C: (),
+}
+#[target_function]
 fn foo(a: MyEnum) {
     let MyEnum::A((x, y, _, z)) = a else {
         bar(0);
@@ -69,16 +71,6 @@ fn foo(a: MyEnum) {
 
 #[allow(extern_outside_corelib)]
 extern fn bar(x: felt252) nopanic;
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: (felt252, felt252, felt252, felt252),
-    B: felt252,
-    C: (),
-}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/literal
+++ b/crates/cairo-lang-lowering/src/test_data/literal
@@ -3,8 +3,9 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
 #[feature("bounded-int-utils")]
+#[target_function]
 fn foo() {
     let _a: u8 = 0x100;
     let _a: u16 = 0x10000;
@@ -16,9 +17,6 @@ fn foo() {
     let _f: core::internal::bounded_int::BoundedInt<3, 15> = 2;
 }
 
-//! > function_name
-foo
-
 //! > lowering_diagnostics
 
 //! > lowering_flat
@@ -26,42 +24,42 @@ foo
 
 //! > semantic_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u8.
- --> lib.cairo:3:18
+ --> lib.cairo:4:18
     let _a: u8 = 0x100;
                  ^^^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u16.
- --> lib.cairo:4:19
+ --> lib.cairo:5:19
     let _a: u16 = 0x10000;
                   ^^^^^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u32.
- --> lib.cairo:5:19
+ --> lib.cairo:6:19
     let _a: u32 = 0x100000000;
                   ^^^^^^^^^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u64.
- --> lib.cairo:6:19
+ --> lib.cairo:7:19
     let _b: u64 = 0x10000000000000000;
                   ^^^^^^^^^^^^^^^^^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u128.
- --> lib.cairo:7:20
+ --> lib.cairo:8:20
     let _c: u128 = 0x100000000000000000000000000000000;
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2008]: The value does not fit within the range of type core::felt252.
- --> lib.cairo:8:23
+ --> lib.cairo:9:23
     let _d: felt252 = 0x800000000000011000000000000000000000000000000000000000000000001;
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E2008]: The value does not fit within the range of type core::zeroable::NonZero::<core::felt252>.
- --> lib.cairo:9:32
+ --> lib.cairo:10:32
     let _e: NonZero<felt252> = 0;
                                ^
 
 error[E2008]: The value does not fit within the range of type core::internal::bounded_int::BoundedInt::<3, 15>.
- --> lib.cairo:10:62
+ --> lib.cairo:11:62
     let _f: core::internal::bounded_int::BoundedInt<3, 15> = 2;
                                                              ^
 
@@ -72,7 +70,8 @@ error[E2008]: The value does not fit within the range of type core::internal::bo
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     let _a: u8 = 'aa';
     let _a: u16 = 'aba';
@@ -82,9 +81,6 @@ fn foo() {
     let _d: felt252 = 'abcdabcdabcdabcdabcdabcdabcdabcd';
 }
 
-//! > function_name
-foo
-
 //! > lowering_diagnostics
 
 //! > lowering_flat
@@ -92,32 +88,32 @@ foo
 
 //! > semantic_diagnostics
 error[E2008]: The value does not fit within the range of type core::integer::u8.
- --> lib.cairo:2:18
+ --> lib.cairo:3:18
     let _a: u8 = 'aa';
                  ^^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u16.
- --> lib.cairo:3:19
+ --> lib.cairo:4:19
     let _a: u16 = 'aba';
                   ^^^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u32.
- --> lib.cairo:4:19
+ --> lib.cairo:5:19
     let _b: u32 = 'abcda';
                   ^^^^^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u64.
- --> lib.cairo:5:19
+ --> lib.cairo:6:19
     let _b: u64 = 'abcdabcda';
                   ^^^^^^^^^^^
 
 error[E2008]: The value does not fit within the range of type core::integer::u128.
- --> lib.cairo:6:20
+ --> lib.cairo:7:20
     let _c: u128 = 'abcdabcdabcdabcda';
                    ^^^^^^^^^^^^^^^^^^^
 
 error[E2008]: The value does not fit within the range of type core::felt252.
- --> lib.cairo:7:23
+ --> lib.cairo:8:23
     let _d: felt252 = 'abcdabcdabcdabcdabcdabcdabcdabcd';
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -128,8 +124,9 @@ error[E2008]: The value does not fit within the range of type core::felt252.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
 #[feature("bounded-int-utils")]
+#[target_function]
 fn foo() -> (
     felt252,
     u8,
@@ -147,9 +144,6 @@ fn foo() -> (
 ) {
     (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/logical_operator
+++ b/crates/cairo-lang-lowering/src/test_data/logical_operator
@@ -3,20 +3,16 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: bool, b: bool) -> bool {
-    (a && extern_get_bool()) || get_bool()
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[allow(extern_outside_corelib)]
 extern fn extern_get_bool() -> bool nopanic;
 #[inline(never)]
 fn get_bool() -> bool {
     extern_get_bool()
+}
+#[target_function]
+fn foo(a: bool, b: bool) -> bool {
+    (a && extern_get_bool()) || get_bool()
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/loop
+++ b/crates/cairo-lang-lowering/src/test_data/loop
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> bool {
     loop {
         // Some statements to prevent the loop function from being inlined.
@@ -19,9 +20,6 @@ fn foo() -> bool {
         break true;
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -43,7 +41,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     loop {
         // Some statements to prevent the loop function from being inlined.
@@ -61,9 +60,6 @@ fn foo() {
         break;
     };
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/match
+++ b/crates/cairo-lang-lowering/src/test_data/match
@@ -3,7 +3,8 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let b = match a {
         5 => { 550 },
@@ -12,9 +13,6 @@ fn foo(a: felt252) -> felt252 {
     };
     return b;
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -67,7 +65,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     match a {
         0 => 11,
@@ -76,9 +75,6 @@ fn foo(a: felt252) -> felt252 {
         _ => 44,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -145,16 +141,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252, x: felt252) -> felt252 {
     match x {
         0 => a + 1,
         _ => x,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -189,13 +183,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: @Array::<felt252>) -> Option<Box<@felt252>> {
     core::array::array_get(a, 1_u32)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -232,7 +224,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let x = 7;
     match x {
@@ -241,14 +234,11 @@ fn foo() -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `_` not covered.
- --> lib.cairo:3:5-6:5
+ --> lib.cairo:4:5-7:5
       match x {
  _____^
 | ...
@@ -265,7 +255,8 @@ error[E3004]: Match is non-exhaustive: `_` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(v: u8) {
     match v {
         0_u8 => 7,
@@ -273,9 +264,6 @@ fn foo(v: u8) {
         _ => 9,
     };
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -339,7 +327,10 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[feature("bounded-int-utils")]
+type Number = core::internal::bounded_int::BoundedInt<-30, 90>;
+#[target_function]
 fn foo(v: Number) {
     match v {
         0 => 7,
@@ -347,13 +338,6 @@ fn foo(v: Number) {
         _ => 9,
     };
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[feature("bounded-int-utils")]
-type Number = core::internal::bounded_int::BoundedInt<-30, 90>;
 
 //! > semantic_diagnostics
 
@@ -417,7 +401,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     match 5 {
         0_u8 => 7,
@@ -426,12 +411,9 @@ fn foo() {
     };
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 error[E2302]: Type mismatch: `core::felt252` and `core::integer::u8`.
- --> lib.cairo:4:9
+ --> lib.cairo:5:9
         1_felt252 | 2_u8 => 8,
         ^^^^^^^^^
 
@@ -447,19 +429,17 @@ error[E2302]: Type mismatch: `core::felt252` and `core::integer::u8`.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     match Some(5) {};
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `_` not covered.
- --> lib.cairo:2:5
+ --> lib.cairo:3:5
     match Some(5) {};
     ^^^^^^^^^^^^^^^^
 
@@ -473,16 +453,12 @@ error[E3004]: Match is non-exhaustive: `_` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum EmptyEnum {}
+#[target_function]
 fn foo(e: EmptyEnum) {
     match e {};
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum EmptyEnum {}
 
 //! > semantic_diagnostics
 
@@ -503,19 +479,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     match felt252_is_zero(5) {};
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `_` not covered.
- --> lib.cairo:2:5
+ --> lib.cairo:3:5
     match felt252_is_zero(5) {};
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -529,18 +503,7 @@ error[E3004]: Match is non-exhaustive: `_` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    match get_a() {
-        A::One(_) => 2,
-        _ => 3,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     One: (),
     Two: (),
@@ -549,6 +512,13 @@ enum A {
 
 #[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
+#[target_function]
+fn foo() -> felt252 {
+    match get_a() {
+        A::One(_) => 2,
+        _ => 3,
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -594,7 +564,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    One: (),
+    Two: (),
+    Three: (felt252, felt252),
+    Four: (felt252,),
+}
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         A::Two(_) => 2,
@@ -605,27 +582,16 @@ fn foo(a: A) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    One: (),
-    Two: (),
-    Three: (felt252, felt252),
-    Four: (felt252,),
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:13:24
+ --> lib.cairo:14:24
         A::Three(_) => 5,
                        ^
 
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:12:22
+ --> lib.cairo:13:22
         A::Two(_) => 4,
                      ^
 
@@ -676,18 +642,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    match get_a() {
-        A::Two(_) => { 2 },
-        A::One(_) => { 1 },
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     One: (),
     Two: (),
@@ -695,6 +650,13 @@ enum A {
 
 #[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
+#[target_function]
+fn foo() -> felt252 {
+    match get_a() {
+        A::Two(_) => { 2 },
+        A::One(_) => { 1 },
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -729,21 +691,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    One: (),
+    Two: (),
+}
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         A::Two(_) => { 2 },
         A::One(_) => { 1 },
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    One: (),
-    Two: (),
 }
 
 //! > semantic_diagnostics
@@ -779,16 +737,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: (felt252, felt252)) -> felt252 {
     match a {
         (0, 1) => 0,
         _ => 1,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -844,7 +800,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Option<Option<felt252>>) -> felt252 {
     match a {
         Some(Some(x)) => x,
@@ -852,14 +809,11 @@ fn foo(a: Option<Option<felt252>>) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `Some(None(_))` not covered.
- --> lib.cairo:2:5-5:5
+ --> lib.cairo:3:5-6:5
       match a {
  _____^
 | ...
@@ -876,7 +830,14 @@ error[E3004]: Match is non-exhaustive: `Some(None(_))` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    One: (),
+    Two: (),
+    Three: (),
+    Four: (),
+}
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         A::Two(_) => 2,
@@ -884,22 +845,11 @@ fn foo(a: A) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    One: (),
-    Two: (),
-    Three: (),
-    Four: (),
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `Three(_)` not covered.
- --> lib.cairo:8:5-11:5
+ --> lib.cairo:9:5-12:5
       match a {
  _____^
 | ...
@@ -916,16 +866,14 @@ error[E3004]: Match is non-exhaustive: `Three(_)` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: bool) -> felt252 {
     match a {
         true => 2,
         false => 1,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -960,18 +908,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: MyEnum) -> felt252 {
-    match a {
-        MyEnum::A(x) | MyEnum::B((x, _)) => x,
-        MyEnum::C((x, _, t)) | MyEnum::D(P { x, z: t, .. }) => x + t,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct P {
     x: felt252,
     y: felt252,
@@ -983,6 +920,13 @@ enum MyEnum {
     C: (felt252, felt252, felt252),
     B: (felt252, felt252),
     D: P,
+}
+#[target_function]
+fn foo(a: MyEnum) -> felt252 {
+    match a {
+        MyEnum::A(x) | MyEnum::B((x, _)) => x,
+        MyEnum::C((x, _, t)) | MyEnum::D(P { x, z: t, .. }) => x + t,
+    }
 }
 
 //! > semantic_diagnostics
@@ -1037,19 +981,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: felt252) -> felt252 {
-    match a {
-        0 | 1 => 11,
-        2 | 3 => 12,
-        4 | _ => 13,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct P {
     x: felt252,
     y: felt252,
@@ -1061,6 +993,14 @@ enum MyEnum {
     B: (felt252, felt252),
     C: (felt252, felt252, felt252),
     D: P,
+}
+#[target_function]
+fn foo(a: felt252) -> felt252 {
+    match a {
+        0 | 1 => 11,
+        2 | 3 => 12,
+        4 | _ => 13,
+    }
 }
 
 //! > semantic_diagnostics
@@ -1152,7 +1092,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+    Two: (felt252, felt252),
+    Three: (),
+}
+#[target_function]
 fn foo(a: A, b: A) -> felt252 {
     let x = (@a, b);
     let y = @x;
@@ -1163,17 +1110,6 @@ fn foo(a: A, b: A) -> felt252 {
         (_, A::Three) => 3,
         (_, _) => 6,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum A {
-    One: felt252,
-    Two: (felt252, felt252),
-    Three: (),
 }
 
 //! > semantic_diagnostics
@@ -1298,7 +1234,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum A {
+    One: felt252,
+    Two: (felt252, felt252),
+    Three: (),
+    Four: (),
+}
+#[target_function]
 fn foo(a: A, b: A) -> felt252 {
     match (a, b) {
         (A::Two(_), A::One(_)) => 5,
@@ -1309,23 +1253,11 @@ fn foo(a: A, b: A) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum A {
-    One: felt252,
-    Two: (felt252, felt252),
-    Three: (),
-    Four: (),
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `(One(_), Two(_))` not covered.
- --> lib.cairo:9:5-15:5
+ --> lib.cairo:10:5-16:5
       match (a, b) {
  _____^
 | ...
@@ -1342,24 +1274,20 @@ error[E3004]: Match is non-exhaustive: `(One(_), Two(_))` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A, b: A) -> felt252 {
-    match (a, (a, b)) {
-        (A::Two(_), (A::One(_), A::One(_))) => 8,
-        _ => 4,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy, Drop)]
 enum A {
     One: felt252,
     Two: (felt252, felt252),
     Three: (),
     Four: (),
+}
+#[target_function]
+fn foo(a: A, b: A) -> felt252 {
+    match (a, (a, b)) {
+        (A::Two(_), (A::One(_), A::One(_))) => 8,
+        _ => 4,
+    }
 }
 
 //! > semantic_diagnostics
@@ -1411,20 +1339,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A) -> felt252 {
-    match (a, get_bool()) {
-        (A::Two(_), true) => 5,
-        (A::Two(_), _) => 2,
-        (A::One(_), false) => 1,
-        (_, _) => 6,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     One: felt252,
     Two: (felt252, felt252),
@@ -1433,6 +1348,15 @@ enum A {
 }
 #[allow(extern_outside_corelib)]
 extern fn get_bool() -> bool nopanic;
+#[target_function]
+fn foo(a: A) -> felt252 {
+    match (a, get_bool()) {
+        (A::Two(_), true) => 5,
+        (A::Two(_), _) => 2,
+        (A::One(_), false) => 1,
+        (_, _) => 6,
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -1534,16 +1458,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     match 5_u256 {
         0 => 1,
         _ => 2,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1564,7 +1486,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(v: u32) -> felt252 {
     match v {
         0 => 1,
@@ -1577,9 +1500,6 @@ fn foo(v: u32) -> felt252 {
         _ => 8,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -1663,7 +1583,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    One: (),
+    Two: (),
+    Three: (),
+    Four: (),
+}
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         A::Two(_) => 2,
@@ -1673,22 +1600,11 @@ fn foo(a: A) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    One: (),
-    Two: (),
-    Three: (),
-    Four: (),
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:12:14
+ --> lib.cairo:13:14
         _ => 5,
              ^
 
@@ -1739,7 +1655,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    One: (),
+    Two: (),
+    Three: (),
+    Four: (),
+}
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         A::Two(_) => 2,
@@ -1749,22 +1672,11 @@ fn foo(a: A) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    One: (),
-    Two: (),
-    Three: (),
-    Four: (),
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:12:22
+ --> lib.cairo:13:22
         A::One(_) => 5,
                      ^
 
@@ -1815,22 +1727,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A, b: A) -> felt252 {
-    match (a, b) {
-        (A::Two((t, _)), A::One(_)) => t + 3,
-        (A::Two(_), _) => 2,
-        (A::One(_), A::One(_)) => 1,
-        (_, A::Three(((_, B::One(x)), _))) => x,
-        (_, A::Three(((_, _), x))) => x,
-        (_, _) => 6,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy, Drop)]
 enum A {
     One: felt252,
@@ -1843,6 +1740,17 @@ enum A {
 enum B {
     One: felt252,
     Two: (felt252, felt252),
+}
+#[target_function]
+fn foo(a: A, b: A) -> felt252 {
+    match (a, b) {
+        (A::Two((t, _)), A::One(_)) => t + 3,
+        (A::Two(_), _) => 2,
+        (A::One(_), A::One(_)) => 1,
+        (_, A::Three(((_, B::One(x)), _))) => x,
+        (_, A::Three(((_, _), x))) => x,
+        (_, _) => 6,
+    }
 }
 
 //! > semantic_diagnostics
@@ -2014,18 +1922,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A) -> felt252 {
-    match a {
-        A::Two(((_, (t,)), _)) => t + 3,
-        _ => 6,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy, Drop)]
 enum A {
     One: felt252,
@@ -2038,6 +1935,13 @@ enum A {
 enum B {
     One: felt252,
     Two: (felt252, felt252),
+}
+#[target_function]
+fn foo(a: A) -> felt252 {
+    match a {
+        A::Two(((_, (t,)), _)) => t + 3,
+        _ => 6,
+    }
 }
 
 //! > semantic_diagnostics
@@ -2094,18 +1998,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A) -> felt252 {
-    match a {
-        A::Three(((_, (B::One(t),)), _)) => t + 3,
-        _ => 6,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy, Drop)]
 enum A {
     One: felt252,
@@ -2118,6 +2011,13 @@ enum A {
 enum B {
     One: felt252,
     Two: (felt252, felt252),
+}
+#[target_function]
+fn foo(a: A) -> felt252 {
+    match a {
+        A::Three(((_, (B::One(t),)), _)) => t + 3,
+        _ => 6,
+    }
 }
 
 //! > semantic_diagnostics
@@ -2187,18 +2087,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: ((felt252, (A,)), felt252)) -> felt252 {
-    match a {
-        ((_, (A::One(t),)), _) => t + 3,
-        _ => 6,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy, Drop)]
 enum A {
     One: felt252,
@@ -2211,6 +2100,13 @@ enum A {
 enum B {
     One: felt252,
     Two: (felt252, felt252),
+}
+#[target_function]
+fn foo(a: ((felt252, (A,)), felt252)) -> felt252 {
+    match a {
+        ((_, (A::One(t),)), _) => t + 3,
+        _ => 6,
+    }
 }
 
 //! > semantic_diagnostics
@@ -2267,7 +2163,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: Option<felt252>) -> felt252 {
     match a {
         Some(_) => 5,
@@ -2276,14 +2173,11 @@ fn foo(a: Option<felt252>) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3004]: Unreachable pattern arm.
- --> lib.cairo:5:14
+ --> lib.cairo:6:14
         _ => 7,
              ^
 
@@ -2316,7 +2210,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     match Some(a) {
         Some => 2,
@@ -2324,12 +2219,9 @@ fn foo(a: felt252) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 warning[E2192]: Pattern missing subpattern for the payload of variant. Consider using `Some(_)`
- --> lib.cairo:3:9
+ --> lib.cairo:4:9
         Some => 2,
         ^^^^
 
@@ -2350,16 +2242,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     match Some(a) {
         Some(_) => 2,
         _ => 0,
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -2380,13 +2270,16 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum EmptyEnum {}
 fn foo(e: EmptyEnum) -> felt252 {
     match e {
         _ => { 1 },
     }
 }
 
+#[target_function]
 fn bar(e: Option<EmptyEnum>) -> felt252 {
     if let Some(e) = e {
         foo(e)
@@ -2394,13 +2287,6 @@ fn bar(e: Option<EmptyEnum>) -> felt252 {
         0
     }
 }
-
-//! > function_name
-bar
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum EmptyEnum {}
 
 //! > semantic_diagnostics
 
@@ -2435,7 +2321,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    One: (),
+    Two: (),
+    Three: (),
+}
+#[target_function]
 fn foo(a: Option<Option<A>>) -> felt252 {
     match a {
         Some(Some(A::One)) => 3,
@@ -2445,21 +2337,11 @@ fn foo(a: Option<Option<A>>) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    One: (),
-    Two: (),
-    Three: (),
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `Some(None(_))` not covered.
- --> lib.cairo:7:5-12:5
+ --> lib.cairo:8:5-13:5
       match a {
  _____^
 | ...
@@ -2476,7 +2358,13 @@ error[E3004]: Match is non-exhaustive: `Some(None(_))` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum A {
+    One: (),
+    Two: (),
+    Three: (),
+}
+#[target_function]
 fn foo(a: Option<Option<A>>) -> felt252 {
     match a {
         Some(Some(A::One)) => 3,
@@ -2485,16 +2373,6 @@ fn foo(a: Option<Option<A>>) -> felt252 {
         Some(None) => 4,
         None(_) => 1,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum A {
-    One: (),
-    Two: (),
-    Three: (),
 }
 
 //! > semantic_diagnostics
@@ -2569,17 +2447,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(c: C) -> felt252 {
-    match c {
-        C::One(B::One(A::Two(x))) | C::One(B::One(A::One(x))) => x + x,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     One: felt252,
     Two: felt252,
@@ -2591,6 +2459,12 @@ enum B {
 
 enum C {
     One: B,
+}
+#[target_function]
+fn foo(c: C) -> felt252 {
+    match c {
+        C::One(B::One(A::Two(x))) | C::One(B::One(A::One(x))) => x + x,
+    }
 }
 
 //! > semantic_diagnostics
@@ -2644,7 +2518,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+type A = Result<B, B>;
+type B = Result<C, C>;
+type C = Result<felt252, felt252>;
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         Ok(Ok(Ok(x))) => x,
@@ -2652,14 +2530,6 @@ fn foo(a: A) -> felt252 {
         Err(Ok(Err(x))) | Ok(Err(Err(x))) | Err(Err(Ok(x))) => x * x,
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type A = Result<B, B>;
-type B = Result<C, C>;
-type C = Result<felt252, felt252>;
 
 //! > semantic_diagnostics
 
@@ -2782,7 +2652,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+type A = Result<B, B>;
+type B = Result<C, C>;
+type C = Result<(), ()>;
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         // Ok(Ok(Ok(()))) => 1,
@@ -2796,19 +2670,11 @@ fn foo(a: A) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-type A = Result<B, B>;
-type B = Result<C, C>;
-type C = Result<(), ()>;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `Ok(Ok(Ok(_)))` not covered.
- --> lib.cairo:5:5-14:5
+ --> lib.cairo:6:5-15:5
       match a {
  _____^
 | ...
@@ -2825,7 +2691,11 @@ error[E3004]: Match is non-exhaustive: `Ok(Ok(Ok(_)))` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+type A = Result<B, B>;
+type B = Result<C, C>;
+type C = Result<(), ()>;
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         Ok(Ok(Ok(()))) => 1,
@@ -2839,19 +2709,11 @@ fn foo(a: A) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-type A = Result<B, B>;
-type B = Result<C, C>;
-type C = Result<(), ()>;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `Ok(Err(_))` not covered.
- --> lib.cairo:5:5-14:5
+ --> lib.cairo:6:5-15:5
       match a {
  _____^
 | ...
@@ -2868,7 +2730,11 @@ error[E3004]: Match is non-exhaustive: `Ok(Err(_))` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+type A = Result<B, B>;
+type B = Result<C, C>;
+type C = Result<(), ()>;
+#[target_function]
 fn foo(a: A) -> felt252 {
     match a {
         // Ok(Ok(Ok(()))) => 1,
@@ -2882,19 +2748,11 @@ fn foo(a: A) -> felt252 {
     }
 }
 
-//! > function_name
-foo
-
-//! > module_code
-type A = Result<B, B>;
-type B = Result<C, C>;
-type C = Result<(), ()>;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3004]: Match is non-exhaustive: `Ok(_)` not covered.
- --> lib.cairo:5:5-14:5
+ --> lib.cairo:6:5-15:5
       match a {
  _____^
 | ...
@@ -2911,17 +2769,7 @@ error[E3004]: Match is non-exhaustive: `Ok(_)` not covered.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(c: C) -> felt252 {
-    match c {
-        C::One(B::One(A::One)) => 1,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 enum A {
     One: (),
@@ -2935,6 +2783,12 @@ enum B {
 #[derive(Drop)]
 enum C {
     One: B,
+}
+#[target_function]
+fn foo(c: C) -> felt252 {
+    match c {
+        C::One(B::One(A::One)) => 1,
+    }
 }
 
 //! > semantic_diagnostics
@@ -2956,17 +2810,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(c: C) -> felt252 {
-    match c {
-        C::One(B::One(A::One(x))) | C::One(B::Two(x)) => x + x,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     One: felt252,
 }
@@ -2978,6 +2822,12 @@ enum B {
 
 enum C {
     One: B,
+}
+#[target_function]
+fn foo(c: C) -> felt252 {
+    match c {
+        C::One(B::One(A::One(x))) | C::One(B::Two(x)) => x + x,
+    }
 }
 
 //! > semantic_diagnostics
@@ -3031,23 +2881,19 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(b: B) -> felt252 {
-    match b {
-        B::One(A::One((x, _))) => x,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     One: (felt252, felt252),
 }
 
 enum B {
     One: A,
+}
+#[target_function]
+fn foo(b: B) -> felt252 {
+    match b {
+        B::One(A::One((x, _))) => x,
+    }
 }
 
 //! > semantic_diagnostics
@@ -3083,23 +2929,19 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(x: @B) -> felt252 {
-    match x {
-        B::Two(A::One(v)) => *****v,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     One: @felt252,
 }
 
 enum B {
     Two: @@@A,
+}
+#[target_function]
+fn foo(x: @B) -> felt252 {
+    match x {
+        B::Two(A::One(v)) => *****v,
+    }
 }
 
 //! > semantic_diagnostics
@@ -3139,24 +2981,20 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    match get_a() {
-        A::One(Some(Some(v))) => v,
-        _ => 3,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     One: Option<Option<felt252>>,
 }
 
 #[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
+#[target_function]
+fn foo() -> felt252 {
+    match get_a() {
+        A::One(Some(Some(v))) => v,
+        _ => 3,
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -3215,18 +3053,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    match @get_a() {
-        A::One(Some(Some(v))) => *****v,
-        _ => 3,
-    }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 enum A {
     One: @Option<@@Option<@felt252>>,
@@ -3234,6 +3061,13 @@ enum A {
 
 #[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
+#[target_function]
+fn foo() -> felt252 {
+    match @get_a() {
+        A::One(Some(Some(v))) => *****v,
+        _ => 3,
+    }
+}
 
 //! > semantic_diagnostics
 
@@ -3298,21 +3132,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct A {
+    opt: Option<felt252>,
+}
+#[target_function]
 fn foo(x: Option<Option<A>>) -> felt252 {
     match x {
         Some(Some(A { opt: Some(v) })) => v,
         _ => 3,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct A {
-    opt: Option<felt252>,
 }
 
 //! > semantic_diagnostics
@@ -3379,21 +3209,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct A {
+    opt: Option<felt252>,
+}
+#[target_function]
 fn foo(x: Option<Option<felt252>>) -> felt252 {
     match x {
         Some(Some(0)) => 0,
         _ => 3,
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct A {
-    opt: Option<felt252>,
 }
 
 //! > semantic_diagnostics
@@ -3460,19 +3286,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> felt252 {
-    match get_a() {}
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {}
 
 #[allow(extern_outside_corelib)]
 extern fn get_a() -> A nopanic;
+#[target_function]
+fn foo() -> felt252 {
+    match get_a() {}
+}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/members
+++ b/crates/cairo-lang-lowering/src/test_data/members
@@ -3,16 +3,7 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(ref a: A) {
-    a.f = 5;
-    mutate(ref a.b.c.f);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     b: B,
     f: felt252,
@@ -27,6 +18,11 @@ struct C {
 }
 #[allow(extern_outside_corelib)]
 extern fn mutate(ref f: felt252) nopanic;
+#[target_function]
+fn foo(ref a: A) {
+    a.f = 5;
+    mutate(ref a.b.c.f);
+}
 
 //! > semantic_diagnostics
 
@@ -54,16 +50,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(ref my_struct: MyStruct) {
-    let result = sub_three(my_struct.value);
-    my_struct.value = result;
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct MyStruct {
     value: felt252,
@@ -73,6 +60,11 @@ struct MyStruct {
 #[inline(never)]
 fn sub_three(value: felt252) -> felt252 {
     value - 3
+}
+#[target_function]
+fn foo(ref my_struct: MyStruct) {
+    let result = sub_three(my_struct.value);
+    my_struct.value = result;
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/panic
+++ b/crates/cairo-lang-lowering/src/test_data/panic
@@ -3,16 +3,14 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(ref x: felt252, a: bool) -> felt252 {
     x = 7;
     let mut data = array![];
     data.append(1);
     panic(data)
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -38,7 +36,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn bar(ref a: bool) -> felt252 {
+    let mut data = array![];
+    data.append(1);
+    panic(data)
+}
+#[target_function]
 fn foo(ref x: felt252, ref a: bool) -> felt252 {
     if true {
         x = 7;
@@ -46,17 +51,6 @@ fn foo(ref x: felt252, ref a: bool) -> felt252 {
         x = 6;
     }
     bar(ref a)
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn bar(ref a: bool) -> felt252 {
-    let mut data = array![];
-    data.append(1);
-    panic(data)
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/rebindings
+++ b/crates/cairo-lang-lowering/src/test_data/rebindings
@@ -3,19 +3,15 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar() -> felt252 nopanic;
+#[target_function]
 fn foo(ref a: felt252, b: felt252, c: felt252) -> felt252 {
     a = b;
     a = bar();
     c
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar() -> felt252 nopanic;
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/refutable_pattern
+++ b/crates/cairo-lang-lowering/src/test_data/refutable_pattern
@@ -3,20 +3,18 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(opt: Option<u32>) -> u32 {
     let Option::Some(x) = opt;
     x
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
- --> lib.cairo:2:9
+ --> lib.cairo:3:9
     let Option::Some(x) = opt;
         ^^^^^^^^^^^^^^^
 
@@ -30,19 +28,17 @@ error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are o
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(x: u32) {
     let 5 = x;
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
- --> lib.cairo:2:9
+ --> lib.cairo:3:9
     let 5 = x;
         ^
 
@@ -56,26 +52,22 @@ error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are o
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
-fn foo(s: Wrapper) -> u32 {
-    let Wrapper { inner: Option::Some(x) } = s;
-    x
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop)]
 struct Wrapper {
     inner: Option<u32>,
+}
+#[target_function]
+fn foo(s: Wrapper) -> u32 {
+    let Wrapper { inner: Option::Some(x) } = s;
+    x
 }
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
- --> lib.cairo:6:26
+ --> lib.cairo:7:26
     let Wrapper { inner: Option::Some(x) } = s;
                          ^^^^^^^^^^^^^^^
 
@@ -89,19 +81,17 @@ error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are o
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(opts: Array<Option<u32>>) {
     for Option::Some(_x) in opts {}
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
- --> lib.cairo:2:9
+ --> lib.cairo:3:9
     for Option::Some(_x) in opts {}
         ^^^^^^^^^^^^^^^^
 
@@ -115,21 +105,19 @@ error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are o
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {
     let arr: Array<u32> = array![100, 200, 300];
     let s: Span<u32> = arr.span();
     let [_a, _b, _c] = s;
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3010]: Refutable pattern in irrefutable binding. Refutable patterns are only supported in `match`, `if let`, `while let`, and `let ... else`.
- --> lib.cairo:4:9
+ --> lib.cairo:5:9
     let [_a, _b, _c] = s;
         ^^^^^^^^^^^^
 

--- a/crates/cairo-lang-lowering/src/test_data/repr_ptr
+++ b/crates/cairo-lang-lowering/src/test_data/repr_ptr
@@ -3,16 +3,7 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(s: Point) {
-    bar(&s.x);
-    baz(&s.y);
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct Point {
     x: u32,
     y: u32,
@@ -21,6 +12,11 @@ struct Point {
 extern fn bar(x: &u32) nopanic;
 #[allow(extern_outside_corelib)]
 extern fn baz(y: &u32) nopanic;
+#[target_function]
+fn foo(s: Point) {
+    bar(&s.x);
+    baz(&s.y);
+}
 
 //! > semantic_diagnostics
 
@@ -47,18 +43,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar(x: &u32, y: &&u32, z: &&&u32) nopanic;
+#[target_function]
 fn foo() {
     let x = 3;
     bar(&x, &&x, &&&x);
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar(x: &u32, y: &&u32, z: &&&u32) nopanic;
 
 //! > semantic_diagnostics
 
@@ -85,19 +77,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar(x: &u32) nopanic;
+#[target_function]
 fn foo() {
     let mut x = 1;
     bar(&x);
     bar(&x);
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar(x: &u32) nopanic;
 
 //! > semantic_diagnostics
 
@@ -120,17 +108,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar(x: &@u32) nopanic;
+#[target_function]
 fn foo(x: @u32) {
     bar(&x)
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar(x: &@u32) nopanic;
 
 //! > semantic_diagnostics
 
@@ -153,20 +137,16 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar(x: &u32) nopanic;
+#[target_function]
 fn foo(opt: Option<u32>) {
     match opt {
         Option::Some(x) => bar(&x),
         Option::None => (),
     }
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar(x: &u32) nopanic;
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/snapshot
+++ b/crates/cairo-lang-lowering/src/test_data/snapshot
@@ -3,17 +3,13 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[allow(extern_outside_corelib)]
+extern fn bar(x: @felt252) nopanic;
+#[target_function]
 fn foo(x: felt252) {
     bar(@x)
 }
-
-//! > function_name
-foo
-
-//! > module_code
-#[allow(extern_outside_corelib)]
-extern fn bar(x: @felt252) nopanic;
 
 //! > semantic_diagnostics
 
@@ -35,24 +31,20 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(orig: @A) -> @A {
-    bar(orig.a, orig.b);
-    let A { a, b } = orig;
-    bar(a, b);
-    orig
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     a: Array<felt252>,
     b: felt252,
 }
 #[inline(never)]
 fn bar(a: @Array::<felt252>, b: @felt252) {}
+#[target_function]
+fn foo(orig: @A) -> @A {
+    bar(orig.a, orig.b);
+    let A { a, b } = orig;
+    bar(a, b);
+    orig
+}
 
 //! > semantic_diagnostics
 
@@ -75,20 +67,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(orig: @A) -> @A {
-    match orig {
-        A::A(a) => bar0(a),
-        A::B(b) => bar1(b),
-        A::C((c, d)) => bar2(c, d),
-    }
-    orig
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 enum A {
     A: Array<felt252>,
     B: felt252,
@@ -100,6 +79,15 @@ fn bar0(a: @Array::<felt252>) {}
 fn bar1(b: @felt252) {}
 #[inline(never)]
 fn bar2(c: @felt252, d: @Array::<felt252>) {}
+#[target_function]
+fn foo(orig: @A) -> @A {
+    match orig {
+        A::A(a) => bar0(a),
+        A::B(b) => bar1(b),
+        A::C((c, d)) => bar2(c, d),
+    }
+    orig
+}
 
 //! > semantic_diagnostics
 
@@ -142,13 +130,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(value: @felt252) -> felt252 {
     *value
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -169,19 +155,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(value: @Array::<felt252>) -> Array<felt252> {
     *value
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 error[E3003]: Cannot desnap a non copyable type.
- --> lib.cairo:2:5
+ --> lib.cairo:3:5
     *value
     ^^^^^^
 note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
@@ -196,21 +180,17 @@ note: Trait has no implementation in context: core::traits::Copy::<core::array::
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: A) -> usize {
-    bar(@a.b);
-    a.b
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct A {
     b: usize,
 }
 #[allow(extern_outside_corelib)]
 extern fn bar(x: @usize) nopanic;
+#[target_function]
+fn foo(a: A) -> usize {
+    bar(@a.b);
+    a.b
+}
 
 //! > semantic_diagnostics
 
@@ -233,7 +213,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn opaque_len(a: @Array<u32>) -> usize {
+    a.len()
+}
+#[target_function]
 fn foo() -> usize {
     let mut array: Array<u32> = array![14];
     let mut i = 0;
@@ -247,15 +232,6 @@ fn foo() -> usize {
     opaque_len(@array)
 }
 
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn opaque_len(a: @Array<u32>) -> usize {
-    a.len()
-}
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -264,7 +240,7 @@ fn opaque_len(a: @Array<u32>) -> usize {
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::integer::u32, ())>) <- test::foo[83-141]{0, @array![14], }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::integer::u32, ())>) <- test::foo[102-160]{0, @array![14], }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -312,7 +288,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct A {
+    b: u8,
+}
+#[target_function]
 fn foo() -> @u8 {
     let mut a = A { b: 8 };
     loop {
@@ -322,15 +303,6 @@ fn foo() -> @u8 {
     a = A { b: 7 };
 
     @(a.b)
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct A {
-    b: u8,
 }
 
 //! > semantic_diagnostics
@@ -353,7 +325,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Drop)]
+struct A {
+    b: u8,
+}
+#[target_function]
 fn foo() {
     let a = A { b: 7 };
     loop {
@@ -364,15 +341,6 @@ fn foo() {
         }
         break;
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Drop)]
-struct A {
-    b: u8,
 }
 
 //! > semantic_diagnostics
@@ -393,21 +361,17 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+struct A {
+    m: u8,
+}
+#[target_function]
 fn foo() -> @A {
     let mut a = A { m: 7 };
     let _z = @a;
     a.m = 0;
     @a
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-struct A {
-    m: u8,
 }
 
 //! > semantic_diagnostics
@@ -431,18 +395,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> @u8 {
-    let mut a = A { m: Member { m: 7 } };
-    let _z = @a.m.m;
-    a.m = Member { m: 0 };
-    @a.m.m
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy, Drop)]
 struct A {
     m: Member,
@@ -451,6 +404,13 @@ struct A {
 #[derive(Copy, Drop)]
 struct Member {
     m: u8,
+}
+#[target_function]
+fn foo() -> @u8 {
+    let mut a = A { m: Member { m: 7 } };
+    let _z = @a.m.m;
+    a.m = Member { m: 0 };
+    @a.m.m
 }
 
 //! > semantic_diagnostics
@@ -476,20 +436,16 @@ test_function_lowering(expect_diagnostics: false)
 //! > crate_settings
 edition = "2025_12"
 
-//! > function_code
+//! > cairo_code
+struct A {
+    a: Array<felt252>,
+    b: felt252,
+}
+#[target_function]
 fn foo(
     a: @A,
 ) -> (@Array<felt252>, @Array<felt252>, @@Array<felt252>, felt252, @felt252, @felt252, @@felt252) {
     (@a.a, @(@a).a, @@(@a).a, a.b, @a.b, @(@a).b, @@(@a).b)
-}
-
-//! > function_name
-foo
-
-//! > module_code
-struct A {
-    a: Array<felt252>,
-    b: felt252,
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/strings
+++ b/crates/cairo-lang-lowering/src/test_data/strings
@@ -3,14 +3,12 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> ByteArray {
     let x = "hello";
     x
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -34,13 +32,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> ByteArray {
     "This is a string of length 31!!"
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -66,13 +62,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> ByteArray {
     "This is a string longer than 31 characters."
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -98,13 +92,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> ByteArray {
     "This is a very very long string. It is longer than 62 characters!"
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -132,14 +124,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> ByteArray {
     let y = "";
     y
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -163,14 +153,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> ByteArray {
     let x = "hello";
     x + " world"
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/struct
+++ b/crates/cairo-lang-lowering/src/test_data/struct
@@ -3,19 +3,15 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(a: felt252) -> MyStruct {
-    MyStruct { a: (), c: (3, 7), b: a }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: (),
     b: felt252,
     c: (felt252, felt252),
+}
+#[target_function]
+fn foo(a: felt252) -> MyStruct {
+    MyStruct { a: (), c: (3, 7), b: a }
 }
 
 //! > semantic_diagnostics
@@ -41,19 +37,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(s: MyStruct) -> felt252 {
-    s.b
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: (),
     b: felt252,
     c: (felt252, felt252),
+}
+#[target_function]
+fn foo(s: MyStruct) -> felt252 {
+    s.b
 }
 
 //! > semantic_diagnostics
@@ -75,20 +67,16 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(s: MyStruct) -> (felt252, felt252) {
-    let MyStruct { a: _, c: (v, _), b } = s;
-    (v, b)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     a: (),
     b: felt252,
     c: (felt252, felt252),
+}
+#[target_function]
+fn foo(s: MyStruct) -> (felt252, felt252) {
+    let MyStruct { a: _, c: (v, _), b } = s;
+    (v, b)
 }
 
 //! > semantic_diagnostics
@@ -112,20 +100,16 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(s: MyStruct) -> MyStruct {
-    MyStruct { c: (1, 2), ..s }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Copy)]
 struct MyStruct {
     a: (),
     b: felt252,
     c: (felt252, felt252),
+}
+#[target_function]
+fn foo(s: MyStruct) -> MyStruct {
+    MyStruct { c: (1, 2), ..s }
 }
 
 //! > semantic_diagnostics
@@ -151,15 +135,7 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo() -> MyStruct {
-    MyStruct { c: f2(), a: (), b: f1() }
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 struct MyStruct {
     b: felt252,
     a: (),
@@ -169,6 +145,10 @@ struct MyStruct {
 extern fn f1() -> felt252 nopanic;
 #[allow(extern_outside_corelib)]
 extern fn f2() -> (felt252, felt252) nopanic;
+#[target_function]
+fn foo() -> MyStruct {
+    MyStruct { c: f2(), a: (), b: f1() }
+}
 
 //! > semantic_diagnostics
 

--- a/crates/cairo-lang-lowering/src/test_data/tests
+++ b/crates/cairo-lang-lowering/src/test_data/tests
@@ -3,11 +3,9 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() {}
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -27,7 +25,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     return a + a * a;
     5;
@@ -35,14 +34,11 @@ fn foo(a: felt252) -> felt252 {
     7
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3000]: Unreachable code
- --> lib.cairo:3:5-5:5
+ --> lib.cairo:4:5-6:5
       5;
  _____^
 |     6;
@@ -65,20 +61,18 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: warnings_only)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: never) -> felt252 {
     match a {}
     1 + 2
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3000]: Unreachable code
- --> lib.cairo:3:5
+ --> lib.cairo:4:5
     1 + 2
     ^^^^^
 
@@ -97,20 +91,18 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: warnings_only)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     loop {}
     1
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
 warning[E3000]: Unreachable code
- --> lib.cairo:3:5
+ --> lib.cairo:4:5
     1
     ^
 
@@ -118,7 +110,7 @@ warning[E3000]: Unreachable code
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252,)>) <- test::foo[22-34](v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252,)>) <- test::foo[41-53](v0, v1)
 End:
   Return(v2, v3, v4)
 
@@ -129,14 +121,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let (_, _b) = (1, a);
     5
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -157,7 +147,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(a: felt252) -> felt252 {
     let x = {
         7;
@@ -175,9 +166,6 @@ fn foo(a: felt252) -> felt252 {
         a + 0
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -256,7 +244,13 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: (),
+    B: felt252,
+    C: Box<((), felt252)>,
+}
+#[target_function]
 fn foo(x: MyEnum) -> felt252 {
     match x {
         MyEnum::A(_inner) => { return 5; },
@@ -267,16 +261,6 @@ fn foo(x: MyEnum) -> felt252 {
             7
         },
     }
-}
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: (),
-    B: felt252,
-    C: Box<((), felt252)>,
 }
 
 //! > semantic_diagnostics
@@ -318,16 +302,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+type Array<T, const N: usize> = (T, felt252);
+#[target_function]
 fn foo(a: Array<felt252, 5>) -> felt252 {
     felt252_const::<17>()
 }
-
-//! > function_name
-foo
-
-//! > module_code
-type Array<T, const N: usize> = (T, felt252);
 
 //! > semantic_diagnostics
 
@@ -351,20 +331,16 @@ TODO(spapini): Make this a semantic diagnostic.
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(mut a: felt252) -> felt252 {
-    bar(ref a, ref a)
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[inline(never)]
 fn bar(ref a: felt252, ref b: felt252) -> felt252 {
     a = 0;
     b = 1;
     a + b
+}
+#[target_function]
+fn foo(mut a: felt252) -> felt252 {
+    bar(ref a, ref a)
 }
 
 //! > semantic_diagnostics
@@ -386,17 +362,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: true)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut data: Span<felt252>) -> u128 {
     serde::Serde::<u128>::deserialize(ref data)
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "core::option::Option::<core::integer::u128>".
- --> lib.cairo:2:5
+ --> lib.cairo:3:5
     serde::Serde::<u128>::deserialize(ref data)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/crates/cairo-lang-lowering/src/test_data/tuple
+++ b/crates/cairo-lang-lowering/src/test_data/tuple
@@ -3,20 +3,16 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[inline(never)]
+fn immovable<T>(t: T) -> T {
+    t
+}
+#[target_function]
 fn foo() {
     let a = (1, 2);
     let (_x, _y) = immovable(a);
     let (_x, _y) = immovable((1, 2));
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[inline(never)]
-fn immovable<T>(t: T) -> T {
-    t
 }
 
 //! > semantic_diagnostics
@@ -42,15 +38,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(t: (felt252, u8)) -> u8 {
     t.1
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -71,15 +63,11 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(t: (felt252, (u8, u16))) -> u16 {
     t.1.1
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -101,16 +89,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(mut t: (felt252, u8)) -> (felt252, u8) {
     t.0 = 5;
     t
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -133,18 +117,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+fn bar(ref x: felt252) {
+    x = 7;
+}
+#[target_function]
 fn foo(mut t: (felt252, u8)) -> (felt252, u8) {
     bar(ref t.0);
     t
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar(ref x: felt252) {
-    x = 7;
 }
 
 //! > semantic_diagnostics
@@ -168,18 +148,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+fn bar(ref x: (felt252, u8)) {
+    x.1 = 7;
+}
+#[target_function]
 fn foo(mut t: ((felt252, u8), u16)) -> ((felt252, u8), u16) {
     bar(ref t.0);
     t
-}
-
-//! > function_name
-foo
-
-//! > module_code
-fn bar(ref x: (felt252, u8)) {
-    x.1 = 7;
 }
 
 //! > semantic_diagnostics
@@ -205,16 +181,12 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(t: (felt252, u8)) -> @u8 {
     let s = @t;
     s.1
 }
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > semantic_diagnostics
 
@@ -236,18 +208,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
-fn foo(w: Wrapper) -> @u8 {
-    w.inner.1
-}
-
-//! > function_name
-foo
-
-//! > module_code
+//! > cairo_code
 #[derive(Drop, Copy)]
 struct Wrapper {
     inner: @(felt252, u8),
+}
+#[target_function]
+fn foo(w: Wrapper) -> @u8 {
+    w.inner.1
 }
 
 //! > semantic_diagnostics

--- a/crates/cairo-lang-lowering/src/test_data/while
+++ b/crates/cairo-lang-lowering/src/test_data/while
@@ -3,16 +3,14 @@
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo(y: felt252) {
     let mut x = 5;
     while x != y {
         x = x - 1;
     }
 }
-
-//! > function_name
-foo
 
 //! > semantic_diagnostics
 
@@ -24,7 +22,7 @@ blk0 (root):
 Statements:
   (v3: core::felt252) <- 5
   (v4: core::felt252, v5: @core::felt252) <- snapshot(v2)
-  (v6: core::RangeCheck, v7: core::gas::GasBuiltin, v8: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[40-84](v0, v1, v3, v5)
+  (v6: core::RangeCheck, v7: core::gas::GasBuiltin, v8: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[59-103](v0, v1, v3, v5)
 End:
   Match(match_enum(v8) {
     PanicResult::Ok(v9) => blk1,
@@ -53,24 +51,20 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[target_function]
 fn foo(a: MyEnum) -> felt252 {
     let mut y = 0;
     while let MyEnum::A(x) = a {
         y = y + x;
     }
     y
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
 }
 
 //! > semantic_diagnostics
@@ -82,7 +76,7 @@ Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: test::MyEnum
 blk0 (root):
 Statements:
   (v3: core::felt252) <- 0
-  (v4: core::RangeCheck, v5: core::gas::GasBuiltin, v6: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[50-108](v0, v1, v2, v3)
+  (v4: core::RangeCheck, v5: core::gas::GasBuiltin, v6: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[69-127](v0, v1, v2, v3)
 End:
   Match(match_enum(v6) {
     PanicResult::Ok(v7) => blk1,
@@ -111,7 +105,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[allow(extern_outside_corelib)]
+extern fn a() -> MyEnum nopanic;
+#[target_function]
 fn foo() -> felt252 {
     let mut y = 0;
     while let MyEnum::A(x) = a() {
@@ -121,18 +123,6 @@ fn foo() -> felt252 {
     return y;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
-}
-#[allow(extern_outside_corelib)]
-extern fn a() -> MyEnum nopanic;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -141,7 +131,7 @@ extern fn a() -> MyEnum nopanic;
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[41-100]{0, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[60-119]{0, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -172,7 +162,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[allow(extern_outside_corelib)]
+extern fn a() -> MyEnum nopanic;
+#[target_function]
 fn foo() -> felt252 {
     let mut y = 0;
     while let (MyEnum::A(x), true) = (a(), 5 == 6) {
@@ -181,18 +179,6 @@ fn foo() -> felt252 {
     y = y + 1;
     return y;
 }
-
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
-}
-#[allow(extern_outside_corelib)]
-extern fn a() -> MyEnum nopanic;
 
 //! > semantic_diagnostics
 
@@ -203,7 +189,7 @@ Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
   (v2: core::felt252) <- 0
-  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[41-118](v0, v1, v2)
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[60-137](v0, v1, v2)
 End:
   Match(match_enum(v5) {
     PanicResult::Ok(v6) => blk1,
@@ -234,7 +220,15 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[allow(extern_outside_corelib)]
+extern fn a() -> MyEnum nopanic;
+#[target_function]
 fn foo() -> felt252 {
     let mut y = 0;
     while let (MyEnum::A(x), 3) = (a(), 3) {
@@ -244,18 +238,6 @@ fn foo() -> felt252 {
     return y;
 }
 
-//! > function_name
-foo
-
-//! > module_code
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
-}
-#[allow(extern_outside_corelib)]
-extern fn a() -> MyEnum nopanic;
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -264,7 +246,7 @@ extern fn a() -> MyEnum nopanic;
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[41-110]{0, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[60-129]{0, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -295,7 +277,8 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[target_function]
 fn foo() -> felt252 {
     let mut y = 0;
     while let x = y {
@@ -305,9 +288,6 @@ fn foo() -> felt252 {
     return y;
 }
 
-//! > function_name
-foo
-
 //! > semantic_diagnostics
 
 //! > lowering_diagnostics
@@ -316,7 +296,7 @@ foo
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin
 blk0 (root):
 Statements:
-  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[41-87]{0, }(v0, v1)
+  (v2: core::RangeCheck, v3: core::gas::GasBuiltin, v4: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[60-106]{0, }(v0, v1)
 End:
   Match(match_enum(v4) {
     PanicResult::Ok(v5) => blk1,
@@ -347,7 +327,14 @@ End:
 //! > test_runner_name
 test_function_lowering(expect_diagnostics: false)
 
-//! > function_code
+//! > cairo_code
+#[derive(Copy, Drop)]
+enum MyEnum {
+    A: felt252,
+    B,
+    C,
+}
+#[target_function]
 fn foo(a: MyEnum) -> felt252 {
     let mut y = 0;
     while let _ = a {
@@ -355,17 +342,6 @@ fn foo(a: MyEnum) -> felt252 {
     }
     y = y + 1;
     return y;
-}
-
-//! > function_name
-foo
-
-//! > module_code
-#[derive(Copy, Drop)]
-enum MyEnum {
-    A: felt252,
-    B,
-    C,
 }
 
 //! > semantic_diagnostics
@@ -376,7 +352,7 @@ enum MyEnum {
 Parameters: v0: core::RangeCheck, v1: core::gas::GasBuiltin, v2: test::MyEnum
 blk0 (root):
 Statements:
-  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[50-97]{NotSpecialized, 0, }(v0, v1, v2)
+  (v3: core::RangeCheck, v4: core::gas::GasBuiltin, v5: core::panics::PanicResult::<(core::felt252, ())>) <- test::foo[69-116]{NotSpecialized, 0, }(v0, v1, v2)
 End:
   Match(match_enum(v5) {
     PanicResult::Ok(v6) => blk1,


### PR DESCRIPTION
Migrates all 66 legacy golden test-data files of `cairo-lang-lowering` (619
blocks) from the `function_code`/`module_code`/`function_name` tag family to a
single `cairo_code` input section with a `#[target_function]` marker, using the
mechanical migration tool. The `module_code + '\n' + function_code` join is
preserved exactly, so the only golden churn is the marker's one extra line.

Runner-side:
* `flow_control/graph_test.rs` no longer hard-codes the target name "foo".
* `cache/test.rs` resolves the target via `resolve_target_functions`, since
  `setup_test_function` can't load a crate cache; the module content is now
  computed once and shared by the cache-generating and cache-loading dbs.
* `block_builder_test.rs` synthesizes its module into a single `cairo_code`
  input; its `module_code` tag is renamed to `helper_code`.
* `analysis/test.rs`'s three inline input maps use `cairo_code`.

Regenerated goldens are span churn only: all `lib.cairo` positions shift by
exactly +1 line, and generated-function byte offsets by exactly +19. Two
diagnostics that span a whole function item now echo the attribute line in
their source snippet.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>