### PR TITLE
Standardize markdown formatting across documentation

### DIFF
--- a/.claude/skills/orizi-review/SKILL.md
+++ b/.claude/skills/orizi-review/SKILL.md
@@ -14,6 +14,7 @@ Review code changes in the style and spirit of Ori Ziv, principal maintainer of 
 Ori values **simplicity above all**. Code should do exactly what it needs to do, nothing more. Every line should earn its place. He is direct, concise, and technically precise. He doesn't sugarcoat — if something is wrong, he says so plainly.
 
 Key principles:
+
 - **Simplicity over cleverness** — the simplest correct solution is the best one
 - **No changes for the sake of changes** — every modification must have clear purpose and value
 - **Correctness first** — understand what the code actually does, not what it looks like it does
@@ -29,9 +30,9 @@ Key principles:
 ### Phase 1: Determine What to Review
 
 1. Parse `$ARGUMENTS`:
-   - If a number: treat as PR number, run `gh pr diff $number`
-   - If a file/directory path: review that file or all files in directory
-   - If empty: run `git diff` and `git diff --cached` to get current changes
+    - If a number: treat as PR number, run `gh pr diff $number`
+    - If a file/directory path: review that file or all files in directory
+    - If empty: run `git diff` and `git diff --cached` to get current changes
 2. Read all changed files completely. Understand the full context of each change.
 3. For each changed file, also read surrounding code (the full function/struct/impl block) to understand context.
 
