### PR TITLE
fix(sierra-to-casm): prevent wide frame offset overflow

### DIFF
--- a/crates/cairo-lang-sierra-to-casm/src/invocations/function_call.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/function_call.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use cairo_lang_casm::casm;
 use cairo_lang_casm::operand::Register;
 use cairo_lang_sierra::extensions::function_call::SignatureAndFunctionConcreteLibfunc;
@@ -8,7 +6,7 @@ use cairo_lang_sierra::extensions::ConcreteLibfunc;
 use super::{
     check_references_on_stack, CompiledInvocation, CompiledInvocationBuilder, InvocationError,
 };
-use crate::references::build_deref_reference;
+use crate::references::{build_deref_reference, ReferenceExpression};
 use crate::relocations::{Relocation, RelocationEntry};
 
 /// Handles a function call.
@@ -21,21 +19,18 @@ pub fn build(
     let output_types = libfunc.output_types();
     let fallthrough_outputs = &output_types[0];
 
-    let mut refs = VecDeque::with_capacity(fallthrough_outputs.len());
-
-    let mut offset = -1_i64;
-    for output_type in fallthrough_outputs.iter().rev() {
-        let size = builder
-            .program_info
-            .type_sizes
-            .get(output_type)
-            .ok_or(InvocationError::UnknownVariableData)?;
-        refs.push_front(
-            build_deref_reference(Register::AP, offset, *size)
-                .ok_or(InvocationError::IntegerOverflow)?,
-        );
-        offset -= i64::from(*size);
-    }
+    let output_sizes = fallthrough_outputs
+        .iter()
+        .map(|output_type| {
+            builder
+                .program_info
+                .type_sizes
+                .get(output_type)
+                .copied()
+                .ok_or(InvocationError::UnknownVariableData)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let refs = build_output_references(&output_sizes)?;
 
     Ok(builder.build(
         casm! { call rel 0; }.instructions,
@@ -45,4 +40,77 @@ pub fn build(
         }],
         [refs.into_iter()].into_iter(),
     ))
+}
+
+fn build_output_references(
+    output_sizes: &[i16],
+) -> Result<Vec<ReferenceExpression>, InvocationError> {
+    let mut refs = Vec::with_capacity(output_sizes.len());
+    let mut offset = -1_i64;
+    for size in output_sizes.iter().rev() {
+        refs.push(
+            build_deref_reference(Register::AP, offset, *size)
+                .ok_or(InvocationError::IntegerOverflow)?,
+        );
+        offset -= i64::from(*size);
+    }
+    Ok(refs.into_iter().rev().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use cairo_lang_casm::cell_expression::CellExpression;
+    use cairo_lang_casm::operand::CellRef;
+    use cairo_lang_sierra::ids::ConcreteTypeId;
+    use cairo_lang_sierra::program::StatementIdx;
+
+    use super::*;
+    use crate::references::{IntroductionPoint, ReferenceValue};
+
+    #[test]
+    fn wide_return_offsets_boundaries() {
+        for sizes in [&[32767][..], &[16384, 16384][..], &[16383, 16385][..]] {
+            let refs = build_output_references(sizes).unwrap();
+            assert_eq!(
+                refs.iter().map(|reference| reference.cells.len()).collect::<Vec<_>>(),
+                sizes.iter().map(|size| usize::try_from(*size).unwrap()).collect::<Vec<_>>()
+            );
+            let first_cell = refs.first().unwrap().cells.first();
+            let first_offset = -sizes.iter().map(|size| i64::from(*size)).sum::<i64>();
+            assert_eq!(
+                first_cell,
+                Some(&CellExpression::Deref(CellRef {
+                    register: Register::AP,
+                    offset: first_offset.try_into().unwrap(),
+                }))
+            );
+            assert_eq!(
+                refs.last().unwrap().cells.last(),
+                Some(&CellExpression::Deref(CellRef { register: Register::AP, offset: -1 }))
+            );
+        }
+
+        assert_eq!(build_output_references(&[16384, 16385]), Err(InvocationError::IntegerOverflow));
+    }
+
+    #[test]
+    fn full_width_return_is_on_stack() {
+        let refs = build_output_references(&[16384, 16384])
+            .unwrap()
+            .into_iter()
+            .enumerate()
+            .map(|(output_idx, expression)| ReferenceValue {
+                expression,
+                ty: ConcreteTypeId::from(output_idx as u64),
+                stack_idx: None,
+                introduction_point: IntroductionPoint {
+                    source_statement_idx: Some(StatementIdx(0)),
+                    destination_statement_idx: StatementIdx(1),
+                    output_idx,
+                },
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(check_references_on_stack(&refs), Ok(()));
+    }
 }

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/function_call.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/function_call.rs
@@ -1,15 +1,14 @@
 use std::collections::VecDeque;
 
 use cairo_lang_casm::casm;
-use cairo_lang_casm::cell_expression::CellExpression;
-use cairo_lang_casm::operand::{CellRef, Register};
+use cairo_lang_casm::operand::Register;
 use cairo_lang_sierra::extensions::function_call::SignatureAndFunctionConcreteLibfunc;
 use cairo_lang_sierra::extensions::ConcreteLibfunc;
 
 use super::{
     check_references_on_stack, CompiledInvocation, CompiledInvocationBuilder, InvocationError,
 };
-use crate::references::ReferenceExpression;
+use crate::references::build_deref_reference;
 use crate::relocations::{Relocation, RelocationEntry};
 
 /// Handles a function call.
@@ -24,19 +23,18 @@ pub fn build(
 
     let mut refs = VecDeque::with_capacity(fallthrough_outputs.len());
 
-    let mut offset = -1;
+    let mut offset = -1_i64;
     for output_type in fallthrough_outputs.iter().rev() {
         let size = builder
             .program_info
             .type_sizes
             .get(output_type)
             .ok_or(InvocationError::UnknownVariableData)?;
-        refs.push_front(ReferenceExpression {
-            cells: ((offset - size + 1)..(offset + 1))
-                .map(|i| CellExpression::Deref(CellRef { register: Register::AP, offset: i }))
-                .collect(),
-        });
-        offset -= size;
+        refs.push_front(
+            build_deref_reference(Register::AP, offset, *size)
+                .ok_or(InvocationError::IntegerOverflow)?,
+        );
+        offset -= i64::from(*size);
     }
 
     Ok(builder.build(

--- a/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/invocations/mod.rs
@@ -288,12 +288,12 @@ pub struct CompiledInvocation {
 /// Checks that the list of references is contiguous on the stack and ends at ap - 1.
 /// This is the requirement for function call and return statements.
 pub fn check_references_on_stack(refs: &[ReferenceValue]) -> Result<(), InvocationError> {
-    let mut expected_offset: i16 = -1;
+    let mut expected_offset = -1_i64;
     for reference in refs.iter().rev() {
         for cell_expr in reference.expression.cells.iter().rev() {
             match cell_expr {
                 CellExpression::Deref(CellRef { register: Register::AP, offset })
-                    if *offset == expected_offset =>
+                    if i64::from(*offset) == expected_offset =>
                 {
                     expected_offset -= 1;
                 }

--- a/crates/cairo-lang-sierra-to-casm/src/references.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/references.rs
@@ -21,6 +21,8 @@ pub enum ReferencesError {
     InvalidReferenceTypeForArgument,
     #[error("Unknown type `{0}`.")]
     UnknownType(ConcreteTypeId),
+    #[error("A function parameter is outside the encodable frame offset range.")]
+    ParameterOffsetOutOfRange,
 }
 
 pub type StatementRefs = OrderedHashMap<VarId, ReferenceValue>;
@@ -149,13 +151,25 @@ impl core::fmt::Display for ReferenceExpression {
     }
 }
 
+pub(crate) fn build_deref_reference(
+    register: Register,
+    end_offset: i64,
+    size: i16,
+) -> Option<ReferenceExpression> {
+    let start_offset = end_offset - i64::from(size) + 1;
+    let cells = (start_offset..=end_offset)
+        .map(|offset| Some(CellExpression::Deref(CellRef { register, offset: offset.try_into().ok()? })))
+        .collect::<Option<_>>()?;
+    Some(ReferenceExpression { cells })
+}
+
 /// Builds the HashMap of references to the parameters of a function.
 pub fn build_function_parameters_refs(
     func: &Function,
     type_sizes: &TypeSizeMap,
 ) -> Result<StatementRefs, ReferencesError> {
     let mut refs = StatementRefs::default();
-    let mut offset = -3_i16;
+    let mut offset = -3_i64;
     for (param_idx, param) in func.params.iter().rev().enumerate() {
         let size = type_sizes
             .get(&param.ty)
@@ -164,13 +178,8 @@ pub fn build_function_parameters_refs(
             .insert(
                 param.id.clone(),
                 ReferenceValue {
-                    expression: ReferenceExpression {
-                        cells: ((offset - size + 1)..(offset + 1))
-                            .map(|i| {
-                                CellExpression::Deref(CellRef { register: Register::FP, offset: i })
-                            })
-                            .collect(),
-                    },
+                    expression: build_deref_reference(Register::FP, offset, *size)
+                        .ok_or(ReferencesError::ParameterOffsetOutOfRange)?,
                     ty: param.ty.clone(),
                     stack_idx: None,
                     introduction_point: IntroductionPoint {
@@ -184,7 +193,7 @@ pub fn build_function_parameters_refs(
         {
             return Err(ReferencesError::InvalidFunctionDeclaration(func.clone()));
         }
-        offset -= size;
+        offset -= i64::from(*size);
     }
     Ok(refs)
 }
@@ -198,5 +207,30 @@ pub fn check_types_match(
         Ok(())
     } else {
         Err(ReferencesError::InvalidReferenceTypeForArgument)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cairo_lang_sierra::ids::{ConcreteTypeId, FunctionId, VarId};
+    use cairo_lang_sierra::program::{Function, Param};
+
+    use super::*;
+
+    #[test]
+    fn wide_parameter_offsets_boundaries() {
+        for size in [32765, 32766] {
+            let ty = ConcreteTypeId::from("Wide");
+            let func = Function::new(
+                FunctionId::from("wide"),
+                vec![Param { id: VarId::from("value"), ty: ty.clone() }],
+                vec![],
+                StatementIdx(0),
+            );
+            let mut type_sizes = TypeSizeMap::default();
+            type_sizes.insert(ty, size);
+            let refs = build_function_parameters_refs(&func, &type_sizes).unwrap();
+            assert_eq!(refs[&VarId::from("value")].expression.cells.len(), size as usize);
+        }
     }
 }

--- a/crates/cairo-lang-sierra-to-casm/src/references.rs
+++ b/crates/cairo-lang-sierra-to-casm/src/references.rs
@@ -158,7 +158,9 @@ pub(crate) fn build_deref_reference(
 ) -> Option<ReferenceExpression> {
     let start_offset = end_offset - i64::from(size) + 1;
     let cells = (start_offset..=end_offset)
-        .map(|offset| Some(CellExpression::Deref(CellRef { register, offset: offset.try_into().ok()? })))
+        .map(|offset| {
+            Some(CellExpression::Deref(CellRef { register, offset: offset.try_into().ok()? }))
+        })
         .collect::<Option<_>>()?;
     Some(ReferenceExpression { cells })
 }


### PR DESCRIPTION
## Summary

Prevent valid wide Sierra function parameter and return layouts from panicking during Sierra-to-CASM reference construction. Frame layout now uses wider signed arithmetic, converts each final CASM offset to `i16` with a checked conversion, and returns existing structured compilation errors when an offset is not encodable.

---

## Type of change

- [x] Bug fix (fixes incorrect behavior)
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation change with concrete technical impact
- [ ] Style, wording, formatting, or typo-only change

---

## Why is this change needed?

A valid 32,766-cell function parameter frame reaches offset `fp - 32768`, but the previous `i16` expression computed an out-of-range intermediate before adding one. Function-call return construction and stack-contiguity validation had symmetric intermediate or sentinel underflows. With overflow checks enabled these layouts panic even though every emitted reference offset is representable.

---

## What was the behavior or documentation before?

Wide but representable parameter and return layouts could panic while constructing or validating reference expressions.

---

## What is the behavior or documentation after?

Frame offsets are accumulated in `i64`; final dereference offsets are checked when converted to `i16`. Representable boundary layouts compile normally, while layouts outside the CASM offset range produce structured errors. Regression coverage exercises the exact parameter and function-call return boundaries, including output ordering and full-width stack validation.

---

## Related issue or discussion (if any)

None.

---

## Additional context

Validation performed on `sierra-minor-update`:

- `./scripts/rust_fmt.sh`
- `./scripts/rust_fmt.sh --check`
- `RUSTUP_TOOLCHAIN=nightly-2024-08-22 cargo test -p cairo-lang-sierra-to-casm wide_` (2 passed)
- `RUSTUP_TOOLCHAIN=nightly-2024-08-22 cargo test -p cairo-lang-sierra-to-casm invocations::function_call::tests` (2 passed)
- `git diff --check origin/sierra-minor-update...HEAD`
