### PR TITLE
(feat): contextualize paths in inference errors and type diagnostics

### DIFF
--- a/crates/cairo-lang-executable-plugin/src/plugin_test_data/diagnostics
+++ b/crates/cairo-lang-executable-plugin/src/plugin_test_data/diagnostics
@@ -58,7 +58,7 @@ fn __executable_wrapper__main(mut input: Span<felt252>, ref output: Array<felt25
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::serde::Serde::<test::NoSerde>.
+error[E2311]: Trait has no implementation in context: Serde::<NoSerde>.
  --> lib.cairo:2:9
 fn main(a: NoSerde, b: felt252) -> felt252 {
         ^^^^^^^^^^
@@ -104,7 +104,7 @@ fn __executable_wrapper__main(mut input: Span<felt252>, ref output: Array<felt25
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::serde::Serde::<test::NoSerde>.
+error[E2311]: Trait has no implementation in context: Serde::<NoSerde>.
  --> lib.cairo:2:33
 fn main(a: felt252, b: felt252) -> NoSerde {
                                 ^^^^^^^^^^

--- a/crates/cairo-lang-lowering/src/borrow_check/mod.rs
+++ b/crates/cairo-lang-lowering/src/borrow_check/mod.rs
@@ -2,7 +2,7 @@
 #[path = "test.rs"]
 mod test;
 
-use cairo_lang_defs::ids::TraitFunctionId;
+use cairo_lang_defs::ids::{ModuleId, TraitFunctionId};
 use cairo_lang_diagnostics::{DiagnosticNote, Diagnostics};
 use cairo_lang_semantic::corelib::CorelibSemantic;
 use cairo_lang_semantic::items::functions::{GenericFunctionId, ImplGenericFunctionId};
@@ -30,6 +30,7 @@ pub struct BorrowChecker<'db, 'mt, 'r> {
     destruct_fn: TraitFunctionId<'db>,
     panic_destruct_fn: TraitFunctionId<'db>,
     is_panic_destruct_fn: bool,
+    context_module: ModuleId<'db>,
 }
 
 /// A state saved for each position in the back analysis.
@@ -137,10 +138,11 @@ impl<'db, 'mt> DemandReporter<VariableId, PanicState> for BorrowChecker<'db, 'mt
         }
         self.diagnostics.report_by_location(
             location
-                .with_note(DiagnosticNote::text_only(drop_err.format(db)))
-                .with_note(DiagnosticNote::text_only(destruct_err.format(db)))
+                .with_note(DiagnosticNote::text_only(drop_err.format(db, self.context_module)))
+                .with_note(DiagnosticNote::text_only(destruct_err.format(db, self.context_module)))
                 .maybe_with_note(
-                    panic_destruct_err.map(|err| DiagnosticNote::text_only(err.format(db))),
+                    panic_destruct_err
+                        .map(|err| DiagnosticNote::text_only(err.format(db, self.context_module))),
                 ),
             VariableNotDropped { drop_err, destruct_err },
         );
@@ -159,7 +161,9 @@ impl<'db, 'mt> DemandReporter<VariableId, PanicState> for BorrowChecker<'db, 'mt
                     .long(self.db)
                     .clone()
                     .add_note_with_location(self.db, "variable was previously used here", position)
-                    .with_note(DiagnosticNote::text_only(inference_error.format(self.db))),
+                    .with_note(DiagnosticNote::text_only(
+                        inference_error.format(self.db, self.context_module),
+                    )),
                 VariableMoved { inference_error },
             );
         }
@@ -197,10 +201,9 @@ impl<'db, 'mt> Analyzer<'db, '_> for BorrowChecker<'db, 'mt, '_> {
                 let var = &self.lowered.variables[stmt.output];
                 if let Err(inference_error) = var.info.copyable.clone() {
                     self.diagnostics.report_by_location(
-                        var.location
-                            .long(self.db)
-                            .clone()
-                            .with_note(DiagnosticNote::text_only(inference_error.format(self.db))),
+                        var.location.long(self.db).clone().with_note(DiagnosticNote::text_only(
+                            inference_error.format(self.db, self.context_module),
+                        )),
                         DesnappingANonCopyableType { inference_error },
                     );
                 }
@@ -293,6 +296,7 @@ pub struct BorrowCheckResult<'db> {
 /// Returns the potential destruct function calls per block.
 pub fn borrow_check<'db>(
     db: &'db dyn Database,
+    context_module: ModuleId<'db>,
     is_panic_destruct_fn: bool,
     lowered: &'db Lowered<'db>,
 ) -> BorrowCheckResult<'db> {
@@ -312,6 +316,7 @@ pub fn borrow_check<'db>(
         destruct_fn,
         panic_destruct_fn,
         is_panic_destruct_fn,
+        context_module,
     };
     let mut analysis = BackAnalysis::new(lowered, checker);
     let mut root_demand = analysis.get_root_info();
@@ -336,6 +341,7 @@ pub fn borrow_check<'db>(
 /// withdrawal.
 pub fn borrow_check_possible_withdraw_gas<'db>(
     db: &'db dyn Database,
+    context_module: ModuleId<'db>,
     location_id: LocationId<'db>,
     lowered: &Lowered<'db>,
     diagnostics: &mut LoweringDiagnostics<'db>,
@@ -351,6 +357,7 @@ pub fn borrow_check_possible_withdraw_gas<'db>(
         destruct_fn,
         panic_destruct_fn,
         is_panic_destruct_fn: false,
+        context_module,
     };
     let position = (
         Some(DropPosition::Panic(location_id.with_auto_generation_note(db, "withdraw_gas"))),

--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/borrow_check
@@ -101,7 +101,7 @@ note: variable was previously used here:
   --> lib.cairo:16:20
         use_a_drop(y);
                    ^
-note: Trait has no implementation in context: core::traits::Copy::<test::ADrop>.
+note: Trait has no implementation in context: Copy::<ADrop>.
 
 error[E3002]: Variable not dropped.
  --> lib.cairo:13:8
@@ -114,8 +114,8 @@ note: the variable needs to be dropped due to the divergence here:
 | ...
 |     } else {}
 |_____________^
-note: Trait has no implementation in context: core::traits::Drop::<test::ACopy>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::ACopy>.
+note: Trait has no implementation in context: Drop::<ACopy>.
+note: Trait has no implementation in context: Destruct::<ACopy>.
 
 //! > lowering
 Parameters: v0: test::ACopy, v1: test::ADrop
@@ -277,9 +277,9 @@ note: the variable needs to be dropped due to the potential panic here:
   --> lib.cairo:4:5
     1 + 1;
     ^^^^^
-note: Trait has no implementation in context: core::traits::Drop::<test::A>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::A>.
-note: Trait has no implementation in context: core::traits::PanicDestruct::<test::A>.
+note: Trait has no implementation in context: Drop::<A>.
+note: Trait has no implementation in context: Destruct::<A>.
+note: Trait has no implementation in context: PanicDestruct::<A>.
 
 //! > lowering
 Parameters: v0: test::A
@@ -328,7 +328,7 @@ note: variable was previously used here:
   --> lib.cairo:10:20
         use_a_drop(y);
                    ^
-note: Trait has no implementation in context: core::traits::Copy::<test::ADrop>.
+note: Trait has no implementation in context: Copy::<ADrop>.
 
 //! > lowering
 Parameters: v0: test::ADrop, v1: test::ADrop
@@ -386,7 +386,7 @@ note: variable was previously used here:
   --> lib.cairo:4:17
     let mut b = arr;
                 ^^^
-note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
+note: Trait has no implementation in context: Copy::<Array::<felt252>>.
 
 //! > lowering
 Parameters:
@@ -435,7 +435,7 @@ note: variable was previously used here:
   --> lib.cairo:11:18
     use_non_copy(x);
                  ^
-note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
+note: Trait has no implementation in context: Copy::<NonCopy>.
 
 //! > lowering
 Parameters: v0: test::NonCopy
@@ -502,7 +502,7 @@ note: variable was previously used here:
   --> lib.cairo:14:18
     use_non_copy(x.b);
                  ^^^
-note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
+note: Trait has no implementation in context: Copy::<NonCopy>.
 
 //! > lowering
 Parameters: v0: test::MyStruct
@@ -548,7 +548,7 @@ note: variable was previously used here:
   --> lib.cairo:11:16
     invalidate(s1.a);
                ^^^^
-note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
+note: Trait has no implementation in context: Copy::<Array::<felt252>>.
 
 error[E3001]: Variable was previously moved.
  --> lib.cairo:10:30
@@ -558,7 +558,7 @@ note: variable was previously used here:
   --> lib.cairo:12:16
     invalidate(s2.a);
                ^^^^
-note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
+note: Trait has no implementation in context: Copy::<Array::<felt252>>.
 
 //! > lowering
 Parameters: v0: test::MyStruct, v1: test::MyStruct
@@ -609,7 +609,7 @@ note: variable was previously used here:
   --> lib.cairo:13:20
         invalidate(self.a);
                    ^^^^^^
-note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
+note: Trait has no implementation in context: Copy::<Array::<felt252>>.
 
 //! > lowering
 Parameters: v0: test::MyStruct
@@ -742,9 +742,9 @@ note: the variable needs to be dropped due to the potential panic here:
   --> lib.cairo:14:5
     x.a += 1;
     ^^^^^^^^
-note: Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::NonCopy>.
-note: Trait has no implementation in context: core::traits::PanicDestruct::<test::NonCopy>.
+note: Trait has no implementation in context: Drop::<NonCopy>.
+note: Trait has no implementation in context: Destruct::<NonCopy>.
+note: Trait has no implementation in context: PanicDestruct::<NonCopy>.
 
 //! > lowering
 Parameters: v0: test::MyStruct
@@ -852,9 +852,9 @@ note: the variable needs to be dropped due to the potential panic here:
   --> lib.cairo:12:9
         x.a += 1;
         ^^^^^^^^
-note: Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::NonCopy>.
-note: Trait has no implementation in context: core::traits::PanicDestruct::<test::NonCopy>.
+note: Trait has no implementation in context: Drop::<NonCopy>.
+note: Trait has no implementation in context: Destruct::<NonCopy>.
+note: Trait has no implementation in context: PanicDestruct::<NonCopy>.
 
 //! > lowering
 Parameters: v0: test::MyStruct
@@ -906,7 +906,7 @@ note: variable was previously used here:
   --> lib.cairo:13:13
     consume(x.b);
             ^^^
-note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
+note: Trait has no implementation in context: Copy::<NonCopy>.
 
 //! > lowering
 Parameters: v0: test::MyStruct
@@ -981,9 +981,9 @@ note: the variable needs to be dropped due to the potential panic here:
 | }
 |_^
 note: this error originates in auto-generated withdraw_gas logic.
-note: Trait has no implementation in context: core::traits::Drop::<test::NonDrop>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::NonDrop>.
-note: Trait has no implementation in context: core::traits::PanicDestruct::<test::NonDrop>.
+note: Trait has no implementation in context: Drop::<NonDrop>.
+note: Trait has no implementation in context: Destruct::<NonDrop>.
+note: Trait has no implementation in context: PanicDestruct::<NonDrop>.
 
 //! > ==========================================================================
 
@@ -1076,7 +1076,7 @@ note: variable was previously used here:
   --> lib.cairo:11:15
         use_x(x); // First use.
               ^
-note: Trait has no implementation in context: core::traits::Copy::<test::Wrapper>.
+note: Trait has no implementation in context: Copy::<Wrapper>.
 
 error[E3002]: Variable not dropped.
  --> lib.cairo:9:8
@@ -1089,8 +1089,8 @@ note: the variable needs to be dropped due to the divergence here:
 |         use_x(x); // First use.
 |     }
 |_____^
-note: Trait has no implementation in context: core::traits::Drop::<test::Wrapper>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::Wrapper>.
+note: Trait has no implementation in context: Drop::<Wrapper>.
+note: Trait has no implementation in context: Destruct::<Wrapper>.
 
 //! > lowering
 Parameters: v0: test::Wrapper
@@ -1156,8 +1156,8 @@ error[E3002]: Variable not dropped.
  --> lib.cairo:11:9
     let x = Wrapper { inner: 5 };
         ^
-note: Trait has no implementation in context: core::traits::Drop::<test::Wrapper>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::Wrapper>.
+note: Trait has no implementation in context: Drop::<Wrapper>.
+note: Trait has no implementation in context: Destruct::<Wrapper>.
 
 //! > lowering
 Parameters:
@@ -1230,8 +1230,8 @@ error[E3002]: Variable not dropped.
  --> lib.cairo:14:8
 fn foo(o: Outer) {
        ^
-note: Trait has no implementation in context: core::traits::Drop::<test::Outer>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::Outer>.
+note: Trait has no implementation in context: Drop::<Outer>.
+note: Trait has no implementation in context: Destruct::<Outer>.
 
 //! > lowering
 Parameters: v0: test::Outer
@@ -1404,7 +1404,7 @@ note: variable was previously used here:
   --> lib.cairo:22:13
     consume(outer.b);
             ^^^^^^^
-note: Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
+note: Trait has no implementation in context: Copy::<NonCopy>.
 
 //! > lowering
 Parameters: v0: test::Outer
@@ -1463,8 +1463,8 @@ error[E3002]: Variable not dropped.
  --> lib.cairo:16:12
 fn foo(mut o: Outer) {
            ^
-note: Trait has no implementation in context: core::traits::Drop::<test::Outer>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::Outer>.
+note: Trait has no implementation in context: Drop::<Outer>.
+note: Trait has no implementation in context: Destruct::<Outer>.
 
 //! > lowering
 Parameters: v0: test::Outer

--- a/crates/cairo-lang-lowering/src/borrow_check/test_data/closure
+++ b/crates/cairo-lang-lowering/src/borrow_check/test_data/closure
@@ -132,7 +132,7 @@ note: variable was previously used here:
   --> lib.cairo:11:15
         use_s(a)
               ^
-note: Trait has no implementation in context: core::traits::Copy::<test::S>.
+note: Trait has no implementation in context: Copy::<S>.
 
 //! > lowering
 Parameters: v0: test::S

--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -455,7 +455,13 @@ fn borrow_check_tracked<'db>(
     function_id: ids::FunctionWithBodyId<'db>,
 ) -> Maybe<BorrowCheckResult<'db>> {
     let lowered = db.function_with_body_lowering(function_id)?;
-    Ok(borrow_check(db, function_id.to_concrete(db)?.is_panic_destruct_fn(db)?, lowered))
+    let context_module = function_id.base_semantic_function(db).parent_module(db);
+    Ok(borrow_check(
+        db,
+        context_module,
+        function_id.to_concrete(db)?.is_panic_destruct_fn(db)?,
+        lowered,
+    ))
 }
 
 #[salsa::tracked(returns(ref))]
@@ -664,15 +670,22 @@ fn function_with_body_lowering_diagnostics<'db>(
         if db.flag_add_withdraw_gas()
             && matches!(db.in_cycle(function_id, DependencyType::Cost), Ok(true))
         {
-            let location =
-                Location::new(function_id.base_semantic_function(db).stable_location(db));
+            let base_semantic_function = function_id.base_semantic_function(db);
+            let location = Location::new(base_semantic_function.stable_location(db));
             if !lowered.signature.panicable {
                 diagnostics.add(LoweringDiagnostic {
                     location: location.clone(),
                     kind: LoweringDiagnosticKind::NoPanicFunctionCycle,
                 });
             }
-            borrow_check_possible_withdraw_gas(db, location.intern(db), lowered, &mut diagnostics)
+            let context_module = base_semantic_function.parent_module(db);
+            borrow_check_possible_withdraw_gas(
+                db,
+                context_module,
+                location.intern(db),
+                lowered,
+                &mut diagnostics,
+            )
         }
     }
 

--- a/crates/cairo-lang-lowering/src/lower/block_builder.rs
+++ b/crates/cairo-lang-lowering/src/lower/block_builder.rs
@@ -1,5 +1,5 @@
 use cairo_lang_debug::DebugWithDb;
-use cairo_lang_defs::ids::NamedLanguageElementId;
+use cairo_lang_defs::ids::{LanguageElementId, NamedLanguageElementId};
 use cairo_lang_diagnostics::{DiagnosticNote, Maybe};
 use cairo_lang_semantic as semantic;
 use cairo_lang_semantic::expr::fmt::ExprFormatter;
