### PR TITLE
(refactor): read the exact Final signature in sierra get_function_signature

### DIFF
--- a/crates/cairo-lang-sierra-generator/src/db.rs
+++ b/crates/cairo-lang-sierra-generator/src/db.rs
@@ -3,17 +3,15 @@ use std::sync::Arc;
 use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{ExternFunctionId, LanguageElementId, TopLevelLanguageElementId};
 use cairo_lang_diagnostics::{Maybe, MaybeAsRef};
-use cairo_lang_filesystem::flag::FlagsGroup;
 use cairo_lang_filesystem::ids::{CrateId, Tracked};
 use cairo_lang_lowering as lowering;
 use cairo_lang_lowering::LoweringStage;
-use cairo_lang_lowering::db::LoweringGroup;
-use cairo_lang_lowering::panic::PanicSignatureInfo;
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::items::constant::ConstValueId;
 use cairo_lang_sierra::extensions::lib_func::SierraApChange;
 use cairo_lang_sierra::extensions::{ConcreteType, GenericTypeEx};
 use cairo_lang_sierra::ids::ConcreteTypeId;
+use itertools::chain;
 use lowering::ids::ConcreteFunctionWithBodyId;
 use salsa::plumbing::FromId;
 use salsa::{Database, Id, Setter};
@@ -416,49 +414,23 @@ fn get_function_signature(
     _tracked: Tracked,
     function_id: cairo_lang_sierra::ids::FunctionId,
 ) -> Maybe<cairo_lang_sierra::program::FunctionSignature> {
-    // TODO(yuval): add another version of this function that directly received semantic FunctionId.
-    // Call it from function_generators::get_function_code. Take ret_types from the result instead
-    // of only the explicit ret_type. Also use it for params instead of the current logic. Then use
-    // it in the end of program_generator::get_sierra_program instead of calling this function from
-    // there.
     let lowered_function_id = db.lookup_sierra_function(&function_id);
-    // TODO(orizi): Read the exact `Final` signature instead of re-deriving the implicits and the
-    // panic wrapping below.
-    let signature = lowered_function_id.signature(db, LoweringStage::Monomorphized)?;
+    let signature = lowered_function_id.signature(db, LoweringStage::Final)?;
 
-    let implicits = db
-        .function_implicits(lowered_function_id)?
+    let param_types = signature
+        .params
         .iter()
-        .map(|ty| db.get_concrete_type_id(*ty).cloned())
-        .collect::<Maybe<Vec<ConcreteTypeId>>>()?;
+        .map(|ty| Ok(db.get_concrete_type_id(*ty)?.clone()))
+        .collect::<Maybe<Vec<_>>>()?;
+    // Functions that return the unit type don't have a return type in the signature.
+    let ret_types = chain!(
+        signature.extra_rets.iter().copied(),
+        (!signature.return_type.is_unit(db)).then_some(signature.return_type)
+    )
+    .map(|ty| Ok(db.get_concrete_type_id(ty)?.clone()))
+    .collect::<Maybe<Vec<_>>>()?;
 
-    // TODO(spapini): Handle ret_types in lowering.
-    let mut all_params = implicits.clone();
-    let mut extra_rets = vec![];
-    for ty in &signature.params {
-        let concrete_type_id = db.get_concrete_type_id(*ty)?;
-        all_params.push(concrete_type_id.clone());
-    }
-    for ty in &signature.extra_rets {
-        let concrete_type_id = db.get_concrete_type_id(*ty)?;
-        extra_rets.push(concrete_type_id.clone());
-    }
-
-    let mut ret_types = implicits;
-
-    let may_panic = !db.flag_unsafe_panic() && db.function_may_panic(lowered_function_id)?;
-    if may_panic {
-        let panic_info = PanicSignatureInfo::new(db, &signature);
-        ret_types.push(db.get_concrete_type_id(panic_info.actual_return_ty)?.clone());
-    } else {
-        ret_types.extend(extra_rets);
-        // Functions that return the unit type don't have a return type in the signature.
-        if !signature.return_type.is_unit(db) {
-            ret_types.push(db.get_concrete_type_id(signature.return_type)?.clone());
-        }
-    }
-
-    Ok(cairo_lang_sierra::program::FunctionSignature { param_types: all_params, ret_types })
+    Ok(cairo_lang_sierra::program::FunctionSignature { param_types, ret_types })
 }
 
 /// Initializes the [`Database`] database to a proper state.


### PR DESCRIPTION
Replaces the hand-rolled implicits prepending and panic re-derivation with a
direct read of the LoweringStage::Final lowering signature, which already has
the implicits folded into params/extra_rets and the panic wrapping applied.
Only the sierra-specific type mapping and unit-return omission remain.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>