### PR TITLE
Fix non-contiguous circuit input diagnostics

### DIFF
--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -43,7 +43,7 @@ mod test;
 pub struct SemanticDiagnostics<'db> {
     builder: DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
     context_module: ModuleId<'db>,
-    diagnosed_circuits: OrderedHashSet<semantic::TypeId<'db>>,
+    pub(crate) diagnosed_circuits: OrderedHashSet<semantic::TypeId<'db>>,
 }
 
 impl<'db> SemanticDiagnostics<'db> {
@@ -69,23 +69,6 @@ impl<'db> SemanticDiagnostics<'db> {
     /// Build a Diagnostics object.
     pub fn build(self) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
         self.builder.build()
-    }
-
-    /// Reports a non-contiguous circuit input set once per concrete circuit type.
-    pub(crate) fn report_circuit_input_indices(
-        &mut self,
-        stable_ptr: impl Into<SyntaxStablePtrId<'db>>,
-        circuit: semantic::TypeId<'db>,
-        expected: usize,
-        actual: usize,
-    ) {
-        if self.diagnosed_circuits.insert(circuit) {
-            self.builder.add(SemanticDiagnostic::new(
-                StableLocation::new(stable_ptr.into()),
-                SemanticDiagnosticKind::CircuitInputIndicesNotContiguous { expected, actual },
-                self.context_module,
-            ));
-        }
     }
 }
 

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -20,6 +20,7 @@ use cairo_lang_parser::ParserDiagnostic;
 use cairo_lang_syntax as syntax;
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::helpers::GetIdentifier;
+use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use itertools::Itertools;
 use salsa::Database;
 use syntax::node::ids::SyntaxStablePtrId;
@@ -42,12 +43,17 @@ mod test;
 pub struct SemanticDiagnostics<'db> {
     builder: DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
     context_module: ModuleId<'db>,
+    diagnosed_circuits: OrderedHashSet<semantic::TypeId<'db>>,
 }
 
 impl<'db> SemanticDiagnostics<'db> {
     /// Create a new SemanticDiagnostics with the given context module.
     pub fn new(context_module: ModuleId<'db>) -> Self {
-        Self { builder: DiagnosticsBuilder::default(), context_module }
+        Self {
+            builder: DiagnosticsBuilder::default(),
+            context_module,
+            diagnosed_circuits: Default::default(),
+        }
     }
 
     /// Create a new SemanticDiagnostics from the given context module and diagnostics.
@@ -57,12 +63,29 @@ impl<'db> SemanticDiagnostics<'db> {
     ) -> Self {
         let mut builder = DiagnosticsBuilder::default();
         builder.extend(diagnostics);
-        Self { builder, context_module }
+        Self { builder, context_module, diagnosed_circuits: Default::default() }
     }
 
     /// Build a Diagnostics object.
     pub fn build(self) -> Diagnostics<'db, SemanticDiagnostic<'db>> {
         self.builder.build()
+    }
+
+    /// Reports a non-contiguous circuit input set once per concrete circuit type.
+    pub(crate) fn report_circuit_input_indices(
+        &mut self,
+        stable_ptr: impl Into<SyntaxStablePtrId<'db>>,
+        circuit: semantic::TypeId<'db>,
+        expected: usize,
+        actual: usize,
+    ) {
+        if self.diagnosed_circuits.insert(circuit) {
+            self.builder.add(SemanticDiagnostic::new(
+                StableLocation::new(stable_ptr.into()),
+                SemanticDiagnosticKind::CircuitInputIndicesNotContiguous { expected, actual },
+                self.context_module,
+            ));
+        }
     }
 }
 
