### PR TITLE
(opt): skip specializing calls that would be inlined

### DIFF
--- a/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/const_folding.rs
@@ -772,6 +772,13 @@ impl<'db, 'mt> ConstFoldingContext<'db, 'mt> {
             return None;
         }
 
+        // A call to a function that would be inlined is inlined right after this visit, folding
+        // the constant arguments in place - specialization would only add the cost of estimating
+        // the specialized size.
+        if self.db.priv_should_inline(called_base).ok()? {
+            return None;
+        }
+
         // Do not specialize the call that should be inlined.
         if call_stmt.is_specialization_base_call {
             return None;

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/split_structs
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/split_structs
@@ -156,43 +156,43 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v17) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v18) => blk2,
+    IsZeroResult::NonZero(v20) => blk2,
   })
 
 blk1:
 Statements:
-  (v19: ()) <- struct_construct()
-  (v20: core::bool) <- bool::True(v19)
+  (v21: ()) <- struct_construct()
+  (v22: core::bool) <- bool::True(v21)
 End:
-  Goto(blk3, {v20 -> v21})
+  Goto(blk3, {v22 -> v23})
 
 blk2:
 Statements:
-  (v22: ()) <- struct_construct()
-  (v23: core::bool) <- bool::False(v22)
+  (v24: ()) <- struct_construct()
+  (v25: core::bool) <- bool::False(v24)
 End:
-  Goto(blk3, {v23 -> v21})
+  Goto(blk3, {v25 -> v23})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v21) {
-    bool::False(v24) => blk4,
-    bool::True(v25) => blk5,
+  Match(match_enum(v23) {
+    bool::False(v26) => blk4,
+    bool::True(v27) => blk5,
   })
 
 blk4:
 Statements:
   () <- test::consume(v11)
-  (v26: core::felt252) <- 1
+  (v28: core::felt252) <- 1
 End:
-  Return(v26)
+  Return(v28)
 
 blk5:
 Statements:
-  (v27: core::felt252, v28: core::array::Array::<core::felt252>) <- struct_destructure(v11)
+  (v29: core::felt252, v30: core::array::Array::<core::felt252>) <- struct_destructure(v11)
 End:
-  Return(v27)
+  Return(v29)
 
 //! > after
 Parameters: v0: core::felt252
@@ -210,38 +210,38 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v17) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v18) => blk2,
+    IsZeroResult::NonZero(v20) => blk2,
   })
 
 blk1:
 Statements:
-  (v19: ()) <- struct_construct()
-  (v20: core::bool) <- bool::True(v19)
+  (v21: ()) <- struct_construct()
+  (v22: core::bool) <- bool::True(v21)
 End:
-  Goto(blk3, {v20 -> v21})
+  Goto(blk3, {v22 -> v23})
 
 blk2:
 Statements:
-  (v22: ()) <- struct_construct()
-  (v23: core::bool) <- bool::False(v22)
+  (v24: ()) <- struct_construct()
+  (v25: core::bool) <- bool::False(v24)
 End:
-  Goto(blk3, {v23 -> v21})
+  Goto(blk3, {v25 -> v23})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v21) {
-    bool::False(v24) => blk4,
-    bool::True(v25) => blk5,
+  Match(match_enum(v23) {
+    bool::False(v26) => blk4,
+    bool::True(v27) => blk5,
   })
 
 blk4:
 Statements:
-  (v29: (core::felt252, core::array::Array::<core::felt252>)) <- struct_construct(v0, v9)
-  () <- test::consume(v29)
-  (v26: core::felt252) <- 1
+  (v31: (core::felt252, core::array::Array::<core::felt252>)) <- struct_construct(v0, v9)
+  () <- test::consume(v31)
+  (v28: core::felt252) <- 1
 End:
-  Return(v26)
+  Return(v28)
 
 blk5:
 Statements:
@@ -559,74 +559,74 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v7) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v8) => blk2,
+    IsZeroResult::NonZero(v10) => blk2,
   })
 
 blk1:
 Statements:
-  (v9: ()) <- struct_construct()
-  (v10: core::bool) <- bool::True(v9)
+  (v11: ()) <- struct_construct()
+  (v12: core::bool) <- bool::True(v11)
 End:
