### PR TITLE
(opt): apply the tests filter before code generation

### DIFF
--- a/crates/cairo-lang-test-plugin/src/lib.rs
+++ b/crates/cairo-lang-test-plugin/src/lib.rs
@@ -68,6 +68,11 @@ pub struct TestsCompilationConfig<'db> {
     /// If not defined, test crates will be searched.
     pub executable_crate_ids: Option<Vec<CrateId<'db>>>,
 
+    /// Only compiles tests whose fully-qualified name contains this string, matching the
+    /// runner-side test filter. Skips the Sierra generation and Sierra-to-casm work of
+    /// filtered-out tests.
+    pub tests_filter: Option<String>,
+
     /// Adds a mapping used by [cairo-profiler](https://github.com/software-mansion/cairo-profiler)
     /// to [Annotations] in [DebugInfo] in the compiled tests.
     pub add_statements_functions: bool,
@@ -145,12 +150,34 @@ pub fn compile_test_prepared_db<'db>(
         tests_compilation_config.executable_crate_ids.unwrap_or_else(|| test_crate_ids.clone()),
     );
     let all_tests = find_all_tests(db, test_crate_ids);
+    // Compute the tests' full names, and apply the tests filter before any code generation.
+    let total_tests_count = all_tests.len();
+    let named_tests = all_tests
+        .into_iter()
+        .map(|(func_id, test)| {
+            let name = format!(
+                "{:?}",
+                FunctionLongId {
+                    function: ConcreteFunction {
+                        generic_function: GenericFunctionId::Free(func_id),
+                        generic_args: vec![]
+                    }
+                }
+                .debug(db)
+            );
+            (name, func_id, test)
+        })
+        .filter(|(name, _, _)| {
+            tests_compilation_config.tests_filter.as_ref().is_none_or(|f| name.contains(f))
+        })
+        .collect_vec();
+    let compilation_filtered_out = total_tests_count - named_tests.len();
 
     let func_ids = chain!(
         executable_functions.keys().cloned(),
         all_entry_points.iter().cloned(),
         // TODO(maciektr): Remove test entrypoints after migration to executable attr.
-        all_tests.iter().flat_map(|(func_id, _cfg)| {
+        named_tests.iter().flat_map(|(_name, func_id, _cfg)| {
             ConcreteFunctionWithBodyId::from_no_generics_free(db, *func_id)
         })
     )
@@ -205,24 +232,8 @@ pub fn compile_test_prepared_db<'db>(
     }
 
     let executables = collect_executables(db, executable_functions, &sierra_program);
-    let named_tests = all_tests
-        .into_iter()
-        .map(|(func_id, test)| {
-            (
-                format!(
-                    "{:?}",
-                    FunctionLongId {
-                        function: ConcreteFunction {
-                            generic_function: GenericFunctionId::Free(func_id),
-                            generic_args: vec![]
-                        }
-                    }
-                    .debug(db)
-                ),
-                test,
-            )
-        })
-        .collect_vec();
+    let named_tests =
+        named_tests.into_iter().map(|(name, _func_id, test)| (name, test)).collect_vec();
     let contracts_info = get_contracts_info(db, contracts, &replacer)?;
     let sierra_program = ProgramArtifact::stripped(sierra_program).with_debug_info(DebugInfo {
         executables,
@@ -234,6 +245,7 @@ pub fn compile_test_prepared_db<'db>(
         sierra_program,
         metadata: TestCompilationMetadata {
             named_tests,
+            compilation_filtered_out,
             function_set_costs,
             contracts_info,
             statements_locations: Some(debug_info.statements_locations.clone()),
@@ -270,6 +282,10 @@ pub struct TestCompilationMetadata<'db> {
     )]
     pub function_set_costs: OrderedHashMap<FunctionId, CostTokenMap<i32>>,
     pub named_tests: Vec<(String, TestConfig)>,
+    /// The number of tests that were filtered out at compilation time (by
+    /// [`TestsCompilationConfig::tests_filter`]), for reporting.
+    #[serde(default)]
+    pub compilation_filtered_out: usize,
     /// Optional `StatementsLocations` for the compiled tests.
     /// See [StatementsLocations] for more information.
     // TODO(Gil): consider serializing this field once it is stable.

--- a/crates/cairo-lang-test-runner/src/lib.rs
+++ b/crates/cairo-lang-test-runner/src/lib.rs
@@ -75,6 +75,7 @@ impl<'db> TestRunner<'db> {
                 contract_declarations: None,
                 contract_crate_ids: None,
                 executable_crate_ids: None,
+                tests_filter: Some(config.filter.clone()),
                 add_functions_debug_info: false,
                 add_type_names: false,
                 replace_ids: false,
@@ -282,7 +283,8 @@ pub fn filter_test_cases<'db>(
     ignored: bool,
     filter: &str,
 ) -> (TestCompilation<'db>, usize) {
-    let total_tests_count = compiled.metadata.named_tests.len();
+    let total_tests_count =
+        compiled.metadata.named_tests.len() + compiled.metadata.compilation_filtered_out;
     let named_tests = compiled
         .metadata
         .named_tests
@@ -344,11 +346,22 @@ pub fn run_tests(
         metadata:
             TestCompilationMetadata {
                 named_tests,
+                compilation_filtered_out: _,
                 function_set_costs,
                 contracts_info,
                 statements_locations,
             },
     } = compiled;
+    if named_tests.is_empty() {
+        // Nothing to run - skip the Sierra-to-casm compilation of the program altogether.
+        println!("running 0 tests");
+        return Ok(TestsSummary {
+            passed: vec![],
+            failed: vec![],
+            ignored: vec![],
+            failed_run_results: vec![],
+        });
+    }
     let sierra_program = sierra_program_with_debug_info.program;
     let runner = SierraCasmRunner::new(
         sierra_program.clone(),

--- a/crates/cairo-lang-test-runner/src/test.rs
+++ b/crates/cairo-lang-test-runner/src/test.rs
@@ -26,6 +26,7 @@ fn test_compiled_serialization() {
             contract_declarations: None,
             contract_crate_ids: None,
             executable_crate_ids: None,
+            tests_filter: None,
             replace_ids: false,
         },
     )
@@ -251,6 +252,7 @@ fn to_test_compilation<'db>(tests: &[(&str, bool)]) -> TestCompilation<'db> {
             funcs: vec![],
         }),
         metadata: TestCompilationMetadata {
+            compilation_filtered_out: 0,
             named_tests: tests.iter().map(to_named_test).collect(),
             contracts_info: Default::default(),
             function_set_costs: Default::default(),

--- a/tests/benches/common/mod.rs
+++ b/tests/benches/common/mod.rs
@@ -241,6 +241,7 @@ pub fn run_cache_to_testing(config: &BenchConfig, cache_bytes: &[u8]) {
     let compiled = compile_test_prepared_db(
         &db,
         TestsCompilationConfig {
+            tests_filter: None,
             starknet: config.starknet,
             contract_declarations: None,
             contract_crate_ids: None,


### PR DESCRIPTION
Running tests with a filter still generated Sierra for every test in the
crate and compiled the entire program to casm (plus gas metadata) before
the filter was consulted - a fully-filtered run did all of the
compilation work and none of the running. The filter is now applied at
test-collection time, so Sierra generation and Sierra-to-casm scale with
the selected tests, and a run whose filter matches nothing skips program
compilation entirely. The compilation-time filtered-out count is carried
in the test metadata (serde-default for artifact compatibility), keeping
the reported totals unchanged.

A fully-filtered cairo-test run over cairo_level_tests drops from 4.6s
to 2.3s wall (27s to 9.6s CPU).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>