### PR TITLE
(opt): cache trivia green ids in the parser

### DIFF
--- a/crates/cairo-lang-parser/src/lexer.rs
+++ b/crates/cairo-lang-parser/src/lexer.rs
@@ -2,8 +2,6 @@
 #[path = "lexer_test.rs"]
 mod test;
 
-use std::sync::Arc;
-
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_filesystem::span::{TextOffset, TextSpan, TextWidth};
 use cairo_lang_syntax::node::Token;
@@ -15,25 +13,25 @@ use cairo_lang_syntax::node::kind::SyntaxKind;
 use salsa::Database;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Lexer {
-    text: Arc<str>,
+pub struct Lexer<'a> {
+    text: &'a str,
     previous_position: TextOffset,
     current_position: TextOffset,
 }
 
-impl Lexer {
+impl<'a> Lexer<'a> {
     /// Creates a new lexer with the given text.
-    pub fn new(text: Arc<str>) -> Self {
+    pub fn new(text: &'a str) -> Self {
         Self { text, previous_position: TextOffset::START, current_position: TextOffset::START }
     }
 
     // Helpers.
     fn peek(&self) -> Option<char> {
-        self.current_position.take_from(&self.text).chars().next()
+        self.current_position.take_from(self.text).chars().next()
     }
 
     fn peek_nth(&self, n: usize) -> Option<char> {
-        self.current_position.take_from(&self.text).chars().nth(n)
+        self.current_position.take_from(self.text).chars().nth(n)
     }
 
     fn take(&mut self) -> Option<char> {
@@ -63,7 +61,7 @@ impl Lexer {
     }
 
     // Trivia matchers.
-    fn match_trivia<'a>(&mut self, db: &'a dyn Database, leading: bool) -> Vec<TriviumGreen<'a>> {
+    fn match_trivia(&mut self, db: &'a dyn Database, leading: bool) -> Vec<TriviumGreen<'a>> {
         let mut res: Vec<TriviumGreen<'a>> = Vec::new();
         while let Some(current) = self.peek() {
             let trivium = match current {
@@ -81,42 +79,42 @@ impl Lexer {
     }
 
     /// Assumes the next character is one of [' ', '\r', '\t'].
-    fn match_trivium_whitespace<'a>(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
+    fn match_trivium_whitespace(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
         self.take_while(|s| matches!(s, ' ' | '\r' | '\t'));
         let span = self.consume_text_span();
-        let text = span.take(&self.text);
+        let text = span.take(self.text);
         TokenWhitespace::new_green(db, SmolStrId::from(db, text)).into()
     }
 
     /// Assumes the next character is '\n'.
-    fn match_trivium_newline<'a>(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
+    fn match_trivium_newline(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
         self.take();
         let span = self.consume_text_span();
-        let text = span.take(&self.text);
+        let text = span.take(self.text);
         TokenNewline::new_green(db, SmolStrId::from(db, text)).into()
     }
 
     /// Assumes the next 2 characters are "//".
-    fn match_trivium_single_line_comment<'a>(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
+    fn match_trivium_single_line_comment(&mut self, db: &'a dyn Database) -> TriviumGreen<'a> {
         match self.peek_nth(2) {
             // `///` is a doc comment, but `////` (4+ slashes) is a regular comment. This matches
             // `cairo-lang-doc`, which discards a doc comment whose content starts with `/`.
             Some('/') if self.peek_nth(3) != Some('/') => {
                 self.take_while(|c| c != '\n');
                 let span = self.consume_text_span();
-                let text = span.take(&self.text);
+                let text = span.take(self.text);
                 TokenSingleLineDocComment::new_green(db, SmolStrId::from(db, text)).into()
             }
             Some('!') => {
                 self.take_while(|c| c != '\n');
                 let span = self.consume_text_span();
-                let text = span.take(&self.text);
+                let text = span.take(self.text);
                 TokenSingleLineInnerComment::new_green(db, SmolStrId::from(db, text)).into()
             }
             _ => {
                 self.take_while(|c| c != '\n');
                 let span = self.consume_text_span();
-                let text = span.take(&self.text);
+                let text = span.take(self.text);
                 TokenSingleLineComment::new_green(db, SmolStrId::from(db, text)).into()
             }
         }
@@ -195,7 +193,7 @@ impl Lexer {
         self.take_while(|c| c.is_ascii_alphanumeric() || c == '_');
 
         let span = self.peek_text_span();
-        match span.take(&self.text) {
+        match span.take(self.text) {
             "as" => TokenKind::As,
             "const" => TokenKind::Const,
             "false" => TokenKind::False,
@@ -253,7 +251,7 @@ impl Lexer {
         }
     }
 
-    pub fn match_terminal<'a>(&mut self, db: &'a dyn Database) -> LexerTerminal<'a> {
+    pub fn match_terminal(&mut self, db: &'a dyn Database) -> LexerTerminal<'a> {
         let leading_trivia = self.match_trivia(db, true);
 
         let kind = if let Some(current) = self.peek() {
@@ -316,7 +314,7 @@ impl Lexer {
         };
 
         let span = self.consume_text_span();
-        let text = SmolStrId::from(db, span.take(&self.text));
+        let text = SmolStrId::from(db, span.take(self.text));
         let trailing_trivia = self.match_trivia(db, false);
         let terminal_kind = token_kind_to_terminal_syntax_kind(kind);
 

--- a/crates/cairo-lang-parser/src/lexer_test.rs
+++ b/crates/cairo-lang-parser/src/lexer_test.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use cairo_lang_filesystem::ids::SmolStrId;
 use cairo_lang_syntax::node::Token;
 use cairo_lang_syntax::node::ast::{TokenSingleLineComment, TokenWhitespace};
@@ -268,7 +266,7 @@ fn test_lex_single_token() {
     let db_val = SimpleParserDatabase::default();
     let db = &db_val;
     for (kind, text) in terminal_kind_and_text() {
-        let terminals = tokenize_all(db, Arc::from(text));
+        let terminals = tokenize_all(db, text);
         let terminal = &terminals[0];
         // TODO(spapini): Remove calling new_detached_root on non root elements.
         assert_eq!(terminal.kind, kind, "Wrong token kind, with text: \"{text}\".");
@@ -295,7 +293,7 @@ fn test_lex_double_token() {
             }
             for separator in separators {
                 let text = format!("{text0}{separator}{text1}");
-                let terminals = tokenize_all(db, Arc::from(text.as_str()));
+                let terminals = tokenize_all(db, &text);
                 let terminal = &terminals[0];
                 let token_text = terminal.text(db);
                 assert_eq!(
@@ -344,7 +342,7 @@ fn test_lex_token_with_trivia() {
         for leading_trivia in trivia_texts() {
             for trailing_trivia in trivia_texts() {
                 let text = format!("{leading_trivia}{expected_token_text} {trailing_trivia}");
-                let terminals = tokenize_all(db, Arc::from(text.as_str()));
+                let terminals = tokenize_all(db, &text);
                 let terminal = &terminals[0];
                 let token_text = terminal.text(db);
                 assert_eq!(terminal.kind, kind, "Wrong token kind, with text: \"{text}\".");
@@ -366,7 +364,7 @@ fn test_lex_token_with_trivia() {
 fn test_cases() {
     let db_val = SimpleParserDatabase::default();
     let db = &db_val;
-    let res = tokenize_all(db, Arc::from("let x: &T = ` 6; //  5+ 3;"));
+    let res = tokenize_all(db, "let x: &T = ` 6; //  5+ 3;");
     assert_eq!(
         res.into_iter().collect::<Vec<_>>(),
         vec![
@@ -454,7 +452,7 @@ fn test_doc_comment_classification() {
     let db_val = SimpleParserDatabase::default();
     let db = &db_val;
     let text = "// regular\n/// doc\n//! inner\n//// regular\n///// regular\n";
-    let terminal = tokenize_all(db, Arc::from(text)).into_iter().exactly_one().unwrap();
+    let terminal = tokenize_all(db, text).into_iter().exactly_one().unwrap();
     assert_eq!(
         terminal.leading_trivia.into_iter().map(|t| t.0.long(db).kind).collect_vec(),
         [
@@ -478,7 +476,7 @@ fn test_bad_character() {
     let db = &db_val;
 
     let text = "`";
-    let terminals = tokenize_all(db, Arc::from(text));
+    let terminals = tokenize_all(db, text);
     let terminal = &terminals[0];
     let token_text = terminal.text(db);
     assert_eq!(
@@ -497,7 +495,7 @@ fn test_bad_character() {
 }
 
 /// Tokenizes the entire text and returns a vector of terminals.
-pub fn tokenize_all<'db>(db: &'db dyn Database, text: Arc<str>) -> Vec<LexerTerminal<'db>> {
+pub fn tokenize_all<'db>(db: &'db dyn Database, text: &'db str) -> Vec<LexerTerminal<'db>> {
     let mut lexer = Lexer::new(text);
     let mut result = vec![];
     loop {

--- a/crates/cairo-lang-parser/src/parser.rs
+++ b/crates/cairo-lang-parser/src/parser.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use std::mem;
-use std::sync::Arc;
 
 use cairo_lang_diagnostics::DiagnosticsBuilder;
 use cairo_lang_filesystem::db::FilesGroup;
@@ -12,6 +11,7 @@ use cairo_lang_syntax::node::ast::*;
 use cairo_lang_syntax::node::helpers::GetIdentifier;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, Token, TypedSyntaxNode};
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use cairo_lang_utils::{extract_matches, require};
 use salsa::Database;
 use syntax::node::green::{GreenNode, GreenNodeDetails};
@@ -47,8 +47,10 @@ enum MacroParsingContext {
 pub struct Parser<'a, 'mt> {
     db: &'a dyn Database,
     file_id: FileId<'a>,
+    /// The parsed text.
+    text: &'a str,
     /// The lexer producing the tokens, pulled lazily into `current_terminals` as parsing advances.
-    lexer: Lexer,
+    lexer: Lexer<'a>,
     /// A small lookahead window of already-lexed, not-yet-consumed terminals, kept filled by
     /// `ensure_next_k_exists`. The front is the next terminal to parse.
     current_terminals: VecDeque<LexerTerminal<'a>>,
@@ -68,6 +70,12 @@ pub struct Parser<'a, 'mt> {
     pending_skipped_token_diagnostics: Vec<PendingParserDiagnostic>,
     /// An indicator if we are inside a macro rule expansion.
     macro_parsing_context: MacroParsingContext,
+    /// Green ids of already-built pure-whitespace trivia lists, keyed by their source text, to
+    /// avoid re-interning the constantly repeating indentation trivia. Sound as the lexer's
+    /// split of a whitespace run into trivia is a pure function of its text.
+    trivia_greens: UnorderedHashMap<&'a str, TriviaGreen<'a>>,
+    /// The green id of an empty trivia list, built once and used for every trivia-less terminal.
+    empty_trivia: TriviaGreen<'a>,
 }
 
 impl<'a> Parser<'a, '_> {
@@ -168,7 +176,8 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         let mut parser = Parser {
             db,
             file_id,
-            lexer: Lexer::new(Arc::from(text)),
+            text,
+            lexer: Lexer::new(text),
             current_terminals: VecDeque::with_capacity(8),
             eof: false,
             pending_trivia: Vec::new(),
@@ -178,6 +187,8 @@ impl<'a, 'mt> Parser<'a, 'mt> {
             diagnostics,
             pending_skipped_token_diagnostics: Vec::new(),
             macro_parsing_context: MacroParsingContext::None,
+            trivia_greens: Default::default(),
+            empty_trivia: Trivia::new_green(db, &[]),
         };
         parser.ensure_next_k_exists(2);
         parser
@@ -339,8 +350,10 @@ impl<'a, 'mt> Parser<'a, 'mt> {
         // token, which doesn't exist.
         self.offset = self.offset.add_width(self.current_width);
 
-        let eof =
-            self.add_trivia_to_terminal::<TerminalEndOfFile<'_>>(self.next_terminal().clone());
+        let eof = self.add_trivia_to_terminal::<TerminalEndOfFile<'_>>(
+            self.next_terminal().clone(),
+            self.offset,
+        );
         SyntaxFile::new_green(self.db, items, eof)
     }
 
@@ -3710,24 +3723,52 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     }
 
     /// Builds a new terminal to replace the given terminal by gluing the recently skipped terminals
-    /// to the given terminal as extra leading trivia.
+    /// to the given terminal as extra leading trivia. `terminal_start` is the offset of
+    /// `lexer_terminal` (including its leading trivia) in the file, keying the trivia cache.
     fn add_trivia_to_terminal<Terminal: syntax::node::Terminal<'a>>(
         &mut self,
         lexer_terminal: LexerTerminal<'a>,
+        terminal_start: TextOffset,
     ) -> Terminal::Green {
         let LexerTerminal { text, kind: _, leading_trivia, trailing_trivia } = lexer_terminal;
         let token = Terminal::TokenType::new_green(self.db, text);
-        let mut new_leading_trivia = mem::take(&mut self.pending_trivia);
+        let mut pending_trivia = mem::take(&mut self.pending_trivia);
 
         self.consume_pending_skipped_diagnostics();
 
-        new_leading_trivia.extend(leading_trivia);
+        // Pending trivia is source-contiguous and ends exactly at `terminal_start`.
+        let leading_start = terminal_start.sub_width(trivia_total_width(self.db, &pending_trivia));
+        let leading_end = terminal_start.add_width(trivia_total_width(self.db, &leading_trivia));
+        let trailing_start = leading_end.add_width(TextWidth::from_str(text.long(self.db)));
+        let trailing_end = trailing_start.add_width(trivia_total_width(self.db, &trailing_trivia));
+        let leading_trivia = if pending_trivia.is_empty() {
+            leading_trivia
+        } else {
+            pending_trivia.extend(leading_trivia);
+            pending_trivia
+        };
         Terminal::new_green(
             self.db,
-            Trivia::new_green(self.db, &new_leading_trivia),
+            self.trivia_green(&leading_trivia, TextSpan::new(leading_start, leading_end)),
             token,
-            Trivia::new_green(self.db, &trailing_trivia),
+            self.trivia_green(&trailing_trivia, TextSpan::new(trailing_start, trailing_end)),
         )
+    }
+
+    /// A cached version of [Trivia::new_green]: `span` locates the trivia's text in the source,
+    /// which keys the cache (for pure-whitespace trivia - see [`Parser::trivia_greens`]).
+    fn trivia_green(&mut self, trivia: &[TriviumGreen<'a>], span: TextSpan) -> TriviaGreen<'a> {
+        if trivia.is_empty() {
+            return self.empty_trivia;
+        }
+        let text = span.take(self.text);
+        // Matching the exact whitespace set of the lexer, as for any other text (e.g. form feed,
+        // which is lexed as a skipped token) the trivia list is not a function of the text alone.
+        if text.bytes().all(|b| matches!(b, b' ' | b'\t' | b'\r' | b'\n')) {
+            *self.trivia_greens.entry(text).or_insert_with(|| Trivia::new_green(self.db, trivia))
+        } else {
+            Trivia::new_green(self.db, trivia)
+        }
     }
 
     /// Adds the pending skipped-tokens diagnostics, merging consecutive similar ones, and reset
@@ -3771,7 +3812,7 @@ impl<'a, 'mt> Parser<'a, 'mt> {
     pub fn take<Terminal: syntax::node::Terminal<'a>>(&mut self) -> Terminal::Green {
         let token = self.take_raw();
         assert_eq!(token.kind, Terminal::KIND);
-        self.add_trivia_to_terminal::<Terminal>(token)
+        self.add_trivia_to_terminal::<Terminal>(token, self.offset)
     }
 
     /// If the current leading trivia start with non-doc comments, creates a new `ItemHeaderDoc` and
@@ -3811,9 +3852,13 @@ impl<'a, 'mt> Parser<'a, 'mt> {
             leading_trivia: header_doc,
             trailing_trivia: vec![],
         };
+        // `self.offset` points at the start of the last taken terminal - the split trivia
+        // starts after it, at the start of the next terminal.
+        let terminal_start = self.offset.add_width(self.current_width);
         self.offset = self.offset.add_width(empty_lexer_terminal.width(self.db));
 
-        let empty_terminal = self.add_trivia_to_terminal::<TerminalEmpty<'_>>(empty_lexer_terminal);
+        let empty_terminal =
+            self.add_trivia_to_terminal::<TerminalEmpty<'_>>(empty_lexer_terminal, terminal_start);
         Some(ItemHeaderDoc::new_green(self.db, empty_terminal))
     }
 

--- a/crates/cairo-lang-parser/src/parser_test.rs
+++ b/crates/cairo-lang-parser/src/parser_test.rs
@@ -214,6 +214,8 @@ cairo_lang_test_utils::test_file_test!(
     "src/parser_test_data/partial_trees_with_trivia",
     {
         comments: "comments",
+        header_doc: "header_doc",
+        skipped: "skipped",
         path: "path",
         path_compat: "path_compat",
         attribute_errors: "attribute_errors",

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees_with_trivia/header_doc
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees_with_trivia/header_doc
@@ -1,0 +1,113 @@
+//! > Test header doc trivia not aliasing same-width indentation
+
+//! > test_runner_name
+test_partial_parser_tree_with_trivia(expect_diagnostics: false)
+
+//! > cairo_code
+#[cairofmt::skip]
+mod m
+        {
+// abc
+fn foo() {}
+       fn bar() {}
+}
+
+//! > top_level_kind
+
+//! > ignored_kinds
+TerminalIdentifier
+FunctionSignature
+ExprBlock
+
+//! > expected_diagnostics
+
+//! > expected_tree
+└── root (kind: SyntaxFile)
+    ├── items (kind: ModuleItemList)
+    │   └── child #0 (kind: ItemModule)
+    │       ├── attributes (kind: AttributeList)
+    │       │   └── child #0 (kind: Attribute)
+    │       │       ├── hash (kind: TerminalHash)
+    │       │       │   ├── leading_trivia (kind: Trivia) []
+    │       │       │   ├── token (kind: TokenHash): '#'
+    │       │       │   └── trailing_trivia (kind: Trivia) []
+    │       │       ├── lbrack (kind: TerminalLBrack)
+    │       │       │   ├── leading_trivia (kind: Trivia) []
+    │       │       │   ├── token (kind: TokenLBrack): '['
+    │       │       │   └── trailing_trivia (kind: Trivia) []
+    │       │       ├── attr (kind: ExprPath)
+    │       │       │   ├── dollar (kind: OptionTerminalDollarEmpty) []
+    │       │       │   └── segments (kind: ExprPathInner)
+    │       │       │       ├── item #0 (kind: PathSegmentSimple)
+    │       │       │       │   └── ident (kind: TerminalIdentifier) <ignored>
+    │       │       │       ├── separator #0 (kind: TerminalColonColon)
+    │       │       │       │   ├── leading_trivia (kind: Trivia) []
+    │       │       │       │   ├── token (kind: TokenColonColon): '::'
+    │       │       │       │   └── trailing_trivia (kind: Trivia) []
+    │       │       │       └── item #1 (kind: PathSegmentSimple)
+    │       │       │           └── ident (kind: TerminalIdentifier) <ignored>
+    │       │       ├── arguments (kind: OptionArgListParenthesizedEmpty) []
+    │       │       └── rbrack (kind: TerminalRBrack)
+    │       │           ├── leading_trivia (kind: Trivia) []
+    │       │           ├── token (kind: TokenRBrack): ']'
+    │       │           └── trailing_trivia (kind: Trivia)
+    │       │               └── child #0 (kind: TokenNewline).
+    │       ├── visibility (kind: VisibilityDefault) []
+    │       ├── module_kw (kind: TerminalModule)
+    │       │   ├── leading_trivia (kind: Trivia) []
+    │       │   ├── token (kind: TokenModule): 'mod'
+    │       │   └── trailing_trivia (kind: Trivia)
+    │       │       └── child #0 (kind: TokenWhitespace).
+    │       ├── name (kind: TerminalIdentifier) <ignored>
+    │       └── body (kind: ModuleBody)
+    │           ├── lbrace (kind: TerminalLBrace)
+    │           │   ├── leading_trivia (kind: Trivia)
+    │           │   │   └── child #0 (kind: TokenWhitespace).
+    │           │   ├── token (kind: TokenLBrace): '{'
+    │           │   └── trailing_trivia (kind: Trivia)
+    │           │       └── child #0 (kind: TokenNewline).
+    │           ├── items (kind: ModuleItemList)
+    │           │   ├── child #0 (kind: ItemHeaderDoc)
+    │           │   │   └── empty (kind: TerminalEmpty)
+    │           │   │       ├── leading_trivia (kind: Trivia)
+    │           │   │       │   ├── child #0 (kind: TokenSingleLineComment): '// abc'
+    │           │   │       │   └── child #1 (kind: TokenNewline).
+    │           │   │       ├── token (kind: TokenEmpty): ''
+    │           │   │       └── trailing_trivia (kind: Trivia) []
+    │           │   ├── child #1 (kind: FunctionWithBody)
+    │           │   │   ├── attributes (kind: AttributeList) []
+    │           │   │   ├── visibility (kind: VisibilityDefault) []
+    │           │   │   ├── declaration (kind: FunctionDeclaration)
+    │           │   │   │   ├── optional_const (kind: OptionTerminalConstEmpty) []
+    │           │   │   │   ├── function_kw (kind: TerminalFunction)
+    │           │   │   │   │   ├── leading_trivia (kind: Trivia) []
+    │           │   │   │   │   ├── token (kind: TokenFunction): 'fn'
+    │           │   │   │   │   └── trailing_trivia (kind: Trivia)
+    │           │   │   │   │       └── child #0 (kind: TokenWhitespace).
+    │           │   │   │   ├── name (kind: TerminalIdentifier) <ignored>
+    │           │   │   │   ├── generic_params (kind: OptionWrappedGenericParamListEmpty) []
+    │           │   │   │   └── signature (kind: FunctionSignature) <ignored>
+    │           │   │   └── body (kind: ExprBlock) <ignored>
+    │           │   └── child #2 (kind: FunctionWithBody)
+    │           │       ├── attributes (kind: AttributeList) []
+    │           │       ├── visibility (kind: VisibilityDefault) []
+    │           │       ├── declaration (kind: FunctionDeclaration)
+    │           │       │   ├── optional_const (kind: OptionTerminalConstEmpty) []
+    │           │       │   ├── function_kw (kind: TerminalFunction)
+    │           │       │   │   ├── leading_trivia (kind: Trivia)
+    │           │       │   │   │   └── child #0 (kind: TokenWhitespace).
+    │           │       │   │   ├── token (kind: TokenFunction): 'fn'
+    │           │       │   │   └── trailing_trivia (kind: Trivia)
+    │           │       │   │       └── child #0 (kind: TokenWhitespace).
+    │           │       │   ├── name (kind: TerminalIdentifier) <ignored>
+    │           │       │   ├── generic_params (kind: OptionWrappedGenericParamListEmpty) []
+    │           │       │   └── signature (kind: FunctionSignature) <ignored>
+    │           │       └── body (kind: ExprBlock) <ignored>
+    │           └── rbrace (kind: TerminalRBrace)
+    │               ├── leading_trivia (kind: Trivia) []
+    │               ├── token (kind: TokenRBrace): '}'
+    │               └── trailing_trivia (kind: Trivia) []
+    └── eof (kind: TerminalEndOfFile)
+        ├── leading_trivia (kind: Trivia) []
+        ├── token (kind: TokenEndOfFile).
+        └── trailing_trivia (kind: Trivia) []

--- a/crates/cairo-lang-parser/src/parser_test_data/partial_trees_with_trivia/skipped
+++ b/crates/cairo-lang-parser/src/parser_test_data/partial_trees_with_trivia/skipped
@@ -1,0 +1,126 @@
+//! > Test identical skipped text yielding different trivia by recovery path
+
+//! > test_runner_name
+test_partial_parser_tree_with_trivia(expect_diagnostics: true)
+
+//! > cairo_code
+fn foo<#[;]>() -> felt252 {
+    5
+}
+#[;]
+
+//! > top_level_kind
+
+//! > ignored_kinds
+FunctionSignature
+
+//! > expected_diagnostics
+error[E1000]: Skipped tokens. Expected: generic param.
+ --> dummy_file.cairo:1:8
+fn foo<#[;]>() -> felt252 {
+       ^^^^
+
+error[E1003]: Missing tokens. Expected a path segment.
+ --> dummy_file.cairo:4:3
+#[;]
+  ^
+
+error[E1001]: Missing token ']'.
+ --> dummy_file.cairo:4:3
+#[;]
+  ^
+
+error[E1023]: Missing tokens. Expected an item after attributes.
+ --> dummy_file.cairo:4:3
+#[;]
+  ^
+
+error[E1000]: Skipped tokens. Expected: Const/Enum/ExternFunction/ExternType/Function/Impl/InlineMacro/Module/Struct/Trait/TypeAlias/Use or an attribute.
+ --> dummy_file.cairo:4:3
+#[;]
+  ^^
+
+//! > expected_tree
+└── root (kind: SyntaxFile)
+    ├── items (kind: ModuleItemList)
+    │   ├── child #0 (kind: FunctionWithBody)
+    │   │   ├── attributes (kind: AttributeList) []
+    │   │   ├── visibility (kind: VisibilityDefault) []
+    │   │   ├── declaration (kind: FunctionDeclaration)
+    │   │   │   ├── optional_const (kind: OptionTerminalConstEmpty) []
+    │   │   │   ├── function_kw (kind: TerminalFunction)
+    │   │   │   │   ├── leading_trivia (kind: Trivia) []
+    │   │   │   │   ├── token (kind: TokenFunction): 'fn'
+    │   │   │   │   └── trailing_trivia (kind: Trivia)
+    │   │   │   │       └── child #0 (kind: TokenWhitespace).
+    │   │   │   ├── name (kind: TerminalIdentifier)
+    │   │   │   │   ├── leading_trivia (kind: Trivia) []
+    │   │   │   │   ├── token (kind: TokenIdentifier): 'foo'
+    │   │   │   │   └── trailing_trivia (kind: Trivia) []
+    │   │   │   ├── generic_params (kind: WrappedGenericParamList)
+    │   │   │   │   ├── langle (kind: TerminalLT)
+    │   │   │   │   │   ├── leading_trivia (kind: Trivia) []
+    │   │   │   │   │   ├── token (kind: TokenLT): '<'
+    │   │   │   │   │   └── trailing_trivia (kind: Trivia) []
+    │   │   │   │   ├── generic_params (kind: GenericParamList) []
+    │   │   │   │   └── rangle (kind: TerminalGT)
+    │   │   │   │       ├── leading_trivia (kind: Trivia)
+    │   │   │   │       │   ├── child #0 (kind: TokenSkipped): '#'
+    │   │   │   │       │   ├── child #1 (kind: TokenSkipped): '['
+    │   │   │   │       │   ├── child #2 (kind: TokenSkipped): ';'
+    │   │   │   │       │   └── child #3 (kind: TokenSkipped): ']'
+    │   │   │   │       ├── token (kind: TokenGT): '>'
+    │   │   │   │       └── trailing_trivia (kind: Trivia) []
+    │   │   │   └── signature (kind: FunctionSignature) <ignored>
+    │   │   └── body (kind: ExprBlock)
+    │   │       ├── lbrace (kind: TerminalLBrace)
+    │   │       │   ├── leading_trivia (kind: Trivia) []
+    │   │       │   ├── token (kind: TokenLBrace): '{'
+    │   │       │   └── trailing_trivia (kind: Trivia)
+    │   │       │       └── child #0 (kind: TokenNewline).
+    │   │       ├── statements (kind: StatementList)
+    │   │       │   └── child #0 (kind: StatementExpr)
+    │   │       │       ├── attributes (kind: AttributeList) []
+    │   │       │       ├── expr (kind: TerminalLiteralNumber)
+    │   │       │       │   ├── leading_trivia (kind: Trivia)
+    │   │       │       │   │   └── child #0 (kind: TokenWhitespace).
+    │   │       │       │   ├── token (kind: TokenLiteralNumber): '5'
+    │   │       │       │   └── trailing_trivia (kind: Trivia)
+    │   │       │       │       └── child #0 (kind: TokenNewline).
+    │   │       │       └── semicolon (kind: OptionTerminalSemicolonEmpty) []
+    │   │       └── rbrace (kind: TerminalRBrace)
+    │   │           ├── leading_trivia (kind: Trivia) []
+    │   │           ├── token (kind: TokenRBrace): '}'
+    │   │           └── trailing_trivia (kind: Trivia)
+    │   │               └── child #0 (kind: TokenNewline).
+    │   └── child #1: Missing []
+    └── eof (kind: TerminalEndOfFile)
+        ├── leading_trivia (kind: Trivia)
+        │   ├── child #0 (kind: TriviumSkippedNode)
+        │   │   └── node (kind: AttributeList)
+        │   │       └── child #0 (kind: Attribute)
+        │   │           ├── hash (kind: TerminalHash)
+        │   │           │   ├── leading_trivia (kind: Trivia) []
+        │   │           │   ├── token (kind: TokenHash): '#'
+        │   │           │   └── trailing_trivia (kind: Trivia) []
+        │   │           ├── lbrack (kind: TerminalLBrack)
+        │   │           │   ├── leading_trivia (kind: Trivia) []
+        │   │           │   ├── token (kind: TokenLBrack): '['
+        │   │           │   └── trailing_trivia (kind: Trivia) []
+        │   │           ├── attr (kind: ExprPath)
+        │   │           │   ├── dollar (kind: OptionTerminalDollarEmpty) []
+        │   │           │   └── segments (kind: ExprPathInner)
+        │   │           │       └── item #0 (kind: PathSegmentSimple)
+        │   │           │           └── ident (kind: TerminalIdentifier)
+        │   │           │               ├── leading_trivia (kind: Trivia) []
+        │   │           │               ├── token: Missing
+        │   │           │               └── trailing_trivia (kind: Trivia) []
+        │   │           ├── arguments (kind: OptionArgListParenthesizedEmpty) []
+        │   │           └── rbrack (kind: TerminalRBrack)
+        │   │               ├── leading_trivia (kind: Trivia) []
+        │   │               ├── token: Missing
+        │   │               └── trailing_trivia (kind: Trivia) []
+        │   ├── child #1 (kind: TokenSkipped): ';'
+        │   └── child #2 (kind: TokenSkipped): ']'
+        ├── token (kind: TokenEndOfFile).
+        └── trailing_trivia (kind: Trivia) []


### PR DESCRIPTION
Most terminals carry one of a handful of leading/trailing trivia lists
(whitespace, newline+indentation), yet each terminal re-interned its
trivia into the global green table - hash, shard lock, and structural
equality against a huge map, which under the parallel warmup became a
contention point (sched_yield inside interning was the top parsing cost).
A parser-local cache serves repeats without touching the global table;
sound since green ids are immortal.

Improves staking diagnostics by ~9%; corelib is unaffected (its trivia
diversity is higher relative to file count).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>