@@ -491,6 +514,12 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
                 format!(
                     r#"Cannot have array of type "{}" that is zero sized."#,
                     ty.contextualized_path(db, self.context_module)
+                )
+            }
+            SemanticDiagnosticKind::CircuitInputIndicesNotContiguous { expected, actual } => {
+                format!(
+                    "Circuit input indices must be contiguous and start at 0. Expected index \
+                     {expected}, found {actual}."
                 )
             }
             SemanticDiagnosticKind::ParamNameRedefinition { function_title_id, param_name } => {
@@ -1376,6 +1405,9 @@ impl<'db> DiagnosticEntry<'db> for SemanticDiagnostic<'db> {
             SemanticDiagnosticKind::EnumVariantRedefinition { .. } => error_code!(E2051),
             SemanticDiagnosticKind::InfiniteSizeType(..) => error_code!(E2052),
             SemanticDiagnosticKind::ArrayOfZeroSizedElements(..) => error_code!(E2053),
+            SemanticDiagnosticKind::CircuitInputIndicesNotContiguous { .. } => {
+                error_code!(E2204)
+            }
             SemanticDiagnosticKind::ParamNameRedefinition { .. } => error_code!(E2054),
             SemanticDiagnosticKind::ConditionNotBool(..) => error_code!(E2055),
             SemanticDiagnosticKind::IncompatibleArms { .. } => error_code!(E2056),
@@ -1704,6 +1736,10 @@ pub enum SemanticDiagnosticKind<'db> {
     },
     InfiniteSizeType(semantic::TypeId<'db>),
     ArrayOfZeroSizedElements(semantic::TypeId<'db>),
+    CircuitInputIndicesNotContiguous {
+        expected: usize,
+        actual: usize,
+    },
     ParamNameRedefinition {
         function_title_id: Option<FunctionTitleId<'db>>,
         param_name: SmolStrId<'db>,

--- a/crates/cairo-lang-semantic/src/diagnostic.rs
+++ b/crates/cairo-lang-semantic/src/diagnostic.rs
@@ -20,7 +20,6 @@ use cairo_lang_parser::ParserDiagnostic;
 use cairo_lang_syntax as syntax;
 use cairo_lang_syntax::node::ast;
 use cairo_lang_syntax::node::helpers::GetIdentifier;
-use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use itertools::Itertools;
 use salsa::Database;
 use syntax::node::ids::SyntaxStablePtrId;
@@ -43,17 +42,12 @@ mod test;
 pub struct SemanticDiagnostics<'db> {
     builder: DiagnosticsBuilder<'db, SemanticDiagnostic<'db>>,
     context_module: ModuleId<'db>,
-    pub(crate) diagnosed_circuits: OrderedHashSet<semantic::TypeId<'db>>,
 }
 
 impl<'db> SemanticDiagnostics<'db> {
     /// Create a new SemanticDiagnostics with the given context module.
     pub fn new(context_module: ModuleId<'db>) -> Self {
-        Self {
-            builder: DiagnosticsBuilder::default(),
-            context_module,
-            diagnosed_circuits: Default::default(),
-        }
+        Self { builder: DiagnosticsBuilder::default(), context_module }
     }
 
     /// Create a new SemanticDiagnostics from the given context module and diagnostics.
@@ -63,7 +57,7 @@ impl<'db> SemanticDiagnostics<'db> {
     ) -> Self {
         let mut builder = DiagnosticsBuilder::default();
         builder.extend(diagnostics);
-        Self { builder, context_module, diagnosed_circuits: Default::default() }
+        Self { builder, context_module }
     }
 
     /// Build a Diagnostics object.

--- a/crates/cairo-lang-semantic/src/expr/test.rs
+++ b/crates/cairo-lang-semantic/src/expr/test.rs
@@ -37,6 +37,7 @@ cairo_lang_test_utils::test_file_test!(
         constructor: "constructor",
         closure: "closure",
         coupon: "coupon",
+        circuit: "circuit",
         deref: "deref",
         enum_: "enum",
         error_propagate: "error_propagate",

--- a/crates/cairo-lang-semantic/src/expr/test_data/circuit
+++ b/crates/cairo-lang-semantic/src/expr/test_data/circuit
@@ -32,6 +32,30 @@ error[E2204]: Circuit input indices must be contiguous and start at 0. Expected 
 |         .new_inputs()
 |_____________________^
 
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 1, found 2.
+ --> lib.cairo:11:19-15:15
+      let outputs = (sum,)
+ ___________________^
+| ...
+|         .done()
+|_______________^
+
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 1, found 2.
+ --> lib.cairo:11:19-16:22
+      let outputs = (sum,)
+ ___________________^
+| ...
+|         .eval(modulus)
+|______________________^
+
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 1, found 2.
+ --> lib.cairo:11:19-17:17
+      let outputs = (sum,)
+ ___________________^
+| ...
+|         .unwrap();
+|_________________^
+
 //! > ==========================================================================
 
 //! > Circuit input indices must start at zero.
@@ -57,6 +81,21 @@ error[E2204]: Circuit input indices must be contiguous and start at 0. Expected 
  --> lib.cairo:9:19
     let outputs = (a,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
                   ^^^^^^^^^^^^^^^^^
+
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 0, found 5.
+ --> lib.cairo:9:19
+    let outputs = (a,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 0, found 5.
+ --> lib.cairo:9:19
+    let outputs = (a,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 0, found 5.
+ --> lib.cairo:9:19
+    let outputs = (a,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 
@@ -84,6 +123,21 @@ error[E2204]: Circuit input indices must be contiguous and start at 0. Expected 
  --> lib.cairo:10:19
     let outputs = (b,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
                   ^^^^^^^^^^^^^^^^^
+
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 0, found 1.
+ --> lib.cairo:10:19
+    let outputs = (b,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 0, found 1.
+ --> lib.cairo:10:19
+    let outputs = (b,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 0, found 1.
+ --> lib.cairo:10:19
+    let outputs = (b,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 //! > ==========================================================================
 

--- a/crates/cairo-lang-semantic/src/expr/test_data/circuit
+++ b/crates/cairo-lang-semantic/src/expr/test_data/circuit
@@ -1,0 +1,109 @@
+//! > Non-contiguous circuit input indices are diagnosed.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > cairo_code
+use core::circuit::{
+    AddInputResultTrait, CircuitElement, CircuitInput, CircuitInputs, CircuitModulus,
+    CircuitOutputsTrait, EvalCircuitTrait, circuit_add,
+};
+
+fn gap() {
+    let a = CircuitElement::<CircuitInput<0>> {};
+    let b = CircuitElement::<CircuitInput<2>> {};
+    let sum = circuit_add(a, b);
+    let modulus = TryInto::<_, CircuitModulus>::try_into([7, 0, 0, 0]).unwrap();
+    let outputs = (sum,)
+        .new_inputs()
+        .next([3, 0, 0, 0])
+        .next([2, 0, 0, 0])
+        .done()
+        .eval(modulus)
+        .unwrap();
+    assert!(outputs.get_output(sum) == 5.into());
+}
+
+//! > expected_diagnostics
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 1, found 2.
+ --> lib.cairo:11:19-12:21
+      let outputs = (sum,)
+ ___________________^
+|         .new_inputs()
+|_____________________^
+
+//! > ==========================================================================
+
+//! > Circuit input indices must start at zero.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > cairo_code
+use core::circuit::{
+    AddInputResultTrait, CircuitElement, CircuitInput, CircuitInputs, CircuitModulus,
+    CircuitOutputsTrait, EvalCircuitTrait,
+};
+
+fn non_zero_start() {
+    let a = CircuitElement::<CircuitInput<5>> {};
+    let modulus = TryInto::<_, CircuitModulus>::try_into([7, 0, 0, 0]).unwrap();
+    let outputs = (a,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+    assert!(outputs.get_output(a) == 3.into());
+}
+
+//! > expected_diagnostics
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 0, found 5.
+ --> lib.cairo:9:19
+    let outputs = (a,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+                  ^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Only inputs reachable from circuit outputs determine contiguity.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: true)
+
+//! > cairo_code
+use core::circuit::{
+    AddInputResultTrait, CircuitElement, CircuitInput, CircuitInputs, CircuitModulus,
+    CircuitOutputsTrait, EvalCircuitTrait,
+};
+
+fn output_subset() {
+    let _a = CircuitElement::<CircuitInput<0>> {};
+    let b = CircuitElement::<CircuitInput<1>> {};
+    let modulus = TryInto::<_, CircuitModulus>::try_into([7, 0, 0, 0]).unwrap();
+    let outputs = (b,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+    assert!(outputs.get_output(b) == 3.into());
+}
+
+//! > expected_diagnostics
+error[E2204]: Circuit input indices must be contiguous and start at 0. Expected index 0, found 1.
+ --> lib.cairo:10:19
+    let outputs = (b,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+                  ^^^^^^^^^^^^^^^^^
+
+//! > ==========================================================================
+
+//! > Reusing one circuit input is valid.
+
+//! > test_runner_name
+test_function_diagnostics(expect_diagnostics: false)
+
+//! > cairo_code
+use core::circuit::{
+    AddInputResultTrait, CircuitElement, CircuitInput, CircuitInputs, CircuitModulus,
+    CircuitOutputsTrait, EvalCircuitTrait, circuit_add,
+};
+
+fn reused_input() {
+    let a = CircuitElement::<CircuitInput<0>> {};
+    let sum = circuit_add(a, a);
+    let modulus = TryInto::<_, CircuitModulus>::try_into([7, 0, 0, 0]).unwrap();
+    let outputs = (sum,).new_inputs().next([3, 0, 0, 0]).done().eval(modulus).unwrap();
+    assert!(outputs.get_output(sum) == 6.into());
+}
+
+//! > expected_diagnostics

--- a/crates/cairo-lang-semantic/src/helper.rs
+++ b/crates/cairo-lang-semantic/src/helper.rs
@@ -1,5 +1,5 @@
 use cairo_lang_defs::ids::{
-    EnumId, ExternFunctionId, FreeFunctionId, ModuleId, ModuleItemId, TraitId,
+    EnumId, ExternFunctionId, ExternTypeId, FreeFunctionId, ModuleId, ModuleItemId, TraitId,
 };
 use cairo_lang_filesystem::ids::SmolStrId;
 use salsa::Database;
@@ -33,6 +33,15 @@ impl<'a> ModuleHelper<'a> {
             self.db.module_item_by_name(self.id, SmolStrId::from(self.db, name))
         else {
             panic!("`{}` not found in `{}`.", name, self.id.full_path(self.db));
+        };
+        id
+    }
+    /// Returns the id of an extern type named `name` in the current module.
+    pub fn extern_type_id(&self, name: &str) -> ExternTypeId<'a> {
+        let Ok(Some(ModuleItemId::ExternType(id))) =
+            self.db.module_item_by_name(self.id, SmolStrId::from(self.db, name))
+        else {
+            panic!("`{name}` not found in `{}`.", self.id.full_path(self.db));
         };
         id
     }

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -7,7 +7,7 @@ use cairo_lang_defs::ids::{
 };
 use cairo_lang_diagnostics::{DiagnosticAdded, Maybe};
 use cairo_lang_filesystem::db::FilesGroup;
-use cairo_lang_filesystem::ids::{CrateId, SmolStrId};
+use cairo_lang_filesystem::ids::CrateId;
 use cairo_lang_proc_macros::{HeapSize, SemanticObject};
 use cairo_lang_syntax::attribute::consts::MUST_USE_ATTR;
 use cairo_lang_syntax::node::ast::PathSegment;
@@ -23,7 +23,7 @@ use sha3::{Digest, Keccak256};
 
 use crate::corelib::{
     CorelibSemantic, concrete_copy_trait, concrete_destruct_trait, concrete_drop_trait,
-    concrete_panic_destruct_trait, core_box_ty, core_submodule, get_usize_ty, unit_ty,
+    concrete_panic_destruct_trait, core_box_ty, get_usize_ty, unit_ty,
 };
 use crate::diagnostic::SemanticDiagnosticKind::{self, *};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
@@ -31,6 +31,7 @@ use crate::expr::compute::{ComputationContext, compute_expr_semantic};
 use crate::expr::inference::canonic::{CanonicalTrait, ResultNoErrEx};
 use crate::expr::inference::solver::{SemanticSolver, SolutionSet};
 use crate::expr::inference::{InferenceData, InferenceError, InferenceId, TypeVar};
+use crate::helper::ModuleHelper;
 use crate::items::attribute::SemanticQueryAttrs;
 use crate::items::constant::{ConstValue, ConstValueId, resolve_const_expr_and_evaluate};
 use crate::items::enm::{EnumSemantic, SemanticEnumEx};
@@ -958,117 +959,10 @@ pub fn add_value_type_based_diagnostics<'db>(
         diagnostics.report(stable_ptr, violation.to_kind());
     } else if let Some(CircuitInputIndexViolation { circuit, expected, actual }) =
         circuit_input_index_violation(db, ty)
+        && diagnostics.diagnosed_circuits.insert(circuit)
     {
-        diagnostics.report_circuit_input_indices(stable_ptr, circuit, expected, actual);
+        diagnostics.report(stable_ptr, CircuitInputIndicesNotContiguous { expected, actual });
     }
-}
-
-/// The first gap in a circuit's sorted input indices.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::SalsaValue)]
-struct CircuitInputIndexViolation<'db> {
-    circuit: TypeId<'db>,
-    expected: usize,
-    actual: usize,
-}
-
-/// Finds a malformed `core::circuit::Circuit` nested in `ty`.
-///
-/// Sierra lays out circuit inputs in index order, so the indices reachable from the circuit's
-/// outputs must be exactly `0..n`. Detecting the gap while the type still has a source location
-/// lets the compiler report a diagnostic instead of failing during Sierra type specialization.
-#[salsa::tracked(returns(copy))]
-fn circuit_input_index_violation<'db>(
-    db: &'db dyn Database,
-    ty: TypeId<'db>,
-) -> Option<CircuitInputIndexViolation<'db>> {
-    let circuit_module = core_submodule(db, SmolStrId::from(db, "circuit"));
-    let mut visited = OrderedHashSet::<TypeId<'db>>::default();
-    let mut stack = vec![ty];
-
-    while let Some(ty) = stack.pop() {
-        if !visited.insert(ty) {
-            continue;
-        }
-        match ty.long(db) {
-            TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
-                let ConcreteExternTypeLongId { extern_type_id, generic_args } = extrn.long(db);
-                if extern_type_id.parent_module(db) == circuit_module
-                    && extern_type_id.name(db).long(db).as_str() == "Circuit"
-                    && let [GenericArgumentId::Type(outputs)] = generic_args[..]
-                    && let Some((expected, actual)) =
-                        non_contiguous_circuit_input(db, outputs, circuit_module)
-                {
-                    return Some(CircuitInputIndexViolation { circuit: ty, expected, actual });
-                }
-                stack.extend(generic_args.iter().filter_map(|arg| match arg {
-                    GenericArgumentId::Type(ty) => Some(*ty),
-                    _ => None,
-                }));
-            }
-            TypeLongId::Concrete(ConcreteTypeId::Struct(id)) => {
-                stack.extend(db.concrete_struct_members(*id).ok()?.iter().map(|(_, m)| m.ty));
-            }
-            TypeLongId::Concrete(ConcreteTypeId::Enum(id)) => {
-                stack.extend(db.concrete_enum_variants(*id).ok()?.iter().map(|v| v.ty));
-            }
-            TypeLongId::Tuple(types) => stack.extend(types.iter().copied()),
-            TypeLongId::Snapshot(inner) => stack.push(*inner),
-            TypeLongId::FixedSizeArray { type_id, .. } => stack.push(*type_id),
-            TypeLongId::Closure(closure) => stack.extend(closure.captured_types.iter().copied()),
-            TypeLongId::GenericParameter(_)
-            | TypeLongId::Var(_)
-            | TypeLongId::NumericLiteral(_)
-            | TypeLongId::Coupon(_)
-            | TypeLongId::ImplType(_)
-            | TypeLongId::Missing(_) => {}
-        }
-    }
-    None
-}
-
-/// Returns the first missing index in the input set reachable from `outputs`.
-fn non_contiguous_circuit_input<'db>(
-    db: &'db dyn Database,
-    outputs: TypeId<'db>,
-    circuit_module: ModuleId<'db>,
-) -> Option<(usize, usize)> {
-    let mut visited = OrderedHashSet::<TypeId<'db>>::default();
-    let mut input_indices = OrderedHashSet::<usize>::default();
-    let mut stack = vec![outputs];
-
-    while let Some(ty) = stack.pop() {
-        if !visited.insert(ty) {
-            continue;
-        }
-        match ty.long(db) {
-            TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
-                let ConcreteExternTypeLongId { extern_type_id, generic_args } = extrn.long(db);
-                if extern_type_id.parent_module(db) == circuit_module
-                    && extern_type_id.name(db).long(db).as_str() == "CircuitInput"
-                {
-                    if let [GenericArgumentId::Constant(index)] = generic_args[..]
-                        && let ConstValue::Int(index, _) = index.long(db)
-                        && let Some(index) = index.to_usize()
-                    {
-                        input_indices.insert(index);
-                    }
-                    continue;
-                }
-                stack.extend(generic_args.iter().filter_map(|arg| match arg {
-                    GenericArgumentId::Type(ty) => Some(*ty),
-                    _ => None,
-                }));
-            }
-            TypeLongId::Tuple(types) => stack.extend(types.iter().copied()),
-            _ => {}
-        }
-    }
-
-    input_indices
-        .into_iter()
-        .sorted_unstable()
-        .enumerate()
-        .find(|(expected, actual)| expected != actual)
 }
 
 /// Adds diagnostics for a type in a definition - a struct member or an enum variant.
@@ -1200,6 +1094,113 @@ fn array_element_deps_or_issue<'db>(
         | TypeLongId::ImplType(_)
         | TypeLongId::Missing(_) => None,
     }
+}
+
+/// The first gap in a circuit's sorted input indices.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::SalsaValue)]
+struct CircuitInputIndexViolation<'db> {
+    circuit: TypeId<'db>,
+    expected: usize,
+    actual: usize,
+}
+
+/// Finds a malformed `core::circuit::Circuit` nested in `ty`.
+///
+/// Sierra lays out circuit inputs in index order, so the indices reachable from the circuit's
+/// outputs must be exactly `0..n`. Detecting the gap while the type still has a source location
+/// lets the compiler report a diagnostic instead of failing during Sierra type specialization.
+#[salsa::tracked(returns(copy))]
+fn circuit_input_index_violation<'db>(
+    db: &'db dyn Database,
+    ty: TypeId<'db>,
+) -> Option<CircuitInputIndexViolation<'db>> {
+    let circuit_module = ModuleHelper::core(db).submodule("circuit");
+    let circuit_extern_id = circuit_module.extern_type_id("Circuit");
+    let circuit_input_extern_id = circuit_module.extern_type_id("CircuitInput");
+    let mut visited = OrderedHashSet::<TypeId<'db>>::default();
+    let mut stack = vec![ty];
+
+    while let Some(ty) = stack.pop() {
+        if !visited.insert(ty) {
+            continue;
+        }
+        match ty.long(db) {
+            TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
+                let ConcreteExternTypeLongId { extern_type_id, generic_args } = extrn.long(db);
+                if *extern_type_id != circuit_extern_id {
+                    stack.extend(generic_args.iter().filter_map(|arg| match arg {
+                        GenericArgumentId::Type(ty) => Some(*ty),
+                        _ => None,
+                    }));
+                } else if let [GenericArgumentId::Type(outputs)] = generic_args[..]
+                    && let Some((expected, actual)) =
+                        non_contiguous_circuit_input(db, outputs, circuit_input_extern_id)
+                {
+                    return Some(CircuitInputIndexViolation { circuit: ty, expected, actual });
+                }
+            }
+            TypeLongId::Concrete(ConcreteTypeId::Struct(id)) => {
+                stack.extend(db.concrete_struct_members(*id).ok()?.iter().map(|(_, m)| m.ty));
+            }
+            TypeLongId::Concrete(ConcreteTypeId::Enum(id)) => {
+                stack.extend(db.concrete_enum_variants(*id).ok()?.iter().map(|v| v.ty));
+            }
+            TypeLongId::Tuple(types) => stack.extend(types.iter().copied()),
+            TypeLongId::Snapshot(inner) => stack.push(*inner),
+            TypeLongId::FixedSizeArray { type_id, .. } => stack.push(*type_id),
+            TypeLongId::Closure(closure) => stack.extend(closure.captured_types.iter().copied()),
+            TypeLongId::GenericParameter(_)
+            | TypeLongId::Var(_)
+            | TypeLongId::NumericLiteral(_)
+            | TypeLongId::Coupon(_)
+            | TypeLongId::ImplType(_)
+            | TypeLongId::Missing(_) => {}
+        }
+    }
+    None
+}
+
+/// Returns the first missing index in the input set reachable from `outputs`.
+fn non_contiguous_circuit_input<'db>(
+    db: &'db dyn Database,
+    outputs: TypeId<'db>,
+    circuit_input_extern_id: ExternTypeId<'db>,
+) -> Option<(usize, usize)> {
+    let mut visited = OrderedHashSet::<TypeId<'db>>::default();
+    let mut input_indices = OrderedHashSet::<usize>::default();
+    let mut stack = vec![outputs];
+
+    while let Some(ty) = stack.pop() {
+        if !visited.insert(ty) {
+            continue;
+        }
+        match ty.long(db) {
+            TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
+                let ConcreteExternTypeLongId { extern_type_id, generic_args } = extrn.long(db);
+                if *extern_type_id == circuit_input_extern_id {
+                    if let [GenericArgumentId::Constant(index)] = generic_args[..]
+                        && let Some(index) = index.to_int(db)
+                        && let Some(index) = index.to_usize()
+                    {
+                        input_indices.insert(index);
+                    }
+                    continue;
+                }
+                stack.extend(generic_args.iter().filter_map(|arg| match arg {
+                    GenericArgumentId::Type(ty) => Some(*ty),
+                    _ => None,
+                }));
+            }
+            TypeLongId::Tuple(types) => stack.extend(types.iter().copied()),
+            _ => {}
+        }
+    }
+
+    input_indices
+        .into_iter()
+        .sorted_unstable()
+        .enumerate()
+        .find(|(expected, actual)| expected != actual)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -7,7 +7,7 @@ use cairo_lang_defs::ids::{
 };
 use cairo_lang_diagnostics::{DiagnosticAdded, Maybe};
 use cairo_lang_filesystem::db::FilesGroup;
