### PR TITLE
(fix): don't prelude-shorten diagnostic paths shadowed by local items

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
+++ b/crates/cairo-lang-semantic/src/diagnostic_test_data/tests
@@ -1094,6 +1094,34 @@ INACCESSIBLE
 
 //! > ==========================================================================
 
+//! > Testing prelude name shadowed by a local item
+
+//! > test_runner_name
+test_expr_diagnostics(expect_diagnostics: true)
+
+//! > crate_settings
+edition = "2024_07"
+
+//! > module_code
+struct u128 {}
+
+//! > function_body
+
+//! > expr_code
+{
+    let _x: core::integer::u128 = 1_felt252;
+}
+
+//! > expected_semantics
+
+//! > expected_diagnostics
+error[E2041]: Unexpected argument type. Expected: "core::integer::u128", found: "felt252".
+ --> lib.cairo:4:35
+    let _x: core::integer::u128 = 1_felt252;
+                                  ^^^^^^^^^
+
+//! > ==========================================================================
+
 //! > Testing use star inaccessible item through a crate root
 
 //! > test_runner_name

--- a/crates/cairo-lang-semantic/src/path.rs
+++ b/crates/cairo-lang-semantic/src/path.rs
@@ -107,11 +107,11 @@ fn get_contextualized_path<'db>(
         return Ok(ItemAccessInfo::new(ItemAccessKind::FullPath(crate_id), vec![], item.name(db)));
     }
 
-    if let Some(access_info) = check_prelude(db, item, context_module)? {
+    let mut resolver = Resolver::new(db, context_module, InferenceId::NoContext);
+
+    if let Some(access_info) = check_prelude(db, item, context_module, &mut resolver)? {
         return Ok(access_info);
     }
-
-    let mut resolver = Resolver::new(db, context_module, InferenceId::NoContext);
 
     // Try to find the item in the context module (includes use statements, macro expansions,
     // and star uses)
@@ -139,7 +139,7 @@ fn get_contextualized_path<'db>(
         }
 
         // Check if the ancestor is in the prelude.
-        if let Some(access_info) = check_prelude(db, *ancestor, context_module)? {
+        if let Some(access_info) = check_prelude(db, *ancestor, context_module, &mut resolver)? {
             let mut res_path_segments = path_items[..i + 1].iter().copied().collect_vec();
             res_path_segments.extend(access_info.path_segments);
             return Ok(ItemAccessInfo::new(
@@ -161,11 +161,13 @@ fn get_contextualized_path<'db>(
     Ok(ItemAccessInfo::new(ItemAccessKind::FullPath(owning_crate), path_items, item_name))
 }
 
-/// Check if the given item is in the prelude module.
+/// Check if the given item is in the prelude module, and its name is not shadowed by a different
+/// item in the context module.
 fn check_prelude<'db>(
     db: &'db dyn Database,
     item: ImportableId<'db>,
     context_module: ModuleId<'db>,
+    resolver: &mut Resolver<'db>,
 ) -> Maybe<Option<ItemAccessInfo<'db>>> {
     let settings = db
         .crate_config(context_module.owning_crate(db))
@@ -222,6 +224,16 @@ fn check_prelude<'db>(
         };
 
         if is_prelude {
+            // A different item bound to the same name in the context module shadows the prelude
+            // item, making the short name refer to the wrong item.
+            if let Some(info) = resolver.resolve_item_in_module(context_module, item.name(db))
+                && !matches!(
+                    info.item_id.try_into(),
+                    Ok::<ImportableId<'_>, _>(found_item) if found_item == item
+                )
+            {
+                return Ok(None);
+            }
             return Ok(Some(ItemAccessInfo::new(
                 ItemAccessKind::ViaPrelude,
                 vec![],


### PR DESCRIPTION
### TL;DR

Fix incorrect short-path resolution when a local item shadows a prelude item with the same name.

### What changed?

`check_prelude` now accepts a `Resolver` and verifies that the prelude item's name is not shadowed by a different item in the context module before returning a short (prelude-based) path. If a local item with the same name exists and resolves to a different item than the prelude one, `check_prelude` returns `None`, falling back to the full path. The `Resolver` is also initialized before the first `check_prelude` call so it can be reused across both call sites.

A new diagnostic test case was added to confirm that when a local `struct u128 {}` shadows the prelude's `u128`, the compiler correctly uses the full path `core::integer::u128` and emits a type mismatch error rather than silently resolving to the wrong type.

### How to test?

Run the semantic diagnostic tests:

```
cargo test -p cairo-lang-semantic
```

The new test case `Testing prelude name shadowed by a local item` should pass, confirming that a locally defined type shadowing a prelude type does not cause the short prelude path to be used incorrectly.

### Why make this change?

Previously, if a module defined an item with the same name as a prelude item (e.g., `struct u128 {}`), the path resolver could still emit the short prelude-based name for the original prelude item, even though that short name would resolve to the local item in that context. This produced misleading or incorrect paths. The fix ensures the short path is only used when it unambiguously refers to the intended item.