### PR TITLE
(refactor): replace ark with lambdaworks for secp syscalls in runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,137 +102,6 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
-name = "ark-ec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
-dependencies = [
- "ahash",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "educe",
- "fnv",
- "hashbrown 0.17.1",
- "itertools 0.14.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
-dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
- "digest 0.10.7",
- "educe",
- "num-bigint",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
-dependencies = [
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
-dependencies = [
- "ahash",
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "educe",
- "fnv",
- "hashbrown 0.17.1",
-]
-
-[[package]]
-name = "ark-secp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41b34e9124731f4834db5a8f92ce085a47cd6f006fdb50359ea508d6256341d"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
-name = "ark-secp256r1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e7450e67fdd507af9e1b70dbabffe335d425cbcdeb531b8979b3a8e838fd78"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
-dependencies = [
- "ark-serialize-derive",
- "ark-std",
- "digest 0.10.7",
- "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
-dependencies = [
- "num-traits",
- "rand 0.8.7",
-]
 
 [[package]]
 name = "arrayvec"
@@ -860,9 +717,6 @@ dependencies = [
 name = "cairo-lang-runner"
 version = "2.20.0"
 dependencies = [
- "ark-ff",
- "ark-secp256k1",
- "ark-secp256r1",
  "cairo-lang-casm",
  "cairo-lang-compiler",
  "cairo-lang-defs",
@@ -880,6 +734,7 @@ dependencies = [
  "indoc",
  "itertools 0.15.0",
  "keccak 0.2.0",
+ "lambdaworks-math",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1793,18 +1648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "educe"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,26 +1687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,10 +99,6 @@ version = "2.20.0"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
-ark-ff = "0.6.0"
-ark-secp256k1 = "0.6.0"
-ark-secp256r1 = "0.6.0"
-ark-std = "0.6.0"
 assert_matches = "1.5"
 bimap = "0.6.3"
 cairo-lang-primitive-token = "1"
@@ -127,6 +123,7 @@ indoc = "2.0.6"
 itertools = { version = "0.15.0", default-features = false }
 keccak = "0.2.0"
 lalrpop-util = { version = "0.23.1", features = ["lexer"] }
+lambdaworks-math = { version = "0.13.0", default-features = false }
 log = "0.4.27"
 mimalloc = { version = "0.1.48" }
 num-bigint = { version = "0.4.6", default-features = false }

--- a/crates/cairo-lang-runner/Cargo.toml
+++ b/crates/cairo-lang-runner/Cargo.toml
@@ -7,10 +7,6 @@ license-file.workspace = true
 description = "Basic cairo runner."
 
 [dependencies]
-ark-ff.workspace = true
-ark-secp256k1.workspace = true
-ark-secp256r1.workspace = true
-
 cairo-lang-casm = { path = "../cairo-lang-casm", version = "=2.20.0" }
 cairo-lang-lowering = { path = "../cairo-lang-lowering", version = "=2.20.0" }
 cairo-lang-runnable-utils = { path = "../cairo-lang-runnable-utils", version = "=2.20.0" }
@@ -23,6 +19,7 @@ cairo-vm.workspace = true
 clap.workspace = true
 itertools = { workspace = true, default-features = true }
 keccak.workspace = true
+lambdaworks-math.workspace = true
 num-bigint = { workspace = true, default-features = true }
 num-integer.workspace = true
 num-traits = { workspace = true, default-features = true }
@@ -41,6 +38,3 @@ cairo-lang-test-utils = { path = "../cairo-lang-test-utils", features = ["testin
 indoc.workspace = true
 test-case.workspace = true
 tracing.workspace = true
-
-[package.metadata.cargo-machete]
-ignored = ["ark-secp256k1", "ark-secp256r1"]

--- a/crates/cairo-lang-runner/src/casm_run/mod.rs
+++ b/crates/cairo-lang-runner/src/casm_run/mod.rs
@@ -5,9 +5,6 @@ use std::ops::{Shl, Sub};
 use std::sync::Arc;
 use std::vec::IntoIter;
 
-use ark_ff::{BigInteger, PrimeField};
-use ark_secp256k1 as secp256k1;
-use ark_secp256r1 as secp256r1;
 use cairo_lang_casm::hints::{CoreHint, DeprecatedHint, ExternalHint, Hint, StarknetHint};
 use cairo_lang_casm::operand::{
     BinOpOperand, CellRef, DerefOrImmediate, Operation, Register, ResOperand,
@@ -39,7 +36,15 @@ use cairo_vm::vm::runners::cairo_runner::{
 use cairo_vm::vm::trace::trace_entry::RelocatedTraceEntry;
 use cairo_vm::vm::vm_core::VirtualMachine;
 use dict_manager::DictManagerExecScope;
-use itertools::Itertools;
+use itertools::{Itertools, chain};
+use lambdaworks_math::cyclic_group::IsGroup;
+use lambdaworks_math::elliptic_curve::short_weierstrass::curves::secp256k1::curve::Secp256k1Curve;
+use lambdaworks_math::elliptic_curve::short_weierstrass::curves::secp256r1::curve::Secp256r1Curve;
+use lambdaworks_math::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
+use lambdaworks_math::elliptic_curve::short_weierstrass::traits::IsShortWeierstrass;
+use lambdaworks_math::field::element::FieldElement;
+use lambdaworks_math::field::traits::{IsField, IsPrimeField};
+use lambdaworks_math::unsigned_integer::element::U256;
 use num_bigint::{BigInt, BigUint};
 use num_integer::{ExtendedGcd, Integer};
 use num_traits::{Signed, ToPrimitive, Zero};
@@ -75,7 +80,7 @@ pub fn hint_to_hint_params(hint: &Hint) -> HintParams {
 struct Secp256k1ExecutionScope {
     /// All elliptic curve points provided by the secp256k1 syscalls.
     /// The id of a point is the index in the vector.
-    ec_points: Vec<secp256k1::Affine>,
+    ec_points: Vec<ShortWeierstrassProjectivePoint<Secp256k1Curve>>,
 }
 
 /// Helper object to allocate and track Secp256r1 elliptic curve points.
@@ -83,7 +88,7 @@ struct Secp256k1ExecutionScope {
 struct Secp256r1ExecutionScope {
     /// All elliptic curve points provided by the secp256r1 syscalls.
     /// The id of a point is the index in the vector.
-    ec_points: Vec<secp256r1::Affine>,
+    ec_points: Vec<ShortWeierstrassProjectivePoint<Secp256r1Curve>>,
 }
 
 /// HintProcessor for Cairo compiler hints.
@@ -590,8 +595,10 @@ impl<'a> MemBuffer<'a> {
     /// it by two.
     /// Fails with `MemoryError` if any of the next two values are not felt252s.
     /// Panics if any of the next two values are not u128.
-    pub fn next_u256(&mut self) -> Result<BigUint, MemoryError> {
-        Ok(self.next_u128()? + BigUint::from(self.next_u128()?).shl(128))
+    pub fn next_u256(&mut self) -> Result<U256, MemoryError> {
+        let low = self.next_u128()?;
+        let high = self.next_u128()?;
+        Ok(U256::from_limbs([(high >> 64) as u64, high as u64, (low >> 64) as u64, low as u64]))
     }
 
     /// Returns the address value in the current position of the buffer and advances it by one.
@@ -1500,30 +1507,12 @@ fn sha_512_process_block(
 /// Executes the `secp256k1_new_syscall` syscall.
 fn secp256k1_new(
     gas_counter: &mut usize,
-    x: BigUint,
-    y: BigUint,
+    x: U256,
+    y: U256,
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256K1_NEW);
-    let modulus = <secp256k1::Fq as PrimeField>::MODULUS.into();
-    if x >= modulus || y >= modulus {
-        fail_syscall!(b"Coordinates out of range");
-    }
-    let p = if x.is_zero() && y.is_zero() {
-        secp256k1::Affine::identity()
-    } else {
-        secp256k1::Affine::new_unchecked(x.into(), y.into())
-    };
-    Ok(SyscallResult::Success(
-        if !(p.is_on_curve() && p.is_in_correct_subgroup_assuming_on_curve()) {
-            vec![1.into(), 0.into()]
-        } else {
-            let ec = get_secp256k1_exec_scope(exec_scopes)?;
-            let id = ec.ec_points.len();
-            ec.ec_points.push(p);
-            vec![0.into(), id.into()]
-        },
-    ))
+    secp_new(x, y, &mut get_secp256k1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Executes the `secp256k1_add_syscall` syscall.
@@ -1534,59 +1523,29 @@ fn secp256k1_add(
     p1_id: usize,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256K1_ADD);
-    let ec = get_secp256k1_exec_scope(exec_scopes)?;
-    let p0 = &ec.ec_points[p0_id];
-    let p1 = &ec.ec_points[p1_id];
-    let sum = *p0 + *p1;
-    let id = ec.ec_points.len();
-    ec.ec_points.push(sum.into());
-    Ok(SyscallResult::Success(vec![id.into()]))
+    secp_add(p0_id, p1_id, &mut get_secp256k1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Executes the `secp256k1_mul_syscall` syscall.
 fn secp256k1_mul(
     gas_counter: &mut usize,
     p_id: usize,
-    scalar: BigUint,
+    scalar: U256,
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256K1_MUL);
-
-    let ec = get_secp256k1_exec_scope(exec_scopes)?;
-    let p = &ec.ec_points[p_id];
-    let product = *p * secp256k1::Fr::from(scalar);
-    let id = ec.ec_points.len();
-    ec.ec_points.push(product.into());
-    Ok(SyscallResult::Success(vec![id.into()]))
+    secp_mul(p_id, scalar, &mut get_secp256k1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Executes the `secp256k1_get_point_from_x_syscall` syscall.
 fn secp256k1_get_point_from_x(
     gas_counter: &mut usize,
-    x: BigUint,
+    x: U256,
     y_parity: bool,
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256K1_GET_POINT_FROM_X);
-    if x >= <secp256k1::Fq as PrimeField>::MODULUS.into() {
-        fail_syscall!(b"Coordinates out of range");
-    }
-    let x = x.into();
-    let maybe_p = secp256k1::Affine::get_ys_from_x_unchecked(x)
-        .map(
-            |(smaller, greater)|
-            // Return the correct y coordinate based on the parity.
-            if smaller.into_bigint().is_odd() == y_parity { smaller } else { greater },
-        )
-        .map(|y| secp256k1::Affine::new_unchecked(x, y))
-        .filter(|p| p.is_in_correct_subgroup_assuming_on_curve());
-    let Some(p) = maybe_p else {
-        return Ok(SyscallResult::Success(vec![1.into(), 0.into()]));
-    };
-    let ec = get_secp256k1_exec_scope(exec_scopes)?;
-    let id = ec.ec_points.len();
-    ec.ec_points.push(p);
-    Ok(SyscallResult::Success(vec![0.into(), id.into()]))
+    secp_get_point_from_x(x, y_parity, &mut get_secp256k1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Executes the `secp256k1_get_xy_syscall` syscall.
@@ -1596,17 +1555,7 @@ fn secp256k1_get_xy(
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256K1_GET_XY);
-    let ec = get_secp256k1_exec_scope(exec_scopes)?;
-    let p = &ec.ec_points[p_id];
-    let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
-    let (x1, x0) = BigUint::from(p.x).div_rem(&pow_2_128);
-    let (y1, y0) = BigUint::from(p.y).div_rem(&pow_2_128);
-    Ok(SyscallResult::Success(vec![
-        Felt252::from(x0).into(),
-        Felt252::from(x1).into(),
-        Felt252::from(y0).into(),
-        Felt252::from(y1).into(),
-    ]))
+    secp_get_xy(p_id, &get_secp256k1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Returns the `Secp256k1ExecScope` managing the different active points.
@@ -1627,30 +1576,12 @@ fn get_secp256k1_exec_scope(
 /// Executes the `secp256r1_new_syscall` syscall.
 fn secp256r1_new(
     gas_counter: &mut usize,
-    x: BigUint,
-    y: BigUint,
+    x: U256,
+    y: U256,
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256R1_NEW);
-    let modulus = <secp256r1::Fq as PrimeField>::MODULUS.into();
-    if x >= modulus || y >= modulus {
-        fail_syscall!(b"Coordinates out of range");
-    }
-    let p = if x.is_zero() && y.is_zero() {
-        secp256r1::Affine::identity()
-    } else {
-        secp256r1::Affine::new_unchecked(x.into(), y.into())
-    };
-    Ok(SyscallResult::Success(
-        if !(p.is_on_curve() && p.is_in_correct_subgroup_assuming_on_curve()) {
-            vec![1.into(), 0.into()]
-        } else {
-            let ec = get_secp256r1_exec_scope(exec_scopes)?;
-            let id = ec.ec_points.len();
-            ec.ec_points.push(p);
-            vec![0.into(), id.into()]
-        },
-    ))
+    secp_new(x, y, &mut get_secp256r1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Executes the `secp256r1_add_syscall` syscall.
@@ -1661,59 +1592,29 @@ fn secp256r1_add(
     p1_id: usize,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256R1_ADD);
-    let ec = get_secp256r1_exec_scope(exec_scopes)?;
-    let p0 = &ec.ec_points[p0_id];
-    let p1 = &ec.ec_points[p1_id];
-    let sum = *p0 + *p1;
-    let id = ec.ec_points.len();
-    ec.ec_points.push(sum.into());
-    Ok(SyscallResult::Success(vec![id.into()]))
+    secp_add(p0_id, p1_id, &mut get_secp256r1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Executes the `secp256r1_mul_syscall` syscall.
 fn secp256r1_mul(
     gas_counter: &mut usize,
     p_id: usize,
-    scalar: BigUint,
+    scalar: U256,
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256R1_MUL);
-
-    let ec = get_secp256r1_exec_scope(exec_scopes)?;
-    let p = &ec.ec_points[p_id];
-    let product = *p * secp256r1::Fr::from(scalar);
-    let id = ec.ec_points.len();
-    ec.ec_points.push(product.into());
-    Ok(SyscallResult::Success(vec![id.into()]))
+    secp_mul(p_id, scalar, &mut get_secp256r1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Executes the `secp256r1_get_point_from_x_syscall` syscall.
 fn secp256r1_get_point_from_x(
     gas_counter: &mut usize,
-    x: BigUint,
+    x: U256,
     y_parity: bool,
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256R1_GET_POINT_FROM_X);
-    if x >= <secp256r1::Fq as PrimeField>::MODULUS.into() {
-        fail_syscall!(b"Coordinates out of range");
-    }
-    let x = x.into();
-    let maybe_p = secp256r1::Affine::get_ys_from_x_unchecked(x)
-        .map(
-            |(smaller, greater)|
-            // Return the correct y coordinate based on the parity.
-            if smaller.into_bigint().is_odd() == y_parity { smaller } else { greater },
-        )
-        .map(|y| secp256r1::Affine::new_unchecked(x, y))
-        .filter(|p| p.is_in_correct_subgroup_assuming_on_curve());
-    let Some(p) = maybe_p else {
-        return Ok(SyscallResult::Success(vec![1.into(), 0.into()]));
-    };
-    let ec = get_secp256r1_exec_scope(exec_scopes)?;
-    let id = ec.ec_points.len();
-    ec.ec_points.push(p);
-    Ok(SyscallResult::Success(vec![0.into(), id.into()]))
+    secp_get_point_from_x(x, y_parity, &mut get_secp256r1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Executes the `secp256r1_get_xy_syscall` syscall.
@@ -1723,17 +1624,7 @@ fn secp256r1_get_xy(
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<SyscallResult, HintError> {
     deduct_gas!(gas_counter, SECP256R1_GET_XY);
-    let ec = get_secp256r1_exec_scope(exec_scopes)?;
-    let p = &ec.ec_points[p_id];
-    let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
-    let (x1, x0) = BigUint::from(p.x).div_rem(&pow_2_128);
-    let (y1, y0) = BigUint::from(p.y).div_rem(&pow_2_128);
-    Ok(SyscallResult::Success(vec![
-        Felt252::from(x0).into(),
-        Felt252::from(x1).into(),
-        Felt252::from(y0).into(),
-        Felt252::from(y1).into(),
-    ]))
+    secp_get_xy(p_id, &get_secp256r1_exec_scope(exec_scopes)?.ec_points)
 }
 
 /// Returns the `Secp256r1ExecScope` managing the different active points.
@@ -1749,7 +1640,117 @@ fn get_secp256r1_exec_scope(
     exec_scopes.get_mut_ref::<Secp256r1ExecutionScope>(NAME)
 }
 
-// ---
+/// Creates a new point on the curve `C` and adds it to `ec_points`.
+///
+/// Note that both secp curves have cofactor 1, so checking the curve equation is enough to
+/// validate group membership.
+fn secp_new<C>(
+    x: U256,
+    y: U256,
+    ec_points: &mut Vec<ShortWeierstrassProjectivePoint<C>>,
+) -> Result<SyscallResult, HintError>
+where
+    C: IsShortWeierstrass,
+    C::BaseField: IsPrimeField<RepresentativeType = U256> + IsField<BaseType = U256>,
+{
+    let modulus_minus_one = C::BaseField::modulus_minus_one();
+    if x > modulus_minus_one || y > modulus_minus_one {
+        fail_syscall!(b"Coordinates out of range");
+    }
+    let maybe_p = if chain!(&x.limbs, &y.limbs).all(|l| *l == 0) {
+        Some(ShortWeierstrassProjectivePoint::neutral_element())
+    } else {
+        ShortWeierstrassProjectivePoint::new([
+            FieldElement::new(x),
+            FieldElement::new(y),
+            FieldElement::one(),
+        ])
+        .ok()
+    };
+    Ok(SyscallResult::Success(match maybe_p {
+        Some(p) => {
+            let id = ec_points.len();
+            ec_points.push(p);
+            vec![0.into(), id.into()]
+        }
+        None => vec![1.into(), 0.into()],
+    }))
+}
+
+/// Adds the points at `p0_id` and `p1_id`, and adds the result to `ec_points`.
+fn secp_add<C: IsShortWeierstrass>(
+    p0_id: usize,
+    p1_id: usize,
+    ec_points: &mut Vec<ShortWeierstrassProjectivePoint<C>>,
+) -> Result<SyscallResult, HintError> {
+    let sum = ec_points[p0_id].operate_with(&ec_points[p1_id]);
+    let id = ec_points.len();
+    ec_points.push(sum);
+    Ok(SyscallResult::Success(vec![id.into()]))
+}
+
+/// Multiplies the point at `p_id` by `scalar`, and adds the result to `ec_points`.
+fn secp_mul<C: IsShortWeierstrass>(
+    p_id: usize,
+    scalar: U256,
+    ec_points: &mut Vec<ShortWeierstrassProjectivePoint<C>>,
+) -> Result<SyscallResult, HintError> {
+    // No need to reduce the scalar by the curve order, as multiplying by it gives the same point.
+    let product = ec_points[p_id].operate_with_self(scalar);
+    let id = ec_points.len();
+    ec_points.push(product);
+    Ok(SyscallResult::Success(vec![id.into()]))
+}
+
+/// Finds a point on the curve `C` with the given `x` coordinate and `y` parity, and adds it to
+/// `ec_points`.
+fn secp_get_point_from_x<C>(
+    x: U256,
+    y_parity: bool,
+    ec_points: &mut Vec<ShortWeierstrassProjectivePoint<C>>,
+) -> Result<SyscallResult, HintError>
+where
+    C: IsShortWeierstrass,
+    C::BaseField: IsPrimeField<RepresentativeType = U256> + IsField<BaseType = U256>,
+{
+    if x > C::BaseField::modulus_minus_one() {
+        fail_syscall!(b"Coordinates out of range");
+    }
+    let x = FieldElement::new(x);
+    // Solve the curve equation `y^2 = x^3 + ax + b` for `y`.
+    let Some((y0, y1)) = ((x.square() + C::a()) * &x + C::b()).sqrt() else {
+        // No point on the curve with the given `x`.
+        return Ok(SyscallResult::Success(vec![1.into(), 0.into()]));
+    };
+    // The roots are `y` and `modulus - y`, and as the modulus is odd, exactly one of them is odd.
+    let y0_is_odd = y0.representative().limbs[3] & 1 == 1;
+    let y = if y0_is_odd == y_parity { y0 } else { y1 };
+    let p = ShortWeierstrassProjectivePoint::new([x, y, FieldElement::one()]).unwrap();
+    let id = ec_points.len();
+    ec_points.push(p);
+    Ok(SyscallResult::Success(vec![0.into(), id.into()]))
+}
+
+/// Returns the coordinates of the point at `p_id`, as pairs of 128-bit limbs.
+fn secp_get_xy<C>(
+    p_id: usize,
+    ec_points: &[ShortWeierstrassProjectivePoint<C>],
+) -> Result<SyscallResult, HintError>
+where
+    C: IsShortWeierstrass,
+    C::BaseField: IsPrimeField<RepresentativeType = U256> + IsField<BaseType = U256>,
+{
+    let p = &ec_points[p_id];
+    if p.is_neutral_element() {
+        return Ok(SyscallResult::Success(vec![Felt252::ZERO.into(); 4]));
+    }
+    let p = p.to_affine();
+    let merge = |l0: u64, l1: u64| Felt252::from(((l1 as u128) << 64) + l0 as u128).into();
+    let split = |U256 { limbs: [l3, l2, l1, l0] }: U256| [merge(l0, l1), merge(l2, l3)];
+    let [x0, x1] = split(p.x().representative());
+    let [y0, y1] = split(p.y().representative());
+    Ok(SyscallResult::Success(vec![x0, x1, y0, y1]))
+}
 
 pub fn execute_core_hint_base(
     vm: &mut VirtualMachine,


### PR DESCRIPTION
### TL;DR

Replace `ark-*` crates with `lambdaworks-math` for secp256k1/r1 elliptic curve operations in the Cairo runner.

### What changed?

The `ark-ff`, `ark-secp256k1`, `ark-secp256r1`, and `ark-std` dependencies (along with their transitive dependencies such as `ahash`, `educe`, `enum-ordinalize`, and the full `ark-*` ecosystem) have been removed and replaced with `lambdaworks-math`.

The secp256k1 and secp256r1 execution scopes now store `ShortWeierstrassProjectivePoint` types instead of `ark` affine points. The previously duplicated per-curve implementations of `secp256k1_new`, `secp256k1_add`, `secp256k1_mul`, `secp256k1_get_point_from_x`, `secp256k1_get_xy` (and their `secp256r1` counterparts) have been consolidated into shared generic functions — `secp_new`, `secp_add`, `secp_mul`, `secp_get_point_from_x`, and `secp_get_xy` — parameterized over the curve type.

The `next_u256` buffer method now returns a `U256` (from `lambdaworks-math`) instead of a `BigUint`, and scalar/coordinate arguments throughout the secp syscall handlers have been updated accordingly. The `secp_get_xy` function now handles the neutral element explicitly and uses `U256` limb splitting directly rather than `BigUint` division.

### How to test?

Run the existing test suite for `cairo-lang-runner`:

```
cargo test -p cairo-lang-runner
```

### Why make this change?

The `ark-*` crates pulled in a large set of heavy dependencies. Switching to `lambdaworks-math` reduces the dependency footprint significantly while also allowing the duplicated secp256k1 and secp256r1 logic to be unified into shared generic implementations, reducing code duplication and improving maintainability.