### PR TITLE
fix(semantic): reject a macro expansion block with nothing repeating at its depth

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -1229,6 +1229,11 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     name.long(db)
                 )
             }
+            SemanticDiagnosticKind::MacroRepetitionWithoutRepeatingPlaceholder => {
+                "Macro expansion block holds no placeholder that repeats at its depth, so the \
+                 number of repetitions cannot be determined."
+                    .into()
+            }
             SemanticDiagnosticKind::MacroExpansionFailed(failure) => match failure {
                 MacroExpansionFailure::RepetitionWithoutPlaceholder => {
                     "Repetition in the macro expansion holds no placeholder, so the number of \
@@ -1520,6 +1525,9 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::UnsupportedItemInStatement => error_code!(E2197),
             SemanticDiagnosticKind::ExternItemOutsideCorelib => error_code!(E2201),
             SemanticDiagnosticKind::MacroExpansionFailed(_) => error_code!(E2202),
+            SemanticDiagnosticKind::MacroRepetitionWithoutRepeatingPlaceholder => {
+                error_code!(E2203)
+            }
             SemanticDiagnosticKind::PluginDiagnostic(diag) => {
                 diag.error_code.unwrap_or(error_code!(E2200))
             }
@@ -1941,6 +1949,7 @@ pub enum SemanticDiagnosticKind<'db> {
         actual: usize,
     },
     MacroPlaceholderRepDriverMismatch(SmolStrId<'db>),
+    MacroRepetitionWithoutRepeatingPlaceholder,
     MacroExpansionFailed(MacroExpansionFailure<'db>),
     UserDefinedInlineMacrosDisabled,
     NonNeverLetElseType,

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -2702,7 +2702,7 @@ error[E2199]: Macro placeholder 'b' is from a different repetition than the one 
 
 //! > ==========================================================================
 
-//! > Test item-position macro call whose expansion repeats a placeholder-free block.
+//! > Test placeholder-free repetition in an expansion, with an item-position call.
 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
@@ -2716,14 +2716,14 @@ m!();
 fn foo() {}
 
 //! > expected_diagnostics
-error[E2202]: Repetition in the macro expansion holds no placeholder, so the number of repetitions cannot be determined.
+error[E2203]: Macro expansion block holds no placeholder that repeats at its depth, so the number of repetitions cannot be determined.
  --> lib.cairo:2:13
     () => { $(foo)* };
             ^^^^^^^
 
 //! > ==========================================================================
 
-//! > Test expression-position macro call whose expansion repeats a placeholder-free block.
+//! > Test placeholder-free repetition in an expansion, with an expression-position call.
 
 //! > test_runner_name
 test_function_diagnostics(expect_diagnostics: true)
@@ -2737,7 +2737,7 @@ fn foo() -> felt252 {
 }
 
 //! > expected_diagnostics
-error[E2202]: Repetition in the macro expansion holds no placeholder, so the number of repetitions cannot be determined.
+error[E2203]: Macro expansion block holds no placeholder that repeats at its depth, so the number of repetitions cannot be determined.
  --> lib.cairo:2:13
     () => { $(foo)* 0 };
             ^^^^^^^
@@ -2798,7 +2798,170 @@ helpers::m!();
 fn foo() {}
 
 //! > expected_diagnostics
-error[E2202]: Repetition in the macro expansion holds no placeholder, so the number of repetitions cannot be determined.
+error[E2203]: Macro expansion block holds no placeholder that repeats at its depth, so the number of repetitions cannot be determined.
  --> lib.cairo:3:17
         () => { $(foo)* };
                 ^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test placeholder-free repetition that is not the first element of the expansion.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > cairo_code
+macro m {
+    ($($name:ident),*) => {
+        $(fn $name() {})*
+        $(fn extra() {})*
+    };
+}
+
+m!(first, second);
+fn foo() {}
+
+//! > expected_diagnostics
+error[E2203]: Macro expansion block holds no placeholder that repeats at its depth, so the number of repetitions cannot be determined.
+ --> lib.cairo:4:9
+        $(fn extra() {})*
+        ^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test repetition over a placeholder that does not repeat in the pattern.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > cairo_code
+macro m {
+    ($base:ident, $($x:ident),*) => { $($base)* };
+}
+fn foo() {
+    m!(base, one, two);
+}
+
+//! > expected_diagnostics
+error[E2203]: Macro expansion block holds no placeholder that repeats at its depth, so the number of repetitions cannot be determined.
+ --> lib.cairo:2:39
+    ($base:ident, $($x:ident),*) => { $($base)* };
+                                      ^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test expansion nested one level deeper than the placeholder repeats.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > cairo_code
+macro m {
+    ($($x:expr),*) => { $($($x),*),* };
+}
+fn foo() {
+    m!(1, 2);
+}
+
+//! > expected_diagnostics
+error[E2203]: Macro expansion block holds no placeholder that repeats at its depth, so the number of repetitions cannot be determined.
+ --> lib.cairo:2:27
+    ($($x:expr),*) => { $($($x),*),* };
+                          ^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test nested placeholder-free expansion blocks reporting only the outer one.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > cairo_code
+// The inner block fails for the same reason as the outer one, so reporting it too would double up
+// on a single defect.
+macro m {
+    () => { $( $(foo)* )* };
+}
+fn foo() {
+    m!();
+}
+
+//! > expected_diagnostics
+error[E2203]: Macro expansion block holds no placeholder that repeats at its depth, so the number of repetitions cannot be determined.
+ --> lib.cairo:4:13
+    () => { $( $(foo)* )* };
+            ^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test an undefined placeholder inside an expansion repetition.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > cairo_code
+// The placeholder is reported as undefined only: whether it would repeat at the block's depth is
+// unknowable for a name the pattern does not bind, so the block is not also reported.
+macro m {
+    () => { $($undefined)* };
+}
+fn foo() {
+    m!();
+}
+
+//! > expected_diagnostics
+error[E2193]: Undefined macro placeholder: 'undefined'.
+ --> lib.cairo:4:15
+    () => { $($undefined)* };
+              ^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Test broadcasting a non-repeating placeholder over a repeating one (valid).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > cairo_code
+macro m {
+    ($base:expr, $($x:expr),*) => { array![$($base + $x),*] };
+}
+fn foo() {
+    let _arr = m!(10, 1, 2);
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test expansion nesting matching the pattern nesting (valid).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > cairo_code
+macro m {
+    ($([$($x:expr),*]),*) => { array![$(array![$($x),*]),*] };
+}
+fn foo() {
+    let _arr = m!([1, 2], [3, 4]);
+}
+
+//! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test zero-match call of a rule whose expansion repeats (valid).
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > cairo_code
+macro m {
+    ($($x:expr),*) => { 0 $(+ $x)* };
+}
+fn foo() -> felt252 {
+    m!() + m!(1, 2)
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -154,6 +154,7 @@ fn priv_macro_declaration_data<'db>(
             placeholder_paths: &placeholder_paths,
             diagnostics: &mut diagnostics,
             rule_err: Ok(()),
+            enclosing_block_reported: false,
         };
         ctx.check_node(expansion.as_syntax_node());
         // Skipping expanding an inline macro if it had a parser error.
@@ -236,31 +237,64 @@ fn collect_placeholder_paths<'db>(
     }
 }
 
+/// Whether a placeholder in `block`'s subtree drives it - see the model on
+/// [`ExpansionCheckCtx`]. `enclosing_depth` is the number of expansion blocks `block` is nested
+/// in.
+///
+/// A placeholder undefined in the pattern counts as driving: it is reported on its own, and
+/// reporting the block too would double up on a single defect.
+fn has_driving_placeholder<'db>(
+    db: &'db dyn Database,
+    block: SyntaxNode<'db>,
+    placeholder_paths: &OrderedHashMap<SmolStrId<'db>, Vec<usize>>,
+    enclosing_depth: usize,
+) -> bool {
+    block
+        .descendants(db)
+        .filter_map(|node| MacroParam::cast(db, node))
+        .filter_map(|param| extract_placeholder(db, &param))
+        .any(|name| placeholder_paths.get(&name).is_none_or(|path| path.len() > enclosing_depth))
+}
+
 /// Context for validating placeholder usage in a macro rule's expansion.
+///
+/// The model: a placeholder nested under `d` pattern repetitions (its *pattern depth*) captures a
+/// `d`-layer nested list of matches, and each `$()` expansion block iterates one layer. So:
+/// * A placeholder must be spliced under at least `d` expansion blocks.
+/// * A block's repetition count is set by a placeholder in its subtree - at any nesting - whose
+///   pattern depth exceeds the block's nesting depth. Such a placeholder *drives* the block; a
+///   driverless block is rejected.
+/// * All placeholders under a block must come from the same pattern repetition, so their counts
+///   agree.
 struct ExpansionCheckCtx<'db, 'a> {
     db: &'db dyn Database,
     /// Maps each placeholder name to its pattern path: the sequence of repetition IDs
     /// (outermost to innermost) of the `$()` blocks it is nested in within the pattern.
     placeholder_paths: &'a OrderedHashMap<SmolStrId<'db>, Vec<usize>>,
-    /// Number of `$()` expansion blocks currently entered. Used for E2198 depth checks
+    /// Number of `$()` expansion blocks currently entered. Used for depth checks
     /// and to trim `known_path` when exiting a block.
     curr_rep_depth: usize,
     /// The deepest placeholder path seen so far within the current expansion scope.
-    /// New placeholders at the same depth are validated against this prefix (E2199).
+    /// New placeholders at the same depth are validated against this prefix.
     /// Invariant: `known_path.len() <= curr_rep_depth`.
     /// Trimmed to `curr_rep_depth` on `$()` exit so sibling blocks start fresh.
     known_path: &'a [usize],
     diagnostics: &'a mut SemanticDiagnostics<'db>,
     /// `Err` if any diagnostic has been emitted; callers skip expansion when set.
     rule_err: Maybe<()>,
+    /// Whether an enclosing `$()` block was already reported as driverless; a block nested in it
+    /// fails for the same reason, so only the outermost one is reported.
+    enclosing_block_reported: bool,
 }
 
 impl<'db> ExpansionCheckCtx<'db, '_> {
     /// Validates placeholder usage by recursively traversing `node`.
     ///
-    /// Two kinds of errors are reported:
-    /// * Depth mismatch (E2198): placeholder used at fewer expansion levels than its pattern depth.
-    /// * Context mismatch (E2199): placeholder from a different repetition than the driving one.
+    /// Three kinds of errors are reported, in the vocabulary of the model on
+    /// [`ExpansionCheckCtx`]:
+    /// * A placeholder spliced under fewer expansion blocks than its pattern depth.
+    /// * A placeholder from a different pattern repetition than the block's driving one.
+    /// * A `$()` block whose repetition count is undetermined, as no placeholder drives it.
     fn check_node(&mut self, node: SyntaxNode<'db>) {
         let db = self.db;
         if let Some(param) = MacroParam::cast(db, node) {
@@ -300,11 +334,22 @@ impl<'db> ExpansionCheckCtx<'db, '_> {
         }
 
         if let Some(repetition) = ast::MacroRepetition::cast(db, node) {
+            let outer_enclosing_block_reported = self.enclosing_block_reported;
+            if !outer_enclosing_block_reported
+                && !has_driving_placeholder(db, node, self.placeholder_paths, self.curr_rep_depth)
+            {
+                self.rule_err = Err(self.diagnostics.report(
+                    repetition.stable_ptr(db).untyped(),
+                    SemanticDiagnosticKind::MacroRepetitionWithoutRepeatingPlaceholder,
+                ));
+                self.enclosing_block_reported = true;
+            }
             self.curr_rep_depth += 1;
             for element in repetition.elements(db).elements(db) {
                 self.check_node(element.as_syntax_node());
             }
             self.curr_rep_depth -= 1;
+            self.enclosing_block_reported = outer_enclosing_block_reported;
             if self.curr_rep_depth < self.known_path.len() {
                 // Trimming `self.known_path` so it won't leak between different repetitions.
                 self.known_path = &self.known_path[..self.curr_rep_depth];


### PR DESCRIPTION
`ExpansionCheckCtx` already tracks, for every placeholder, its pattern repetition depth
(`placeholder_paths[name].len()`) and the expansion depth it is used at (`curr_rep_depth`).
It now also validates each `$()` block of the expansion itself: a block nested in
`enclosing_depth` other blocks is legal only if it holds a placeholder whose pattern depth
exceeds `enclosing_depth`, i.e. something that actually repeats at this level and can drive
the block. Otherwise the number of repetitions is undetermined, and the new
declaration-time error E2203 is reported on the offending `MacroRepetition` and sets
`rule.err`, so the rule never expands.

Placeholders nested deeper inside the block count as drivers: in `$($($x),*),*` with `$x` at
pattern depth 1, `$x` sits in the inner block but is consumed by the outer repetition too, so
the outer block is legal and only the inner one is rejected.

E2203 was unallocated (main's general band ended at E2201, the parent commit took E2202;
E2300-E2315 is the `InferenceError` sub-band and is not part of this band). The next free
general semantic code is E2204.

## Semantics mirrored from rustc

Probed with rustc 1.96.0 (ac68faa20 2026-05-25) in this change. rustc's transcriber-side
definition errors are LAZY, so every probe below invokes the macro; rustc then reports the
definition-site error upon invocation. Probe sources are transcribed inline.

REJECTED - all four report
`attempted to repeat an expression containing no syntax variables matched as repeating at this
depth`:

* no metavariable: `macro_rules! m1 { () => { $(foo)* }; }` + `m1!();`
  -> caret on `(foo)`.
* depth-0-only metavariable: `macro_rules! m2 { ($a:ident) => { $($a)* }; }` + `m2!(x);`
  -> caret on `($a)`, plus `this similarly named macro metavariable is unrepeatable`.
* over-deep inner block: `macro_rules! m3 { ($($x:ident),*) => { $($($x),*),* }; }`
  + `m3!(a, b)` -> caret on the INNER `($x)`, not the outer block.
* offender not first: `macro_rules! m9 { ($($x:ident),*) => { stringify!($($x),* ; $(bar)*) }; }`
  + `m9!(a, b)` -> caret on `(bar)`; the leading well-formed block is silent.

ACCEPTED:

* broadcast: `macro_rules! m4 { ($p:ident, $($x:ident),*) => { stringify!($($p $x),*) }; }`
  + `m4!(f, a, b)` prints `f a, f b`.
* properly nested:
  `macro_rules! m5 { ($([$($x:ident),*]),*) => { stringify!($([$($x),*]),*) }; }`
  + `m5!([a, b], [c, d])` prints `[a, b], [c, d]`.
* zero-match calls of those same two rules: `m4!(f,)` and `m5!()` print nothing, `m5!([], [])`
  prints `[], []`.

Two rustc behaviours copied deliberately:

* `macro_rules! m7 { ($($x:ident),*) => { stringify!($($(foo),*),*) }; }` + `m7!(a, b)` reports
  exactly ONE error, anchored at the OUTER block. A block nested in a failing block always
  fails for the same reason (`inner_max <= outer_max <= d < d+1`), so `in_non_repeating_block`
  suppresses nested E2203s. E2193/E2198/E2199 are still reported inside a suppressed block.
* `macro_rules! m10 { ($($x:ident),*) => { stringify!($($q)*) }; }` + `m10!(a, b)` reports one
  error, not a separate "unbound metavariable" one. So an undefined placeholder counts as a
  driver here and `$($undef)*` keeps reporting E2193 alone rather than E2193 + E2203.

STRICTER THAN RUSTC, deliberately: Cairo reports E2203 from `priv_macro_declaration_data`, so a
bad `macro` is rejected with no call anywhere, unlike rustc's lazy transcriber check. This
matches the neighbouring declaration-time checks E2193/E2198/E2199.

`$defsite`/`$callsite` are not placeholders (`extract_placeholder` filters them), so a block
holding only those is now E2203 too; it previously expanded to nothing silently. Grepping every
`$(` under corelib/ and all crate `test_data` found no such block - corelib's only
expansion-side repetitions (macro_test.cairo:239/241/281/321) are all driven by a depth-1
placeholder.

## Goldens

crates/cairo-lang-semantic/src/expr/test_data/inline_macros, re-blessed with a narrow
`CAIRO_FIX_TESTS=1` + `--lib expr::test::expr_diagnostics::inline_macros`. Hunk by hunk:

1. `:3067` title `Test item-position macro call whose expansion repeats a placeholder-free
   block.` -> `Test placeholder-free repetition in an expansion, with an item-position call.`
   The diagnostic is no longer produced by the call.
2. `:3086` `E2202` -> `E2203` with the new message. The caret is byte-identical: both the old
   expansion-time error and the new check anchor on the same `MacroRepetition` node in the
   declaration, and nothing else appears or disappears - `m!();` in item position adds no
   fallout.
3. `:3093` title renamed for the same reason as hunk 1.
4. `:3112` `E2202` -> `E2203`, same caret. The expression-position call stays silent because
   `compute.rs` propagates `rule.err` without reporting again.
5. `:3188` (cross-module `mod helpers`) `E2202` -> `E2203`, same caret in the declaring module,
   title unchanged. The location survives for a new reason: the diagnostic used to live on the
   root module's `MacroCallData` with a stable ptr into `helpers`; it now lives on `helpers`'s
   own macro-declaration diagnostics, which the runner collects via
   `get_recursive_module_semantic_diagnostics` (inline submodules).
6. seven new sections appended - three error shapes and three legal controls, plus an
   offender-not-first variant modelled on rustc probe m9. Every repetition level with a
   repetition carries >= 2 captures (`m!(first, second)`, `m!(base, one, two)`, `m!(1, 2)`,
   `m!(10, 1, 2)`, `m!([1, 2], [3, 4])`).

Bless-then-revert: with only this commit's report disabled on this branch (`if false && ...`),
all six error goldens fail as output-tag mismatches, no panics -

* the three re-homed goldens and the offender-not-first golden fall back to E2202 (the
  expansion-time path the parent commit added),
* `$($base)*` falls back to `error[E0006]: Identifier not found.` - the block silently
  expanded to nothing,
* `$($($x),*),*` falls back to
  `error[E2117]: Parser error in macro-expanded code: Skipped tokens. Expected: statement.`

The three legal controls pass with and without the check; a golden that emits no diagnostic
cannot change when the check is removed, so revert-mode evidence does not apply to them.

Those last two reverted outputs are the evidence for `rule.err`: E0006 and E2117 are produced
*by the expansion*, and they are gone once E2203 sets `rule.err`. The rule genuinely stops
expanding rather than expanding to nothing.

## E2202 reachability

`MacroExpansionFailure::RepetitionWithoutPlaceholder` needs `find_first_repetition_param` to
return `None`, i.e. an expansion `$()` block with zero `MacroParam` descendants. Such a block
can never have a driving placeholder, so E2203 now rejects the rule at declaration time and
that arm is unreachable through Cairo source. `MacroExpansionFailure::MissingCapture` is
untouched; per the plan it should still be reachable via duplicate placeholder names in a
pattern (see the `TODO(Dean): Verify uniqueness of param names.`), which a later change rejects
at declaration time. E2202 stays either way as defensive hardening - neither arm may panic.

Gates: `cargo test --profile=ci-dev -p cairo-lang-semantic` (106 passed),
`./scripts/rust_fmt.sh`, `./scripts/clippy.sh --profile=ci-dev`,
`./scripts/validate_error_codes.sh`, `scripts/check_comment_punctuation.py crates`,
`cargo run --profile=ci-dev --bin cairo-test -- corelib/` (737 passed),
`cargo run --profile=ci-dev --bin cairo-test -- tests/bug_samples --starknet` (68 passed), plus
`cargo test --profile=ci-dev` over lowering / doc / starknet / sierra-generator / defs / plugins
as a declaration-time-fallout check.