### PR TITLE
fix(sierra): avoid overflow when simulating array_slice

### DIFF
--- a/crates/cairo-lang-sierra/src/simulation/core.rs
+++ b/crates/cairo-lang-sierra/src/simulation/core.rs
@@ -169,7 +169,9 @@ pub fn simulate<
                 CoreValue::Uint32(start),
                 CoreValue::Uint32(length),
             ] = inputs);
-            match arr.get(start as usize..(start + length) as usize) {
+            let start = start as usize;
+            let end = start.checked_add(length as usize);
+            match end.and_then(|end| arr.get(start..end)) {
                 Some(elements) => {
                     (vec![CoreValue::RangeCheck, CoreValue::Array(elements.to_vec())], 0)
                 }

--- a/crates/cairo-lang-sierra/src/simulation/test.rs
+++ b/crates/cairo-lang-sierra/src/simulation/test.rs
@@ -154,6 +154,13 @@ fn simulate(
              vec![RangeCheck, Felt252(((BigInt::from(3) << 128_u32) + BigInt::from(7)).into())]
              => Ok((vec![RangeCheck, Uint128(3), Uint128(7)], 1));
             "u128s_from_felt252(3 * 2**128 + 7)")]
+#[test_case("array_slice", vec![type_arg("u128")],
+             vec![RangeCheck, Array(vec![]), Uint32(u32::MAX), Uint32(1)]
+             => Ok((vec![RangeCheck], 1)); "array_slice([], u32::MAX, 1)")]
+#[test_case("array_slice", vec![type_arg("u128")],
+             vec![RangeCheck, Array(vec![Uint128(1), Uint128(2), Uint128(3)]), Uint32(1), Uint32(2)]
+             => Ok((vec![RangeCheck, Array(vec![Uint128(2), Uint128(3)])], 0));
+            "array_slice([1, 2, 3], 1, 2)")]
 fn simulate_branch(
     id: &str,
     generic_args: Vec<GenericArg>,


### PR DESCRIPTION

## Summary

Fix `array_slice` simulation so that host integer overflow cannot panic while computing the slice end.

---

## Type of change

Please check **one**:

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

## Why is this change needed?

`array_slice` simulation currently evaluates `start + length` as `u32` before casting the result to `usize`.

When the addition overflows, Rust debug/test builds panic instead of returning the failure branch required by the Sierra/CASM semantics.

## What was the behavior before?

The simulator used:

```rust
arr.get(start as usize..(start + length) as usize)
```

For example, simulating `array_slice([], u32::MAX, 1)` could panic in debug/test builds.

## What is the behavior after?

The simulator converts the operands to `usize` before addition and uses `checked_add`.

If the end index cannot be represented or the range is outside the array, the simulator returns the failure branch.

## Related issue or discussion

Fixes https://github.com/starkware-libs/cairo/issues/10372

## Additional context

Added regression coverage for:

```text
array_slice([], u32::MAX, 1)
```

which must select the failure branch, and:

```text
array_slice([1, 2, 3], 1, 2)
```

which must return `[2, 3]` on the success branch.

