### PR TITLE
Parse the generated function paths in generated Sierra

### DIFF
--- a/crates/cairo-lang-sierra/src/parser.lalrpop
+++ b/crates/cairo-lang-sierra/src/parser.lalrpop
@@ -108,6 +108,7 @@ TokenTree: String = {
     "/" => <>.to_string(),
     "\\" => <>.to_string(),
     "-" => <>.to_string(),
+    "#" => <>.to_string(),
 }
 
 BracesTokenTree: String = {
@@ -219,6 +220,7 @@ ConcreteLabel: String = {
     "(" <generic_args:GenericArgsString> "," ")" => format!("({generic_args})"),
     "(" ")" => format!("()"),
     <base:ConcreteLabel> "::" <next:BasicLabel> => format!("{base}::{next}"),
+    <base:ConcreteLabel> "::" <next:BracesTokenTree> => format!("{base}::{next}"),
     <base:ConcreteLabel> "::" "<" <generic_args:GenericArgsString> ">" => format!("{base}::<{generic_args}>"),
     <base:ConcreteLabel> "<" <generic_args:GenericArgsString> ">" => format!("{base}<{generic_args}>"),
 }

--- a/crates/cairo-lang-sierra/tests/format_test.rs
+++ b/crates/cairo-lang-sierra/tests/format_test.rs
@@ -17,12 +17,15 @@ fn format_test() {
                 type [4]= Enum<ut@core::option ::Option:: <core::felt252>, [3],[2]>;
                 type Complex = Struct<ut@Complex:: <core::felt252, @core::felt252>,[8],[9]>;
                 type ClosureName = Struct<ut@{closure@/path/examples/fib.cairo:3:15: 3:23}>;
+                type GeneratedName = Struct<ut@test::foo ::{closure#0}>;
+                type NestedGeneratedName = Struct<ut@test::foo::{closure#0}:: {loop#0}>;
 
                 libfunc CalleeId = LibfuncId ;
                 // Additional comment.
                 libfunc OtherCalleeId = LibfuncId <arg, 4>;
                 libfunc [5642] = LibfuncId<[22 ], 4>;
                 libfunc CallFunction = Call<user@Function>;
+                libfunc CallGenerated = Call<user@core::sha256::compute_sha256_byte_array::{loop#0}>;
                 libfunc LibDependent = LibDependent<lib@[124]>;
                 callee() -> ();
                 callee(arg1) -> (res1);
@@ -38,6 +41,7 @@ fn format_test() {
                 Name@5() -> ();
                 Other@3([5]: T1) -> (T2);
                 [343]@3([5]: [6343]) -> ([341]);
+                test::foo::{closure#0}::{loop#0}@9() -> ();
             "},)
             .map(|p| p.to_string()),
         Ok(indoc! {"
@@ -48,11 +52,14 @@ fn format_test() {
             type [4] = Enum<ut@core::option::Option::<core::felt252>, [3], [2]>;
             type Complex = Struct<ut@Complex::<core::felt252, @core::felt252>, [8], [9]>;
             type ClosureName = Struct<ut@{closure@/path/examples/fib.cairo:3:15:3:23}>;
+            type GeneratedName = Struct<ut@test::foo::{closure#0}>;
+            type NestedGeneratedName = Struct<ut@test::foo::{closure#0}::{loop#0}>;
 
             libfunc CalleeId = LibfuncId;
             libfunc OtherCalleeId = LibfuncId<arg, 4>;
             libfunc [5642] = LibfuncId<[22], 4>;
             libfunc CallFunction = Call<user@Function>;
+            libfunc CallGenerated = Call<user@core::sha256::compute_sha256_byte_array::{loop#0}>;
             libfunc LibDependent = LibDependent<lib@[124]>;
 
             callee() -> ();
@@ -68,11 +75,13 @@ fn format_test() {
             F0_B0:
             return(r);
             return(r1, r2);
+            F3:
             return([1], [45], [0]);
 
             Name@F0() -> ();
             Other@F2([5]: T1) -> (T2);
             [343]@F2([5]: [6343]) -> ([341]);
+            test::foo::{closure#0}::{loop#0}@F3() -> ();
         "}
         .to_string())
     );
@@ -95,6 +104,7 @@ fn versioned_program_display_test() {
                 libfunc OtherCalleeId = LibfuncId <arg, 4>;
                 libfunc [5642] = LibfuncId<[22 ], 4>;
                 libfunc CallFunction = Call<user@Function>;
+                libfunc CallGenerated = Call<user@core::sha256::compute_sha256_byte_array::{loop#0}>;
                 libfunc LibDependent = LibDependent<lib@[124]>;
                 callee() -> ();
                 callee(arg1) -> (res1);


### PR DESCRIPTION
Based on `main`, so it can merge independently of #10359 - and it should merge before or with it, since on that PR alone the compiler emits Sierra its own parser cannot read.

## Summary

Extends the Sierra parser to accept path segments that are braces token trees, by accepting:
- a braces token tree as a path segment of a label - `foo::{closure#0}`, where previously only `ConcreteLabel` immediately followed by braces (`foo{...}`) was accepted;
- `#` within a token tree, which was not a token of the grammar at all.

Both are additions - the existing bracketed (`test::foo[57-168]`) and braced (`{closure@lib.cairo:3:5: 3:7}`) forms still parse.

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

## Why is this change needed?

#10359 names generated functions `test::foo::{closure#0}` / `test::foo::{loop#0}`, and those names reach Sierra function ids and type debug names. With that PR and without this one, the parser cannot read the Sierra the compiler emits. On the `libfuncs_coverage` Sierra as regenerated there, which contains `core::sha256::compute_sha256_byte_array::{loop#0}`:

```
$ cargo run --bin sierra-compile -- \
    crates/cairo-lang-starknet/test_data/libfuncs_coverage__libfuncs_coverage.sierra out.casm
Error: Failed to parse sierra program with: `UnrecognizedToken { token: (233278, Token(35, "{"), 233279),
expected: ["r#\"[a-zA-Z_][a-zA-Z_0-9]*\"#", "\"<\""] }`.
```

It fails at the `{` after `::`, before `#` is even reached. With this change the same file parses and compiles to CASM.

Note that CI on #10359 is fully green, `sierra-updated-check` included - that check verifies the `.sierra` goldens are up to date, not that they can be read back.

## What was the behavior or documentation before?

A label's path segments had to be identifiers, so a name with a `{...}` segment was a parse error.

## What is the behavior or documentation after?

A path segment may also be a braces token tree, and `#` is a token tree token, so these all parse:

```
test::foo::{closure#0}
test::foo::{loop#0}
test::foo::{closure#0}::{loop#0}
core::sha256::compute_sha256_byte_array::{loop#0}
```

## Related issue or discussion (if any)

#10359 - which produces such names. This PR only widens what the parser accepts, so it is harmless on its own.

## Additional context

The cases live in the existing round-trip test, `crates/cairo-lang-sierra/tests/format_test.rs`, which parses Sierra and compares its printed form - so the grammar and the printer are kept in step. Generated paths are added there in each position they occur: a `ut@` user type, a `user@` generic arg of a libfunc, and a function id, with loose spacing around `::` so normalization is covered too. The added function is anchored at the last statement so that no existing statement label is renumbered.

`cargo test -p cairo-lang-sierra` passes in full on `main` with this change, so no existing input parses differently.

https://claude.ai/code/session_01MMkzrvP4FJZyzEYn9B4j7W