-use cairo_lang_filesystem::ids::CrateId;
+use cairo_lang_filesystem::ids::{CrateId, SmolStrId};
 use cairo_lang_proc_macros::{HeapSize, SemanticObject};
 use cairo_lang_syntax::attribute::consts::MUST_USE_ATTR;
 use cairo_lang_syntax::node::ast::PathSegment;
@@ -17,13 +17,13 @@ use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_lang_utils::{Intern, OptionFrom, define_short_id, extract_matches, try_extract_matches};
 use itertools::{Itertools, chain};
 use num_bigint::BigInt;
-use num_traits::Zero;
+use num_traits::{ToPrimitive, Zero};
 use salsa::Database;
 use sha3::{Digest, Keccak256};
 
 use crate::corelib::{
     CorelibSemantic, concrete_copy_trait, concrete_destruct_trait, concrete_drop_trait,
-    concrete_panic_destruct_trait, core_box_ty, get_usize_ty, unit_ty,
+    concrete_panic_destruct_trait, core_box_ty, core_submodule, get_usize_ty, unit_ty,
 };
 use crate::diagnostic::SemanticDiagnosticKind::{self, *};
 use crate::diagnostic::{NotFoundItemType, SemanticDiagnostics, SemanticDiagnosticsBuilder};
@@ -956,7 +956,119 @@ pub fn add_value_type_based_diagnostics<'db>(
         diagnostics.report(stable_ptr, InstancesOfPhantomTypes);
     } else if let Some(violation) = array_element_violation(db, ty) {
         diagnostics.report(stable_ptr, violation.to_kind());
+    } else if let Some(CircuitInputIndexViolation { circuit, expected, actual }) =
+        circuit_input_index_violation(db, ty)
+    {
+        diagnostics.report_circuit_input_indices(stable_ptr, circuit, expected, actual);
     }
