### PR TITLE
Updated nightly version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
-          toolchain: nightly-2026-07-27
+          toolchain: nightly-2026-08-31
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       - run: |
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           components: rustfmt
-          toolchain: nightly-2026-07-27
+          toolchain: nightly-2026-08-31
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       - run: cargo test --profile=ci-dev -p cairo-lang-syntax-codegen
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           components: rustfmt
-          toolchain: nightly-2026-07-27
+          toolchain: nightly-2026-08-31
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       - run: scripts/rust_fmt.sh --check
 
@@ -169,7 +169,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           components: clippy
-          toolchain: nightly-2026-07-27
+          toolchain: nightly-2026-08-31
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       - run: >
           scripts/clippy.sh
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
-          toolchain: nightly-2026-07-27
+          toolchain: nightly-2026-08-31
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       - run: >
           scripts/docs.sh

--- a/crates/cairo-lang-formatter/src/formatter_impl.rs
+++ b/crates/cairo-lang-formatter/src/formatter_impl.rs
@@ -566,8 +566,8 @@ impl LineBuilder {
             };
             let cur_indent = base_indent + added_indent;
             trees.push(LineBuilder::new(cur_indent));
-            for j in current_line_start..*current_line_end {
-                match &self.children[j] {
+            for child in &self.children[current_line_start..*current_line_end] {
+                match child {
                     LineComponent::Indent(_) => {}
                     LineComponent::Space => {
                         // Ignore spaces at the start of a line
@@ -587,10 +587,10 @@ impl LineBuilder {
                             is_trailing: *is_trailing,
                         });
                     }
-                    _ => trees.last_mut().unwrap().push_child(self.children[j].clone()),
+                    _ => trees.last_mut().unwrap().push_child(child.clone()),
                 }
                 // Indent the comment only if it directly follows the break point.
-                if !self.children[j].is_trivia() {
+                if !child.is_trivia() {
                     comment_only_added_indent = 0;
                 }
             }

--- a/crates/cairo-lang-semantic/src/items/imp.rs
+++ b/crates/cairo-lang-semantic/src/items/imp.rs
@@ -1780,44 +1780,38 @@ impl<'db> ImplLookupContext<'db> {
         db: &'db dyn Database,
     ) -> ImplLookupContext<'db> {
         let crate_id = module_id.owning_crate(db);
-        let negative_impls = generic_params
-            .iter()
-            .filter(|generic_param_id| matches!(generic_param_id.kind(db), GenericKind::NegImpl))
-            .copied()
-            .collect_vec();
-        let generic_params = generic_params
-            .iter()
-            .filter(|generic_param_id| {
-                if !matches!(generic_param_id.kind(db), GenericKind::Impl) {
-                    return false;
+        let mut negative_impls = vec![];
+        let mut constrained_generic_params = vec![];
+        let mut inner_impls = BTreeSet::default();
+        for id in generic_params {
+            match id.kind(db) {
+                GenericKind::Type | GenericKind::Const => {}
+                GenericKind::NegImpl => {
+                    negative_impls.push(id);
                 }
-
-                let uninferred_impl = UninferredImpl::GenericParam(**generic_param_id);
-
-                let Ok(trait_id) = uninferred_impl.trait_id(db) else {
-                    return true;
-                };
-                let Some(set) = db.crate_global_impls(crate_id).get(&trait_id) else {
-                    return true;
-                };
-                let uninferred_impl: UninferredImplById<'db> = uninferred_impl.into();
-                if set.contains(&uninferred_impl) {
-                    return false;
-                };
-                true
-            })
-            .copied()
-            .collect_vec();
+                GenericKind::Impl => {
+                    let uninferred_impl = UninferredImpl::GenericParam(id);
+                    let valid = if let Ok(trait_id) = uninferred_impl.trait_id(db)
+                        && let Some(set) = db.crate_global_impls(crate_id).get(&trait_id)
+                    {
+                        let uninferred_impl: UninferredImplById<'db> = uninferred_impl.into();
+                        !set.contains(&uninferred_impl)
+                    } else {
+                        true
+                    };
+                    if valid {
+                        inner_impls.insert(uninferred_impl.into());
+                        if id.long(db).has_type_constraints_syntax(db) {
+                            constrained_generic_params.push(id);
+                        }
+                    }
+                }
+            }
+        }
         let mut res = Self {
             crate_id,
-            generic_params: generic_params
-                .clone()
-                .into_iter()
-                .filter(|id| id.long(db).has_type_constraints_syntax(db))
-                .collect_vec(),
-            inner_impls: BTreeSet::from_iter(
-                generic_params.into_iter().map(|id| UninferredImpl::GenericParam(id).into()),
-            ),
+            generic_params: constrained_generic_params,
+            inner_impls,
             negative_impls,
         };
         res.insert_module(module_id, db);

--- a/crates/cairo-lang-sierra-generator/src/program_generator.rs
+++ b/crates/cairo-lang-sierra-generator/src/program_generator.rs
@@ -234,8 +234,8 @@ impl<'db> DebugWithDb<'db> for SierraProgramWithDebug<'db> {
             for param in &func.params {
                 writeln!(f, "//   {param}")?;
             }
-            for i in start..end {
-                writeln!(f, "{}; // {i}", sierra_program.statements[i])?;
+            for (i, stmt) in sierra_program.statements.iter().enumerate().take(end).skip(start) {
+                writeln!(f, "{stmt}; // {i}")?;
                 if let Some(loc) =
                     &self.debug_info.statements_locations.locations.get(&StatementIdx(i))
                 {

--- a/crates/cairo-lang-syntax-codegen/src/generator.rs
+++ b/crates/cairo-lang-syntax-codegen/src/generator.rs
@@ -49,7 +49,7 @@ pub fn reformat_rust_code(text: String) -> String {
 }
 pub fn reformat_rust_code_inner(text: String) -> String {
     let sh = Shell::new().unwrap();
-    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-07-27");
+    let cmd = sh.cmd("rustfmt").env("RUSTUP_TOOLCHAIN", "nightly-2026-08-31");
     let cmd_with_args = cmd.arg("--config-path").arg(project_root().join("rustfmt.toml"));
     let mut stdout = cmd_with_args.stdin(text).read().unwrap();
     if !stdout.ends_with('\n') {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The `rustfmt` configuration used by Cairo requires a nightly version of Rust.
 You can install the nightly version by running:
 
 ```sh
-rustup install nightly-2026-07-27
+rustup install nightly-2026-08-31
 ```
 
 ## Running Tests

--- a/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
+++ b/docs/reference/src/components/cairo/modules/getting_started/pages/prerequisites.adoc
@@ -35,5 +35,5 @@ You can install the nightly version by running:
 
 [source,bash]
 ----
-rustup install nightly-2026-07-27
+rustup install nightly-2026-08-31
 ----

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,11 +23,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2026-07-27",
+#         "nightly-2026-08-31",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2024",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2026-07-27".
+# and run "rustup toolchain install nightly-2026-08-31".

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-07-27}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-08-31}"
 
 cargo clippy "$@" --all-targets --all-features -- -D warnings -D future-incompatible \
     -D nonstandard-style -D rust-2018-idioms -D unused

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-07-27}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-08-31}"
 
 RUSTDOCFLAGS="-Dwarnings" cargo doc --document-private-items --no-deps --all-features

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-07-27}"
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly-2026-08-31}"
 
 cargo fmt --all -- "$@"


### PR DESCRIPTION
### TL;DR

Bumps the Rust nightly toolchain from `nightly-2026-07-27` to `nightly-2026-08-31`.

### What changed?

The nightly Rust toolchain version has been updated to `nightly-2026-08-31` across CI workflows, formatting/linting/docs scripts, the syntax codegen tool, and all documentation references. Additionally, a few minor code improvements were made alongside the toolchain bump:

- In `formatter_impl.rs`, index-based loops were replaced with iterator-based loops for cleaner child access.
- In `program_generator.rs`, an index-based loop was replaced with an `enumerate().take().skip()` iterator chain.
- In `imp.rs`, the `ImplLookupContext` construction logic was refactored from chained iterator filters into a single loop with match arms, and now correctly populates `inner_impls` and `constrained_generic_params` in one pass.

### How to test?

Run the existing CI pipeline. Formatting, clippy, and doc generation should all pass with the new toolchain.

### Why make this change?

Keeping the nightly toolchain up to date ensures access to the latest compiler features, bug fixes, and compatibility with nightly-only features used in the project such as advanced `rustfmt` configuration options.