### PR TITLE
(refactor): support multiple named expansion instances per inline-macro expansion test

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/expansion_test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/expansion_test_data/inline_macros
@@ -1,173 +1,84 @@
-//! > Test expansion of consteval_int! simple usage
+//! > Test expansion of consteval_int!
 
 //! > test_runner_name
 test_expand_expr(expect_diagnostics: warnings_only)
 
 //! > expr_code
-consteval_int!(4 + 5)
+let simple = consteval_int!(4 + 5);
+let complex = consteval_int!(23 + 4 * 5 + (4 + 5) / 2);
+let temp_overflow = consteval_int!(255 + 1 - 1);
 
 //! > expanded_code
-9
+simple: 9
+complex: 47
+temp_overflow: 255
 
 //! > diagnostics
 warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
- --> lib.cairo:2:1
-consteval_int!(4 + 5)
-^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:2:14
+let simple = consteval_int!(4 + 5);
+             ^^^^^^^^^^^^^^^^^^^^^
 
-//! > ==========================================================================
-
-//! > Test expansion of consteval_int! complex usage
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: warnings_only)
-
-//! > expr_code
-consteval_int!(23 + 4 * 5 + (4 + 5) / 2)
-
-//! > expanded_code
-47
-
-//! > diagnostics
 warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
- --> lib.cairo:2:1
-consteval_int!(23 + 4 * 5 + (4 + 5) / 2)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:3:15
+let complex = consteval_int!(23 + 4 * 5 + (4 + 5) / 2);
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-//! > ==========================================================================
-
-//! > Test expansion of consteval_int! handle temporary overflow
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: warnings_only)
-
-//! > expr_code
-consteval_int!(255 + 1 - 1)
-
-//! > expanded_code
-255
-
-//! > diagnostics
 warning[E2200]: Plugin diagnostic: Usage of deprecated macro `consteval_int` with no `#[feature("deprecated-consteval-int-macro")]` attribute. Note: Use simple calculations instead, as these are supported in const context.
- --> lib.cairo:2:1
-consteval_int!(255 + 1 - 1)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> lib.cairo:4:21
+let temp_overflow = consteval_int!(255 + 1 - 1);
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 
 //! > Test expansion of array macro
 
 //! > test_runner_name
-test_expand_expr(expect_diagnostics: false)
+test_expand_expr(expect_diagnostics: true)
 
 //! > expr_code
-array![1, 2, 3]
+let full = array![1, 2, 3];
+let empty = array![];
 
 //! > expanded_code
-{
+full: {
     let mut __array_builder_macro_result__ = core::array::ArrayTrait::new();
     core::array::ArrayTrait::append(ref __array_builder_macro_result__,1);
     core::array::ArrayTrait::append(ref __array_builder_macro_result__,2);
     core::array::ArrayTrait::append(ref __array_builder_macro_result__,3);
     __array_builder_macro_result__
 }
-
-//! > diagnostics
-
-//! > ==========================================================================
-
-//! > Test expansion of array macro empty
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: true)
-
-//! > expr_code
-array![]
-
-//! > expanded_code
-{
+empty: {
     let mut __array_builder_macro_result__ = core::array::ArrayTrait::new();
     __array_builder_macro_result__
 }
 
 //! > diagnostics
-error[E2314]: Type annotations needed. Failed to infer ?0.
- --> lib.cairo:2:1
-array![]
-^^^^^^^^
+error[E2314]: Type annotations needed. Failed to infer ?7.
+ --> lib.cairo:3:13
+let empty = array![];
+            ^^^^^^^^
 
 //! > ==========================================================================
 
-//! > Test expansion of panic macro with no arguments
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: false)
-
-//! > expr_code
-panic!()
-
-//! > expanded_code
-core::panics::panic_with_byte_array(@"")
-
-//! > diagnostics
-
-//! > ==========================================================================
-
-//! > Test expansion of panic macro with a simple short string
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: false)
-
-//! > expr_code
-panic!("0123456")
-
-//! > expanded_code
-core::panics::panic_with_byte_array(@"0123456")
-
-//! > diagnostics
-
-//! > ==========================================================================
-
-//! > Test expansion of panic macro with a 31 byte string.
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: false)
-
-//! > expr_code
-panic!("0123456789012345678901234567890")
-
-//! > expanded_code
-core::panics::panic_with_byte_array(@"0123456789012345678901234567890")
-
-//! > diagnostics
-
-//! > ==========================================================================
-
-//! > Test expansion of panic macro with a simple 35 bytes string.
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: false)
-
-//! > expr_code
-panic!("01234567890123456789012345678901234")
-
-//! > expanded_code
-core::panics::panic_with_byte_array(@"01234567890123456789012345678901234")
-
-//! > diagnostics
-
-//! > ==========================================================================
-
-//! > Test expansion of panic macro with args
+//! > Test expansion of panic macro
 
 //! > test_runner_name
 test_expand_expr(expect_diagnostics: true)
 
 //! > expr_code
