### PR TITLE
Enable `RedepositGas` with disabled optimizations

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -242,6 +242,9 @@ pub fn final_optimization_strategy<'db>(db: &'db dyn Database) -> OptimizationSt
             ])
         }
         Optimizations::Disabled => OptimizationStrategy(vec![
+            // This phase preserves the gas invariant at control-flow convergence points. It is
+            // required for correctness even when optional optimizations are disabled.
+            OptimizationPhase::GasRedeposit,
             OptimizationPhase::LowerImplicits,
             OptimizationPhase::ReorganizeBlocks,
         ]),


### PR DESCRIPTION
Without `RedepositGas`, some unoptimized programs operate on incorrect gas budgets, leading to blockifier errors. We observed an example in snforge: https://github.com/orgs/foundry-rs/projects/3/views/2?pane=issue&itemId=213666798&issue=foundry-rs%7Cstarknet-foundry%7C4493