@@ -40,6 +41,7 @@ Key principles:
 For each change, evaluate against the following checklist — ordered by priority (Ori's actual review priorities, from most to least common):
 
 #### 1. Unnecessary Complexity / Needless Abstraction
+
 - Is there a helper function that's only called once? → **"useless function. inline it."**
 - Is there an abstraction that doesn't earn its keep? → **"needlessly complicated code for the likely zero gain"**
 - Is a simple operation wrapped in unnecessary layers? → flag it
@@ -50,6 +52,7 @@ For each change, evaluate against the following checklist — ordered by priorit
 - Is there a manual trait impl where a derive would work? → **"just derive it"**
 
 #### 2. Redundant or Dead Code
+
 - Are there unnecessary clones? → **"remove unnecessary clone"**
 - Are there unnecessary `Box` wrappers that don't reduce type size? → check before flagging — **"not redundant - this reduces the size of the error type"** (but if truly useless, flag it)
 - Are there unused variables, parameters, or imports? → **"remove - unused."**
@@ -61,6 +64,7 @@ For each change, evaluate against the following checklist — ordered by priorit
 - Are there functions taking `Vec<T>` when `&[T]` or an iterator would work? → change the signature
 
 #### 3. Performance Concerns
+
 - Unnecessary allocations (`.collect()` when iterator would work, `Vec` when slice suffices)
 - Unnecessary `.clone()` calls — prefer borrowing, references, or moving
 - Using `HashMap` where a `Vec` indexed by known indices would work
@@ -72,6 +76,7 @@ For each change, evaluate against the following checklist — ordered by priorit
 - Taking `&StatementIdx` instead of `StatementIdx` for `Copy` types
 
 #### 4. Naming and Clarity
+
 - Variable names should accurately describe what they hold — e.g., **rename `input_reps` to `output_reps` when it represents outputs**
 - Comments should explain **why**, not **what** (the code already says what)
 - Comments that are stale after code changes → **"this comment is weird now."**
@@ -81,6 +86,7 @@ For each change, evaluate against the following checklist — ordered by priorit
 - Generated identifiers should use leading + trailing delimiters → **"let's make it both leading and trailing `__calldata__`"**
 
 #### 5. Code Organization
+
 - Helper functions should come **after** the functions that use them → **"move helper to after usage function."**
 - Don't mix unrelated changes in the same PR → **"revert - as not part of the change."**
 - Separate concerns clearly → **"the multiple contracts concept is completely separate issue than single-file vs package. mention these in different areas."**
@@ -89,6 +95,7 @@ For each change, evaluate against the following checklist — ordered by priorit
 - Refactors should be separated into base PRs → **"can you make the refactor here as a base PR?"**
 
 #### 6. Breaking Changes and API Surface
+
 - Don't remove unused imports in public crates — **"currently we do not remove unused imports - as it is a possible breaking change."**
 - Don't make things `pub` unnecessarily → **"so add only the consts required - and additionally don't make it pub."**
 - Use `pub(super)` to match nearby declarations → **"let's conform to the others."**
@@ -98,6 +105,7 @@ For each change, evaluate against the following checklist — ordered by priorit
 - Functions that appear to panic in public APIs → **"this causes the function to seem as if it might panic - not allowed. revert."**
 
 #### 7. Test Quality
+
 - Tests should be minimal and focused → **"can you write a simpler test here?"**
 - Don't add unnecessary test code → **"no need here - this is a test for the for concept - this adds nothing specific for the test."**
 - Test data changes should include comments showing what changed → **"add here a comment with the diff from before the change for this test."**
@@ -107,15 +115,17 @@ For each change, evaluate against the following checklist — ordered by priorit
 - Add edge-case tests like macros-within-macros → **"add a test for a macro within another macro."**
 
 #### 8. Documentation and Formatting
+
 - Run `./scripts/rust_fmt.sh` → **"run `./scripts/rust_fmt.sh`"**
 - Finish all sentences with periods → **"finish all sentences with `.`"**
 - Limit lines to 100 chars → **"limit lines to 100 chars."**
 - Don't remove existing docs without good reason → **"why remove the doc?"**
-- Short, targeted doc comments — describe *what* and *why*, not *how*
+- Short, targeted doc comments — describe _what_ and _why_, not _how_
 - Per-field documentation for complex helper structs
 - Safety/invariant comments for non-obvious preconditions
 
 #### 9. Correctness
+
 - Understand the semantics — don't just pattern-match code
 - Things that are "there on purpose" should not be removed → **"there on purpose. close PR."** or **"there on purpose - revert."**
 - Verify that the PR actually addresses the stated goal → **"this actually doesn't address it"**
@@ -136,6 +146,7 @@ When flagging an issue, provide the exact code fix. Ori almost never describes w
 Provide **complete, working replacement code** — not pseudocode. The suggestion IS the review comment. For small changes, post the code suggestion with no explanation. For architecture-level changes, provide a brief rationale (one sentence) then the full code suggestion.
 
 Example patterns Ori commonly suggests:
+
 - Combine a chain of operations into a cleaner form
 - Show how to inline a function
 - Show how to use `.zip(&other)` instead of `.zip(other.iter())`
@@ -147,6 +158,7 @@ Example patterns Ori commonly suggests:
 ### Phase 4: Determine Verdict
 
 Apply Ori's cost-benefit framework:
+
 1. **Is this change necessary?** If not → reject. ("change for the sake of a change")
 2. **Could this break something?** If so → be very cautious. ("possible breaking change")
 3. **Is there a simpler way?** If so → suggest it. ("useless function. inline it.")
@@ -154,6 +166,7 @@ Apply Ori's cost-benefit framework:
 5. **Is it idiomatic?** If not → suggest the idiomatic form.
 
 Verdicts:
+
 - **Close PR** — if fundamentally broken, unnecessary, or counterproductive → **"close PR."**
 - **Revert specific changes** — if parts of the PR are unrelated or harmful → **"revert - as not part of the change."**
 - **Request changes** — if there are concrete issues to fix
@@ -164,6 +177,7 @@ Verdicts:
 Present findings in Ori's communication style:
 
 **Style rules:**
+
 - Be **direct and concise**. No filler, no pleasantries, no hedging.
 - State the issue plainly. If something is wrong, say it's wrong.
 - Use **lowercase, casual tone** — Ori doesn't capitalize unnecessarily, often uses sentence fragments
@@ -198,6 +212,7 @@ For each issue:
 These are patterns Ori consistently uses and prefers in his own code:
 
 **Ownership and borrowing:**
+
 - Prefer `?` over `.unwrap()` for non-OS failures
 - Pass by value when consumed, by reference when not
 - Use `core::mem::take` over `core::mem::swap` with default — `let state = core::mem::take(&mut self.main_state);`
@@ -206,6 +221,7 @@ These are patterns Ori consistently uses and prefers in his own code:
 - Change `Vec<T>` parameters to `&[T]` or `impl IntoIterator<Item = T>`
 
 **Iterators and collections:**
+
 - Keep iterators as iterators — avoid premature `.collect()`
 - Use `exactly_one()` from itertools instead of `.collect::<Vec<_>>()` then index
 - Use `.extend()` over loop-with-push
@@ -218,6 +234,7 @@ These are patterns Ori consistently uses and prefers in his own code:
 - Return `impl Iterator` from functions instead of `Vec`
 
 **Control flow and patterns:**
+
 - Use `let-chains` for cleaner conditional logic — `if let Some(x) = opt && condition {`
 - Use `let ... else` for early returns — `let Some(x) = opt else { return; };`
 - Use `is_none_or` for Option checks
@@ -225,6 +242,7 @@ These are patterns Ori consistently uses and prefers in his own code:
 - Use `unreachable!` with descriptive messages for impossible branches
 
 **Formatting and style:**
+
 - Inline format args: `format!("{name}")` not `format!("{}", name)`
 - Use `#[derive(Default)]` instead of manual `new()` when applicable
 - Use `pub(super)` to match nearby declarations' visibility

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -47,9 +47,9 @@ it. A behavior covered at its home layer is not re-asserted at other layers.
 6. **Performance-sensitive path** → benchmark, only per
    `references/benchmarks.md` (benches run nightly, not on PRs).
 
-Go up a layer only when the behavior is the *interaction* of stages; reserve
+Go up a layer only when the behavior is the _interaction_ of stages; reserve
 e2e (`tests/e2e_test_data/`) for behavior that individual stage suites cannot
-express. When a plugin/codegen change alters what generated code *does* at
+express. When a plugin/codegen change alters what generated code _does_ at
 runtime, add the executed Cairo-level test in addition to the codegen golden —
 that pair is two different behaviors (shape vs. semantics), not duplication.
 
@@ -106,7 +106,7 @@ from the code inherit its bugs. Cover, in order of demonstrated payoff here:
 No property-testing framework exists in this workspace, so do not write
 property tests today, and do not add the dependency inside an unrelated PR —
 adoption is a team decision. What you can do: when a change touches one of the
-candidates below, suggest adoption *once* (a review note or follow-up task,
+candidates below, suggest adoption _once_ (a review note or follow-up task,
 not a nag on every PR). Recommended framework: **proptest** (composable
 strategies suit compiler-shaped inputs better than quickcheck's one-strategy-
 per-type). Evidence-backed candidates, each motivated by an escaped bug:

--- a/.claude/skills/writing-tests/references/cairo.md
+++ b/.claude/skills/writing-tests/references/cairo.md
@@ -1,7 +1,7 @@
 # Cairo-language test mechanics (this repo)
 
 Self-sufficient reference for tests written in Cairo and executed on the VM.
-Use this layer when the behavior under test is what the code *does when run*
+Use this layer when the behavior under test is what the code _does when run_
 (corelib semantics, arithmetic, Starknet storage/events/syscalls) — codegen
 goldens only prove output stability, and the VM is this repo's execution
 oracle (lambdaclass cairo-vm, via cairo-lang-runner).
@@ -38,7 +38,7 @@ fn bounded_loop() { ... }
 
 Assertion/attribute vocabulary: `assert!`, `assert_eq!`, `assert_ne!`,
 `#[should_panic(expected: ...)]`, `#[available_gas(N)]`, `#[ignore]`.
-Compile-rejection cases (code that must *not* compile) are not written here —
+Compile-rejection cases (code that must _not_ compile) are not written here —
 those are semantic-diagnostic golden cases (see `rust.md`).
 
 ## Running

--- a/.claude/skills/writing-tests/references/golden-framework.md
+++ b/.claude/skills/writing-tests/references/golden-framework.md
@@ -30,6 +30,7 @@ more expected output
 ```
 
 Key points:
+
 - `//! >` is the tag prefix
 - First tag after separator is the test name/description
 - `test_runner_name` specifies which runner function to use (with optional arguments)
@@ -59,6 +60,7 @@ fn foo() -> felt252 {
 ```
 
 Rules:
+
 - `setup_test_function(db, inputs)` (in `cairo_lang_semantic::test_utils`) reads `cairo_code` and
   resolves the single `#[target_function]`-marked free function. Marking several functions is
   supported at the resolution level (`resolve_target_functions` returns all, in definition order),
@@ -129,6 +131,7 @@ cairo_lang_test_utils::test_file_test!(
 ```
 
 Common arguments:
+
 - `expect_diagnostics`: `true`, `false`, or `warnings_only` - use with `verify_diagnostics_expectation`
 
 ### Verifying Diagnostics Expectation
@@ -207,6 +210,7 @@ CAIRO_FIX_TESTS=1 cargo test -p <crate> <test_name>
 This updates the test file with actual outputs.
 
 **CRITICAL**: After using `CAIRO_FIX_TESTS=1`:
+
 1. **Always review the diff** - compare against the state before your branch
 2. Use `git diff` to see exactly what changed in test data files
 3. Verify changes are expected and intentional
@@ -227,6 +231,7 @@ CAIRO_SKIP_FORMAT_TESTS=1 cargo test ...
 ## Test Data File Locations
 
 Convention in this codebase:
+
 - Main tests: `src/test_data/`
 - Optimization tests: `src/optimizations/test_data/`
 - Inline tests: `src/inline/test_data/`
@@ -257,10 +262,10 @@ Two variants take one extra parameter each, for tests the plain entry point cann
 
 - `run_lowering_phases_test_with_db(db, inputs, stage, before_phases, after_phases)` — runs on the
   `LoweringDatabaseForTesting` you pass in instead of a default one, for tests that must configure
-  the database *before* the test function is lowered. `early_unsafe_panic_test.rs` uses it to set
+  the database _before_ the test function is lowered. `early_unsafe_panic_test.rs` uses it to set
   `Flag::UnsafePanic`.
-- `run_lowering_phases_test_with_extra_outputs(inputs, stage, before_phases, after_phases,
-  extra_outputs)` — `extra_outputs` is a `|before, after| -> Vec<(String, String)>` closure whose
+- `run_lowering_phases_test_with_extra_outputs(inputs, stage, before_phases, after_phases, extra_outputs)`
+  — `extra_outputs` is a `|before, after| -> Vec<(String, String)>` closure whose
   entries are appended as output tags after the standard four; it is not called if the function
   failed to lower. `reboxing_test.rs` uses it to emit a `candidates` tag computed from `before`.
 
@@ -307,9 +312,9 @@ When creating a new runner, ensure tests fail appropriately:
 
 1. **Invalid arguments**: Test passes an argument not in `allowed_args` → should fail
 2. **Diagnostic expectations**:
-   - `expect_diagnostics: true` with no diagnostics → should fail
-   - `expect_diagnostics: false` with diagnostics → should fail
-   - `expect_diagnostics: warnings_only` with errors → should fail
+    - `expect_diagnostics: true` with no diagnostics → should fail
+    - `expect_diagnostics: false` with diagnostics → should fail
+    - `expect_diagnostics: warnings_only` with errors → should fail
 3. **Output mismatch**: Actual output differs from expected → should fail
 
 Run without `CAIRO_FIX_TESTS` to verify failures are caught.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -69,4 +69,3 @@ Docs-only PRs without a linked issue are less likely to be accepted.
 Anything else reviewers should know.
 If this is a documentation PR, explain why this change is important for users.
 -->
-

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 
 - [About](#about)
 - [Getting Started](#getting-started)
-  - [Prerequisites](#prerequisites)
-  - [Compiling and running Cairo files](#compiling-and-running-cairo-files)
-  - [Compiling Starknet Contracts](#compiling-starknet-contracts)
+    - [Prerequisites](#prerequisites)
+    - [Compiling and running Cairo files](#compiling-and-running-cairo-files)
+    - [Compiling Starknet Contracts](#compiling-starknet-contracts)
 - [Support](#support)
 - [Project assistance](#project-assistance)
 - [Contributing](#contributing)
@@ -49,11 +49,13 @@
 
 - Install [Rust](https://www.rust-lang.org/tools/install)
 - Set up Rust:
+
 ```bash
 rustup override set stable && rustup update
 ```
 
 Ensure Rust was installed correctly by running the following from the root project directory:
+
 ```bash
 cargo test
 ```
@@ -61,16 +63,19 @@ cargo test
 ### Compiling and running Cairo files
 
 Compile Cairo to Sierra:
+
 ```bash
 cargo run --bin cairo-compile -- --single-file /path/to/input.cairo /path/to/output.sierra --replace-ids
 ```
 
 Compile Sierra to casm (Cairo assembly):
+
 ```bash
 cargo run --bin sierra-compile -- /path/to/input.sierra /path/to/output.casm
 ```
 
 Run Cairo code directly:
+
 ```bash
 cargo run --bin cairo-run -- --single-file /path/to/file.cairo
 ```
@@ -82,21 +87,25 @@ For running tests specifically, see here: [cairo-test](./crates/cairo-lang-test-
 ### Compiling Starknet Contracts
 
 Compile a Starknet contract from a crate/project path to a Sierra ContractClass:
+
 ```bash
 cargo run --bin starknet-compile -- /path/to/input/crate /path/to/output.json
 ```
 
 If multiple contracts are defined in the same crate/project, specify `--contract-path`:
+
 ```bash
 cargo run --bin starknet-compile -- /path/to/input/crate /path/to/output.json --contract-path path::to::contract
 ```
 
 For a single-file `.cairo` input, use `--single-file`:
+
 ```bash
 cargo run --bin starknet-compile -- --single-file /path/to/input.cairo /path/to/output.json
 ```
 
 Compile a Sierra ContractClass to a CASM CompiledClass:
+
 ```bash
 cargo run --bin starknet-sierra-compile -- /path/to/input.json /path/to/output.casm
 ```

--- a/adrs/001_enum_definition_syntax.md
+++ b/adrs/001_enum_definition_syntax.md
@@ -9,6 +9,7 @@ Accepted 2021-08-04
 ## Context
 
 Proposed syntax for enum (i.e. sum-type):
+
 ```
 // Definition.
 enum MyEnum {
@@ -28,6 +29,7 @@ MyEnum::Variant0(value0)
 ```
 
 This is a deviation from the Rust syntax
+
 ```
 enum MyEnum {
     Variant0,
@@ -38,22 +40,25 @@ enum MyEnum {
 ```
 
 Advantages of the suggestion:
-* More similar to struct. Simplicity.
-* May be less code in the compiler (possibly shared with struct, for example, the syntax and
+
+- More similar to struct. Simplicity.
+- May be less code in the compiler (possibly shared with struct, for example, the syntax and
   parsing).
-* Every variant has a type. This allows functions to express that they only access a
+- Every variant has a type. This allows functions to express that they only access a
   specific variant. For example, when the variant is defined as `Variant0: Type0`, we can always
   refer to `Type0`, it's a real type.
 
 Disadvantages:
-* Straying away from Rust.
-* Unfamiliar syntax for most users.
-* Tuple types need an extra parenthesis. On `Variant0: (A, B)`, the construction is using
+
+- Straying away from Rust.
+- Unfamiliar syntax for most users.
+- Tuple types need an extra parenthesis. On `Variant0: (A, B)`, the construction is using
   `Variant0((a, b))`.
 
 ## Open questions
 
 Pattern matching might be made less verbose. Suggestions:
+
 ```
 MyEnum::Variant0(value0) =>
 Variant0(value0) =>

--- a/adrs/003_simple_trait_system.md
+++ b/adrs/003_simple_trait_system.md
@@ -6,67 +6,86 @@ Proposed 2021-07-29
 Accepted ?
 
 ## Context
+
 This suggestion introduces a basic `trait` and `impl` system.
-* It is flexible enough to allow anything that can be expressed in Rust's trait system, excluding
+
+- It is flexible enough to allow anything that can be expressed in Rust's trait system, excluding
   dynamics.
-* It is simple, without edge cases, and hopefully easy on the compiler work.
+- It is simple, without edge cases, and hopefully easy on the compiler work.
 
 The suggestion introduces these elements:
+
 ### Trait top level item
+
 ```
 trait MyTrait<A, B> {
   type T;
   fn f(a: A, t: T) -> (T, B);
 }
 ```
+
 This item introduces an "interface", with function signatures and associated types that need to be
 defined by the implementations.
 Note that there is no `Self` or a type this trait is `for`. It is standalone.
 
 ### Impl top level item
+
 ```
 impl MyImpl<A> for MyTrait<A, felt252> {
   type T = A;
   fn f(a: A, b: felt252) -> T { ... }
 }
 ```
+
 This item introduces an implementation for this trait.
 It needs to implement exactly every associated type and function in the trait.
 
 ### Impl associated type and function
+
 ```
 fn foo() {
   let res: MyImpl<felt252>::T = MyImpl<felt252>::f(...);
 }
 ```
+
 References functions and types defined in an impl.
 
 ### Impl generic arg
+
 ```
 fn foo<A, impl VarImpl: MyTrait<A, felt252>>() {
   VarImpl::f(...);
 }
 ```
+
 Impls have a GenericArg, and can be passed as a GenericValue.
 
 ### Inference
+
 At first, no inference would be supported. This will result in more verbose and explicit code, but
 less ergonomic. These can be added in a later phase.
 
 ### Usage
+
 Examples:
-* Generate impl for X, from any impl for Y.
+
+- Generate impl for X, from any impl for Y.
+
 ```
 impl CloneFromCopy<T, CopyImpl: impl Copy<T>> of Clone<T> {}
 ```
+
 roughly equivalent to Rust's
+
 ```
 impl<T: Copy> Clone for T {}
 ```
 
 ## Decision
+
 ?
 
 ## Consequences
+
 - Traits and impls have no inherent Self type or instance. Their functions are not methods.
 - It is not clear if obj.fn() syntax will be present and how it will work if it is.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -8,19 +8,19 @@ In the interest of fostering an open and welcoming environment, we as contributo
 
 Examples of behavior that contributes to creating a positive environment include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,9 +11,9 @@ To set up a development environment, please follow these steps:
 
 1. Clone the repo
 
-   ```sh
-   git clone https://github.com/starkware-libs/cairo
-   ```
+    ```sh
+    git clone https://github.com/starkware-libs/cairo
+    ```
 
 2. Download and install [Visual Studio Code](https://code.visualstudio.com/).
 
@@ -114,17 +114,17 @@ Please try to create bug reports that are:
 7. Push to the branch (`git push origin feat/amazing_feature`)
 8. [Open a Pull Request](https://github.com/starkware-libs/cairo/compare) to one of the following
    branches:
-    * [main](https://github.com/starkware-libs/cairo/tree/main) -
+    - [main](https://github.com/starkware-libs/cairo/tree/main) -
       If the change does not break any existing Cairo code (**Cairo backward-compatible**), and does
       not affect Sierra to CASM compilation.
-    * [cairo-major-update](https://github.com/starkware-libs/cairo/tree/cairo-major-update) -
+    - [cairo-major-update](https://github.com/starkware-libs/cairo/tree/cairo-major-update) -
       If the change breaks the existing high-level code (**Cairo non-backward-compatible**), and
       does not affect Sierra to CASM compilation.
-    * [sierra-minor-update](https://github.com/starkware-libs/cairo/tree/sierra-minor-update) -
+    - [sierra-minor-update](https://github.com/starkware-libs/cairo/tree/sierra-minor-update) -
       If Sierra to CASM compilation changed in a **backward-compatible** manner — meaning existing
       Sierra code will compile to the same CASM.
       For example, addition of a new libfunc.
-    * [sierra-major-update](https://github.com/starkware-libs/cairo/tree/sierra-major-update) -
+    - [sierra-major-update](https://github.com/starkware-libs/cairo/tree/sierra-major-update) -
       If Sierra to CASM compilation changed in a **non-backward-compatible** manner — meaning
       existing Sierra code will compile to different CASM.
       For example, editing the CASM implementation of an existing libfunc.

--- a/docs/FEATURE_PARITY.md
+++ b/docs/FEATURE_PARITY.md
@@ -1,12 +1,13 @@
 # Cairo 0 Feature Parity
 
- On this page we track the missing features to reach feature parity with the old compiler version. We've divided them into Cairo, Starknet and specific system calls in Starknet OS.
+On this page we track the missing features to reach feature parity with the old compiler version. We've divided them into Cairo, Starknet and specific system calls in Starknet OS.
 
- If we missed a feature, please let us know.
+If we missed a feature, please let us know.
 
 ## Cairo features
+
 | name                   | status |
-|------------------------|--------|
+| ---------------------- | ------ |
 | `if (x == y)`          | ✅     |
 | `if (x == y & z == w)` | ✅     |
 | Short strings          | ✅     |
@@ -23,13 +24,12 @@
 | `if (cond1 && cond2)`  | ✅     |
 | Find element           |        |
 
-
 ---
 
 ## Starknet features
 
 | name                                      | status |
-|-------------------------------------------|--------|
+| ----------------------------------------- | ------ |
 | Contract interface                        | ✅     |
 | External functions and view functions     | ✅     |
 | Storage variables - felts                 | ✅     |
@@ -37,13 +37,12 @@
 | Storage variables - other types as values | ✅     |
 | Events                                    | ✅     |
 
-
 ---
 
 ## Starknet system calls
 
 | name                  | status |
-|-----------------------|--------|
+| --------------------- | ------ |
 | storage_read          | ✅     |
 | storage_write         | ✅     |
 | get_caller_address    | ✅     |
@@ -56,4 +55,3 @@
 | get_sequencer_address | ✅     |
 | get_transaction_info  | ✅     |
 | send_message_to_l1    | ✅     |
-

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,10 +7,10 @@ If there are any vulnerabilities in **Cairo**, don't hesitate to _report them_.
 1. Use any of the [private contact addresses](https://github.com/starkware-libs/cairo#support).
 2. Describe the vulnerability.
 
-   If you have a fix, that is most welcome -- please attach or summarize it in your message!
+    If you have a fix, that is most welcome -- please attach or summarize it in your message!
 
 3. We will evaluate the vulnerability and, if necessary, release a fix or mitigation steps. We will contact you to let you know the outcome and credit you in the report.
 
-   Please **do not disclose the vulnerability publicly** until a fix has been released!
+    Please **do not disclose the vulnerability publicly** until a fix has been released!
 
 4. Once we have either a) published a fix, or b) declined to address the vulnerability for whatever reason, you are free to publicly disclose it.

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -3,9 +3,9 @@
 The documentation is written in [AsciiDoc](https://asciidoc.org/) (`.adoc`).
 You can view it in several ways:
 
-* View in IDE
-* Convert to HTML
-* Convert to PDF
+- View in IDE
+- Convert to HTML
+- Convert to PDF
 
 ---
 
@@ -13,8 +13,8 @@ You can view it in several ways:
 
 Install an AsciiDoc plugin for your IDE:
 
-* **VS Code**: *AsciiDoc by asciidoctor*
-* **IntelliJ IDEA**: *AsciiDoc Plugin*
+- **VS Code**: _AsciiDoc by asciidoctor_
+- **IntelliJ IDEA**: _AsciiDoc Plugin_
 
 After installing the plugin, open any `.adoc` file in `docs/reference/src/components/cairo/modules`.
 


### PR DESCRIPTION
## Summary
This PR standardizes markdown formatting across documentation and skill files to improve consistency and readability. The changes focus on list formatting, spacing, and emphasis styling.

## Key Changes
- **List formatting**: Converted all bullet lists from `*` to `-` syntax for consistency across all markdown files
- **Spacing**: Added blank lines after section headers and before code blocks to improve visual separation
- **Emphasis**: Changed emphasis markers from `*text*` to `_text_` for consistency with markdown best practices
- **Indentation**: Fixed indentation in nested lists (e.g., in README.md table of contents and CONTRIBUTING.md)
- **Table formatting**: Standardized markdown table separators in FEATURE_PARITY.md

## Files Modified
- `.claude/skills/orizi-review/SKILL.md` - Standardized list formatting and spacing
- `.claude/skills/writing-tests/SKILL.md` - Updated emphasis markers
- `.claude/skills/writing-tests/references/golden-framework.md` - Added spacing after headers
- `.claude/skills/writing-tests/references/cairo.md` - Updated emphasis markers
- `adrs/001_enum_definition_syntax.md` - Converted lists and added spacing
- `adrs/003_simple_trait_system.md` - Converted lists and added spacing
- `docs/CODE_OF_CONDUCT.md` - Converted all lists to `-` syntax
- `docs/CONTRIBUTING.md` - Fixed indentation and list formatting
- `docs/FEATURE_PARITY.md` - Standardized table formatting and spacing
- `docs/SECURITY.md` - Fixed indentation
- `docs/reference/readme.md` - Updated emphasis markers and list formatting
- `README.md` - Fixed nested list indentation and added spacing
- `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md` - Removed trailing blank line

These changes improve documentation consistency without altering any content or functionality.

https://claude.ai/code/session_01JXuk9zVa2URozD46f6MDqX