### PR TITLE
docs(array): format None as inline code

### DIFF
--- a/corelib/src/array.cairo
+++ b/corelib/src/array.cairo
@@ -507,7 +507,7 @@ pub impl SpanImpl<T> of SpanTrait<T> {
 
     /// Pops multiple values from the front of the span.
     /// Returns an option containing a snapshot of a box that contains the values as a fixed-size
-    /// array if the action completed successfully, 'None' otherwise.
+    /// array if the action completed successfully, `None` otherwise.
     ///
     /// # Examples
     ///
@@ -523,7 +523,7 @@ pub impl SpanImpl<T> of SpanTrait<T> {
 
     /// Pops multiple values from the back of the span.
     /// Returns an option containing a snapshot of a box that contains the values as a fixed-size
-    /// array if the action completed successfully, 'None' otherwise.
+    /// array if the action completed successfully, `None` otherwise.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Render `None` as an inline-code identifier in the documentation for both fixed-size span pop methods.


Single quotes make `'None'` look like source syntax even though the text is naming a Cairo enum variant. Inline-code formatting accurately presents the identifier and matches how code names are rendered elsewhere in the API docs. Maintainers confirmed the focused change in #ISSUE_NUMBER.