### PR TITLE
(opt): memoize lookup-context enrichment for trait solving

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/inference.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference.rs
@@ -25,7 +25,7 @@ use cairo_lang_utils::{Intern, define_short_id, extract_matches};
 use salsa::Database;
 
 use self::canonic::{CanonicalImpl, CanonicalMapping, CanonicalTrait, NoError};
-use self::solver::{Ambiguity, SolutionSet, enrich_lookup_context};
+use self::solver::{Ambiguity, SolutionSet};
 use crate::corelib::{CorelibSemantic, is_valid_literal_type};
 use crate::diagnostic::{SemanticDiagnosticKind, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::inference::canonic::ResultNoErrEx;
@@ -1375,8 +1375,7 @@ impl<'db, 'id> Inference<'db, 'id> {
         let impl_var_trait_item_mappings = self.rewrite(impl_var_trait_item_mappings).no_err();
         // TODO(spapini): This is done twice. Consider doing it only here.
         let concrete_trait_id = self.rewrite(concrete_trait_id).no_err();
-        let mut lookup_context = lookup_context_id.long(self.db).clone();
-        enrich_lookup_context(self.db, concrete_trait_id, &mut lookup_context);
+        let lookup_context = lookup_context_id.enriched(self.db, concrete_trait_id);
 
         // Don't try to resolve impls if the first generic param is a variable.
         let generic_args = concrete_trait_id.generic_args(self.db);
@@ -1411,7 +1410,7 @@ impl<'db, 'id> Inference<'db, 'id> {
         // is consistent.
         let solution_set = match self.db.canonic_trait_solutions(
             canonical_trait,
-            lookup_context.intern(self.db),
+            lookup_context,
             (*self.data.impl_type_bounds).clone(),
         ) {
             Ok(solution_set) => solution_set,

--- a/crates/cairo-lang-semantic/src/expr/inference/solver.rs
+++ b/crates/cairo-lang-semantic/src/expr/inference/solver.rs
@@ -101,7 +101,7 @@ impl<'db> Ambiguity<'db> {
 }
 
 /// Implementation of [SemanticSolver::canonic_trait_solutions].
-/// Assumes the lookup context is already enriched by [enrich_lookup_context].
+/// Assumes the lookup context is already enriched by [ImplLookupContextId::enriched].
 pub fn canonic_trait_solutions<'db>(
     db: &'db dyn Database,
     canonical_trait: CanonicalTrait<'db>,
@@ -134,7 +134,7 @@ pub fn canonic_trait_solutions<'db>(
 }
 
 /// Query implementation of [SemanticSolver::canonic_trait_solutions].
-/// Assumes the lookup context is already enriched by [enrich_lookup_context].
+/// Assumes the lookup context is already enriched by [ImplLookupContextId::enriched].
 #[salsa::tracked(returns(clone), cycle_result=canonic_trait_solutions_cycle)]
 pub fn canonic_trait_solutions_tracked<'db>(
     db: &'db dyn Database,
@@ -156,21 +156,36 @@ pub fn canonic_trait_solutions_cycle<'db>(
     Err(InferenceError::Cycle(InferenceVar::Impl(LocalImplVarId(0))))
 }
 
-/// Adds the defining module of the trait and the generic arguments to the lookup context.
-pub fn enrich_lookup_context<'db>(
-    db: &'db dyn Database,
-    concrete_trait_id: ConcreteTraitId<'db>,
-    lookup_context: &mut ImplLookupContext<'db>,
-) {
-    lookup_context.insert_module(concrete_trait_id.trait_id(db).parent_module(db), db);
-    let generic_args = concrete_trait_id.generic_args(db);
-    // Add the defining module of the generic args to the lookup.
-    for generic_arg in generic_args {
-        if let GenericArgumentId::Type(ty) = generic_arg {
-            enrich_lookup_context_with_ty(db, *ty, lookup_context);
+impl<'db> ImplLookupContextId<'db> {
+    /// Returns this context enriched for `concrete_trait_id`: with the defining modules of the
+    /// trait and its generic arguments added, stripped for the trait. Memoized, as enrichment
+    /// scans module and crate impls - a pure function of the two interned ids - and the same
+    /// (context, trait) pair recurs constantly during solving.
+    pub fn enriched(
+        self,
+        db: &'db dyn Database,
+        concrete_trait_id: ConcreteTraitId<'db>,
+    ) -> ImplLookupContextId<'db> {
+        #[salsa::tracked(returns(copy))]
+        fn query<'db>(
+            db: &'db dyn Database,
+            lookup_context: ImplLookupContextId<'db>,
+            concrete_trait_id: ConcreteTraitId<'db>,
+        ) -> ImplLookupContextId<'db> {
+            let mut context = lookup_context.long(db).clone();
+            let trait_id = concrete_trait_id.trait_id(db);
+            context.insert_module(trait_id.parent_module(db), db);
+            // Add the defining module of the generic args to the lookup.
+            for generic_arg in concrete_trait_id.generic_args(db) {
+                if let GenericArgumentId::Type(ty) = generic_arg {
+                    enrich_lookup_context_with_ty(db, *ty, &mut context);
+                }
+            }
+            context.strip_for_trait_id(db, trait_id);
+            context.intern(db)
         }
+        query(db, self, concrete_trait_id)
     }
-    lookup_context.strip_for_trait_id(db, concrete_trait_id.trait_id(db));
 }
 
 /// Adds the defining module of the type to the lookup context.
@@ -473,11 +488,10 @@ impl<'db> LiteInference<'db> {
                         id: imp_concrete_trait_id,
                         mappings: ImplVarTraitItemMappings::default(),
                     };
-                    let mut inner_context = lookup_context.long(self.db).clone();
-                    enrich_lookup_context(self.db, imp_concrete_trait_id, &mut inner_context);
+                    let inner_context = lookup_context.enriched(self.db, imp_concrete_trait_id);
                     let Ok(solution) = self.db.canonic_trait_solutions(
                         canonical_trait,
-                        inner_context.intern(self.db),
+                        inner_context,
                         (*impl_type_bounds).clone(),
                     ) else {
                         return Err(super::ErrorSet);

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -29,7 +29,7 @@ use crate::diagnostic::SemanticDiagnosticKind::{self, *};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
 use crate::expr::compute::{ComputationContext, compute_expr_semantic};
 use crate::expr::inference::canonic::{CanonicalTrait, ResultNoErrEx};
-use crate::expr::inference::solver::{SemanticSolver, SolutionSet, enrich_lookup_context};
+use crate::expr::inference::solver::{SemanticSolver, SolutionSet};
 use crate::expr::inference::{InferenceData, InferenceError, InferenceId, TypeVar};
 use crate::items::attribute::SemanticQueryAttrs;
 use crate::items::constant::{ConstValue, ConstValueId, resolve_const_expr_and_evaluate};
@@ -1221,9 +1221,7 @@ fn solve_concrete_trait_no_constraints<'db>(
     lookup_context: ImplLookupContextId<'db>,
     id: ConcreteTraitId<'db>,
 ) -> Result<ImplId<'db>, InferenceError<'db>> {
-    let mut lookup_context = lookup_context.long(db).clone();
-    enrich_lookup_context(db, id, &mut lookup_context);
-    let lookup_context = lookup_context.intern(db);
+    let lookup_context = lookup_context.enriched(db, id);
     match db.canonic_trait_solutions(
         CanonicalTrait { id, mappings: Default::default() },
         lookup_context,


### PR DESCRIPTION
enrich_lookup_context scans module and crate impls and re-interns the
context - a pure function of (ImplLookupContextId, ConcreteTraitId) - and
was recomputed on every trait resolution before the memoized solver query
was consulted. Profiling corelib diagnostics attributed ~8s of 214s CPU to
it. All three clone+enrich+intern call sites now share a tracked query.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>