### PR TITLE
(opt): warm up module discovery in parallel

### DIFF
--- a/crates/cairo-lang-compiler/src/lib.rs
+++ b/crates/cairo-lang-compiler/src/lib.rs
@@ -8,6 +8,8 @@ use std::sync::Mutex;
 use ::cairo_lang_diagnostics::ToOption;
 use anyhow::{Context, Result};
 use cairo_lang_defs::db::DefsGroup;
+use cairo_lang_defs::ids::ModuleId;
+use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CrateId, CrateInput};
 use cairo_lang_lowering::db::LoweringGroup;
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
@@ -207,19 +209,47 @@ pub fn ensure_diagnostics(
 /// Spawns threads to compute the diagnostics queries, making sure later calls for these queries
 /// would be faster as the queries were already computed.
 fn warmup_diagnostics_blocking(db: &dyn CloneableDatabase, crates: Vec<CrateInput>) {
-    crates.into_par_iter().for_each_with(db.dyn_clone(), |db, crate_input| {
-        let db = db.as_ref();
-        let crate_id = crate_input.into_crate_long_id(db).intern(db);
-        db.crate_modules(crate_id).into_par_iter().for_each_with(
-            db.dyn_clone(),
-            |db, module_id| {
-                for file_id in db.module_files(*module_id).unwrap_or_default().iter().copied() {
-                    db.file_syntax_diagnostics(file_id);
-                }
-                let _ = db.module_semantic_diagnostics(*module_id);
-                let _ = db.module_lowering_diagnostics(*module_id);
-            },
-        );
+    let discovery_db = db.dyn_clone();
+    let warmup_db = db.dyn_clone();
+    rayon::join(
+        move || {
+            // Warming up the modules to speed up `crate_modules` call.
+            let db = discovery_db.as_ref();
+            db.crates().into_par_iter().for_each_with(db.dyn_clone(), |db, crate_id| {
+                warmup_module_discovery_blocking(db.as_ref(), ModuleId::CrateRoot(*crate_id));
+            });
+        },
+        move || {
+            crates.into_par_iter().for_each_with(warmup_db, |db, crate_input| {
+                let db = db.as_ref();
+                let crate_id = crate_input.into_crate_long_id(db).intern(db);
+                db.crate_modules(crate_id).into_par_iter().for_each_with(
+                    db.dyn_clone(),
+                    |db, module_id| {
+                        for file_id in
+                            db.module_files(*module_id).unwrap_or_default().iter().copied()
+                        {
+                            db.file_syntax_diagnostics(file_id);
+                        }
+                        let _ = db.module_semantic_diagnostics(*module_id);
+                        let _ = db.module_lowering_diagnostics(*module_id);
+                    },
+                );
+            });
+        },
+    );
+}
+
+/// Expands the module tree under `module_id` in parallel: each module's files (including plugin
+/// expansion, the expensive part of discovery) are computed concurrently across the submodule
+/// fan-out, so the serial walk in `crate_modules` afterwards hits warm memos instead of expanding
+/// every module of the crate on a single thread.
+fn warmup_module_discovery_blocking(db: &dyn CloneableDatabase, module_id: ModuleId<'_>) {
+    let Ok(submodules) = db.module_submodules_ids(module_id) else {
+        return;
+    };
+    submodules.into_par_iter().for_each_with(db.dyn_clone(), |db, submodule_id| {
+        warmup_module_discovery_blocking(db.as_ref(), ModuleId::Submodule(*submodule_id));
     });
 }
 


### PR DESCRIPTION
crate_modules discovers the module tree serially: each module's files
(including plugin expansion - the expensive part on Starknet projects)
were expanded one after another on a single thread before any parallel
warmup could start, capping real-world diagnostics at ~1.5 busy threads.
The diagnostics warmup now expands submodule trees concurrently across
the fan-out - for all crates, as dependency crates' modules are needed by
the checked crates' semantic analysis and were otherwise discovered
serially on demand.

Improves staking diagnostics by ~40% and corelib diagnostics by ~15%.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>