### PR TITLE
(opt): compute expansion offsets only within macro expansions

### DIFF
--- a/crates/cairo-lang-semantic/src/expr/compute.rs
+++ b/crates/cairo-lang-semantic/src/expr/compute.rs
@@ -4427,18 +4427,23 @@ pub fn get_binded_expr_by_name<'db>(
     is_callsite_prefixed: bool,
     stable_ptr: ast::ExprPtr<'db>,
 ) -> Option<Expr<'db>> {
+    let db = ctx.db;
     let mut maybe_env = Some(&mut *ctx.environment);
-    let mut cur_offset =
-        ExpansionOffset::new(stable_ptr.lookup(ctx.db).as_syntax_node().offset(ctx.db));
+    // Computed lazily, preventing unneeded querying.
+    let mut cur_offset: Option<ExpansionOffset> = None;
     let mut found_callsite_scope = false;
     while let Some(env) = maybe_env {
         // If a variable is from an expanded macro placeholder, we need to look for it in the parent
         // env.
         if let Some(macro_info) = &env.macro_info
-            && let Some(new_offset) = cur_offset.mapped(&macro_info.mappings)
+            && let Some(new_offset) = cur_offset
+                .get_or_insert_with(|| {
+                    ExpansionOffset::new(stable_ptr.lookup(db).as_syntax_node().offset(db))
+                })
+                .mapped(&macro_info.mappings)
         {
             maybe_env = env.parent.as_deref_mut();
-            cur_offset = new_offset;
+            cur_offset = Some(new_offset);
             continue;
         }
         if (!is_callsite_prefixed || found_callsite_scope)

--- a/crates/cairo-lang-semantic/src/resolve/mod.rs
+++ b/crates/cairo-lang-semantic/src/resolve/mod.rs
@@ -1075,11 +1075,16 @@ impl<'db> Resolver<'db> {
         stable_ptr: SyntaxStablePtrId<'db>,
     ) -> Maybe<Vec<GenericArgumentId<'db>>> {
         let mut resolved_args = vec![];
-        let arg_syntax_per_param = self.get_arg_syntax_per_param(
-            diagnostics,
-            &generic_params.iter().map(|generic_param| generic_param.id()).collect_vec(),
-            generic_args_syntax,
-        )?;
+        // In the common inference-driven case no args are spelled out, and the mapping is empty.
+        let arg_syntax_per_param = if generic_args_syntax.is_empty() {
+            Default::default()
+        } else {
+            self.get_arg_syntax_per_param(
+                diagnostics,
+                &generic_params.iter().map(|generic_param| generic_param.id()).collect_vec(),
+                generic_args_syntax,
+            )?
+        };
 
         for generic_param in generic_params {
             let generic_param = substitution.substitute(self.db, generic_param.clone())?;
@@ -1748,21 +1753,25 @@ impl<'db, 'a> Resolution<'db, 'a> {
         let db = resolver.db;
         let placeholder_marker = path.placeholder_marker(db);
 
-        let mut cur_offset =
-            ExpansionOffset::new(path.offset(db).expect("Trying to resolve an empty path."));
-        let mut segments = path.to_segments(db).into_iter().peekable();
         let mut cur_macro_call_data = resolver.macro_call_data.as_ref();
         let mut path_defining_module = resolver.data.module_id;
         // Climb up the macro call data while the current resolved path is being mapped to an
-        // argument of a macro call.
-        while let Some(macro_call_data) = &cur_macro_call_data {
-            let Some(new_offset) = cur_offset.mapped(&macro_call_data.expansion_mappings) else {
-                break;
-            };
-            path_defining_module = macro_call_data.callsite_module_id;
-            cur_macro_call_data = macro_call_data.parent_macro_call_data.as_ref();
-            cur_offset = new_offset;
+        // argument of a macro call. The offset is computed only when resolving inside a macro
+        // call, as it recursively resolves the node's absolute position.
+        if cur_macro_call_data.is_some() {
+            let mut cur_offset =
+                ExpansionOffset::new(path.offset(db).expect("Trying to resolve an empty path."));
+            while let Some(macro_call_data) = &cur_macro_call_data {
+                let Some(new_offset) = cur_offset.mapped(&macro_call_data.expansion_mappings)
+                else {
+                    break;
+                };
+                path_defining_module = macro_call_data.callsite_module_id;
+                cur_macro_call_data = macro_call_data.parent_macro_call_data.as_ref();
+                cur_offset = new_offset;
+            }
         }
+        let mut segments = path.to_segments(db).into_iter().peekable();
         let macro_call_data = cur_macro_call_data.cloned();
 
         let macro_context_modifier = if let Some(marker) = placeholder_marker {


### PR DESCRIPTION
Resolution::new computed the path's absolute offset - a recursive query
chain up the syntax tree - on every path resolution, though it is only
consumed when climbing macro call data; get_binded_expr_by_name did the
same per name lookup, needed only in macro subscopes. Also skip building
the generic-arg-per-param map when no generic args are spelled out - the
common inference-driven case.

Improves cairo-to-diagnostics/corelib by ~13%.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>