### PR TITLE
(opt): use foldhash for unordered hash containers

### DIFF
--- a/crates/cairo-lang-utils/src/unordered_hash_map.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_map.rs
@@ -22,8 +22,6 @@ pub use std::collections::hash_map::Entry;
 #[cfg(feature = "std")]
 use std::collections::hash_map::OccupiedEntry;
 #[cfg(feature = "std")]
-use std::collections::hash_map::RandomState;
-#[cfg(feature = "std")]
 use std::vec;
 
 #[cfg(not(feature = "std"))]
@@ -32,9 +30,9 @@ use hashbrown::HashMap;
 pub use hashbrown::hash_map::Entry;
 use itertools::Itertools;
 
-#[cfg(feature = "std")]
-type BHImpl = RandomState;
-#[cfg(not(feature = "std"))]
+// hashbrown's default hasher (foldhash) rather than std's SipHash: the map forbids iteration, so
+// determinism is unaffected, and these maps sit on hot compiler paths where hashing shows up in
+// profiles.
 type BHImpl = hashbrown::DefaultHashBuilder;
 
 /// A hash map that does not care about the order of insertion.

--- a/crates/cairo-lang-utils/src/unordered_hash_set.rs
+++ b/crates/cairo-lang-utils/src/unordered_hash_set.rs
@@ -11,8 +11,6 @@ use core::hash::{BuildHasher, Hash};
 use core::ops::Sub;
 #[cfg(feature = "std")]
 use std::collections::HashSet;
-#[cfg(feature = "std")]
-use std::collections::hash_map::RandomState;
 
 #[cfg(not(feature = "std"))]
 use hashbrown::HashSet;
@@ -21,10 +19,8 @@ use hashbrown::HashSet;
 ///
 /// In particular, it does not support iterating, in order to guarantee deterministic compilation.
 /// For an iterable version see [OrderedHashSet](crate::ordered_hash_set::OrderedHashSet).
-#[cfg(feature = "std")]
-#[derive(Clone, Debug)]
-pub struct UnorderedHashSet<Key, BH = RandomState>(HashSet<Key, BH>);
-#[cfg(not(feature = "std"))]
+/// Uses hashbrown's default hasher (foldhash) rather than std's SipHash: the set forbids
+/// iteration, so determinism is unaffected, and it sits on hot compiler paths.
 #[derive(Clone, Debug)]
 pub struct UnorderedHashSet<Key, BH = hashbrown::DefaultHashBuilder>(HashSet<Key, BH>);
 
@@ -79,14 +75,6 @@ impl<Key, BH> UnorderedHashSet<Key, BH> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<Key: Hash + Eq> UnorderedHashSet<Key> {
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self(HashSet::with_capacity(capacity))
-    }
-}
-
-#[cfg(not(feature = "std"))]
 impl<Key: Hash + Eq> UnorderedHashSet<Key> {
     pub fn with_capacity(capacity: usize) -> Self {
         Self(HashSet::with_capacity_and_hasher(capacity, Default::default()))


### PR DESCRIPTION
UnorderedHashMap/Set forbid iteration by contract, so SipHash's DoS
resistance buys nothing here while its cost shows up on hot compiler
paths (red-tree range lookups, resolver bookkeeping - several seconds of
a corelib diagnostics profile). Use hashbrown's default hasher, already
the behavior of the no-std variant.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>