-panic!("bad_format(})")
+let no_args = panic!();
+let short_string = panic!("0123456");
+let exactly_31_bytes = panic!("0123456789012345678901234567890");
+let more_than_31_bytes = panic!("01234567890123456789012345678901234");
+let bad_format = panic!("bad_format(})");
 
 //! > expanded_code
-{
+no_args: core::panics::panic_with_byte_array(@"")
+short_string: core::panics::panic_with_byte_array(@"0123456")
+exactly_31_bytes: core::panics::panic_with_byte_array(@"0123456789012345678901234567890")
+more_than_31_bytes: core::panics::panic_with_byte_array(@"01234567890123456789012345678901234")
+bad_format: {
     let mut __formatter_for_panic_macro__: core::fmt::Formatter = core::traits::Default::default();
     core::result::ResultTrait::<(), core::fmt::Error>::unwrap(
 write!(__formatter_for_panic_macro__, "bad_format(})")
@@ -177,32 +88,13 @@ write!(__formatter_for_panic_macro__, "bad_format(})")
 
 //! > diagnostics
 error[E2200]: Plugin diagnostic: Closing `}` without a matching `{`.
- --> lib.cairo:2:8
-panic!("bad_format(})")
-       ^^^^^^^^^^^^^^^
+ --> lib.cairo:6:25
+let bad_format = panic!("bad_format(})");
+                        ^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 
-//! > Test expansion of macro with inner parse errors.
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: true)
-
-//! > expr_code
-array![format!]
-
-//! > expanded_code
-array![format!]
-
-//! > diagnostics
-error[E2200]: Plugin diagnostic: Macro cannot be parsed as legacy macro. Expected an argument list wrapped in either parentheses, brackets, or braces.
- --> lib.cairo:2:1
-array![format!]
-^^^^^^^^^^^^^^^
-
-//! > ==========================================================================
-
-//! > Test call-site `+` matched as a literal token and expanded.
+//! > Test expansion of user-defined macros
 
 //! > test_runner_name
 test_expand_expr(expect_diagnostics: false)
@@ -213,22 +105,6 @@ macro plus_lit {
     (+) => { 7 };
 }
 
-//! > expr_code
-plus_lit!(+)
-
-//! > expanded_code
-7
-
-//! > diagnostics
-
-//! > ==========================================================================
-
-//! > Test call-site `+` matched as a literal token between two captures.
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: false)
-
-//! > module_code
 #[feature("user_defined_inline_macros")]
 macro keep_plus {
     ($a:ident + $b:ident) => { $a + $b };
@@ -239,16 +115,18 @@ let x = 1_felt252;
 let y = 2_felt252;
 
 //! > expr_code
-keep_plus!(x + y)
+let plus_as_literal_token = plus_lit!(+);
+let literal_token_between_captures = keep_plus!(x + y);
 
 //! > expanded_code
-x+ y
+plus_as_literal_token: 7 
+literal_token_between_captures: x+ y
 
 //! > diagnostics
 
 //! > ==========================================================================
 
-//! > Test call-site bare `$` is an opaque token that matches no ident rule.
+//! > Test macro calls that are not expanded due to errors.
 
 //! > test_runner_name
 test_expand_expr(expect_diagnostics: true)
@@ -260,32 +138,32 @@ macro take_ident {
 }
 
 //! > expr_code
-take_ident!($)
+let inner_parse_error = array![format!];
+let bare_dollar_matches_no_ident_rule = take_ident!($);
+let missing_token = array![1, 2;
 
 //! > expanded_code
-take_ident!($)
-
-//! > diagnostics
-error[E2158]: No matching rule found in inline macro `take_ident`.
- --> lib.cairo:6:1
-take_ident!($)
-^^^^^^^^^^^^^^
-
-//! > ==========================================================================
-
-//! > Test that a macro call with a missing token is not expanded (the parse error is enough).
-
-//! > test_runner_name
-test_expand_expr(expect_diagnostics: true)
-
-//! > expr_code
-array![1, 2
-
-//! > expanded_code
-array![1, 2
+inner_parse_error: array![format!]
+bare_dollar_matches_no_ident_rule: take_ident!($)
+missing_token: array![1, 2;
 
 //! > diagnostics
 error[E1001]: Missing token ']'.
- --> lib.cairo:2:12
-array![1, 2
-           ^
+ --> lib.cairo:8:33
+let missing_token = array![1, 2;
+                                ^
+
+error[E1001]: Missing token ';'.
+ --> lib.cairo:8:33
+let missing_token = array![1, 2;
+                                ^
+
+error[E2200]: Plugin diagnostic: Macro cannot be parsed as legacy macro. Expected an argument list wrapped in either parentheses, brackets, or braces.
+ --> lib.cairo:6:25
+let inner_parse_error = array![format!];
+                        ^^^^^^^^^^^^^^^
+
+error[E2158]: No matching rule found in inline macro `take_ident`.
+ --> lib.cairo:7:41
+let bare_dollar_matches_no_ident_rule = take_ident!($);
+                                        ^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test.rs
+++ b/crates/cairo-lang-semantic/src/expr/test.rs
@@ -12,8 +12,8 @@ use crate::expr::fmt::ExprFormatter;
 use crate::items::function_with_body::FunctionWithBodySemantic;
 use crate::semantic;
 use crate::test_utils::{
-    SemanticDatabaseForTesting, setup_test_expr, setup_test_function_from_content,
-    test_function_diagnostics,
+    SemanticDatabaseForTesting, setup_test_expr, setup_test_exprs,
+    setup_test_function_from_content, test_function_diagnostics,
 };
 
 cairo_lang_test_utils::test_file_test!(
@@ -99,14 +99,14 @@ cairo_lang_test_utils::test_file_test!(
     ["expect_diagnostics"]
 );
 
-/// Tests the syntactic expansion of a given expression. Can be use to test the expansion of inline
-/// macros.
+/// Tests the syntactic expansion of the given expressions, each provided as a
+/// `let <name> = <expr>;` statement. Can be used to test the expansion of inline macros.
 fn test_expand_expr(
     inputs: &OrderedHashMap<String, String>,
     args: &OrderedHashMap<String, String>,
 ) -> TestRunnerResult {
     let db = &SemanticDatabaseForTesting::default();
-    let (test_expr, diagnostics) = setup_test_expr(
+    let (test_exprs, diagnostics) = setup_test_exprs(
         db,
         inputs["expr_code"].as_str(),
         inputs.get("module_code").map_or("", String::as_str),
@@ -115,12 +115,19 @@ fn test_expand_expr(
     )
     .split();
     let sdb: &dyn Database = db;
-    let expr = sdb.expr_semantic(test_expr.function_id, test_expr.expr_id);
 
     let error = verify_diagnostics_expectation(args, &diagnostics);
 
-    let expanded_code = expr.stable_ptr().0.lookup(db).get_text(db);
-    let expanded_code = expanded_code.replace("\n        ", "\n");
+    let expanded_code = test_exprs
+        .named_exprs
+        .iter()
+        .map(|(name, expr_id)| {
+            let expr = sdb.expr_semantic(test_exprs.function_id, *expr_id);
+            let text = expr.stable_ptr().0.lookup(db).get_text(db).replace("\n        ", "\n");
+            format!("{}: {text}", name.long(db))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
     TestRunnerResult {
         outputs: OrderedHashMap::from([
             ("expanded_code".into(), expanded_code),

--- a/crates/cairo-lang-semantic/src/test_utils.rs
+++ b/crates/cairo-lang-semantic/src/test_utils.rs
@@ -316,9 +316,81 @@ pub fn setup_test_expr<'a>(
     function_body: &str,
     crate_settings: Option<&str>,
 ) -> WithStringDiagnostics<TestExpr<'a>> {
-    // The marker shares the wrapper's first line so the spans of `expr_code` do not shift.
+    let ((test_function, statements, tail), diagnostics) =
+        setup_test_code_block(db, expr_code, module_code, function_body, crate_settings, false)
+            .split();
+    assert!(statements.is_empty(), "expr_code is not a valid expression.");
+    WithStringDiagnostics {
+        value: TestExpr {
+            module_id: test_function.module_id,
+            function_id: test_function.function_id,
+            signature: test_function.signature,
+            body: test_function.body,
+            expr_id: tail.unwrap(),
+        },
+        diagnostics,
+    }
+}
+
+/// Helper struct for the return value of [setup_test_exprs].
+pub struct TestExprs<'a> {
+    pub function_id: FunctionWithBodyId<'a>,
+    /// The tested expressions, each with the name it was bound to.
+    pub named_exprs: Vec<(SmolStrId<'a>, semantic::ExprId)>,
+}
+
+/// Returns the semantic model of the given expressions, each provided as a
+/// `let <name> = <expr>;` statement, paired with its name.
+/// module_code - extra setup code in the module context.
+/// function_body - extra setup code in the function context.
+pub fn setup_test_exprs<'a>(
+    db: &'a dyn Database,
+    exprs_code: &str,
+    module_code: &str,
+    function_body: &str,
+    crate_settings: Option<&str>,
+) -> WithStringDiagnostics<TestExprs<'a>> {
+    let ((test_function, statements, tail), diagnostics) =
+        setup_test_code_block(db, exprs_code, module_code, function_body, crate_settings, true)
+            .split();
+    const EXPECTATION: &str = "exprs_code must consist of `let <name> = <expr>;` statements.";
+    assert!(tail.is_none(), "{EXPECTATION}");
+    let function_id = test_function.function_id;
+    let named_exprs = statements
+        .iter()
+        .map(|statement| {
+            let statement_let = extract_matches!(
+                db.statement_semantic(function_id, *statement),
+                semantic::Statement::Let,
+                "{EXPECTATION}"
+            );
+            let pattern = extract_matches!(
+                db.pattern_semantic(function_id, statement_let.pattern),
+                semantic::Pattern::Variable,
+                "{EXPECTATION}"
+            );
+            (pattern.name, statement_let.expr)
+        })
+        .collect();
+    WithStringDiagnostics { value: TestExprs { function_id, named_exprs }, diagnostics }
+}
+
+/// Returns the test function created by wrapping the given `code` in a block within a test
+/// function, together with the statements and tail of that block.
+fn setup_test_code_block<'a>(
+    db: &'a dyn Database,
+    code: &str,
+    module_code: &str,
+    function_body: &str,
+    crate_settings: Option<&str>,
+    allow_unused_variables: bool,
+) -> WithStringDiagnostics<(TestFunction<'a>, Vec<semantic::StatementId>, Option<semantic::ExprId>)>
+{
+    let allow_attr = if allow_unused_variables { "#[allow(unused_variables)] " } else { "" };
+    // The attributes share the wrapper's first line so the spans of `code` do not shift.
     let function_code = format!(
-        "#[{TARGET_FUNCTION_ATTR}] fn test_func() {{ {function_body} {{\n{expr_code}\n}}; }}"
+        "{allow_attr}#[{TARGET_FUNCTION_ATTR}] fn test_func() {{ {function_body} {{\n{code}\n}}; \
+         }}"
     );
     let content = if module_code.is_empty() {
         function_code
@@ -339,17 +411,7 @@ pub fn setup_test_expr<'a>(
         db.expr_semantic(test_function.function_id, statement_expr.expr),
         semantic::Expr::Block
     );
-    assert!(statements.is_empty(), "expr_code is not a valid expression.");
-    WithStringDiagnostics {
-        value: TestExpr {
-            module_id: test_function.module_id,
-            function_id: test_function.function_id,
-            signature: test_function.signature,
-            body: test_function.body,
-            expr_id: tail.unwrap(),
-        },
-        diagnostics,
-    }
+    WithStringDiagnostics { value: (test_function, statements, tail), diagnostics }
 }
 
 pub fn test_expr_diagnostics(


### PR DESCRIPTION
Expansion tests now provide their expressions as `let <name> = <expr>;`
statements, allowing several macro instances per test block, with the
expansion of each labeled by its binding name. Merged the existing
expansion tests accordingly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>