### PR TITLE
(opt): key get_children memo on the tracked SyntaxNodeData struct

### DIFF
--- a/crates/cairo-lang-syntax/src/node/db.rs
+++ b/crates/cairo-lang-syntax/src/node/db.rs
@@ -1,4 +1,3 @@
-use cairo_lang_filesystem::ids::Tracked;
 use salsa::Database;
 
 use super::SyntaxNode;
@@ -6,16 +5,7 @@ use super::SyntaxNode;
 pub trait SyntaxGroup: Database {
     /// Query for caching [SyntaxNode::get_children].
     fn get_children<'db>(&'db self, node: SyntaxNode<'db>) -> &'db [SyntaxNode<'db>] {
-        get_children(self.as_dyn_database(), (), node)
+        node.get_children(self.as_dyn_database())
     }
 }
 impl<T: Database + ?Sized> SyntaxGroup for T {}
-
-#[salsa::tracked(returns(ref))]
-fn get_children<'db>(
-    db: &'db dyn Database,
-    _tracked: Tracked,
-    node: SyntaxNode<'db>,
-) -> Vec<SyntaxNode<'db>> {
-    node.get_children_impl(db)
-}

--- a/crates/cairo-lang-syntax/src/node/mod.rs
+++ b/crates/cairo-lang-syntax/src/node/mod.rs
@@ -12,7 +12,6 @@ use self::ast::TriviaGreen;
 use self::green::GreenNode;
 use self::ids::{GreenId, SyntaxStablePtrId};
 use self::kind::SyntaxKind;
-use crate::node::db::SyntaxGroup;
 use crate::node::iter::{Preorder, WalkEvent};
 
 pub mod ast;
@@ -364,7 +363,20 @@ impl<'a> SyntaxNode<'a> {
 
     /// Gets the children syntax nodes of the current node.
     pub fn get_children(&self, db: &'a dyn Database) -> &'a [SyntaxNode<'a>] {
-        db.get_children(*self)
+        /// Keyed on the tracked [`SyntaxNodeData`] struct rather than the full [`SyntaxNode`]
+        /// wrapper, so the memo is attached to the tracked struct instead of interning a key
+        /// tuple per call. The wrapper's other fields are caches derived from `data`, so they
+        /// are reconstructed here.
+        #[salsa::tracked(returns(ref))]
+        fn query<'db>(db: &'db dyn Database, data: SyntaxNodeData<'db>) -> Vec<SyntaxNode<'db>> {
+            let (parent, parent_kind) = match data.id(db) {
+                SyntaxNodeId::Child { parent, .. } => (Some(parent.data), Some(parent.kind)),
+                SyntaxNodeId::Root(_) => (None, None),
+            };
+            let kind = data.green(db).long(db).kind;
+            SyntaxNode { data, parent, kind, parent_kind }.get_children_impl(db)
+        }
+        query(db, self.data)
     }
 
     /// Implementation of [SyntaxNode::get_children].


### PR DESCRIPTION
The query was keyed on ((), SyntaxNode) - a 4-field value struct - so salsa
interned a key tuple per call, and get_children is called on every typed-AST
field access. Keying on the tracked SyntaxNodeData attaches the memo to the
struct (as absolute_offset already does), eliminating the key interning and
most of the sync-table contention: profiling corelib diagnostics showed
sched_yield dropping 11.4s->4.4s and the interned ingredient (plus its 5.1s
teardown drop) disappearing. Improves cairo-to-diagnostics/corelib by ~17%
on top of the green-tree missing-check change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>