@@ -163,16 +163,21 @@ impl<'db> BlockBuilder<'db> {
                 inference_error,
                 last_use_location,
             })) => {
+                let db = ctx.db;
                 // If the variable was already moved, report an error.
-                let diag_location = location
-                    .long(ctx.db)
-                    .clone()
-                    .add_note_with_location(
-                        ctx.db,
-                        "variable was previously used here",
-                        last_use_location,
-                    )
-                    .with_note(DiagnosticNote::text_only(inference_error.format(ctx.db)));
+                let diag_location =
+                    location
+                        .long(db)
+                        .clone()
+                        .add_note_with_location(
+                            db,
+                            "variable was previously used here",
+                            last_use_location,
+                        )
+                        .with_note(DiagnosticNote::text_only(inference_error.format(
+                            db,
+                            ctx.function_id.base_semantic_function(db).parent_module(db),
+                        )));
                 ctx.diagnostics.report_by_location(
                     diag_location,
                     LoweringDiagnosticKind::VariableMoved { inference_error },

--- a/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
+++ b/crates/cairo-lang-lowering/src/lower/flow_control/test_data/match
@@ -1446,17 +1446,17 @@ Root: 7
 0 ArmExpr { expr: ExprId(1) }
 
 //! > semantic_diagnostics
-error[E2103]: Mismatched types: pattern cannot match against type "core::felt252".
+error[E2103]: Mismatched types: pattern cannot match against type "felt252".
  --> lib.cairo:4:13
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
             ^^
 
-error[E2103]: Mismatched types: pattern cannot match against type "core::option::Option::<(core::felt252, core::felt252)>".
+error[E2103]: Mismatched types: pattern cannot match against type "Option::<(felt252, felt252)>".
  --> lib.cairo:4:20
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
                    ^^
 
-error[E2103]: Mismatched types: pattern cannot match against type "(core::felt252, core::felt252)".
+error[E2103]: Mismatched types: pattern cannot match against type "(felt252, felt252)".
  --> lib.cairo:4:35
         (_, ()) | ((), _) | (Some(None), _) | _ => 0,
                                   ^^^^

--- a/crates/cairo-lang-lowering/src/test_data/closure
+++ b/crates/cairo-lang-lowering/src/test_data/closure
@@ -75,7 +75,7 @@ error[E3003]: Cannot desnap a non copyable type.
  --> lib.cairo:3:16
     let f = || *(@a);
                ^^^^^
-note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
+note: Trait has no implementation in context: Copy::<Array::<felt252>>.
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>
@@ -105,7 +105,7 @@ error[E3003]: Cannot desnap a non copyable type.
  --> lib.cairo:6:9
         *(@a)
         ^^^^^
-note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
+note: Trait has no implementation in context: Copy::<Array::<felt252>>.
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>

--- a/crates/cairo-lang-lowering/src/test_data/coupon
+++ b/crates/cairo-lang-lowering/src/test_data/coupon
@@ -112,7 +112,7 @@ note: variable was previously used here:
   --> lib.cairo:4:21
     bar(__coupon__: x);
                     ^
-note: Trait has no implementation in context: core::traits::Copy::<test::bar::Coupon>.
+note: Trait has no implementation in context: Copy::<bar::Coupon>.
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>

--- a/crates/cairo-lang-lowering/src/test_data/if
+++ b/crates/cairo-lang-lowering/src/test_data/if
@@ -1037,53 +1037,53 @@ error[E3002]: Variable not dropped.
  --> lib.cairo:26:34
     if let MyEnum3::D(MyEnum2::B(_)) = e {}
                                  ^
-note: Trait has no implementation in context: core::traits::Drop::<test::MyEnum>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::MyEnum>.
+note: Trait has no implementation in context: Drop::<MyEnum>.
+note: Trait has no implementation in context: Destruct::<MyEnum>.
 
 error[E3002]: Variable not dropped.
  --> lib.cairo:26:23
     if let MyEnum3::D(MyEnum2::B(_)) = e {}
                       ^^^^^^^^^^^^^
 note: In variant MyEnum2::C.
-note: Trait has no implementation in context: core::traits::Drop::<test::NonDroppable>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::NonDroppable>.
+note: Trait has no implementation in context: Drop::<NonDroppable>.
+note: Trait has no implementation in context: Destruct::<NonDroppable>.
 
 error[E3002]: Variable not dropped.
  --> lib.cairo:24:23
     if let MyEnum2::B(_) = d {}
                       ^
-note: Trait has no implementation in context: core::traits::Drop::<test::MyEnum>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::MyEnum>.
+note: Trait has no implementation in context: Drop::<MyEnum>.
+note: Trait has no implementation in context: Destruct::<MyEnum>.
 
 error[E3002]: Variable not dropped.
  --> lib.cairo:24:28
     if let MyEnum2::B(_) = d {}
                            ^
 note: In variant MyEnum2::C.
-note: Trait has no implementation in context: core::traits::Drop::<test::NonDroppable>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::NonDroppable>.
+note: Trait has no implementation in context: Drop::<NonDroppable>.
+note: Trait has no implementation in context: Destruct::<NonDroppable>.
 
 error[E3002]: Variable not dropped.
  --> lib.cairo:23:23
     if let MyEnum2::B(_x) = c {}
                       ^^
-note: Trait has no implementation in context: core::traits::Drop::<test::MyEnum>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::MyEnum>.
+note: Trait has no implementation in context: Drop::<MyEnum>.
+note: Trait has no implementation in context: Destruct::<MyEnum>.
 
 error[E3002]: Variable not dropped.
  --> lib.cairo:23:29
     if let MyEnum2::B(_x) = c {}
                             ^
 note: In variant MyEnum2::C.
-note: Trait has no implementation in context: core::traits::Drop::<test::NonDroppable>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::NonDroppable>.
+note: Trait has no implementation in context: Drop::<NonDroppable>.
+note: Trait has no implementation in context: Destruct::<NonDroppable>.
 
 error[E3002]: Variable not dropped.
  --> lib.cairo:16:19
 fn foo(a: MyEnum, b: MyEnum, c: MyEnum2, d: MyEnum2, e: MyEnum3) {
                   ^
-note: Trait has no implementation in context: core::traits::Drop::<test::MyEnum>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::MyEnum>.
+note: Trait has no implementation in context: Drop::<MyEnum>.
+note: Trait has no implementation in context: Destruct::<MyEnum>.
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>

--- a/crates/cairo-lang-lowering/src/test_data/match
+++ b/crates/cairo-lang-lowering/src/test_data/match
@@ -412,7 +412,7 @@ fn foo() {
 }
 
 //! > semantic_diagnostics
-error[E2302]: Type mismatch: `core::felt252` and `core::integer::u8`.
+error[E2302]: Type mismatch: `felt252` and `u8`.
  --> lib.cairo:5:9
         1_felt252 | 2_u8 => 8,
         ^^^^^^^^^

--- a/crates/cairo-lang-lowering/src/test_data/snapshot
+++ b/crates/cairo-lang-lowering/src/test_data/snapshot
@@ -168,7 +168,7 @@ error[E3003]: Cannot desnap a non copyable type.
  --> lib.cairo:3:5
     *value
     ^^^^^^
-note: Trait has no implementation in context: core::traits::Copy::<core::array::Array::<core::felt252>>.
+note: Trait has no implementation in context: Copy::<Array::<felt252>>.
 
 //! > lowering_flat
 <Failed lowering function - run with RUST_LOG=warn (or less) to see diagnostics>

--- a/crates/cairo-lang-lowering/src/test_data/tests
+++ b/crates/cairo-lang-lowering/src/test_data/tests
@@ -369,7 +369,7 @@ fn foo(mut data: Span<felt252>) -> u128 {
 }
 
 //! > semantic_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "core::option::Option::<core::integer::u128>".
+error[E2042]: Unexpected return type. Expected: "u128", found: "Option::<u128>".
  --> lib.cairo:3:5
     serde::Serde::<u128>::deserialize(ref data)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -280,8 +280,8 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     function_name,
                     trait_id.name(db).long(db),
                     function_name,
-                    expected_ty.format(db),
-                    actual_ty.format(db)
+                    expected_ty.contextualized_path(db, self.context_module),
+                    actual_ty.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::VariantCtorNotImmutable => {
@@ -342,8 +342,8 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::WrongType { expected_ty, actual_ty } => {
                 format!(
                     r#"Expected type "{}", found: "{}"."#,
-                    expected_ty.format(db),
-                    actual_ty.format(db)
+                    expected_ty.contextualized_path(db, self.context_module),
+                    actual_ty.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::InconsistentBinding => "variable is bound inconsistently \
@@ -353,8 +353,8 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::WrongArgumentType { expected_ty, actual_ty } => {
                 let diagnostic_prefix = format!(
                     r#"Unexpected argument type. Expected: "{}", found: "{}"."#,
-                    expected_ty.format(db),
-                    actual_ty.format(db)
+                    expected_ty.contextualized_path(db, self.context_module),
+                    actual_ty.contextualized_path(db, self.context_module)
                 );
                 if (expected_ty.is_fully_concrete(db) && actual_ty.is_fully_concrete(db))
                     || peel_snapshots(db, *expected_ty).0 == peel_snapshots(db, *actual_ty).0
@@ -371,15 +371,15 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::WrongReturnType { expected_ty, actual_ty } => {
                 format!(
                     r#"Unexpected return type. Expected: "{}", found: "{}"."#,
-                    expected_ty.format(db),
-                    actual_ty.format(db)
+                    expected_ty.contextualized_path(db, self.context_module),
+                    actual_ty.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::WrongExprType { expected_ty, actual_ty } => {
                 format!(
                     r#"Unexpected expression type. Expected: "{}", found: "{}"."#,
-                    expected_ty.format(db),
-                    actual_ty.format(db)
+                    expected_ty.contextualized_path(db, self.context_module),
+                    actual_ty.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::WrongNumberOfGenericParamsForImplFunction {
@@ -406,8 +406,8 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     function_name,
                     trait_id.name(db).long(db),
                     function_name,
-                    expected_ty.format(db),
-                    actual_ty.format(db)
+                    expected_ty.contextualized_path(db, self.context_module),
+                    actual_ty.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::WrongGenericParamTraitForImplFunction {
@@ -481,10 +481,16 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 )
             }
             SemanticDiagnosticKind::InfiniteSizeType(ty) => {
-                format!(r#"Recursive type "{}" has infinite size."#, ty.format(db))
+                format!(
+                    r#"Recursive type "{}" has infinite size."#,
+                    ty.contextualized_path(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::ArrayOfZeroSizedElements(ty) => {
-                format!(r#"Cannot have array of type "{}" that is zero sized."#, ty.format(db))
+                format!(
+                    r#"Cannot have array of type "{}" that is zero sized."#,
+                    ty.contextualized_path(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::ParamNameRedefinition { function_title_id, param_name } => {
                 format!(
@@ -499,7 +505,10 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 )
             }
             SemanticDiagnosticKind::ConditionNotBool(condition_ty) => {
-                format!(r#"Condition has type "{}", expected bool."#, condition_ty.format(db))
+                format!(
+                    r#"Condition has type "{}", expected bool."#,
+                    condition_ty.contextualized_path(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::IncompatibleArms {
                 multi_arm_expr_kind: incompatibility_kind,
@@ -511,10 +520,17 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     MultiArmExprKind::If => "If blocks have incompatible types",
                     MultiArmExprKind::Loop => "Loop has incompatible return types",
                 };
-                format!(r#"{prefix}: "{}" and "{}""#, first_ty.format(db), different_ty.format(db))
+                format!(
+                    r#"{prefix}: "{}" and "{}""#,
+                    first_ty.contextualized_path(db, self.context_module),
+                    different_ty.contextualized_path(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::TypeHasNoMembers { ty, member_name: _ } => {
-                format!(r#"Type "{}" has no members."#, ty.format(db))
+                format!(
+                    r#"Type "{}" has no members."#,
+                    ty.contextualized_path(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::NoSuchStructMember { struct_id, member_name } => {
                 format!(
@@ -524,7 +540,11 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 )
             }
             SemanticDiagnosticKind::NoSuchTypeMember { ty, member_name } => {
-                format!(r#"Type "{}" has no member "{}""#, ty.format(db), member_name.long(db))
+                format!(
+                    r#"Type "{}" has no member "{}""#,
+                    ty.contextualized_path(db, self.context_module),
+                    member_name.long(db)
+                )
             }
             SemanticDiagnosticKind::MemberNotVisible(member_name) => {
                 format!(r#"Member "{}" is not visible in this context."#, member_name.long(db))
@@ -542,15 +562,21 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::IncompatibleErrorPropagateType { return_ty, err_ty } => {
                 format!(
                     r#"Return type "{}" does not wrap error "{}""#,
-                    return_ty.format(db),
-                    err_ty.format(db)
+                    return_ty.contextualized_path(db, self.context_module),
+                    err_ty.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::ErrorPropagateOnNonErrorType(ty) => {
-                format!(r#"Type "{}" cannot error propagate"#, ty.format(db))
+                format!(
+                    r#"Type "{}" cannot error propagate"#,
+                    ty.contextualized_path(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::UnhandledMustUseType(ty) => {
-                format!(r#"Unhandled `#[must_use]` type `{}`"#, ty.format(db))
+                format!(
+                    r#"Unhandled `#[must_use]` type `{}`"#,
+                    ty.contextualized_path(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::UnhandledMustUseFunction => {
                 "Unhandled `#[must_use]` function.".into()
@@ -696,7 +722,9 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 // Several distinct items may share the name when reached through global uses; in
                 // that case no single item can be pointed at, so it is reported without a name.
                 let item = match item_id {
-                    Some(item_id) => format!("Item `{}`", item_id.full_path(db)),
+                    Some(item_id) => {
+                        format!("Item `{}`", item_id.contextualized_path(db, self.context_module))
+                    }
                     None => "Item".to_string(),
                 };
                 format!(
@@ -704,12 +732,18 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     if containing_modules.is_empty() {
                         "".to_string()
                     } else if let [module_id] = &containing_modules[..] {
-                        format!(" through module `{}`", module_id.full_path(db))
+                        format!(
+                            " through module `{}`",
+                            module_id.contextualized_path(db, self.context_module)
+                        )
                     } else {
                         format!(
                             " through any of the modules: {}",
                             containing_modules.iter().format_with(", ", |module_id, f| {
-                                f(&format_args!("`{}`", module_id.full_path(db)))
+                                f(&format_args!(
+                                    "`{}`",
+                                    module_id.contextualized_path(db, self.context_module)
+                                ))
                             })
                         )
                     }
@@ -721,7 +755,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::BadPatternForInputType(ty) => {
                 format!(
                     "Mismatched types: pattern cannot match against type \"{}\".",
-                    ty.format(db),
+                    ty.contextualized_path(db, self.context_module),
                 )
             }
             SemanticDiagnosticKind::WrongNumberOfTupleElements { expected, actual } => format!(
@@ -753,10 +787,16 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     .to_string()
             }
             SemanticDiagnosticKind::InvalidCopyTraitImpl(inference_error) => {
-                format!("Invalid copy trait implementation, {}", inference_error.format(db))
+                format!(
+                    "Invalid copy trait implementation, {}",
+                    inference_error.format(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::InvalidDropTraitImpl(inference_error) => {
-                format!("Invalid drop trait implementation, {}", inference_error.format(db))
+                format!(
+                    "Invalid drop trait implementation, {}",
+                    inference_error.format(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::InvalidImplItem(item_kw) => {
                 format!("`{}` is not allowed inside impl.", item_kw.long(db))
@@ -857,28 +897,33 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     actual_trt.debug(db),
                 )
             }
-            SemanticDiagnosticKind::InternalInferenceError(err) => err.format(db),
+            SemanticDiagnosticKind::InternalInferenceError(err) => {
+                err.format(db, self.context_module)
+            }
             SemanticDiagnosticKind::DerefNonRef { ty } => {
-                format!("Type `{}` cannot be dereferenced", ty.format(db))
+                format!(
+                    "Type `{}` cannot be dereferenced",
+                    ty.contextualized_path(db, self.context_module)
+                )
             }
             SemanticDiagnosticKind::NoImplementationOfIndexOperator { ty, inference_errors } => {
                 if inference_errors.is_empty() {
                     format!(
                         "Type `{}` does not implement the `Index` trait nor the `IndexView` trait.",
-                        ty.format(db)
+                        ty.contextualized_path(db, self.context_module)
                     )
                 } else {
                     format!(
                         "Type `{}` could not be indexed.\n{}",
-                        ty.format(db),
-                        inference_errors.format(db)
+                        ty.contextualized_path(db, self.context_module),
+                        inference_errors.format(db, self.context_module)
                     )
                 }
             }
             SemanticDiagnosticKind::MultipleImplementationOfIndexOperator(ty) => {
                 format!(
                     r#"Type "{}" implements both the "Index" trait and the "IndexView" trait."#,
-                    ty.format(db)
+                    ty.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::UnsupportedInlineArguments => {
@@ -904,8 +949,8 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                     return format!(
                         "Method `{}` could not be called on type `{}`.\n{}",
                         method_name.long(db),
-                        ty.format(db),
-                        inference_errors.format(db)
+                        ty.contextualized_path(db, self.context_module),
+                        inference_errors.format(db, self.context_module)
                     );
                 }
                 if !relevant_traits.is_empty() {
@@ -917,14 +962,14 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                         "Method `{}` not found on type `{}`. Consider importing one of the \
                          following traits: {suggestions}.",
                         method_name.long(db),
-                        ty.format(db),
+                        ty.contextualized_path(db, self.context_module),
                     )
                 } else {
                     format!(
                         "Method `{}` not found on type `{}`. Did you import the correct trait and \
                          impl?",
                         method_name.long(db),
-                        ty.format(db)
+                        ty.contextualized_path(db, self.context_module)
                     )
                 }
             }
@@ -1078,32 +1123,35 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                         "Implementation of trait `{}` not found on type `{}`. Did you import the \
                          correct trait and impl?",
                         trait_name.long(db),
-                        ty.format(db)
+                        ty.contextualized_path(db, self.context_module)
                     )
                 } else {
                     format!(
                         "Could not find implementation of trait `{}` on type `{}`.\n{}",
                         trait_name.long(db),
-                        ty.format(db),
-                        inference_errors.format(db)
+                        ty.contextualized_path(db, self.context_module),
+                        inference_errors.format(db, self.context_module)
                     )
                 }
             }
             SemanticDiagnosticKind::CallExpressionRequiresFunction { ty, inference_errors } => {
                 if inference_errors.is_empty() {
-                    format!("Call expression requires a function, found `{}`.", ty.format(db))
+                    format!(
+                        "Call expression requires a function, found `{}`.",
+                        ty.contextualized_path(db, self.context_module)
+                    )
                 } else {
                     format!(
                         "Call expression requires a function, found `{}`.\n{}",
-                        ty.format(db),
-                        inference_errors.format(db)
+                        ty.contextualized_path(db, self.context_module),
+                        inference_errors.format(db, self.context_module)
                     )
                 }
             }
             SemanticDiagnosticKind::CompilerTraitReImplementation { trait_id } => {
                 format!(
                     "Trait `{}` should not be implemented outside of the corelib.",
-                    trait_id.full_path(db)
+                    trait_id.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::ClosureInGlobalScope => {
@@ -1126,7 +1174,7 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 format!(
                     "'{}' implementation must be defined in the same module as either the type \
                      being dereferenced or the trait itself",
-                    trait_id.name(db).long(db)
+                    trait_id.contextualized_path(db, self.context_module)
                 )
             }
             SemanticDiagnosticKind::MutableCapturedVariable => {
@@ -1988,14 +2036,14 @@ impl<'db> TraitInferenceErrors<'db> {
         self.traits_and_errors.is_empty()
     }
     /// Format the list of errors.
-    fn format(&self, db: &dyn Database) -> String {
+    fn format(&self, db: &dyn Database, context_module: ModuleId<'_>) -> String {
         self.traits_and_errors
             .iter()
             .map(|(trait_function_id, inference_error)| {
                 format!(
                     "Candidate `{}` inference failed with: {}",
-                    trait_function_id.full_path(db),
-                    inference_error.format(db)
+                    trait_function_id.contextualized_path(db, context_module),
+                    inference_error.format(db, context_module)
                 )
             })
             .join("\n")

--- a/crates/cairo-lang-semantic/src/diagnostic_test.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic_test.rs
@@ -167,12 +167,12 @@ fn test_inline_module_diagnostics() {
     assert_eq!(
         get_crate_semantic_diagnostics(db, crate_id).format(db),
         indoc! {r#"
-            error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "core::felt252".
+            error[E2042]: Unexpected return type. Expected: "u128", found: "felt252".
              --> lib.cairo:4:16
                     return 5_felt252;
                            ^^^^^^^^^
 
-            error[E2042]: Unexpected return type. Expected: "test::a::inner_mod::NewType", found: "core::felt252".
+            error[E2042]: Unexpected return type. Expected: "NewType", found: "felt252".
              --> lib.cairo:4:16
                     return 5_felt252;
                            ^^^^^^^^^
@@ -212,12 +212,12 @@ fn test_inline_inline_module_diagnostics() {
 
     assert_eq!(
         get_crate_semantic_diagnostics(db, crate_id).format(db),
-        indoc! {r#"error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "core::felt252".
+        indoc! {r#"error[E2042]: Unexpected return type. Expected: "u128", found: "felt252".
              --> lib.cairo:3:16
                     return 1_felt252;
                            ^^^^^^^^^
 
-            error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "core::felt252".
+            error[E2042]: Unexpected return type. Expected: "u128", found: "felt252".
              --> lib.cairo:9:20
                         return 2_felt252;
                                ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/deref
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/deref
@@ -158,10 +158,10 @@ for mut inner_s in span_of_spans {
 let span_of_spans = array![array![1_u32].span()].span();
 
 //! > expected_diagnostics
-error[E0002]: Method `pop_front` could not be called on type `@core::array::Span::<core::integer::u32>`.
-Candidate `core::array::ArrayTrait::pop_front` inference failed with: Type mismatch: `@core::array::Span::<core::integer::u32>` and `core::array::Array::<?12>`.
-Candidate `core::array::SpanTrait::pop_front` inference failed with: Type mismatch: `@core::array::Span::<core::integer::u32>` and `core::array::Span::<?12>`.
-Candidate `core::array::ArrayTrait::pop_front` inference failed with: Type mismatch: `core::array::Span::<core::integer::u32>` and `core::array::Array::<?12>`.
+error[E0002]: Method `pop_front` could not be called on type `@Span::<u32>`.
+Candidate `ArrayTrait::pop_front` inference failed with: Type mismatch: `@Span::<u32>` and `Array::<?12>`.
+Candidate `SpanTrait::pop_front` inference failed with: Type mismatch: `@Span::<u32>` and `Span::<?12>`.
+Candidate `ArrayTrait::pop_front` inference failed with: Type mismatch: `Span::<u32>` and `Array::<?12>`.
  --> lib.cairo:3:13
     inner_s.pop_front();
             ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/not_found
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/not_found
@@ -105,7 +105,7 @@ mod module {
 //! > function_body
 
 //! > expected_diagnostics
-error[E0002]: Method `foo` not found on type `test::A`. Consider importing one of the following traits: `module::Trt1`.
+error[E0002]: Method `foo` not found on type `A`. Consider importing one of the following traits: `module::Trt1`.
  --> lib.cairo:18:14
     struct_a.foo()
              ^^^
@@ -140,7 +140,7 @@ mod b {
 let a = A {a: 0};
 
 //! > expected_diagnostics
-error[E0002]: Method `foo` not found on type `test::A`. Consider importing one of the following traits: `b::Trt1`, `b::Trt2`.
+error[E0002]: Method `foo` not found on type `A`. Consider importing one of the following traits: `b::Trt1`, `b::Trt2`.
  --> lib.cairo:16:3
 a.foo()
   ^^^
@@ -158,7 +158,7 @@ test_expr_diagnostics(expect_diagnostics: true)
 //! > function_body
 
 //! > expected_diagnostics
-error[E0002]: Method `sqrt` not found on type `core::integer::u32`. Consider importing one of the following traits: `core::num::traits::Sqrt`.
+error[E0002]: Method `sqrt` not found on type `u32`. Consider importing one of the following traits: `core::num::traits::Sqrt`.
  --> lib.cairo:2:7
 9_u32.sqrt()
       ^^^^
@@ -205,22 +205,22 @@ pub mod a {
 //! > function_body
 
 //! > expected_diagnostics
-error[E0002]: Method `foo` not found on type `core::integer::u32`. Consider importing one of the following traits: `a::b::Trt`.
+error[E0002]: Method `foo` not found on type `u32`. Consider importing one of the following traits: `a::b::Trt`.
  --> lib.cairo:29:7
 1_u32.foo()
       ^^^
 
-error[E0002]: Method `foo` not found on type `core::integer::u32`. Consider importing one of the following traits: `super::b::Trt`.
+error[E0002]: Method `foo` not found on type `u32`. Consider importing one of the following traits: `super::b::Trt`.
  --> lib.cairo:14:19
             2_u32.foo();
                   ^^^
 
-error[E0002]: Method `foo` not found on type `core::integer::u32`. Consider importing one of the following traits: `crate::a::b::Trt`.
+error[E0002]: Method `foo` not found on type `u32`. Consider importing one of the following traits: `crate::a::b::Trt`.
  --> lib.cairo:18:23
                 3_u32.foo();
                       ^^^
 
-error[E0002]: Method `foo` not found on type `core::integer::u32`. Consider importing one of the following traits: `crate::a::b::Trt`.
+error[E0002]: Method `foo` not found on type `u32`. Consider importing one of the following traits: `crate::a::b::Trt`.
  --> lib.cairo:22:27
                     4_u32.foo();
                           ^^^

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/plus_eq
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/plus_eq
@@ -82,7 +82,7 @@ fn foo() {
 //! > function_body
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::ops::arith::AddAssign::<core::felt252, core::bool>.
+error[E2311]: Trait has no implementation in context: core::ops::arith::AddAssign::<felt252, bool>.
  --> lib.cairo:3:5
     x += true;
     ^^^^^^^^^
@@ -106,7 +106,7 @@ fn foo() {
 //! > function_body
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::ops::arith::DivAssign::<core::bool, core::bool>.
+error[E2311]: Trait has no implementation in context: core::ops::arith::DivAssign::<bool, bool>.
  --> lib.cairo:3:5
     x /= false;
     ^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -328,7 +328,7 @@ test_expr_diagnostics(expect_diagnostics: warnings_only)
 //! > function_body
 
 //! > expected_diagnostics
-warning[E2064]: Unhandled `#[must_use]` type `core::option::Option::<core::felt252>`
+warning[E2064]: Unhandled `#[must_use]` type `Option::<felt252>`
  --> lib.cairo:3:3
   Option::<felt252>::None;
   ^^^^^^^^^^^^^^^^^^^^^^^
@@ -348,7 +348,7 @@ test_expr_diagnostics(expect_diagnostics: warnings_only)
 //! > function_body
 
 //! > expected_diagnostics
-warning[E2064]: Unhandled `#[must_use]` type `core::result::Result::<core::felt252, core::felt252>`
+warning[E2064]: Unhandled `#[must_use]` type `Result::<felt252, felt252>`
  --> lib.cairo:3:3
   Result::<felt252, felt252>::Err(4);
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1087,10 +1087,36 @@ INACCESSIBLE
 //! > expected_semantics
 
 //! > expected_diagnostics
-error[E2099]: Item `test::a::INACCESSIBLE` is not visible in this context through module `test::a`.
+error[E2099]: Item `a::INACCESSIBLE` is not visible in this context through module `a`.
  --> lib.cairo:6:1
 INACCESSIBLE
 ^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Testing use star inaccessible item through a crate root
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: true)
+
+//! > crate_settings
+edition = "2024_07"
+
+//! > module_code
+use core::*;
+
+//! > function_body
+
+//! > expr_code
+felt_252::Felt252One
+
+//! > expected_semantics
+
+//! > expected_diagnostics
+error[E2099]: Item `core::felt_252` is not visible in this context through module `core`.
+ --> lib.cairo:3:1
+felt_252::Felt252One
+^^^^^^^^
 
 //! > ==========================================================================
 
@@ -1118,7 +1144,7 @@ inaccessible::C
 //! > expected_semantics
 
 //! > expected_diagnostics
-error[E2099]: Item `test::a::inaccessible` is not visible in this context through module `test::a`.
+error[E2099]: Item `a::inaccessible` is not visible in this context through module `a`.
  --> lib.cairo:8:1
 inaccessible::C
 ^^^^^^^^^^^^
@@ -1155,12 +1181,12 @@ C
 //! > expected_semantics
 
 //! > expected_diagnostics
-error[E2099]: Item `test::a::b::C` is not visible in this context through module `test::a::b`.
+error[E2099]: Item `a::b::C` is not visible in this context through module `a::b`.
  --> lib.cairo:14:1
 C
 ^
 
-error[E2099]: Item `test::a::b` is not visible in this context.
+error[E2099]: Item `crate::a::b` is not visible in this context.
  --> lib.cairo:9:30
         use super::super::a::b::*;
                              ^
@@ -1197,7 +1223,7 @@ C
 //! > expected_semantics
 
 //! > expected_diagnostics
-error[E2099]: Item `test::a::b::C` is not visible in this context through module `test::a::b`.
+error[E2099]: Item `a::b::C` is not visible in this context through module `a::b`.
  --> lib.cairo:14:1
 C
 ^
@@ -1240,7 +1266,7 @@ C
 //! > expected_semantics
 
 //! > expected_diagnostics
-error[E2099]: Item `test::a::b::C` is not visible in this context through module `test::a::b`.
+error[E2099]: Item `a::b::C` is not visible in this context through module `a::b`.
  --> lib.cairo:20:1
 C
 ^
@@ -1283,7 +1309,7 @@ C
 //! > expected_semantics
 
 //! > expected_diagnostics
-error[E2099]: Item `test::a::b` is not visible in this context.
+error[E2099]: Item `crate::a::b` is not visible in this context.
  --> lib.cairo:9:34
         pub use super::super::a::b::*;
                                  ^
@@ -1470,7 +1496,7 @@ impl SDictValue of Felt252DictValue<S> {
 //! > function_body
 
 //! > expected_diagnostics
-error[E2181]: Trait `core::traits::Felt252DictValue` should not be implemented outside of the corelib.
+error[E2181]: Trait `Felt252DictValue` should not be implemented outside of the corelib.
  --> lib.cairo:3:20
 impl SDictValue of Felt252DictValue<S> {
                    ^^^^^^^^^^^^^^^^^^^
@@ -1496,12 +1522,12 @@ impl SStringLiteral of StringLiteral<S> {}
 //! > function_body
 
 //! > expected_diagnostics
-error[E2181]: Trait `core::integer::NumericLiteral` should not be implemented outside of the corelib.
+error[E2181]: Trait `NumericLiteral` should not be implemented outside of the corelib.
  --> lib.cairo:3:25
 impl SNumericLiteral of NumericLiteral<S> {}
                         ^^^^^^^^^^^^^^^^^
 
-error[E2181]: Trait `core::string::StringLiteral` should not be implemented outside of the corelib.
+error[E2181]: Trait `StringLiteral` should not be implemented outside of the corelib.
  --> lib.cairo:5:24
 impl SStringLiteral of StringLiteral<S> {}
                        ^^^^^^^^^^^^^^^^
@@ -1526,7 +1552,7 @@ struct S {
 //! > function_body
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::integer::u8", found: "@{numeric}".
+error[E2041]: Unexpected argument type. Expected: "u8", found: "@{numeric}".
 It is possible that the type inference failed because the types differ in the number of snapshots.
 Consider adding or removing snapshots.
  --> lib.cairo:6:12
@@ -1663,7 +1689,7 @@ AMBIGUOUS
 //! > expected_semantics
 
 //! > expected_diagnostics
-error[E2099]: Item is not visible in this context through any of the modules: `test::a`, `test::b`.
+error[E2099]: Item is not visible in this context through any of the modules: `a`, `b`.
  --> lib.cairo:11:1
 AMBIGUOUS
 ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -11,7 +11,7 @@ use cairo_lang_debug::DebugWithDb;
 use cairo_lang_defs::ids::{
     ConstantId, EnumId, ExternFunctionId, ExternTypeId, FreeFunctionId, GenericKind,
     GenericParamId, GlobalUseId, ImplAliasId, ImplDefId, ImplFunctionId, ImplImplDefId, LocalVarId,
-    LookupItemId, MacroCallId, MemberId, NamedLanguageElementId, ParamId, StructId,
+    LookupItemId, MacroCallId, MemberId, ModuleId, NamedLanguageElementId, ParamId, StructId,
     TraitConstantId, TraitFunctionId, TraitId, TraitImplId, TraitTypeId, VarId, VariantId,
 };
 use cairo_lang_diagnostics::{DiagnosticAdded, skip_diagnostic};
@@ -51,6 +51,7 @@ use crate::items::trt::{
     ConcreteTraitGenericFunctionId, ConcreteTraitGenericFunctionLongId, ConcreteTraitTypeId,
     ConcreteTraitTypeLongId,
 };
+use crate::path::ContextualizePath;
 use crate::substitution::{GenericSubstitution, HasDb, RewriteResult, SemanticRewriter};
 use crate::types::{
     ClosureTypeLongId, ConcreteEnumLongId, ConcreteExternTypeLongId, ConcreteStructLongId,
@@ -247,18 +248,30 @@ pub enum InferenceError<'db> {
     InvalidLiteralType(TypeId<'db>),
 }
 impl<'db> InferenceError<'db> {
-    pub fn format(&self, db: &dyn Database) -> String {
+    pub fn format(&self, db: &dyn Database, context_module: ModuleId<'db>) -> String {
         match self {
             InferenceError::Reported(_) => "Inference error occurred.".into(),
             InferenceError::Cycle(_var) => "Inference cycle detected".into(),
             InferenceError::TypeKindMismatch { ty0, ty1 } => {
-                format!("Type mismatch: `{:?}` and `{:?}`.", ty0.debug(db), ty1.debug(db))
+                format!(
+                    "Type mismatch: `{}` and `{}`.",
+                    ty0.contextualized_path(db, context_module),
+                    ty1.contextualized_path(db, context_module)
+                )
             }
             InferenceError::ConstKindMismatch { const0, const1 } => {
-                format!("Const mismatch: `{:?}` and `{:?}`.", const0.debug(db), const1.debug(db))
+                format!(
+                    "Const mismatch: `{}` and `{}`.",
+                    const0.contextualized_path(db, context_module),
+                    const1.contextualized_path(db, context_module)
+                )
             }
             InferenceError::ImplKindMismatch { impl0, impl1 } => {
-                format!("Impl mismatch: `{:?}` and `{:?}`.", impl0.debug(db), impl1.debug(db))
+                format!(
+                    "Impl mismatch: `{}` and `{}`.",
+                    impl0.contextualized_path(db, context_module),
+                    impl1.contextualized_path(db, context_module)
+                )
             }
             InferenceError::NegativeImplKindMismatch { impl0, impl1 } => {
                 format!(
@@ -269,13 +282,17 @@ impl<'db> InferenceError<'db> {
             }
             InferenceError::GenericArgMismatch { garg0, garg1 } => {
                 format!(
-                    "Generic arg mismatch: `{:?}` and `{:?}`.",
-                    garg0.debug(db),
-                    garg1.debug(db)
+                    "Generic arg mismatch: `{}` and `{}`.",
+                    garg0.contextualized_path(db, context_module),
+                    garg1.contextualized_path(db, context_module)
                 )
             }
             InferenceError::TraitMismatch { trt0, trt1 } => {
-                format!("Trait mismatch: `{:?}` and `{:?}`.", trt0.debug(db), trt1.debug(db))
+                format!(
+                    "Trait mismatch: `{}` and `{}`.",
+                    trt0.contextualized_path(db, context_module),
+                    trt1.contextualized_path(db, context_module)
+                )
             }
             InferenceError::ConstNotInferred => "Failed to infer constant.".into(),
             InferenceError::NoImplsFound(concrete_trait_id) => {
@@ -285,38 +302,47 @@ impl<'db> InferenceError<'db> {
                         GenericArgumentId::Type
                     );
                     return format!(
-                        "Mismatched types. The type `{:?}` cannot be created from a string \
-                         literal.",
-                        generic_type.debug(db)
+                        "Mismatched types. The type `{}` cannot be created from a string literal.",
+                        generic_type.contextualized_path(db, context_module)
                     );
                 }
                 format!(
-                    "Trait has no implementation in context: {:?}.",
-                    concrete_trait_id.debug(db)
+                    "Trait has no implementation in context: {}.",
+                    concrete_trait_id.contextualized_path(db, context_module)
                 )
             }
             InferenceError::NoNegativeImplsFound(concrete_trait_id) => {
-                format!("Trait has implementation in context: {:?}.", concrete_trait_id.debug(db))
+                format!(
+                    "Trait has implementation in context: {}.",
+                    concrete_trait_id.contextualized_path(db, context_module)
+                )
             }
-            InferenceError::Ambiguity(ambiguity) => ambiguity.format(db),
+            InferenceError::Ambiguity(ambiguity) => ambiguity.format(db, context_module),
             InferenceError::TypeNotInferred(ty) => {
-                format!("Type annotations needed. Failed to infer {:?}.", ty.debug(db))
+                format!(
+                    "Type annotations needed. Failed to infer {}.",
+                    ty.contextualized_path(db, context_module)
+                )
             }
             InferenceError::GenericFunctionMismatch { func0, func1 } => {
-                format!("Function mismatch: `{}` and `{}`.", func0.format(db), func1.format(db))
+                format!(
+                    "Function mismatch: `{}` and `{}`.",
+                    func0.contextualized_path(db, context_module),
+                    func1.contextualized_path(db, context_module)
+                )
             }
             InferenceError::ImplTypeMismatch { impl_id, trait_type_id, ty0, ty1 } => {
                 format!(
-                    "`{}::{}` type mismatch: `{:?}` and `{:?}`.",
-                    impl_id.format(db),
+                    "`{}::{}` type mismatch: `{}` and `{}`.",
+                    impl_id.contextualized_path(db, context_module),
                     trait_type_id.name(db).long(db),
-                    ty0.debug(db),
-                    ty1.debug(db)
+                    ty0.contextualized_path(db, context_module),
+                    ty1.contextualized_path(db, context_module)
                 )
             }
             InferenceError::InvalidLiteralType(ty) => format!(
-                "Mismatched types. The type `{:?}` cannot be created from a numeric literal.",
-                ty.debug(db),
+                "Mismatched types. The type `{}` cannot be created from a numeric literal.",
+                ty.contextualized_path(db, context_module),
             ),
         }
     }

--- a/crates/cairo-lang-semantic/src/expr/inference/solver.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/solver.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use cairo_lang_debug::DebugWithDb;
-use cairo_lang_defs::ids::{GenericParamId, LanguageElementId};
+use cairo_lang_defs::ids::{GenericParamId, LanguageElementId, ModuleId};
 use cairo_lang_proc_macros::SemanticObject;
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_map::Entry;
@@ -24,6 +24,7 @@ use crate::items::imp::{
     find_closure_generated_candidate, find_integer_literal_generated_candidate,
 };
 use crate::items::trt::TraitSemantic;
+use crate::path::ContextualizePath;
 use crate::substitution::{GenericSubstitution, SemanticRewriter};
 use crate::types::{ImplTypeById, ImplTypeId};
 use crate::{
@@ -56,28 +57,41 @@ pub enum Ambiguity<'db> {
 }
 
 impl<'db> Ambiguity<'db> {
-    pub fn format(&self, db: &dyn Database) -> String {
+    pub fn format(&self, db: &'db dyn Database, context_module: ModuleId<'db>) -> String {
         match self {
             Ambiguity::MultipleImplsFound { concrete_trait_id, impls } => {
-                let impls = impls
+                let mut impl_paths = impls
                     .iter()
-                    .format_with(", ", |imp, f| f(&format_args!("`{}`", imp.format(db))));
+                    .map(|imp| imp.contextualized_path(db, context_module))
+                    .collect_vec();
+                // If contextualization renders distinct impls identically (e.g. impls generated
+                // by different macro expansions), fall back to full paths to keep them apart.
+                if !impl_paths.iter().all_unique() {
+                    impl_paths = impls.iter().map(|imp| imp.format(db)).collect_vec();
+                }
                 format!(
-                    "Trait `{:?}` has multiple implementations, in: {impls}",
-                    concrete_trait_id.debug(db)
+                    "Trait `{}` has multiple implementations, in: {}",
+                    concrete_trait_id.contextualized_path(db, context_module),
+                    impl_paths.iter().format_with(", ", |path, f| f(&format_args!("`{path}`")))
                 )
             }
             Ambiguity::FreeVariable { impl_id, var: _ } => {
-                format!("Candidate impl {:?} has an unused generic parameter.", impl_id.debug(db),)
+                format!(
+                    "Candidate impl {} has an unused generic parameter.",
+                    impl_id.contextualized_path(db, context_module),
+                )
             }
             Ambiguity::WillNotInfer(concrete_trait_id) => {
                 format!(
-                    "Cannot infer trait {:?}. First generic argument must be known.",
-                    concrete_trait_id.debug(db)
+                    "Cannot infer trait {}. First generic argument must be known.",
+                    concrete_trait_id.contextualized_path(db, context_module)
                 )
             }
             Ambiguity::NegativeImplWithUnsupportedExtractedArgs(garg) => {
-                format!("Negative impl has an unsupported generic argument {:?}.", garg.debug(db),)
+                format!(
+                    "Negative impl has an unsupported generic argument {}.",
+                    garg.contextualized_path(db, context_module),
+                )
             }
             Ambiguity::NegativeImplWithUnsupportedGenericParam(gparam) => {
                 format!("Negative impl has an unsupported generic argument {:?}.", gparam.debug(db),)

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/if
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/if
@@ -148,7 +148,7 @@ If(
 )
 
 //! > expected_diagnostics
-error[E2056]: If blocks have incompatible types: "core::integer::u32" and "core::integer::u16"
+error[E2056]: If blocks have incompatible types: "u32" and "u16"
  --> lib.cairo:2:1-6:1
   if a {
  _^
@@ -256,7 +256,7 @@ If(
 )
 
 //! > expected_diagnostics
-error[E2056]: If blocks have incompatible types: "core::integer::u32" and "core::integer::u16"
+error[E2056]: If blocks have incompatible types: "u32" and "u16"
  --> lib.cairo:2:1-6:1
   if a {
  _^

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/loop
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/loop
@@ -16,7 +16,7 @@ loop {
 }
 
 //! > expected_diagnostics
-error[E2056]: Loop has incompatible return types: "core::integer::u32" and "core::integer::u16"
+error[E2056]: Loop has incompatible return types: "u32" and "u16"
  --> lib.cairo:6:15
         break 3_u16;
               ^^^^^
@@ -110,7 +110,7 @@ loop {
 }
 
 //! > expected_diagnostics
-error[E2056]: Loop has incompatible return types: "core::integer::u32" and "core::integer::u16"
+error[E2056]: Loop has incompatible return types: "u32" and "u16"
  --> lib.cairo:6:15
         break 3 + 3_u16;
               ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/match
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/match
@@ -409,7 +409,7 @@ match a {
 }
 
 //! > expected_diagnostics
-error[E2056]: Match arms have incompatible types: "core::integer::u32" and "core::integer::u16"
+error[E2056]: Match arms have incompatible types: "u32" and "u16"
  --> lib.cairo:8:18
     MyEnum::B => 3_u16,
                  ^^^^^
@@ -483,7 +483,7 @@ match a {
 }
 
 //! > expected_diagnostics
-error[E2056]: Match arms have incompatible types: "core::integer::u32" and "core::integer::u16"
+error[E2056]: Match arms have incompatible types: "u32" and "u16"
  --> lib.cairo:8:18
     MyEnum::B => 3 + 3_u16,
                  ^^^^^^^^^
@@ -782,7 +782,7 @@ error[E2048]: Missing variable in pattern.
     MyEnum::A(x) | MyEnum::B((t, _)) => x + t,
                    ^^^^^^^^^^^^^^^^^
 
-error[E2056]: Match arms have incompatible types: "core::felt252" and "core::integer::u8"
+error[E2056]: Match arms have incompatible types: "felt252" and "u8"
  --> lib.cairo:15:60
     MyEnum::C((x, _, t)) | MyEnum::D(P{x, y: _, z: t }) => x + t,
                                                            ^^^^^
@@ -959,7 +959,7 @@ Match(
 )
 
 //! > expected_diagnostics
-error[E2039]: Expected type "core::integer::u32", found: "core::integer::u8".
+error[E2039]: Expected type "u32", found: "u8".
  --> lib.cairo:15:40
     MyEnum::C((x, _, _)) | MyEnum::D(P{x, y: _, z: _ }) => x,
                                        ^

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/repr_ptr
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/repr_ptr
@@ -494,7 +494,7 @@ FunctionCall(
 )
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::traits::BitAnd::<core::box::Box::<@core::integer::u32>>.
+error[E2311]: Trait has no implementation in context: BitAnd::<Box::<@u32>>.
  --> lib.cairo:3:1
 a & &b
 ^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/semantic_test_data/use
+++ b/crates/cairo-lang-semantic/src/expr/semantic_test_data/use
@@ -1483,7 +1483,7 @@ Missing(
 )
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::integer::i64", found: "core::integer::u32".
+error[E2041]: Unexpected argument type. Expected: "i64", found: "u32".
  --> lib.cairo:2:13
 Some::<i64>(3_u32)
             ^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/assignment
+++ b/crates/cairo-lang-semantic/src/expr/test_data/assignment
@@ -36,7 +36,7 @@ error[E2083]: Cannot assign to an immutable variable.
     let _c: felt252 = (b = 5);
                        ^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "()".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "()".
  --> lib.cairo:7:23
     let _c: felt252 = (b = 5);
                       ^^^^^^^
@@ -68,7 +68,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Mismatched types. The type `core::felt252` cannot be created from a string literal.
+error[E2311]: Mismatched types. The type `felt252` cannot be created from a string literal.
  --> lib.cairo:2:23
     let _x: felt252 = "error";
                       ^^^^^^^
@@ -100,7 +100,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2315]: Mismatched types. The type `core::byte_array::ByteArray` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `ByteArray` cannot be created from a numeric literal.
  --> lib.cairo:2:25
     let _x: ByteArray = 252;
                         ^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/closure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/closure
@@ -12,7 +12,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::i32", found: "core::integer::u32".
+error[E2042]: Unexpected return type. Expected: "i32", found: "u32".
  --> lib.cairo:2:11
     || -> i32 {
           ^^^
@@ -50,7 +50,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::integer::i32", found: "core::integer::u32".
+error[E2041]: Unexpected argument type. Expected: "i32", found: "u32".
  --> lib.cairo:3:22
         let d: i32 = a;
                      ^
@@ -71,7 +71,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::integer::i32", found: "{closure@lib.cairo:2:19: 2:21}".
+error[E2041]: Unexpected argument type. Expected: "i32", found: "{closure@lib.cairo:2:19: 2:21}".
  --> lib.cairo:2:19-5:5
       let _x: i32 = || {
  ___________________^
@@ -101,7 +101,7 @@ error[E2182]: Closures are not allowed in this context.
 | };
 |_^
 
-error[E2302]: Type mismatch: `{closure@lib.cairo:1:17: 1:19}` and `core::integer::i32`.
+error[E2302]: Type mismatch: `{closure@lib.cairo:1:17: 1:19}` and `i32`.
  --> lib.cairo:1:17-4:1
   const _x: i32 = || {
  _________________^
@@ -133,7 +133,7 @@ error[E2182]: Closures are not allowed in this context.
 |     } }>();
 |_____^
 
-error[E2302]: Type mismatch: `{closure@lib.cairo:3:13: 3:15}` and `core::integer::u32`.
+error[E2302]: Type mismatch: `{closure@lib.cairo:3:13: 3:15}` and `u32`.
  --> lib.cairo:3:11-5:7
       bar::<{ || -> u32 {
  ___________^
@@ -204,7 +204,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::ops::function::FnOnce::<{closure@lib.cairo:5:13: 5:16}, (core::integer::u32,)>.
+error[E2311]: Trait has no implementation in context: core::ops::function::FnOnce::<{closure@lib.cairo:5:13: 5:16}, (u32,)>.
  --> lib.cairo:10:23
     let _k: felt252 = bar(c);
                       ^^^
@@ -230,7 +230,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2308]: `core::ops::function::FnOnceImpl::<{closure@lib.cairo:5:13: 5:16}, (core::integer::u32,), core::traits::DestructFromDrop::<{closure@lib.cairo:5:13: 5:16}, Generated core::traits::Drop::<{closure@lib.cairo:5:13: 5:16}>>, Generated core::ops::function::Fn::<{closure@lib.cairo:5:13: 5:16}, (core::integer::u32,)>>::Output` type mismatch: `core::integer::u128` and `core::felt252`.
+error[E2308]: `core::ops::function::FnOnceImpl::<{closure@lib.cairo:5:13: 5:16}, (u32,), traits::DestructFromDrop::<{closure@lib.cairo:5:13: 5:16}, Generated core::traits::Drop::<{closure@lib.cairo:5:13: 5:16}>>, Generated core::ops::function::Fn::<{closure@lib.cairo:5:13: 5:16}, (core::integer::u32,)>>::Output` type mismatch: `u128` and `felt252`.
  --> lib.cairo:9:39
     let _f: u128 = core::ops::FnOnce::call(c, (2,));
                                       ^^^^
@@ -268,7 +268,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::traits::Into::<core::integer::u256, core::integer::u32>.
+error[E2311]: Trait has no implementation in context: Into::<u256, u32>.
  --> lib.cairo:3:22
         a.into() + b.into() + c.into()
                      ^^^^
@@ -319,12 +319,12 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::ops::function::Fn::<core::felt252, ()>.
+error[E2311]: Trait has no implementation in context: core::ops::function::Fn::<felt252, ()>.
  --> lib.cairo:7:19
     let _x: u32 = bar();
                   ^^^^^
 
-error[E2311]: Trait has no implementation in context: core::traits::Into::<core::integer::u32, core::integer::u16>.
+error[E2311]: Trait has no implementation in context: Into::<u32, u16>.
  --> lib.cairo:12:11
         a.into()
           ^^^^
@@ -348,7 +348,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::ops::function::Fn::<{closure@lib.cairo:5:15: 5:27}, (core::felt252,)>.
+error[E2311]: Trait has no implementation in context: core::ops::function::Fn::<{closure@lib.cairo:5:15: 5:27}, (felt252,)>.
  --> lib.cairo:8:19
     let _f: u32 = bar(2);
                   ^^^^^^
@@ -561,8 +561,8 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2138]: Call expression requires a function, found `core::integer::u32`.
-Candidate `core::ops::function::FnOnce::call` inference failed with: Trait has no implementation in context: core::ops::function::FnOnce::<core::integer::u32, ?4>.
+error[E2138]: Call expression requires a function, found `u32`.
+Candidate `core::ops::function::FnOnce::call` inference failed with: Trait has no implementation in context: core::ops::function::FnOnce::<u32, ?4>.
  --> lib.cairo:4:5
     x()
     ^^^
@@ -690,7 +690,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2302]: Type mismatch: `()` and `(core::integer::i32,)`.
+error[E2302]: Type mismatch: `()` and `(i32,)`.
  --> lib.cairo:5:15
     call_with(|| {})
               ^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/constant
+++ b/crates/cairo-lang-semantic/src/expr/test_data/constant
@@ -269,7 +269,7 @@ error[E2125]: The '?' operator is not supported outside of functions.
     Option::<felt252>::Some(0)?
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `bool` cannot be created from a numeric literal.
  --> lib.cairo:6:42
 const WRONG_TYPE_AND_NOT_LITERAL: bool = 1 + 2;
                                          ^^^^^
@@ -328,7 +328,7 @@ test_function_diagnostics(expect_diagnostics: true)
 const DEFAULT_VAR: bool = 1;
 
 //! > expected_diagnostics
-error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `bool` cannot be created from a numeric literal.
  --> lib.cairo:1:27
 const DEFAULT_VAR: bool = 1;
                           ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/coupon
+++ b/crates/cairo-lang-semantic/src/expr/test_data/coupon
@@ -39,7 +39,7 @@ error[E2086]: Invalid path.
 type E = foo::UnknownIdentifier;
               ^^^^^^^^^^^^^^^^^
 
-error[E2057]: Type "test::foo::Coupon" has no members.
+error[E2057]: Type "foo::Coupon" has no members.
  --> lib.cairo:14:7
     x.a;
       ^
@@ -81,37 +81,37 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "test::bar::<S, T>::Coupon", found: "()".
+error[E2042]: Unexpected return type. Expected: "bar::<S, T>::Coupon", found: "()".
  --> lib.cairo:8:46
 fn get_coupon<S, T>() -> bar::<S, T>::Coupon {}
                                              ^^
 
-error[E2042]: Unexpected return type. Expected: "test::bar2::<S, T>::Coupon", found: "()".
+error[E2042]: Unexpected return type. Expected: "bar2::<S, T>::Coupon", found: "()".
  --> lib.cairo:9:48
 fn get_coupon2<S, T>() -> bar2::<S, T>::Coupon {}
                                                ^^
 
-error[E2042]: Unexpected return type. Expected: "test::MyStruct::<S>", found: "()".
+error[E2042]: Unexpected return type. Expected: "MyStruct::<S>", found: "()".
  --> lib.cairo:10:35
 fn get_struct<S>() -> MyStruct<S> {}
                                   ^^
 
-error[E2057]: Type "test::bar::<core::integer::u8, core::integer::u16>::Coupon" has no members.
+error[E2057]: Type "bar::<u8, u16>::Coupon" has no members.
  --> lib.cairo:15:7
     x.a;
       ^
 
-error[E2057]: Type "test::bar::<core::integer::u8, core::integer::u16>::Coupon" has no members.
+error[E2057]: Type "bar::<u8, u16>::Coupon" has no members.
  --> lib.cairo:20:12
     x_snap.a;
            ^
 
-error[E2041]: Unexpected argument type. Expected: "test::bar::<?8, ?9>::Coupon", found: "test::bar2::<?10, ?11>::Coupon".
+error[E2041]: Unexpected argument type. Expected: "bar::<?8, ?9>::Coupon", found: "bar2::<?10, ?11>::Coupon".
  --> lib.cairo:23:9
     y = get_coupon2();
         ^^^^^^^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "test::bar::<?12, ?13>::Coupon", found: "test::MyStruct::<?14>".
+error[E2041]: Unexpected argument type. Expected: "bar::<?12, ?13>::Coupon", found: "MyStruct::<?14>".
  --> lib.cairo:26:9
     z = get_struct();
         ^^^^^^^^^^^^
@@ -150,7 +150,7 @@ fn foo2(x: m::MyImpl::<u8>::trait_fn::Coupon) {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::traits::Drop::<test::m::bar_no_drop::Coupon>.
+error[E2311]: Trait has no implementation in context: Drop::<m::bar_no_drop::Coupon>.
  --> lib.cairo:19:5
     use_drop(x);
     ^^^^^^^^
@@ -176,7 +176,7 @@ fn foo(x: bar::<u8, u16>::Coupon) {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "test::bar2::<?6, ?7>::Coupon", found: "test::bar::<core::integer::u8, core::integer::u16>::Coupon".
+error[E2041]: Unexpected argument type. Expected: "bar2::<?6, ?7>::Coupon", found: "bar::<u8, u16>::Coupon".
  --> lib.cairo:8:25
     bar2(1, __coupon__: x); // Wrong coupon type.
                         ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/deref
+++ b/crates/cairo-lang-semantic/src/expr/test_data/deref
@@ -172,7 +172,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2135]: Type `test::S1` cannot be dereferenced
+error[E2135]: Type `S1` cannot be dereferenced
  --> lib.cairo:13:14
     let _ = (*a);
              ^
@@ -244,10 +244,10 @@ error[E0004]: Not all trait items are implemented. Missing: 'Target'.
 impl MyDeref of core::ops::Deref<MyBox> {
      ^^^^^^^
 
-error[E0002]: Method `get` could not be called on type `test::MyBox`.
-Candidate `core::array::ArrayTrait::get` inference failed with: Type mismatch: `test::MyBox` and `@core::array::Array::<?0>`.
-Candidate `core::array::SpanTrait::get` inference failed with: Type mismatch: `test::MyBox` and `core::array::Span::<?0>`.
-Candidate `core::dict::Felt252DictTrait::get` inference failed with: Type mismatch: `test::MyBox` and `core::dict::Felt252Dict::<?0>`.
+error[E0002]: Method `get` could not be called on type `MyBox`.
+Candidate `ArrayTrait::get` inference failed with: Type mismatch: `MyBox` and `@Array::<?0>`.
+Candidate `SpanTrait::get` inference failed with: Type mismatch: `MyBox` and `Span::<?0>`.
+Candidate `Felt252DictTrait::get` inference failed with: Type mismatch: `MyBox` and `Felt252Dict::<?0>`.
  --> lib.cairo:15:7
     b.get();
       ^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/error_propagate
+++ b/crates/cairo-lang-semantic/src/expr/test_data/error_propagate
@@ -97,12 +97,12 @@ fn foo() -> Result<felt252, u128> {
 }
 
 //! > expected_diagnostics
-error[E2062]: Return type "core::result::Result::<core::felt252, core::integer::u128>" does not wrap error "core::felt252"
+error[E2062]: Return type "Result::<felt252, u128>" does not wrap error "felt252"
  --> lib.cairo:5:5
     with_other_err()?;
     ^^^^^^^^^^^^^^^^^
 
-error[E2042]: Unexpected return type. Expected: "core::result::Result::<core::felt252, core::integer::u128>", found: "core::result::Result::<core::felt252, core::felt252>".
+error[E2042]: Unexpected return type. Expected: "Result::<felt252, u128>", found: "Result::<felt252, felt252>".
  --> lib.cairo:6:5
     Result::<felt252, felt252>::Ok((0))
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ fn foo() -> Option<felt252> {
 }
 
 //! > expected_diagnostics
-error[E2063]: Type "core::integer::u32" cannot error propagate
+error[E2063]: Type "u32" cannot error propagate
  --> lib.cairo:2:5
     6_u32?;
     ^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
+++ b/crates/cairo-lang-semantic/src/expr/test_data/fixed_size_array
@@ -43,12 +43,12 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[{numeric}; 3]".
+error[E2041]: Unexpected argument type. Expected: "[u32; 2]", found: "[{numeric}; 3]".
  --> lib.cairo:2:24
     let _x: [u32; 2] = [1, 2, 3];
                        ^^^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[{numeric}; 3]".
+error[E2041]: Unexpected argument type. Expected: "[u32; 2]", found: "[{numeric}; 3]".
  --> lib.cairo:3:24
     let _x: [u32; 2] = [1; 3];
                        ^^^^^^
@@ -85,7 +85,7 @@ error[E2173]: Fixed size array with defined size must have exactly one value.
     let _x: [u32; 2] = [1, 2; 2];
                        ^^^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[?7; 0]".
+error[E2041]: Unexpected argument type. Expected: "[u32; 2]", found: "[?7; 0]".
  --> lib.cairo:5:24
     let _x: [u32; 2] = [];
                        ^^
@@ -164,17 +164,17 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[core::integer::u16; 2]".
+error[E2041]: Unexpected argument type. Expected: "[u32; 2]", found: "[u16; 2]".
  --> lib.cairo:3:24
     let _x: [u32; 2] = [1, 2_u16];
                        ^^^^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "core::integer::u32", found: "core::integer::u16".
+error[E2041]: Unexpected argument type. Expected: "u32", found: "u16".
  --> lib.cairo:4:22
     let _x = [1_u32, 2_u16];
                      ^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "[core::integer::u32; 2]", found: "[core::bool; 2]".
+error[E2041]: Unexpected argument type. Expected: "[u32; 2]", found: "[bool; 2]".
  --> lib.cairo:5:24
     let _x: [u32; 2] = [true, false];
                        ^^^^^^^^^^^^^
@@ -278,7 +278,7 @@ fn f() -> [felt252; for _ in 0..1_u32 {}] {
 }
 
 //! > expected_diagnostics
-error[E2302]: Type mismatch: `()` and `core::integer::u32`.
+error[E2302]: Type mismatch: `()` and `u32`.
  --> lib.cairo:1:21
 fn f() -> [felt252; for _ in 0..1_u32 {}] {
                     ^^^^^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/function_call
+++ b/crates/cairo-lang-semantic/src/expr/test_data/function_call
@@ -23,7 +23,7 @@ fn foo(d: bool) {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "core::bool".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "bool".
  --> lib.cairo:8:19
     bar(0, 1, 2, :d, e: 0);
                   ^
@@ -151,18 +151,18 @@ error[E0006]: Function not found.
     bar(0);
     ^^^
 
-error[E2315]: Mismatched types. The type `test::MyStruct` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `MyStruct` cannot be created from a numeric literal.
  --> lib.cairo:13:9
     d + 0;
         ^
 
-error[E0002]: Method `bar` not found on type `test::MyStruct`. Did you import the correct trait and impl?
+error[E0002]: Method `bar` not found on type `MyStruct`. Did you import the correct trait and impl?
  --> lib.cairo:15:7
     d.bar();
       ^^^
 
-error[E0002]: Method `baz` could not be called on type `test::MyStruct`.
-Candidate `test::MyTrait::baz` inference failed with: Trait has no implementation in context: test::MyTrait::<test::MyStruct>.
+error[E0002]: Method `baz` could not be called on type `MyStruct`.
+Candidate `MyTrait::baz` inference failed with: Trait has no implementation in context: MyTrait::<MyStruct>.
  --> lib.cairo:16:7
     d.baz();
       ^^^
@@ -180,7 +180,7 @@ fn foo() -> () {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u8".
+error[E2042]: Unexpected return type. Expected: "()", found: "u8".
  --> lib.cairo:2:5
     4_u8
     ^^^^
@@ -196,7 +196,7 @@ test_function_diagnostics(expect_diagnostics: true)
 fn foo() -> u8 {}
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "()".
+error[E2042]: Unexpected return type. Expected: "u8", found: "()".
  --> lib.cairo:1:16
 fn foo() -> u8 {}
                ^^
@@ -217,7 +217,7 @@ trait MyTrait {
 fn foo() -> () {}
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u8", found: "u16".
  --> lib.cairo:3:9
         1_u16
         ^^^^^
@@ -242,7 +242,7 @@ impl MyImpl of MyTrait {
 fn foo() -> () {}
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u8", found: "u16".
  --> lib.cairo:7:9
         1_u16
         ^^^^^
@@ -262,7 +262,7 @@ fn foo() -> () {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u8", found: "u16".
  --> lib.cairo:2:11
     || -> u8 {
           ^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/generics
+++ b/crates/cairo-lang-semantic/src/expr/test_data/generics
@@ -16,7 +16,7 @@ fn foo(a: A<felt252>) -> A<A<felt252>> {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "test::A::<test::A::<core::bool>>", found: "test::A::<test::A::<core::felt252>>".
+error[E2041]: Unexpected argument type. Expected: "A::<A::<bool>>", found: "A::<A::<felt252>>".
  --> lib.cairo:8:28
     let _bad: A<A<bool>> = res;
                            ^^^
@@ -257,7 +257,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "test::MyStruct::<core::felt252, core::integer::u8>", found: "test::MyStruct::<core::integer::u16, core::integer::u32>".
+error[E2041]: Unexpected argument type. Expected: "MyStruct::<felt252, u8>", found: "MyStruct::<u16, u32>".
  --> lib.cairo:9:9
     x = bar::<u16, u32>();
         ^^^^^^^^^^^^^^^^^
@@ -514,12 +514,12 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "test::S::<-1>", found: "test::S::<11>".
+error[E2041]: Unexpected argument type. Expected: "S::<-1>", found: "S::<11>".
  --> lib.cairo:12:28
     let _s: S<{ 1 - 2 }> = bar();
                            ^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "test::S::<107>", found: "test::S::<11>".
+error[E2041]: Unexpected argument type. Expected: "crate::S::<107>", found: "crate::S::<11>".
  --> lib.cairo:8:46
         let _x: super::S<{ super::K + 9 }> = super::bar();
                                              ^^^^^^^^^^^^
@@ -560,7 +560,7 @@ fn foo() -> S<1> {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "test::S::<1>", found: "test::S::<N>".
+error[E2042]: Unexpected return type. Expected: "S::<1>", found: "S::<N>".
  --> lib.cairo:2:5
     S::<N> { field: 1 }
     ^^^^^^^^^^^^^^^^^^^
@@ -588,7 +588,7 @@ fn foo() -> MyStruct<1> {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "test::MyStruct::<2>", found: "test::MyStruct::<1>".
+error[E2041]: Unexpected argument type. Expected: "MyStruct::<2>", found: "MyStruct::<1>".
  --> lib.cairo:11:10
     bar2(s);
          ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/if
+++ b/crates/cairo-lang-semantic/src/expr/test_data/if
@@ -14,12 +14,12 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2055]: Condition has type "core::felt252", expected bool.
+error[E2055]: Condition has type "felt252", expected bool.
  --> lib.cairo:3:8
     if x {
        ^
 
-error[E2056]: If blocks have incompatible types: "core::bool" and "{numeric}"
+error[E2056]: If blocks have incompatible types: "bool" and "{numeric}"
  --> lib.cairo:3:5-7:5
       if x {
  _____^
@@ -27,7 +27,7 @@ error[E2056]: If blocks have incompatible types: "core::bool" and "{numeric}"
 |     }
 |_____^
 
-error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
+error[E2042]: Unexpected return type. Expected: "()", found: "bool".
  --> lib.cairo:4:9
         true
         ^^^^
@@ -49,7 +49,7 @@ fn foo() -> bool {
 }
 
 //! > expected_diagnostics
-error[E2055]: Condition has type "core::integer::u64", expected bool.
+error[E2055]: Condition has type "u64", expected bool.
  --> lib.cairo:3:8
     if x {
        ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/impl
+++ b/crates/cairo-lang-semantic/src/expr/test_data/impl
@@ -37,7 +37,7 @@ error[E0006]: Type not found.
     fn foo(x: T, y: u8, z: u16) -> T {}
                                    ^
 
-error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `core::integer::u8`, actual: `core::integer::u16`.
+error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `u8`, actual: `u16`.
  --> lib.cairo:7:28
     fn foo(x: T, y: u8, z: u16) -> T {}
                            ^^^
@@ -92,12 +92,12 @@ error[E2014]: Impl item const `MyImpl::AsType` is not a member of trait `MyTrait
     const AsType: felt252 = 5;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::MyTrait.
+error[E2311]: Trait has no implementation in context: MyTrait.
  --> lib.cairo:22:1
 fn foo() -> MyImpl::AsType {
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2042]: Unexpected return type. Expected: "test::MyImpl::AsType", found: "core::felt252".
+error[E2042]: Unexpected return type. Expected: "MyImpl::AsType", found: "felt252".
  --> lib.cairo:24:5
     MyImpl::AsImpl::method(0)
     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/inference
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inference
@@ -84,7 +84,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "core::array::Array::<core::felt252>".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "Array::<felt252>".
  --> lib.cairo:2:29
     let mut _arr: felt252 = array::array_new::<felt252>();
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -116,7 +116,7 @@ fn foo() -> never {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::never", found: "core::felt252".
+error[E2042]: Unexpected return type. Expected: "never", found: "felt252".
  --> lib.cairo:2:5
     5_felt252
     ^^^^^^^^^
@@ -177,7 +177,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::MyTrait::<core::bool>.
+error[E2311]: Trait has no implementation in context: MyTrait::<bool>.
  --> lib.cairo:17:14
     MyTrait::foo(true);
              ^^^
@@ -211,7 +211,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::MyTrait::<core::felt252>` has multiple implementations, in: `test::MyImpl1`, `test::MyImpl2`
+error[E2313]: Trait `MyTrait::<felt252>` has multiple implementations, in: `MyImpl1`, `MyImpl2`
  --> lib.cairo:17:14
     MyTrait::foo(5);
              ^^^
@@ -273,7 +273,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::MyTrait::<core::option::Option::<?0>>` has multiple implementations, in: `test::MyImpl3`, `test::MyImpl4`
+error[E2313]: Trait `MyTrait::<Option::<?0>>` has multiple implementations, in: `MyImpl3`, `MyImpl4`
  --> lib.cairo:17:14
     MyTrait::foo(None);
              ^^^
@@ -378,7 +378,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::MyTrait::<core::bool>.
+error[E2311]: Trait has no implementation in context: MyTrait::<bool>.
  --> lib.cairo:19:5
     bar(true);
     ^^^
@@ -597,7 +597,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::MyTrait::<T>` has multiple implementations, in: `+MyTrait<T>`, `test::MyIpls::<T, +Drop<T>>`
+error[E2313]: Trait `MyTrait::<T>` has multiple implementations, in: `+MyTrait<T>`, `MyIpls::<T, +Drop<T>>`
  --> lib.cairo:12:5
     baz(a)
     ^^^
@@ -618,7 +618,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "@?2", found: "core::integer::u32".
+error[E2041]: Unexpected argument type. Expected: "@?2", found: "u32".
 It is possible that the type inference failed because the types differ in the number of snapshots.
 Consider adding or removing snapshots.
  --> lib.cairo:5:24

--- a/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
+++ b/crates/cairo-lang-semantic/src/expr/test_data/inline_macros
@@ -233,7 +233,7 @@ error[E2200]: Plugin diagnostic: Macro `array` does not support this bracket typ
     let _x = array!(0);
                    ^
 
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "core::integer::u8".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "u8".
  --> lib.cairo:3:32
     let _x = array![0_felt252, 1_u8];
                                ^^^^
@@ -1255,7 +1255,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::integer::u8", found: "core::integer::u16".
+error[E2041]: Unexpected argument type. Expected: "u8", found: "u16".
  --> lib.cairo:7:21
     add_nums!(1_u8, 2_u16);
                     ^^^^^
@@ -1837,7 +1837,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Mismatched types. The type `core::felt252` cannot be created from a string literal.
+error[E2311]: Mismatched types. The type `felt252` cannot be created from a string literal.
  --> lib.cairo:8:1
 macro_item_level!();
 ^^^^^^^^^^^^^^^^^^^^
@@ -2645,7 +2645,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::make_impl!_#156::ConflictImpl`, `test::make_impl!_#171::ConflictImpl`
+error[E2313]: Trait `MyTrait` has multiple implementations, in: `test::make_impl!_#156::ConflictImpl`, `test::make_impl!_#171::ConflictImpl`
  --> lib.cairo:16:14
     MyTrait::foo();
              ^^^
@@ -2679,7 +2679,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::make_impl!_#204::ConflictImpl`, `test::make_impl!_#228::ConflictImpl`
+error[E2313]: Trait `MyTrait` has multiple implementations, in: `test::make_impl!_#204::ConflictImpl`, `test::make_impl!_#228::ConflictImpl`
  --> lib.cairo:18:14
     MyTrait::foo();
              ^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/let_else
+++ b/crates/cairo-lang-semantic/src/expr/test_data/let_else
@@ -26,17 +26,17 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "test::MyEnum".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "MyEnum".
  --> lib.cairo:11:33
     let MyEnum::A(x): felt252 = MyEnum::A(7) else {
                                 ^^^^^^^^^^^^
 
-error[E2103]: Mismatched types: pattern cannot match against type "core::felt252".
+error[E2103]: Mismatched types: pattern cannot match against type "felt252".
  --> lib.cairo:11:9
     let MyEnum::A(x): felt252 = MyEnum::A(7) else {
         ^^^^^^^^^^^^
 
-error[E2103]: Mismatched types: pattern cannot match against type "core::felt252".
+error[E2103]: Mismatched types: pattern cannot match against type "felt252".
  --> lib.cairo:14:9
     let MyEnum::A(x): felt252 = 7 else {
         ^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/let_statement
+++ b/crates/cairo-lang-semantic/src/expr/test_data/let_statement
@@ -107,7 +107,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "()", found: "core::felt252".
+error[E2041]: Unexpected argument type. Expected: "()", found: "felt252".
  --> lib.cairo:2:18
     let _a: () = 3_felt252;
                  ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/literal
+++ b/crates/cairo-lang-semantic/src/expr/test_data/literal
@@ -160,7 +160,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2315]: Mismatched types. The type `core::byte_array::ByteArray` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `ByteArray` cannot be created from a numeric literal.
  --> lib.cairo:2:25
     let _x: ByteArray = 252;
                         ^^^
@@ -178,7 +178,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `bool` cannot be created from a numeric literal.
  --> lib.cairo:2:20
     let _x: bool = 5;
                    ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/logical_operator
+++ b/crates/cairo-lang-semantic/src/expr/test_data/logical_operator
@@ -9,17 +9,17 @@ fn foo(a: u128, b: u128, c: u128) -> bool {
 }
 
 //! > expected_diagnostics
-error[E2039]: Expected type "core::bool", found: "core::integer::u128".
+error[E2039]: Expected type "bool", found: "u128".
  --> lib.cairo:2:5
     a && b || c
     ^
 
-error[E2039]: Expected type "core::bool", found: "core::integer::u128".
+error[E2039]: Expected type "bool", found: "u128".
  --> lib.cairo:2:10
     a && b || c
          ^
 
-error[E2039]: Expected type "core::bool", found: "core::integer::u128".
+error[E2039]: Expected type "bool", found: "u128".
  --> lib.cairo:2:15
     a && b || c
               ^
@@ -40,12 +40,12 @@ fn foo(a: bool, b: bool, c: bool) -> bool {
 }
 
 //! > expected_diagnostics
-error[E2039]: Expected type "core::bool", found: "S".
+error[E2039]: Expected type "bool", found: "S".
  --> lib.cairo:2:5
     a && Default::default() || c
     ^
 
-error[E2039]: Expected type "core::bool", found: "T".
+error[E2039]: Expected type "bool", found: "T".
  --> lib.cairo:2:32
     a && Default::default() || c
                                ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/loop
+++ b/crates/cairo-lang-semantic/src/expr/test_data/loop
@@ -15,7 +15,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2056]: Loop has incompatible return types: "core::bool" and "{numeric}"
+error[E2056]: Loop has incompatible return types: "bool" and "{numeric}"
  --> lib.cairo:6:19
             break 0;
                   ^
@@ -39,12 +39,12 @@ fn foo(x: Option<()>) {
 }
 
 //! > expected_diagnostics
-error[E2056]: Loop has incompatible return types: "core::bool" and "{numeric}"
+error[E2056]: Loop has incompatible return types: "bool" and "{numeric}"
  --> lib.cairo:6:19
             break 0;
                   ^
 
-error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
+error[E2042]: Unexpected return type. Expected: "()", found: "bool".
  --> lib.cairo:2:5-8:5
       loop {
  _____^
@@ -117,7 +117,7 @@ fn foo() -> bool {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
+error[E2042]: Unexpected return type. Expected: "bool", found: "()".
  --> lib.cairo:2:11
     return;
           ^
@@ -151,7 +151,7 @@ fn foo() -> bool {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
+error[E2042]: Unexpected return type. Expected: "bool", found: "()".
  --> lib.cairo:3:15
         return;
               ^
@@ -171,7 +171,7 @@ fn foo() -> bool {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::bool", found: "()".
+error[E2042]: Unexpected return type. Expected: "bool", found: "()".
  --> lib.cairo:2:5-4:5
       loop {
  _____^
@@ -310,7 +310,7 @@ fn foo(a: u32) -> Option<bool> {
 }
 
 //! > expected_diagnostics
-error[E2056]: Loop has incompatible return types: "core::never" and "()"
+error[E2056]: Loop has incompatible return types: "never" and "()"
  --> lib.cairo:6:14
         break;
              ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/match
+++ b/crates/cairo-lang-semantic/src/expr/test_data/match
@@ -21,7 +21,7 @@ fn foo(b: A) -> felt252 {
 }
 
 //! > expected_diagnostics
-error[E2315]: Mismatched types. The type `test::A` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `A` cannot be created from a numeric literal.
  --> lib.cairo:9:10
         (7, 1) => { x },
          ^
@@ -61,7 +61,7 @@ fn foo(a: bool) -> felt252 {
 }
 
 //! > expected_diagnostics
-error[E2315]: Mismatched types. The type `core::bool` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `bool` cannot be created from a numeric literal.
  --> lib.cairo:6:15
     match a + 1 {
               ^
@@ -96,7 +96,7 @@ fn foo(a: felt252, b: bool) -> felt252 {
 }
 
 //! > expected_diagnostics
-error[E2056]: Match arms have incompatible types: "core::felt252" and "core::bool"
+error[E2056]: Match arms have incompatible types: "felt252" and "bool"
  --> lib.cairo:8:14
         _ => b,
              ^
@@ -147,12 +147,12 @@ fn foo(x: Option<()>) {
 }
 
 //! > expected_diagnostics
-error[E2056]: Match arms have incompatible types: "core::bool" and "{numeric}"
+error[E2056]: Match arms have incompatible types: "bool" and "{numeric}"
  --> lib.cairo:4:17
         None => 0,
                 ^
 
-error[E2042]: Unexpected return type. Expected: "()", found: "core::bool".
+error[E2042]: Unexpected return type. Expected: "()", found: "bool".
  --> lib.cairo:3:20
         Some(_) => true,
                    ^^^^
@@ -217,7 +217,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "test::MyEnum::<core::integer::u32>", found: "test::MyEnum::<core::felt252>".
+error[E2041]: Unexpected argument type. Expected: "MyEnum::<u32>", found: "MyEnum::<felt252>".
  --> lib.cairo:11:9
     bar(a);
         ^
@@ -402,7 +402,7 @@ fn foo() -> u32 {
 }
 
 //! > expected_diagnostics
-error[E2302]: Type mismatch: `core::option::Option::<core::integer::u32>` and `core::option::Option::<core::integer::u8>`.
+error[E2302]: Type mismatch: `Option::<u32>` and `Option::<u8>`.
  --> lib.cairo:5:9
         None::<u8> => 6,
         ^^^^^^^^^^
@@ -423,7 +423,7 @@ fn foo(x: Result<Option<u8>, felt252>) {
 }
 
 //! > expected_diagnostics
-error[E2039]: Expected type "core::integer::u8", found: "core::felt252".
+error[E2039]: Expected type "u8", found: "felt252".
  --> lib.cairo:3:27
         Ok(Some(x)) | Err(x) => x,
                           ^
@@ -473,7 +473,7 @@ fn bar(x: felt252) {
 }
 
 //! > expected_diagnostics
-error[E2039]: Expected type "T", found: "core::felt252".
+error[E2039]: Expected type "T", found: "felt252".
  --> lib.cairo:3:27
         Ok(Some(x)) | Err(x) => x,
                           ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/method
+++ b/crates/cairo-lang-semantic/src/expr/test_data/method
@@ -73,7 +73,7 @@ fn foo() -> Option<felt252> {
 }
 
 //! > expected_diagnostics
-error[E0002]: Method `is_foo` not found on type `core::option::Option::<?0>`. Did you import the correct trait and impl?
+error[E0002]: Method `is_foo` not found on type `Option::<?0>`. Did you import the correct trait and impl?
  --> lib.cairo:37:7
     x.is_foo();
       ^^^^^^
@@ -88,7 +88,7 @@ error[E2085]: Invalid member expression.
     y.SomeOtherPrefix::is_bar();
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2313]: Candidate impl test::AnotherMyTraitImpl::<?0> has an unused generic parameter.
+error[E2313]: Candidate impl AnotherMyTraitImpl::<?0> has an unused generic parameter.
  --> lib.cairo:38:7
     x.is_bla();
       ^^^^^^
@@ -271,8 +271,8 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E0002]: Method `bar` could not be called on type `core::integer::u16`.
-Candidate `test::MyTrait::bar` inference failed with: Trait has no implementation in context: test::MyTrait::<core::integer::u16>.
+error[E0002]: Method `bar` could not be called on type `u16`.
+Candidate `MyTrait::bar` inference failed with: Trait has no implementation in context: MyTrait::<u16>.
  --> lib.cairo:5:11
     3_u16.bar();
           ^^^
@@ -293,8 +293,8 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E0002]: Method `bar` could not be called on type `core::integer::u16`.
-Candidate `test::MyTrait::bar` inference failed with: Trait has no implementation in context: test::MyTrait::<core::integer::u16>.
+error[E0002]: Method `bar` could not be called on type `u16`.
+Candidate `MyTrait::bar` inference failed with: Trait has no implementation in context: MyTrait::<u16>.
  --> lib.cairo:5:21
     (3_u16 + 3_u16).bar();
                     ^^^
@@ -358,8 +358,8 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E0002]: Method `draw_felt` could not be called on type `test::PoseidonChannel`.
-Candidate `test::ChannelTrait::draw_felt` inference failed with: Type mismatch: `test::PoseidonChannel` and `test::ChannelTrait::Channel`.
+error[E0002]: Method `draw_felt` could not be called on type `PoseidonChannel`.
+Candidate `ChannelTrait::draw_felt` inference failed with: Type mismatch: `PoseidonChannel` and `ChannelTrait::Channel`.
  --> lib.cairo:18:13
     channel.draw_felt();
             ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
+++ b/crates/cairo-lang-semantic/src/expr/test_data/neg_impl
@@ -52,7 +52,7 @@ fn foo(a: u8) -> u8 {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::MyTrait::<T>.
+error[E2311]: Trait has no implementation in context: MyTrait::<T>.
  --> lib.cairo:11:14
     MyTrait::f(t)
              ^
@@ -83,7 +83,7 @@ fn foo() -> u32 {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::MyTrait2::<core::integer::u32>.
+error[E2311]: Trait has no implementation in context: MyTrait2::<u32>.
  --> lib.cairo:15:15
     MyTrait2::foo(5_u32)
               ^^^
@@ -114,7 +114,7 @@ fn foo() -> u32 {
 }
 
 //! > expected_diagnostics
-error[E2312]: Trait has implementation in context: test::MyTrait::<core::integer::u32>.
+error[E2312]: Trait has implementation in context: MyTrait::<u32>.
  --> lib.cairo:15:5
     I2::foo(5_u32)
     ^^
@@ -193,7 +193,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::Trait3.
+error[E2311]: Trait has no implementation in context: Trait3.
  --> lib.cairo:24:13
     Trait3::bar();
             ^^^
@@ -285,7 +285,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Cannot infer trait core::metaprogramming::TypeEqual::<test::A::<?0>, test::A::<0>>. First generic argument must be known.
+error[E2313]: Cannot infer trait core::metaprogramming::TypeEqual::<A::<?0>, A::<0>>. First generic argument must be known.
  --> lib.cairo:7:10
     Bad::bad();
          ^^^
@@ -363,7 +363,7 @@ error[E0006]: Trait not found.
 impl BlanketNonCopy<T, -MissomgTrait<T>> of MyTrait<T> {
                         ^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::MyTrait::<core::felt252>.
+error[E2311]: Trait has no implementation in context: MyTrait::<felt252>.
  --> lib.cairo:11:25
     MyTrait::<felt252>::f()
                         ^
@@ -395,7 +395,7 @@ error[E0006]: Trait not found.
 impl BlanketNonCopy<T, +MissingTrait<T>> of MyTrait<T> {
                         ^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::MyTrait::<core::felt252>.
+error[E2311]: Trait has no implementation in context: MyTrait::<felt252>.
  --> lib.cairo:11:25
     MyTrait::<felt252>::f()
                         ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/operators
+++ b/crates/cairo-lang-semantic/src/expr/test_data/operators
@@ -11,7 +11,7 @@ fn foo(a: MyType) {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::traits::Add::<test::MyType>.
+error[E2311]: Trait has no implementation in context: Add::<MyType>.
  --> lib.cairo:4:5
     a + a * a;
     ^^^^^^^^^
@@ -39,17 +39,17 @@ error[E1028]: Consecutive comparison operators are not allowed: '>' followed by 
     a > a > a;
           ^
 
-error[E2041]: Unexpected argument type. Expected: "core::bool", found: "core::integer::u128".
+error[E2041]: Unexpected argument type. Expected: "bool", found: "u128".
  --> lib.cairo:6:13
     a > a > a;
             ^
 
-error[E2041]: Unexpected argument type. Expected: "core::integer::u128", found: "core::bool".
+error[E2041]: Unexpected argument type. Expected: "u128", found: "bool".
  --> lib.cairo:7:9
     a - b
         ^
 
-error[E2042]: Unexpected return type. Expected: "()", found: "core::integer::u128".
+error[E2042]: Unexpected return type. Expected: "()", found: "u128".
  --> lib.cairo:7:5
     a - b
     ^^^^^
@@ -74,7 +74,7 @@ error[E2008]: The value does not fit within the range of type core::integer::u8.
     -1_u8;
     ^^^^^
 
-error[E2311]: Trait has no implementation in context: core::traits::Neg::<core::bool>.
+error[E2311]: Trait has no implementation in context: Neg::<bool>.
  --> lib.cairo:2:5
     -(1 == 2);
     ^^^^^^^^^
@@ -113,14 +113,14 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2136]: Type `test::Struct1` could not be indexed.
-Candidate `core::ops::index::Index::index` inference failed with: Trait has no implementation in context: core::ops::index::Index::<test::Struct1, ?3>.
-Candidate `core::ops::index::IndexView::index` inference failed with: Trait has no implementation in context: core::ops::index::IndexView::<test::Struct1, ?3>.
+error[E2136]: Type `Struct1` could not be indexed.
+Candidate `core::ops::index::Index::index` inference failed with: Trait has no implementation in context: core::ops::index::Index::<Struct1, ?3>.
+Candidate `core::ops::index::IndexView::index` inference failed with: Trait has no implementation in context: core::ops::index::IndexView::<Struct1, ?3>.
  --> lib.cairo:21:15
     let _y1 = x1[0];
               ^^^^^
 
-error[E2139]: Type "test::Struct2" implements both the "Index" trait and the "IndexView" trait.
+error[E2139]: Type "Struct2" implements both the "Index" trait and the "IndexView" trait.
  --> lib.cairo:23:15
     let _y2 = x2[0];
               ^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/pattern
+++ b/crates/cairo-lang-semantic/src/expr/test_data/pattern
@@ -169,7 +169,7 @@ fn foo(s: (felt252, felt252, felt252)) {
 }
 
 //! > expected_diagnostics
-error[E2103]: Mismatched types: pattern cannot match against type "(core::felt252, core::felt252, core::felt252)".
+error[E2103]: Mismatched types: pattern cannot match against type "(felt252, felt252, felt252)".
  --> lib.cairo:2:9
     let [_a, _b, _c] = s;
         ^^^^^^^^^^^^
@@ -187,7 +187,7 @@ fn foo(s: [felt252; 3]) {
 }
 
 //! > expected_diagnostics
-error[E2103]: Mismatched types: pattern cannot match against type "[core::felt252; 3]".
+error[E2103]: Mismatched types: pattern cannot match against type "[felt252; 3]".
  --> lib.cairo:2:9
     let (_a, _b, _c) = s;
         ^^^^^^^^^^^^
@@ -208,7 +208,7 @@ fn foo(s: [felt252; 3]) {
 }
 
 //! > expected_diagnostics
-error[E2056]: If blocks have incompatible types: "()" and "(core::array::Array::<({numeric}, {numeric}, {numeric})>,)"
+error[E2056]: If blocks have incompatible types: "()" and "(Array::<({numeric}, {numeric}, {numeric})>,)"
  --> lib.cairo:2:25-4:5
       let (unresolved,) = if true {} else {
  _________________________^
@@ -303,7 +303,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::array::ToSpanTrait::<core::array::Array::<core::integer::u8>, core::integer::u16>.
+error[E2311]: Trait has no implementation in context: ToSpanTrait::<Array::<u8>, u16>.
  --> lib.cairo:4:13
     match a.span() {
             ^^^^
@@ -324,7 +324,7 @@ fn foo(s: MyStruct<u8>) {
 }
 
 //! > expected_diagnostics
-error[E2103]: Mismatched types: pattern cannot match against type "test::MyStruct::<core::integer::u8>".
+error[E2103]: Mismatched types: pattern cannot match against type "MyStruct::<u8>".
  --> lib.cairo:5:9
     let [_x, _y] = s;
         ^^^^^^^^
@@ -346,7 +346,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2103]: Mismatched types: pattern cannot match against type "core::array::Array::<core::integer::u8>".
+error[E2103]: Mismatched types: pattern cannot match against type "Array::<u8>".
  --> lib.cairo:4:9
         [_x, _y, _z] => {},
         ^^^^^^^^^^^^
@@ -387,12 +387,12 @@ fn foo(s: Span<u32>) -> u32 {
 }
 
 //! > expected_diagnostics
-error[E2315]: Mismatched types. The type `core::array::Span::<core::integer::u32>` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `Span::<u32>` cannot be created from a numeric literal.
  --> lib.cairo:4:9
         5 => 0,
         ^
 
-error[E2103]: Mismatched types: pattern cannot match against type "core::array::Span::<core::integer::u32>".
+error[E2103]: Mismatched types: pattern cannot match against type "Span::<u32>".
  --> lib.cairo:5:9
         (a, b) => *a + *b,
         ^^^^^^
@@ -407,7 +407,7 @@ error[E2135]: Type `<missing>` cannot be dereferenced
         (a, b) => *a + *b,
                        ^
 
-error[E2103]: Mismatched types: pattern cannot match against type "core::array::Span::<core::integer::u32>".
+error[E2103]: Mismatched types: pattern cannot match against type "Span::<u32>".
  --> lib.cairo:6:9
         Some(a) => *a,
         ^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/return
+++ b/crates/cairo-lang-semantic/src/expr/test_data/return
@@ -54,7 +54,7 @@ test_function_diagnostics(expect_diagnostics: true)
 fn foo() -> felt252 {}
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::felt252", found: "()".
+error[E2042]: Unexpected return type. Expected: "felt252", found: "()".
  --> lib.cairo:1:21
 fn foo() -> felt252 {}
                     ^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/snapshot
+++ b/crates/cairo-lang-semantic/src/expr/test_data/snapshot
@@ -29,12 +29,12 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2315]: Mismatched types. The type `@core::felt252` cannot be created from a numeric literal.
+error[E2315]: Mismatched types. The type `@felt252` cannot be created from a numeric literal.
  --> lib.cairo:2:24
     let _x: @felt252 = 5;
                        ^
 
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "@{numeric}".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "@{numeric}".
 It is possible that the type inference failed because the types differ in the number of snapshots.
 Consider adding or removing snapshots.
  --> lib.cairo:3:23
@@ -55,12 +55,12 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "@core::felt252", found: "core::felt252".
+error[E2041]: Unexpected argument type. Expected: "@felt252", found: "felt252".
  --> lib.cairo:2:24
     let _x: @felt252 = 5_felt252;
                        ^^^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "@core::felt252".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "@felt252".
  --> lib.cairo:3:23
     let _y: felt252 = @6_felt252;
                       ^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/expr/test_data/structure
+++ b/crates/cairo-lang-semantic/src/expr/test_data/structure
@@ -21,7 +21,7 @@ fn foo(a: A) -> A {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "()", found: "core::felt252".
+error[E2041]: Unexpected argument type. Expected: "()", found: "felt252".
  --> lib.cairo:8:12
         b: 1_felt252,
            ^^^^^^^^^
@@ -67,7 +67,7 @@ fn foo(a: A) {
 }
 
 //! > expected_diagnostics
-error[E0007]: Type "test::A" has no member "f"
+error[E0007]: Type "A" has no member "f"
  --> lib.cairo:7:7
     a.f;
       ^
@@ -77,12 +77,12 @@ error[E2085]: Invalid member expression.
     a.a::b;
       ^^^^
 
-error[E0007]: Type "test::A" has no member "4"
+error[E0007]: Type "A" has no member "4"
  --> lib.cairo:9:7
     a.4.4;
       ^
 
-error[E0007]: Type "core::felt252" has no member "a"
+error[E0007]: Type "felt252" has no member "a"
  --> lib.cairo:10:15
     5_felt252.a;
               ^

--- a/crates/cairo-lang-semantic/src/expr/test_data/tuple
+++ b/crates/cairo-lang-semantic/src/expr/test_data/tuple
@@ -23,7 +23,7 @@ fn foo(t: (felt252, u8)) -> felt252 {
 }
 
 //! > expected_diagnostics
-error[E0007]: Type "(core::felt252, core::integer::u8)" has no member "5"
+error[E0007]: Type "(felt252, u8)" has no member "5"
  --> lib.cairo:2:7
     t.5
       ^
@@ -41,7 +41,7 @@ fn foo(x: felt252) -> felt252 {
 }
 
 //! > expected_diagnostics
-error[E0007]: Type "core::felt252" has no member "0"
+error[E0007]: Type "felt252" has no member "0"
  --> lib.cairo:2:7
     x.0
       ^
@@ -95,7 +95,7 @@ fn foo(t: (felt252, u8)) -> (felt252, felt252) {
 }
 
 //! > expected_diagnostics
-error[E0007]: Type "(core::felt252, core::integer::u8)" has no member "00"
+error[E0007]: Type "(felt252, u8)" has no member "00"
  --> lib.cairo:2:8
     (t.00, t.0x1)
        ^^

--- a/crates/cairo-lang-semantic/src/items/tests/enum
+++ b/crates/cairo-lang-semantic/src/items/tests/enum
@@ -28,7 +28,7 @@ enum A {
 }
 
 //! > expected_diagnostics
-error[E2052]: Recursive type "test::A" has infinite size.
+error[E2052]: Recursive type "A" has infinite size.
  --> lib.cairo:2:5
     Variant: A,
     ^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/tests/impl_alias
+++ b/crates/cairo-lang-semantic/src/items/tests/impl_alias
@@ -99,7 +99,7 @@ fn foo(x: Option<Box<usize>>) -> usize {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::MyTrait::<core::option::Option::<core::box::Box::<core::integer::u32>>>.
+error[E2311]: Trait has no implementation in context: MyTrait::<Option::<Box::<u32>>>.
  --> lib.cairo:15:14
     MyTrait::foo(x)
              ^^^

--- a/crates/cairo-lang-semantic/src/items/tests/struct
+++ b/crates/cairo-lang-semantic/src/items/tests/struct
@@ -35,22 +35,22 @@ struct C {
 }
 
 //! > expected_diagnostics
-error[E2052]: Recursive type "test::A" has infinite size.
+error[E2052]: Recursive type "A" has infinite size.
  --> lib.cairo:2:5
     member: A,
     ^^^^^^^^^
 
-error[E2052]: Recursive type "test::C" has infinite size.
+error[E2052]: Recursive type "C" has infinite size.
  --> lib.cairo:6:5
     member: C,
     ^^^^^^^^^
 
-error[E2052]: Recursive type "test::A" has infinite size.
+error[E2052]: Recursive type "A" has infinite size.
  --> lib.cairo:7:5
     member2: A,
     ^^^^^^^^^^
 
-error[E2052]: Recursive type "test::B" has infinite size.
+error[E2052]: Recursive type "B" has infinite size.
  --> lib.cairo:11:5
     member: B,
     ^^^^^^^^^
@@ -71,7 +71,7 @@ fn foo(a: A) -> A {
 }
 
 //! > expected_diagnostics
-error[E2052]: Recursive type "test::A" has infinite size.
+error[E2052]: Recursive type "A" has infinite size.
  --> lib.cairo:2:5
     member: A,
     ^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/tests/trait
+++ b/crates/cairo-lang-semantic/src/items/tests/trait
@@ -121,7 +121,7 @@ error[E2029]: The number of parameters in the impl function `MyImpl2::param_test
     fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2031]: Parameter type of impl function `MyImpl2::param_test` is incompatible with `MyTrait::param_test`. Expected: `core::integer::u128`, actual: `core::felt252`.
+error[E2031]: Parameter type of impl function `MyImpl2::param_test` is incompatible with `MyTrait::param_test`. Expected: `u128`, actual: `felt252`.
  --> lib.cairo:28:22
     fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
                      ^^^^^^^
@@ -136,7 +136,7 @@ error[E2113]: The signature of function `param_test` is incompatible with trait 
     fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2042]: Unexpected return type. Expected: "core::integer::u128", found: "()".
+error[E2042]: Unexpected return type. Expected: "u128", found: "()".
  --> lib.cairo:28:63-30:5
       fn param_test(a: felt252, b: felt252, c: felt252) -> u128 {
  _______________________________________________________________^
@@ -149,7 +149,7 @@ error[E2035]: Parameter of impl function MyImpl2::no_ret_ty is incompatible with
     fn no_ret_ty(ref a: u128) {
                  ^^^
 
-error[E2045]: Return type of impl function `MyImpl2::no_ret_ty` is incompatible with `MyTrait::no_ret_ty`. Expected: `core::felt252`, actual: `()`.
+error[E2045]: Return type of impl function `MyImpl2::no_ret_ty` is incompatible with `MyTrait::no_ret_ty`. Expected: `felt252`, actual: `()`.
  --> lib.cairo:32:31
     fn no_ret_ty(ref a: u128) {
                               ^
@@ -238,32 +238,32 @@ impl T2Copy of Copy<(felt252, NonCopy)>;
 impl T2Drop of Drop<(felt252, NonCopy)>;
 
 //! > expected_diagnostics
-error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
+error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: Copy::<NonCopy>.
  --> lib.cairo:20:1
 impl CCopy of Copy<C>;
 ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
+error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: Drop::<NonCopy>.
  --> lib.cairo:21:1
 impl CDrop of Drop<C>;
 ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
+error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: Copy::<NonCopy>.
  --> lib.cairo:22:1
 impl DCopy of Copy<D>;
 ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
+error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: Drop::<NonCopy>.
  --> lib.cairo:23:1
 impl DDrop of Drop<D>;
 ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: core::traits::Copy::<test::NonCopy>.
+error[E2110]: Invalid copy trait implementation, Trait has no implementation in context: Copy::<NonCopy>.
  --> lib.cairo:28:1
 impl T2Copy of Copy<(felt252, NonCopy)>;
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: core::traits::Drop::<test::NonCopy>.
+error[E2111]: Invalid drop trait implementation, Trait has no implementation in context: Drop::<NonCopy>.
  --> lib.cairo:29:1
 impl T2Drop of Drop<(felt252, NonCopy)>;
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -336,7 +336,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::MyTrait.
+error[E2311]: Trait has no implementation in context: MyTrait.
  --> lib.cairo:5:14
     MyTrait::foo()
              ^^^
@@ -363,7 +363,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::MyImpl1`, `test::MyImpl2`
+error[E2313]: Trait `MyTrait` has multiple implementations, in: `MyImpl1`, `MyImpl2`
  --> lib.cairo:11:14
     MyTrait::foo()
              ^^^
@@ -419,7 +419,7 @@ Could not find implementation of trait `test::OtherTrait`
 impl MyImpl of MyTrait;
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::OtherTrait.
+error[E2311]: Trait has no implementation in context: OtherTrait.
  --> lib.cairo:9:1
 impl MyImpl of MyTrait;
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -469,7 +469,7 @@ Could not find implementation of trait `test::OtherTrait`
 | }
 |_^
 
-error[E2311]: Trait has no implementation in context: test::OtherTrait.
+error[E2311]: Trait has no implementation in context: OtherTrait.
  --> lib.cairo:16:1-21:1
   impl MyImpl of MyTrait {
  _^
@@ -533,7 +533,7 @@ impl Felt252Identity of Identity<felt252> {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `Felt252Identity::foo` is incompatible with `Identity::foo`. Expected: `core::felt252`, actual: `core::integer::u128`.
+error[E2031]: Parameter type of impl function `Felt252Identity::foo` is incompatible with `Identity::foo`. Expected: `felt252`, actual: `u128`.
  --> lib.cairo:6:15
     fn foo(a: u128) {}
               ^^^^
@@ -559,7 +559,7 @@ impl Felt252Identity of Identity<felt252> {
 }
 
 //! > expected_diagnostics
-error[E2045]: Return type of impl function `Felt252Identity::foo` is incompatible with `Identity::foo`. Expected: `core::felt252`, actual: `core::integer::u128`.
+error[E2045]: Return type of impl function `Felt252Identity::foo` is incompatible with `Identity::foo`. Expected: `felt252`, actual: `u128`.
  --> lib.cairo:6:17
     fn foo() -> u128 {
                 ^^^^
@@ -599,7 +599,7 @@ impl Felt252Identity of Identity<felt252> {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `Felt252Identity::foo` is incompatible with `Identity::foo`. Expected: `T`, actual: `core::felt252`.
+error[E2031]: Parameter type of impl function `Felt252Identity::foo` is incompatible with `Identity::foo`. Expected: `T`, actual: `felt252`.
  --> lib.cairo:6:18
     fn foo<T>(a: felt252) {}
                  ^^^^^^^
@@ -857,7 +857,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u32", found: "u16".
  --> lib.cairo:7:9
         Self::foo2()
         ^^^^^^^^^^^^
@@ -907,17 +907,17 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:5:15
     fn foo(x: u32, y: u32) -> u32 {
               ^^^
 
-error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:5:23
     fn foo(x: u32, y: u32) -> u32 {
                       ^^^
 
-error[E2045]: Return type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2045]: Return type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:5:31
     fn foo(x: u32, y: u32) -> u32 {
                               ^^^
@@ -953,7 +953,7 @@ Could not find implementation of trait `core::iter::traits::iterator::Iterator::
 | }
 |_^
 
-error[E2311]: Trait has no implementation in context: core::iter::traits::iterator::Iterator::<test::FooIter>.
+error[E2311]: Trait has no implementation in context: Iterator::<FooIter>.
  --> lib.cairo:5:1-12:1
   #[feature("collections-into-iter")]
  _^
@@ -1177,7 +1177,7 @@ fn foo() -> felt252 {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `I::foo` is incompatible with `Tr::foo`. Expected: `T`, actual: `core::integer::i32`.
+error[E2031]: Parameter type of impl function `I::foo` is incompatible with `Tr::foo`. Expected: `T`, actual: `i32`.
  --> lib.cairo:6:15
     fn foo<T, const C: i32>() {}
               ^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/tests/trait_const
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_const
@@ -133,7 +133,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2039]: Expected type "core::integer::u32", found: "core::integer::i32".
+error[E2039]: Expected type "u32", found: "i32".
  --> lib.cairo:5:14
     const X: i32 = 9;
              ^^^
@@ -185,7 +185,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::traits::Neg::<core::integer::u32>.
+error[E2311]: Trait has no implementation in context: Neg::<u32>.
  --> lib.cairo:8:9
         -Self::X
         ^^^^^^^^
@@ -212,7 +212,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::traits::PartialOrd::<core::felt252>.
+error[E2311]: Trait has no implementation in context: PartialOrd::<felt252>.
  --> lib.cairo:10:9
         Self::X < Self::Y
         ^^^^^^^^^^^^^^^^^
@@ -266,7 +266,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "core::integer::u32".
+error[E2042]: Unexpected return type. Expected: "u16", found: "u32".
  --> lib.cairo:12:9
         AnotherTrait::X
         ^^^^^^^^^^^^^^^
@@ -307,12 +307,12 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::AnotherTrait2` has multiple implementations, in: `test::AnotherImpl20`, `test::AnotherImpl21`
+error[E2313]: Trait `AnotherTrait2` has multiple implementations, in: `AnotherImpl20`, `AnotherImpl21`
  --> lib.cairo:21:24
         AnotherTrait2::X
                        ^
 
-error[E2311]: Trait has no implementation in context: test::AnotherTrait0.
+error[E2311]: Trait has no implementation in context: AnotherTrait0.
  --> lib.cairo:24:24
         AnotherTrait0::X
                        ^
@@ -377,12 +377,12 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `test::S::<32>`, actual: `test::S::<16>`.
+error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `S::<32>`, actual: `S::<16>`.
  --> lib.cairo:16:18
     fn foo1() -> S<AnotherTrait::X> {
                  ^^^^^^^^^^^^^^^^^^
 
-error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `test::S::<32>`, actual: `test::S::<16>`.
+error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `S::<32>`, actual: `S::<16>`.
  --> lib.cairo:19:16
     fn foo2(x: S<Self::Y>) {}
                ^^^^^^^^^^
@@ -453,12 +453,12 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `test::S::<3>`, actual: `test::S::<4>`.
+error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `S::<3>`, actual: `S::<4>`.
  --> lib.cairo:10:18
     fn foo1() -> S<4> {
                  ^^^^
 
-error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `test::S::<3>`, actual: `test::S::<4>`.
+error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `S::<3>`, actual: `S::<4>`.
  --> lib.cairo:13:16
     fn foo2(x: S<4>) {}
                ^^^^
@@ -528,7 +528,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2302]: Type mismatch: `core::integer::u32` and `core::integer::u16`.
+error[E2302]: Type mismatch: `u32` and `u16`.
  --> lib.cairo:6:20
     const X: u16 = Self::Y;
                    ^^^^^^^
@@ -604,7 +604,7 @@ error[E0004]: Not all trait items are implemented. Missing: 'Y'.
 impl MyImpl of MyTrait {}
      ^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::MyTrait.
+error[E2311]: Trait has no implementation in context: MyTrait.
  --> lib.cairo:5:17-7:1
   fn foo() -> i32 {
  _________________^

--- a/crates/cairo-lang-semantic/src/items/tests/trait_impl
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_impl
@@ -200,12 +200,12 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `MyImpl::bar1` is incompatible with `MyTrait::bar1`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2031]: Parameter type of impl function `MyImpl::bar1` is incompatible with `MyTrait::bar1`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:20:16
     fn bar1(x: u32) {}
                ^^^
 
-error[E2045]: Return type of impl function `MyImpl::bar2` is incompatible with `MyTrait::bar2`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2045]: Return type of impl function `MyImpl::bar2` is incompatible with `MyTrait::bar2`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:21:18
     fn bar2() -> u32 {
                  ^^^
@@ -249,22 +249,22 @@ trait MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::AnotherTrait0.
+error[E2311]: Trait has no implementation in context: AnotherTrait0.
  --> lib.cairo:25:31
     fn bar1(x: AnotherTrait0::Impl::InputType);
                               ^^^^
 
-error[E2311]: Trait has no implementation in context: test::AnotherTrait0.
+error[E2311]: Trait has no implementation in context: AnotherTrait0.
  --> lib.cairo:26:33
     fn bar2() -> AnotherTrait0::Impl::InputType;
                                 ^^^^
 
-error[E2313]: Trait `test::AnotherTrait2` has multiple implementations, in: `test::AnotherImpl20`, `test::AnotherImpl21`
+error[E2313]: Trait `AnotherTrait2` has multiple implementations, in: `AnotherImpl20`, `AnotherImpl21`
  --> lib.cairo:27:31
     fn bar3(x: AnotherTrait2::Impl::InputType);
                               ^^^^
 
-error[E2313]: Trait `test::AnotherTrait2` has multiple implementations, in: `test::AnotherImpl20`, `test::AnotherImpl21`
+error[E2313]: Trait `AnotherTrait2` has multiple implementations, in: `AnotherImpl20`, `AnotherImpl21`
  --> lib.cairo:28:33
     fn bar4() -> AnotherTrait2::Impl::InputType;
                                 ^^^^
@@ -334,17 +334,17 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `core::integer::u32`, actual: `core::integer::u16`.
+error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `u32`, actual: `u16`.
  --> lib.cairo:18:18
     fn foo1() -> AnotherTrait::Impl::InputType {
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "core::integer::u32".
+error[E2042]: Unexpected return type. Expected: "u16", found: "u32".
  --> lib.cairo:19:9
         3_u32
         ^^^^^
 
-error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `core::integer::u32`, actual: `core::integer::u16`.
+error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `u32`, actual: `u16`.
  --> lib.cairo:21:16
     fn foo2(x: AnotherTrait::Impl::InputType) {}
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -446,7 +446,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "core::integer::u32".
+error[E2042]: Unexpected return type. Expected: "u16", found: "u32".
  --> lib.cairo:15:9
         3_u32
         ^^^^^
@@ -564,7 +564,7 @@ fn complex(
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "@(core::integer::u32, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)", found: "@(core::integer::u16, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u16>; 3], (@core::integer::u16, core::integer::u16)>>)".
+error[E2042]: Unexpected return type. Expected: "@(u32, Option::<@Result::<[Option::<u32>; 3], (@u32, u32)>>)", found: "@(u16, Option::<@Result::<[Option::<u16>; 3], (@u16, u16)>>)".
  --> lib.cairo:45:5
     x
     ^
@@ -626,7 +626,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u32", found: "u16".
  --> lib.cairo:16:9
         x
         ^
@@ -982,12 +982,12 @@ Could not find implementation of trait `test::OtherTrait`
 impl MyImpl of MyTrait {}
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::OtherTrait.
+error[E2311]: Trait has no implementation in context: OtherTrait.
  --> lib.cairo:7:1
 impl MyImpl of MyTrait {}
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::MyTrait.
+error[E2311]: Trait has no implementation in context: MyTrait.
  --> lib.cairo:8:10-10:1
   fn foo() {
  __________^
@@ -1177,7 +1177,7 @@ Could not find implementation of trait `test::Inner::<core::integer::u32>`
 | }
 |_^
 
-error[E2311]: Trait has no implementation in context: test::Inner::<core::integer::u32>.
+error[E2311]: Trait has no implementation in context: Inner::<u32>.
  --> lib.cairo:24:1-29:1
   impl OuterU32 of Outer<u32> {
  _^
@@ -1185,7 +1185,7 @@ error[E2311]: Trait has no implementation in context: test::Inner::<core::intege
 | }
 |_^
 
-error[E2311]: Trait has no implementation in context: core::metaprogramming::TypeEqual::<core::integer::u32, test::OuterU32::InnerImpl::Item>.
+error[E2311]: Trait has no implementation in context: core::metaprogramming::TypeEqual::<u32, OuterU32::InnerImpl::Item>.
  --> lib.cairo:31:11
     1_u64.foo(1_u32);
           ^^^
@@ -1237,7 +1237,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2308]: `test::Outer::<core::integer::u64>::Impl::InnerMost` type mismatch: `core::integer::u128` and `test::Outer::<core::integer::u64>::Impl::InnerMost`.
+error[E2308]: `Outer::<u64>::Impl::InnerMost` type mismatch: `u128` and `Outer::<u64>::Impl::InnerMost`.
  --> lib.cairo:36:5
     extra_into_inner(Outer::into_inner(1_u32));
     ^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-semantic/src/items/tests/trait_type
+++ b/crates/cairo-lang-semantic/src/items/tests/trait_type
@@ -325,12 +325,12 @@ impl MyImpl<T> of MyTrait<T> {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `T`, actual: `core::integer::u32`.
+error[E2031]: Parameter type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `T`, actual: `u32`.
  --> lib.cairo:9:15
     fn foo(x: MyImpl::<u32>::InputType, y: Self::InputType) -> MyImpl::<u32>::OutputType {
               ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2045]: Return type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `T`, actual: `core::integer::u32`.
+error[E2045]: Return type of impl function `MyImpl::foo` is incompatible with `MyTrait::foo`. Expected: `T`, actual: `u32`.
  --> lib.cairo:9:64
     fn foo(x: MyImpl::<u32>::InputType, y: Self::InputType) -> MyImpl::<u32>::OutputType {
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -505,22 +505,22 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `core::integer::u32`, actual: `core::integer::u16`.
+error[E2031]: Parameter type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `u32`, actual: `u16`.
  --> lib.cairo:12:16
     fn foo1(x: u16) {} // param type doesn't match.
                ^^^
 
-error[E2045]: Return type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `core::integer::u32`, actual: `core::integer::u16`.
+error[E2045]: Return type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `u32`, actual: `u16`.
  --> lib.cairo:13:18
     fn foo2() -> u16 {
                  ^^^
 
-error[E2031]: Parameter type of impl function `MyImpl::foo3` is incompatible with `MyTrait::foo3`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2031]: Parameter type of impl function `MyImpl::foo3` is incompatible with `MyTrait::foo3`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:16:16
     fn foo3(x: Self::InputType) {} // param type doesn't match.
                ^^^^^^^^^^^^^^^
 
-error[E2045]: Return type of impl function `MyImpl::foo4` is incompatible with `MyTrait::foo4`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2045]: Return type of impl function `MyImpl::foo4` is incompatible with `MyTrait::foo4`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:17:18
     fn foo4() -> Self::OutputType {
                  ^^^^^^^^^^^^^^^^
@@ -599,9 +599,9 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E0002]: Method `unwrap` could not be called on type `core::integer::u32`.
-Candidate `core::option::OptionTrait::unwrap` inference failed with: Type mismatch: `core::integer::u32` and `core::option::Option::<?0>`.
-Candidate `core::result::ResultTrait::unwrap` inference failed with: Type mismatch: `core::integer::u32` and `core::result::Result::<?0, ?1>`.
+error[E0002]: Method `unwrap` could not be called on type `u32`.
+Candidate `OptionTrait::unwrap` inference failed with: Type mismatch: `u32` and `Option::<?0>`.
+Candidate `ResultTrait::unwrap` inference failed with: Type mismatch: `u32` and `Result::<?0, ?1>`.
  --> lib.cairo:8:11
         x.unwrap();
           ^^^^^^
@@ -650,7 +650,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::traits::Neg::<core::integer::u32>.
+error[E2311]: Trait has no implementation in context: Neg::<u32>.
  --> lib.cairo:8:9
         -x; // u32 doesn't implement `Neg`.
         ^^
@@ -703,7 +703,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::traits::Add::<core::option::Option::<core::integer::u32>>.
+error[E2311]: Trait has no implementation in context: Add::<Option::<u32>>.
  --> lib.cairo:8:17
         let _ = x + x; // Option<usize> doesn't implement `Add`.
                 ^^^^^
@@ -754,9 +754,9 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2136]: Type `core::integer::u32` could not be indexed.
-Candidate `core::ops::index::Index::index` inference failed with: Trait has no implementation in context: core::ops::index::Index::<core::integer::u32, ?2>.
-Candidate `core::ops::index::IndexView::index` inference failed with: Trait has no implementation in context: core::ops::index::IndexView::<core::integer::u32, ?2>.
+error[E2136]: Type `u32` could not be indexed.
+Candidate `core::ops::index::Index::index` inference failed with: Trait has no implementation in context: core::ops::index::Index::<u32, ?2>.
+Candidate `core::ops::index::IndexView::index` inference failed with: Trait has no implementation in context: core::ops::index::IndexView::<u32, ?2>.
  --> lib.cairo:8:9
         x[0];
         ^^^^
@@ -814,12 +814,12 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `MyImpl::bar1` is incompatible with `MyTrait::bar1`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2031]: Parameter type of impl function `MyImpl::bar1` is incompatible with `MyTrait::bar1`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:12:16
     fn bar1(x: u32) {}
                ^^^
 
-error[E2045]: Return type of impl function `MyImpl::bar2` is incompatible with `MyTrait::bar2`. Expected: `core::integer::u16`, actual: `core::integer::u32`.
+error[E2045]: Return type of impl function `MyImpl::bar2` is incompatible with `MyTrait::bar2`. Expected: `u16`, actual: `u32`.
  --> lib.cairo:13:18
     fn bar2() -> u32 {
                  ^^^
@@ -855,22 +855,22 @@ trait MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::AnotherTrait0.
+error[E2311]: Trait has no implementation in context: AnotherTrait0.
  --> lib.cairo:17:31
     fn bar1(x: AnotherTrait0::AnotherType);
                               ^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::AnotherTrait0.
+error[E2311]: Trait has no implementation in context: AnotherTrait0.
  --> lib.cairo:18:33
     fn bar2() -> AnotherTrait0::AnotherType;
                                 ^^^^^^^^^^^
 
-error[E2313]: Trait `test::AnotherTrait2` has multiple implementations, in: `test::AnotherImpl20`, `test::AnotherImpl21`
+error[E2313]: Trait `AnotherTrait2` has multiple implementations, in: `AnotherImpl20`, `AnotherImpl21`
  --> lib.cairo:19:31
     fn bar3(x: AnotherTrait2::AnotherType);
                               ^^^^^^^^^^^
 
-error[E2313]: Trait `test::AnotherTrait2` has multiple implementations, in: `test::AnotherImpl20`, `test::AnotherImpl21`
+error[E2313]: Trait `AnotherTrait2` has multiple implementations, in: `AnotherImpl20`, `AnotherImpl21`
  --> lib.cairo:20:33
     fn bar4() -> AnotherTrait2::AnotherType;
                                 ^^^^^^^^^^^
@@ -950,27 +950,27 @@ fn bar3() {
 }
 
 //! > expected_diagnostics
-error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `core::integer::u32`, actual: `core::integer::u16`.
+error[E2045]: Return type of impl function `MyImpl::foo1` is incompatible with `MyTrait::foo1`. Expected: `u32`, actual: `u16`.
  --> lib.cairo:14:18
     fn foo1() -> AnotherTrait::AnotherType {
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `core::integer::u32`, actual: `core::integer::u16`.
+error[E2031]: Parameter type of impl function `MyImpl::foo2` is incompatible with `MyTrait::foo2`. Expected: `u32`, actual: `u16`.
  --> lib.cairo:17:16
     fn foo2(x: AnotherTrait::AnotherType) {}
                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2042]: Unexpected return type. Expected: "core::integer::u16", found: "core::integer::u32".
+error[E2042]: Unexpected return type. Expected: "u16", found: "u32".
  --> lib.cairo:20:5
     3_u32
     ^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "core::integer::u32", found: "core::integer::u16".
+error[E2041]: Unexpected argument type. Expected: "u32", found: "u16".
  --> lib.cairo:23:18
     let _: u32 = x;
                  ^
 
-error[E2308]: `test::MyImpl::MyType` type mismatch: `core::integer::u32` and `core::integer::u16`.
+error[E2308]: `MyImpl::MyType` type mismatch: `u32` and `u16`.
  --> lib.cairo:26:21
     let _: MyTrait::MyType = 3_u32;
                     ^^^^^^
@@ -1007,27 +1007,27 @@ fn bar3() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::AnotherTrait.
+error[E2311]: Trait has no implementation in context: AnotherTrait.
  --> lib.cairo:9:32
     fn foo1() -> AnotherTrait::AnotherType {
                                ^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::AnotherTrait.
+error[E2311]: Trait has no implementation in context: AnotherTrait.
  --> lib.cairo:12:30
     fn foo2(x: AnotherTrait::AnotherType) {}
                              ^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::AnotherTrait.
+error[E2311]: Trait has no implementation in context: AnotherTrait.
  --> lib.cairo:14:28
 fn bar1() -> AnotherTrait::AnotherType {
                            ^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::AnotherTrait.
+error[E2311]: Trait has no implementation in context: AnotherTrait.
  --> lib.cairo:17:26
 fn bar2(x: AnotherTrait::AnotherType) {}
                          ^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::AnotherTrait.
+error[E2311]: Trait has no implementation in context: AnotherTrait.
  --> lib.cairo:19:26
     let _: AnotherTrait::AnotherType = 3_u32;
                          ^^^^^^^^^^^
@@ -1068,27 +1068,27 @@ fn bar3() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::AnotherTrait` has multiple implementations, in: `test::AnotherImpl1`, `test::AnotherImpl2`
+error[E2313]: Trait `AnotherTrait` has multiple implementations, in: `AnotherImpl1`, `AnotherImpl2`
  --> lib.cairo:15:32
     fn foo1() -> AnotherTrait::AnotherType {
                                ^^^^^^^^^^^
 
-error[E2313]: Trait `test::AnotherTrait` has multiple implementations, in: `test::AnotherImpl1`, `test::AnotherImpl2`
+error[E2313]: Trait `AnotherTrait` has multiple implementations, in: `AnotherImpl1`, `AnotherImpl2`
  --> lib.cairo:18:30
     fn foo2(x: AnotherTrait::AnotherType) {}
                              ^^^^^^^^^^^
 
-error[E2313]: Trait `test::AnotherTrait` has multiple implementations, in: `test::AnotherImpl1`, `test::AnotherImpl2`
+error[E2313]: Trait `AnotherTrait` has multiple implementations, in: `AnotherImpl1`, `AnotherImpl2`
  --> lib.cairo:20:28
 fn bar1() -> AnotherTrait::AnotherType {
                            ^^^^^^^^^^^
 
-error[E2313]: Trait `test::AnotherTrait` has multiple implementations, in: `test::AnotherImpl1`, `test::AnotherImpl2`
+error[E2313]: Trait `AnotherTrait` has multiple implementations, in: `AnotherImpl1`, `AnotherImpl2`
  --> lib.cairo:23:26
 fn bar2(x: AnotherTrait::AnotherType) {}
                          ^^^^^^^^^^^
 
-error[E2313]: Trait `test::AnotherTrait` has multiple implementations, in: `test::AnotherImpl1`, `test::AnotherImpl2`
+error[E2313]: Trait `AnotherTrait` has multiple implementations, in: `AnotherImpl1`, `AnotherImpl2`
  --> lib.cairo:25:26
     let _: AnotherTrait::AnotherType = 3_u32;
                          ^^^^^^^^^^^
@@ -1175,7 +1175,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u32", found: "u16".
  --> lib.cairo:9:9
         3_u16
         ^^^^^
@@ -1293,32 +1293,32 @@ fn error_propagation(x: Option<MyTrait::MyType1>) -> Option<MyTrait::MyType2> {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u32", found: "u16".
  --> lib.cairo:10:12
     return x;
            ^
 
-error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u32", found: "u16".
  --> lib.cairo:13:5
     x
     ^
 
-error[E2308]: `test::MyImpl::MyType1` type mismatch: `core::integer::u32` and `core::integer::u16`.
+error[E2308]: `MyImpl::MyType1` type mismatch: `u32` and `u16`.
  --> lib.cairo:16:21
     let _: MyTrait::MyType1 = x;
                     ^^^^^^^
 
-error[E2056]: Loop has incompatible return types: "core::integer::u16" and "core::integer::u32"
+error[E2056]: Loop has incompatible return types: "u16" and "u32"
  --> lib.cairo:23:19
             break y;
                   ^
 
-error[E2056]: Match arms have incompatible types: "core::integer::u16" and "core::integer::u32"
+error[E2056]: Match arms have incompatible types: "u16" and "u32"
  --> lib.cairo:34:29
         MyEnum::VariantB => { y },
                             ^^^^^
 
-error[E2056]: If blocks have incompatible types: "core::integer::u16" and "core::integer::u32"
+error[E2056]: If blocks have incompatible types: "u16" and "u32"
  --> lib.cairo:38:5-42:5
       if cond {
  _____^
@@ -1326,7 +1326,7 @@ error[E2056]: If blocks have incompatible types: "core::integer::u16" and "core:
 |     };
 |_____^
 
-error[E2042]: Unexpected return type. Expected: "core::option::Option::<core::integer::u32>", found: "core::option::Option::<core::integer::u16>".
+error[E2042]: Unexpected return type. Expected: "Option::<u32>", found: "Option::<u16>".
  --> lib.cairo:45:5
     Some(x?)
     ^^^^^^^^
@@ -1438,37 +1438,37 @@ fn complex2(
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::option::Option::<core::integer::u32>", found: "core::option::Option::<core::integer::u16>".
+error[E2042]: Unexpected return type. Expected: "Option::<u32>", found: "Option::<u16>".
  --> lib.cairo:14:5
     Some(x?)
     ^^^^^^^^
 
-error[E2042]: Unexpected return type. Expected: "(core::integer::u32, core::integer::u16)", found: "(core::integer::u16, core::integer::u32)".
+error[E2042]: Unexpected return type. Expected: "(u32, u16)", found: "(u16, u32)".
  --> lib.cairo:17:5
     (x, y)
     ^^^^^^
 
-error[E2042]: Unexpected return type. Expected: "[core::integer::u32; 3]", found: "[core::integer::u16; 3]".
+error[E2042]: Unexpected return type. Expected: "[u32; 3]", found: "[u16; 3]".
  --> lib.cairo:20:5
     x
     ^
 
-error[E2042]: Unexpected return type. Expected: "@@core::integer::u32", found: "@@core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "@@u32", found: "@@u16".
  --> lib.cairo:23:5
     x
     ^
 
-error[E2042]: Unexpected return type. Expected: "@@core::integer::u32", found: "@@core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "@@u32", found: "@@u16".
  --> lib.cairo:26:5
     @x
     ^^
 
-error[E2042]: Unexpected return type. Expected: "@(core::integer::u32, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)", found: "@(core::integer::u16, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)".
+error[E2042]: Unexpected return type. Expected: "@(u32, Option::<@Result::<[Option::<u32>; 3], (@u32, u32)>>)", found: "@(u16, Option::<@Result::<[Option::<u32>; 3], (@u32, u32)>>)".
  --> lib.cairo:34:5
     x
     ^
 
-error[E2042]: Unexpected return type. Expected: "@(core::integer::u16, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)", found: "@(core::integer::u32, core::option::Option::<@core::result::Result::<[core::option::Option::<core::integer::u32>; 3], (@core::integer::u32, core::integer::u32)>>)".
+error[E2042]: Unexpected return type. Expected: "@(u16, Option::<@Result::<[Option::<u32>; 3], (@u32, u32)>>)", found: "@(u32, Option::<@Result::<[Option::<u32>; 3], (@u32, u32)>>)".
  --> lib.cairo:42:5
     x
     ^
@@ -1551,7 +1551,7 @@ impl MyImpl of MyTrait {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u16".
+error[E2042]: Unexpected return type. Expected: "u32", found: "u16".
  --> lib.cairo:10:9
         x
         ^
@@ -1734,7 +1734,7 @@ fn foo() -> u32 {
 }
 
 //! > expected_diagnostics
-error[E2313]: Candidate impl test::MyImpl::<?0> has an unused generic parameter.
+error[E2313]: Candidate impl MyImpl::<?0> has an unused generic parameter.
  --> lib.cairo:10:21
     let x: MyTrait::ty = 4_u32;
                     ^^
@@ -1862,7 +1862,7 @@ error[E2314]: Type annotations needed. Failed to infer ?0.
     x.t
       ^
 
-error[E2311]: Trait has no implementation in context: test::Trt.
+error[E2311]: Trait has no implementation in context: Trt.
  --> lib.cairo:6:18
     let x = Trt::foo();
                  ^^^
@@ -1933,7 +1933,7 @@ error[E0004]: Not all trait items are implemented. Missing: 'ty'.
 impl MyImpl of MyTrait {}
      ^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::MyTrait.
+error[E2311]: Trait has no implementation in context: MyTrait.
  --> lib.cairo:5:10-7:1
   fn foo() {
  __________^
@@ -1981,7 +1981,7 @@ fn bar<
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::felt252", found: "core::integer::u32".
+error[E2042]: Unexpected return type. Expected: "felt252", found: "u32".
  --> lib.cairo:10:5
     3_u32
     ^^^^^
@@ -2008,7 +2008,7 @@ fn bar<
 }
 
 //! > expected_diagnostics
-error[E2302]: Type mismatch: `core::felt252` and `core::integer::u32`.
+error[E2302]: Type mismatch: `felt252` and `u32`.
  --> lib.cairo:10:18-12:1
   ) -> MyTrait::ty {
  __________________^
@@ -2050,12 +2050,12 @@ fn bar<
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: test::OtherTrait::<+MyTrait::ty>.
+error[E2311]: Trait has no implementation in context: OtherTrait::<+MyTrait::ty>.
  --> lib.cairo:19:6
     +TraitWithInferredParams<MyTrait::ty>,
      ^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: test::TraitWithInferredParams::<core::felt252, test::OtherImpl>.
+error[E2311]: Trait has no implementation in context: TraitWithInferredParams::<felt252, OtherImpl>.
  --> lib.cairo:23:50
     _y + TraitWithInferredParams::<MyTrait::ty>::foo()
                                                  ^^^
@@ -2130,7 +2130,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::metaprogramming::TypeEqual::<core::integer::u32, core::felt252>.
+error[E2311]: Trait has no implementation in context: core::metaprogramming::TypeEqual::<u32, felt252>.
  --> lib.cairo:23:5
     bar::<MyImplu32, MyImplfelt252>();
     ^^^
@@ -2234,7 +2234,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2308]: `test::MyImpl::MyType` type mismatch: `core::felt252` and `core::integer::u16`.
+error[E2308]: `MyImpl::MyType` type mismatch: `felt252` and `u16`.
  --> lib.cairo:13:31
     let _: felt252 = MyTrait::my_function();
                               ^^^^^^^^^^^
@@ -2272,7 +2272,7 @@ fn bar<impl I1: MyTrait[ty: u32], impl I2: MyTrait[ty: I1::ty]>() -> I2::ty {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u32", found: "core::integer::u8".
+error[E2042]: Unexpected return type. Expected: "u32", found: "u8".
  --> lib.cairo:5:5
     3_u8
     ^^^^
@@ -2295,7 +2295,7 @@ fn bar<+MyTrait[ty: felt252], +core::metaprogramming::TypeEqual<MyTrait::ty, u32
 }
 
 //! > expected_diagnostics
-error[E2302]: Type mismatch: `core::felt252` and `core::integer::u32`.
+error[E2302]: Type mismatch: `felt252` and `u32`.
  --> lib.cairo:6:18-8:1
   ) -> MyTrait::ty {
  __________________^
@@ -2369,7 +2369,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2302]: Type mismatch: `core::integer::u32` and `I2::ty`.
+error[E2302]: Type mismatch: `u32` and `I2::ty`.
  --> lib.cairo:21:5
     bar::<MyImplu32, MyImplfelt252>();
     ^^^
@@ -2394,7 +2394,7 @@ fn bar2<impl J1: MyTrait>() -> J1::ty {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "J1::ty", found: "core::felt252".
+error[E2042]: Unexpected return type. Expected: "J1::ty", found: "felt252".
  --> lib.cairo:9:5
     bar()
     ^^^^^
@@ -2441,7 +2441,7 @@ fn bar2<impl I1: MyTrait[ty: u8]>() -> I1::ty {
 }
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "core::integer::u8", found: "core::integer::u32".
+error[E2042]: Unexpected return type. Expected: "u8", found: "u32".
  --> lib.cairo:9:5
     bar()
     ^^^^^
@@ -2480,7 +2480,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::MyTrait` has multiple implementations, in: `test::I1`, `test::I2`
+error[E2313]: Trait `MyTrait` has multiple implementations, in: `I1`, `I2`
  --> lib.cairo:23:5
     bar();
     ^^^
@@ -2556,7 +2556,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2302]: Type mismatch: `core::integer::u8` and `core::integer::u32`.
+error[E2302]: Type mismatch: `u8` and `u32`.
  --> lib.cairo:15:5
     bar::<MyImpl>();
     ^^^
@@ -2637,7 +2637,7 @@ fn bar<impl I1: MyTrait[ty: u32], +OtherTrait<I1::ty>, +OtherTrait<u32>>() {
 }
 
 //! > expected_diagnostics
-error[E2313]: Trait `test::OtherTrait::<core::integer::u32>` has multiple implementations, in: `+OtherTrait<I1::ty>`, `+OtherTrait<u32>`
+error[E2313]: Trait `OtherTrait::<u32>` has multiple implementations, in: `+OtherTrait<I1::ty>`, `+OtherTrait<u32>`
  --> lib.cairo:9:17
     OtherTrait::foo(5_u32);
                 ^^^
@@ -2691,7 +2691,7 @@ fn foo() -> S<M> {
 }
 
 //! > expected_diagnostics
-error[E2308]: `test::M::InputType` type mismatch: `core::felt252` and `core::integer::u32`.
+error[E2308]: `M::InputType` type mismatch: `felt252` and `u32`.
  --> lib.cairo:13:5
     S { x: 3_felt252 }
     ^

--- a/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
+++ b/crates/cairo-lang-semantic/src/items/tests/type_mismatch_diagnostics
@@ -9,7 +9,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "({numeric}, {numeric})".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "({numeric}, {numeric})".
  --> lib.cairo:2:22
     let _: felt252 = (3, 3);
                      ^^^^^^
@@ -28,12 +28,12 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::felt252", found: "@core::felt252".
+error[E2041]: Unexpected argument type. Expected: "felt252", found: "@felt252".
  --> lib.cairo:2:22
     let _: felt252 = @3_felt252;
                      ^^^^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "@core::integer::u32", found: "@core::felt252".
+error[E2041]: Unexpected argument type. Expected: "@u32", found: "@felt252".
  --> lib.cairo:3:19
     let _: @u32 = @3_felt252;
                   ^^^^^^^^^^
@@ -51,7 +51,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2135]: Type `core::integer::u32` cannot be dereferenced
+error[E2135]: Type `u32` cannot be dereferenced
  --> lib.cairo:2:22
     let _: felt252 = *3_u32;
                      ^
@@ -69,7 +69,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "[core::felt252; 2]", found: "[core::integer::u16; 2]".
+error[E2041]: Unexpected argument type. Expected: "[felt252; 2]", found: "[u16; 2]".
  --> lib.cairo:2:27
     let _: [felt252; 2] = [3_u16; 2];
                           ^^^^^^^^^^
@@ -87,7 +87,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::integer::u16", found: "core::integer::u32".
+error[E2041]: Unexpected argument type. Expected: "u16", found: "u32".
  --> lib.cairo:2:35
     let _: [felt252; 2] = [3_u16, 3_u32];
                                   ^^^^^
@@ -108,7 +108,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "test::MyGenericType::<core::felt252>", found: "test::MyGenericType::<core::integer::u32>".
+error[E2041]: Unexpected argument type. Expected: "MyGenericType::<felt252>", found: "MyGenericType::<u32>".
  --> lib.cairo:5:37
     let _: MyGenericType<felt252> = MyGenericType { x: 3_u32 };
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,7 +129,7 @@ fn foo(other: MyGenericType<u32>) {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "test::MyGenericType::<core::felt252>", found: "test::MyGenericType::<core::integer::u32>".
+error[E2041]: Unexpected argument type. Expected: "MyGenericType::<felt252>", found: "MyGenericType::<u32>".
  --> lib.cairo:5:69
     let _: MyGenericType<felt252> = MyGenericType { x: 3_felt252, ..other };
                                                                     ^^^^^
@@ -147,7 +147,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::option::Option::<core::felt252>", found: "core::option::Option::<core::integer::u16>".
+error[E2041]: Unexpected argument type. Expected: "Option::<felt252>", found: "Option::<u16>".
  --> lib.cairo:2:30
     let _: Option<felt252> = Some(3_u16);
                              ^^^^^^^^^^^
@@ -176,7 +176,7 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2308]: `test::ImplIssue::Index` type mismatch: `@core::felt252` and `core::felt252`.
+error[E2308]: `ImplIssue::Index` type mismatch: `@felt252` and `felt252`.
  --> lib.cairo:13:15
     1_felt252.issue(@2_felt252);
               ^^^^^
@@ -195,12 +195,12 @@ fn foo() {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "core::box::Box::<core::integer::u32>", found: "core::box::Box::<@core::integer::u32>".
+error[E2041]: Unexpected argument type. Expected: "Box::<u32>", found: "Box::<@u32>".
  --> lib.cairo:2:23
     let _: Box<u32> = &3_u32;
                       ^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "core::box::Box::<@core::felt252>", found: "core::box::Box::<@core::integer::u32>".
+error[E2041]: Unexpected argument type. Expected: "Box::<@felt252>", found: "Box::<@u32>".
  --> lib.cairo:3:28
     let _: Box<@felt252> = &3_u32;
                            ^^^^^^

--- a/crates/cairo-lang-semantic/src/path.rs
+++ b/crates/cairo-lang-semantic/src/path.rs
@@ -102,6 +102,11 @@ fn get_contextualized_path<'db>(
     item: ImportableId<'db>,
     context_module: ModuleId<'db>,
 ) -> Maybe<ItemAccessInfo<'db>> {
+    // A crate has no parent to shorten the path through - it is always accessed by its name.
+    if let ImportableId::Crate(crate_id) = item {
+        return Ok(ItemAccessInfo::new(ItemAccessKind::FullPath(crate_id), vec![], item.name(db)));
+    }
+
     if let Some(access_info) = check_prelude(db, item, context_module)? {
         return Ok(access_info);
     }

--- a/crates/cairo-lang-starknet/src/analyzer.rs
+++ b/crates/cairo-lang-starknet/src/analyzer.rs
@@ -199,7 +199,7 @@ fn analyze_storage_struct<'db>(
                          `#[storage_node]`, or use valid args for `Vec` or `Map` library types. \
                          To suppress this warning, use \
                          `#[allow(starknet::invalid_storage_member_types)]`.",
-                        inference_error.format(db)
+                        inference_error.format(db, struct_id.parent_module(db))
                     ),
                 ));
             }

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/diagnostics
@@ -924,7 +924,7 @@ impl StorageStorageBaseMutDrop<> of core::traits::Drop::<StorageStorageBaseMut>;
 impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
 
 //! > expected_diagnostics
-error[E2311]: Trait has no implementation in context: core::serde::Serde::<test::MyType>.
+error[E2311]: Trait has no implementation in context: Serde::<crate::MyType>.
  --> lib.cairo:5:5
     #[external(v0)]
     ^^^^^^^^^^^^^^^
@@ -1135,7 +1135,7 @@ impl StorageStorageBaseMutDrop<> of core::traits::Drop::<StorageStorageBaseMut>;
 impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "(core::felt252, core::felt252)", found: "()".
+error[E2042]: Unexpected return type. Expected: "(felt252, felt252)", found: "()".
  --> lib.cairo:6:59
     fn foo(ref self: ContractState) -> (felt252, felt252) {}
                                                           ^^
@@ -1363,7 +1363,7 @@ error[E0006]: Type not found.
     #[external(v0)]
     ^^^^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: core::serde::Serde::<<missing>>.
+error[E2311]: Trait has no implementation in context: Serde::<<missing>>.
  --> lib.cairo:5:5
     #[external(v0)]
     ^^^^^^^^^^^^^^^
@@ -1372,8 +1372,8 @@ error[E3002]: Variable not dropped.
  --> lib.cairo:6:40
     fn foo<T>(ref self: ContractState, x: T) {}
                                        ^
-note: Trait has no implementation in context: core::traits::Drop::<T>.
-note: Trait has no implementation in context: core::traits::Destruct::<T>.
+note: Trait has no implementation in context: Drop::<T>.
+note: Trait has no implementation in context: Destruct::<T>.
 
 //! > ==========================================================================
 
@@ -1592,7 +1592,7 @@ impl StorageStorageBaseMutDrop<> of core::traits::Drop::<StorageStorageBaseMut>;
 impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
 
 //! > expected_diagnostics
-error[E2042]: Unexpected return type. Expected: "(core::felt252, core::felt252)", found: "()".
+error[E2042]: Unexpected return type. Expected: "(felt252, felt252)", found: "()".
  --> lib.cairo:8:29
     ) -> (felt252, felt252) {}
                             ^^
@@ -10535,7 +10535,7 @@ mod component3 {
 }
 
 //! > expected_diagnostics
-error[E2041]: Unexpected argument type. Expected: "@test::component3::ComponentState::<?2>", found: "test::component3::ComponentState::<TContractState>".
+error[E2041]: Unexpected argument type. Expected: "@ComponentState::<?2>", found: "ComponentState::<TContractState>".
 It is possible that the type inference failed because the types differ in the number of snapshots.
 Consider adding or removing snapshots.
  --> lib.cairo:55:32
@@ -10562,7 +10562,7 @@ error[E2005]: Expected variable or constant, found impl.
             get_dep_component!(Comp1, Comp1).foo1();
                                ^^^^^
 
-error[E0002]: Method `foo1` not found on type `@test::component2::ComponentState::<TContractState>`. Did you import the correct trait and impl?
+error[E0002]: Method `foo1` not found on type `@crate::component2::ComponentState::<TContractState>`. Did you import the correct trait and impl?
  --> lib.cairo:59:46
             get_dep_component!(@self, Comp2).foo1();
                                              ^^^^
@@ -10572,7 +10572,7 @@ error[E2086]: Invalid path.
             get_dep_component!(@self, super::NotHasComponent).foo1();
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "@test::component3::ComponentState::<?14>", found: "core::felt252".
+error[E2041]: Unexpected argument type. Expected: "@ComponentState::<?14>", found: "felt252".
 It is possible that the type inference failed because the types differ in the number of snapshots.
 Consider adding or removing snapshots.
  --> lib.cairo:62:32
@@ -12052,8 +12052,8 @@ error[E2079]: ref argument must be a variable.
             get_dep_component_mut!(ref Comp1, Comp1).foo1();
                                        ^^^^^
 
-error[E0002]: Method `foo1` could not be called on type `test::component2::ComponentState::<TContractState>`.
-Candidate `test::component1::Comp1HelperTrait::foo1` inference failed with: Type mismatch: `test::component2::ComponentState::<TContractState>` and `@test::component1::ComponentState::<?8>`.
+error[E0002]: Method `foo1` could not be called on type `crate::component2::ComponentState::<TContractState>`.
+Candidate `crate::component1::Comp1HelperTrait::foo1` inference failed with: Type mismatch: `crate::component2::ComponentState::<TContractState>` and `@crate::component1::ComponentState::<?8>`.
  --> lib.cairo:54:53
             get_dep_component_mut!(ref self, Comp2).foo1();
                                                     ^^^^
@@ -13383,15 +13383,15 @@ mod contract {
 }
 
 //! > expected_diagnostics
-error[E0002]: Method `write` could not be called on type `core::starknet::storage::storage_base::StorageBase::<core::felt252>`.
-Candidate `core::starknet::storage::map::StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::map::StorageMapWriteAccess::<core::starknet::storage::storage_base::StorageBase::<core::felt252>>.
-Candidate `core::starknet::storage::StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::StoragePointerWriteAccess::<core::starknet::storage::storage_base::StorageBase::<core::felt252>>.
-Candidate `core::starknet::storage::map::StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::map::StorageMapWriteAccess::<core::starknet::storage::StoragePath::<core::felt252>>.
-Candidate `core::starknet::storage::StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::StoragePointerWriteAccess::<core::starknet::storage::StoragePath::<core::felt252>>.
-Candidate `core::starknet::storage::map::StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::map::StorageMapWriteAccess::<core::starknet::storage::StoragePointer0Offset::<core::felt252>>.
-Candidate `core::starknet::storage::StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::StoragePointerWriteAccess::<core::starknet::storage::StoragePointer0Offset::<core::felt252>>.
-Candidate `core::starknet::storage::map::StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::map::StorageMapWriteAccess::<core::starknet::storage::StoragePointer::<core::felt252>>.
-Candidate `core::starknet::storage::StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::StoragePointerWriteAccess::<core::starknet::storage::StoragePointer::<core::felt252>>.
+error[E0002]: Method `write` could not be called on type `starknet::storage::storage_base::StorageBase::<felt252>`.
+Candidate `StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: StorageMapWriteAccess::<starknet::storage::storage_base::StorageBase::<felt252>>.
+Candidate `StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: StoragePointerWriteAccess::<starknet::storage::storage_base::StorageBase::<felt252>>.
+Candidate `StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: StorageMapWriteAccess::<starknet::storage::StoragePath::<felt252>>.
+Candidate `StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: StoragePointerWriteAccess::<starknet::storage::StoragePath::<felt252>>.
+Candidate `StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: StorageMapWriteAccess::<starknet::storage::StoragePointer0Offset::<felt252>>.
+Candidate `StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: StoragePointerWriteAccess::<starknet::storage::StoragePointer0Offset::<felt252>>.
+Candidate `StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: StorageMapWriteAccess::<starknet::storage::StoragePointer::<felt252>>.
+Candidate `StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: StoragePointerWriteAccess::<starknet::storage::StoragePointer::<felt252>>.
  --> lib.cairo:18:27
             self.a_member.write(0);
                           ^^^^^
@@ -14364,15 +14364,15 @@ mod contract {
 }
 
 //! > expected_diagnostics
-error[E0002]: Method `write` could not be called on type `core::starknet::storage::storage_base::StorageBase::<core::integer::u32>`.
-Candidate `core::starknet::storage::map::StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::map::StorageMapWriteAccess::<core::starknet::storage::storage_base::StorageBase::<core::integer::u32>>.
-Candidate `core::starknet::storage::StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::StoragePointerWriteAccess::<core::starknet::storage::storage_base::StorageBase::<core::integer::u32>>.
-Candidate `core::starknet::storage::map::StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::map::StorageMapWriteAccess::<core::starknet::storage::StoragePath::<core::integer::u32>>.
-Candidate `core::starknet::storage::StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::StoragePointerWriteAccess::<core::starknet::storage::StoragePath::<core::integer::u32>>.
-Candidate `core::starknet::storage::map::StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::map::StorageMapWriteAccess::<core::starknet::storage::StoragePointer0Offset::<core::integer::u32>>.
-Candidate `core::starknet::storage::StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::StoragePointerWriteAccess::<core::starknet::storage::StoragePointer0Offset::<core::integer::u32>>.
-Candidate `core::starknet::storage::map::StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::map::StorageMapWriteAccess::<core::starknet::storage::StoragePointer::<core::integer::u32>>.
-Candidate `core::starknet::storage::StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: core::starknet::storage::StoragePointerWriteAccess::<core::starknet::storage::StoragePointer::<core::integer::u32>>.
+error[E0002]: Method `write` could not be called on type `starknet::storage::storage_base::StorageBase::<u32>`.
+Candidate `StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: StorageMapWriteAccess::<starknet::storage::storage_base::StorageBase::<u32>>.
+Candidate `StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: StoragePointerWriteAccess::<starknet::storage::storage_base::StorageBase::<u32>>.
+Candidate `StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: StorageMapWriteAccess::<starknet::storage::StoragePath::<u32>>.
+Candidate `StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: StoragePointerWriteAccess::<starknet::storage::StoragePath::<u32>>.
+Candidate `StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: StorageMapWriteAccess::<starknet::storage::StoragePointer0Offset::<u32>>.
+Candidate `StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: StoragePointerWriteAccess::<starknet::storage::StoragePointer0Offset::<u32>>.
+Candidate `StorageMapWriteAccess::write` inference failed with: Trait has no implementation in context: StorageMapWriteAccess::<starknet::storage::StoragePointer::<u32>>.
+Candidate `StoragePointerWriteAccess::write` inference failed with: Trait has no implementation in context: StoragePointerWriteAccess::<starknet::storage::StoragePointer::<u32>>.
  --> lib.cairo:34:40
             self.component_member.data.write();
                                        ^^^^^
@@ -15565,7 +15565,7 @@ mod contract {
 }
 
 //! > expected_diagnostics
-error[E0007]: Type "core::starknet::storage::storage_base::StorageBase::<test::u256Pair>" has no member "a"
+error[E0007]: Type "starknet::storage::storage_base::StorageBase::<crate::u256Pair>" has no member "a"
  --> lib.cairo:59:28
             self.u256_pair.a.read()
                            ^
@@ -17788,8 +17788,8 @@ error[E3002]: Variable not dropped.
  --> lib.cairo:15:13
         let _ = self.field.read();
             ^
-note: Trait has no implementation in context: core::traits::Drop::<test::test_contract::InvalidStorageStruct>.
-note: Trait has no implementation in context: core::traits::Destruct::<test::test_contract::InvalidStorageStruct>.
+note: Trait has no implementation in context: Drop::<InvalidStorageStruct>.
+note: Trait has no implementation in context: Destruct::<InvalidStorageStruct>.
 
 //! > diagnostics
 
@@ -18158,7 +18158,7 @@ error[E0006]: Type not found.
     #[external(v0)]
     ^^^^^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: core::serde::Serde::<<missing>>.
+error[E2311]: Trait has no implementation in context: Serde::<<missing>>.
  --> lib.cairo:6:5
     #[external(v0)]
     ^^^^^^^^^^^^^^^
@@ -18382,12 +18382,12 @@ pub mod my_contract {
 }
 
 //! > expected_diagnostics
-error[E2031]: Parameter type of impl function `Impl::foo` is incompatible with `Interface::foo`. Expected: `core::integer::u256`, actual: `core::felt252`.
+error[E2031]: Parameter type of impl function `Impl::foo` is incompatible with `Interface::foo`. Expected: `u256`, actual: `felt252`.
  --> lib.cairo:15:48
         fn foo(ref self: ContractState, value: felt252) {}
                                                ^^^^^^^
 
-error[E2041]: Unexpected argument type. Expected: "core::integer::u256", found: "core::felt252".
+error[E2041]: Unexpected argument type. Expected: "u256", found: "felt252".
  --> lib.cairo:13:5
     #[abi(embed_v0)]
     ^^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
+++ b/crates/cairo-lang-starknet/src/plugin/plugin_test_data/contracts/new_storage_interface
@@ -4086,7 +4086,7 @@ impl StorageStorageBaseMutDrop<> of core::traits::Drop::<StorageStorageBaseMut>;
 impl StorageStorageBaseMutCopy<> of core::traits::Copy::<StorageStorageBaseMut>;
 
 //! > expected_diagnostics
-warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: core::starknet::storage::ValidStorageTypeTrait::<T>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
+warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: starknet::storage::ValidStorageTypeTrait::<T>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
  --> lib.cairo:61:12
     value: T,
            ^

--- a/crates/cairo-lang-starknet/src/test_data/abi_failures
+++ b/crates/cairo-lang-starknet/src/test_data/abi_failures
@@ -28,7 +28,7 @@ warning[E2200]: Plugin diagnostic: Failed to generate ABI: Event type must deriv
         A: super::A,
         ^^^^^^^^^^^
 
-error[E2311]: Trait has no implementation in context: core::starknet::event::Event::<test::A>.
+error[E2311]: Trait has no implementation in context: starknet::event::Event::<crate::A>.
  --> lib.cairo:10:20
     #[derive(Drop, starknet::Event)]
                    ^^^^^^^^^^^^^^^

--- a/crates/cairo-lang-starknet/src/test_data/storage_path_check
+++ b/crates/cairo-lang-starknet/src/test_data/storage_path_check
@@ -281,17 +281,17 @@ struct InvalidMapStorage {
 }
 
 //! > diagnostics
-warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: core::starknet::storage::ValidStorageTypeTrait::<core::array::Array::<core::felt252>>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
+warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: starknet::storage::ValidStorageTypeTrait::<Array::<felt252>>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
  --> lib.cairo:10:24
     pub invalid_array: Array<felt252>,
                        ^^^^^^^^^^^^^^
 
-warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: core::starknet::storage::ValidStorageTypeTrait::<core::starknet::storage::vec::Vec::<test::InvalidStorageStruct>>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
+warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: starknet::storage::ValidStorageTypeTrait::<starknet::storage::vec::Vec::<InvalidStorageStruct>>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
  --> lib.cairo:21:22
     pub invalid_vec: Vec<InvalidStorageStruct>,
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: core::starknet::storage::ValidStorageTypeTrait::<core::starknet::storage::map::Map::<core::felt252, test::InvalidStorageStruct>>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
+warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: starknet::storage::ValidStorageTypeTrait::<starknet::storage::map::Map::<felt252, InvalidStorageStruct>>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
  --> lib.cairo:31:22
     pub invalid_map: Map<felt252, InvalidStorageStruct>,
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -360,7 +360,7 @@ warning[E2200]: Plugin diagnostic: The path `b` collides with existing path `a`.
     pub b: felt252,
         ^
 
-warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: core::starknet::storage::ValidStorageTypeTrait::<test::InvalidStorageStruct>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
+warning[E2200]: Plugin diagnostic: Missing `ValidStorageTypeTrait` for member type. Inference failed with: `Trait has no implementation in context: starknet::storage::ValidStorageTypeTrait::<InvalidStorageStruct>.`. Possible solutions: implement `Store`, mark type with `#[storage_node]`, or use valid args for `Vec` or `Map` library types. To suppress this warning, use `#[allow(starknet::invalid_storage_member_types)]`.
  --> lib.cairo:16:12
     pub a: InvalidStorageStruct,
            ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Diagnostic messages for type errors, trait implementation failures, and inference errors now display types and paths relative to the context module rather than using fully-qualified `core::` prefixes. For example, `core::traits::Copy::<test::NoSerde>` is now shown as `Copy::<NoSerde>`, and `core::integer::u128` is shown as `u128`. The `InferenceError::format` method, `TraitInferenceErrors::format`, and all diagnostic formatting in `SemanticDiagnostic` now accept a `context_module: ModuleId` parameter and call `contextualized_path` instead of `format` or `full_path` on types, traits, impls, and generic arguments. The borrow checker propagates the context module from the function being checked through to all diagnostic note formatting.

---

## Type of change

Please check **one**:

- [x] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Diagnostic messages previously displayed fully-qualified paths such as `core::traits::Drop::<test::NonCopy>` even when the referenced types were in scope or were primitive types. This made error messages unnecessarily verbose and harder to read, especially for common types like `felt252`, `u32`, `bool`, `Option`, `Array`, etc.

---

## What was the behavior or documentation before?

Errors referenced types with their full module paths, e.g.:
```
Trait has no implementation in context: core::traits::Copy::<test::ADrop>.
Unexpected return type. Expected: "core::integer::u128", found: "core::felt252".
```

---

## What is the behavior or documentation after?

Errors now display types relative to the context module, e.g.:
```
Trait has no implementation in context: Copy::<ADrop>.
Unexpected return type. Expected: "u128", found: "felt252".
```

---

## Related issue or discussion (if any)

---

## Additional context

The `context_module` is derived from the parent module of the semantic function being analyzed and is threaded through `borrow_check`, `borrow_check_possible_withdraw_gas`, and all diagnostic formatting call sites. Items from external crates that are not directly accessible from the context module retain enough path prefix to remain unambiguous (e.g., `starknet::storage::StoragePath::<felt252>`).