-  Goto(blk3, {v10 -> v11})
+  Goto(blk3, {v12 -> v13})
 
 blk2:
 Statements:
-  (v12: ()) <- struct_construct()
-  (v13: core::bool) <- bool::False(v12)
+  (v14: ()) <- struct_construct()
+  (v15: core::bool) <- bool::False(v14)
 End:
-  Goto(blk3, {v13 -> v11})
+  Goto(blk3, {v15 -> v13})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v11) {
-    bool::False(v14) => blk4,
-    bool::True(v15) => blk5,
+  Match(match_enum(v13) {
+    bool::False(v16) => blk4,
+    bool::True(v17) => blk5,
   })
 
 blk4:
 Statements:
-  (v16: core::felt252, v17: (core::felt252, core::felt252)) <- test::get_tuple::<(core::felt252, core::felt252)>()
-  (v18: (core::felt252, (core::felt252, core::felt252))) <- struct_construct(v16, v17)
+  (v18: core::felt252, v19: (core::felt252, core::felt252)) <- test::get_tuple::<(core::felt252, core::felt252)>()
+  (v20: (core::felt252, (core::felt252, core::felt252))) <- struct_construct(v18, v19)
 End:
-  Goto(blk6, {v18 -> v19})
+  Goto(blk6, {v20 -> v21})
 
 blk5:
 Statements:
-  (v20: (core::felt252, (core::felt252, core::felt252))) <- struct_construct(v2, v1)
+  (v22: (core::felt252, (core::felt252, core::felt252))) <- struct_construct(v2, v1)
 End:
-  Goto(blk6, {v20 -> v19})
+  Goto(blk6, {v22 -> v21})
 
 blk6:
 Statements:
-  (v21: core::felt252, v22: @core::felt252) <- snapshot(v2)
-  (v26: core::felt252) <- desnap(v22)
+  (v23: core::felt252, v24: @core::felt252) <- snapshot(v2)
+  (v28: core::felt252) <- desnap(v24)
 End:
-  Match(match core::felt252_is_zero(v26) {
+  Match(match core::felt252_is_zero(v28) {
     IsZeroResult::Zero => blk7,
-    IsZeroResult::NonZero(v27) => blk8,
+    IsZeroResult::NonZero(v31) => blk8,
   })
 
 blk7:
 Statements:
-  (v28: ()) <- struct_construct()
-  (v29: core::bool) <- bool::True(v28)
+  (v32: ()) <- struct_construct()
+  (v33: core::bool) <- bool::True(v32)
 End:
-  Goto(blk9, {v29 -> v30})
+  Goto(blk9, {v33 -> v34})
 
 blk8:
 Statements:
-  (v31: ()) <- struct_construct()
-  (v32: core::bool) <- bool::False(v31)
+  (v35: ()) <- struct_construct()
+  (v36: core::bool) <- bool::False(v35)
 End:
-  Goto(blk9, {v32 -> v30})
+  Goto(blk9, {v36 -> v34})
 
 blk9:
 Statements:
 End:
-  Match(match_enum(v30) {
-    bool::False(v33) => blk10,
-    bool::True(v34) => blk11,
+  Match(match_enum(v34) {
+    bool::False(v37) => blk10,
+    bool::True(v38) => blk11,
   })
 
 blk10:
@@ -636,35 +636,35 @@ End:
 
 blk11:
 Statements:
-  (v35: core::felt252, v36: (core::felt252, core::felt252)) <- struct_destructure(v19)
-  (v37: core::felt252, v38: @core::felt252) <- snapshot(v35)
-  (v42: core::felt252) <- desnap(v38)
+  (v39: core::felt252, v40: (core::felt252, core::felt252)) <- struct_destructure(v21)
+  (v41: core::felt252, v42: @core::felt252) <- snapshot(v39)
+  (v46: core::felt252) <- desnap(v42)
 End:
-  Match(match core::felt252_is_zero(v42) {
+  Match(match core::felt252_is_zero(v46) {
     IsZeroResult::Zero => blk12,
-    IsZeroResult::NonZero(v43) => blk13,
+    IsZeroResult::NonZero(v49) => blk13,
   })
 
 blk12:
 Statements:
-  (v44: ()) <- struct_construct()
-  (v45: core::bool) <- bool::True(v44)
+  (v50: ()) <- struct_construct()
+  (v51: core::bool) <- bool::True(v50)
 End:
-  Goto(blk14, {v45 -> v46})
+  Goto(blk14, {v51 -> v52})
 
 blk13:
 Statements:
-  (v47: ()) <- struct_construct()
-  (v48: core::bool) <- bool::False(v47)
+  (v53: ()) <- struct_construct()
+  (v54: core::bool) <- bool::False(v53)
 End:
-  Goto(blk14, {v48 -> v46})
+  Goto(blk14, {v54 -> v52})
 
 blk14:
 Statements:
 End:
-  Match(match_enum(v46) {
-    bool::False(v49) => blk15,
-    bool::True(v50) => blk17,
+  Match(match_enum(v52) {
+    bool::False(v55) => blk15,
+    bool::True(v56) => blk17,
   })
 
 blk15:
@@ -675,14 +675,14 @@ End:
 blk16:
 Statements:
 End:
-  Return(v21)
+  Return(v23)
 
 blk17:
 Statements:
-  (v51: core::felt252, v52: core::felt252) <- struct_destructure(v36)
-  (v53: core::felt252) <- core::felt252_add(v51, v52)
+  (v57: core::felt252, v58: core::felt252) <- struct_destructure(v40)
+  (v59: core::felt252) <- core::felt252_add(v57, v58)
 End:
-  Return(v53)
+  Return(v59)
 
 //! > after
 Parameters: v0: core::felt252
@@ -693,73 +693,73 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v7) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v8) => blk2,
+    IsZeroResult::NonZero(v10) => blk2,
   })
 
 blk1:
 Statements:
-  (v9: ()) <- struct_construct()
-  (v10: core::bool) <- bool::True(v9)
+  (v11: ()) <- struct_construct()
+  (v12: core::bool) <- bool::True(v11)
 End:
-  Goto(blk3, {v10 -> v11})
+  Goto(blk3, {v12 -> v13})
 
 blk2:
 Statements:
-  (v12: ()) <- struct_construct()
-  (v13: core::bool) <- bool::False(v12)
+  (v14: ()) <- struct_construct()
+  (v15: core::bool) <- bool::False(v14)
 End:
-  Goto(blk3, {v13 -> v11})
+  Goto(blk3, {v15 -> v13})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v11) {
-    bool::False(v14) => blk4,
-    bool::True(v15) => blk5,
+  Match(match_enum(v13) {
+    bool::False(v16) => blk4,
+    bool::True(v17) => blk5,
   })
 
 blk4:
 Statements:
-  (v16: core::felt252, v17: (core::felt252, core::felt252)) <- test::get_tuple::<(core::felt252, core::felt252)>()
-  (v58: core::felt252, v59: core::felt252) <- struct_destructure(v17)
+  (v18: core::felt252, v19: (core::felt252, core::felt252)) <- test::get_tuple::<(core::felt252, core::felt252)>()
+  (v64: core::felt252, v65: core::felt252) <- struct_destructure(v19)
 End:
-  Goto(blk6, {v16 -> v54, v58 -> v56, v59 -> v57})
+  Goto(blk6, {v18 -> v60, v64 -> v62, v65 -> v63})
 
 blk5:
 Statements:
 End:
-  Goto(blk6, {v2 -> v54, v0 -> v56, v0 -> v57})
+  Goto(blk6, {v2 -> v60, v0 -> v62, v0 -> v63})
 
 blk6:
 Statements:
-  (v21: core::felt252, v22: @core::felt252) <- snapshot(v2)
-  (v26: core::felt252) <- desnap(v22)
+  (v23: core::felt252, v24: @core::felt252) <- snapshot(v2)
+  (v28: core::felt252) <- desnap(v24)
 End:
-  Match(match core::felt252_is_zero(v26) {
+  Match(match core::felt252_is_zero(v28) {
     IsZeroResult::Zero => blk7,
-    IsZeroResult::NonZero(v27) => blk8,
+    IsZeroResult::NonZero(v31) => blk8,
   })
 
 blk7:
 Statements:
-  (v28: ()) <- struct_construct()
-  (v29: core::bool) <- bool::True(v28)
+  (v32: ()) <- struct_construct()
+  (v33: core::bool) <- bool::True(v32)
 End:
-  Goto(blk9, {v29 -> v30})
+  Goto(blk9, {v33 -> v34})
 
 blk8:
 Statements:
-  (v31: ()) <- struct_construct()
-  (v32: core::bool) <- bool::False(v31)
+  (v35: ()) <- struct_construct()
+  (v36: core::bool) <- bool::False(v35)
 End:
-  Goto(blk9, {v32 -> v30})
+  Goto(blk9, {v36 -> v34})
 
 blk9:
 Statements:
 End:
-  Match(match_enum(v30) {
-    bool::False(v33) => blk10,
-    bool::True(v34) => blk11,
+  Match(match_enum(v34) {
+    bool::False(v37) => blk10,
+    bool::True(v38) => blk11,
   })
 
 blk10:
@@ -769,34 +769,34 @@ End:
 
 blk11:
 Statements:
-  (v37: core::felt252, v38: @core::felt252) <- snapshot(v54)
-  (v42: core::felt252) <- desnap(v38)
+  (v41: core::felt252, v42: @core::felt252) <- snapshot(v60)
+  (v46: core::felt252) <- desnap(v42)
 End:
-  Match(match core::felt252_is_zero(v42) {
+  Match(match core::felt252_is_zero(v46) {
     IsZeroResult::Zero => blk12,
-    IsZeroResult::NonZero(v43) => blk13,
+    IsZeroResult::NonZero(v49) => blk13,
   })
 
 blk12:
 Statements:
-  (v44: ()) <- struct_construct()
-  (v45: core::bool) <- bool::True(v44)
+  (v50: ()) <- struct_construct()
+  (v51: core::bool) <- bool::True(v50)
 End:
-  Goto(blk14, {v45 -> v46})
+  Goto(blk14, {v51 -> v52})
 
 blk13:
 Statements:
-  (v47: ()) <- struct_construct()
-  (v48: core::bool) <- bool::False(v47)
+  (v53: ()) <- struct_construct()
+  (v54: core::bool) <- bool::False(v53)
 End:
-  Goto(blk14, {v48 -> v46})
+  Goto(blk14, {v54 -> v52})
 
 blk14:
 Statements:
 End:
-  Match(match_enum(v46) {
-    bool::False(v49) => blk15,
-    bool::True(v50) => blk17,
+  Match(match_enum(v52) {
+    bool::False(v55) => blk15,
+    bool::True(v56) => blk17,
   })
 
 blk15:
@@ -807,13 +807,13 @@ End:
 blk16:
 Statements:
 End:
-  Return(v21)
+  Return(v23)
 
 blk17:
 Statements:
-  (v53: core::felt252) <- core::felt252_add(v56, v57)
+  (v59: core::felt252) <- core::felt252_add(v62, v63)
 End:
-  Return(v53)
+  Return(v59)
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-lowering/src/optimizations/test_data/variable_forwarding
+++ b/crates/cairo-lang-lowering/src/optimizations/test_data/variable_forwarding
@@ -70,48 +70,48 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v6) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v7) => blk2,
+    IsZeroResult::NonZero(v9) => blk2,
   })
 
 blk1:
 Statements:
-  (v8: ()) <- struct_construct()
-  (v9: core::bool) <- bool::True(v8)
+  (v10: ()) <- struct_construct()
+  (v11: core::bool) <- bool::True(v10)
 End:
-  Goto(blk3, {v9 -> v10})
+  Goto(blk3, {v11 -> v12})
 
 blk2:
 Statements:
-  (v11: ()) <- struct_construct()
-  (v12: core::bool) <- bool::False(v11)
+  (v13: ()) <- struct_construct()
+  (v14: core::bool) <- bool::False(v13)
 End:
-  Goto(blk3, {v12 -> v10})
+  Goto(blk3, {v14 -> v12})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v10) {
-    bool::False(v13) => blk4,
-    bool::True(v14) => blk5,
+  Match(match_enum(v12) {
+    bool::False(v15) => blk4,
+    bool::True(v16) => blk5,
   })
 
 blk4:
 Statements:
-  (v15: core::felt252) <- 1
-  (v16: core::felt252) <- core::felt252_add(v1, v15)
+  (v17: core::felt252) <- 1
+  (v18: core::felt252) <- core::felt252_add(v1, v17)
 End:
-  Goto(blk6, {v16 -> v17})
+  Goto(blk6, {v18 -> v19})
 
 blk5:
 Statements:
 End:
-  Goto(blk6, {v1 -> v17})
+  Goto(blk6, {v1 -> v19})
 
 blk6:
 Statements:
-  (v18: core::felt252) <- core::felt252_add(v17, v1)
+  (v20: core::felt252) <- core::felt252_add(v19, v1)
 End:
-  Return(v18)
+  Return(v20)
 
 //! > after
 Parameters: v0: core::felt252
@@ -120,48 +120,48 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v0) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v7) => blk2,
+    IsZeroResult::NonZero(v9) => blk2,
   })
 
 blk1:
 Statements:
-  (v8: ()) <- struct_construct()
-  (v9: core::bool) <- bool::True(v8)
+  (v10: ()) <- struct_construct()
+  (v11: core::bool) <- bool::True(v10)
 End:
-  Goto(blk3, {v9 -> v10})
+  Goto(blk3, {v11 -> v12})
 
 blk2:
 Statements:
-  (v11: ()) <- struct_construct()
-  (v12: core::bool) <- bool::False(v11)
+  (v13: ()) <- struct_construct()
+  (v14: core::bool) <- bool::False(v13)
 End:
-  Goto(blk3, {v12 -> v10})
+  Goto(blk3, {v14 -> v12})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v10) {
-    bool::False(v13) => blk4,
-    bool::True(v14) => blk5,
+  Match(match_enum(v12) {
+    bool::False(v15) => blk4,
+    bool::True(v16) => blk5,
   })
 
 blk4:
 Statements:
-  (v15: core::felt252) <- 1
-  (v16: core::felt252) <- core::felt252_add(v0, v15)
+  (v17: core::felt252) <- 1
+  (v18: core::felt252) <- core::felt252_add(v0, v17)
 End:
-  Goto(blk6, {v16 -> v17})
+  Goto(blk6, {v18 -> v19})
 
 blk5:
 Statements:
 End:
-  Goto(blk6, {v0 -> v17})
+  Goto(blk6, {v0 -> v19})
 
 blk6:
 Statements:
-  (v18: core::felt252) <- core::felt252_add(v17, v0)
+  (v20: core::felt252) <- core::felt252_add(v19, v0)
 End:
-  Return(v18)
+  Return(v20)
 
 //! > ==========================================================================
 
@@ -834,43 +834,43 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v17) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v18) => blk2,
+    IsZeroResult::NonZero(v20) => blk2,
   })
 
 blk1:
 Statements:
-  (v19: ()) <- struct_construct()
-  (v20: core::bool) <- bool::True(v19)
+  (v21: ()) <- struct_construct()
+  (v22: core::bool) <- bool::True(v21)
 End:
-  Goto(blk3, {v20 -> v21})
+  Goto(blk3, {v22 -> v23})
 
 blk2:
 Statements:
-  (v22: ()) <- struct_construct()
-  (v23: core::bool) <- bool::False(v22)
+  (v24: ()) <- struct_construct()
+  (v25: core::bool) <- bool::False(v24)
 End:
-  Goto(blk3, {v23 -> v21})
+  Goto(blk3, {v25 -> v23})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v21) {
-    bool::False(v24) => blk4,
-    bool::True(v25) => blk5,
+  Match(match_enum(v23) {
+    bool::False(v26) => blk4,
+    bool::True(v27) => blk5,
   })
 
 blk4:
 Statements:
   () <- test::consume(v11)
-  (v26: core::felt252) <- 1
+  (v28: core::felt252) <- 1
 End:
-  Return(v26)
+  Return(v28)
 
 blk5:
 Statements:
-  (v27: core::felt252, v28: core::array::Array::<core::felt252>) <- struct_destructure(v11)
+  (v29: core::felt252, v30: core::array::Array::<core::felt252>) <- struct_destructure(v11)
 End:
-  Return(v27)
+  Return(v29)
 
 //! > after
 Parameters: v0: core::felt252
@@ -887,37 +887,37 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v0) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v18) => blk2,
+    IsZeroResult::NonZero(v20) => blk2,
   })
 
 blk1:
 Statements:
-  (v19: ()) <- struct_construct()
-  (v20: core::bool) <- bool::True(v19)
+  (v21: ()) <- struct_construct()
+  (v22: core::bool) <- bool::True(v21)
 End:
-  Goto(blk3, {v20 -> v21})
+  Goto(blk3, {v22 -> v23})
 
 blk2:
 Statements:
-  (v22: ()) <- struct_construct()
-  (v23: core::bool) <- bool::False(v22)
+  (v24: ()) <- struct_construct()
+  (v25: core::bool) <- bool::False(v24)
 End:
-  Goto(blk3, {v23 -> v21})
+  Goto(blk3, {v25 -> v23})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v21) {
-    bool::False(v24) => blk4,
-    bool::True(v25) => blk5,
+  Match(match_enum(v23) {
+    bool::False(v26) => blk4,
+    bool::True(v27) => blk5,
   })
 
 blk4:
 Statements:
   () <- test::consume(v11)
-  (v26: core::felt252) <- 1
+  (v28: core::felt252) <- 1
 End:
-  Return(v26)
+  Return(v28)
 
 blk5:
 Statements:
@@ -1065,49 +1065,49 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v7) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v8) => blk2,
+    IsZeroResult::NonZero(v10) => blk2,
   })
 
 blk1:
 Statements:
-  (v9: ()) <- struct_construct()
-  (v10: core::bool) <- bool::True(v9)
+  (v11: ()) <- struct_construct()
+  (v12: core::bool) <- bool::True(v11)
 End:
-  Goto(blk3, {v10 -> v11})
+  Goto(blk3, {v12 -> v13})
 
 blk2:
 Statements:
-  (v12: ()) <- struct_construct()
-  (v13: core::bool) <- bool::False(v12)
+  (v14: ()) <- struct_construct()
+  (v15: core::bool) <- bool::False(v14)
 End:
-  Goto(blk3, {v13 -> v11})
+  Goto(blk3, {v15 -> v13})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v11) {
-    bool::False(v14) => blk4,
-    bool::True(v15) => blk5,
+  Match(match_enum(v13) {
+    bool::False(v16) => blk4,
+    bool::True(v17) => blk5,
   })
 
 blk4:
 Statements:
-  (v16: core::integer::u32) <- struct_destructure(v0)
+  (v18: core::integer::u32) <- struct_destructure(v0)
 End:
-  Goto(blk6, {v16 -> v17})
+  Goto(blk6, {v18 -> v19})
 
 blk5:
 Statements:
-  (v18: core::integer::u32) <- struct_destructure(v0)
+  (v20: core::integer::u32) <- struct_destructure(v0)
 End:
-  Goto(blk6, {v18 -> v17})
+  Goto(blk6, {v20 -> v19})
 
 blk6:
 Statements:
-  (v19: core::integer::u32, v20: @core::integer::u32) <- snapshot(v17)
-  (v21: core::integer::u32) <- desnap(v20)
+  (v21: core::integer::u32, v22: @core::integer::u32) <- snapshot(v19)
+  (v23: core::integer::u32) <- desnap(v22)
 End:
-  Return(v21)
+  Return(v23)
 
 //! > after
 Parameters: v0: (core::integer::u32,), v1: core::felt252
@@ -1116,47 +1116,47 @@ Statements:
 End:
   Match(match core::felt252_is_zero(v1) {
     IsZeroResult::Zero => blk1,
-    IsZeroResult::NonZero(v8) => blk2,
+    IsZeroResult::NonZero(v10) => blk2,
   })
 
 blk1:
 Statements:
-  (v9: ()) <- struct_construct()
-  (v10: core::bool) <- bool::True(v9)
+  (v11: ()) <- struct_construct()
+  (v12: core::bool) <- bool::True(v11)
 End:
-  Goto(blk3, {v10 -> v11})
+  Goto(blk3, {v12 -> v13})
 
 blk2:
 Statements:
-  (v12: ()) <- struct_construct()
-  (v13: core::bool) <- bool::False(v12)
+  (v14: ()) <- struct_construct()
+  (v15: core::bool) <- bool::False(v14)
 End:
-  Goto(blk3, {v13 -> v11})
+  Goto(blk3, {v15 -> v13})
 
 blk3:
 Statements:
 End:
-  Match(match_enum(v11) {
-    bool::False(v14) => blk4,
-    bool::True(v15) => blk5,
+  Match(match_enum(v13) {
+    bool::False(v16) => blk4,
+    bool::True(v17) => blk5,
   })
 
 blk4:
 Statements:
-  (v16: core::integer::u32) <- struct_destructure(v0)
+  (v18: core::integer::u32) <- struct_destructure(v0)
 End:
-  Goto(blk6, {v16 -> v17})
+  Goto(blk6, {v18 -> v19})
 
 blk5:
 Statements:
-  (v18: core::integer::u32) <- struct_destructure(v0)
+  (v20: core::integer::u32) <- struct_destructure(v0)
 End:
-  Goto(blk6, {v18 -> v17})
+  Goto(blk6, {v20 -> v19})
 
 blk6:
 Statements:
 End:
-  Return(v17)
+  Return(v19)
 
 //! > lowering_diagnostics
 

--- a/crates/cairo-lang-sierra-generator/src/statement_location_test_data/simple
+++ b/crates/cairo-lang-sierra-generator/src/statement_location_test_data/simple
@@ -1264,13 +1264,6 @@ Originating location:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: core::byte_array::ByteArrayImpl::append_word
 Inlined at:
-      fn append_word(ref self: ByteArray, word: felt252, len: usize) {
- _____^
-| ...
-|     }
-|_____^
-In function: core::byte_array::ByteArrayImpl::append_word
-Inlined at:
     core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
@@ -1874,13 +1867,6 @@ Originating location:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: core::byte_array::ByteArrayImpl::append_word
 Inlined at:
-      fn append_word(ref self: ByteArray, word: felt252, len: usize) {
- _____^
-| ...
-|     }
-|_____^
-In function: core::byte_array::ByteArrayImpl::append_word
-Inlined at:
     core::byte_array::ByteArrayTrait::append_word(ref __formatter_for_print_macros__.buffer, 0x7820213d20790a, 7);
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: writeln_macro::writeln_macro
@@ -2186,8 +2172,12 @@ Inlined at:
 In function: println_macro::println_macro
 [27]:
 Originating location:
-    const fn unwrap<+Destruct<E>>(self: Result<T, E>) -> T {
-                                  ^^^^
+            Ok(x) => x,
+               ^
+In function: core::result::ResultTraitImpl::expect
+Inlined at:
+        self.expect('Result::unwrap failed.')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In function: core::result::ResultTraitImpl::unwrap
 Inlined at:
       core::result::ResultTrait::<(), core::fmt::Error>::unwrap(
@@ -2205,22 +2195,8 @@ Originating location:
 |_____^
 In function: core::result::ResultTraitImpl::expect
 Inlined at:
-      const fn expect<+PanicDestruct<E>>(self: Result<T, E>, err: felt252) -> T {
- _____^
-| ...
-|     }
-|_____^
-In function: core::result::ResultTraitImpl::expect
-Inlined at:
         self.expect('Result::unwrap failed.')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In function: core::result::ResultTraitImpl::unwrap
-Inlined at:
-      const fn unwrap<+Destruct<E>>(self: Result<T, E>) -> T {
- _____^
-|         self.expect('Result::unwrap failed.')
-|     }
-|_____^
 In function: core::result::ResultTraitImpl::unwrap
 Inlined at:
       core::result::ResultTrait::<(), core::fmt::Error>::unwrap(


### PR DESCRIPTION
During the interleaved inlining/const-folding pass, a call with constant
arguments to a function that would be inlined was first specialized - paying
a full casm size estimation of the specialized function in
priv_should_specialize - and the specialized function was then immediately
inlined anyway (a specialized function inherits its base's inline
configuration, and a small base's specialization is smaller yet). Inlining
the base directly and const folding in place reaches equivalent code without
the extra estimation and specialized function lowering.

Skip specialization for such calls. As every statement is checked for
inlining right after its const-folding visit, such calls are always inlined
by the interleaved pass and never survive to the standalone const-folding
pass.

Improves full-compilation time by ~4.5% (measured on top of the size
estimation memoization). Emitted code is equivalent: e2e and contract
outputs are unchanged, and debug locations lose a redundant self-inlining
frame.