### PR TITLE
(opt): check for missing nodes via green tree walk instead of red tree materialization

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -809,7 +809,7 @@ fn expand_inline_macro<'db>(
     let macro_path = syntax.path(db);
     let crate_id = ctx.resolver.owning_crate_id;
     // Skipping expanding an inline macro if it had a parser error.
-    if syntax.as_syntax_node().descendants(db).any(|node| node.kind(db).is_missing()) {
+    if syntax.as_syntax_node().contains_missing(db) {
         return Err(skip_diagnostic());
     }
     // We call the resolver with a new diagnostics, since the diagnostics should not be reported

--- a/crates/cairo-lang-semantic/src/items/macro_declaration.rs
+++ b/crates/cairo-lang-semantic/src/items/macro_declaration.rs
@@ -157,7 +157,7 @@ fn priv_macro_declaration_data<'db>(
         };
         ctx.check_node(expansion.as_syntax_node());
         // Skipping expanding an inline macro if it had a parser error.
-        if pattern.as_syntax_node().descendants(db).any(|node| node.kind(db).is_missing()) {
+        if pattern.as_syntax_node().contains_missing(db) {
             continue;
         }
         rules.push(MacroRuleData { pattern, expansion, err: ctx.rule_err });

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -326,6 +326,21 @@ impl<'a> SyntaxNode<'a> {
         self.data.green(db).long(db)
     }
 
+    /// Returns whether the subtree rooted at this node contains a node of a missing kind, i.e.
+    /// whether it had a parser error.
+    pub fn contains_missing(&self, db: &'a dyn Database) -> bool {
+        /// Whether the green subtree rooted at `green_id` contains a node of a missing kind.
+        /// Walks the green tree directly - materializing the red tree just for this check would
+        /// create (and memoize) a `SyntaxNode` per descendant. Memoized per green id, so shared
+        /// subtrees are walked once.
+        #[salsa::tracked(returns(copy))]
+        fn query<'db>(db: &'db dyn Database, green_id: GreenId<'db>) -> bool {
+            let node = green_id.long(db);
+            node.kind.is_missing() || node.children().iter().any(|child| query(db, *child))
+        }
+        query(db, *self.data.green(db))
+    }
+
     /// Returns the span of the syntax node without trivia.
     pub fn span_without_trivia(&self, db: &dyn Database) -> TextSpan {
         let green_node = self.green_node(db);


### PR DESCRIPTION
Checking a macro subtree for parser errors used descendants(), which
materializes a SyntaxNode tracked struct (a full salsa query per node) for
every descendant. Profiling corelib diagnostics showed this walk alone at
~8% of total CPU. Walking the green tree directly, memoized per green id,
improves cairo-to-diagnostics/corelib by ~10%.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>