+}
+
+/// The first gap in a circuit's sorted input indices.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::SalsaValue)]
+struct CircuitInputIndexViolation<'db> {
+    circuit: TypeId<'db>,
+    expected: usize,
+    actual: usize,
+}
+
+/// Finds a malformed `core::circuit::Circuit` nested in `ty`.
+///
+/// Sierra lays out circuit inputs in index order, so the indices reachable from the circuit's
+/// outputs must be exactly `0..n`. Detecting the gap while the type still has a source location
+/// lets the compiler report a diagnostic instead of failing during Sierra type specialization.
+#[salsa::tracked(returns(copy))]
+fn circuit_input_index_violation<'db>(
+    db: &'db dyn Database,
+    ty: TypeId<'db>,
+) -> Option<CircuitInputIndexViolation<'db>> {
+    let circuit_module = core_submodule(db, SmolStrId::from(db, "circuit"));
+    let mut visited = OrderedHashSet::<TypeId<'db>>::default();
+    let mut stack = vec![ty];
+
+    while let Some(ty) = stack.pop() {
+        if !visited.insert(ty) {
+            continue;
+        }
+        match ty.long(db) {
+            TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
+                let ConcreteExternTypeLongId { extern_type_id, generic_args } = extrn.long(db);
+                if extern_type_id.parent_module(db) == circuit_module
+                    && extern_type_id.name(db).long(db).as_str() == "Circuit"
+                    && let [GenericArgumentId::Type(outputs)] = generic_args[..]
+                    && let Some((expected, actual)) =
+                        non_contiguous_circuit_input(db, outputs, circuit_module)
+                {
+                    return Some(CircuitInputIndexViolation { circuit: ty, expected, actual });
+                }
+                stack.extend(generic_args.iter().filter_map(|arg| match arg {
+                    GenericArgumentId::Type(ty) => Some(*ty),
+                    _ => None,
+                }));
+            }
+            TypeLongId::Concrete(ConcreteTypeId::Struct(id)) => {
+                stack.extend(db.concrete_struct_members(*id).ok()?.iter().map(|(_, m)| m.ty));
+            }
+            TypeLongId::Concrete(ConcreteTypeId::Enum(id)) => {
+                stack.extend(db.concrete_enum_variants(*id).ok()?.iter().map(|v| v.ty));
+            }
+            TypeLongId::Tuple(types) => stack.extend(types.iter().copied()),
+            TypeLongId::Snapshot(inner) => stack.push(*inner),
+            TypeLongId::FixedSizeArray { type_id, .. } => stack.push(*type_id),
+            TypeLongId::Closure(closure) => stack.extend(closure.captured_types.iter().copied()),
+            TypeLongId::GenericParameter(_)
+            | TypeLongId::Var(_)
+            | TypeLongId::NumericLiteral(_)
+            | TypeLongId::Coupon(_)
+            | TypeLongId::ImplType(_)
+            | TypeLongId::Missing(_) => {}
+        }
+    }
+    None
+}
+
+/// Returns the first missing index in the input set reachable from `outputs`.
+fn non_contiguous_circuit_input<'db>(
+    db: &'db dyn Database,
+    outputs: TypeId<'db>,
+    circuit_module: ModuleId<'db>,
+) -> Option<(usize, usize)> {
+    let mut visited = OrderedHashSet::<TypeId<'db>>::default();
+    let mut input_indices = OrderedHashSet::<usize>::default();
+    let mut stack = vec![outputs];
+
+    while let Some(ty) = stack.pop() {
+        if !visited.insert(ty) {
+            continue;
+        }
+        match ty.long(db) {
+            TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
+                let ConcreteExternTypeLongId { extern_type_id, generic_args } = extrn.long(db);
+                if extern_type_id.parent_module(db) == circuit_module
+                    && extern_type_id.name(db).long(db).as_str() == "CircuitInput"
+                {
+                    if let [GenericArgumentId::Constant(index)] = generic_args[..]
+                        && let ConstValue::Int(index, _) = index.long(db)
+                        && let Some(index) = index.to_usize()
+                    {
+                        input_indices.insert(index);
+                    }
+                    continue;
+                }
+                stack.extend(generic_args.iter().filter_map(|arg| match arg {
+                    GenericArgumentId::Type(ty) => Some(*ty),
+                    _ => None,
+                }));
+            }
+            TypeLongId::Tuple(types) => stack.extend(types.iter().copied()),
+            _ => {}
+        }
+    }
+
+    input_indices
+        .into_iter()
+        .sorted_unstable()
+        .enumerate()
+        .find(|(expected, actual)| expected != actual)
 }
 
 /// Adds diagnostics for a type in a definition - a struct member or an enum variant.

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -957,9 +957,8 @@ pub fn add_value_type_based_diagnostics<'db>(
         diagnostics.report(stable_ptr, InstancesOfPhantomTypes);
     } else if let Some(violation) = array_element_violation(db, ty) {
         diagnostics.report(stable_ptr, violation.to_kind());
-    } else if let Some(CircuitInputIndexViolation { circuit, expected, actual }) =
+    } else if let Some(CircuitInputIndexViolation { expected, actual }) =
         circuit_input_index_violation(db, ty)
