### PR TITLE
(opt): memoize function code size estimation

### DIFF
--- a/crates/cairo-lang-lowering/src/db.rs
+++ b/crates/cairo-lang-lowering/src/db.rs
@@ -48,6 +48,7 @@ pub struct LoweringGroupInput {
     #[returns(ref)]
     pub optimizations: Option<Optimizations>,
     /// A configurable function to get estimated size of the function with the given id.
+    /// Must be a pure function of the db - results are memoized.
     #[returns(ref)]
     code_size_estimator: Option<CodeSizeEstimator>,
 }
@@ -833,6 +834,7 @@ fn type_size<'db>(db: &'db dyn Database, ty: TypeId<'db>) -> usize {
     }
 }
 
+#[salsa::tracked(returns(copy))]
 fn estimate_size<'db>(
     db: &'db dyn Database,
     function_id: ConcreteFunctionWithBodyId<'db>,


### PR DESCRIPTION
estimate_size was a plain function - each call built a dummy Sierra
program and ran a full Sierra-to-casm compilation - and the inlining and
specialization heuristics repeatedly request it for the same functions
(measured: 9976 calls, 5878 distinct, single ids requested up to 700
times). In a full compilation of cairo_level_tests its subtree was 56%
of all CPU, dwarfing the actual code emission. Now a tracked query.

Improves full-compilation CPU by ~9%.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>