### PR TITLE
(fix): lazily format the function path in optimization dump traces

### DIFF
--- a/crates/cairo-lang-lowering/src/ids.rs
+++ b/crates/cairo-lang-lowering/src/ids.rs
@@ -184,11 +184,21 @@ impl<'db> ConcreteFunctionWithBodyLongId<'db> {
         }
     }
     pub fn full_path(&self, db: &dyn Database) -> String {
+        format!("{:?}", self.debug(db))
+    }
+}
+impl<'db> DebugWithDb<'db> for ConcreteFunctionWithBodyLongId<'db> {
+    type Db = dyn Database;
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &'db dyn Database) -> std::fmt::Result {
         match self {
-            ConcreteFunctionWithBodyLongId::Semantic(semantic) => semantic.full_path(db),
-            ConcreteFunctionWithBodyLongId::Generated(generated) => generated.full_path(db),
+            ConcreteFunctionWithBodyLongId::Semantic(semantic) => {
+                write!(f, "{:?}", semantic.debug(db))
+            }
+            ConcreteFunctionWithBodyLongId::Generated(generated) => {
+                write!(f, "{:?}", generated.debug(db))
+            }
             ConcreteFunctionWithBodyLongId::Specialized(specialized) => {
-                specialized.long(db).full_path(db)
+                write!(f, "{:?}", specialized.debug(db))
             }
         }
     }

--- a/crates/cairo-lang-lowering/src/optimizations/strategy.rs
+++ b/crates/cairo-lang-lowering/src/optimizations/strategy.rs
@@ -149,8 +149,8 @@ impl<'db> ApplyOptimization<'db> for [OptimizationPhase<'db>] {
         let fmt = crate::fmt::LoweredFormatter::new(db, &lowered.variables);
         tracing::trace!(
             target: "optimization_dump",
-            "({})\nInitial:\n{:?}",
-            function.full_path(db),
+            "({:?})\nInitial:\n{:?}",
+            function.debug(db),
             lowered.debug(&fmt)
         );
 
@@ -159,8 +159,8 @@ impl<'db> ApplyOptimization<'db> for [OptimizationPhase<'db>] {
             let fmt = crate::fmt::LoweredFormatter::new(db, &lowered.variables);
             tracing::trace!(
                 target: "optimization_dump",
-                "({})\nAfter {phase:?}:\n{:?}",
-                function.full_path(db),
+                "({:?})\nAfter {phase:?}:\n{:?}",
+                function.debug(db),
                 lowered.debug(&fmt)
             );
         }


### PR DESCRIPTION
Under subscribers with per-layer filters (e.g. scarb's), tracing event
argument expressions are evaluated even when no layer records the event.
The optimization dump eagerly computed `full_path` per phase per
function, and for functions specialized by deeply-nested types (e.g.
circuit gates) formatting expands the type DAG into an
exponentially-sized string, hanging the build.

Added the missing `DebugWithDb` impl for
`ConcreteFunctionWithBodyLongId` (delegating to the existing per-variant
impls) and pass the lazy `function.debug(db)` to the trace events.

Fixes the 2.19.0 regression reported in #9711.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>