-        && diagnostics.diagnosed_circuits.insert(circuit)
     {
         diagnostics.report(stable_ptr, CircuitInputIndicesNotContiguous { expected, actual });
     }
@@ -1098,8 +1097,7 @@ fn array_element_deps_or_issue<'db>(
 
 /// The first gap in a circuit's sorted input indices.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::SalsaValue)]
-struct CircuitInputIndexViolation<'db> {
-    circuit: TypeId<'db>,
+struct CircuitInputIndexViolation {
     expected: usize,
     actual: usize,
 }
@@ -1113,7 +1111,7 @@ struct CircuitInputIndexViolation<'db> {
 fn circuit_input_index_violation<'db>(
     db: &'db dyn Database,
     ty: TypeId<'db>,
-) -> Option<CircuitInputIndexViolation<'db>> {
+) -> Option<CircuitInputIndexViolation> {
     let circuit_module = ModuleHelper::core(db).submodule("circuit");
     let circuit_extern_id = circuit_module.extern_type_id("Circuit");
     let circuit_input_extern_id = circuit_module.extern_type_id("CircuitInput");
@@ -1136,7 +1134,7 @@ fn circuit_input_index_violation<'db>(
                     && let Some((expected, actual)) =
                         non_contiguous_circuit_input(db, outputs, circuit_input_extern_id)
                 {
-                    return Some(CircuitInputIndexViolation { circuit: ty, expected, actual });
+                    return Some(CircuitInputIndexViolation { expected, actual });
                 }
             }
             TypeLongId::Concrete(ConcreteTypeId::Struct(id)) => {

--- a/crates/cairo-lang-semantic/src/types.rs
+++ b/crates/cairo-lang-semantic/src/types.rs
@@ -1126,10 +1126,11 @@ fn circuit_input_index_violation<'db>(
             TypeLongId::Concrete(ConcreteTypeId::Extern(extrn)) => {
                 let ConcreteExternTypeLongId { extern_type_id, generic_args } = extrn.long(db);
                 if *extern_type_id != circuit_extern_id {
-                    stack.extend(generic_args.iter().filter_map(|arg| match arg {
-                        GenericArgumentId::Type(ty) => Some(*ty),
-                        _ => None,
-                    }));
+                    stack.extend(
+                        generic_args
+                            .iter()
+                            .filter_map(|arg| try_extract_matches!(arg, GenericArgumentId::Type)),
+                    );
                 } else if let [GenericArgumentId::Type(outputs)] = generic_args[..]
                     && let Some((expected, actual)) =
                         non_contiguous_circuit_input(db, outputs, circuit_input_extern_id)


### PR DESCRIPTION
## Summary

- detect malformed `core::circuit::Circuit` types while they still have a source location
- report the first missing transitive input index at each malformed use instead of reaching Sierra specialization
- cover gaps, non-zero starts, output subsets, and valid reuse of one input

---

## Type of change

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

Sierra circuit specialization assumes that the input indices reachable from a circuit's outputs are exactly `0..N`. A gap currently reaches an infallible specialization path and crashes the compiler instead of producing an actionable source diagnostic.

---

## What was the behavior or documentation before?

Circuits using inputs such as `{0, 2}`, starting at a non-zero index, or exposing only input `1` as an output caused an internal compiler panic.

---

## What is the behavior or documentation after?

Semantic analysis emits `E2204` at the circuit expression, identifying the expected and actual index. Reusing a contiguous input remains valid.

---

## Related issue or discussion (if any)

Closes #10138.

---

## Additional context

Latest helper refactor (`636760d`): the focused circuit regression, strict all-target/all-feature Clippy, workspace formatting and diff checks pass.

Earlier implementation validation (September 3):

- focused `expr_diagnostics::circuit` regression: 1 passed
- `cargo test -p cairo-lang-semantic`: 111 passed
- strict all-target/all-feature Clippy for `cairo-lang-semantic`
- nightly Rust formatting check and `git diff --check`
